### PR TITLE
Cypher: implement OPTIONAL MATCH execution semantics (#557)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -556,9 +556,12 @@ let results = db.execute_cypher_with_params("MATCH (n:Person {name: $name}) RETU
   patterns preserve the base row and bind null; the clause's `WHERE` and inline
   properties are scoped inside the optional pattern (they decide matched vs
   unmatched); multiple/leading `OPTIONAL MATCH` clauses supported. The first
-  node of a subsequent `OPTIONAL MATCH` must be an unlabeled bound variable
-  (e.g. `(a)`), and comma-separated patterns per optional clause are rejected
-  (no variable-binding analysis yet -- both would silently produce wrong rows)
+  node of a subsequent `OPTIONAL MATCH` must be unlabeled and either unnamed
+  (`()`) or name the previous clause's binding (the last node of the prior
+  MATCH/OPTIONAL MATCH, or the `WITH`-projected variable) -- re-anchoring on an
+  earlier variable is rejected, and comma-separated patterns per optional
+  clause are rejected (no variable-binding analysis yet -- all three would
+  silently produce wrong rows)
 - Variable-depth: `-[:KNOWS*1..3]->`
 - Directions: `->` (outgoing), `<-` (incoming), `-` (both)
 - Filtering: `WHERE n.age > 18 AND n.name = 'Alice'`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -552,6 +552,10 @@ let results = db.execute_cypher_with_params("MATCH (n:Person {name: $name}) RETU
 
 **Supported Syntax:**
 - Graph patterns: `MATCH (n:Label {prop: value})-[:REL]->(m)`
+- Left-outer patterns (Issue #557): `OPTIONAL MATCH (a)-[:KNOWS]->(x)` -- unmatched
+  patterns preserve the base row and bind null; the clause's `WHERE` and inline
+  properties are scoped inside the optional pattern (they decide matched vs
+  unmatched); multiple/leading `OPTIONAL MATCH` clauses supported
 - Variable-depth: `-[:KNOWS*1..3]->`
 - Directions: `->` (outgoing), `<-` (incoming), `-` (both)
 - Filtering: `WHERE n.age > 18 AND n.name = 'Alice'`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -555,7 +555,10 @@ let results = db.execute_cypher_with_params("MATCH (n:Person {name: $name}) RETU
 - Left-outer patterns (Issue #557): `OPTIONAL MATCH (a)-[:KNOWS]->(x)` -- unmatched
   patterns preserve the base row and bind null; the clause's `WHERE` and inline
   properties are scoped inside the optional pattern (they decide matched vs
-  unmatched); multiple/leading `OPTIONAL MATCH` clauses supported
+  unmatched); multiple/leading `OPTIONAL MATCH` clauses supported. The first
+  node of a subsequent `OPTIONAL MATCH` must be an unlabeled bound variable
+  (e.g. `(a)`), and comma-separated patterns per optional clause are rejected
+  (no variable-binding analysis yet -- both would silently produce wrong rows)
 - Variable-depth: `-[:KNOWS*1..3]->`
 - Directions: `->` (outgoing), `<-` (incoming), `-` (both)
 - Filtering: `WHERE n.age > 18 AND n.name = 'Alice'`

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "aletheiadb"
-version = "0.1.1"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "arc-swap",

--- a/python/src/query.rs
+++ b/python/src/query.rs
@@ -92,6 +92,18 @@ pub fn execute_cypher(
                 d.set_item("kind", "edge_id")?;
                 d.set_item("entity", id.as_u64())?;
             }
+            // Null binding from an unmatched OPTIONAL MATCH pattern (left-outer
+            // semantics): the row is preserved but carries no entity.
+            EntityResult::Null => {
+                d.set_item("kind", "null")?;
+                d.set_item("entity", py.None())?;
+            }
+            // EntityResult is #[non_exhaustive]; surface future variants
+            // rather than failing the whole result set.
+            _ => {
+                d.set_item("kind", "unknown")?;
+                d.set_item("entity", py.None())?;
+            }
         }
         if let Some(score) = row.score {
             d.set_item("score", score as f64)?;
@@ -128,6 +140,18 @@ pub fn execute_aql(py: Python<'_>, db: &crate::db::PyAletheiaDB, query: &str) ->
             EntityResult::EdgeId(id) => {
                 d.set_item("kind", "edge_id")?;
                 d.set_item("entity", id.as_u64())?;
+            }
+            // Null binding from an unmatched OPTIONAL MATCH pattern (left-outer
+            // semantics): the row is preserved but carries no entity.
+            EntityResult::Null => {
+                d.set_item("kind", "null")?;
+                d.set_item("entity", py.None())?;
+            }
+            // EntityResult is #[non_exhaustive]; surface future variants
+            // rather than failing the whole result set.
+            _ => {
+                d.set_item("kind", "unknown")?;
+                d.set_item("entity", py.None())?;
             }
         }
         if let Some(score) = row.score {

--- a/src/cypher/ast.rs
+++ b/src/cypher/ast.rs
@@ -44,7 +44,30 @@ pub enum CypherStatement {
         temporal: Option<CypherTemporal>,
         /// Zero or more intermediate `WITH` projections.
         with_clauses: Vec<CypherWith>,
+        /// Zero or more subsequent `OPTIONAL MATCH` clauses.
+        ///
+        /// Source ordering relative to `with_clauses` is preserved via
+        /// [`CypherOptionalMatch::preceding_withs`].
+        optional_matches: Vec<CypherOptionalMatch>,
     },
+}
+
+/// A subsequent `OPTIONAL MATCH` clause within a `MATCH` statement.
+///
+/// Per openCypher semantics the clause's `WHERE` is part of the optional
+/// pattern itself: it participates in the matched/unmatched decision rather
+/// than filtering rows afterwards.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CypherOptionalMatch {
+    /// One or more comma-separated graph patterns to match optionally.
+    pub pattern: Vec<CypherPattern>,
+    /// An optional `WHERE` clause scoped to this optional pattern.
+    pub where_clause: Option<CypherExpr>,
+    /// Number of `WITH` clauses (in the statement's `with_clauses`) that
+    /// appear before this clause in the query text. This preserves clause
+    /// ordering so conversion can interleave `WITH ... WHERE` filters and
+    /// optional patterns exactly as written.
+    pub preceding_withs: usize,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cypher/converter.rs
+++ b/src/cypher/converter.rs
@@ -185,6 +185,19 @@ impl CypherConverter {
                         self.convert_with_clause(&with_clauses[with_idx], &mut ops)?;
                         with_idx += 1;
                     }
+                    // Without variable-binding analysis, comma-separated
+                    // patterns in one OPTIONAL MATCH clause would silently
+                    // chain positionally (the second pattern would traverse
+                    // the first pattern's result instead of re-seeding from
+                    // the bound variable), returning wrong entities. Reject
+                    // until binding analysis exists.
+                    if opt_match.pattern.len() > 1 {
+                        return Err(CypherError::UnsupportedFeature(
+                            "comma-separated patterns in an OPTIONAL MATCH clause; \
+                             use one pattern per OPTIONAL MATCH clause instead"
+                                .to_string(),
+                        ));
+                    }
                     let mut sub_ops = Vec::new();
                     for pat in &opt_match.pattern {
                         self.convert_optional_pattern(pat, &mut sub_ops)?;
@@ -303,15 +316,33 @@ impl CypherConverter {
     /// inside the optional segment and therefore participate in the
     /// matched/unmatched decision.
     ///
-    /// Limitation: like the rest of the converter, this performs no variable
-    /// binding analysis -- an OPTIONAL MATCH pattern starting from a variable
-    /// not bound by the preceding pipeline is treated positionally as if it
-    /// referred to the current row.
+    /// Limitation and design choice: the converter performs no variable
+    /// binding analysis, so the first node is bound purely positionally to
+    /// the current row. A **label** on that node therefore cannot be honored
+    /// (there is no label predicate to lower it to), and silently dropping it
+    /// would turn `MATCH (a:Person) OPTIONAL MATCH (b:City) RETURN b` into a
+    /// query that returns `a`. Such clauses are **rejected** with
+    /// [`CypherError::UnsupportedFeature`] rather than answered wrongly;
+    /// inline properties on the first node remain supported because they
+    /// lower cheaply and correctly to seed-row filters.
     fn convert_optional_pattern(
         &self,
         pattern: &CypherPattern,
         ops: &mut Vec<QueryOp>,
     ) -> Result<(), CypherError> {
+        // Reject a labeled first node: it is bound positionally to the seed
+        // row and its label would be silently ignored (see rustdoc above).
+        if let Some(CypherPatternElement::Node(first)) = pattern.elements.first()
+            && !first.labels.is_empty()
+        {
+            return Err(CypherError::UnsupportedFeature(format!(
+                "label ':{}' on the first node of a subsequent OPTIONAL MATCH; \
+                 the first node refers to the current row and must be an \
+                 unlabeled bound variable (e.g. `(a)`) -- move the constraint \
+                 into the preceding MATCH or a WHERE clause",
+                first.labels.join(":"),
+            )));
+        }
         for element in &pattern.elements {
             match element {
                 CypherPatternElement::Node(node) => {

--- a/src/cypher/converter.rs
+++ b/src/cypher/converter.rs
@@ -140,39 +140,67 @@ impl CypherConverter {
     pub fn convert(&self, stmt: CypherStatement) -> Result<Query, CypherError> {
         match stmt {
             CypherStatement::Match {
+                optional,
                 pattern,
                 where_clause,
                 return_clause,
                 temporal,
                 with_clauses,
-                ..
+                optional_matches,
             } => {
                 let mut ops = Vec::new();
 
-                // 1. Convert graph patterns → ScanNodes + Traverse + Filter ops
+                // 1. Convert graph patterns → ScanNodes + Traverse + Filter ops,
+                //    followed by the base WHERE clause → Filter op.
+                //
+                //    For a leading OPTIONAL MATCH the whole base segment
+                //    (scan + filters + WHERE) is wrapped in a single
+                //    QueryOp::Optional so an empty result yields one null row.
+                let mut base_ops = Vec::new();
                 for pat in &pattern {
-                    self.convert_pattern(pat, &mut ops)?;
+                    self.convert_pattern(pat, &mut base_ops)?;
                 }
-
-                // 2. Convert WHERE clause → Filter ops
                 if let Some(expr) = where_clause {
                     let predicate = self.convert_expr_to_predicate(&expr)?;
-                    ops.push(QueryOp::Filter(predicate));
+                    base_ops.push(QueryOp::Filter(predicate));
+                }
+                if optional {
+                    ops.push(QueryOp::Optional { ops: base_ops });
+                } else {
+                    ops.append(&mut base_ops);
                 }
 
-                // 3. Convert temporal clause → TemporalContext + ops
+                // 2. Convert temporal clause → TemporalContext + ops
                 let temporal_context = if let Some(ref temporal_clause) = temporal {
                     Some(self.convert_temporal(temporal_clause, &mut ops)?)
                 } else {
                     None
                 };
 
-                // 3b. Convert WITH clauses → Filter ops for WITH WHERE
-                for with in &with_clauses {
-                    if let Some(ref where_expr) = with.where_clause {
-                        let predicate = self.convert_expr_to_predicate(where_expr)?;
-                        ops.push(QueryOp::Filter(predicate));
+                // 3. Interleave WITH clauses (→ Filter ops for WITH WHERE) and
+                //    OPTIONAL MATCH clauses (→ Optional ops) in source order.
+                let mut with_idx = 0;
+                for opt_match in &optional_matches {
+                    while with_idx < opt_match.preceding_withs && with_idx < with_clauses.len() {
+                        self.convert_with_clause(&with_clauses[with_idx], &mut ops)?;
+                        with_idx += 1;
                     }
+                    let mut sub_ops = Vec::new();
+                    for pat in &opt_match.pattern {
+                        self.convert_optional_pattern(pat, &mut sub_ops)?;
+                    }
+                    if let Some(ref where_expr) = opt_match.where_clause {
+                        // Per openCypher, the clause's WHERE is part of the
+                        // optional pattern: it must run before the
+                        // matched/unmatched decision, hence inside the op.
+                        let predicate = self.convert_expr_to_predicate(where_expr)?;
+                        sub_ops.push(QueryOp::Filter(predicate));
+                    }
+                    ops.push(QueryOp::Optional { ops: sub_ops });
+                }
+                while with_idx < with_clauses.len() {
+                    self.convert_with_clause(&with_clauses[with_idx], &mut ops)?;
+                    with_idx += 1;
                 }
 
                 // 4. Convert RETURN clause modifiers
@@ -261,6 +289,54 @@ impl CypherConverter {
             }
         }
 
+        Ok(())
+    }
+
+    /// Convert a graph pattern from a *subsequent* `OPTIONAL MATCH` clause
+    /// into query operations for the optional sub-pipeline.
+    ///
+    /// Unlike [`Self::convert_pattern`], the first node does **not** emit a
+    /// `ScanNodes` op: it is assumed to refer to the current row produced by
+    /// the preceding pipeline (e.g. `a` in
+    /// `MATCH (a) OPTIONAL MATCH (a)-[:KNOWS]->(x)`). Its inline property
+    /// constraints still become `Filter` ops, which run against the seed row
+    /// inside the optional segment and therefore participate in the
+    /// matched/unmatched decision.
+    ///
+    /// Limitation: like the rest of the converter, this performs no variable
+    /// binding analysis -- an OPTIONAL MATCH pattern starting from a variable
+    /// not bound by the preceding pipeline is treated positionally as if it
+    /// referred to the current row.
+    fn convert_optional_pattern(
+        &self,
+        pattern: &CypherPattern,
+        ops: &mut Vec<QueryOp>,
+    ) -> Result<(), CypherError> {
+        for element in &pattern.elements {
+            match element {
+                CypherPatternElement::Node(node) => {
+                    // No ScanNodes: the seed row is the pattern's entry point.
+                    self.convert_node_properties(node, ops)?;
+                }
+                CypherPatternElement::Relationship(rel) => {
+                    self.convert_relationship(rel, ops)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Convert a `WITH` clause into query operations (currently only its
+    /// `WHERE` sub-clause produces a `Filter`; projections are not lowered).
+    fn convert_with_clause(
+        &self,
+        with: &CypherWith,
+        ops: &mut Vec<QueryOp>,
+    ) -> Result<(), CypherError> {
+        if let Some(ref where_expr) = with.where_clause {
+            let predicate = self.convert_expr_to_predicate(where_expr)?;
+            ops.push(QueryOp::Filter(predicate));
+        }
         Ok(())
     }
 

--- a/src/cypher/converter.rs
+++ b/src/cypher/converter.rs
@@ -170,6 +170,14 @@ impl CypherConverter {
                     ops.append(&mut base_ops);
                 }
 
+                // Track the variable the pipeline is positionally "on" after
+                // each clause: the last node of the base pattern, then the
+                // last node of each OPTIONAL MATCH pattern (or a WITH
+                // projection). Subsequent OPTIONAL MATCH clauses must
+                // continue from this binding (see convert_optional_pattern).
+                let mut current_var: Option<&str> =
+                    pattern.last().and_then(Self::last_node_variable);
+
                 // 2. Convert temporal clause → TemporalContext + ops
                 let temporal_context = if let Some(ref temporal_clause) = temporal {
                     Some(self.convert_temporal(temporal_clause, &mut ops)?)
@@ -183,6 +191,15 @@ impl CypherConverter {
                 for opt_match in &optional_matches {
                     while with_idx < opt_match.preceding_withs && with_idx < with_clauses.len() {
                         self.convert_with_clause(&with_clauses[with_idx], &mut ops)?;
+                        // A `WITH v` projection makes `v` the current binding
+                        // for the clauses that follow. Other projection shapes
+                        // are not lowered and leave the positional row (and
+                        // therefore the current binding) unchanged.
+                        if let [CypherReturnItem::Variable(name)] =
+                            with_clauses[with_idx].items.as_slice()
+                        {
+                            current_var = Some(name.as_str());
+                        }
                         with_idx += 1;
                     }
                     // Without variable-binding analysis, comma-separated
@@ -200,8 +217,10 @@ impl CypherConverter {
                     }
                     let mut sub_ops = Vec::new();
                     for pat in &opt_match.pattern {
-                        self.convert_optional_pattern(pat, &mut sub_ops)?;
+                        self.convert_optional_pattern(pat, &mut sub_ops, current_var)?;
                     }
+                    // The next clause continues from this pattern's last node.
+                    current_var = opt_match.pattern.last().and_then(Self::last_node_variable);
                     if let Some(ref where_expr) = opt_match.where_clause {
                         // Per openCypher, the clause's WHERE is part of the
                         // optional pattern: it must run before the
@@ -318,30 +337,66 @@ impl CypherConverter {
     ///
     /// Limitation and design choice: the converter performs no variable
     /// binding analysis, so the first node is bound purely positionally to
-    /// the current row. A **label** on that node therefore cannot be honored
-    /// (there is no label predicate to lower it to), and silently dropping it
-    /// would turn `MATCH (a:Person) OPTIONAL MATCH (b:City) RETURN b` into a
-    /// query that returns `a`. Such clauses are **rejected** with
-    /// [`CypherError::UnsupportedFeature`] rather than answered wrongly;
-    /// inline properties on the first node remain supported because they
-    /// lower cheaply and correctly to seed-row filters.
+    /// the current row. Two constructs that would silently produce wrong
+    /// rows are therefore **rejected** with
+    /// [`CypherError::UnsupportedFeature`] rather than answered wrongly:
+    ///
+    /// - A **label** on the first node cannot be honored (there is no label
+    ///   predicate to lower it to), and silently dropping it would turn
+    ///   `MATCH (a:Person) OPTIONAL MATCH (b:City) RETURN b` into a query
+    ///   that returns `a`.
+    /// - A first-node **variable that does not name the positionally-current
+    ///   binding** (`current_var`, the last node of the previous
+    ///   MATCH/OPTIONAL MATCH or a `WITH` projection) would silently bind to
+    ///   whatever the pipeline is positioned on: in `MATCH (a:Person)
+    ///   OPTIONAL MATCH (a)-[:KNOWS]->(x) OPTIONAL MATCH (a)-[:OWNS]->(y)`
+    ///   the second `(a)` would bind to `x` (or null) and traverse `OWNS`
+    ///   from the wrong node. Re-anchoring on an earlier variable requires
+    ///   real binding analysis and is not yet supported.
+    ///
+    /// An unnamed first node `()` (explicit positional reference) and a
+    /// first node naming `current_var` are accepted; inline properties on
+    /// the first node remain supported because they lower cheaply and
+    /// correctly to seed-row filters.
     fn convert_optional_pattern(
         &self,
         pattern: &CypherPattern,
         ops: &mut Vec<QueryOp>,
+        current_var: Option<&str>,
     ) -> Result<(), CypherError> {
-        // Reject a labeled first node: it is bound positionally to the seed
-        // row and its label would be silently ignored (see rustdoc above).
-        if let Some(CypherPatternElement::Node(first)) = pattern.elements.first()
-            && !first.labels.is_empty()
-        {
-            return Err(CypherError::UnsupportedFeature(format!(
-                "label ':{}' on the first node of a subsequent OPTIONAL MATCH; \
-                 the first node refers to the current row and must be an \
-                 unlabeled bound variable (e.g. `(a)`) -- move the constraint \
-                 into the preceding MATCH or a WHERE clause",
-                first.labels.join(":"),
-            )));
+        if let Some(CypherPatternElement::Node(first)) = pattern.elements.first() {
+            // Reject a labeled first node: it is bound positionally to the
+            // seed row and its label would be silently ignored (see rustdoc
+            // above).
+            if !first.labels.is_empty() {
+                return Err(CypherError::UnsupportedFeature(format!(
+                    "label ':{}' on the first node of a subsequent OPTIONAL MATCH; \
+                     the first node refers to the current row and must be an \
+                     unlabeled bound variable (e.g. `(a)`) -- move the constraint \
+                     into the preceding MATCH or a WHERE clause",
+                    first.labels.join(":"),
+                )));
+            }
+            // Reject a first-node variable that re-anchors on something other
+            // than the positionally-current binding (see rustdoc above).
+            if let Some(ref first_var) = first.variable
+                && current_var != Some(first_var.as_str())
+            {
+                return Err(CypherError::UnsupportedFeature(match current_var {
+                    Some(cur) => format!(
+                        "OPTIONAL MATCH must continue from the previous clause's \
+                         binding '{cur}'; re-anchoring on '{first_var}' is not \
+                         yet supported -- start the pattern with `({cur})` or \
+                         restructure the query"
+                    ),
+                    None => format!(
+                        "OPTIONAL MATCH must continue from the previous clause's \
+                         binding, but its last node is unnamed; re-anchoring on \
+                         '{first_var}' is not yet supported -- name the previous \
+                         pattern's last node or restructure the query"
+                    ),
+                }));
+            }
         }
         for element in &pattern.elements {
             match element {
@@ -355,6 +410,24 @@ impl CypherConverter {
             }
         }
         Ok(())
+    }
+
+    /// The variable bound to a pattern's last node element, if named.
+    ///
+    /// This is the binding the pipeline is positionally "on" after the
+    /// pattern converts: each relationship traversal moves the current row
+    /// to its target node, so the last node of the pattern is where a
+    /// subsequent `OPTIONAL MATCH` continues from.
+    fn last_node_variable(pattern: &CypherPattern) -> Option<&str> {
+        pattern
+            .elements
+            .iter()
+            .rev()
+            .find_map(|element| match element {
+                CypherPatternElement::Node(node) => Some(node.variable.as_deref()),
+                CypherPatternElement::Relationship(_) => None,
+            })
+            .flatten()
     }
 
     /// Convert a `WITH` clause into query operations (currently only its

--- a/src/cypher/parser.rs
+++ b/src/cypher/parser.rs
@@ -142,7 +142,9 @@ impl CypherParser {
     }
 
     /// ```text
-    /// match_stmt := [OPTIONAL] MATCH pattern_list [where_clause] [temporal_clause] return_clause
+    /// match_stmt := [OPTIONAL] MATCH pattern_list [where_clause] [temporal_clause]
+    ///               (with_clause | optional_match_clause)* return_clause
+    /// optional_match_clause := OPTIONAL MATCH pattern_list [where_clause]
     /// ```
     fn parse_match(
         &mut self,
@@ -167,8 +169,21 @@ impl CypherParser {
             self.try_parse_post_pattern_temporal()?
         };
 
-        // Parse zero or more WITH clauses between pattern/WHERE/temporal and RETURN.
-        let with_clauses = self.parse_with_clauses()?;
+        // Parse zero or more WITH and OPTIONAL MATCH clauses (in any order)
+        // between pattern/WHERE/temporal and RETURN. Source ordering between
+        // WITH clauses and OPTIONAL MATCH clauses is preserved via
+        // `preceding_withs` on each `CypherOptionalMatch`.
+        let mut with_clauses = Vec::new();
+        let mut optional_matches = Vec::new();
+        loop {
+            if self.at(TokenKind::With) {
+                with_clauses.push(self.parse_with()?);
+            } else if self.at(TokenKind::OptionalMatch) {
+                optional_matches.push(self.parse_optional_match(with_clauses.len())?);
+            } else {
+                break;
+            }
+        }
 
         let return_clause = self.parse_return()?;
 
@@ -179,6 +194,34 @@ impl CypherParser {
             return_clause,
             temporal,
             with_clauses,
+            optional_matches,
+        })
+    }
+
+    /// Parse a subsequent `OPTIONAL MATCH` clause.
+    ///
+    /// ```text
+    /// optional_match_clause := OPTIONAL MATCH pattern_list [where_clause]
+    /// ```
+    fn parse_optional_match(
+        &mut self,
+        preceding_withs: usize,
+    ) -> Result<CypherOptionalMatch, CypherError> {
+        self.expect(TokenKind::OptionalMatch)?;
+        self.expect(TokenKind::Match)?;
+
+        let pattern = self.parse_pattern_list()?;
+
+        let where_clause = if self.at(TokenKind::Where) {
+            Some(self.parse_where()?)
+        } else {
+            None
+        };
+
+        Ok(CypherOptionalMatch {
+            pattern,
+            where_clause,
+            preceding_withs,
         })
     }
 
@@ -637,19 +680,6 @@ impl CypherParser {
     }
 
     // -- WITH clause --------------------------------------------------------
-
-    /// Parse zero or more `WITH` clauses.
-    ///
-    /// ```text
-    /// with_clauses := (WITH return_items [WHERE expr])*
-    /// ```
-    fn parse_with_clauses(&mut self) -> Result<Vec<CypherWith>, CypherError> {
-        let mut clauses = Vec::new();
-        while self.at(TokenKind::With) {
-            clauses.push(self.parse_with()?);
-        }
-        Ok(clauses)
-    }
 
     /// Parse a single `WITH` clause.
     ///

--- a/src/cypher/parser.rs
+++ b/src/cypher/parser.rs
@@ -388,6 +388,11 @@ impl CypherParser {
                 // `*N..` or `*N..M`
                 if self.at(TokenKind::IntegerLiteral) {
                     let m = self.parse_usize("expected integer after '..'")?;
+                    if n > m {
+                        return Err(
+                            self.error(&format!("invalid depth range: min ({n}) > max ({m})"))
+                        );
+                    }
                     Ok(CypherDepth::Range { min: n, max: m })
                 } else {
                     Ok(CypherDepth::Min(n))

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -1937,3 +1937,218 @@ fn test_e2e_plain_match_unchanged_regression() {
     );
     assert_eq!(rows.len(), 0);
 }
+
+// ============================================================================
+// OPTIONAL MATCH: rejected unsupported constructs (review findings, PR #3401)
+// ============================================================================
+
+#[test]
+fn test_convert_optional_match_multiple_patterns_rejected() {
+    // Without variable-binding analysis, comma-separated patterns in a
+    // subsequent OPTIONAL MATCH would silently chain positionally
+    // (`(a)-[:KNOWS]->(x), (a)-[:KNOWS]->(y)` would traverse x's result,
+    // not re-seed from `a`), returning the wrong entity for `y`. Reject
+    // rather than answer wrongly.
+    let err = parse_cypher(
+        "MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x), (a)-[:KNOWS]->(y) RETURN y",
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, CypherError::UnsupportedFeature(_)),
+        "expected UnsupportedFeature, got {err:?}"
+    );
+    assert!(
+        err.to_string().contains("OPTIONAL MATCH"),
+        "error should name the offending construct: {err}"
+    );
+}
+
+#[test]
+fn test_convert_optional_match_labeled_first_node_rejected() {
+    // The first node of a subsequent OPTIONAL MATCH is bound positionally to
+    // the current row; a label on it cannot be honored without
+    // variable-binding analysis (`MATCH (a:Person) OPTIONAL MATCH (b:City)
+    // RETURN b` would silently return `a`). Reject rather than drop the label.
+    let err = parse_cypher("MATCH (a:Person) OPTIONAL MATCH (b:City) RETURN b").unwrap_err();
+    assert!(
+        matches!(err, CypherError::UnsupportedFeature(_)),
+        "expected UnsupportedFeature, got {err:?}"
+    );
+    assert!(
+        err.to_string().contains("label"),
+        "error should explain the label restriction: {err}"
+    );
+
+    // Same restriction when the labeled first node starts a traversal pattern.
+    let err =
+        parse_cypher("MATCH (a:Person) OPTIONAL MATCH (b:City)-[:NEAR]->(c) RETURN c").unwrap_err();
+    assert!(matches!(err, CypherError::UnsupportedFeature(_)));
+
+    // An unlabeled first node (positional reference to the current row)
+    // still works.
+    assert!(parse_cypher("MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) RETURN x").is_ok());
+}
+
+#[test]
+fn test_parse_depth_range_inverted_rejected() {
+    // `*3..1` is an inverted variable-length range; the AQL parser rejects
+    // min > max, and the Cypher parser must too instead of silently
+    // accepting it.
+    let err = CypherParser::parse("MATCH (a)-[:KNOWS*3..1]->(b) RETURN b").unwrap_err();
+    assert!(
+        matches!(err, CypherError::ParseError { .. }),
+        "expected ParseError, got {err:?}"
+    );
+    assert!(
+        err.to_string().contains("min"),
+        "error should describe the inverted range: {err}"
+    );
+
+    // Valid ranges still parse (min == max and min < max).
+    assert!(CypherParser::parse("MATCH (a)-[:KNOWS*1..3]->(b) RETURN b").is_ok());
+    assert!(CypherParser::parse("MATCH (a)-[:KNOWS*2..2]->(b) RETURN b").is_ok());
+}
+
+// ============================================================================
+// OPTIONAL MATCH: fan-out, null-predicate, and parameter e2e coverage
+// ============================================================================
+
+/// Alice (Person) -KNOWS-> Bob (Friend) and Alice -KNOWS-> Eve (Friend);
+/// Dave (Person) has no outgoing edges.
+fn fan_out_test_db() -> AletheiaDB {
+    let db = AletheiaDB::new().unwrap();
+    let alice = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .unwrap();
+    let _dave = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Dave").build(),
+        )
+        .unwrap();
+    let bob = db
+        .create_node(
+            "Friend",
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+        )
+        .unwrap();
+    let eve = db
+        .create_node(
+            "Friend",
+            PropertyMapBuilder::new().insert("name", "Eve").build(),
+        )
+        .unwrap();
+    db.create_edge(alice, bob, "KNOWS", CorePropertyMap::new())
+        .unwrap();
+    db.create_edge(alice, eve, "KNOWS", CorePropertyMap::new())
+        .unwrap();
+    db
+}
+
+#[test]
+fn test_e2e_optional_match_fan_out_two_matches() {
+    let db = fan_out_test_db();
+    // One seed (Alice) with TWO optional matches: exactly 2 non-null rows,
+    // one per matched edge, carrying both names.
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (a:Person {name: 'Alice'}) OPTIONAL MATCH (a)-[:KNOWS]->(x) RETURN x",
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 2, "fan-out must yield one row per match");
+    assert!(rows.iter().all(|r| !r.entity.is_null()));
+    let names: Vec<_> = rows.iter().filter_map(row_name).collect();
+    assert!(names.contains(&"Bob".to_string()), "names: {names:?}");
+    assert!(names.contains(&"Eve".to_string()), "names: {names:?}");
+}
+
+#[test]
+fn test_e2e_optional_match_fan_out_with_unmatched_seed() {
+    let db = fan_out_test_db();
+    // Two seeds: Alice fans out to 2 matches, Dave is unmatched -> exactly
+    // 3 rows, of which 1 is null.
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) RETURN x")
+            .unwrap(),
+    );
+    assert_eq!(rows.len(), 3, "2 matched + 1 null row expected");
+    let nulls = rows.iter().filter(|r| r.entity.is_null()).count();
+    assert_eq!(nulls, 1);
+    let names: Vec<_> = rows.iter().filter_map(row_name).collect();
+    assert!(names.contains(&"Bob".to_string()));
+    assert!(names.contains(&"Eve".to_string()));
+}
+
+#[test]
+fn test_e2e_optional_match_is_not_null_keeps_only_matched() {
+    let db = optional_match_test_db();
+    // `x IS NOT NULL` after the optional segment keeps exactly the matched
+    // rows (Alice->Bob, Bob->Carol) and drops the null rows (Carol, Dave).
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) WITH x WHERE x IS NOT NULL RETURN x",
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 2);
+    assert!(rows.iter().all(|r| !r.entity.is_null()));
+    let names: Vec<_> = rows.iter().filter_map(row_name).collect();
+    assert!(names.contains(&"Bob".to_string()));
+    assert!(names.contains(&"Carol".to_string()));
+}
+
+#[test]
+fn test_e2e_optional_match_null_in_boolean_connective() {
+    let db = optional_match_test_db();
+    // Boolean connective over a null binding: `x IS NULL` is true for the two
+    // null rows; `x.age > 100` is not-true for every matched row (Bob is 40,
+    // Carol is 50) and not-true for null rows. The OR keeps exactly the nulls.
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) WITH x WHERE x IS NULL OR x.age > 100 RETURN x",
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 2);
+    assert!(rows.iter().all(|r| r.entity.is_null()));
+}
+
+#[test]
+fn test_e2e_optional_match_where_with_param() {
+    use std::collections::HashMap;
+
+    let db = optional_match_test_db();
+
+    // A `$param` inside the optional clause's WHERE resolves and is scoped
+    // inside the optional segment: Bob (age 40) passes `x.age > $minAge`.
+    let mut params = HashMap::new();
+    params.insert("minAge".to_string(), CypherParameterValue::Int(35));
+    let rows = collect_rows(
+        db.execute_cypher_with_params(
+            "MATCH (a:Person {name: 'Alice'}) OPTIONAL MATCH (a)-[:KNOWS]->(x) WHERE x.age > $minAge RETURN x",
+            params,
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(row_name(&rows[0]).as_deref(), Some("Bob"));
+
+    // A binding that eliminates every match yields a null row (never a
+    // dropped row): the parameterized WHERE participates in the
+    // matched/unmatched decision.
+    let mut params = HashMap::new();
+    params.insert("minAge".to_string(), CypherParameterValue::Int(100));
+    let rows = collect_rows(
+        db.execute_cypher_with_params(
+            "MATCH (a:Person {name: 'Alice'}) OPTIONAL MATCH (a)-[:KNOWS]->(x) WHERE x.age > $minAge RETURN x",
+            params,
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].entity.is_null());
+}

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -101,6 +101,7 @@ fn test_cypher_ast_basic_match() {
         },
         temporal: None,
         with_clauses: vec![],
+        optional_matches: vec![],
     };
     assert!(matches!(ast, CypherStatement::Match { .. }));
 }
@@ -1147,9 +1148,150 @@ fn test_parse_with_clause() {
 
 #[test]
 fn test_parse_optional_match() {
+    // Plain MATCH is not optional.
     let ast = CypherParser::parse("MATCH (n:Person) RETURN n").unwrap();
     let CypherStatement::Match { optional, .. } = ast;
     assert!(!optional);
+
+    // A leading OPTIONAL MATCH sets the optional flag.
+    let ast = CypherParser::parse("OPTIONAL MATCH (n:Person) RETURN n").unwrap();
+    let CypherStatement::Match {
+        optional,
+        pattern,
+        optional_matches,
+        ..
+    } = ast;
+    assert!(optional);
+    assert_eq!(pattern.len(), 1);
+    assert!(optional_matches.is_empty());
+}
+
+#[test]
+fn test_parse_match_then_optional_match() {
+    let ast = CypherParser::parse(
+        "MATCH (a:Person {name: 'Alice'}) OPTIONAL MATCH (a)-[:KNOWS]->(x) WHERE x.age > 30 RETURN x",
+    )
+    .unwrap();
+    let CypherStatement::Match {
+        optional,
+        pattern,
+        where_clause,
+        optional_matches,
+        ..
+    } = ast;
+    assert!(!optional);
+    assert_eq!(pattern.len(), 1);
+    // The WHERE belongs to the OPTIONAL MATCH clause, not the base MATCH.
+    assert!(where_clause.is_none());
+    assert_eq!(optional_matches.len(), 1);
+    assert!(optional_matches[0].where_clause.is_some());
+    assert_eq!(optional_matches[0].pattern.len(), 1);
+    // Pattern is (a)-[:KNOWS]->(x): node, rel, node.
+    assert_eq!(optional_matches[0].pattern[0].elements.len(), 3);
+    assert_eq!(optional_matches[0].preceding_withs, 0);
+}
+
+#[test]
+fn test_parse_multiple_optional_matches() {
+    let ast = CypherParser::parse(
+        "MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) OPTIONAL MATCH (a)-[:OWNS]->(y) RETURN y",
+    )
+    .unwrap();
+    let CypherStatement::Match {
+        optional_matches, ..
+    } = ast;
+    assert_eq!(optional_matches.len(), 2);
+    assert!(optional_matches[0].where_clause.is_none());
+    assert!(optional_matches[1].where_clause.is_none());
+}
+
+#[test]
+fn test_parse_optional_match_after_with() {
+    let ast = CypherParser::parse(
+        "MATCH (a:Person) WITH a WHERE a.age > 18 OPTIONAL MATCH (a)-[:KNOWS]->(x) RETURN x",
+    )
+    .unwrap();
+    let CypherStatement::Match {
+        with_clauses,
+        optional_matches,
+        ..
+    } = ast;
+    assert_eq!(with_clauses.len(), 1);
+    assert_eq!(optional_matches.len(), 1);
+    // The WITH precedes the OPTIONAL MATCH in source order.
+    assert_eq!(optional_matches[0].preceding_withs, 1);
+}
+
+#[test]
+fn test_parse_optional_match_base_where_and_clause_where() {
+    let ast = CypherParser::parse(
+        "MATCH (a:Person) WHERE a.age > 18 OPTIONAL MATCH (a)-[:KNOWS]->(x) WHERE x.age > 30 RETURN x",
+    )
+    .unwrap();
+    let CypherStatement::Match {
+        where_clause,
+        optional_matches,
+        ..
+    } = ast;
+    assert!(where_clause.is_some());
+    assert_eq!(optional_matches.len(), 1);
+    assert!(optional_matches[0].where_clause.is_some());
+}
+
+#[test]
+fn test_convert_optional_match_emits_optional_op() {
+    let query = parse_cypher(
+        "MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x {name: 'Z'}) WHERE x.age > 30 RETURN x",
+    )
+    .unwrap();
+
+    // The base pipeline scans, then a single Optional op wraps the whole
+    // optional segment (traverse + inline property filter + clause WHERE).
+    assert!(
+        query
+            .ops
+            .iter()
+            .any(|op| matches!(op, QueryOp::ScanNodes { .. }))
+    );
+    let optional = query
+        .ops
+        .iter()
+        .find_map(|op| match op {
+            QueryOp::Optional { ops } => Some(ops),
+            _ => None,
+        })
+        .expect("expected a QueryOp::Optional in converted ops");
+    assert!(
+        optional
+            .iter()
+            .any(|op| matches!(op, QueryOp::TraverseOut { .. }))
+    );
+    // Inline property filter + clause WHERE both live INSIDE the optional op.
+    let inner_filters = optional
+        .iter()
+        .filter(|op| matches!(op, QueryOp::Filter(_)))
+        .count();
+    assert_eq!(inner_filters, 2);
+    // No traversal or filter leaked outside the Optional op.
+    assert!(
+        !query
+            .ops
+            .iter()
+            .any(|op| matches!(op, QueryOp::TraverseOut { .. } | QueryOp::Filter(_)))
+    );
+}
+
+#[test]
+fn test_convert_leading_optional_match() {
+    let query = parse_cypher("OPTIONAL MATCH (n:Person) WHERE n.age > 200 RETURN n").unwrap();
+    // A leading OPTIONAL MATCH wraps its own scan pipeline in an Optional op.
+    match &query.ops[0] {
+        QueryOp::Optional { ops } => {
+            assert!(matches!(ops[0], QueryOp::ScanNodes { .. }));
+            assert!(ops.iter().any(|op| matches!(op, QueryOp::Filter(_))));
+        }
+        other => panic!("expected leading Optional op, got {other:?}"),
+    }
 }
 
 #[test]
@@ -1427,4 +1569,371 @@ fn test_parse_where_ends_with() {
     } else {
         panic!("Expected ENDS WITH");
     }
+}
+
+// ============================================================================
+// OPTIONAL MATCH execution semantics (Issue #557)
+// ============================================================================
+
+/// Build a small test graph:
+///   Alice -KNOWS-> Bob -KNOWS-> Carol
+///   Dave (no outgoing KNOWS edges)
+/// Returns the db.
+fn optional_match_test_db() -> AletheiaDB {
+    let db = AletheiaDB::new().unwrap();
+    let alice = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .insert("age", 30i64)
+                .build(),
+        )
+        .unwrap();
+    let bob = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Bob")
+                .insert("age", 40i64)
+                .build(),
+        )
+        .unwrap();
+    let carol = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Carol")
+                .insert("age", 50i64)
+                .build(),
+        )
+        .unwrap();
+    let _dave = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Dave")
+                .insert("age", 60i64)
+                .build(),
+        )
+        .unwrap();
+    db.create_edge(alice, bob, "KNOWS", CorePropertyMap::new())
+        .unwrap();
+    db.create_edge(bob, carol, "KNOWS", CorePropertyMap::new())
+        .unwrap();
+    db
+}
+
+fn collect_rows(results: crate::query::QueryResults) -> Vec<crate::query::executor::QueryRow> {
+    results.collect_all().unwrap()
+}
+
+fn row_name(row: &crate::query::executor::QueryRow) -> Option<String> {
+    row.entity.as_node().and_then(|n| {
+        n.properties
+            .get("name")
+            .and_then(|v| v.as_str().map(|s| s.to_string()))
+    })
+}
+
+#[test]
+fn test_e2e_optional_match_matched() {
+    let db = optional_match_test_db();
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (a:Person {name: 'Alice'}) OPTIONAL MATCH (a)-[:KNOWS]->(x) RETURN x",
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(row_name(&rows[0]).as_deref(), Some("Bob"));
+}
+
+#[test]
+fn test_e2e_optional_match_unmatched_returns_null_row() {
+    let db = optional_match_test_db();
+    // Dave has no outgoing KNOWS edges: openCypher requires ONE row with x = null,
+    // not zero rows.
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (a:Person {name: 'Dave'}) OPTIONAL MATCH (a)-[:KNOWS]->(x) RETURN x",
+        )
+        .unwrap(),
+    );
+    assert_eq!(
+        rows.len(),
+        1,
+        "unmatched OPTIONAL MATCH must preserve the base row"
+    );
+    assert!(
+        rows[0].entity.is_null(),
+        "unmatched OPTIONAL MATCH must bind null, got {:?}",
+        rows[0].entity
+    );
+}
+
+#[test]
+fn test_e2e_optional_match_mixed_matched_and_unmatched() {
+    let db = optional_match_test_db();
+    // All four Persons: Alice->Bob, Bob->Carol match; Carol and Dave don't.
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) RETURN x")
+            .unwrap(),
+    );
+    assert_eq!(rows.len(), 4, "one row per base row (2 matched + 2 null)");
+    let nulls = rows.iter().filter(|r| r.entity.is_null()).count();
+    assert_eq!(nulls, 2);
+    let names: Vec<_> = rows.iter().filter_map(row_name).collect();
+    assert!(names.contains(&"Bob".to_string()));
+    assert!(names.contains(&"Carol".to_string()));
+}
+
+#[test]
+fn test_e2e_optional_match_multi_hop_unmatched_midway() {
+    let db = optional_match_test_db();
+    // Carol has no outgoing KNOWS at hop 1, so a 2-hop optional pattern is
+    // unmatched: expect one null row, not a partial result and not zero rows.
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (a:Person {name: 'Carol'}) OPTIONAL MATCH (a)-[:KNOWS]->(m)-[:KNOWS]->(x) RETURN x",
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].entity.is_null());
+
+    // And a fully-matched 2-hop optional pattern still works.
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (a:Person {name: 'Alice'}) OPTIONAL MATCH (a)-[:KNOWS]->(m)-[:KNOWS]->(x) RETURN x",
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(row_name(&rows[0]).as_deref(), Some("Carol"));
+}
+
+#[test]
+fn test_e2e_optional_match_inline_property_scoped_inside() {
+    let db = optional_match_test_db();
+    // Alice knows Bob, but nobody named 'Zed': the inline property filter is
+    // part of the optional pattern, so the result is a null row -- the filter
+    // must NOT run outside the optional segment and kill the base row.
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (a:Person {name: 'Alice'}) OPTIONAL MATCH (a)-[:KNOWS]->(x {name: 'Zed'}) RETURN x",
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].entity.is_null());
+}
+
+#[test]
+fn test_e2e_optional_match_where_eliminates_all() {
+    let db = optional_match_test_db();
+    // Bob (Alice's only acquaintance) is 40, so WHERE x.age > 100 makes the
+    // optional pattern unmatched -> null row.
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (a:Person {name: 'Alice'}) OPTIONAL MATCH (a)-[:KNOWS]->(x) WHERE x.age > 100 RETURN x",
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].entity.is_null());
+}
+
+#[test]
+fn test_e2e_optional_match_where_keeps_some() {
+    let db = optional_match_test_db();
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (a:Person {name: 'Alice'}) OPTIONAL MATCH (a)-[:KNOWS]->(x) WHERE x.age > 35 RETURN x",
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(row_name(&rows[0]).as_deref(), Some("Bob"));
+}
+
+#[test]
+fn test_e2e_two_optional_matches_chained() {
+    let db = optional_match_test_db();
+    // Second optional chains from the first's result: Alice -> Bob -> Carol.
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (a:Person {name: 'Alice'}) OPTIONAL MATCH (a)-[:KNOWS]->(m) OPTIONAL MATCH (m)-[:KNOWS]->(x) RETURN x",
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(row_name(&rows[0]).as_deref(), Some("Carol"));
+}
+
+#[test]
+fn test_e2e_two_optional_matches_second_unmatched() {
+    let db = optional_match_test_db();
+    // Bob -> Carol matches, but Carol knows nobody: second optional yields null.
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (a:Person {name: 'Bob'}) OPTIONAL MATCH (a)-[:KNOWS]->(m) OPTIONAL MATCH (m)-[:KNOWS]->(x) RETURN x",
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].entity.is_null());
+}
+
+#[test]
+fn test_e2e_two_optional_matches_both_unmatched() {
+    let db = optional_match_test_db();
+    // Dave knows nobody: first optional is null; second optional over a null
+    // seed must also produce a single null row (null propagates, row preserved).
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (a:Person {name: 'Dave'}) OPTIONAL MATCH (a)-[:KNOWS]->(m) OPTIONAL MATCH (m)-[:KNOWS]->(x) RETURN x",
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].entity.is_null());
+}
+
+#[test]
+fn test_e2e_optional_match_after_with_where() {
+    let db = optional_match_test_db();
+    // WITH ... WHERE filters base rows BEFORE the optional segment:
+    // only Dave (age 60) survives, and his optional pattern is unmatched.
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (a:Person) WITH a WHERE a.age > 55 OPTIONAL MATCH (a)-[:KNOWS]->(x) RETURN x",
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].entity.is_null());
+}
+
+#[test]
+fn test_e2e_optional_match_null_row_dropped_by_downstream_where() {
+    let db = optional_match_test_db();
+    // A WITH ... WHERE AFTER the optional segment applies to its results:
+    // comparisons against a null binding are not-true, so null rows drop.
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) WITH x WHERE x.age > 45 RETURN x",
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(row_name(&rows[0]).as_deref(), Some("Carol"));
+}
+
+#[test]
+fn test_e2e_optional_match_null_row_kept_by_is_null() {
+    let db = optional_match_test_db();
+    // `x IS NULL` after the optional segment keeps exactly the unmatched rows
+    // (Carol and Dave have no outgoing KNOWS).
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) WITH x WHERE x IS NULL RETURN x",
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 2);
+    assert!(rows.iter().all(|r| r.entity.is_null()));
+}
+
+#[test]
+fn test_e2e_optional_match_skip_limit() {
+    let db = optional_match_test_db();
+    // 4 rows total (2 matched + 2 null); SKIP 1 LIMIT 2 -> exactly 2 rows.
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) RETURN x SKIP 1 LIMIT 2",
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 2);
+}
+
+#[test]
+fn test_e2e_leading_optional_match_no_matches_returns_one_null_row() {
+    let db = AletheiaDB::new().unwrap();
+    // Empty database: a leading OPTIONAL MATCH with no matches returns a
+    // single row of nulls per openCypher.
+    let rows = collect_rows(
+        db.execute_cypher("OPTIONAL MATCH (n:Person) RETURN n")
+            .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].entity.is_null());
+}
+
+#[test]
+fn test_e2e_leading_optional_match_with_matches() {
+    let db = optional_match_test_db();
+    let rows = collect_rows(
+        db.execute_cypher("OPTIONAL MATCH (n:Person) RETURN n")
+            .unwrap(),
+    );
+    assert_eq!(rows.len(), 4);
+    assert!(rows.iter().all(|r| !r.entity.is_null()));
+}
+
+#[test]
+fn test_e2e_leading_optional_match_where_eliminates_all() {
+    let db = optional_match_test_db();
+    // The WHERE is part of the leading optional pattern: nobody is older
+    // than 200, so one null row.
+    let rows = collect_rows(
+        db.execute_cypher("OPTIONAL MATCH (n:Person) WHERE n.age > 200 RETURN n")
+            .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].entity.is_null());
+}
+
+#[test]
+fn test_e2e_optional_match_with_as_of_does_not_panic() {
+    let db = optional_match_test_db();
+    // Temporal contexts are currently inert for label scans (pre-existing);
+    // this test documents that OPTIONAL MATCH combined with AS OF executes
+    // without panicking and preserves left-outer row semantics. The AS OF
+    // coordinate is in the future of all writes, so edges are visible.
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (a:Person {name: 'Dave'}) AS OF VALID_TIME '2999-01-01T00:00:00Z' OPTIONAL MATCH (a)-[:KNOWS]->(x) RETURN x",
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].entity.is_null());
+
+    // An AS OF coordinate before any write excludes the edges: the optional
+    // traversal finds nothing, so the base row is preserved with a null.
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (a:Person {name: 'Alice'}) AS OF VALID_TIME '1970-01-02T00:00:00Z' AS OF SYSTEM_TIME '1970-01-02T00:00:00Z' OPTIONAL MATCH (a)-[:KNOWS]->(x) RETURN x",
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert!(
+        rows[0].entity.is_null(),
+        "edges created after the AS OF coordinate must not match, got {:?}",
+        rows[0].entity
+    );
+}
+
+#[test]
+fn test_e2e_plain_match_unchanged_regression() {
+    let db = optional_match_test_db();
+    // Plain (inner) MATCH still returns zero rows when the pattern is unmatched.
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (a:Person {name: 'Dave'})-[:KNOWS]->(x) RETURN x")
+            .unwrap(),
+    );
+    assert_eq!(rows.len(), 0);
 }

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -1193,6 +1193,11 @@ fn test_parse_match_then_optional_match() {
 
 #[test]
 fn test_parse_multiple_optional_matches() {
+    // Parse-only: the grammar accepts multiple OPTIONAL MATCH clauses in any
+    // shape. Note this particular query re-anchors the second clause on `a`
+    // and is rejected later, at CONVERSION (see
+    // test_convert_optional_match_reanchored_variable_rejected) -- parsing
+    // it is still correct.
     let ast = CypherParser::parse(
         "MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) OPTIONAL MATCH (a)-[:OWNS]->(y) RETURN y",
     )
@@ -1987,6 +1992,96 @@ fn test_convert_optional_match_labeled_first_node_rejected() {
     // An unlabeled first node (positional reference to the current row)
     // still works.
     assert!(parse_cypher("MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) RETURN x").is_ok());
+}
+
+#[test]
+fn test_convert_optional_match_reanchored_variable_rejected() {
+    // The first node of a subsequent OPTIONAL MATCH binds positionally to
+    // the current row (the previous clause's last binding). Here the second
+    // OPTIONAL MATCH names `(a)` but the pipeline is positioned on `x`, so
+    // without the check `(a)` would silently bind to `x` (or null) and
+    // traverse OWNS from the wrong node. Reject rather than answer wrongly.
+    let err = parse_cypher(
+        "MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) OPTIONAL MATCH (a)-[:OWNS]->(y) RETURN y",
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, CypherError::UnsupportedFeature(_)),
+        "expected UnsupportedFeature, got {err:?}"
+    );
+    assert!(
+        err.to_string().contains("re-anchor"),
+        "error should explain that re-anchoring is unsupported: {err}"
+    );
+    assert!(
+        err.to_string().contains('x') && err.to_string().contains('a'),
+        "error should name both the expected and the offending variable: {err}"
+    );
+
+    // Positive control: chaining each OPTIONAL MATCH from the previous
+    // clause's binding still converts.
+    assert!(parse_cypher(
+        "MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) OPTIONAL MATCH (x)-[:OWNS]->(y) RETURN y"
+    )
+    .is_ok());
+
+    // An unnamed first node `()` is an explicit positional reference and
+    // remains accepted.
+    assert!(
+        parse_cypher("MATCH (a:Person) OPTIONAL MATCH ()-[:KNOWS]->(x) RETURN x").is_ok(),
+        "unnamed first node must keep working"
+    );
+}
+
+#[test]
+fn test_convert_optional_match_reanchored_after_multi_hop_base_rejected() {
+    // Same hole for the FIRST OPTIONAL MATCH after a multi-hop base MATCH:
+    // the positionally-current variable is the base pattern's LAST node
+    // (`b`), so `(a)` would silently bind to `b` and traverse from the
+    // wrong end of the base pattern.
+    let err =
+        parse_cypher("MATCH (a:Person)-[:KNOWS]->(b) OPTIONAL MATCH (a)-[:OWNS]->(y) RETURN y")
+            .unwrap_err();
+    assert!(
+        matches!(err, CypherError::UnsupportedFeature(_)),
+        "expected UnsupportedFeature, got {err:?}"
+    );
+
+    // Continuing from the base pattern's last node converts fine.
+    assert!(
+        parse_cypher("MATCH (a:Person)-[:KNOWS]->(b) OPTIONAL MATCH (b)-[:OWNS]->(y) RETURN y")
+            .is_ok()
+    );
+
+    // When the previous clause's last node is unnamed, ANY named first node
+    // is a re-anchor and is rejected.
+    let err =
+        parse_cypher("MATCH (a:Person)-[:KNOWS]->() OPTIONAL MATCH (a)-[:OWNS]->(y) RETURN y")
+            .unwrap_err();
+    assert!(
+        matches!(err, CypherError::UnsupportedFeature(_)),
+        "expected UnsupportedFeature, got {err:?}"
+    );
+}
+
+#[test]
+fn test_convert_optional_match_after_with_projection_tracks_variable() {
+    // A `WITH v` projection makes `v` the positionally-current binding for
+    // a following OPTIONAL MATCH.
+    assert!(parse_cypher(
+        "MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) WITH x WHERE x IS NULL OPTIONAL MATCH (x)-[:OWNS]->(y) RETURN y"
+    )
+    .is_ok());
+
+    // Naming a stale variable after the projection is a re-anchor.
+    let err = parse_cypher(
+        "MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) WITH x OPTIONAL MATCH (a)-[:OWNS]->(y) RETURN y",
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, CypherError::UnsupportedFeature(_)),
+        "expected UnsupportedFeature, got {err:?}"
+    );
 }
 
 #[test]

