### PR TITLE
Flatten temporal iterator reconstruction (#356) and compute avg_delta_chain from historical storage (#366)

### DIFF
--- a/benches/query_optimization.rs
+++ b/benches/query_optimization.rs
@@ -190,12 +190,53 @@ fn bench_statistics(c: &mut Criterion) {
     group.finish();
 }
 
+/// Benchmark the average delta chain calculation feeding the cost model (Issue #366).
+///
+/// `refresh_statistics` now calls `HistoricalStorage::calculate_avg_delta_chain()`
+/// instead of using a hardcoded estimate. This validates the calculation is O(1)
+/// (cached counters, no version scan), so the statistic stays safe to refresh
+/// frequently regardless of how many versions are stored.
+fn bench_avg_delta_chain(c: &mut Criterion) {
+    use aletheiadb::core::VersionId;
+    use aletheiadb::core::interning::GLOBAL_INTERNER;
+    use aletheiadb::storage::historical::HistoricalStorage;
+
+    let mut group = c.benchmark_group("statistics/avg_delta_chain");
+
+    for version_count in [100u64, 10_000] {
+        let mut storage = HistoricalStorage::new();
+        let label = GLOBAL_INTERNER.intern("Bench").unwrap();
+
+        // ~20 versions per node: chains of 1 anchor + deltas (default interval 10)
+        for i in 0..version_count {
+            storage
+                .add_node_version(
+                    NodeId::new(1 + i / 20).unwrap(),
+                    VersionId::new(1 + i).unwrap(),
+                    (1_000 + i as i64).into(),
+                    (1_000 + i as i64).into(),
+                    label,
+                    PropertyMapBuilder::new().insert("v", i as i64).build(),
+                    false,
+                )
+                .unwrap();
+        }
+
+        group.bench_function(format!("calculate/{version_count}_versions"), |b| {
+            b.iter(|| black_box(storage.calculate_avg_delta_chain()));
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_planning_overhead,
     bench_explain,
     bench_cost_estimation,
     bench_statistics,
+    bench_avg_delta_chain,
 );
 
 criterion_main!(benches);

--- a/docs/guides/query-pipeline-guide.md
+++ b/docs/guides/query-pipeline-guide.md
@@ -228,6 +228,16 @@ let plan = planner.plan(query)?;
 println!("{}", plan.explain());
 ```
 
+The planner's cost model reads cached `Statistics` (node/edge counts, label
+cardinalities, average out-degree, and the average delta chain length). The
+average delta chain length estimates how many delta versions a temporal
+(`AS OF`) lookup must apply on top of an anchor; since Issue #366 it is the
+actual average computed by `HistoricalStorage::calculate_avg_delta_chain()`
+(total deltas / total anchors, across node and edge version chains, in O(1)
+from cached counters) rather than a hardcoded estimate. It falls back to `5.0`
+only when historical storage is empty. `AletheiaDB::refresh_statistics()`
+refreshes all of these values.
+
 ### Executor (`aletheiadb::query::QueryExecutor`)
 
 Executes physical plans:

--- a/src/db/admin.rs
+++ b/src/db/admin.rs
@@ -289,22 +289,12 @@ impl AletheiaDB {
         // Collect label counts from current storage
         let label_counts = self.current.label_counts();
 
-        // Calculate average delta chain length from historical storage
-        // This is used for cost estimation of temporal lookups.
-        let historical_stats = self.historical.read().stats();
-        let total_versions =
-            historical_stats.total_node_versions + historical_stats.total_edge_versions;
-        let total_anchors = historical_stats.node_anchor_count + historical_stats.edge_anchor_count;
-
-        let avg_delta_chain = if total_anchors > 0 {
-            let interval = total_versions as f64 / total_anchors as f64;
-            // Average reconstruction depth is roughly (interval - 1) / 2
-            (interval - 1.0) / 2.0
-        } else {
-            // Default estimate if historical storage is empty or has no anchors
-            // (Assumes anchor_interval=10, so avg depth ~5)
-            5.0
-        };
+        // Calculate the average delta chain length from historical storage
+        // (Issue #366). This feeds the query planner's temporal-lookup cost
+        // model. O(1): reads incrementally-maintained anchor/delta counters
+        // (Issue #212) and falls back to the default estimate of 5.0 when the
+        // historical storage is empty.
+        let avg_delta_chain = self.historical.read().calculate_avg_delta_chain();
 
         self.stats.refresh(
             node_count,

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -1542,6 +1542,51 @@ fn test_refresh_statistics() {
 }
 
 #[test]
+fn test_refresh_statistics_avg_delta_chain_from_historical() {
+    // Issue #366: refresh_statistics must feed the planner the actual average
+    // delta chain length computed from historical storage, not a hardcoded
+    // estimate.
+    let db = AletheiaDB::new().unwrap();
+
+    let node = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("v", 0i64).build(),
+        )
+        .unwrap();
+    // Three updates create delta versions behind the initial anchor.
+    for i in 1..=3i64 {
+        db.update_node_with_valid_time(
+            node,
+            PropertyMapBuilder::new().insert("v", i).build(),
+            None,
+        )
+        .unwrap();
+    }
+
+    db.refresh_statistics();
+
+    // Hand-compute the expected value from the historical storage counters.
+    let hist = db.historical_stats().unwrap();
+    let total_deltas = (hist.node_delta_count + hist.edge_delta_count) as f64;
+    let total_anchors = (hist.node_anchor_count + hist.edge_anchor_count) as f64;
+    assert!(total_anchors > 0.0, "expected at least one anchor version");
+    assert!(
+        total_deltas > 0.0,
+        "expected delta versions from the updates"
+    );
+    let expected = total_deltas / total_anchors;
+
+    let stats = db.statistics();
+    assert!(
+        (stats.average_delta_chain_length() - expected).abs() < f64::EPSILON,
+        "avg delta chain {} should equal deltas/anchors {}",
+        stats.average_delta_chain_length(),
+        expected
+    );
+}
+
+#[test]
 fn test_invalidate_statistics() {
     let db = AletheiaDB::new().unwrap();
 

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -279,6 +279,58 @@ impl ResultIterator for VectorResultIterator {
     }
 }
 
+/// Reconstruct a node as it existed at `(valid_time, transaction_time)` from an
+/// already-locked historical storage (Issue #356).
+///
+/// This is the single, flat implementation of the temporal reconstruction path
+/// shared by [`TemporalNodeIterator`], [`BatchTemporalNodeIterator`], and
+/// [`TemporalNodeScanIterator`], replacing the previously duplicated (and
+/// originally deeply nested) per-iterator logic:
+///
+/// 1. Find the version valid at the requested bi-temporal point.
+/// 2. Retrieve the version metadata (validates that
+///    `find_node_version_at_time` only returns existing version IDs).
+/// 3. Reconstruct properties from the anchor+delta compression.
+/// 4. Build a `Node` with the historical label and properties.
+///
+/// The caller decides the locking strategy (per-node vs batch) and passes the
+/// already-locked storage, so this helper never affects lock semantics.
+///
+/// # Errors
+///
+/// - [`TemporalError::NodeNotFoundAtTime`](crate::core::error::TemporalError::NodeNotFoundAtTime)
+///   if no version exists at the requested time point
+/// - [`TemporalError::VersionNotFound`](crate::core::error::TemporalError::VersionNotFound)
+///   if version metadata is missing (data inconsistency)
+/// - Any error from property reconstruction
+fn reconstruct_node_at(
+    historical: &HistoricalStorage,
+    node_id: NodeId,
+    valid_time: Timestamp,
+    transaction_time: Timestamp,
+) -> Result<Node> {
+    // Step 1: Find the version valid at the requested time
+    let version_id = historical
+        .find_node_version_at_time(node_id, valid_time, transaction_time)
+        .ok_or(crate::core::error::TemporalError::NodeNotFoundAtTime {
+            node_id,
+            valid_time,
+            transaction_time,
+        })?;
+
+    // Step 2: Get the version metadata (also validates the invariant that
+    // find_node_version_at_time only returns existing version IDs)
+    let version = historical.get_node_version(version_id).ok_or(
+        crate::core::error::TemporalError::VersionNotFound(version_id),
+    )?;
+
+    // Step 3: Reconstruct the properties from the version
+    let properties = historical.reconstruct_node_properties(version_id)?;
+
+    // Step 4: Build and return the node with the historical data
+    Ok(Node::new(node_id, version.label, properties, version_id))
+}
+
 /// Iterator for temporal node lookups.
 ///
 /// # Context
@@ -361,26 +413,9 @@ impl ResultIterator for TemporalNodeIterator {
             // For bulk queries, use BatchTemporalNodeIterator instead
             let historical = self.historical.read();
 
-            // Find the version valid at the requested time
-            let version_id = historical
-                .find_node_version_at_time(id, self.valid_time, self.transaction_time)
-                .ok_or(crate::core::error::TemporalError::NodeNotFoundAtTime {
-                    node_id: id,
-                    valid_time: self.valid_time,
-                    transaction_time: self.transaction_time,
-                })?;
-
-            // Get the version metadata (also validates the invariant that
-            // find_node_version_at_time only returns existing version IDs)
-            let version = historical.get_node_version(version_id).ok_or(
-                crate::core::error::TemporalError::VersionNotFound(version_id),
-            )?;
-
-            // Reconstruct the properties from the version
-            let properties = historical.reconstruct_node_properties(version_id)?;
-
-            // Construct a node with the historical data
-            let node = Node::new(id, version.label, properties, version_id);
+            // Reconstruct the node at the requested bi-temporal point (Issue #356)
+            let node =
+                reconstruct_node_at(&historical, id, self.valid_time, self.transaction_time)?;
 
             Ok(QueryRow::from_entity(EntityResult::Node(node)).at_time(self.valid_time))
         })
@@ -470,26 +505,8 @@ impl BatchTemporalNodeIterator {
         let results: Vec<Result<QueryRow>> = node_ids
             .into_iter()
             .map(|id| {
-                // Find the version valid at the requested time
-                let version_id = guard
-                    .find_node_version_at_time(id, valid_time, transaction_time)
-                    .ok_or(crate::core::error::TemporalError::NodeNotFoundAtTime {
-                        node_id: id,
-                        valid_time,
-                        transaction_time,
-                    })?;
-
-                // Get the version metadata (also validates the invariant that
-                // find_node_version_at_time only returns existing version IDs)
-                let version = guard.get_node_version(version_id).ok_or(
-                    crate::core::error::TemporalError::VersionNotFound(version_id),
-                )?;
-
-                // Reconstruct the properties from the version
-                let properties = guard.reconstruct_node_properties(version_id)?;
-
-                // Construct a node with the historical data
-                let node = Node::new(id, version.label, properties, version_id);
+                // Reconstruct the node at the requested bi-temporal point (Issue #356)
+                let node = reconstruct_node_at(&guard, id, valid_time, transaction_time)?;
 
                 Ok(QueryRow::from_entity(EntityResult::Node(node)).at_time(valid_time))
             })
@@ -607,11 +624,8 @@ impl TemporalNodeScanIterator {
 
     /// Retrieve the temporal version of a node at the configured time point.
     ///
-    /// This helper method encapsulates the temporal reconstruction logic:
-    /// 1. Find the version valid at (valid_time, transaction_time)
-    /// 2. Retrieve the version metadata
-    /// 3. Reconstruct properties from anchor+delta compression
-    /// 4. Return a fully reconstructed Node
+    /// Thin wrapper over the shared [`reconstruct_node_at`] helper (Issue #356),
+    /// binding this iterator's configured `(valid_time, transaction_time)`.
     ///
     /// # Errors
     ///
@@ -624,26 +638,7 @@ impl TemporalNodeScanIterator {
         node_id: NodeId,
         guard: &parking_lot::RwLockReadGuard<'_, HistoricalStorage>,
     ) -> Result<Node> {
-        // Step 1: Find the version valid at the requested time
-        let version_id = guard
-            .find_node_version_at_time(node_id, self.valid_time, self.transaction_time)
-            .ok_or(crate::core::error::TemporalError::NodeNotFoundAtTime {
-                node_id,
-                valid_time: self.valid_time,
-                transaction_time: self.transaction_time,
-            })?;
-
-        // Step 2: Get the version metadata (also validates the invariant that
-        // find_node_version_at_time only returns existing version IDs)
-        let version = guard.get_node_version(version_id).ok_or(
-            crate::core::error::TemporalError::VersionNotFound(version_id),
-        )?;
-
-        // Step 3: Reconstruct properties
-        let properties = guard.reconstruct_node_properties(version_id)?;
-
-        // Step 4: Build and return the node
-        Ok(Node::new(node_id, version.label, properties, version_id))
+        reconstruct_node_at(guard, node_id, self.valid_time, self.transaction_time)
     }
 
     /// Check if a node passes the label filter.
@@ -2880,6 +2875,187 @@ mod tests {
         let mut iter = TemporalNodeIterator::new(node_ids, now, now, historical);
 
         assert!(iter.next().is_none());
+    }
+
+    // Characterization tests (Issue #356): capture the exact behavior of the
+    // temporal reconstruction path before/after flattening it into a shared
+    // helper. Behavior must not change.
+
+    /// Helper: extract the "name" string property from a QueryRow's node.
+    fn row_name(row: &QueryRow) -> String {
+        let node = row.entity.as_node().expect("row should contain a node");
+        match node.properties.get("name") {
+            Some(PropertyValue::String(s)) => s.to_string(),
+            other => panic!("unexpected name property: {:?}", other),
+        }
+    }
+
+    /// Helper: historical storage with two versions of node 1:
+    /// name=Alice at t=1000, name=Alicia at t=2000 (valid == tx time).
+    fn historical_with_two_versions() -> Arc<RwLock<HistoricalStorage>> {
+        use crate::storage::historical::HistoricalStorage;
+
+        let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
+        let label = GLOBAL_INTERNER.intern("Person").unwrap();
+        {
+            let mut hist = historical.write();
+            hist.add_node_version(
+                NodeId::new(1).unwrap(),
+                VersionId::new(100).unwrap(),
+                1000.into(),
+                1000.into(),
+                label,
+                PropertyMapBuilder::new().insert("name", "Alice").build(),
+                false, // not a tombstone
+            )
+            .unwrap();
+            hist.add_node_version(
+                NodeId::new(1).unwrap(),
+                VersionId::new(101).unwrap(),
+                2000.into(),
+                2000.into(),
+                label,
+                PropertyMapBuilder::new().insert("name", "Alicia").build(),
+                false, // not a tombstone
+            )
+            .unwrap();
+        }
+        historical
+    }
+
+    #[test]
+    fn test_temporal_node_iterator_not_found_before_first_version() {
+        let historical = historical_with_two_versions();
+        let node_ids = vec![NodeId::new(1).unwrap()];
+
+        // Query before the node's first version: not found at that time
+        let mut iter = TemporalNodeIterator::new(node_ids, 500.into(), 500.into(), historical);
+
+        let result = iter.next().unwrap();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_temporal_node_iterator_multiple_versions_selects_point_in_time() {
+        let historical = historical_with_two_versions();
+
+        // Between the two versions: the older version's properties are returned
+        let mut iter = TemporalNodeIterator::new(
+            vec![NodeId::new(1).unwrap()],
+            1500.into(),
+            1500.into(),
+            historical.clone(),
+        );
+        let row = iter.next().unwrap().unwrap();
+        assert_eq!(row_name(&row), "Alice");
+        assert_eq!(row.timestamp, Some(1500.into()));
+
+        // At/after the second version: the newer version's properties are returned
+        let mut iter = TemporalNodeIterator::new(
+            vec![NodeId::new(1).unwrap()],
+            2500.into(),
+            2500.into(),
+            historical,
+        );
+        let row = iter.next().unwrap().unwrap();
+        assert_eq!(row_name(&row), "Alicia");
+    }
+
+    #[test]
+    fn test_temporal_node_iterator_boundary_timestamps() {
+        let historical = historical_with_two_versions();
+
+        // Exactly at the first version's start: that version is visible
+        let mut iter = TemporalNodeIterator::new(
+            vec![NodeId::new(1).unwrap()],
+            1000.into(),
+            1000.into(),
+            historical.clone(),
+        );
+        let row = iter.next().unwrap().unwrap();
+        assert_eq!(row_name(&row), "Alice");
+
+        // Exactly at the second version's start: the new version wins
+        // (intervals are half-open: the old version ends at 2000, the new begins)
+        let mut iter = TemporalNodeIterator::new(
+            vec![NodeId::new(1).unwrap()],
+            2000.into(),
+            2000.into(),
+            historical,
+        );
+        let row = iter.next().unwrap().unwrap();
+        assert_eq!(row_name(&row), "Alicia");
+    }
+
+    #[test]
+    fn test_temporal_node_iterator_tombstone_semantics() {
+        use crate::storage::historical::HistoricalStorage;
+
+        let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
+        let label = GLOBAL_INTERNER.intern("Person").unwrap();
+        {
+            let mut hist = historical.write();
+            hist.add_node_version(
+                NodeId::new(1).unwrap(),
+                VersionId::new(100).unwrap(),
+                1000.into(),
+                1000.into(),
+                label,
+                PropertyMapBuilder::new().insert("name", "Alice").build(),
+                false, // not a tombstone
+            )
+            .unwrap();
+            // Tombstone (deletion) at t=2000
+            hist.add_node_version(
+                NodeId::new(1).unwrap(),
+                VersionId::new(101).unwrap(),
+                2000.into(),
+                2000.into(),
+                label,
+                PropertyMapBuilder::new().build(),
+                true, // tombstone
+            )
+            .unwrap();
+        }
+
+        // Before the deletion: node is visible with its original properties
+        let mut iter = TemporalNodeIterator::new(
+            vec![NodeId::new(1).unwrap()],
+            1500.into(),
+            1500.into(),
+            historical.clone(),
+        );
+        let row = iter.next().unwrap().unwrap();
+        assert_eq!(row_name(&row), "Alice");
+
+        // After the deletion: node is not found at that time
+        let mut iter = TemporalNodeIterator::new(
+            vec![NodeId::new(1).unwrap()],
+            2500.into(),
+            2500.into(),
+            historical,
+        );
+        let result = iter.next().unwrap();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_batch_temporal_node_iterator_multiple_versions_selects_point_in_time() {
+        // The batch iterator must reconstruct the same point-in-time state as
+        // the per-node iterator (shared logic, Issue #356).
+        let historical = historical_with_two_versions();
+
+        let mut iter = BatchTemporalNodeIterator::new(
+            vec![NodeId::new(1).unwrap()],
+            1500.into(),
+            1500.into(),
+            historical,
+        )
+        .unwrap();
+
+        let row = iter.next().unwrap().unwrap();
+        assert_eq!(row_name(&row), "Alice");
+        assert_eq!(row.timestamp, Some(1500.into()));
     }
 
     // ==================== BatchTemporalNodeIterator Tests ====================

--- a/src/query/planner/stats.rs
+++ b/src/query/planner/stats.rs
@@ -157,6 +157,12 @@ pub struct Statistics {
     ///
     /// - **Low value (near 1.0)**: Most lookups hit anchors directly (fast).
     /// - **High value**: Lookups require applying many deltas (slow).
+    ///
+    /// Since Issue #366 this is the actual average computed by
+    /// [`HistoricalStorage::calculate_avg_delta_chain`](crate::storage::historical::HistoricalStorage::calculate_avg_delta_chain)
+    /// (total deltas / total anchors, over both node and edge versions),
+    /// not a hardcoded estimate. The 5.0 fallback only applies when the
+    /// historical storage is empty.
     avg_delta_chain: AtomicF64,
 
     /// Property statistics for selectivity estimation.

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -166,6 +166,14 @@ const ANCHOR_CACHE_SIZE_RATIO: usize = 5; // 20% of main cache
 /// at least a few anchors to avoid immediate evictions.
 const MIN_ANCHOR_CACHE_SIZE: usize = 100;
 
+/// Default average delta chain length estimate used when historical storage
+/// is empty (Issue #366).
+///
+/// Assumes the default `anchor_interval` of 10 (one anchor followed by up to
+/// nine deltas), matching the query planner's fallback in
+/// [`Statistics::average_delta_chain_length`](crate::query::planner::Statistics::average_delta_chain_length).
+pub const DEFAULT_AVG_DELTA_CHAIN: f64 = 5.0;
+
 /// Historical storage for versioned nodes and edges.
 ///
 /// This storage engine maintains version chains for all temporal data,
@@ -3034,6 +3042,54 @@ impl HistoricalStorage {
             node_anchor_cache_entries: self.node_anchor_cache.len(),
             edge_anchor_cache_entries: self.edge_anchor_cache.len(),
         }
+    }
+
+    /// Calculate the average delta chain length across all version chains (Issue #366).
+    ///
+    /// A delta chain is the run of delta versions that follows an anchor in the
+    /// anchor+delta compression scheme. Every chain starts at exactly one anchor,
+    /// so the chains partition the delta versions among the anchors and the exact
+    /// average chain length is `total deltas / total anchors`, computed over both
+    /// node and edge versions.
+    ///
+    /// The result feeds the query planner's temporal-lookup cost model (via
+    /// [`AletheiaDB::refresh_statistics`](crate::db::AletheiaDB::refresh_statistics)):
+    /// it estimates how many delta versions a point-in-time reconstruction must
+    /// walk back through before reaching an anchor.
+    ///
+    /// # Returns
+    ///
+    /// - The actual average delta chain length when historical data exists.
+    ///   A storage containing only anchors returns `0.0` (every lookup hits an
+    ///   anchor directly).
+    /// - [`DEFAULT_AVG_DELTA_CHAIN`] (5.0) when the storage is empty (no anchors),
+    ///   matching the query planner's default assumption of `anchor_interval = 10`.
+    ///
+    /// # Performance
+    ///
+    /// O(1): reads the incrementally-maintained anchor/delta counters (Issue #212);
+    /// no version scan is performed, so this is safe to call on every statistics
+    /// refresh.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use aletheiadb::storage::historical::HistoricalStorage;
+    /// let storage = HistoricalStorage::new();
+    /// // Empty storage falls back to the default estimate
+    /// assert_eq!(storage.calculate_avg_delta_chain(), 5.0);
+    /// ```
+    #[must_use]
+    pub fn calculate_avg_delta_chain(&self) -> f64 {
+        let total_anchors = self.cached_node_anchor_count + self.cached_edge_anchor_count;
+        if total_anchors == 0 {
+            // No historical data: fall back to the default estimate
+            // (assumes anchor_interval=10, so avg chain length ~5)
+            return DEFAULT_AVG_DELTA_CHAIN;
+        }
+
+        let total_deltas = self.cached_node_delta_count + self.cached_edge_delta_count;
+        total_deltas as f64 / total_anchors as f64
     }
 
     /// Get cache performance metrics (Improvement #3: Adaptive Cache Sizing).

--- a/src/storage/historical/tests.rs
+++ b/src/storage/historical/tests.rs
@@ -352,6 +352,127 @@ fn test_stats() {
 }
 
 // ============================================================
+// Average Delta Chain Length (Issue #366)
+// ============================================================
+
+#[test]
+fn test_calculate_avg_delta_chain_hand_computed() {
+    // Issue #366: hand-computed expected average over known constructed chains.
+    // With anchor_interval=10, the first version of each entity is an anchor and
+    // the following versions (up to the interval) are deltas.
+    let mut storage = HistoricalStorage::with_config(AnchorConfig {
+        anchor_interval: 10,
+        max_delta_chain: 20,
+    });
+    let label = GLOBAL_INTERNER.intern("Test").unwrap();
+
+    // Node 1: 4 versions -> 1 anchor + 3 deltas
+    for i in 0..4u64 {
+        storage
+            .add_node_version(
+                NodeId::new(1).unwrap(),
+                VersionId::new(100 + i).unwrap(),
+                (1000 + (i as i64) * 100).into(),
+                (1000 + (i as i64) * 100).into(),
+                label,
+                PropertyMapBuilder::new().insert("v", i as i64).build(),
+                false, // not a tombstone
+            )
+            .unwrap();
+    }
+
+    // Node 2: 1 version -> 1 anchor + 0 deltas
+    storage
+        .add_node_version(
+            NodeId::new(2).unwrap(),
+            VersionId::new(200).unwrap(),
+            1000.into(),
+            1000.into(),
+            label,
+            PropertyMapBuilder::new().build(),
+            false, // not a tombstone
+        )
+        .unwrap();
+
+    // Expected: (3 deltas + 0 deltas) / 2 anchors = 1.5
+    assert!((storage.calculate_avg_delta_chain() - 1.5).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_calculate_avg_delta_chain_empty_storage_fallback() {
+    // Issue #366: empty historical storage falls back to the default estimate 5.0.
+    let storage = HistoricalStorage::new();
+    assert!((storage.calculate_avg_delta_chain() - 5.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_calculate_avg_delta_chain_includes_edge_versions() {
+    // Issue #366: the average considers both node and edge version chains.
+    let mut storage = HistoricalStorage::with_config(AnchorConfig {
+        anchor_interval: 10,
+        max_delta_chain: 20,
+    });
+    let label = GLOBAL_INTERNER.intern("Test").unwrap();
+
+    // Node chain: 3 versions -> 1 anchor + 2 deltas
+    for i in 0..3u64 {
+        storage
+            .add_node_version(
+                NodeId::new(1).unwrap(),
+                VersionId::new(100 + i).unwrap(),
+                (1000 + (i as i64) * 100).into(),
+                (1000 + (i as i64) * 100).into(),
+                label,
+                PropertyMapBuilder::new().insert("v", i as i64).build(),
+                false, // not a tombstone
+            )
+            .unwrap();
+    }
+
+    // Edge chain: 3 versions -> 1 anchor + 2 deltas
+    for i in 0..3u64 {
+        storage
+            .add_edge_version(
+                EdgeId::new(1).unwrap(),
+                VersionId::new(300 + i).unwrap(),
+                (1000 + (i as i64) * 100).into(),
+                (1000 + (i as i64) * 100).into(),
+                label,
+                NodeId::new(1).unwrap(),
+                NodeId::new(2).unwrap(),
+                PropertyMapBuilder::new().insert("w", i as i64).build(),
+                false, // not a tombstone
+            )
+            .unwrap();
+    }
+
+    // Expected: (2 node deltas + 2 edge deltas) / (1 + 1 anchors) = 2.0
+    assert!((storage.calculate_avg_delta_chain() - 2.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_calculate_avg_delta_chain_anchors_only_is_zero() {
+    // Anchors with no deltas: the actual average chain length is 0.0
+    // (every lookup hits an anchor directly), not the 5.0 fallback.
+    let mut storage = HistoricalStorage::new();
+    let label = GLOBAL_INTERNER.intern("Test").unwrap();
+
+    storage
+        .add_node_version(
+            NodeId::new(1).unwrap(),
+            VersionId::new(100).unwrap(),
+            1000.into(),
+            1000.into(),
+            label,
+            PropertyMapBuilder::new().build(),
+            false, // not a tombstone
+        )
+        .unwrap();
+
+    assert!(storage.calculate_avg_delta_chain().abs() < f64::EPSILON);
+}
+
+// ============================================================
 // Vector Property Tests (VS-012)
 // ============================================================
 //


### PR DESCRIPTION
Closes #356
Closes #366

## Summary

Two quick wins: completes the #356 de-nesting refactor of the temporal node iterators (pure refactor, zero behavior change) and replaces the estimated `avg_delta_chain` statistic with an actual calculation from historical storage (#366).

## Before / After

### #356 — Temporal iterator reconstruction logic (refactor)

**Before:** The 4-step temporal node reconstruction (find version at time → load version metadata → reconstruct properties → build `Node`) was duplicated verbatim in three places in `src/query/executor/iterators.rs`: `TemporalNodeIterator::next`, `BatchTemporalNodeIterator::new`, and `TemporalNodeScanIterator::get_temporal_version`. (The original 8-level nesting quoted in the issue had already been partially flattened by the earlier `TemporalNodeScanIterator` work; this PR finishes the job by eliminating the remaining triplication.)

**After:** One flat, documented helper — `reconstruct_node_at(&HistoricalStorage, NodeId, valid_time, transaction_time) -> Result<Node>` — used by all three iterators. Nesting stays at 2 levels max, errors and their order are identical, and each caller keeps its own locking strategy (per-node lock vs single batch guard), so lock semantics are untouched. Characterization tests were added **before** the refactor to pin down current behavior (not-found before first version, multiple versions with point-in-time selection, half-open boundary timestamps, tombstone visibility) and pass unchanged after it.

### #366 — `avg_delta_chain` from historical storage

**Before:** `refresh_statistics` (`src/db/admin.rs`) fed the query planner an inline approximation `(total_versions/total_anchors - 1) / 2` (and 5.0 when empty); the issue's requested `HistoricalStorage` method did not exist.

**After:** New `HistoricalStorage::calculate_avg_delta_chain()` returns the **exact** average delta chain length: `total deltas / total anchors` across node and edge versions (every chain starts at exactly one anchor, so chains partition deltas among anchors). Falls back to `DEFAULT_AVG_DELTA_CHAIN` (5.0) when storage is empty. `refresh_statistics` now calls it. O(1) — reads the Issue #212 incrementally-maintained counters, no version scan.

## Approach and tradeoffs

- **#356:** chose a single shared free-function helper over (a) guard-clause rewrites of each `next()` (they were already flat; wouldn't remove duplication) and (b) an iterator-combinator rewrite (bigger diff, risk of changing laziness/lock behavior). The helper takes an already-locked `&HistoricalStorage`, so it cannot change locking.
- **#366:** chose O(1) cached-counter arithmetic over a per-chain version scan (same result, but a scan would violate the repo's stats convention — Issue #212: no version scans in stats paths) and over adding a new dedicated counter (redundant). Semantics note: the planner statistic (documented as "average number of versions one must walk back to find an anchor") now receives the actual average chain length (`deltas/anchors`) instead of the previous halved mid-chain heuristic (`(interval-1)/2`); for a chain head — the version a reconstruction actually starts from — the walk-back is the full chain, so this is the truthful, slightly conservative value. All planner/cost tests pass unchanged (no plan-selection flips).

## Acceptance criteria with evidence

### #356 (derived from issue body; no explicit AC section)
1. **Nesting refactored via extracted helper methods** — `reconstruct_node_at` in `src/query/executor/iterators.rs`; all three temporal iterators delegate to it.
2. **2-3 levels of nesting max** — helper body is straight-line `?`-chained steps; callers are `map`/loop + one call.
3. **Each helper independently testable** — exercised directly via the `TemporalNodeScanIterator::get_temporal_version` unit tests plus the new characterization tests.
4. **Clear separation of concerns** — reconstruction vs row assembly vs label filtering are separate functions.
5. **Easier to modify** — the reconstruction contract now lives in exactly one place.
6. **Behavior unchanged** — characterization tests (`test_temporal_node_iterator_not_found_before_first_version`, `test_temporal_node_iterator_multiple_versions_selects_point_in_time`, `test_temporal_node_iterator_boundary_timestamps`, `test_temporal_node_iterator_tombstone_semantics`, `test_batch_temporal_node_iterator_multiple_versions_selects_point_in_time`) were added and pass **before and after** the refactor; the full pre-existing suite passes.

### #366 (verbatim AC)
1. **`HistoricalStorage::calculate_avg_delta_chain()` implemented** — `src/storage/historical/mod.rs` (with new `DEFAULT_AVG_DELTA_CHAIN` const).
2. **Statistics refresh uses actual calculation** — `src/db/admin.rs::refresh_statistics`; verified by `test_refresh_statistics_avg_delta_chain_from_historical` (`src/db/tests.rs`).
3. **Fallback to 5.0 when historical storage is empty** — `test_calculate_avg_delta_chain_empty_storage_fallback`.
4. **Tests verify calculation accuracy** — hand-computed fixtures: `test_calculate_avg_delta_chain_hand_computed` (1 anchor + 3 deltas and 1 anchor + 0 deltas → 1.5), `test_calculate_avg_delta_chain_includes_edge_versions` (node + edge chains → 2.0), `test_calculate_avg_delta_chain_anchors_only_is_zero`.
5. **Benchmark query plan impact before/after** — new `bench_avg_delta_chain` in `benches/query_optimization.rs`: ~367 ps at 100 versions and ~367 ps at 10,000 versions (flat → O(1); refresh cost unchanged vs the old inline arithmetic). Cost-model input change documented above (`deltas/anchors` vs previous `deltas/anchors/2`); `bench_cost_estimation` (~3.4 ns simple / ~26.4 ns complex) and all planner cost tests unchanged.
6. **Documentation updated** — rustdoc on the new method/const, `Statistics::avg_delta_chain` field docs (`src/query/planner/stats.rs`), refresh comments in `src/db/admin.rs`, and a planner-statistics paragraph in `docs/guides/query-pipeline-guide.md`.

## Test plan

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all` — applied
- `cargo test --no-fail-fast` — lib: 3414 passed / 0 failed (2 ignored); doc-tests: 410 passed; all integration targets pass except the two pre-existing fault-injection failures that occur on any branch when running as uid 0 in this environment (`havoc::havoc_suites::wal::havoc_flush_deadlock::test_flush_deadlock_on_io_error` and `regression_flush_corruption::test_metadata_corruption_on_error` — both assert that an injected I/O error occurs, which root bypasses). Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQvYxmvRfzTnRDFnPhTQgX

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQvYxmvRfzTnRDFnPhTQgX)_