### PR TITLE
fix: WAL replay honors logged valid_from for DeleteNode/DeleteEdge (closes #3400)

### DIFF
--- a/src/storage/recovery.rs
+++ b/src/storage/recovery.rs
@@ -337,7 +337,7 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
             }
             WalOperation::DeleteNode {
                 node_id,
-                valid_from: _,
+                valid_from,
             } => {
                 // If the node doesn't exist in current storage, it might have been deleted already
                 // or never existed (if we're replaying a delete for something we missed creation of?).
@@ -356,12 +356,15 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                     let tombstone_version_id = VersionId::new(next_version_id)?;
                     next_version_id += 1;
 
-                    // Tombstones use commit_timestamp for both valid_from and tx_time
-                    // The is_tombstone=true flag closes the valid_time immediately
+                    // Honor the LOGGED valid_from (possibly backdated, Issues
+                    // #3221/#3400) — mirroring the live path's
+                    // `apply_node_delete` — while tx_time comes from the WAL
+                    // entry. The is_tombstone=true flag closes the valid_time
+                    // immediately at valid_from (empty interval).
                     historical.add_node_version(
                         node_id,
                         tombstone_version_id,
-                        commit_timestamp,
+                        valid_from,
                         commit_timestamp,
                         node.label,
                         node.properties.clone(),
@@ -373,7 +376,7 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
             }
             WalOperation::DeleteEdge {
                 edge_id,
-                valid_from: _,
+                valid_from,
             } => {
                 if let Ok(edge) = current.get_edge(edge_id) {
                     let commit_timestamp = entry.timestamp;
@@ -388,12 +391,15 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                     let tombstone_version_id = VersionId::new(next_version_id)?;
                     next_version_id += 1;
 
-                    // Tombstones use commit_timestamp for both valid_from and tx_time
-                    // The is_tombstone=true flag closes the valid_time immediately
+                    // Honor the LOGGED valid_from (possibly backdated, Issues
+                    // #3221/#3400) — mirroring the live path's
+                    // `apply_edge_delete` — while tx_time comes from the WAL
+                    // entry. The is_tombstone=true flag closes the valid_time
+                    // immediately at valid_from (empty interval).
                     historical.add_edge_version(
                         edge_id,
                         tombstone_version_id,
-                        commit_timestamp,
+                        valid_from,
                         commit_timestamp,
                         edge.label,
                         edge.source,

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -1323,11 +1323,14 @@ mod tests {
 
     #[test]
     fn test_parse_entry_at_delete_node() {
-        // Create a DeleteNode entry
+        // Create a DeleteNode entry with a distinct BACKDATED valid_from
+        // (Issue #3221/#3400: the logged delete valid_from must roundtrip
+        // through serialization exactly, it is honored by WAL replay).
         let node_id = NodeId::new(42).unwrap();
+        let valid_from = HybridTimestamp::new(time::now().wallclock() - 3_600_000_000, 0).unwrap(); // 1h ago
         let operation = WalOperation::DeleteNode {
             node_id,
-            valid_from: time::now(),
+            valid_from,
         };
         let entry = WalEntry::new(LSN(5), operation);
 
@@ -1343,9 +1346,14 @@ mod tests {
         assert_eq!(bytes_consumed, buffer.len());
         match parsed_entry.operation {
             WalOperation::DeleteNode {
-                node_id: parsed_id, ..
+                node_id: parsed_id,
+                valid_from: parsed_valid_from,
             } => {
                 assert_eq!(parsed_id, node_id);
+                assert_eq!(
+                    parsed_valid_from, valid_from,
+                    "backdated delete valid_from must roundtrip exactly"
+                );
             }
             _ => panic!("Expected DeleteNode operation"),
         }
@@ -1353,11 +1361,14 @@ mod tests {
 
     #[test]
     fn test_parse_entry_at_delete_edge() {
-        // Create a DeleteEdge entry
+        // Create a DeleteEdge entry with a distinct BACKDATED valid_from
+        // (Issue #3221/#3400: the logged delete valid_from must roundtrip
+        // through serialization exactly, it is honored by WAL replay).
         let edge_id = EdgeId::new(100).unwrap();
+        let valid_from = HybridTimestamp::new(time::now().wallclock() - 3_600_000_000, 0).unwrap(); // 1h ago
         let operation = WalOperation::DeleteEdge {
             edge_id,
-            valid_from: time::now(),
+            valid_from,
         };
         let entry = WalEntry::new(LSN(6), operation);
 
@@ -1373,9 +1384,14 @@ mod tests {
         assert_eq!(bytes_consumed, buffer.len());
         match parsed_entry.operation {
             WalOperation::DeleteEdge {
-                edge_id: parsed_id, ..
+                edge_id: parsed_id,
+                valid_from: parsed_valid_from,
             } => {
                 assert_eq!(parsed_id, edge_id);
+                assert_eq!(
+                    parsed_valid_from, valid_from,
+                    "backdated delete valid_from must roundtrip exactly"
+                );
             }
             _ => panic!("Expected DeleteEdge operation"),
         }

--- a/tests/recovery/replay_create_tests.rs
+++ b/tests/recovery/replay_create_tests.rs
@@ -461,9 +461,10 @@ fn test_replay_preserves_temporal_interval() -> Result<()> {
             .is_ok(),
         "node must be visible at its creation bi-temporal coordinate after replay"
     );
+    let now_after_replay = time::now();
     assert!(
         historical
-            .get_node_at_time(node_id, time::now(), time::now())
+            .get_node_at_time(node_id, now_after_replay, now_after_replay)
             .is_ok(),
         "node must be visible at the current bi-temporal coordinate after replay"
     );

--- a/tests/recovery/replay_delete_tests.rs
+++ b/tests/recovery/replay_delete_tests.rs
@@ -217,18 +217,11 @@ fn test_replay_delete_node_preserves_temporal_intervals() -> Result<()> {
     // Issue #452: after replaying Create + Delete, the version chain must
     // carry exact bi-temporal intervals:
     // - prior head: valid_from preserved, valid time closed at the
-    //   tombstone's valid_from, transaction time closed at the delete
+    //   tombstone's LOGGED valid_from, transaction time closed at the delete
     //   entry's LOGGED timestamp;
-    // - tombstone: empty valid interval, transaction [delete ts, open).
-    //
-    // NOTE: we deliberately do NOT assert the tombstone's exact valid_from
-    // (nor, therefore, the prior head's exact valid_to, which is closed at
-    // the tombstone's valid_from). The live write path honors a
-    // user-supplied (possibly backdated, Issue #3221) valid_from for the
-    // tombstone, while replay currently drops the logged value and
-    // substitutes the entry timestamp — that divergence is pinned by the
-    // ignored test `backdated_delete_valid_from_survives_replay` in
-    // tests/wal_recovery_integration.rs.
+    // - tombstone: empty valid interval anchored at the LOGGED valid_from
+    //   (issue #3400: replay honors the logged value, mirroring the live
+    //   path), transaction [delete ts, open).
     let temp_dir = TempDir::new().unwrap();
     let wal_dir = temp_dir.path().join("wal");
 
@@ -238,6 +231,7 @@ fn test_replay_delete_node_preserves_temporal_intervals() -> Result<()> {
     let node_id = NodeId::new(1).unwrap();
     let now = time::now().wallclock();
     let vf = HybridTimestamp::new(now - 7_200_000_000, 0).unwrap(); // 2h ago
+    let delete_vf = time::now();
 
     wal.append(WalOperation::CreateNode {
         node_id,
@@ -248,7 +242,7 @@ fn test_replay_delete_node_preserves_temporal_intervals() -> Result<()> {
     })?;
     wal.append(WalOperation::DeleteNode {
         node_id,
-        valid_from: time::now(),
+        valid_from: delete_vf,
     })?;
     wal.flush()?;
 
@@ -278,8 +272,8 @@ fn test_replay_delete_node_preserves_temporal_intervals() -> Result<()> {
     );
     assert_eq!(
         prior.temporal.valid_time().end(),
-        tombstone.temporal.valid_time().start(),
-        "prior head's valid time must be closed exactly at the tombstone's valid_from"
+        delete_vf,
+        "prior head's valid time must be closed exactly at the tombstone's LOGGED valid_from"
     );
     assert_eq!(
         prior.temporal.transaction_time().start(),
@@ -292,6 +286,11 @@ fn test_replay_delete_node_preserves_temporal_intervals() -> Result<()> {
         "prior head's tx-time closure must survive replay at the LOGGED delete timestamp"
     );
 
+    assert_eq!(
+        tombstone.temporal.valid_time().start(),
+        delete_vf,
+        "tombstone valid_from must equal the LOGGED delete valid_from (issue #3400)"
+    );
     assert!(
         tombstone.temporal.valid_time().is_empty(),
         "tombstone must carry an empty valid interval"
@@ -340,6 +339,7 @@ fn test_replay_delete_edge_preserves_temporal_intervals() -> Result<()> {
     let edge_id = EdgeId::new(1).unwrap();
     let now = time::now().wallclock();
     let vf = HybridTimestamp::new(now - 7_200_000_000, 0).unwrap();
+    let delete_vf = time::now();
 
     for node_id in [source_id, target_id] {
         wal.append(WalOperation::CreateNode {
@@ -361,7 +361,7 @@ fn test_replay_delete_edge_preserves_temporal_intervals() -> Result<()> {
     })?;
     wal.append(WalOperation::DeleteEdge {
         edge_id,
-        valid_from: time::now(),
+        valid_from: delete_vf,
     })?;
     wal.flush()?;
 
@@ -393,8 +393,8 @@ fn test_replay_delete_edge_preserves_temporal_intervals() -> Result<()> {
     );
     assert_eq!(
         prior.temporal.valid_time().end(),
-        tombstone.temporal.valid_time().start(),
-        "prior head's valid time must be closed exactly at the tombstone's valid_from"
+        delete_vf,
+        "prior head's valid time must be closed exactly at the tombstone's LOGGED valid_from"
     );
     assert_eq!(
         prior.temporal.transaction_time().start(),
@@ -407,6 +407,11 @@ fn test_replay_delete_edge_preserves_temporal_intervals() -> Result<()> {
         "prior head's tx-time closure must survive replay at the LOGGED delete timestamp"
     );
 
+    assert_eq!(
+        tombstone.temporal.valid_time().start(),
+        delete_vf,
+        "tombstone valid_from must equal the LOGGED delete valid_from (issue #3400)"
+    );
     assert!(
         tombstone.temporal.valid_time().is_empty(),
         "tombstone must carry an empty valid interval"
@@ -438,6 +443,168 @@ fn test_replay_delete_edge_preserves_temporal_intervals() -> Result<()> {
         historical
             .get_edge_at_time(edge_id, time::now(), time::now())
             .is_err()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_replay_delete_node_honors_logged_valid_from() -> Result<()> {
+    // Issue #3400: a backdated delete (Issue #3221) logs a user-supplied
+    // valid_from that differs from the WAL entry's timestamp. Replay must
+    // stamp the tombstone with the LOGGED valid_from — mirroring the live
+    // path (`apply_node_delete`) — not the entry timestamp.
+    let temp_dir = TempDir::new().unwrap();
+    let wal_dir = temp_dir.path().join("wal");
+
+    let wal_config = ConcurrentWalSystemConfig::new(wal_dir);
+    let wal = ConcurrentWalSystem::new(wal_config)?;
+
+    let node_id = NodeId::new(1).unwrap();
+    let now = time::now().wallclock();
+    let create_vf = HybridTimestamp::new(now - 7_200_000_000, 0).unwrap(); // 2h ago
+    let delete_vf = HybridTimestamp::new(now - 3_600_000_000, 0).unwrap(); // 1h ago (backdated)
+
+    wal.append(WalOperation::CreateNode {
+        node_id,
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
+        properties: PropertyMapBuilder::new().insert("name", "Zoe").build(),
+        valid_from: create_vf,
+        provenance: None,
+    })?;
+    wal.append(WalOperation::DeleteNode {
+        node_id,
+        valid_from: delete_vf,
+    })?;
+    wal.flush()?;
+
+    let delete_ts = logged_timestamp(&wal, |op| matches!(op, WalOperation::DeleteNode { .. }))?;
+    assert!(
+        delete_vf < delete_ts,
+        "premise: the backdated valid_from must differ from the entry timestamp"
+    );
+
+    let config = CheckpointConfig::with_data_dir(temp_dir.path().join("checkpoints"));
+    let mut manager = CheckpointManager::new(config)?;
+    let (current, historical, _lsn) = manager.recover(&wal)?;
+
+    assert!(current.get_node(node_id).is_err());
+
+    let history = historical.get_node_history(node_id)?;
+    assert_eq!(history.version_count(), 2, "create + delete tombstone");
+
+    let prior = &history.versions[0];
+    let tombstone = &history.versions[1];
+
+    assert_eq!(
+        tombstone.temporal.valid_time().start(),
+        delete_vf,
+        "tombstone valid_from must equal the LOGGED backdated valid_from, not the entry timestamp"
+    );
+    assert!(
+        tombstone.temporal.valid_time().is_empty(),
+        "tombstone must carry an empty valid interval"
+    );
+    assert_eq!(
+        prior.temporal.valid_time().end(),
+        delete_vf,
+        "prior head's valid_to must be closed at the LOGGED backdated valid_from"
+    );
+    assert_eq!(
+        tombstone.temporal.transaction_time().start(),
+        delete_ts,
+        "tombstone tx time must still start at the LOGGED delete entry timestamp"
+    );
+    assert_eq!(
+        prior.temporal.transaction_time().end(),
+        delete_ts,
+        "prior head's tx-time closure must still use the LOGGED delete entry timestamp"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_replay_delete_edge_honors_logged_valid_from() -> Result<()> {
+    // Issue #3400: edge mirror of test_replay_delete_node_honors_logged_valid_from.
+    let temp_dir = TempDir::new().unwrap();
+    let wal_dir = temp_dir.path().join("wal");
+
+    let wal_config = ConcurrentWalSystemConfig::new(wal_dir);
+    let wal = ConcurrentWalSystem::new(wal_config)?;
+
+    let source_id = NodeId::new(1).unwrap();
+    let target_id = NodeId::new(2).unwrap();
+    let edge_id = EdgeId::new(1).unwrap();
+    let now = time::now().wallclock();
+    let create_vf = HybridTimestamp::new(now - 7_200_000_000, 0).unwrap(); // 2h ago
+    let delete_vf = HybridTimestamp::new(now - 3_600_000_000, 0).unwrap(); // 1h ago (backdated)
+
+    for node_id in [source_id, target_id] {
+        wal.append(WalOperation::CreateNode {
+            node_id,
+            label: GLOBAL_INTERNER.intern("Person").unwrap(),
+            properties: PropertyMap::new(),
+            valid_from: create_vf,
+            provenance: None,
+        })?;
+    }
+    wal.append(WalOperation::CreateEdge {
+        edge_id,
+        source: source_id,
+        target: target_id,
+        label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
+        properties: PropertyMap::new(),
+        valid_from: create_vf,
+        provenance: None,
+    })?;
+    wal.append(WalOperation::DeleteEdge {
+        edge_id,
+        valid_from: delete_vf,
+    })?;
+    wal.flush()?;
+
+    let delete_ts = logged_timestamp(&wal, |op| matches!(op, WalOperation::DeleteEdge { .. }))?;
+    assert!(
+        delete_vf < delete_ts,
+        "premise: the backdated valid_from must differ from the entry timestamp"
+    );
+
+    let config = CheckpointConfig::with_data_dir(temp_dir.path().join("checkpoints"));
+    let mut manager = CheckpointManager::new(config)?;
+    let (current, historical, _lsn) = manager.recover(&wal)?;
+
+    assert!(current.get_edge(edge_id).is_err());
+
+    let history = historical.get_edge_history(edge_id)?;
+    assert_eq!(history.version_count(), 2, "create + delete tombstone");
+
+    let prior = &history.versions[0];
+    let tombstone = &history.versions[1];
+
+    assert_eq!(
+        tombstone.temporal.valid_time().start(),
+        delete_vf,
+        "tombstone valid_from must equal the LOGGED backdated valid_from, not the entry timestamp"
+    );
+    assert!(
+        tombstone.temporal.valid_time().is_empty(),
+        "tombstone must carry an empty valid interval"
+    );
+    assert_eq!(
+        prior.temporal.valid_time().end(),
+        delete_vf,
+        "prior head's valid_to must be closed at the LOGGED backdated valid_from"
+    );
+    assert_eq!(
+        tombstone.temporal.transaction_time().start(),
+        delete_ts,
+        "tombstone tx time must still start at the LOGGED delete entry timestamp"
+    );
+    assert_eq!(
+        prior.temporal.transaction_time().end(),
+        delete_ts,
+        "prior head's tx-time closure must still use the LOGGED delete entry timestamp"
     );
 
     Ok(())

--- a/tests/recovery/replay_delete_tests.rs
+++ b/tests/recovery/replay_delete_tests.rs
@@ -229,9 +229,9 @@ fn test_replay_delete_node_preserves_temporal_intervals() -> Result<()> {
     let wal = ConcurrentWalSystem::new(wal_config)?;
 
     let node_id = NodeId::new(1).unwrap();
-    let now = time::now().wallclock();
-    let vf = HybridTimestamp::new(now - 7_200_000_000, 0).unwrap(); // 2h ago
-    let delete_vf = time::now();
+    let now_ts = time::now();
+    let vf = HybridTimestamp::new(now_ts.wallclock() - 7_200_000_000, 0).unwrap(); // 2h ago
+    let delete_vf = now_ts;
 
     wal.append(WalOperation::CreateNode {
         node_id,
@@ -316,9 +316,10 @@ fn test_replay_delete_node_preserves_temporal_intervals() -> Result<()> {
         historical.get_node_at_time(node_id, vf, delete_ts).is_err(),
         "node must be gone when anchored at the delete's commit"
     );
+    let now_after_replay = time::now();
     assert!(
         historical
-            .get_node_at_time(node_id, time::now(), time::now())
+            .get_node_at_time(node_id, now_after_replay, now_after_replay)
             .is_err()
     );
 
@@ -337,9 +338,9 @@ fn test_replay_delete_edge_preserves_temporal_intervals() -> Result<()> {
     let source_id = NodeId::new(1).unwrap();
     let target_id = NodeId::new(2).unwrap();
     let edge_id = EdgeId::new(1).unwrap();
-    let now = time::now().wallclock();
-    let vf = HybridTimestamp::new(now - 7_200_000_000, 0).unwrap();
-    let delete_vf = time::now();
+    let now_ts = time::now();
+    let vf = HybridTimestamp::new(now_ts.wallclock() - 7_200_000_000, 0).unwrap();
+    let delete_vf = now_ts;
 
     for node_id in [source_id, target_id] {
         wal.append(WalOperation::CreateNode {
@@ -439,9 +440,10 @@ fn test_replay_delete_edge_preserves_temporal_intervals() -> Result<()> {
             .is_err(),
         "edge must be gone when anchored at the delete's commit"
     );
+    let now_after_replay = time::now();
     assert!(
         historical
-            .get_edge_at_time(edge_id, time::now(), time::now())
+            .get_edge_at_time(edge_id, now_after_replay, now_after_replay)
             .is_err()
     );
 

--- a/tests/recovery/replay_update_tests.rs
+++ b/tests/recovery/replay_update_tests.rs
@@ -496,7 +496,8 @@ fn test_replay_update_preserves_temporal_intervals() -> Result<()> {
         old.properties.get("count"),
         Some(PropertyValue::Int(1))
     ));
-    let new = historical.get_node_at_time(node_id, time::now(), time::now())?;
+    let now_after_replay = time::now();
+    let new = historical.get_node_at_time(node_id, now_after_replay, now_after_replay)?;
     assert!(matches!(
         new.properties.get("count"),
         Some(PropertyValue::Int(2))
@@ -613,7 +614,8 @@ fn test_replay_update_edge_preserves_temporal_intervals() -> Result<()> {
         old.properties.get("weight"),
         Some(PropertyValue::Int(1))
     ));
-    let new = historical.get_edge_at_time(edge_id, time::now(), time::now())?;
+    let now_after_replay = time::now();
+    let new = historical.get_edge_at_time(edge_id, now_after_replay, now_after_replay)?;
     assert!(matches!(
         new.properties.get("weight"),
         Some(PropertyValue::Int(2))

--- a/tests/wal_recovery_integration.rs
+++ b/tests/wal_recovery_integration.rs
@@ -26,10 +26,10 @@
 //! at append time, a few microseconds earlier). Both are correct
 //! representations of "when the fact was recorded"; the tests therefore
 //! assert transaction-time *structure* (open/closed flags, chain continuity)
-//! rather than exact bounds. Valid-time bounds ARE asserted exactly — they
-//! are logged in the WAL and must be honored faithfully (the one known gap,
-//! delete tombstone valid_from, is pinned by the ignored test at the bottom
-//! of this file).
+//! rather than exact bounds. Valid-time bounds ARE asserted exactly for every
+//! version, including delete tombstones — they are logged in the WAL and must
+//! be honored faithfully (issue #3400, pinned by the backdated-delete tests
+//! at the bottom of this file).
 
 use aletheiadb::config::WalConfigBuilder;
 use aletheiadb::core::history::EntityHistory;
@@ -96,15 +96,10 @@ fn snapshot_history(history: &EntityHistory) -> Vec<VersionSnapshot> {
 
 /// Assert a recovered history matches its pre-crash snapshot.
 ///
-/// Valid-time bounds are compared exactly, with a single carve-out around
-/// delete tombstones: a tombstone's (empty) valid interval — and therefore
-/// the valid_to of the version it closes, which is stamped from the
-/// tombstone's valid_from — is compared structurally rather than exactly.
-/// Replay currently stamps delete tombstones with the entry timestamp
-/// instead of the logged valid_from (see
-/// `backdated_delete_valid_from_survives_replay` below), and even the
-/// non-backdated tombstone valid_from differs by microseconds (transaction
-/// start time vs WAL entry timestamp).
+/// Valid-time bounds are compared exactly for EVERY version, including delete
+/// tombstones: the tombstone's valid_from is logged in the WAL and honored by
+/// replay (issue #3400), so both its (empty) valid interval and the valid_to
+/// of the version it closes must survive recovery bit-for-bit.
 ///
 /// Transaction-time bounds are compared structurally (open/closed + chain
 /// continuity), not exactly — see the module docs for why exact equality
@@ -133,22 +128,14 @@ fn assert_history_matches(entity: &str, pre: &[VersionSnapshot], recovered: &Ent
             p.valid_open, q.valid_open,
             "{entity} v{i}: valid-time openness must survive recovery"
         );
-        let next_is_tombstone = pre.get(i + 1).is_some_and(|n| n.valid_empty);
-        if !p.valid_empty {
-            assert_eq!(
-                p.valid_start, q.valid_start,
-                "{entity} v{i}: valid_from must survive recovery exactly"
-            );
-            if !next_is_tombstone {
-                assert_eq!(
-                    p.valid_end, q.valid_end,
-                    "{entity} v{i}: valid_to must survive recovery exactly"
-                );
-            }
-            // else: this version was closed by a delete tombstone; its exact
-            // valid_to inherits the tombstone valid_from divergence (openness
-            // is asserted above, continuity is asserted below).
-        }
+        assert_eq!(
+            p.valid_start, q.valid_start,
+            "{entity} v{i}: valid_from must survive recovery exactly"
+        );
+        assert_eq!(
+            p.valid_end, q.valid_end,
+            "{entity} v{i}: valid_to must survive recovery exactly"
+        );
         assert_eq!(
             p.tx_open, q.tx_open,
             "{entity} v{i}: transaction-time openness must survive recovery"
@@ -586,27 +573,15 @@ fn test_wal_recovery_on_reopen() {
     assert!(db.get_edge_at_valid_time(e_respects, t1).is_err());
 }
 
-/// Pins the known live-path/replay divergence for BACKDATED deletes
-/// (Issues #3221 + #452 follow-up):
-///
-/// - the live write path logs the user-supplied `valid_from` for
-///   `DeleteNode`/`DeleteEdge` (src/api/transaction/write_buffer.rs) and
-///   stamps the tombstone with it (src/api/transaction/write/apply.rs,
-///   `apply_node_delete`);
-/// - WAL replay destructures the logged field as `valid_from: _` and
-///   substitutes the entry timestamp (src/storage/recovery.rs, DeleteNode /
-///   DeleteEdge arms).
-///
-/// So a backdated delete's tombstone `valid_from` (when the fact stopped
-/// being true in reality) is silently replaced by the delete's commit time
-/// after crash recovery. This test FAILS until replay honors the logged
-/// value; run it with `--ignored` to observe the divergence.
+/// Pins the fix for issue #3400 (BACKDATED deletes, Issues #3221 + #452
+/// follow-up): the live write path logs the user-supplied `valid_from` for
+/// `DeleteNode`/`DeleteEdge` (src/api/transaction/write_buffer.rs) and stamps
+/// the tombstone with it (src/api/transaction/write/apply.rs,
+/// `apply_node_delete`); WAL replay (src/storage/recovery.rs, DeleteNode /
+/// DeleteEdge arms) must honor that logged value rather than substituting the
+/// entry timestamp, so a backdated delete's tombstone `valid_from` (when the
+/// fact stopped being true in reality) survives crash recovery exactly.
 #[test]
-#[ignore = "known divergence (see issue #3400): WAL replay drops the logged valid_from for \
-            DeleteNode/DeleteEdge (src/storage/recovery.rs destructures `valid_from: _` and \
-            stamps the tombstone with entry.timestamp), while the live path honors the #3221 \
-            backdated valid_time. Un-ignore once issue #3400 is fixed and replay honors the \
-            logged delete valid_from."]
 fn backdated_delete_valid_from_survives_replay() {
     let temp_dir = tempfile::tempdir().unwrap();
     let wal_dir = temp_dir.path().join("wal");
@@ -646,5 +621,72 @@ fn backdated_delete_valid_from_survives_replay() {
         history.versions[1].temporal.valid_time().start(),
         t_delete,
         "replay must honor the LOGGED backdated delete valid_from, not the entry timestamp"
+    );
+}
+
+/// Edge counterpart of `backdated_delete_valid_from_survives_replay`
+/// (issue #3400): a backdated `delete_edge_with_valid_time` must recover with
+/// the tombstone stamped at the LOGGED backdated `valid_from`, and the prior
+/// head's valid_to closed at that same point.
+#[test]
+fn backdated_edge_delete_valid_from_survives_replay() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let wal_dir = temp_dir.path().join("wal");
+
+    let now = time::now().wallclock();
+    let t_create = hours_ago(now, 3);
+    let t_delete = hours_ago(now, 1); // backdated: fact stopped being true 1h ago
+
+    let edge_id;
+    {
+        let db = AletheiaDB::with_unified_config(crash_recovery_config(&wal_dir)).unwrap();
+        let source = db
+            .create_node_with_valid_time(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Ann").build(),
+                Some(t_create),
+            )
+            .unwrap();
+        let target = db
+            .create_node_with_valid_time(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Ben").build(),
+                Some(t_create),
+            )
+            .unwrap();
+        edge_id = db
+            .create_edge_with_valid_time(
+                source,
+                target,
+                "KNOWS",
+                PropertyMapBuilder::new().build(),
+                Some(t_create),
+            )
+            .unwrap();
+        db.delete_edge_with_valid_time(edge_id, Some(t_delete))
+            .unwrap();
+
+        let history = db.get_edge_history(edge_id).unwrap();
+        assert_eq!(history.version_count(), 2);
+        assert_eq!(
+            history.versions[1].temporal.valid_time().start(),
+            t_delete,
+            "live path stamps the tombstone with the backdated valid_from"
+        );
+        // Simulated crash: drop without a checkpoint.
+    }
+
+    let db = AletheiaDB::with_unified_config(crash_recovery_config(&wal_dir)).unwrap();
+    let history = db.get_edge_history(edge_id).unwrap();
+    assert_eq!(history.version_count(), 2);
+    assert_eq!(
+        history.versions[1].temporal.valid_time().start(),
+        t_delete,
+        "replay must honor the LOGGED backdated edge-delete valid_from, not the entry timestamp"
+    );
+    assert_eq!(
+        history.versions[0].temporal.valid_time().end(),
+        t_delete,
+        "prior head's valid_to must be closed at the backdated tombstone valid_from after replay"
     );
 }

--- a/tests/wal_recovery_integration.rs
+++ b/tests/wal_recovery_integration.rs
@@ -23,7 +23,8 @@
 //! Exact transaction-time equality across a crash is impossible by design:
 //! the live path stamps historical versions with the HLC *commit* timestamp,
 //! while replay stamps them with the WAL entry's *logged* timestamp (assigned
-//! at append time, a few microseconds earlier). Both are correct
+//! at append time, which can differ by a few microseconds in either
+//! direction). Both are correct
 //! representations of "when the fact was recorded"; the tests therefore
 //! assert transaction-time *structure* (open/closed flags, chain continuity)
 //! rather than exact bounds. Valid-time bounds ARE asserted exactly for every
@@ -492,8 +493,9 @@ fn test_wal_recovery_on_reopen() {
             .is_ok(),
         "deleted node must remain recallable at pre-delete coordinates"
     );
+    let carol_now_probe = time::now();
     assert!(
-        db.get_node_at_time(carol, time::now(), time::now())
+        db.get_node_at_time(carol, carol_now_probe, carol_now_probe)
             .is_err()
     );
 
@@ -515,8 +517,9 @@ fn test_wal_recovery_on_reopen() {
         db.get_edge_at_time(e_likes, e_likes_valid_from, e_likes_create_tx)
             .is_ok()
     );
+    let e_likes_now_probe = time::now();
     assert!(
-        db.get_edge_at_time(e_likes, time::now(), time::now())
+        db.get_edge_at_time(e_likes, e_likes_now_probe, e_likes_now_probe)
             .is_err()
     );
 
@@ -557,8 +560,9 @@ fn test_wal_recovery_on_reopen() {
         db.get_node_at_time(erin, t2, erin_delete_tx).is_err(),
         "erin must be gone when transaction time is anchored at the delete's commit"
     );
+    let now_probe = time::now();
     assert!(
-        db.get_node_at_time(erin, time::now(), time::now()).is_err(),
+        db.get_node_at_time(erin, now_probe, now_probe).is_err(),
         "erin must be gone at the current bi-temporal coordinate"
     );
 
@@ -592,6 +596,7 @@ fn backdated_delete_valid_from_survives_replay() {
 
     let node_id;
     let pre_tombstone_valid_from;
+    let probe_in_window;
     {
         let db = AletheiaDB::with_unified_config(crash_recovery_config(&wal_dir)).unwrap();
         node_id = db
@@ -611,6 +616,33 @@ fn backdated_delete_valid_from_survives_replay() {
             pre_tombstone_valid_from, t_delete,
             "live path stamps the tombstone with the backdated valid_from"
         );
+
+        // Divergence window: the pre-fix bug (replay substituting the entry
+        // timestamp for the LOGGED valid_from) is user-visible exactly at
+        // valid times strictly between the backdated t_delete and the
+        // delete's commit timestamp, with transaction time anchored before
+        // the delete's commit (here: at the create's tx start). At that
+        // coordinate the node must be invisible — the buggy replay would
+        // leave the prior head's valid_to open until the commit timestamp
+        // and make it visible.
+        let create_tx = history.versions[0].temporal.transaction_time().start();
+        let tombstone_tx = history.versions[1].temporal.transaction_time().start();
+        assert!(
+            t_delete < tombstone_tx,
+            "premise: the backdated valid_from must precede the delete's commit timestamp"
+        );
+        probe_in_window =
+            HybridTimestamp::new((t_delete.wallclock() + tombstone_tx.wallclock()) / 2, 0)
+                .expect("divergence-window probe timestamp must be valid");
+        assert!(
+            t_delete < probe_in_window && probe_in_window < tombstone_tx,
+            "premise: probe must fall strictly inside the backdate-to-commit window"
+        );
+        assert!(
+            db.get_node_at_time(node_id, probe_in_window, create_tx)
+                .is_err(),
+            "AS OF in the backdate-to-commit window must be invisible (live)"
+        );
         // Simulated crash: drop without a checkpoint.
     }
 
@@ -621,6 +653,17 @@ fn backdated_delete_valid_from_survives_replay() {
         history.versions[1].temporal.valid_time().start(),
         t_delete,
         "replay must honor the LOGGED backdated delete valid_from, not the entry timestamp"
+    );
+    // Re-derive the tx anchor from the RECOVERED history: replay stamps
+    // transaction time with the WAL entry's logged timestamp, which can
+    // differ from the live commit timestamp by a few microseconds in either
+    // direction, so the pre-crash anchor may fall outside the recovered
+    // create version's tx interval.
+    let recovered_create_tx = history.versions[0].temporal.transaction_time().start();
+    assert!(
+        db.get_node_at_time(node_id, probe_in_window, recovered_create_tx)
+            .is_err(),
+        "AS OF in the backdate-to-commit window must be invisible (post-replay)"
     );
 }
 
@@ -638,6 +681,7 @@ fn backdated_edge_delete_valid_from_survives_replay() {
     let t_delete = hours_ago(now, 1); // backdated: fact stopped being true 1h ago
 
     let edge_id;
+    let probe_in_window;
     {
         let db = AletheiaDB::with_unified_config(crash_recovery_config(&wal_dir)).unwrap();
         let source = db
@@ -673,6 +717,29 @@ fn backdated_edge_delete_valid_from_survives_replay() {
             t_delete,
             "live path stamps the tombstone with the backdated valid_from"
         );
+
+        // Divergence window (see the node twin above): a valid-time probe
+        // strictly between the backdated t_delete and the delete's commit
+        // timestamp, with transaction time anchored at the create's tx
+        // start, must NOT see the edge.
+        let create_tx = history.versions[0].temporal.transaction_time().start();
+        let tombstone_tx = history.versions[1].temporal.transaction_time().start();
+        assert!(
+            t_delete < tombstone_tx,
+            "premise: the backdated valid_from must precede the delete's commit timestamp"
+        );
+        probe_in_window =
+            HybridTimestamp::new((t_delete.wallclock() + tombstone_tx.wallclock()) / 2, 0)
+                .expect("divergence-window probe timestamp must be valid");
+        assert!(
+            t_delete < probe_in_window && probe_in_window < tombstone_tx,
+            "premise: probe must fall strictly inside the backdate-to-commit window"
+        );
+        assert!(
+            db.get_edge_at_time(edge_id, probe_in_window, create_tx)
+                .is_err(),
+            "AS OF in the backdate-to-commit window must be invisible (live)"
+        );
         // Simulated crash: drop without a checkpoint.
     }
 
@@ -688,5 +755,13 @@ fn backdated_edge_delete_valid_from_survives_replay() {
         history.versions[0].temporal.valid_time().end(),
         t_delete,
         "prior head's valid_to must be closed at the backdated tombstone valid_from after replay"
+    );
+    // Re-derive the tx anchor from the RECOVERED history (see the node twin
+    // above for why the pre-crash anchor is not reusable post-replay).
+    let recovered_create_tx = history.versions[0].temporal.transaction_time().start();
+    assert!(
+        db.get_edge_at_time(edge_id, probe_in_window, recovered_create_tx)
+            .is_err(),
+        "AS OF in the backdate-to-commit window must be invisible (post-replay)"
     );
 }


### PR DESCRIPTION
Closes #3400

**Stacked on #3399; GitHub will retarget to trunk when it merges.**

## Before / After

**Before:** A backdated delete (Issue #3221, `delete_node_with_valid_time` / `delete_edge_with_valid_time`) recorded *when the fact stopped being true in reality* — but after a crash and WAL replay, that boundary was silently replaced by the delete&#39;s commit time. Point-in-time (`AS OF VALID_TIME`) reads changed answers across a restart: a fact deleted &#34;as of 1h ago&#34; appeared valid until the commit moment after recovery.

**After:** Replay reconstructs the exact pre-crash temporal bounds. Backdated and non-backdated deletes alike recover with the tombstone stamped at the LOGGED `valid_from`, and the prior head&#39;s `valid_to` closed at that same point. Point-in-time reads return identical answers before and after a restart.

## How

`src/storage/recovery.rs`, `DeleteNode` / `DeleteEdge` replay arms: destructure the logged `valid_from` (previously discarded as `valid_from: _`) and pass it to `HistoricalStorage::add_node_version` / `add_edge_version` instead of `entry.timestamp` — exactly what the live path (`apply_node_delete` / `apply_edge_delete` in `src/api/transaction/write/apply.rs`) does. The shared `add_*_version` path builds the tombstone&#39;s empty valid interval `[valid_from, valid_from)` and closes the prior head&#39;s `valid_to` at the tombstone&#39;s `valid_from` via `close_previous_version_intervals`, so chain continuity holds automatically. Transaction time is unchanged (still the WAL entry&#39;s logged timestamp); non-backdated deletes behave as before since their logged `valid_from` equals the transaction start time. No new validation was added in replay: replay accepts whatever the live path successfully committed and logged (the live path already rejects `valid_from` before entity creation or &gt;1 year in the future at commit time).

## Red → Green evidence

**RED (pre-fix), all four tests failed with the entry-ts vs logged-backdate mismatch, e.g.:**
```
assertion `left == right` failed: replay must honor the LOGGED backdated edge-delete valid_from, not the entry timestamp
  left: HybridTimestamp { wallclock: 1783533972597632, logical: 0 }   // entry timestamp (now)
 right: HybridTimestamp { wallclock: 1783530372573950, logical: 0 }   // logged backdate (1h ago)
```

**GREEN (post-fix):**
- `cargo test --test wal_recovery_integration` — 3 passed, 0 failed
- `cargo test --test recovery` — 64 passed, 0 failed (6 pre-existing ignores)
- `cargo test --test regression_wal_replay` — 1 passed

**Mutation check:** re-introduced the bug (tombstone stamped with `entry.timestamp` again) — the un-ignored pin test, its new edge counterpart, and both raw-WAL unit tests all failed; restored the fix and verified via `git diff` that only the intended change remains.

## Tests

- **Un-ignored pin test** `backdated_delete_valid_from_survives_replay` (was `#[ignore]`d pending this fix) + new edge counterpart `backdated_edge_delete_valid_from_survives_replay` (`tests/wal_recovery_integration.rs`).
- **New raw-WAL unit tests** `test_replay_delete_node_honors_logged_valid_from` / `test_replay_delete_edge_honors_logged_valid_from` (`tests/recovery/replay_delete_tests.rs`): append a Delete op with an explicit backdated `valid_from`, replay, assert tombstone `valid_from` == logged, prior head `valid_to` == logged, tx bounds still at the logged entry timestamp.
- **Strengthened #3399 carve-outs:** `assert_history_matches` now asserts exact valid bounds for every version including tombstones (carve-out removed); the #452 interval tests assert the tombstone&#39;s exact `valid_from` and the prior head&#39;s exact `valid_to`; stale divergence comments updated.
- **WAL roundtrip:** `test_parse_entry_at_delete_node` / `test_parse_entry_at_delete_edge` (`src/storage/wal/segment_reader.rs`) now use a distinct backdated `valid_from` and assert it survives serialize → parse exactly.

## Gates

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all` — no churn
- `cargo test --no-fail-fast` — 136 suites green; only failures are the two known uid-0 havoc tests (`test_flush_deadlock_on_io_error`, `test_metadata_corruption_on_error`), unrelated to this change. `checkpoint_recovery_tests` untouched and green.

## Review round

- **Bi-temporal correctness review: approve.** Finding applied: the backdated-delete tests now include query-level **divergence-window `AS OF` assertions** — a valid-time probe strictly between the backdated `valid_from` and the delete's commit timestamp, transaction time anchored at the create's tx start, asserted invisible both live and post-replay (`tests/wal_recovery_integration.rs`). Mutation-verified: re-introducing the bug in the DeleteNode replay arm makes the new post-replay assertion fail. Note: the post-replay probe re-derives its tx anchor from the recovered history, since logged vs commit timestamps can differ by microseconds in either direction (the module-doc claim about direction was corrected).
- **Mutation review: 4/4 non-equivalent mutants killed.** One equivalent mutant (removing the explicit transaction-time closure in the replay delete arm, shadowed by `close_previous_version_intervals`) → follow-up cleanup issue #3407.
- **Bot suggestions applied:** single `time::now()` capture per test in `tests/recovery/replay_delete_tests.rs` (the two #452 interval tests) with backdates/probes derived from it; the same double-`now()` probe pattern normalized in `tests/wal_recovery_integration.rs`, `tests/recovery/replay_create_tests.rs`, and `tests/recovery/replay_update_tests.rs`.
- **Follow-up issues filed:** #3406 (WAL delete ops do not log the tombstone `version_id` — replay-synthesized ids can diverge/collide), #3407 (redundant explicit transaction-time closure calls in WAL replay arms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lin7A9BAETpE5piSbcw5UD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lin7A9BAETpE5piSbcw5UD)_