--- a/src/http/converters.rs
+++ b/src/http/converters.rs
@@ -230,6 +230,11 @@ pub fn query_row_to_json(row: QueryRow) -> Result<serde_json::Value, String> {
         EntityResult::EdgeId(id) => {
             obj.insert("edge_id".to_string(), json!(id.as_u64()));
         }
+        EntityResult::Null => {
+            // Null binding from an unmatched OPTIONAL MATCH: the row is
+            // preserved but carries no entity payload.
+            obj.insert("null".to_string(), json!(true));
+        }
     }
 
     // Add metadata

--- a/src/http/converters.rs
+++ b/src/http/converters.rs
@@ -497,4 +497,23 @@ mod tests {
         // Should hit vector limit, not array limit
         assert!(res.unwrap_err().contains("Vector dimension"));
     }
+
+    #[test]
+    fn test_query_row_to_json_null_binding() {
+        // A null binding from an unmatched OPTIONAL MATCH serializes as
+        // documented: `{"null": true}` with no entity payload key.
+        let row = QueryRow::from_entity(EntityResult::Null);
+        let value = query_row_to_json(row).unwrap();
+        assert_eq!(value.get("null"), Some(&json!(true)));
+        assert!(value.get("node").is_none());
+        assert!(value.get("edge").is_none());
+        assert!(value.get("node_id").is_none());
+        assert!(value.get("edge_id").is_none());
+
+        // Row metadata still serializes alongside the null marker.
+        let row = QueryRow::with_score(EntityResult::Null, 0.5);
+        let value = query_row_to_json(row).unwrap();
+        assert_eq!(value.get("null"), Some(&json!(true)));
+        assert_eq!(value.get("score"), Some(&json!(0.5)));
+    }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -4668,4 +4668,18 @@ mod server_unit_tests {
         assert!(val["valid_time"]["earliest"].is_null());
         assert!(val["transaction_time"]["latest"].is_null());
     }
