### PR TITLE
Make ReadOps edge-listing methods return Result and document the trait (#358, #359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING**: `ReadOps::get_outgoing_edges`, `ReadOps::get_incoming_edges`,
+  and `ReadOps::get_outgoing_edges_with_label` now return
+  `Result<Vec<EdgeId>>` instead of `Vec<EdgeId>` (Issue #359). A node that
+  does not exist (or is not visible in the transaction's snapshot) returns
+  `Err(NodeNotFound)`, consistent with `get_node`/`get_edge`; an existing
+  node with no (matching) edges returns `Ok(vec![])`, so callers can finally
+  distinguish "node has no edges" from "node doesn't exist". Within a write
+  transaction the existence check is buffer-aware: a node created in the
+  transaction exists, a node deleted in it does not. The non-transactional
+  `AletheiaDB::get_outgoing_edges`/`get_incoming_edges` convenience methods
+  are unchanged. Migration: append `?` (or `.unwrap_or_default()` to keep
+  the old silent-empty behavior) at call sites. The `ReadOps` trait methods
+  also gained comprehensive rustdoc with runnable examples covering the
+  empty-vs-missing contract (Issue #358).
+
 - MCP tool error responses are now structured (Issue #3234): every error is
   `{"error": {"code", "message", "retriable", "details"?}}` instead of
   `{"error": "<string>"}`. `code` is drawn from a stable seven-value enum

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,11 +65,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   distinguish "node has no edges" from "node doesn't exist". Within a write
   transaction the existence check is buffer-aware: a node created in the
   transaction exists, a node deleted in it does not. The non-transactional
-  `AletheiaDB::get_outgoing_edges`/`get_incoming_edges` convenience methods
-  are unchanged. Migration: append `?` (or `.unwrap_or_default()` to keep
+  `AletheiaDB::get_outgoing_edges`/`get_incoming_edges`/
+  `get_outgoing_edges_with_label` convenience methods are unchanged.
+  Migration: append `?` (or `.unwrap_or_default()` to keep
   the old silent-empty behavior) at call sites. The `ReadOps` trait methods
   also gained comprehensive rustdoc with runnable examples covering the
   empty-vs-missing contract (Issue #358).
+  Two edge-case behavior changes ride along: `retract_node_detach` on a node
+  previously removed via the plain (non-cascade) `delete_node` no longer
+  co-retracts that node's orphaned edges (`edges_retracted: 0`) — consistent
+  with the documented "retracting a deleted node is a no-op" contract; and
+  `delete_node_cascade` on a node already deleted in the same transaction
+  now fails fast with `NodeNotFound` at edge enumeration (same final outcome
+  as before, earlier failure point).
 
 - MCP tool error responses are now structured (Issue #3234): every error is
   `{"error": {"code", "message", "retriable", "details"?}}` instead of

--- a/docs/architecture/transaction-system.md
+++ b/docs/architecture/transaction-system.md
@@ -118,9 +118,9 @@ sequenceDiagram
 pub trait ReadOps {
     fn get_node(&self, id: NodeId) -> Result<Node>;
     fn get_edge(&self, id: EdgeId) -> Result<Edge>;
-    fn get_outgoing_edges(&self, node_id: NodeId) -> Vec<EdgeId>;
-    fn get_incoming_edges(&self, node_id: NodeId) -> Vec<EdgeId>;
-    fn get_outgoing_edges_with_label(&self, node_id: NodeId, label: &str) -> Vec<EdgeId>;
+    fn get_outgoing_edges(&self, node_id: NodeId) -> Result<Vec<EdgeId>>;
+    fn get_incoming_edges(&self, node_id: NodeId) -> Result<Vec<EdgeId>>;
+    fn get_outgoing_edges_with_label(&self, node_id: NodeId, label: &str) -> Result<Vec<EdgeId>>;
     fn node_count(&self) -> usize;
     fn edge_count(&self) -> usize;
 }

--- a/src/api/transaction/mod.rs
+++ b/src/api/transaction/mod.rs
@@ -221,12 +221,26 @@ pub trait ReadOps {
     ///
     /// # Snapshot Isolation
     ///
-    /// This method filters edges to ensure only those visible in the current transaction
-    /// snapshot are returned. Edges created by concurrent transactions will not be seen.
+    /// In a read transaction, this method filters edges to ensure only those visible
+    /// in the current transaction snapshot are returned. Edges created by concurrent
+    /// transactions will not be seen.
+    ///
+    /// # Write transactions
+    ///
+    /// In a write transaction, only the **node existence check** is buffer-aware;
+    /// the returned edge list is read directly from committed current storage
+    /// **without snapshot filtering**. Consequently:
+    ///
+    /// - edges committed by concurrent transactions after this transaction
+    ///   started **are** returned,
+    /// - edges created in this transaction (still buffered, not yet committed)
+    ///   are **not** returned, and
+    /// - edges deleted in this transaction are **still** listed until commit.
     ///
     /// # Performance
     ///
-    /// - **Time**: O(degree) to collect visible edges, plus an O(1) node existence check
+    /// - **Time**: O(degree) to collect visible edges, plus a node existence check
+    ///   (O(1) fast path; may consult historical storage, O(log N), on a miss)
     /// - **Space**: Allocates a new `Vec` containing all edge IDs
     ///
     /// # Example
@@ -286,12 +300,25 @@ pub trait ReadOps {
     ///
     /// # Snapshot Isolation
     ///
-    /// This method filters edges to ensure only those visible in the current transaction
-    /// snapshot are returned.
+    /// In a read transaction, this method filters edges to ensure only those visible
+    /// in the current transaction snapshot are returned.
+    ///
+    /// # Write transactions
+    ///
+    /// In a write transaction, only the **node existence check** is buffer-aware;
+    /// the returned edge list is read directly from committed current storage
+    /// **without snapshot filtering**. Consequently:
+    ///
+    /// - edges committed by concurrent transactions after this transaction
+    ///   started **are** returned,
+    /// - edges created in this transaction (still buffered, not yet committed)
+    ///   are **not** returned, and
+    /// - edges deleted in this transaction are **still** listed until commit.
     ///
     /// # Performance
     ///
-    /// - **Time**: O(degree) to collect visible edges, plus an O(1) node existence check
+    /// - **Time**: O(degree) to collect visible edges, plus a node existence check
+    ///   (O(1) fast path; may consult historical storage, O(log N), on a miss)
     /// - **Space**: Allocates a new `Vec` containing all edge IDs
     ///
     /// # Example
@@ -343,9 +370,22 @@ pub trait ReadOps {
     ///
     /// The order of edges is **not guaranteed**.
     ///
+    /// # Write transactions
+    ///
+    /// In a write transaction, only the **node existence check** is buffer-aware;
+    /// the returned edge list is read directly from committed current storage
+    /// **without snapshot filtering**. Consequently:
+    ///
+    /// - edges committed by concurrent transactions after this transaction
+    ///   started **are** returned,
+    /// - edges created in this transaction (still buffered, not yet committed)
+    ///   are **not** returned, and
+    /// - edges deleted in this transaction are **still** listed until commit.
+    ///
     /// # Performance
     ///
-    /// - **Time**: O(degree) scan with label filtering, plus an O(1) node existence check
+    /// - **Time**: O(degree) scan with label filtering, plus a node existence check
+    ///   (O(1) fast path; may consult historical storage, O(log N), on a miss)
     /// - **Space**: Allocates a new `Vec` containing matching edge IDs
     ///
     /// # Example
@@ -380,7 +420,8 @@ pub trait ReadOps {
     ///
     /// The count of nodes currently committed in the storage engine. Returns `0`
     /// for an empty database. Deleted nodes are not counted. Nodes created in
-    /// this transaction but not yet committed are **not** included.
+    /// this transaction but not yet committed are **not** included. Conversely,
+    /// nodes deleted in this transaction but not yet committed are still included.
     ///
     /// # Consistency Note
     ///
@@ -411,7 +452,8 @@ pub trait ReadOps {
     ///
     /// The count of edges currently committed in the storage engine. Returns `0`
     /// for an empty database. Deleted edges are not counted. Edges created in
-    /// this transaction but not yet committed are **not** included.
+    /// this transaction but not yet committed are **not** included. Conversely,
+    /// edges deleted in this transaction but not yet committed are still included.
     ///
     /// # Consistency Note
     ///

--- a/src/api/transaction/mod.rs
+++ b/src/api/transaction/mod.rs
@@ -197,6 +197,22 @@ pub trait ReadOps {
     ///
     /// Returns all edges where `source == node_id` that are visible in the current snapshot.
     ///
+    /// # Arguments
+    ///
+    /// * `node_id` - The source node to get edges from
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(edge_ids)` - The node exists (is visible in this transaction's snapshot).
+    ///   The vector is **empty if the node has no outgoing edges** - that is a valid
+    ///   state, not an error.
+    /// - `Err(NodeNotFound)` - The node does not exist (or is not visible in this
+    ///   transaction's snapshot).
+    ///
+    /// This mirrors [`get_node`](Self::get_node): the same condition (a missing node)
+    /// produces an error, so callers can distinguish "node has no edges" from
+    /// "node doesn't exist" (Issue #359).
+    ///
     /// # Ordering
     ///
     /// The order of edges is **not guaranteed**. Do not rely on edges being returned
@@ -210,30 +226,59 @@ pub trait ReadOps {
     ///
     /// # Performance
     ///
-    /// - **Time**: O(degree) to collect visible edges
+    /// - **Time**: O(degree) to collect visible edges, plus an O(1) node existence check
     /// - **Space**: Allocates a new `Vec` containing all edge IDs
     ///
     /// # Example
     ///
-    /// ```rust,no_run
-    /// # use aletheiadb::{AletheiaDB, core::NodeId, api::transaction::ReadOps};
+    /// ```rust
+    /// # use aletheiadb::{AletheiaDB, properties, core::NodeId};
+    /// # use aletheiadb::api::transaction::{ReadOps, WriteOps};
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let db = AletheiaDB::new()?;
-    /// # let tx = db.read_transaction()?;
-    /// # let node_id = NodeId::new(1)?;
-    /// let edges = tx.get_outgoing_edges(node_id);
+    /// let (alice, bob) = db.write(|tx| {
+    ///     let alice = tx.create_node("Person", properties! { "name" => "Alice" })?;
+    ///     let bob = tx.create_node("Person", properties! { "name" => "Bob" })?;
+    ///     tx.create_edge(alice, bob, "KNOWS", properties! {})?;
+    ///     Ok::<_, aletheiadb::Error>((alice, bob))
+    /// })?;
+    ///
+    /// let tx = db.read_transaction()?;
+    ///
+    /// // Alice has one outgoing edge:
+    /// let edges = tx.get_outgoing_edges(alice)?;
+    /// assert_eq!(edges.len(), 1);
     /// for edge_id in edges {
     ///     let edge = tx.get_edge(edge_id)?;
-    ///     println!("-> {}", edge.target);
+    ///     assert_eq!(edge.target, bob);
     /// }
+    ///
+    /// // Bob exists but has no outgoing edges: Ok(empty), not an error.
+    /// assert!(tx.get_outgoing_edges(bob)?.is_empty());
+    ///
+    /// // A node that doesn't exist is an error, distinguishable from "no edges".
+    /// let missing = NodeId::new(999_999)?;
+    /// assert!(tx.get_outgoing_edges(missing).is_err());
     /// # Ok(())
     /// # }
     /// ```
-    fn get_outgoing_edges(&self, node_id: NodeId) -> Vec<EdgeId>;
+    fn get_outgoing_edges(&self, node_id: NodeId) -> Result<Vec<EdgeId>>;
 
     /// Get incoming edges to a node.
     ///
     /// Returns all edges where `target == node_id` that are visible in the current snapshot.
+    ///
+    /// # Arguments
+    ///
+    /// * `node_id` - The target node to get edges to
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(edge_ids)` - The node exists (is visible in this transaction's snapshot).
+    ///   The vector is **empty if the node has no incoming edges** - that is a valid
+    ///   state, not an error.
+    /// - `Err(NodeNotFound)` - The node does not exist (or is not visible in this
+    ///   transaction's snapshot).
     ///
     /// # Ordering
     ///
@@ -246,14 +291,53 @@ pub trait ReadOps {
     ///
     /// # Performance
     ///
-    /// - **Time**: O(degree) to collect visible edges
+    /// - **Time**: O(degree) to collect visible edges, plus an O(1) node existence check
     /// - **Space**: Allocates a new `Vec` containing all edge IDs
-    fn get_incoming_edges(&self, node_id: NodeId) -> Vec<EdgeId>;
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use aletheiadb::{AletheiaDB, properties};
+    /// # use aletheiadb::api::transaction::{ReadOps, WriteOps};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = AletheiaDB::new()?;
+    /// let (alice, bob) = db.write(|tx| {
+    ///     let alice = tx.create_node("Person", properties! { "name" => "Alice" })?;
+    ///     let bob = tx.create_node("Person", properties! { "name" => "Bob" })?;
+    ///     tx.create_edge(alice, bob, "KNOWS", properties! {})?;
+    ///     Ok::<_, aletheiadb::Error>((alice, bob))
+    /// })?;
+    ///
+    /// let tx = db.read_transaction()?;
+    ///
+    /// // Bob has one incoming edge (from Alice):
+    /// assert_eq!(tx.get_incoming_edges(bob)?.len(), 1);
+    ///
+    /// // Alice exists but has no incoming edges: Ok(empty), not an error.
+    /// assert!(tx.get_incoming_edges(alice)?.is_empty());
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn get_incoming_edges(&self, node_id: NodeId) -> Result<Vec<EdgeId>>;
 
     /// Get outgoing edges with a specific label.
     ///
     /// Returns all edges where `source == node_id` AND `label == label` that are
     /// visible in the current snapshot.
+    ///
+    /// # Arguments
+    ///
+    /// * `node_id` - The source node
+    /// * `label` - Edge label to filter by (e.g., "KNOWS", "CREATED")
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(edge_ids)` - The node exists (is visible in this transaction's snapshot).
+    ///   The vector is **empty if no outgoing edges carry the given label** - the
+    ///   label is a filter, not an existence check, so an unmatched label on an
+    ///   existing node is a valid state, not an error.
+    /// - `Err(NodeNotFound)` - The node does not exist (or is not visible in this
+    ///   transaction's snapshot).
     ///
     /// # Ordering
     ///
@@ -261,11 +345,42 @@ pub trait ReadOps {
     ///
     /// # Performance
     ///
-    /// - **Time**: O(degree) scan with label filtering
+    /// - **Time**: O(degree) scan with label filtering, plus an O(1) node existence check
     /// - **Space**: Allocates a new `Vec` containing matching edge IDs
-    fn get_outgoing_edges_with_label(&self, node_id: NodeId, label: &str) -> Vec<EdgeId>;
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use aletheiadb::{AletheiaDB, properties};
+    /// # use aletheiadb::api::transaction::{ReadOps, WriteOps};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = AletheiaDB::new()?;
+    /// let (alice, bob) = db.write(|tx| {
+    ///     let alice = tx.create_node("Person", properties! { "name" => "Alice" })?;
+    ///     let bob = tx.create_node("Person", properties! { "name" => "Bob" })?;
+    ///     tx.create_edge(alice, bob, "KNOWS", properties! {})?;
+    ///     Ok::<_, aletheiadb::Error>((alice, bob))
+    /// })?;
+    ///
+    /// let tx = db.read_transaction()?;
+    ///
+    /// // One outgoing KNOWS edge:
+    /// assert_eq!(tx.get_outgoing_edges_with_label(alice, "KNOWS")?.len(), 1);
+    ///
+    /// // No FOLLOWS edges, but Alice exists: Ok(empty), not an error.
+    /// assert!(tx.get_outgoing_edges_with_label(alice, "FOLLOWS")?.is_empty());
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn get_outgoing_edges_with_label(&self, node_id: NodeId, label: &str) -> Result<Vec<EdgeId>>;
 
     /// Get the approximate number of nodes in the database.
+    ///
+    /// # Returns
+    ///
+    /// The count of nodes currently committed in the storage engine. Returns `0`
+    /// for an empty database. Deleted nodes are not counted. Nodes created in
+    /// this transaction but not yet committed are **not** included.
     ///
     /// # Consistency Note
     ///
@@ -291,6 +406,12 @@ pub trait ReadOps {
     fn node_count(&self) -> usize;
 
     /// Get the approximate number of edges in the database.
+    ///
+    /// # Returns
+    ///
+    /// The count of edges currently committed in the storage engine. Returns `0`
+    /// for an empty database. Deleted edges are not counted. Edges created in
+    /// this transaction but not yet committed are **not** included.
     ///
     /// # Consistency Note
     ///

--- a/src/api/transaction/read_tx.rs
+++ b/src/api/transaction/read_tx.rs
@@ -618,10 +618,16 @@ mod tests {
         let current = Arc::new(CurrentStorage::new());
         let tx = create_test_read_tx(TxId::new(1), current);
 
-        let result = tx.get_outgoing_edges(NodeId::new(999).unwrap());
+        let missing = NodeId::new(999).unwrap();
+        let result = tx.get_outgoing_edges(missing);
         assert!(
-            result.is_err(),
-            "get_outgoing_edges on a nonexistent node must return Err, got {result:?}"
+            matches!(
+                result,
+                Err(crate::core::error::Error::Storage(
+                    crate::core::error::StorageError::NodeNotFound(id)
+                )) if id == missing
+            ),
+            "get_outgoing_edges on a nonexistent node must return Err(NodeNotFound), got {result:?}"
         );
     }
 

--- a/src/api/transaction/read_tx.rs
+++ b/src/api/transaction/read_tx.rs
@@ -296,25 +296,34 @@ impl ReadOps for ReadTransaction {
         result.record_error_metric()
     }
 
-    fn get_outgoing_edges(&self, node_id: NodeId) -> Vec<EdgeId> {
+    fn get_outgoing_edges(&self, node_id: NodeId) -> Result<Vec<EdgeId>> {
+        // Existence check (Issue #359): a missing node is an error, so callers can
+        // distinguish "node has no edges" (Ok(empty)) from "node doesn't exist".
+        self.get_node(node_id)?;
         // Filter edges to only return those visible in our snapshot
         // This prevents phantom reads where we see edges created after our snapshot
         // Note: CurrentStorage::get_outgoing_edges() uses frozen view when available
         let edge_ids = self.current.get_outgoing_edges(node_id);
-        self.filter_visible_edges(edge_ids)
+        Ok(self.filter_visible_edges(edge_ids))
     }
 
-    fn get_incoming_edges(&self, node_id: NodeId) -> Vec<EdgeId> {
+    fn get_incoming_edges(&self, node_id: NodeId) -> Result<Vec<EdgeId>> {
+        // Existence check (Issue #359): a missing node is an error.
+        self.get_node(node_id)?;
         // Filter edges to only return those visible in our snapshot
         // Note: CurrentStorage::get_incoming_edges() uses frozen view when available
         let edge_ids = self.current.get_incoming_edges(node_id);
-        self.filter_visible_edges(edge_ids)
+        Ok(self.filter_visible_edges(edge_ids))
     }
 
-    fn get_outgoing_edges_with_label(&self, node_id: NodeId, label: &str) -> Vec<EdgeId> {
+    fn get_outgoing_edges_with_label(&self, node_id: NodeId, label: &str) -> Result<Vec<EdgeId>> {
+        // Existence check (Issue #359): a missing node is an error. An existing
+        // node with no edges matching `label` is Ok(empty) - the label is a
+        // filter, not an existence check.
+        self.get_node(node_id)?;
         // Filter edges to only return those visible in our snapshot
         let edge_ids = self.current.get_outgoing_edges_with_label(node_id, label);
-        self.filter_visible_edges(edge_ids)
+        Ok(self.filter_visible_edges(edge_ids))
     }
 
     fn node_count(&self) -> usize {
@@ -461,12 +470,12 @@ mod tests {
         assert_eq!(edge.target, node2);
 
         // Get outgoing edges
-        let outgoing = tx.get_outgoing_edges(node1);
+        let outgoing = tx.get_outgoing_edges(node1).unwrap();
         assert_eq!(outgoing.len(), 1);
         assert_eq!(outgoing[0], edge_id);
 
         // Get incoming edges
-        let incoming = tx.get_incoming_edges(node2);
+        let incoming = tx.get_incoming_edges(node2).unwrap();
         assert_eq!(incoming.len(), 1);
         assert_eq!(incoming[0], edge_id);
     }
@@ -489,12 +498,12 @@ mod tests {
         let tx = create_test_read_tx(TxId::new(1), current);
 
         // Get only KNOWS edges
-        let knows_edges = tx.get_outgoing_edges_with_label(node1, "KNOWS");
+        let knows_edges = tx.get_outgoing_edges_with_label(node1, "KNOWS").unwrap();
         assert_eq!(knows_edges.len(), 1);
         assert_eq!(knows_edges[0], edge1);
 
         // Get only FOLLOWS edges
-        let follows_edges = tx.get_outgoing_edges_with_label(node1, "FOLLOWS");
+        let follows_edges = tx.get_outgoing_edges_with_label(node1, "FOLLOWS").unwrap();
         assert_eq!(follows_edges.len(), 1);
     }
 
@@ -599,6 +608,88 @@ mod tests {
             &crate::core::property::PropertyValue::String("Alice".into()),
         );
         assert_eq!(results, vec![alice_id]);
+    }
+
+    // Issue #359: edge-listing methods return Result so callers can
+    // distinguish "node doesn't exist" (Err) from "node has no edges" (Ok(empty)).
+
+    #[test]
+    fn test_get_outgoing_edges_nonexistent_node_errors() {
+        let current = Arc::new(CurrentStorage::new());
+        let tx = create_test_read_tx(TxId::new(1), current);
+
+        let result = tx.get_outgoing_edges(NodeId::new(999).unwrap());
+        assert!(
+            result.is_err(),
+            "get_outgoing_edges on a nonexistent node must return Err, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_get_incoming_edges_nonexistent_node_errors() {
+        let current = Arc::new(CurrentStorage::new());
+        let tx = create_test_read_tx(TxId::new(1), current);
+
+        let result = tx.get_incoming_edges(NodeId::new(999).unwrap());
+        assert!(
+            result.is_err(),
+            "get_incoming_edges on a nonexistent node must return Err, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_get_outgoing_edges_with_label_nonexistent_node_errors() {
+        let current = Arc::new(CurrentStorage::new());
+        let tx = create_test_read_tx(TxId::new(1), current);
+
+        let result = tx.get_outgoing_edges_with_label(NodeId::new(999).unwrap(), "KNOWS");
+        assert!(
+            result.is_err(),
+            "get_outgoing_edges_with_label on a nonexistent node must return Err, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_get_outgoing_edges_existing_node_no_edges_ok_empty() {
+        let current = Arc::new(CurrentStorage::new());
+        let props = PropertyMapBuilder::new().build();
+        let node = current.create_node("Person", props).unwrap();
+
+        let tx = create_test_read_tx(TxId::new(1), current);
+        let edges = tx
+            .get_outgoing_edges(node)
+            .expect("existing node with no edges must be Ok");
+        assert!(edges.is_empty(), "expected Ok(empty), got {edges:?}");
+    }
+
+    #[test]
+    fn test_get_incoming_edges_existing_node_no_edges_ok_empty() {
+        let current = Arc::new(CurrentStorage::new());
+        let props = PropertyMapBuilder::new().build();
+        let node = current.create_node("Person", props).unwrap();
+
+        let tx = create_test_read_tx(TxId::new(1), current);
+        let edges = tx
+            .get_incoming_edges(node)
+            .expect("existing node with no edges must be Ok");
+        assert!(edges.is_empty(), "expected Ok(empty), got {edges:?}");
+    }
+
+    #[test]
+    fn test_get_outgoing_edges_with_label_no_match_ok_empty() {
+        let current = Arc::new(CurrentStorage::new());
+        let props = PropertyMapBuilder::new().build();
+        let node1 = current.create_node("Person", props.clone()).unwrap();
+        let node2 = current.create_node("Person", props.clone()).unwrap();
+        current.create_edge(node1, node2, "KNOWS", props).unwrap();
+
+        let tx = create_test_read_tx(TxId::new(1), current);
+        // Node exists and has edges, but none with this label: the label is a
+        // filter, not an existence check, so this is Ok(empty) and not an error.
+        let edges = tx
+            .get_outgoing_edges_with_label(node1, "FOLLOWS")
+            .expect("existing node with no matching label must be Ok");
+        assert!(edges.is_empty(), "expected Ok(empty), got {edges:?}");
     }
 
     #[test]

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -862,16 +862,25 @@ impl ReadOps for WriteTransaction {
         result.record_error_metric()
     }
 
-    fn get_outgoing_edges(&self, node_id: NodeId) -> Vec<EdgeId> {
-        self.current.get_outgoing_edges(node_id)
+    fn get_outgoing_edges(&self, node_id: NodeId) -> Result<Vec<EdgeId>> {
+        // Existence check (Issue #359): consults the write buffer first (a node
+        // created in this tx exists; a node deleted in this tx does not), then
+        // falls back to a snapshot-isolated storage read.
+        self.get_node(node_id)?;
+        Ok(self.current.get_outgoing_edges(node_id))
     }
 
-    fn get_incoming_edges(&self, node_id: NodeId) -> Vec<EdgeId> {
-        self.current.get_incoming_edges(node_id)
+    fn get_incoming_edges(&self, node_id: NodeId) -> Result<Vec<EdgeId>> {
+        // Existence check (Issue #359): see get_outgoing_edges.
+        self.get_node(node_id)?;
+        Ok(self.current.get_incoming_edges(node_id))
     }
 
-    fn get_outgoing_edges_with_label(&self, node_id: NodeId, label: &str) -> Vec<EdgeId> {
-        self.current.get_outgoing_edges_with_label(node_id, label)
+    fn get_outgoing_edges_with_label(&self, node_id: NodeId, label: &str) -> Result<Vec<EdgeId>> {
+        // Existence check (Issue #359): see get_outgoing_edges. An existing node
+        // with no edges matching `label` is Ok(empty).
+        self.get_node(node_id)?;
+        Ok(self.current.get_outgoing_edges_with_label(node_id, label))
     }
 
     fn node_count(&self) -> usize {
@@ -1286,8 +1295,8 @@ impl WriteOps for WriteTransaction {
         // in the same transaction (but not yet committed) won't be found and deleted.
         // This is consistent with the existing ReadOps behavior but may leave orphaned
         // edges in same-transaction scenarios. See issue for future improvement.
-        let outgoing_edges = self.get_outgoing_edges(node_id);
-        let incoming_edges = self.get_incoming_edges(node_id);
+        let outgoing_edges = self.get_outgoing_edges(node_id)?;
+        let incoming_edges = self.get_incoming_edges(node_id)?;
 
         // Delete all connected edges first to maintain referential integrity
         // This prevents orphaned edges that reference a deleted node

--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -811,9 +811,15 @@ mod general_tests {
         let (tx, _temp_dir) = create_test_write_tx();
 
         let missing = NodeId::new(999).unwrap();
+        let result = tx.get_outgoing_edges(missing);
         assert!(
-            tx.get_outgoing_edges(missing).is_err(),
-            "get_outgoing_edges on a nonexistent node must return Err"
+            matches!(
+                result,
+                Err(crate::core::error::Error::Storage(
+                    crate::core::error::StorageError::NodeNotFound(id)
+                )) if id == missing
+            ),
+            "get_outgoing_edges on a nonexistent node must return Err(NodeNotFound), got {result:?}"
         );
         assert!(
             tx.get_incoming_edges(missing).is_err(),
@@ -842,6 +848,43 @@ mod general_tests {
             .get_incoming_edges(node)
             .expect("node created in this tx must be visible to the existence check");
         assert!(edges.is_empty(), "expected Ok(empty), got {edges:?}");
+
+        let edges = tx
+            .get_outgoing_edges_with_label(node, "KNOWS")
+            .expect("node created in this tx must be visible to the existence check");
+        assert!(edges.is_empty(), "expected Ok(empty), got {edges:?}");
+    }
+
+    /// Pins the documented write-transaction caveat: an edge created in this
+    /// transaction (still buffered, not yet committed) is NOT listed by the
+    /// edge-listing methods — only the node existence check is buffer-aware.
+    #[test]
+    fn test_write_tx_buffered_edge_not_listed_before_commit() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+        let current = Arc::clone(&tx.current);
+
+        // Source and target are committed nodes; the edge exists only in the
+        // transaction's write buffer.
+        let props = PropertyMapBuilder::new().build();
+        let source = current.create_node("Person", props.clone()).unwrap();
+        let target = current.create_node("Person", props.clone()).unwrap();
+        tx.create_edge(source, target, "KNOWS", props).unwrap();
+
+        assert_eq!(
+            tx.get_outgoing_edges(source).unwrap(),
+            Vec::new(),
+            "an edge buffered in this tx must not be listed before commit"
+        );
+        assert_eq!(
+            tx.get_incoming_edges(target).unwrap(),
+            Vec::new(),
+            "an edge buffered in this tx must not be listed before commit"
+        );
+        assert_eq!(
+            tx.get_outgoing_edges_with_label(source, "KNOWS").unwrap(),
+            Vec::new(),
+            "an edge buffered in this tx must not be listed before commit"
+        );
     }
 
     #[test]
@@ -860,6 +903,10 @@ mod general_tests {
         );
         assert!(
             tx.get_incoming_edges(node).is_err(),
+            "node deleted in this tx must not be treated as existing"
+        );
+        assert!(
+            tx.get_outgoing_edges_with_label(node, "KNOWS").is_err(),
             "node deleted in this tx must not be treated as existing"
         );
     }

--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -793,9 +793,75 @@ mod general_tests {
         assert_eq!(tx.node_count(), 2);
         assert_eq!(tx.edge_count(), 1);
         assert!(tx.get_node(node1).is_ok());
-        assert_eq!(tx.get_outgoing_edges(node1).len(), 1);
-        assert_eq!(tx.get_incoming_edges(node2).len(), 1);
-        assert_eq!(tx.get_outgoing_edges_with_label(node1, "KNOWS").len(), 1);
+        assert_eq!(tx.get_outgoing_edges(node1).unwrap().len(), 1);
+        assert_eq!(tx.get_incoming_edges(node2).unwrap().len(), 1);
+        assert_eq!(
+            tx.get_outgoing_edges_with_label(node1, "KNOWS")
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    // Issue #359: edge-listing methods return Result so callers can
+    // distinguish "node doesn't exist" (Err) from "node has no edges" (Ok(empty)).
+
+    #[test]
+    fn test_write_tx_get_outgoing_edges_nonexistent_node_errors() {
+        let (tx, _temp_dir) = create_test_write_tx();
+
+        let missing = NodeId::new(999).unwrap();
+        assert!(
+            tx.get_outgoing_edges(missing).is_err(),
+            "get_outgoing_edges on a nonexistent node must return Err"
+        );
+        assert!(
+            tx.get_incoming_edges(missing).is_err(),
+            "get_incoming_edges on a nonexistent node must return Err"
+        );
+        assert!(
+            tx.get_outgoing_edges_with_label(missing, "KNOWS").is_err(),
+            "get_outgoing_edges_with_label on a nonexistent node must return Err"
+        );
+    }
+
+    #[test]
+    fn test_write_tx_get_outgoing_edges_node_created_in_tx_ok() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+
+        // Node exists only in this transaction's write buffer.
+        let props = PropertyMapBuilder::new().build();
+        let node = tx.create_node("Person", props).unwrap();
+
+        let edges = tx
+            .get_outgoing_edges(node)
+            .expect("node created in this tx must be visible to the existence check");
+        assert!(edges.is_empty(), "expected Ok(empty), got {edges:?}");
+
+        let edges = tx
+            .get_incoming_edges(node)
+            .expect("node created in this tx must be visible to the existence check");
+        assert!(edges.is_empty(), "expected Ok(empty), got {edges:?}");
+    }
+
+    #[test]
+    fn test_write_tx_get_outgoing_edges_node_deleted_in_tx_errors() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+        let current = Arc::clone(&tx.current);
+
+        // Node exists in current storage, but is deleted in this transaction.
+        let props = PropertyMapBuilder::new().build();
+        let node = current.create_node("Person", props).unwrap();
+        tx.delete_node(node).unwrap();
+
+        assert!(
+            tx.get_outgoing_edges(node).is_err(),
+            "node deleted in this tx must not be treated as existing"
+        );
+        assert!(
+            tx.get_incoming_edges(node).is_err(),
+            "node deleted in this tx must not be treated as existing"
+        );
     }
 
     #[test]

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -2465,6 +2465,83 @@ mod tests {
             assert!(db.get_node(id).is_err());
         }
 
+        /// Review follow-up (#358/#359 fix round): retract_node_detach is
+        /// idempotent — a second detach on an already-retracted node is a
+        /// no-op returning already_retracted with edges_retracted: 0 (a
+        /// retracted node has no enumerable edges left to co-retract).
+        #[test]
+        fn double_retract_node_detach_is_idempotent() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let now = time::now().wallclock();
+            let t_create = hours_ago(now, 3);
+            let t_retract = hours_ago(now, 1);
+
+            let a = db
+                .create_node_with_valid_time(
+                    "Person",
+                    PropertyMapBuilder::new().build(),
+                    Some(t_create),
+                )
+                .unwrap();
+            let b = db
+                .create_node_with_valid_time(
+                    "Person",
+                    PropertyMapBuilder::new().build(),
+                    Some(t_create),
+                )
+                .unwrap();
+            db.create_edge_with_valid_time(
+                a,
+                b,
+                "KNOWS",
+                PropertyMapBuilder::new().build(),
+                Some(t_create),
+            )
+            .unwrap();
+
+            let first = db.retract_node_detach(a, t_retract).unwrap();
+            assert!(!first.already_retracted);
+            assert_eq!(first.edges_retracted, 1);
+            let versions = db.get_node_history(a).unwrap().version_count();
+
+            let second = db.retract_node_detach(a, t_retract).unwrap();
+            assert!(second.already_retracted);
+            assert_eq!(
+                second.edges_retracted, 0,
+                "an idempotent re-detach must not re-count edges"
+            );
+            assert_eq!(
+                second.valid_to, t_retract,
+                "must return the existing valid_to"
+            );
+            assert_eq!(
+                db.get_node_history(a).unwrap().version_count(),
+                versions,
+                "idempotent re-detach must not append a version"
+            );
+        }
+
+        /// Review follow-up (#358/#359 fix round): retract_node_detach on a
+        /// NodeId that never existed is a typed NodeNotFound (the edge
+        /// enumeration tolerates the missing node; retract_node owns the
+        /// not-found semantics).
+        #[test]
+        fn retract_node_detach_nonexistent_node_is_node_not_found() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let now = time::now().wallclock();
+            let missing = NodeId::new(999_999).unwrap();
+
+            let err = db
+                .retract_node_detach(missing, hours_ago(now, 1))
+                .unwrap_err();
+            match err {
+                Error::Storage(crate::core::error::StorageError::NodeNotFound(nid)) => {
+                    assert_eq!(nid, missing);
+                }
+                other => panic!("Expected StorageError::NodeNotFound, got: {other:?}"),
+            }
+        }
+
         /// Fix-round #11 pin: a buffered retraction in a transaction that
         /// ABORTS (closure error, never committed) leaves the node fully
         /// present with no version appended.

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -380,8 +380,8 @@ impl AletheiaDB {
                 // always equals what retract_node_detach would retract (a
                 // self-loop appears in both adjacency directions but is one
                 // edge — count_connected_edges would report 2).
-                let mut edge_ids = tx.get_outgoing_edges(node_id);
-                edge_ids.extend(tx.get_incoming_edges(node_id));
+                let mut edge_ids = tx.get_outgoing_edges(node_id)?;
+                edge_ids.extend(tx.get_incoming_edges(node_id)?);
                 edge_ids.sort_unstable();
                 edge_ids.dedup();
                 let connected_edges = edge_ids.len();
@@ -430,8 +430,12 @@ impl AletheiaDB {
             // no-check-then-act rationale as retract_node). Deduplicate so a
             // self-loop (present in both adjacency directions) is retracted
             // once.
-            let mut edge_ids = tx.get_outgoing_edges(node_id);
-            edge_ids.extend(tx.get_incoming_edges(node_id));
+            // A node that is not visible (e.g. already retracted or never
+            // created) has no enumerable edges; `retract_node` below still
+            // owns the idempotency / not-found semantics for that case, so a
+            // NodeNotFound here must not fail the detach early (Issue #359).
+            let mut edge_ids = tx.get_outgoing_edges(node_id).unwrap_or_default();
+            edge_ids.extend(tx.get_incoming_edges(node_id).unwrap_or_default());
             edge_ids.sort_unstable();
             edge_ids.dedup();
 

--- a/src/experimental/diagnostics/paradox.rs
+++ b/src/experimental/diagnostics/paradox.rs
@@ -191,7 +191,7 @@ impl<'a> ParadoxDetector<'a> {
         // If temporal query returned nothing, fall back to current transaction state
         if edges.is_empty() {
              let _ = self.db.read(|tx| {
-                 edges = tx.get_outgoing_edges(node_id).into_iter().filter_map(|eid| {
+                 edges = tx.get_outgoing_edges(node_id)?.into_iter().filter_map(|eid| {
                      if let Ok(edge) = tx.get_edge(eid) {
                          Some(edge.target)
                      } else {

--- a/src/experimental/reasoning/alchemy.rs
+++ b/src/experimental/reasoning/alchemy.rs
@@ -174,7 +174,6 @@ impl<'a> Alchemist<'a> {
                 // Actually ReadOps allows reading while WriteTx is active
                 let outgoing = tx.get_outgoing_edges(victim)?;
                 for edge_id in outgoing {
-                    // Safe to unwrap here because get_outgoing_edges returns existing edges
                     if let Ok(edge) = tx.get_edge(edge_id) {
                         // Resolve label to string for creation
                         let label_str = GLOBAL_INTERNER

--- a/src/experimental/reasoning/alchemy.rs
+++ b/src/experimental/reasoning/alchemy.rs
@@ -172,7 +172,7 @@ impl<'a> Alchemist<'a> {
                 // 2a. Move Outgoing Edges
                 // Collect edge data first to avoid borrow issues while mutating
                 // Actually ReadOps allows reading while WriteTx is active
-                let outgoing = tx.get_outgoing_edges(victim);
+                let outgoing = tx.get_outgoing_edges(victim)?;
                 for edge_id in outgoing {
                     // Safe to unwrap here because get_outgoing_edges returns existing edges
                     if let Ok(edge) = tx.get_edge(edge_id) {
@@ -195,7 +195,7 @@ impl<'a> Alchemist<'a> {
                 }
 
                 // 2b. Move Incoming Edges
-                let incoming = tx.get_incoming_edges(victim);
+                let incoming = tx.get_incoming_edges(victim)?;
                 for edge_id in incoming {
                     if let Ok(edge) = tx.get_edge(edge_id) {
                         let label_str = GLOBAL_INTERNER
@@ -272,7 +272,7 @@ mod tests {
         // 3. Verify Edge Exists
         let found = db
             .read(|tx| {
-                let outgoing = tx.get_outgoing_edges(a);
+                let outgoing = tx.get_outgoing_edges(a)?;
                 let mut found_edge = false;
                 for eid in outgoing {
                     #[allow(clippy::collapsible_if)]
@@ -345,7 +345,7 @@ mod tests {
         // Check Outgoing: A -> D should exist (inherited from B -> D)
         let has_a_to_d = db
             .read(|tx| {
-                let edges = tx.get_outgoing_edges(a);
+                let edges = tx.get_outgoing_edges(a)?;
                 let mut found = false;
                 for eid in edges {
                     #[allow(clippy::collapsible_if)]
@@ -364,7 +364,7 @@ mod tests {
         // One with label LINKS, one with label LINKS_TO_B
         let has_c_to_a_inherited = db
             .read(|tx| {
-                let edges = tx.get_outgoing_edges(c);
+                let edges = tx.get_outgoing_edges(c)?;
                 let mut found = false;
                 for eid in edges {
                     #[allow(clippy::collapsible_if)]

--- a/src/experimental/reasoning/chimera.rs
+++ b/src/experimental/reasoning/chimera.rs
@@ -167,7 +167,7 @@ impl<'a> ChimeraEngine<'a> {
             // Outgoing: A -> X becomes New -> X
             // We do this for both A and B
             for &source in &[node_a, node_b] {
-                let edges = tx.get_outgoing_edges(source);
+                let edges = tx.get_outgoing_edges(source)?;
                 for edge_id in edges {
                     let edge = tx.get_edge(edge_id)?;
                     let label_str = GLOBAL_INTERNER
@@ -184,7 +184,7 @@ impl<'a> ChimeraEngine<'a> {
 
             // Incoming: X -> A becomes X -> New
             for &target in &[node_a, node_b] {
-                let edges = tx.get_incoming_edges(target);
+                let edges = tx.get_incoming_edges(target)?;
                 for edge_id in edges {
                     let edge = tx.get_edge(edge_id)?;
                     let label_str = GLOBAL_INTERNER

--- a/src/experimental/reasoning/synergy.rs
+++ b/src/experimental/reasoning/synergy.rs
@@ -128,7 +128,7 @@ impl<'a> Synergy<'a> {
                 let mut neighbor_vectors = Vec::new();
 
                 // Get internal outgoing edges
-                let outgoing = tx.get_outgoing_edges(node_id);
+                let outgoing = tx.get_outgoing_edges(node_id)?;
                 for edge_id in outgoing {
                     if let Ok(edge) = tx.get_edge(edge_id) {
                         let target = edge.target;
@@ -141,7 +141,7 @@ impl<'a> Synergy<'a> {
                 }
 
                 // Get internal incoming edges
-                let incoming = tx.get_incoming_edges(node_id);
+                let incoming = tx.get_incoming_edges(node_id)?;
                 for edge_id in incoming {
                     if let Ok(edge) = tx.get_edge(edge_id) {
                         let source = edge.source;

--- a/src/experimental/temporal/chronos.rs
+++ b/src/experimental/temporal/chronos.rs
@@ -54,7 +54,7 @@
 //!
 //! db.write(|tx| {
 //!     // Delete the link between Bob and Charlie
-//!     let edges = tx.get_outgoing_edges(bob);
+//!     let edges = tx.get_outgoing_edges(bob)?;
 //!     for e in edges { tx.delete_edge(e)?; }
 //!     Ok::<_, Error>(())
 //! })?;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1553,8 +1553,8 @@ impl AletheiaMcpServer {
                 // sort/dedup list, so `connected_edges` always equals what
                 // `detach: true` would retract (a self-loop appears in both
                 // adjacency directions but is one edge).
-                let mut edge_ids = tx.get_outgoing_edges(node_id);
-                edge_ids.extend(tx.get_incoming_edges(node_id));
+                let mut edge_ids = tx.get_outgoing_edges(node_id)?;
+                edge_ids.extend(tx.get_incoming_edges(node_id)?);
                 edge_ids.sort_unstable();
                 edge_ids.dedup();
                 let connected_edges = edge_ids.len();

--- a/src/semantic_search/highlander.rs
+++ b/src/semantic_search/highlander.rs
@@ -104,7 +104,7 @@ impl<'a> EntityMerger<'a> {
             let mut edges_processed = std::collections::HashSet::new();
 
             // Outgoing: Victim -> Target
-            let outgoing = tx.get_outgoing_edges(victim);
+            let outgoing = tx.get_outgoing_edges(victim)?;
             for edge_id in outgoing {
                 if edges_processed.insert(edge_id) {
                     let edge = tx.get_edge(edge_id)?;
@@ -133,7 +133,7 @@ impl<'a> EntityMerger<'a> {
             }
 
             // Incoming: Source -> Victim
-            let incoming = tx.get_incoming_edges(victim);
+            let incoming = tx.get_incoming_edges(victim)?;
             for edge_id in incoming {
                 if edges_processed.insert(edge_id) {
                     let edge = tx.get_edge(edge_id)?;

--- a/src/semantic_search/horizon.rs
+++ b/src/semantic_search/horizon.rs
@@ -115,12 +115,12 @@ impl<'a> HorizonEngine<'a> {
 
                 // Get all neighbors (both outgoing and incoming for true semantic reach)
                 let outgoing = tx
-                    .get_outgoing_edges(current_node_id)
+                    .get_outgoing_edges(current_node_id)?
                     .into_iter()
                     .filter_map(|e| tx.get_edge(e).ok().map(|edge| edge.target));
 
                 let incoming = tx
-                    .get_incoming_edges(current_node_id)
+                    .get_incoming_edges(current_node_id)?
                     .into_iter()
                     .filter_map(|e| tx.get_edge(e).ok().map(|edge| edge.source));
 

--- a/tests/readops_snapshot_isolation.rs
+++ b/tests/readops_snapshot_isolation.rs
@@ -1,0 +1,92 @@
+//! Snapshot-isolation tests for the `ReadOps` edge-listing error path
+//! (Issue #359 review follow-up).
+//!
+//! The edge-listing methods (`get_outgoing_edges`, `get_incoming_edges`,
+//! `get_outgoing_edges_with_label`) gate on node existence *as seen by the
+//! transaction's snapshot*, not by current storage. These tests pin that
+//! contract under concurrency:
+//!
+//! - a node committed AFTER a read transaction's snapshot is not visible to
+//!   it, so edge listing returns `Err(NodeNotFound)` even though the node
+//!   exists in current storage;
+//! - a node visible AT snapshot time that a later transaction deletes is
+//!   still visible to the old read transaction (historical fallback), so
+//!   edge listing returns `Ok`.
+
+use aletheiadb::api::transaction::{ReadOps, WriteOps};
+use aletheiadb::{AletheiaDB, Error, PropertyMapBuilder, StorageError};
+
+#[test]
+fn read_tx_edge_listing_errors_for_node_committed_after_snapshot() {
+    let db = AletheiaDB::new().unwrap();
+
+    // Snapshot taken BEFORE the node exists.
+    let read_tx = db.read_transaction().unwrap();
+
+    // A concurrent transaction commits a new node after the snapshot.
+    let node = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // The node exists in current storage but is not visible at the old
+    // snapshot: the existence gate must report NodeNotFound.
+    let result = read_tx.get_outgoing_edges(node);
+    assert!(
+        matches!(
+            result,
+            Err(Error::Storage(StorageError::NodeNotFound(id))) if id == node
+        ),
+        "node committed after the snapshot must not be visible, got {result:?}"
+    );
+    assert!(read_tx.get_incoming_edges(node).is_err());
+    assert!(
+        read_tx
+            .get_outgoing_edges_with_label(node, "KNOWS")
+            .is_err()
+    );
+
+    // A fresh transaction (snapshot after the commit) sees it.
+    let fresh_tx = db.read_transaction().unwrap();
+    assert!(
+        fresh_tx.get_outgoing_edges(node).unwrap().is_empty(),
+        "a fresh snapshot must see the committed node (Ok(empty))"
+    );
+}
+
+#[test]
+fn read_tx_edge_listing_ok_for_node_deleted_after_snapshot() {
+    let db = AletheiaDB::new().unwrap();
+
+    let node = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // Snapshot taken while the node is alive.
+    let read_tx = db.read_transaction().unwrap();
+    assert!(read_tx.get_node(node).is_ok());
+
+    // A later transaction commits a delete.
+    db.write(|tx| tx.delete_node(node)).unwrap();
+
+    // The old snapshot still sees the node (historical fallback), so edge
+    // listing is Ok — not NodeNotFound.
+    let outgoing = read_tx.get_outgoing_edges(node);
+    assert!(
+        outgoing.is_ok(),
+        "node visible at snapshot time (deleted later) must stay visible \
+         via the historical fallback, got {outgoing:?}"
+    );
+    assert!(outgoing.unwrap().is_empty());
+    assert!(read_tx.get_incoming_edges(node).is_ok());
+    assert!(read_tx.get_outgoing_edges_with_label(node, "KNOWS").is_ok());
+
+    // A fresh transaction (snapshot after the delete) reports NodeNotFound.
+    let fresh_tx = db.read_transaction().unwrap();
+    assert!(
+        matches!(
+            fresh_tx.get_outgoing_edges(node),
+            Err(Error::Storage(StorageError::NodeNotFound(id))) if id == node
+        ),
+        "a fresh snapshot must not see the deleted node"
+    );
+}

--- a/tests/regressions/adjacency_incoming_edges.rs
+++ b/tests/regressions/adjacency_incoming_edges.rs
@@ -29,20 +29,14 @@ fn incoming_edges_multiple_sources_same_target() {
         .unwrap();
 
     // Verify outgoing edges work
-    let child1_out = db
-        .read(|tx| Ok::<_, aletheiadb::Error>(tx.get_outgoing_edges(child1)))
-        .unwrap();
+    let child1_out = db.read(|tx| tx.get_outgoing_edges(child1)).unwrap();
     assert_eq!(child1_out.len(), 1, "child1 should have 1 outgoing edge");
 
-    let child2_out = db
-        .read(|tx| Ok::<_, aletheiadb::Error>(tx.get_outgoing_edges(child2)))
-        .unwrap();
+    let child2_out = db.read(|tx| tx.get_outgoing_edges(child2)).unwrap();
     assert_eq!(child2_out.len(), 1, "child2 should have 1 outgoing edge");
 
     // This should return 2 edges
-    let parent_in = db
-        .read(|tx| Ok::<_, aletheiadb::Error>(tx.get_incoming_edges(parent)))
-        .unwrap();
+    let parent_in = db.read(|tx| tx.get_incoming_edges(parent)).unwrap();
 
     assert!(
         parent_in.contains(&edge1),
@@ -78,9 +72,7 @@ fn incoming_edges_multiple_sources_single_transaction() {
         })
         .unwrap();
 
-    let parent_in = db
-        .read(|tx| Ok::<_, aletheiadb::Error>(tx.get_incoming_edges(parent)))
-        .unwrap();
+    let parent_in = db.read(|tx| tx.get_incoming_edges(parent)).unwrap();
     assert_eq!(
         parent_in.len(),
         2,
@@ -111,9 +103,7 @@ fn incoming_edges_fan_in_pattern() {
         edge_ids.push(eid);
     }
 
-    let incoming = db
-        .read(|tx| Ok::<_, aletheiadb::Error>(tx.get_incoming_edges(target)))
-        .unwrap();
+    let incoming = db.read(|tx| tx.get_incoming_edges(target)).unwrap();
     assert_eq!(
         incoming.len(),
         5,

--- a/tests/temporal_adjacency_default_enabled_test.rs
+++ b/tests/temporal_adjacency_default_enabled_test.rs
@@ -40,7 +40,7 @@ fn test_temporal_adjacency_index_enabled_by_default() {
     thread::sleep(Duration::from_millis(10));
     let (_edge_id, _t1) = db
         .write_with_timestamp(|tx| {
-            let edges = tx.get_outgoing_edges(alice);
+            let edges = tx.get_outgoing_edges(alice)?;
             tx.delete_edge(edges[0])
         })
         .unwrap();


### PR DESCRIPTION
Closes #358
Closes #359

## Before / After

**Before**: The three edge-listing methods on the public `ReadOps` transaction trait returned a bare `Vec<EdgeId>`. A caller asking for the edges of a node that does not exist got back an empty vector — indistinguishable from a node that exists but simply has no edges. This was inconsistent with `get_node`/`get_edge` on the same trait, which return `Err(NodeNotFound)` for the same condition. Several of the trait's methods also lacked the documented contract for these edge cases (issue #358 predates docs that were later added; the empty-vs-missing contract, `# Arguments`/`# Returns` sections, and examples on `get_incoming_edges`/`get_outgoing_edges_with_label` were still missing).

**After**:

```rust
// ReadOps (implemented by ReadTransaction and WriteTransaction)
fn get_outgoing_edges(&self, node_id: NodeId) -> Result<Vec<EdgeId>>;
fn get_incoming_edges(&self, node_id: NodeId) -> Result<Vec<EdgeId>>;
fn get_outgoing_edges_with_label(&self, node_id: NodeId, label: &str) -> Result<Vec<EdgeId>>;
```

- `Err(NodeNotFound)` when the node does not exist or is not visible in the transaction's snapshot — the same condition that makes `get_node` fail now fails here too.
- `Ok(vec[])` when the node exists but has no (matching) edges — a valid state, not an error. An unmatched label on an existing node is `Ok(empty)`: the label is a filter, not an existence check.
- Every `ReadOps` method now carries `# Arguments` / `# Returns` sections documenting the empty-result and non-existent-node contract, and the three edge methods have **runnable** doc examples (`cargo test --doc`) demonstrating the happy path, the `Ok(empty)` case, and the `Err` case. `node_count`/`edge_count` gained explicit `# Returns` sections that document the *actual* behavior (current committed count, not snapshot-isolated, excluding this transaction's uncommitted writes — the issue's suggested wording did not match the implementation, and doc claims must match behavior).

## How

- **Trait** (`src/api/transaction/mod.rs`): signatures changed to `Result<Vec<EdgeId>>`; full rustdoc per issue #358 (issue's Option 1 in #359, marked "Recommended" there).
- **`ReadTransaction`** (`src/api/transaction/read_tx.rs`): each method performs the same snapshot-visibility existence check as `get_node` (including the historical-storage fallback), then returns the snapshot-filtered edge list.
- **`WriteTransaction`** (`src/api/transaction/write/mod.rs`): the existence check goes through the buffer-aware `get_node`, so a node created in the transaction exists (`Ok`), and a node deleted/retracted in the transaction does not (`Err`) — previously a deleted-in-tx node silently returned stale storage edges.
- **Callers updated** (all internal): `delete_node_cascade`, `AletheiaDB::retract_node`/`retract_node_detach` (`src/db/ops.rs`), the MCP `retract_node` handler (`src/mcp/server.rs`), `semantic_search/{highlander,horizon}`, `experimental/reasoning/{alchemy,chimera,synergy}`, the `chronos` doc example, and tests. In `retract_node_detach` the result is deliberately `unwrap_or_default()` so retracting an already-retracted node stays an idempotent no-op (its edge list is unenumerable once the node is invisible; `retract_node` still owns not-found/idempotency semantics).
- `docs/architecture/transaction-system.md` API snippet and `CHANGELOG.md` updated.

TDD: the new tests were written first against the `Result` API and failed to compile (16 errors, red), then the implementation made them pass (green). New tests:

- `read_tx`: `test_get_{outgoing,incoming}_edges_nonexistent_node_errors`, `test_get_outgoing_edges_with_label_nonexistent_node_errors`, `test_get_{outgoing,incoming}_edges_existing_node_no_edges_ok_empty`, `test_get_outgoing_edges_with_label_no_match_ok_empty`
- `write/tests`: `test_write_tx_get_outgoing_edges_nonexistent_node_errors`, `test_write_tx_get_outgoing_edges_node_created_in_tx_ok`, `test_write_tx_get_outgoing_edges_node_deleted_in_tx_errors`

## Semver

**This is a breaking change to the public `ReadOps` trait** (three method signatures), as explicitly recommended by issue #359 ("Option 1: Return Result for Consistency (Recommended)"). The crate is pre-1.0 (`0.3.0`); per cargo semver conventions this should ship in the next 0.x minor (e.g. `0.4.0`). No version bump is made in this PR — left to the release process. Not affected: the non-transactional `AletheiaDB::get_outgoing_edges`/`get_incoming_edges`/`get_outgoing_edges_with_label` convenience methods, the `GraphAccess` query trait, `CurrentStorage`, and the MCP tool JSON surface (unchanged shapes).

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all` — applied
- `cargo test --no-fail-fast` — 135 test targets pass (4,811 tests passed in aggregate); the only 2 failures are **pre-existing fault-injection tests that cannot fail-inject when running as uid 0 (root)** in this sandbox — they rely on file-permission-based I/O fault injection, which root bypasses — and are unrelated to this change:
  - `havoc_suites::wal::havoc_flush_deadlock::test_flush_deadlock_on_io_error` (tests/havoc.rs; panics at "Flush should fail due to I/O error")
  - `test_metadata_corruption_on_error` (tests/regression_flush_corruption.rs)
- `cargo test --doc` — 411 passed, 0 failed (default features); 484 passed, 0 failed with `--all-features` — includes the new runnable examples on the three edge methods
- Coverage: instrumented coverage cannot run in this sandbox (ENOSPC); deferred to CI.

## Review follow-ups (commit ce490d9)

Three review passes (docs accuracy, backward compatibility, test adequacy) found **no blockers**; this commit addresses their findings:

- **Write-transaction doc caveats**: the trait docs' snapshot/visibility wording overstated what `WriteTransaction` does. All three edge-listing methods now carry a `# Write transactions` section: only the node existence check is buffer-aware — the returned edge list is read from committed current storage without snapshot filtering (edges committed by concurrent transactions after this transaction started ARE returned; edges created in this transaction are NOT; edges deleted in this transaction are still listed until commit).
- **Performance wording**: "O(1) node existence check" corrected — the miss path may consult historical storage (O(log N)).
- **`node_count`/`edge_count`**: added the symmetric statement that nodes/edges deleted in this transaction but not yet committed are still included.
- **New tests**:
  - `tests/readops_snapshot_isolation.rs`: `read_tx_edge_listing_errors_for_node_committed_after_snapshot` and `read_tx_edge_listing_ok_for_node_deleted_after_snapshot` pin the #359 error path under concurrency (node committed after a read tx's snapshot → `Err(NodeNotFound)`; node deleted after the snapshot → still `Ok` via the historical fallback). Both pass — actual behavior matches the documented contract.
  - Variant assertions: one read-tx and one write-tx missing-node test now `matches!` on `Error::Storage(StorageError::NodeNotFound(_))` instead of bare `is_err()`.
  - `test_write_tx_buffered_edge_not_listed_before_commit` pins the documented buffered-edge invisibility.
  - Write-tx `with_label` coverage: node created in tx → `Ok`, node deleted in tx → `Err`.
  - `double_retract_node_detach_is_idempotent` and `retract_node_detach_nonexistent_node_is_node_not_found` (`src/db/ops.rs`).
- **Hygiene**: `experimental/diagnostics/paradox.rs` (dead code awaiting revival) updated to the `Result` call shape so revival won't hit a stale-signature type error; stale comment removed from `experimental/reasoning/alchemy.rs`.
- **CHANGELOG**: `get_outgoing_edges_with_label` added to the unchanged convenience-method list, plus the two disclosures below.

### Edge-case behavior disclosures

- `retract_node_detach` on a node previously removed via the plain (non-cascade) `delete_node` no longer co-retracts that node's orphaned edges (`edges_retracted: 0`) — consistent with the documented "retracting a deleted node is a no-op" contract.
- `delete_node_cascade` on a node already deleted in the same transaction now fails fast with `NodeNotFound` at edge enumeration (same final outcome as before, earlier failure point).

### CI note

The failing **macOS x86_64** check on d37c35c (run 28962463331) is the Python wheel build job: `maturin build` failed during `cargo metadata` because the crates.io registry download of `js-sys` failed with `curl [16] Error in the HTTP2 framing layer` — a transient network error on the runner, before any code compiled. Not caused by this PR (the diff touches no Python/wheel code); a re-run should clear it.

The failing **Code Coverage** check on ce490d9 (run [28964896530](https://github.com/madmax983/AletheiaDB/actions/runs/28964896530), job [85945494467](https://github.com/madmax983/AletheiaDB/actions/runs/28964896530/job/85945494467)) is the pre-existing trunk flake tracked in #3405 — `find_nodes_at_time_tests::node_deleted_before_t_found_when_both_dimensions_anchor_before_deletion` fails under llvm-cov instrumentation (the identical failure occurred on trunk itself at d54eb25, this PR's merge-base, in run 28957000897). Not caused by this PR; the job is being re-run (a re-run was already queued when attempted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BksxbcKgoSbHwVqz2p963p

---
_Generated by [Claude Code](https://claude.ai/code/session_01BksxbcKgoSbHwVqz2p963p)_