+
+    #[test]
+    fn query_row_to_json_null_binding_serializes_entity_as_json_null() {
+        // A null binding from an unmatched OPTIONAL MATCH pattern must
+        // surface as an explicit JSON null entity (row preserved).
+        let server = make_server();
+        let value = server.query_row_to_json(QueryRow::from_entity(EntityResult::Null));
+        assert!(
+            value["entity"].is_null(),
+            "null binding must serialize as JSON null: {value}"
+        );
+        assert!(value["score"].is_null());
+        assert!(value["path"].is_null());
+    }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -3675,6 +3675,9 @@ impl AletheiaMcpServer {
             }
             EntityResult::NodeId(id) => json!({"type": "node", "id": id.as_u64()}),
             EntityResult::EdgeId(id) => json!({"type": "edge", "id": id.as_u64()}),
+            // Null binding from an unmatched OPTIONAL MATCH pattern: surface
+            // as JSON null so an LLM/caller sees the preserved row explicitly.
+            EntityResult::Null => serde_json::Value::Null,
         };
         json!({
             "entity": entity,

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -3675,6 +3675,30 @@ mod query_tool_tests {
 
     #[cfg(feature = "cypher")]
     #[test]
+    fn test_query_cypher_optional_match_null_row_serializes_as_json_null() {
+        let server = create_test_server();
+        seed_named(&server, "Person", "Alice");
+        // Alice has no outgoing KNOWS edges: OPTIONAL MATCH preserves the
+        // base row and the null binding must surface as JSON null, not crash.
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "cypher".to_string(),
+                query: "MATCH (a:Person {name: 'Alice'}) OPTIONAL MATCH (a)-[:KNOWS]->(x) RETURN x"
+                    .to_string(),
+                params: None,
+                limit: None,
+            },
+        );
+        assert_eq!(value["row_count"].as_u64(), Some(1), "{value}");
+        assert!(
+            value["rows"][0]["entity"].is_null(),
+            "unmatched OPTIONAL MATCH row must serialize entity as JSON null: {value}"
+        );
+    }
+
+    #[cfg(feature = "cypher")]
+    #[test]
     fn test_query_cypher_with_params() {
         let server = create_test_server();
         seed_named(&server, "Person", "Alice");

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -1317,6 +1317,10 @@ pub struct OptionalApplyIterator {
     inner_matched: bool,
     /// Set when the input (or the single standalone run) is exhausted.
     done: bool,
+    /// The seed row currently being processed, kept so an unmatched fallback
+    /// preserves its metadata (score, path, timestamp). `None` in the
+    /// standalone form, which has no seed row.
+    current_seed: Option<QueryRow>,
 }
 
 impl OptionalApplyIterator {
@@ -1329,7 +1333,7 @@ impl OptionalApplyIterator {
     ) -> Self {
         use crate::query::planner::physical::OptionalPhysicalStep;
         let standalone = matches!(steps.first(), Some(OptionalPhysicalStep::Scan { .. }));
-        OptionalApplyIterator {
+        Self {
             input,
             steps,
             current,
@@ -1338,6 +1342,7 @@ impl OptionalApplyIterator {
             inner: None,
             inner_matched: false,
             done: false,
+            current_seed: None,
         }
     }
 
@@ -1394,14 +1399,28 @@ impl ResultIterator for OptionalApplyIterator {
                         self.inner_matched = true;
                         return Some(Ok(row));
                     }
-                    Some(Err(e)) => return Some(Err(e)),
+                    Some(Err(e)) => {
+                        // Abandon the errored seed entirely: a consumer that
+                        // iterates past the error must not receive a
+                        // fabricated null row for it.
+                        self.inner = None;
+                        self.inner_matched = false;
+                        self.current_seed = None;
+                        return Some(Err(e));
+                    }
                     None => {
                         let unmatched = !self.inner_matched;
                         self.inner = None;
+                        let seed = self.current_seed.take();
                         if unmatched {
-                            // Left-outer semantics: preserve the input row
-                            // with a null binding.
-                            return Some(Ok(QueryRow::from_entity(EntityResult::Null)));
+                            // Left-outer semantics: preserve the input row --
+                            // including its metadata (score, path, timestamp)
+                            // -- with a null binding. The standalone form has
+                            // no seed row, so it falls back to a bare null row.
+                            let mut row =
+                                seed.unwrap_or_else(|| QueryRow::from_entity(EntityResult::Null));
+                            row.entity = EntityResult::Null;
+                            return Some(Ok(row));
                         }
                         continue;
                     }
@@ -1423,6 +1442,7 @@ impl ResultIterator for OptionalApplyIterator {
             // Pull the next seed row from the input.
             match self.input.next() {
                 Some(Ok(seed)) => {
+                    self.current_seed = Some(seed.clone());
                     self.inner = Some(self.build_pipeline(Some(seed)));
                     self.inner_matched = false;
                 }
@@ -3706,6 +3726,176 @@ mod tests {
         iter.sorted = None; // Force re-initialization
 
         // This used to unwrap and panic because input was taken in the first call
+        assert!(iter.next().is_none());
+    }
+
+    // ==================== evaluate_null Tests ====================
+
+    /// Exhaustively covers every arm of [`FilterIterator::evaluate_null`]:
+    /// comparisons/membership/string predicates over a null binding are
+    /// not-true, `IS NULL` (encoded `Eq { value: Null }`) is true,
+    /// `IS NOT NULL` (encoded `Ne { value: Null }`) is false, a null binding
+    /// has no properties (`Exists` false / `NotExists` true), and the
+    /// boolean connectives compose (with `Not` documented as two-valued).
+    #[test]
+    fn test_evaluate_null_all_predicate_arms() {
+        let filter = FilterIterator::new(Box::new(EmptyIterator), Predicate::True);
+        let eval = |p: &Predicate| filter.evaluate_null(p);
+
+        // Constants.
+        assert!(eval(&Predicate::True));
+        assert!(!eval(&Predicate::False));
+
+        // IS NULL / IS NOT NULL encodings.
+        assert!(eval(&Predicate::Eq {
+            key: "x".into(),
+            value: PredicateValue::Null,
+        }));
+        assert!(!eval(&Predicate::Ne {
+            key: "x".into(),
+            value: PredicateValue::Null,
+        }));
+
+        // Eq/Ne against non-null values are not-true.
+        assert!(!eval(&Predicate::eq("x", 1i64)));
+        assert!(!eval(&Predicate::ne("x", 1i64)));
+
+        // Ordering comparisons are not-true.
+        assert!(!eval(&Predicate::Gt {
+            key: "x".into(),
+            value: PredicateValue::Int(1),
+        }));
+        assert!(!eval(&Predicate::Lt {
+            key: "x".into(),
+            value: PredicateValue::Int(1),
+        }));
+        assert!(!eval(&Predicate::Gte {
+            key: "x".into(),
+            value: PredicateValue::Int(1),
+        }));
+        assert!(!eval(&Predicate::Lte {
+            key: "x".into(),
+            value: PredicateValue::Int(1),
+        }));
+
+        // Membership and string predicates are not-true.
+        assert!(!eval(&Predicate::In {
+            key: "x".into(),
+            values: vec![PredicateValue::Int(1), PredicateValue::Null],
+        }));
+        assert!(!eval(&Predicate::Contains {
+            key: "x".into(),
+            substring: "a".into(),
+        }));
+        assert!(!eval(&Predicate::StartsWith {
+            key: "x".into(),
+            prefix: "a".into(),
+        }));
+        assert!(!eval(&Predicate::EndsWith {
+            key: "x".into(),
+            suffix: "a".into(),
+        }));
+
+        // A null binding has no properties.
+        assert!(!eval(&Predicate::Exists("x".into())));
+        assert!(eval(&Predicate::NotExists("x".into())));
+
+        // Connectives compose.
+        assert!(eval(&Predicate::And(vec![
+            Predicate::True,
+            Predicate::NotExists("x".into()),
+        ])));
+        assert!(!eval(&Predicate::And(vec![
+            Predicate::True,
+            Predicate::eq("x", 1i64),
+        ])));
+        assert!(eval(&Predicate::Or(vec![
+            Predicate::eq("x", 1i64),
+            Predicate::Eq {
+                key: "x".into(),
+                value: PredicateValue::Null,
+            },
+        ])));
+        assert!(!eval(&Predicate::Or(vec![
+            Predicate::False,
+            Predicate::eq("x", 1i64),
+        ])));
+
+        // Not is two-valued (documented deviation from openCypher 3VL):
+        // NOT (not-true) is true.
+        assert!(eval(&Predicate::Not(Box::new(Predicate::eq("x", 1i64)))));
+        assert!(!eval(&Predicate::Not(Box::new(Predicate::True))));
+    }
+
+    // ==================== OptionalApplyIterator Tests ====================
+
+    fn optional_test_storages() -> (
+        Arc<CurrentStorage>,
+        Arc<RwLock<crate::storage::historical::HistoricalStorage>>,
+    ) {
+        let current = Arc::new(CurrentStorage::new());
+        let historical = Arc::new(RwLock::new(
+            crate::storage::historical::HistoricalStorage::with_config(
+                crate::core::version::AnchorConfig::default(),
+            ),
+        ));
+        (current, historical)
+    }
+
+    /// The unmatched fallback row must preserve the seed row's metadata
+    /// (score, path, timestamp), with only the entity replaced by Null.
+    #[test]
+    fn test_optional_apply_unmatched_preserves_seed_metadata() {
+        use crate::query::planner::physical::OptionalPhysicalStep;
+
+        let (current, historical) = optional_test_storages();
+
+        let seed = QueryRow::with_score(EntityResult::Node(test_node(1, "Alice")), 0.75)
+            .at_time(Timestamp::from(12345i64));
+        let input = Box::new(MockIterator::from_results(vec![Ok(seed)]));
+
+        // A Filter(False) step can never match: the seed row falls back to
+        // the null form.
+        let mut iter = OptionalApplyIterator::new(
+            input,
+            vec![OptionalPhysicalStep::Filter(Predicate::False)],
+            current,
+            historical,
+        );
+
+        let row = iter.next().expect("one row expected").expect("no error");
+        assert!(row.entity.is_null(), "unmatched seed must bind null");
+        assert_eq!(row.score, Some(0.75), "seed score must be preserved");
+        assert_eq!(
+            row.timestamp,
+            Some(Timestamp::from(12345i64)),
+            "seed timestamp must be preserved"
+        );
+        assert!(iter.next().is_none());
+    }
+
+    /// The standalone (leading OPTIONAL MATCH) form has no seed row: the
+    /// unmatched fallback is a bare null row.
+    #[test]
+    fn test_optional_apply_standalone_unmatched_bare_null_row() {
+        use crate::query::planner::physical::OptionalPhysicalStep;
+
+        let (current, historical) = optional_test_storages();
+
+        let mut iter = OptionalApplyIterator::new(
+            Box::new(EmptyIterator),
+            vec![OptionalPhysicalStep::Scan {
+                label: Some("Person".to_string()),
+            }],
+            current,
+            historical,
+        );
+
+        let row = iter.next().expect("one row expected").expect("no error");
+        assert!(row.entity.is_null());
+        assert!(row.score.is_none());
+        assert!(row.path.is_none());
+        assert!(row.timestamp.is_none());
         assert!(iter.next().is_none());
     }
 }

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -4074,4 +4074,177 @@ mod tests {
         assert!(row.timestamp.is_none());
         assert!(iter.next().is_none());
     }
+
+    /// The matched case: a seed row whose optional traversal produces rows
+    /// yields those rows (not a null fallback), then moves to the next seed.
+    #[test]
+    fn test_optional_apply_matched_rows_pass_through() {
+        use crate::query::planner::physical::OptionalPhysicalStep;
+
+        let (current, historical) = optional_test_storages();
+        let alice = current
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Alice").build(),
+            )
+            .unwrap();
+        let bob = current
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Bob").build(),
+            )
+            .unwrap();
+        current
+            .create_edge(alice, bob, "KNOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        let seed = QueryRow::from_entity(EntityResult::Node(current.get_node(alice).unwrap()));
+        let input = Box::new(MockIterator::from_results(vec![Ok(seed)]));
+
+        let mut iter = OptionalApplyIterator::new(
+            input,
+            vec![OptionalPhysicalStep::Traverse {
+                direction: Direction::Outgoing,
+                label: Some("KNOWS".to_string()),
+                depth: 1,
+                temporal_context: None,
+            }],
+            current,
+            historical,
+        );
+
+        let row = iter.next().expect("one row expected").expect("no error");
+        assert_eq!(
+            row.entity.node_id(),
+            Some(bob),
+            "matched optional must yield the traversal target, not null"
+        );
+        // The matched seed must NOT be followed by a fabricated null row.
+        assert!(iter.next().is_none());
+    }
+
+    /// An error from the input (seed) iterator is propagated as-is.
+    #[test]
+    fn test_optional_apply_input_error_propagates() {
+        use crate::query::planner::physical::OptionalPhysicalStep;
+
+        let (current, historical) = optional_test_storages();
+        let input = Box::new(MockIterator::from_results(vec![Err(
+            crate::core::error::Error::other("test error"),
+        )]));
+
+        let mut iter = OptionalApplyIterator::new(
+            input,
+            vec![OptionalPhysicalStep::Filter(Predicate::True)],
+            current,
+            historical,
+        );
+
+        assert!(iter.next().expect("error row expected").is_err());
+        assert!(iter.next().is_none());
+    }
+
+    /// An error inside the optional sub-pipeline abandons the seed: the
+    /// error is surfaced and NO fabricated null row follows for that seed.
+    #[test]
+    fn test_optional_apply_inner_error_abandons_seed() {
+        use crate::query::planner::physical::OptionalPhysicalStep;
+
+        let (current, historical) = optional_test_storages();
+        let alice = current
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Alice").build(),
+            )
+            .unwrap();
+        let bob = current
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Bob").build(),
+            )
+            .unwrap();
+        current
+            .create_edge(alice, bob, "KNOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+        let seed = QueryRow::from_entity(EntityResult::Node(current.get_node(alice).unwrap()));
+        // Delete Bob but keep the edge (low-level delete_node preserves
+        // edges): the traversal reaches a missing endpoint and errors.
+        current.delete_node(bob).unwrap();
+
+        let input = Box::new(MockIterator::from_results(vec![Ok(seed)]));
+        let mut iter = OptionalApplyIterator::new(
+            input,
+            vec![OptionalPhysicalStep::Traverse {
+                direction: Direction::Outgoing,
+                label: Some("KNOWS".to_string()),
+                depth: 1,
+                temporal_context: None,
+            }],
+            current,
+            historical,
+        );
+
+        assert!(iter.next().expect("error row expected").is_err());
+        // The errored seed must not fall back to a null row.
+        assert!(iter.next().is_none());
+    }
+
+    /// size_hint: at least one row per remaining input row, no upper bound.
+    #[test]
+    fn test_optional_apply_size_hint() {
+        use crate::query::planner::physical::OptionalPhysicalStep;
+
+        let (current, historical) = optional_test_storages();
+        let input = Box::new(MockIterator::from_nodes(vec![
+            test_node(1, "Alice"),
+            test_node(2, "Bob"),
+        ]));
+
+        let iter = OptionalApplyIterator::new(
+            input,
+            vec![OptionalPhysicalStep::Filter(Predicate::True)],
+            current,
+            historical,
+        );
+        assert_eq!(iter.size_hint(), (2, None));
+    }
+
+    /// SeedRowIterator yields its single row exactly once, with exact hints.
+    #[test]
+    fn test_seed_row_iterator() {
+        let row = QueryRow::from_entity(EntityResult::Node(test_node(1, "Alice")));
+        let mut iter = SeedRowIterator::new(row);
+
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+        assert!(iter.next().expect("one row").is_ok());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+        assert!(iter.next().is_none());
+    }
+
+    /// FilterIterator applies null semantics to null-binding rows from an
+    /// unmatched OPTIONAL MATCH: IS NULL keeps them, comparisons drop them.
+    #[test]
+    fn test_filter_iterator_null_row_semantics() {
+        // `x IS NULL` (encoded Eq { value: Null }) keeps the null row.
+        let input = Box::new(MockIterator::from_results(vec![Ok(QueryRow::from_entity(
+            EntityResult::Null,
+        ))]));
+        let mut keep = FilterIterator::new(
+            input,
+            Predicate::Eq {
+                key: "x".into(),
+                value: PredicateValue::Null,
+            },
+        );
+        let row = keep.next().expect("one row expected").expect("no error");
+        assert!(row.entity.is_null());
+        assert!(keep.next().is_none());
+
+        // A comparison against the null binding is not-true: row dropped.
+        let input = Box::new(MockIterator::from_results(vec![Ok(QueryRow::from_entity(
+            EntityResult::Null,
+        ))]));
+        let mut dropped = FilterIterator::new(input, Predicate::eq("x", 1i64));
+        assert!(dropped.next().is_none());
+    }
 }

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -1181,6 +1181,54 @@ impl FilterIterator {
     }
 }
 
+impl FilterIterator {
+    /// Evaluate a predicate against a null binding (an unmatched
+    /// `OPTIONAL MATCH` row).
+    ///
+    /// Approximates openCypher three-valued logic at the "not true" level:
+    /// any comparison, string predicate, or membership test involving the
+    /// null binding is not-true (row filtered), `IS NULL` (encoded as
+    /// `Eq { value: Null }`) is true, and `IS NOT NULL` (encoded as
+    /// `Ne { value: Null }`) is false.
+    ///
+    /// Known deviation: `NOT` uses two-valued negation (`NOT (null.p = 1)`
+    /// keeps the row where openCypher's `NOT null` would drop it). This
+    /// mirrors the engine's existing missing-property semantics.
+    fn evaluate_null(&self, predicate: &Predicate) -> bool {
+        match predicate {
+            Predicate::True => true,
+            Predicate::False => false,
+            // `x IS NULL` is converted to Eq { value: Null }: true for a null row.
+            Predicate::Eq {
+                value: PredicateValue::Null,
+                ..
+            } => true,
+            // `x IS NOT NULL` is converted to Ne { value: Null }: false for a null row.
+            Predicate::Ne {
+                value: PredicateValue::Null,
+                ..
+            } => false,
+            // A null binding has no properties.
+            Predicate::NotExists(_) => true,
+            Predicate::Exists(_) => false,
+            // Any comparison/membership/string predicate against null is not-true.
+            Predicate::Eq { .. }
+            | Predicate::Ne { .. }
+            | Predicate::Gt { .. }
+            | Predicate::Gte { .. }
+            | Predicate::Lt { .. }
+            | Predicate::Lte { .. }
+            | Predicate::In { .. }
+            | Predicate::Contains { .. }
+            | Predicate::StartsWith { .. }
+            | Predicate::EndsWith { .. } => false,
+            Predicate::And(preds) => preds.iter().all(|p| self.evaluate_null(p)),
+            Predicate::Or(preds) => preds.iter().any(|p| self.evaluate_null(p)),
+            Predicate::Not(pred) => !self.evaluate_null(pred),
+        }
+    }
+}
+
 impl ResultIterator for FilterIterator {
     fn next(&mut self) -> Option<Result<QueryRow>> {
         loop {
@@ -1188,6 +1236,14 @@ impl ResultIterator for FilterIterator {
                 Some(Ok(row)) => {
                     if let Some(node) = row.entity.as_node() {
                         if self.evaluate(node) {
+                            return Some(Ok(row));
+                        }
+                        // Filter didn't pass, continue to next
+                    } else if row.entity.is_null() {
+                        // Null bindings from unmatched OPTIONAL MATCH rows are
+                        // evaluated with null semantics (comparisons are
+                        // not-true, IS NULL is true).
+                        if self.evaluate_null(&self.predicate) {
                             return Some(Ok(row));
                         }
                         // Filter didn't pass, continue to next
@@ -1200,6 +1256,190 @@ impl ResultIterator for FilterIterator {
                 None => return None,
             }
         }
+    }
+}
+
+/// Iterator that yields a single, pre-built row.
+///
+/// Used by [`OptionalApplyIterator`] to seed the per-row optional
+/// sub-pipeline with the current input row.
+struct SeedRowIterator {
+    row: Option<QueryRow>,
+}
+
+impl SeedRowIterator {
+    fn new(row: QueryRow) -> Self {
+        SeedRowIterator { row: Some(row) }
+    }
+}
+
+impl ResultIterator for SeedRowIterator {
+    fn next(&mut self) -> Option<Result<QueryRow>> {
+        self.row.take().map(Ok)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let n = usize::from(self.row.is_some());
+        (n, Some(n))
+    }
+}
+
+/// Iterator implementing left-outer (`OPTIONAL MATCH`) semantics.
+///
+/// For each input row, the configured sub-pipeline (traversal hops and
+/// filters) is executed seeded from that row:
+///
+/// - If it produces at least one row, those rows are yielded (matched case).
+/// - If it produces nothing, a single row with [`EntityResult::Null`] is
+///   yielded instead, preserving the input row (unmatched case).
+///
+/// Because the sub-pipeline includes the optional pattern's inline property
+/// filters and its `WHERE` clause, filtering happens *before* the
+/// matched/unmatched decision, per openCypher semantics.
+///
+/// When the first step is a `Scan` the iterator is *standalone* (a leading
+/// `OPTIONAL MATCH` with no prior rows): the sub-pipeline runs exactly once
+/// from its own node scan, and an empty result yields one null row.
+///
+/// A null seed row (from a preceding unmatched optional) traverses to nothing,
+/// so a chained `OPTIONAL MATCH` over it yields another null row -- null
+/// propagates without dropping the row.
+pub struct OptionalApplyIterator {
+    input: Box<dyn ResultIterator>,
+    steps: Vec<crate::query::planner::physical::OptionalPhysicalStep>,
+    current: Arc<CurrentStorage>,
+    historical: Arc<RwLock<HistoricalStorage>>,
+    /// True when the first step is a Scan (leading OPTIONAL MATCH form).
+    standalone: bool,
+    /// The sub-pipeline currently being drained (one per seed row).
+    inner: Option<Box<dyn ResultIterator>>,
+    /// Whether the current sub-pipeline has produced at least one row.
+    inner_matched: bool,
+    /// Set when the input (or the single standalone run) is exhausted.
+    done: bool,
+}
+
+impl OptionalApplyIterator {
+    /// Create a new OptionalApplyIterator.
+    pub fn new(
+        input: Box<dyn ResultIterator>,
+        steps: Vec<crate::query::planner::physical::OptionalPhysicalStep>,
+        current: Arc<CurrentStorage>,
+        historical: Arc<RwLock<HistoricalStorage>>,
+    ) -> Self {
+        use crate::query::planner::physical::OptionalPhysicalStep;
+        let standalone = matches!(steps.first(), Some(OptionalPhysicalStep::Scan { .. }));
+        OptionalApplyIterator {
+            input,
+            steps,
+            current,
+            historical,
+            standalone,
+            inner: None,
+            inner_matched: false,
+            done: false,
+        }
+    }
+
+    /// Build the optional sub-pipeline for one seed row (or, for the
+    /// standalone form, from the leading scan step).
+    fn build_pipeline(&self, seed: Option<QueryRow>) -> Box<dyn ResultIterator> {
+        use crate::query::planner::physical::OptionalPhysicalStep;
+
+        let mut iter: Box<dyn ResultIterator> = match seed {
+            Some(row) => Box::new(SeedRowIterator::new(row)),
+            None => Box::new(EmptyIterator),
+        };
+
+        for step in &self.steps {
+            iter = match step {
+                OptionalPhysicalStep::Scan { label } => {
+                    // Source step (standalone form): replaces the seed input.
+                    Box::new(NodeScanIterator::new(
+                        label.clone(),
+                        Arc::clone(&self.current),
+                    ))
+                }
+                OptionalPhysicalStep::Traverse {
+                    direction,
+                    label,
+                    depth,
+                    temporal_context,
+                } => Box::new(TraversalIterator::new(
+                    iter,
+                    *direction,
+                    label.clone(),
+                    *depth,
+                    Arc::clone(&self.current),
+                    Arc::clone(&self.historical),
+                    *temporal_context,
+                )),
+                OptionalPhysicalStep::Filter(predicate) => {
+                    Box::new(FilterIterator::new(iter, predicate.clone()))
+                }
+            };
+        }
+
+        iter
+    }
+}
+
+impl ResultIterator for OptionalApplyIterator {
+    fn next(&mut self) -> Option<Result<QueryRow>> {
+        loop {
+            // Drain the current sub-pipeline, if any.
+            if let Some(inner) = self.inner.as_mut() {
+                match inner.next() {
+                    Some(Ok(row)) => {
+                        self.inner_matched = true;
+                        return Some(Ok(row));
+                    }
+                    Some(Err(e)) => return Some(Err(e)),
+                    None => {
+                        let unmatched = !self.inner_matched;
+                        self.inner = None;
+                        if unmatched {
+                            // Left-outer semantics: preserve the input row
+                            // with a null binding.
+                            return Some(Ok(QueryRow::from_entity(EntityResult::Null)));
+                        }
+                        continue;
+                    }
+                }
+            }
+
+            if self.done {
+                return None;
+            }
+
+            if self.standalone {
+                // Leading OPTIONAL MATCH: run the scan pipeline exactly once.
+                self.inner = Some(self.build_pipeline(None));
+                self.inner_matched = false;
+                self.done = true;
+                continue;
+            }
+
+            // Pull the next seed row from the input.
+            match self.input.next() {
+                Some(Ok(seed)) => {
+                    self.inner = Some(self.build_pipeline(Some(seed)));
+                    self.inner_matched = false;
+                }
+                Some(Err(e)) => return Some(Err(e)),
+                None => {
+                    self.done = true;
+                    return None;
+                }
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // At least one row per remaining input row (matched rows may add
+        // more, so no useful upper bound).
+        let (lower, _) = self.input.size_hint();
+        (lower, None)
     }
 }
 

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -338,6 +338,16 @@ impl QueryExecutor {
                 )))
             }
 
+            PhysicalOp::OptionalApply { input, steps } => {
+                let input_iter = self.execute_op(input)?;
+                Ok(Box::new(iterators::OptionalApplyIterator::new(
+                    input_iter,
+                    steps.clone(),
+                    Arc::clone(&self.current),
+                    Arc::clone(&self.historical),
+                )))
+            }
+
             PhysicalOp::Empty => Ok(Box::new(iterators::EmptyIterator)),
             PhysicalOp::SimilarToNode {
                 source_node,
@@ -1481,6 +1491,140 @@ mod tests {
             }
             _ => panic!("Expected Node or NodeId result"),
         }
+    }
+
+    // ==================== OptionalApply Tests ====================
+
+    #[test]
+    fn test_execute_optional_apply_matched() {
+        use crate::query::planner::physical::OptionalPhysicalStep;
+
+        let (current, historical, alice, bob) = create_test_storage_with_data();
+        let executor = QueryExecutor::new(current, historical);
+
+        // Alice -KNOWS-> Bob exists: the optional traversal matches.
+        let plan = PhysicalPlan {
+            root: PhysicalOp::OptionalApply {
+                input: Box::new(PhysicalOp::NodeLookup {
+                    node_ids: vec![alice],
+                }),
+                steps: vec![OptionalPhysicalStep::Traverse {
+                    direction: crate::query::ir::Direction::Outgoing,
+                    label: Some("KNOWS".to_string()),
+                    depth: 1,
+                    temporal_context: None,
+                }],
+            },
+            estimated_cost: Default::default(),
+            temporal_context: None,
+            parallel: false,
+            include_provenance: false,
+        };
+
+        let results = executor.execute(plan).expect("Execution failed");
+        let rows: Vec<_> = results.collect_all().expect("Collection failed");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].entity.node_id(), Some(bob));
+    }
+
+    #[test]
+    fn test_execute_optional_apply_unmatched_yields_null_row() {
+        use crate::query::planner::physical::OptionalPhysicalStep;
+
+        let (current, historical, alice, _bob) = create_test_storage_with_data();
+        let executor = QueryExecutor::new(current, historical);
+
+        // No FOLLOWS edges exist: left-outer semantics require one null row
+        // per input row, not zero rows.
+        let plan = PhysicalPlan {
+            root: PhysicalOp::OptionalApply {
+                input: Box::new(PhysicalOp::NodeLookup {
+                    node_ids: vec![alice],
+                }),
+                steps: vec![OptionalPhysicalStep::Traverse {
+                    direction: crate::query::ir::Direction::Outgoing,
+                    label: Some("FOLLOWS".to_string()),
+                    depth: 1,
+                    temporal_context: None,
+                }],
+            },
+            estimated_cost: Default::default(),
+            temporal_context: None,
+            parallel: false,
+            include_provenance: false,
+        };
+
+        let results = executor.execute(plan).expect("Execution failed");
+        let rows: Vec<_> = results.collect_all().expect("Collection failed");
+
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].entity.is_null());
+    }
+
+    #[test]
+    fn test_execute_optional_apply_filter_scoped_inside() {
+        use crate::query::planner::physical::OptionalPhysicalStep;
+
+        let (current, historical, alice, _bob) = create_test_storage_with_data();
+        let executor = QueryExecutor::new(current, historical);
+
+        // The traversal matches Bob, but the filter inside the optional
+        // segment eliminates him: the row survives as null.
+        let plan = PhysicalPlan {
+            root: PhysicalOp::OptionalApply {
+                input: Box::new(PhysicalOp::NodeLookup {
+                    node_ids: vec![alice],
+                }),
+                steps: vec![
+                    OptionalPhysicalStep::Traverse {
+                        direction: crate::query::ir::Direction::Outgoing,
+                        label: Some("KNOWS".to_string()),
+                        depth: 1,
+                        temporal_context: None,
+                    },
+                    OptionalPhysicalStep::Filter(crate::query::Predicate::eq("name", "Zed")),
+                ],
+            },
+            estimated_cost: Default::default(),
+            temporal_context: None,
+            parallel: false,
+            include_provenance: false,
+        };
+
+        let results = executor.execute(plan).expect("Execution failed");
+        let rows: Vec<_> = results.collect_all().expect("Collection failed");
+
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].entity.is_null());
+    }
+
+    #[test]
+    fn test_execute_optional_apply_standalone_scan() {
+        use crate::query::planner::physical::OptionalPhysicalStep;
+
+        let (current, historical) = create_test_storage();
+        let executor = QueryExecutor::new(current, historical);
+
+        // Standalone (leading OPTIONAL MATCH) over an empty store: one null row.
+        let plan = PhysicalPlan {
+            root: PhysicalOp::OptionalApply {
+                input: Box::new(PhysicalOp::Empty),
+                steps: vec![OptionalPhysicalStep::Scan {
+                    label: Some("Person".to_string()),
+                }],
+            },
+            estimated_cost: Default::default(),
+            temporal_context: None,
+            parallel: false,
+            include_provenance: false,
+        };
+
+        let results = executor.execute(plan).expect("Execution failed");
+        let rows: Vec<_> = results.collect_all().expect("Collection failed");
+
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].entity.is_null());
     }
 
     #[test]

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -76,18 +76,31 @@ pub enum EntityResult {
     NodeId(NodeId),
     /// Just an edge ID
     EdgeId(EdgeId),
+    /// A null binding produced by an unmatched `OPTIONAL MATCH` pattern.
+    ///
+    /// Preserves the row (openCypher left-outer semantics) while carrying no
+    /// entity. Predicates evaluated against a null row are not-true except
+    /// `IS NULL`-style checks.
+    Null,
 }
 
 impl EntityResult {
-    /// Get the entity ID
+    /// Get the entity ID, or `None` for a null binding.
     #[must_use]
-    pub fn id(&self) -> EntityId {
+    pub fn id(&self) -> Option<EntityId> {
         match self {
-            EntityResult::Node(n) => EntityId::Node(n.id),
-            EntityResult::Edge(e) => EntityId::Edge(e.id),
-            EntityResult::NodeId(id) => EntityId::Node(*id),
-            EntityResult::EdgeId(id) => EntityId::Edge(*id),
+            EntityResult::Node(n) => Some(EntityId::Node(n.id)),
+            EntityResult::Edge(e) => Some(EntityId::Edge(e.id)),
+            EntityResult::NodeId(id) => Some(EntityId::Node(*id)),
+            EntityResult::EdgeId(id) => Some(EntityId::Edge(*id)),
+            EntityResult::Null => None,
         }
+    }
+
+    /// Returns `true` if this is a null binding from an unmatched optional pattern.
+    #[must_use]
+    pub fn is_null(&self) -> bool {
+        matches!(self, EntityResult::Null)
     }
 
     /// Try to get as a Node
@@ -852,8 +865,8 @@ mod tests {
         assert_eq!(result.node_id(), None);
 
         match result.id() {
-            EntityId::Edge(id) => assert_eq!(id, edge.id),
-            EntityId::Node(_) => panic!("Expected Edge"),
+            Some(EntityId::Edge(id)) => assert_eq!(id, edge.id),
+            other => panic!("Expected Edge, got {:?}", other),
         }
     }
 
@@ -867,9 +880,20 @@ mod tests {
         assert_eq!(result.node_id(), None);
 
         match result.id() {
-            EntityId::Edge(id) => assert_eq!(id, edge_id),
-            EntityId::Node(_) => panic!("Expected Edge"),
+            Some(EntityId::Edge(id)) => assert_eq!(id, edge_id),
+            other => panic!("Expected Edge, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_entity_result_null() {
+        let result = EntityResult::Null;
+
+        assert!(result.is_null());
+        assert!(result.as_node().is_none());
+        assert!(result.as_edge().is_none());
+        assert_eq!(result.node_id(), None);
+        assert_eq!(result.id(), None);
     }
 
     #[test]
@@ -918,8 +942,8 @@ mod tests {
         let entity = EntityResult::NodeId(node_id);
 
         match entity.id() {
-            EntityId::Node(id) => assert_eq!(id, node_id),
-            EntityId::Edge(_) => panic!("Expected Node"),
+            Some(EntityId::Node(id)) => assert_eq!(id, node_id),
+            other => panic!("Expected Node, got {:?}", other),
         }
     }
 

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -66,7 +66,12 @@ pub enum EntityId {
 }
 
 /// Query result entity (full node or edge).
+///
+/// Marked `#[non_exhaustive]`: downstream crates must include a wildcard arm
+/// when matching, so future variants (like the [`EntityResult::Null`] binding
+/// added for `OPTIONAL MATCH`) are not semver-breaking.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum EntityResult {
     /// Full node data
     Node(Node),
@@ -86,7 +91,6 @@ pub enum EntityResult {
 
 impl EntityResult {
     /// Get the entity ID, or `None` for a null binding.
-    #[must_use]
     pub fn id(&self) -> Option<EntityId> {
         match self {
             EntityResult::Node(n) => Some(EntityId::Node(n.id)),

--- a/src/query/ir.rs
+++ b/src/query/ir.rs
@@ -127,6 +127,27 @@ pub enum QueryOp {
         time_range: TimeRange,
     },
 
+    /// Left-outer application of an optional sub-pattern (Cypher `OPTIONAL MATCH`).
+    ///
+    /// For each input row, the sub-pipeline in `ops` is executed seeded from
+    /// that row. If it produces at least one row, those rows are emitted;
+    /// otherwise a single null-bound row is emitted so the input row is
+    /// preserved (openCypher left-outer semantics).
+    ///
+    /// Allowed sub-operations are `TraverseOut`/`TraverseIn`/`TraverseBoth`
+    /// and `Filter`. When `Optional` is the *first* operation of a query
+    /// (a leading `OPTIONAL MATCH`), the sub-pipeline must instead begin with
+    /// a `ScanNodes` source; if the whole scan pipeline yields nothing, one
+    /// null row is emitted.
+    ///
+    /// Filters inside `ops` (inline pattern properties and the clause's
+    /// `WHERE`) participate in the matched/unmatched decision -- they run
+    /// *before* the null-row fallback, not after it.
+    Optional {
+        /// Sub-pipeline executed per input row (or once, for the leading form).
+        ops: Vec<QueryOp>,
+    },
+
     // === Filter Operations ===
     /// Filter by property predicate
     Filter(Predicate),

--- a/src/query/plan.rs
+++ b/src/query/plan.rs
@@ -286,6 +286,48 @@ pub enum UnaryOp {
 
     /// Count results (aggregate)
     Count,
+
+    /// Left-outer application of an optional sub-pattern (`OPTIONAL MATCH`).
+    ///
+    /// For each input row, the `steps` sub-pipeline runs seeded from that row;
+    /// if it produces nothing, a single null-bound row is emitted instead, so
+    /// the input row is never lost. When the first step is
+    /// [`OptionalStep::Scan`] the operator is *standalone* (a leading
+    /// `OPTIONAL MATCH`): the sub-pipeline runs once from its own scan and
+    /// the input (typically [`LogicalOp::Empty`]) is ignored.
+    ///
+    /// The steps are deliberately opaque to optimization rules: filters
+    /// inside the optional segment participate in the matched/unmatched
+    /// decision and must not be reordered across this boundary.
+    OptionalApply {
+        /// The optional sub-pipeline, applied per input row.
+        steps: Vec<OptionalStep>,
+    },
+}
+
+/// A single step inside an [`UnaryOp::OptionalApply`] sub-pipeline.
+#[derive(Debug, Clone, PartialEq)]
+pub enum OptionalStep {
+    /// Scan source for a standalone (first-clause) `OPTIONAL MATCH`.
+    /// Only valid as the first step.
+    Scan {
+        /// Optional node label filter.
+        label: Option<String>,
+    },
+
+    /// A traversal hop inside the optional pattern.
+    Traverse {
+        /// Traversal direction.
+        direction: Direction,
+        /// Optional edge label filter.
+        label: Option<String>,
+        /// Depth specification.
+        depth: TraversalDepth,
+    },
+
+    /// A predicate filter inside the optional pattern (inline pattern
+    /// properties or the clause's `WHERE`).
+    Filter(Predicate),
 }
 
 /// Binary operations that combine two inputs.

--- a/src/query/planner/cost.rs
+++ b/src/query/planner/cost.rs
@@ -911,4 +911,69 @@ mod tests {
         assert_eq!(node_cost.io, edge_cost.io);
         assert_eq!(node_cost.memory, edge_cost.memory);
     }
+
+    // ==================== OptionalApply Cost Tests ====================
+
+    #[test]
+    fn test_optional_apply_cost_adds_to_input() {
+        let model = CostModel::default();
+        let stats = test_stats();
+
+        let input = PhysicalOp::NodeLookup {
+            node_ids: vec![NodeId::new(1).unwrap(), NodeId::new(2).unwrap()],
+        };
+        let input_cost = model.estimate(&input, &stats);
+
+        let op = PhysicalOp::OptionalApply {
+            input: Box::new(input),
+            steps: vec![],
+        };
+        let cost = model.estimate(&op, &stats);
+
+        // The per-row optional sub-pipeline (approximated as a single-hop
+        // traversal) adds CPU cost on top of the input.
+        assert!(
+            cost.cpu > input_cost.cpu,
+            "OptionalApply must cost more than its input: {} vs {}",
+            cost.cpu,
+            input_cost.cpu
+        );
+    }
+
+    #[test]
+    fn test_optional_apply_cost_empty_input_clamps_cardinality() {
+        let model = CostModel::default();
+        let stats = test_stats();
+
+        // Empty input has cardinality 0; the estimate clamps to 1 row so the
+        // standalone (leading OPTIONAL MATCH) sub-pipeline cost never vanishes.
+        let op = PhysicalOp::OptionalApply {
+            input: Box::new(PhysicalOp::Empty),
+            steps: vec![],
+        };
+        let cost = model.estimate(&op, &stats);
+        assert!(cost.cpu > 0.0, "standalone OptionalApply must have cost");
+    }
+
+    #[test]
+    fn test_optional_apply_cardinality_left_outer_floor() {
+        let model = CostModel::default();
+        let stats = test_stats();
+
+        // Left-outer semantics: at least one output row per input row.
+        let op = PhysicalOp::OptionalApply {
+            input: Box::new(PhysicalOp::NodeLookup {
+                node_ids: vec![NodeId::new(1).unwrap(), NodeId::new(2).unwrap()],
+            }),
+            steps: vec![],
+        };
+        assert_eq!(model.estimate_cardinality(&op, &stats), 2);
+
+        // Even an empty input yields one (null) row in the standalone form.
+        let standalone = PhysicalOp::OptionalApply {
+            input: Box::new(PhysicalOp::Empty),
+            steps: vec![],
+        };
+        assert_eq!(model.estimate_cardinality(&standalone, &stats), 1);
+    }
 }

--- a/src/query/planner/cost.rs
+++ b/src/query/planner/cost.rs
@@ -472,6 +472,15 @@ impl CostModel {
                 lookup_cost + search_cost
             }
 
+            PhysicalOp::OptionalApply { input, .. } => {
+                // Per input row, a small sub-pipeline (traversal + filters)
+                // runs; approximate with a single-hop traversal over the
+                // input cardinality on top of the input cost.
+                let input_cost = self.estimate(input, stats);
+                let input_card = self.estimate_cardinality(input, stats);
+                self.estimate_traversal(input_cost, input_card.max(1), 1, stats)
+            }
+
             PhysicalOp::Empty => Cost::zero(),
         }
     }
@@ -543,6 +552,10 @@ impl CostModel {
                 self.estimate_cardinality(input, stats)
             }
             PhysicalOp::SimilarToNode { k, .. } => *k,
+            PhysicalOp::OptionalApply { input, .. } => {
+                // Left-outer semantics: at least one output row per input row.
+                self.estimate_cardinality(input, stats).max(1)
+            }
             PhysicalOp::Empty => 0,
         }
     }

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -1967,4 +1967,282 @@ mod tests {
             explain
         );
     }
+
+    // ==================== OPTIONAL MATCH (OptionalApply) Tests ====================
+
+    /// A non-leading `QueryOp::Optional` plans to a `PhysicalOp::OptionalApply`
+    /// whose steps mirror the traverse + filter sub-ops (per-row apply form).
+    #[test]
+    fn test_optional_apply_planning_after_scan() {
+        let planner = test_planner();
+        let query = Query {
+            ops: vec![
+                QueryOp::ScanNodes {
+                    label: Some("Person".to_string()),
+                },
+                QueryOp::Optional {
+                    ops: vec![
+                        QueryOp::TraverseOut {
+                            label: Some("KNOWS".to_string()),
+                            depth: TraversalDepth::Exact(1),
+                        },
+                        QueryOp::Filter(Predicate::eq("name", "Alice")),
+                    ],
+                },
+            ],
+            temporal_context: None,
+            hints: QueryHints::default(),
+        };
+
+        let plan = planner.plan(query).unwrap();
+        match &plan.root {
+            PhysicalOp::OptionalApply { input, steps } => {
+                assert!(matches!(**input, PhysicalOp::NodeScan { .. }));
+                assert_eq!(steps.len(), 2);
+                match &steps[0] {
+                    physical::OptionalPhysicalStep::Traverse {
+                        direction,
+                        label,
+                        depth,
+                        temporal_context,
+                    } => {
+                        assert_eq!(*direction, Direction::Outgoing);
+                        assert_eq!(label.as_deref(), Some("KNOWS"));
+                        assert_eq!(*depth, 1);
+                        assert!(temporal_context.is_none());
+                    }
+                    other => panic!("expected Traverse step, got {other:?}"),
+                }
+                assert!(matches!(
+                    steps[1],
+                    physical::OptionalPhysicalStep::Filter(_)
+                ));
+            }
+            other => panic!("expected OptionalApply root, got {other:?}"),
+        }
+    }
+
+    /// TraverseIn / TraverseBoth inside an optional map to Incoming / Both,
+    /// and unbounded `Variable` depth falls back to the planner default.
+    #[test]
+    fn test_optional_apply_traverse_directions_and_default_depth() {
+        let planner = test_planner();
+        let query = Query {
+            ops: vec![
+                QueryOp::ScanNodes { label: None },
+                QueryOp::Optional {
+                    ops: vec![
+                        QueryOp::TraverseIn {
+                            label: None,
+                            depth: TraversalDepth::Exact(2),
+                        },
+                        QueryOp::TraverseBoth {
+                            label: None,
+                            depth: TraversalDepth::Variable,
+                        },
+                    ],
+                },
+            ],
+            temporal_context: None,
+            hints: QueryHints::default(),
+        };
+
+        let plan = planner.plan(query).unwrap();
+        match &plan.root {
+            PhysicalOp::OptionalApply { steps, .. } => {
+                match &steps[0] {
+                    physical::OptionalPhysicalStep::Traverse {
+                        direction, depth, ..
+                    } => {
+                        assert_eq!(*direction, Direction::Incoming);
+                        assert_eq!(*depth, 2);
+                    }
+                    other => panic!("expected Traverse step, got {other:?}"),
+                }
+                match &steps[1] {
+                    physical::OptionalPhysicalStep::Traverse {
+                        direction, depth, ..
+                    } => {
+                        assert_eq!(*direction, Direction::Both);
+                        assert_eq!(*depth, DEFAULT_MAX_TRAVERSAL_DEPTH);
+                    }
+                    other => panic!("expected Traverse step, got {other:?}"),
+                }
+            }
+            other => panic!("expected OptionalApply root, got {other:?}"),
+        }
+    }
+
+    /// A leading `Optional` (source position) plans to OptionalApply over an
+    /// Empty input with a Scan first step (standalone form).
+    #[test]
+    fn test_leading_optional_match_planning() {
+        let planner = test_planner();
+        let query = Query {
+            ops: vec![QueryOp::Optional {
+                ops: vec![
+                    QueryOp::ScanNodes {
+                        label: Some("Person".to_string()),
+                    },
+                    QueryOp::TraverseOut {
+                        label: Some("KNOWS".to_string()),
+                        depth: TraversalDepth::Exact(1),
+                    },
+                ],
+            }],
+            temporal_context: None,
+            hints: QueryHints::default(),
+        };
+
+        let plan = planner.plan(query).unwrap();
+        match &plan.root {
+            PhysicalOp::OptionalApply { input, steps } => {
+                assert!(matches!(**input, PhysicalOp::Empty));
+                assert_eq!(steps.len(), 2);
+                match &steps[0] {
+                    physical::OptionalPhysicalStep::Scan { label } => {
+                        assert_eq!(label.as_deref(), Some("Person"));
+                    }
+                    other => panic!("expected Scan step, got {other:?}"),
+                }
+            }
+            other => panic!("expected OptionalApply root, got {other:?}"),
+        }
+    }
+
+    /// Sub-ops other than scan/traverse/filter are rejected inside an
+    /// optional pattern.
+    #[test]
+    fn test_optional_unsupported_op_rejected() {
+        let planner = test_planner();
+        let query = Query {
+            ops: vec![
+                QueryOp::ScanNodes { label: None },
+                QueryOp::Optional {
+                    ops: vec![QueryOp::Limit(10)],
+                },
+            ],
+            temporal_context: None,
+            hints: QueryHints::default(),
+        };
+
+        let err = planner.plan(query).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("unsupported operation inside OPTIONAL MATCH"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// A leading OPTIONAL MATCH whose first sub-op is not a node scan is
+    /// rejected.
+    #[test]
+    fn test_leading_optional_without_scan_rejected() {
+        let planner = test_planner();
+        let query = Query {
+            ops: vec![QueryOp::Optional {
+                ops: vec![QueryOp::TraverseOut {
+                    label: None,
+                    depth: TraversalDepth::Exact(1),
+                }],
+            }],
+            temporal_context: None,
+            hints: QueryHints::default(),
+        };
+
+        let err = planner.plan(query).unwrap_err();
+        assert!(
+            err.to_string().contains("must begin with a node scan"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// A scan is only allowed as the *first* step of a *leading* optional:
+    /// in apply position (after a source), it is rejected.
+    #[test]
+    fn test_optional_scan_rejected_in_apply_position() {
+        let planner = test_planner();
+        let query = Query {
+            ops: vec![
+                QueryOp::ScanNodes { label: None },
+                QueryOp::Optional {
+                    ops: vec![QueryOp::ScanNodes {
+                        label: Some("Person".to_string()),
+                    }],
+                },
+            ],
+            temporal_context: None,
+            hints: QueryHints::default(),
+        };
+
+        let err = planner.plan(query).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("unsupported operation inside OPTIONAL MATCH"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// Even in a leading optional, a scan after the first step is rejected
+    /// (the `i == 0` guard).
+    #[test]
+    fn test_leading_optional_second_scan_rejected() {
+        let planner = test_planner();
+        let query = Query {
+            ops: vec![QueryOp::Optional {
+                ops: vec![
+                    QueryOp::ScanNodes {
+                        label: Some("Person".to_string()),
+                    },
+                    QueryOp::ScanNodes {
+                        label: Some("Place".to_string()),
+                    },
+                ],
+            }],
+            temporal_context: None,
+            hints: QueryHints::default(),
+        };
+
+        let err = planner.plan(query).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("unsupported operation inside OPTIONAL MATCH"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// The query's AS OF temporal context propagates into optional traverse
+    /// steps, mirroring `UnaryOp::Traverse`.
+    #[test]
+    fn test_optional_traverse_inherits_temporal_context() {
+        let planner = test_planner();
+        let query = Query {
+            ops: vec![
+                QueryOp::ScanNodes { label: None },
+                QueryOp::Optional {
+                    ops: vec![QueryOp::TraverseOut {
+                        label: None,
+                        depth: TraversalDepth::Exact(1),
+                    }],
+                },
+            ],
+            temporal_context: Some(TemporalContext::as_of(1000.into(), 2000.into())),
+            hints: QueryHints::default(),
+        };
+
+        let plan = planner.plan(query).unwrap();
+        match &plan.root {
+            PhysicalOp::OptionalApply { steps, .. } => match &steps[0] {
+                physical::OptionalPhysicalStep::Traverse {
+                    temporal_context, ..
+                } => {
+                    let (valid, tx) = temporal_context.expect("temporal context must propagate");
+                    assert_eq!(valid, 1000.into());
+                    assert_eq!(tx, 2000.into());
+                }
+                other => panic!("expected Traverse step, got {other:?}"),
+            },
+            other => panic!("expected OptionalApply root, got {other:?}"),
+        }
+    }
 }

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -67,7 +67,7 @@ use crate::storage::CurrentStorage;
 
 use super::builder::Query;
 use super::ir::QueryOp;
-use super::plan::{LogicalOp, LogicalPlan, ScanOp, TemporalContext, UnaryOp};
+use super::plan::{LogicalOp, LogicalPlan, OptionalStep, ScanOp, TemporalContext, UnaryOp};
 
 pub use cost::{Cost, CostModel};
 pub use physical::{PhysicalOp, PhysicalPlan};
@@ -265,6 +265,15 @@ impl QueryPlanner {
 
     /// Apply a QueryOp to the current logical plan
     fn apply_query_op(&self, current: Option<LogicalOp>, op: &QueryOp) -> Result<LogicalOp> {
+        // Optional (OPTIONAL MATCH) can appear both in source position (as a
+        // leading clause with its own scan) and as a per-row apply operator.
+        if let QueryOp::Optional { ops } = op {
+            let source_position = current.is_none();
+            let steps = self.convert_optional_steps(ops, source_position)?;
+            let input = current.unwrap_or(LogicalOp::Empty);
+            return Ok(LogicalOp::unary(UnaryOp::OptionalApply { steps }, input));
+        }
+
         // Check if it is a source operation (starts a new pipeline)
         if let Some(source_op) = self.apply_source_op(op)? {
             return Ok(source_op);
@@ -274,6 +283,55 @@ impl QueryPlanner {
         let input = current.ok_or_else(|| self.missing_source_error(op))?;
 
         self.apply_unary_op(input, op)
+    }
+
+    /// Convert the sub-operations of a [`QueryOp::Optional`] into
+    /// [`OptionalStep`]s for the logical plan.
+    ///
+    /// In source position (a leading `OPTIONAL MATCH`) the first sub-op must
+    /// be a `ScanNodes` source; otherwise only traversals and filters are
+    /// allowed.
+    fn convert_optional_steps(
+        &self,
+        ops: &[QueryOp],
+        source_position: bool,
+    ) -> Result<Vec<OptionalStep>> {
+        let mut steps = Vec::with_capacity(ops.len());
+        for (i, op) in ops.iter().enumerate() {
+            let step = match op {
+                QueryOp::ScanNodes { label } if source_position && i == 0 => OptionalStep::Scan {
+                    label: label.clone(),
+                },
+                QueryOp::TraverseOut { label, depth } => OptionalStep::Traverse {
+                    direction: super::ir::Direction::Outgoing,
+                    label: label.clone(),
+                    depth: *depth,
+                },
+                QueryOp::TraverseIn { label, depth } => OptionalStep::Traverse {
+                    direction: super::ir::Direction::Incoming,
+                    label: label.clone(),
+                    depth: *depth,
+                },
+                QueryOp::TraverseBoth { label, depth } => OptionalStep::Traverse {
+                    direction: super::ir::Direction::Both,
+                    label: label.clone(),
+                    depth: *depth,
+                },
+                QueryOp::Filter(predicate) => OptionalStep::Filter(predicate.clone()),
+                other => {
+                    return Err(Error::Query(QueryError::SyntaxError {
+                        message: format!("unsupported operation inside OPTIONAL MATCH: {other:?}"),
+                    }));
+                }
+            };
+            steps.push(step);
+        }
+        if source_position && !matches!(steps.first(), Some(OptionalStep::Scan { .. })) {
+            return Err(Error::Query(QueryError::SyntaxError {
+                message: "a leading OPTIONAL MATCH must begin with a node scan".to_string(),
+            }));
+        }
+        Ok(steps)
     }
 
     /// Try to apply a source operation. Returns Ok(Some(op)) if successful,
@@ -749,6 +807,37 @@ impl QueryPlanner {
                 input: Box::new(input),
                 time_range: *time_range,
             }),
+
+            UnaryOp::OptionalApply { steps } => {
+                // Mirror UnaryOp::Traverse: extract the temporal context for
+                // edge filtering inside optional traversal steps.
+                let temporal_ctx = temporal.as_ref().and_then(|ctx| ctx.as_of_tuple());
+                let physical_steps = steps
+                    .iter()
+                    .map(|step| match step {
+                        OptionalStep::Scan { label } => physical::OptionalPhysicalStep::Scan {
+                            label: label.clone(),
+                        },
+                        OptionalStep::Traverse {
+                            direction,
+                            label,
+                            depth,
+                        } => physical::OptionalPhysicalStep::Traverse {
+                            direction: *direction,
+                            label: label.clone(),
+                            depth: depth.max_depth().unwrap_or(DEFAULT_MAX_TRAVERSAL_DEPTH),
+                            temporal_context: temporal_ctx,
+                        },
+                        OptionalStep::Filter(predicate) => {
+                            physical::OptionalPhysicalStep::Filter(predicate.clone())
+                        }
+                    })
+                    .collect();
+                Ok(PhysicalOp::OptionalApply {
+                    input: Box::new(input),
+                    steps: physical_steps,
+                })
+            }
         }
     }
 

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -295,7 +295,8 @@ impl PhysicalPlan {
             | PhysicalOp::Count { input, .. }
             | PhysicalOp::Materialize { input, .. }
             | PhysicalOp::TemporalTrack { input, .. }
-            | PhysicalOp::IndexedTraversal { input, .. } => {
+            | PhysicalOp::IndexedTraversal { input, .. }
+            | PhysicalOp::OptionalApply { input, .. } => {
                 self.explain_op(input, output, indent + 1, "└─ ");
             }
 
@@ -574,8 +575,50 @@ pub enum PhysicalOp {
         input: Box<PhysicalOp>,
     },
 
+    /// Left-outer application of an optional sub-pattern (`OPTIONAL MATCH`).
+    ///
+    /// For each input row the `steps` sub-pipeline is executed seeded from
+    /// that row; if it yields nothing, one null-bound row is emitted so the
+    /// input row is preserved. When the first step is
+    /// [`OptionalPhysicalStep::Scan`] the operator is standalone (leading
+    /// `OPTIONAL MATCH`): the sub-pipeline runs once from its own scan and
+    /// `input` (typically [`PhysicalOp::Empty`]) is ignored.
+    OptionalApply {
+        /// Input operator providing seed rows.
+        input: Box<PhysicalOp>,
+        /// The optional sub-pipeline, applied per seed row.
+        steps: Vec<OptionalPhysicalStep>,
+    },
+
     /// Empty result set
     Empty,
+}
+
+/// A single step inside a [`PhysicalOp::OptionalApply`] sub-pipeline.
+#[derive(Debug, Clone)]
+pub enum OptionalPhysicalStep {
+    /// Scan source for a standalone (first-clause) `OPTIONAL MATCH`.
+    /// Only valid as the first step.
+    Scan {
+        /// Optional node label filter.
+        label: Option<String>,
+    },
+
+    /// A traversal hop inside the optional pattern.
+    Traverse {
+        /// Traversal direction.
+        direction: Direction,
+        /// Optional edge label filter.
+        label: Option<String>,
+        /// Maximum depth.
+        depth: usize,
+        /// Optional temporal context (valid_time, transaction_time) for edge
+        /// filtering, mirroring [`PhysicalOp::IndexedTraversal`].
+        temporal_context: Option<(Timestamp, Timestamp)>,
+    },
+
+    /// A predicate filter inside the optional pattern.
+    Filter(Predicate),
 }
 
 impl PhysicalOp {
@@ -605,6 +648,7 @@ impl PhysicalOp {
             PhysicalOp::Count { .. } => "Count",
             PhysicalOp::TemporalTrack { .. } => "TemporalTrack",
             PhysicalOp::Materialize { .. } => "Materialize",
+            PhysicalOp::OptionalApply { .. } => "OptionalApply",
             PhysicalOp::Empty => "Empty",
         }
     }
@@ -649,7 +693,8 @@ impl PhysicalOp {
             | PhysicalOp::Distinct { input, .. }
             | PhysicalOp::Count { input, .. }
             | PhysicalOp::TemporalTrack { input, .. }
-            | PhysicalOp::Materialize { input, .. } => 1 + input.depth(),
+            | PhysicalOp::Materialize { input, .. }
+            | PhysicalOp::OptionalApply { input, .. } => 1 + input.depth(),
 
             PhysicalOp::HashJoin { left, right, .. }
             | PhysicalOp::Union { left, right }
@@ -832,7 +877,8 @@ impl PhysicalOp {
             | PhysicalOp::Distinct { input, .. }
             | PhysicalOp::Count { input, .. }
             | PhysicalOp::TemporalTrack { input, .. }
-            | PhysicalOp::Materialize { input, .. } => Some(input),
+            | PhysicalOp::Materialize { input, .. }
+            | PhysicalOp::OptionalApply { input, .. } => Some(input),
             _ => None,
         }
     }

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -2088,4 +2088,53 @@ mod tests {
         };
         assert!(op.get_input().is_none());
     }
+
+    // ==================== OptionalApply Coverage Tests ====================
+
+    fn optional_apply_op() -> PhysicalOp {
+        PhysicalOp::OptionalApply {
+            input: Box::new(PhysicalOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: 100,
+            }),
+            steps: vec![OptionalPhysicalStep::Traverse {
+                direction: Direction::Outgoing,
+                label: Some("KNOWS".to_string()),
+                depth: 1,
+                temporal_context: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn test_optional_apply_op_metadata() {
+        let op = optional_apply_op();
+        assert_eq!(op.name(), "OptionalApply");
+        assert!(!op.is_leaf());
+        // Unary operator: one level above its NodeScan input.
+        assert_eq!(op.depth(), 2);
+        assert!(matches!(op.get_input(), Some(PhysicalOp::NodeScan { .. })));
+    }
+
+    #[test]
+    fn test_optional_apply_op_explain_recurses_into_input() {
+        let explain = optional_apply_op().explain();
+        assert!(explain.contains("OptionalApply"), "{explain}");
+        assert!(explain.contains("NodeScan"), "{explain}");
+    }
+
+    #[test]
+    fn test_physical_plan_explain_optional_apply() {
+        let plan = PhysicalPlan {
+            root: optional_apply_op(),
+            estimated_cost: Cost::default(),
+            temporal_context: None,
+            parallel: false,
+            include_provenance: false,
+        };
+        let explain = plan.explain();
+        assert!(explain.contains("OptionalApply"), "{explain}");
+        // The plan-level explain must recurse into OptionalApply's input.
+        assert!(explain.contains("NodeScan"), "{explain}");
+    }
 }


### PR DESCRIPTION
Closes #557

## Before / After

**Before:** the lexer, parser, and AST recognized `OPTIONAL MATCH`, but the converter silently discarded the flag — an `OPTIONAL MATCH` executed exactly like an inner `MATCH`. A query like `MATCH (a {name:'Dave'}) OPTIONAL MATCH (a)-[:KNOWS]->(x) RETURN x` returned **0 rows** when Dave knows nobody, where openCypher requires **1 row with `x = null`**. There was also no way to write `MATCH … OPTIONAL MATCH …` at all — the parser rejected a second clause.

**After:** `OPTIONAL MATCH` is a real left-outer match:

- Unmatched optional patterns preserve the base row and bind null (`EntityResult::Null` internally, JSON `null` through the MCP `query` tool, `{"null": true}` through the HTTP row converter, `kind: "null"` / `entity: None` through the Python bindings). The unmatched fallback row keeps the seed row's metadata (score, path, timestamp) — only the entity is replaced by null.
- Matched optional patterns return the expected entities, including fan-out (one seed with several matches yields one row per match).
- The clause's `WHERE` and inline pattern properties are scoped **inside** the optional segment: they participate in the matched/unmatched decision (eliminating all matches yields a null row, never a dropped row). `$param` references inside the optional clause's `WHERE` resolve normally.
- Multiple `OPTIONAL MATCH` clauses work in one query, including chained ones (`OPTIONAL MATCH (a)-->(m) OPTIONAL MATCH (m)-->(x)`); a null seed propagates as another null row.
- `OPTIONAL MATCH` interleaves correctly with `WITH … WHERE` in source order: a `WITH … WHERE` before the optional filters base rows; after it, it filters optional results with null semantics (comparisons against null are not-true; `x IS NULL` keeps null rows, `x IS NOT NULL` drops them; connectives compose, e.g. `x IS NULL OR x.age > 100`).
- A **leading** `OPTIONAL MATCH` (first clause) returns one row of nulls when its pattern has no matches, per openCypher.
- **Rejected rather than answered wrongly** (no variable-binding analysis exists in the converter yet — all three constructs silently produced wrong rows before):
  - comma-separated patterns in one `OPTIONAL MATCH` clause (`OPTIONAL MATCH (a)-->(x), (a)-->(y)`) — the second pattern chained positionally off the first's result;
  - a **labeled** first node in a subsequent `OPTIONAL MATCH` (`MATCH (a:Person) OPTIONAL MATCH (b:City) RETURN b` used to silently return `a`). The first node is bound positionally to the current row and must be an unlabeled bound variable (e.g. `(a)`); its inline properties remain supported because they lower cheaply and correctly to seed-row filters;
  - a first-node variable that **re-anchors** on something other than the positionally-current binding (`MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) OPTIONAL MATCH (a)-[:OWNS]->(y)` used to silently bind the second `(a)` to `x` — or null — and traverse `OWNS` from the wrong node). The converter now tracks the current binding across clauses (the last node of the previous MATCH/OPTIONAL MATCH pattern, updated by a single-variable `WITH` projection); the first node of a subsequent `OPTIONAL MATCH` must be unnamed (`()`) or name that binding. All three return `CypherError::UnsupportedFeature` (surfaced as `unsupported_construct` through the MCP query tool).
- The Cypher parser now rejects inverted variable-length ranges (`*3..1`) with a `ParseError`, matching the AQL parser's `min <= max` validation.

## Breaking change

`EntityResult` (pub enum, `src/query/executor/results.rs`) gained the `Null` variant, and `EntityResult::id()` changed from `EntityId` to `Option` (`None` for a null binding). Downstream code that matches on `EntityResult` or calls `.id()` must be updated. To prevent this class of break from recurring, `EntityResult` is now `#[non_exhaustive]`: downstream crates must include a wildcard arm, so future variants are additive. The in-repo Python bindings (`python/src/query.rs`) were updated accordingly (explicit `Null` arm mapping to `kind: "null"` / `entity: None`, plus a wildcard arm mapping unknown variants to `kind: "unknown"`).

## How

The whole pipeline is threaded end-to-end:

| Layer | Change |
|---|---|
| AST (`cypher/ast.rs`) | new `CypherOptionalMatch { pattern, where_clause, preceding_withs }` + `optional_matches` field on `Match`; `preceding_withs` preserves source ordering vs. `WITH` clauses |
| Parser (`cypher/parser.rs`) | grammar extended to `(with_clause \| optional_match_clause)*` between the base MATCH and RETURN; `parse_depth` validates `min <= max` for `*N..M` |
| Converter (`cypher/converter.rs`) | each optional clause becomes one `QueryOp::Optional { ops }` whose sub-ops are the pattern's traversals + inline-property filters + the clause `WHERE` filter; the first node of a subsequent optional pattern emits **no** scan (it refers to the current row) and must be unlabeled; comma-separated patterns per optional clause are rejected; a leading `OPTIONAL MATCH` wraps its own scan pipeline |
| IR (`query/ir.rs`) | new `QueryOp::Optional { ops: Vec }` |
| Logical plan (`query/plan.rs`, `query/planner/mod.rs`) | new `UnaryOp::OptionalApply { steps: Vec }` (`Scan`/`Traverse`/`Filter`); in source position the first step must be a scan |
| Physical plan (`query/planner/physical.rs`, `cost.rs`) | new `PhysicalOp::OptionalApply { input, steps }` with `OptionalPhysicalStep` (depth resolved, temporal context propagated like `IndexedTraversal`); cost/cardinality arms added (cardinality ≥ input — left-outer never shrinks the row set below its input) |
| Executor (`query/executor/iterators.rs`, `mod.rs`) | new `OptionalApplyIterator`: per input row, builds the sub-pipeline seeded from that row (`SeedRowIterator` → `TraversalIterator`/`FilterIterator` chain); if it yields nothing, emits the seed row with its entity replaced by `EntityResult::Null` (metadata preserved; bare null row in the standalone form); a sub-pipeline error clears the seed state so no fabricated null row follows the error; standalone form runs the scan pipeline once |
| Results (`query/executor/results.rs`) | new `EntityResult::Null` variant + `is_null()`; `EntityResult::id()` now returns `Option` (`None` for null bindings); enum is `#[non_exhaustive]` (see Breaking change) |
| Null predicate semantics (`FilterIterator`) | null rows are evaluated with dedicated null semantics instead of the old "non-node rows pass through": comparisons/membership/string predicates are not-true, `IS NULL` (→ `Eq {value: Null}`) is true, `IS NOT NULL` is false, `Exists` false / `NotExists` true, And/Or compose |
| Serialization | MCP `query` tool emits `entity: null`; HTTP row converter emits `"null": true`; Python bindings emit `kind: "null"`, `entity: None` |

## Design: approaches considered

**A) Nested optional-apply operator (chosen).** `QueryOp::Optional { ops }` → `UnaryOp::OptionalApply { steps }` → `PhysicalOp::OptionalApply` → `OptionalApplyIterator`. Per input row, the sub-pipeline (traversals + all of the clause's filters) runs seeded from that row; empty result ⇒ one null row. The steps are **opaque to the optimizer** (stored as data, not as plan children), which is what guarantees the openCypher scoping rule: no optimization rule (predicate pushdown, filter reordering, limit pushdown — all audited) can move a filter across the matched/unmatched boundary. Fits the streaming pull-based iterator model with no extra scans.

**B) Optional flag on the traversal op (left-outer traversal).** Smaller surface, but semantically wrong for anything beyond a single bare hop: the unmatched decision must be made after *all* of the optional clause's constraints (multi-hop patterns, inline property filters, clause `WHERE`). A per-hop flag emits partial/null rows before later filters run, silently producing wrong answers (e.g. `OPTIONAL MATCH (a)-[:KNOWS]->(x {name:'Z'})` would null-out or row-kill depending on filter placement). Rejected.

**C) Converter-level rewrite (matched ∪ anti-joined null rows).** Two scans of the base pipeline, needs materialization/anti-join machinery that doesn't exist, doesn't fit the streaming iterator model. Rejected.

### Null semantics documented

- **Row model**: engine rows are single entities (`QueryRow { entity, … }`), not binding maps. A null row means the optional variable is null. `RETURN a` (projecting the *base* variable instead of the pipeline's current entity) is a pre-existing engine-wide projection gap, out of scope here.
- **Predicates over null**: three-valued logic approximated at the "not true" level — any comparison with the null binding is not-true (row filtered); `x IS NULL` is true; `x IS NOT NULL` is false. Known deviation (documented in code): `NOT` is two-valued, mirroring the engine's existing missing-property semantics.
- **Chained optionals**: a null seed traverses to nothing, so the next `OPTIONAL MATCH` re-emits a null row — the row is never dropped.
- **`AS OF` interaction**: optional traversal steps receive the same temporal context as `IndexedTraversal` (edges filtered bi-temporally); label scans remain temporally inert (pre-existing, out of scope) — covered by a test documenting the interaction.
- **Converter design choice (documented in rustdoc)**: no variable-binding analysis exists in the converter; the first node of a subsequent `OPTIONAL MATCH` is bound positionally to the current row. Constructs whose meaning depends on binding analysis (labeled first node, comma-separated patterns per optional clause, a first-node variable re-anchoring on anything other than the positionally-current binding) are **rejected** with a clear error instead of silently returning wrong rows. The converter tracks the positionally-current binding across clauses (last node of each MATCH/OPTIONAL MATCH pattern, single-variable `WITH` projections) purely syntactically — enough to detect and refuse mis-binds, not to support re-anchoring. Labels on non-first pattern nodes are ignored, matching existing `MATCH` behavior.

## Known deviations / follow-ups

- **Two-valued `NOT` over null bindings**: `NOT (x.p = 1)` keeps a null row where openCypher's 3VL `NOT null` would drop it. This mirrors the engine's existing missing-property semantics; a full 3VL evaluator is a follow-up.
- **`RANK BY SIMILARITY` drops null rows**: the left-outer guarantee does not survive a vector rerank — a null binding has no embedding, so reranking after an `OPTIONAL MATCH` discards unmatched rows.
- **`EXPLAIN` does not render the optional sub-pipeline**: `OptionalApply` steps are opaque to the plan renderer; the operator shows as a single node without its inner traversals/filters.
- **Re-anchored `OPTIONAL MATCH` variables are rejected, not supported**: naming any variable other than the positionally-current binding as the first node of a subsequent `OPTIONAL MATCH` (e.g. the second clause of `MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) OPTIONAL MATCH (a)-[:OWNS]->(y)`) returns `UnsupportedFeature` rather than silently binding to `x`/null and traversing from the wrong node. Real re-anchoring support needs variable-binding analysis (rows keyed by variable, re-seeding from an earlier binding) — a candidate follow-up.
- **Pre-existing stack-overflow aborts on pathologically deep expressions** (reproduced on trunk, not a regression from this PR; filed as #3404): ~1000 nested parens/NOTs overflow the recursive-descent parser and ~2000-term `AND` chains overflow the recursive converter — both reachable via the MCP query tool.

## Tests (all new, red-first TDD)

Parser/converter (`src/cypher/tests.rs`):
- `test_parse_optional_match` (fixed — previously didn't parse an OPTIONAL MATCH at all), `test_parse_match_then_optional_match`, `test_parse_multiple_optional_matches`, `test_parse_optional_match_after_with`, `test_parse_optional_match_base_where_and_clause_where`, `test_convert_optional_match_emits_optional_op`, `test_convert_leading_optional_match`
- Review round: `test_convert_optional_match_multiple_patterns_rejected`, `test_convert_optional_match_labeled_first_node_rejected`, `test_parse_depth_range_inverted_rejected` (all red-first)
- AC audit round (re-anchoring, all red-first): `test_convert_optional_match_reanchored_variable_rejected` (including positive controls: chained `(x)` and unnamed `()` first nodes still convert), `test_convert_optional_match_reanchored_after_multi_hop_base_rejected` (same hole for the first optional after a multi-hop base MATCH, plus the unnamed-last-node case), `test_convert_optional_match_after_with_projection_tracks_variable` (`WITH v` updates the binding; stale variables reject)

Execution e2e (`src/cypher/tests.rs`):
- `test_e2e_optional_match_matched`, `..._unmatched_returns_null_row`, `..._mixed_matched_and_unmatched`, `..._multi_hop_unmatched_midway`, `..._inline_property_scoped_inside`, `..._where_eliminates_all`, `..._where_keeps_some`, `test_e2e_two_optional_matches_chained` / `_second_unmatched` / `_both_unmatched`, `..._after_with_where`, `..._null_row_dropped_by_downstream_where`, `..._null_row_kept_by_is_null`, `..._skip_limit`, `test_e2e_leading_optional_match_no_matches_returns_one_null_row` / `_with_matches` / `_where_eliminates_all`, `..._with_as_of_does_not_panic`, `test_e2e_plain_match_unchanged_regression`
- Review round: `test_e2e_optional_match_fan_out_two_matches`, `test_e2e_optional_match_fan_out_with_unmatched_seed`, `test_e2e_optional_match_is_not_null_keeps_only_matched`, `test_e2e_optional_match_null_in_boolean_connective`, `test_e2e_optional_match_where_with_param` (uses `execute_cypher_with_params`)

Executor unit (`src/query/executor/mod.rs`, `iterators.rs`): `test_execute_optional_apply_matched`, `_unmatched_yields_null_row`, `_filter_scoped_inside`, `_standalone_scan`; review round: `test_evaluate_null_all_predicate_arms` (every `Predicate` arm), `test_optional_apply_unmatched_preserves_seed_metadata` (red-first), `test_optional_apply_standalone_unmatched_bare_null_row`

Results/serialization: `test_entity_result_null` (`results.rs`), `test_query_cypher_optional_match_null_row_serializes_as_json_null` (MCP query tool), `test_query_row_to_json_null_binding` (HTTP converter)

## Verification

- `cargo test --features cypher --no-fail-fast`: lib `test result: ok. 3548 passed; 0 failed; 2 ignored`; doc-tests `test result: ok. 415 passed; 0 failed; 111 ignored`; all integration targets green except two **pre-existing, environment-dependent** failures unrelated to this change (`havoc::havoc_flush_deadlock::test_flush_deadlock_on_io_error`, `regression_flush_corruption::test_metadata_corruption_on_error`): both inject I/O errors by chmod-ing a directory read-only, which is a no-op when tests run as root (as in this sandbox). Neither file (nor any WAL code) is touched by this PR. (One unrelated timing-flaky test, `db::ops::…::node_deleted_before_t_found_when_both_dimensions_anchor_before_deletion` from the #3236 feature, failed once under a fully parallel run and passes consistently in isolation and on re-run; this PR does not touch that code.)
- `cargo test` (default features): `test result: ok. 3412 passed; 0 failed; 2 ignored` lib, doc-tests `409 passed; 0 failed`, same two pre-existing havoc failures, everything else green.
- `cargo check` in `python/`: passes (the bindings compile against the new `EntityResult` shape; only pre-existing pyo3 deprecation warnings).
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --all`: applied (python/ has pre-existing rustfmt drift untouched by this PR; the new code follows the file's existing style).
- Re-anchoring rejection commit: `cargo test --features cypher --no-fail-fast` lib `test result: ok. 3551 passed; 0 failed; 2 ignored`, all integration targets green except the same two pre-existing root-environment failures; clippy (`--all-targets --all-features -- -D warnings`) clean; `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DcvFpzsJ8cJJmBePGySuPh

---
_Generated by [Claude Code](https://claude.ai/code/session_01DcvFpzsJ8cJJmBePGySuPh)_