### PR TITLE
Load vector indexes in parallel with per-index error isolation at startup (Issue #451)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,10 +60,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   isolation (Issue #451): with index persistence enabled, all per-property
   HNSW vector indexes are loaded concurrently (one rayon task per property)
   and a corrupted or unreadable vector index (bad `meta.idx`,
-  `mappings.idx`, or `current.usearch`, unknown metric) is skipped with a
-  warning instead of aborting the loading of every remaining vector index.
-  Startup now also logs a loaded/skipped summary when any index is skipped.
-  A skipped index can be re-enabled and rebuilt from node properties. See
+  `mappings.idx`, `current.usearch`, or `current.usearch.mappings`; unknown
+  metric; out-of-range mapping key; even a panic inside one load task) is
+  skipped with a warning instead of aborting the loading of every remaining
+  vector index. Startup logs a loaded/skipped summary when any index is
+  skipped and reports the actually restored vector count per index. A
+  skipped index is recovered with the new
+  `AletheiaDB::rebuild_vector_index(property, config)`, which re-enables the
+  index and backfills it from the vector properties of current nodes —
+  merely re-enabling via `enable_vector_index` creates an empty index that
+  the next persistence cycle writes over the on-disk files, losing the
+  vectors. See
   [docs/guides/index-persistence-guide.md](docs/guides/index-persistence-guide.md#vector-index-persistence).
 
 - MCP tool error responses are now structured (Issue #3234): every error is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Vector index loading at startup is now parallel with per-index error
+  isolation (Issue #451): with index persistence enabled, all per-property
+  HNSW vector indexes are loaded concurrently (one rayon task per property)
+  and a corrupted or unreadable vector index (bad `meta.idx`,
+  `mappings.idx`, or `current.usearch`, unknown metric) is skipped with a
+  warning instead of aborting the loading of every remaining vector index.
+  Startup now also logs a loaded/skipped summary when any index is skipped.
+  A skipped index can be re-enabled and rebuilt from node properties. See
+  [docs/guides/index-persistence-guide.md](docs/guides/index-persistence-guide.md#vector-index-persistence).
+
 - MCP tool error responses are now structured (Issue #3234): every error is
   `{"error": {"code", "message", "retriable", "details"?}}` instead of
   `{"error": "<string>"}`. `code` is drawn from a stable seven-value enum

--- a/docs/guides/index-persistence-guide.md
+++ b/docs/guides/index-persistence-guide.md
@@ -85,14 +85,22 @@ let db = AletheiaDB::with_unified_config(config)?;
 **What this creates:**
 ```
 .my-app-data/
-├── wal/           # Write-ahead log (transaction durability)
-│   ├── 00000X.log # WAL segments
+├── wal/                # Write-ahead log (transaction durability)
+│   ├── 00000X.log      # WAL segments
 │   └── manifest.json
-└── indexes/       # Persisted indexes (fast restart)
-    ├── graph.bin.zst        # Graph structure (compressed)
-    ├── temporal.bin.zst     # Temporal indexes
-    └── vector/{prop}/       # Vector HNSW indexes (per property)
+└── indexes/            # PersistenceConfig.data_dir (fast restart)
+    └── indexes/        # …the manager nests everything under a second indexes/
+        ├── manifest.idx           # Index registry + LSN
+        ├── strings/               # String interner
+        ├── graph/adjacency.idx    # Graph structure
+        ├── temporal/versions.idx  # Temporal indexes
+        └── vector/<prop>/         # Vector HNSW indexes (per property)
 ```
+
+The doubled `indexes/indexes/` segment is real, not a typo: `data_dir` is the
+persistence *base* directory and the manager stores all index files under an
+`indexes/` subdirectory of it. `AletheiaDB::open(path)` sets
+`data_dir = path.join("indexes")`, producing exactly this layout.
 
 **Benefits:**
 - ✅ Data survives process restarts
@@ -172,11 +180,13 @@ data/my-database/
 │       ├── embedding/
 │       │   ├── meta.idx
 │       │   ├── mappings.idx
-│       │   └── current.usearch
+│       │   ├── current.usearch
+│       │   └── current.usearch.mappings
 │       └── title_embedding/
 │           ├── meta.idx
 │           ├── mappings.idx
-│           └── current.usearch
+│           ├── current.usearch
+│           └── current.usearch.mappings
 └── wal/                       # Write-ahead log (separate)
     └── ...
 ```
@@ -184,13 +194,14 @@ data/my-database/
 ### Vector Index Persistence
 
 Each vector-indexed property gets its own directory under `indexes/vector/`
-containing three files:
+containing four files:
 
 | File | Format | Contents |
 |------|--------|----------|
 | `meta.idx` | bitcode + CRC32 (`GVEC` magic, versioned) | Property name, dimensions, distance metric, HNSW hyper-parameters (`m`, `ef_construction`, `ef_search`), vector count |
 | `mappings.idx` | bitcode + CRC32 | `NodeId` <-> usearch key translation table |
 | `current.usearch` | usearch native binary | The HNSW graph itself (vectors + links) |
+| `current.usearch.mappings` | sidecar written alongside the usearch file | `NodeId` <-> usearch key mapping + integrity metadata used by `HnswIndex::load` |
 
 **Save:** vector indexes are persisted by `persist_indexes()`, the background
 persistence worker (per the vector persistence policy), and shutdown
@@ -205,11 +216,28 @@ After the restart, `find_similar` / `find_similar_in` work immediately and
 newly created nodes with vector properties are indexed as usual.
 
 **Per-index error isolation:** a corrupted or unreadable vector index
-(bad `meta.idx`, `mappings.idx`, or `current.usearch`, unknown metric) is
+(bad `meta.idx`, `mappings.idx`, `current.usearch`, or
+`current.usearch.mappings`; unknown metric; out-of-range mapping key) is
 skipped with a warning; it never aborts startup and never prevents the
 remaining vector indexes from loading. A skipped index is simply not
-registered — re-enable it and rebuild from node properties
-(`db.rebuild_vector_index("property")`) to recover.
+registered, and its directory is **left in place on disk** — nothing is
+deleted or quarantined, so the same warning repeats on every startup until
+the index is rebuilt and re-persisted (automatic quarantine-rename of
+skipped directories is a possible future enhancement).
+
+**Recovering a skipped index:** call
+`db.rebuild_vector_index("property", config)` — it re-enables the index
+(with the same `HnswConfig` you originally used) and **backfills it from the
+vector properties of current nodes**, restoring searchability for
+pre-existing data. The next persistence cycle then overwrites the corrupt
+files with the rebuilt index.
+
+> **Warning — do not just re-enable:** `enable_vector_index` creates an
+> **empty** index with no backfill. If you re-enable a skipped index without
+> rebuilding, the next persistence cycle (background worker, shutdown, or
+> `persist_indexes()`) overwrites the on-disk files with that empty index,
+> permanently losing the previously indexed vectors. Always use
+> `rebuild_vector_index` to recover a skipped index.
 
 ### Persistence Config Options
 
@@ -461,11 +489,11 @@ Error: Size limit exceeded: Vector dimension 150000 exceeds maximum allowed dime
 
 **Solution:**
 ```rust
-// Delete the malformed file
-fs::remove_file("data/my-db/indexes/vector/embedding/mappings.idx")?;
-
-// Rebuild vector index
-db.rebuild_vector_index("embedding")?;
+// Rebuild the vector index from node properties (re-enables it if it was
+// skipped at startup, then backfills; the next persist overwrites the
+// malformed files)
+use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
+db.rebuild_vector_index("embedding", HnswConfig::new(384, DistanceMetric::Cosine))?;
 ```
 
 #### 3. Missing Index File

--- a/docs/guides/index-persistence-guide.md
+++ b/docs/guides/index-persistence-guide.md
@@ -91,7 +91,7 @@ let db = AletheiaDB::with_unified_config(config)?;
 └── indexes/       # Persisted indexes (fast restart)
     ├── graph.bin.zst        # Graph structure (compressed)
     ├── temporal.bin.zst     # Temporal indexes
-    └── vector_*.bin         # Vector HNSW indexes
+    └── vector/{prop}/       # Vector HNSW indexes (per property)
 ```
 
 **Benefits:**
@@ -180,6 +180,36 @@ data/my-database/
 └── wal/                       # Write-ahead log (separate)
     └── ...
 ```
+
+### Vector Index Persistence
+
+Each vector-indexed property gets its own directory under `indexes/vector/`
+containing three files:
+
+| File | Format | Contents |
+|------|--------|----------|
+| `meta.idx` | bitcode + CRC32 (`GVEC` magic, versioned) | Property name, dimensions, distance metric, HNSW hyper-parameters (`m`, `ef_construction`, `ef_search`), vector count |
+| `mappings.idx` | bitcode + CRC32 | `NodeId` <-> usearch key translation table |
+| `current.usearch` | usearch native binary | The HNSW graph itself (vectors + links) |
+
+**Save:** vector indexes are persisted by `persist_indexes()`, the background
+persistence worker (per the vector persistence policy), and shutdown
+persistence — no separate call needed.
+
+**Load (Issue #451):** on startup with `load_on_startup: true`, all
+per-property vector indexes are loaded **in parallel** (one rayon task per
+property) and registered before the database becomes ready. The full HNSW
+graph is restored from `current.usearch` — vectors are **not** re-indexed
+from node properties, so startup cost is disk I/O, not index construction.
+After the restart, `find_similar` / `find_similar_in` work immediately and
+newly created nodes with vector properties are indexed as usual.
+
+**Per-index error isolation:** a corrupted or unreadable vector index
+(bad `meta.idx`, `mappings.idx`, or `current.usearch`, unknown metric) is
+skipped with a warning; it never aborts startup and never prevents the
+remaining vector indexes from loading. A skipped index is simply not
+registered — re-enable it and rebuild from node properties
+(`db.rebuild_vector_index("property")`) to recover.
 
 ### Persistence Config Options
 
@@ -355,7 +385,7 @@ fn setup_shutdown_handler(
 1. **Use parallel loading** - `load_indexes_parallel()` loads graph, temporal, and vector indexes concurrently (~3x faster)
 2. **Use memory-mapped loading** - `load_graph_index_mmap()` for multi-GB indexes that exceed available RAM
 3. **Use SSD storage** for index files
-4. **Enable multiple vector indexes** (they load in parallel)
+4. **Multiple vector indexes load in parallel** on startup (one rayon task per property, Issue #451)
 5. **Keep manifest small** (it loads first)
 6. **Prewarm the page cache** (OS-level optimization)
 

--- a/src/db/vector.rs
+++ b/src/db/vector.rs
@@ -44,6 +44,67 @@ impl AletheiaDB {
             .record_error_metric()
     }
 
+    /// Rebuild a vector index from the vector properties of current nodes.
+    ///
+    /// This is the recovery path for a vector index that was **skipped at
+    /// startup** because its persisted files (`meta.idx`, `mappings.idx`,
+    /// `current.usearch`, or the `current.usearch.mappings` sidecar) were
+    /// corrupted or unreadable (Issue #451). It enables the index with
+    /// `config` if it is not registered, then backfills it by scanning every
+    /// current node and indexing the node's `property_name` vector.
+    ///
+    /// # Why not just `enable_vector_index`?
+    ///
+    /// [`enable_vector_index`](Self::enable_vector_index) creates an **empty**
+    /// index with no backfill. If you re-enable a skipped index without
+    /// rebuilding, the next persistence cycle (background worker, shutdown,
+    /// or `persist_indexes`) **overwrites the on-disk files with that empty
+    /// index**, permanently losing the previously indexed vectors. Use this
+    /// method instead to restore searchability for pre-existing nodes.
+    ///
+    /// If an index is already registered for `property_name`, `config` is
+    /// ignored and the backfill runs against the existing index (entries are
+    /// updated in place, so the call is idempotent). The rebuild covers
+    /// **current state only** — temporal vector indexes are not rebuilt.
+    ///
+    /// Returns the number of node vectors indexed by the backfill.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use aletheiadb::index::vector::{HnswConfig, DistanceMetric};
+    ///
+    /// // Startup skipped the "embedding" index (corrupted files on disk):
+    /// let indexed = db.rebuild_vector_index(
+    ///     "embedding",
+    ///     HnswConfig::new(384, DistanceMetric::Cosine),
+    /// )?;
+    /// println!("re-indexed {indexed} vectors");
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the index cannot be created (e.g. the maximum
+    /// number of vector-indexed properties is reached) or if indexing a
+    /// node's vector fails (e.g. dimension mismatch with `config`).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn rebuild_vector_index(&self, property_name: &str, config: HnswConfig) -> Result<usize> {
+        #[cfg(feature = "observability")]
+        let _span = crate::observability::vector_index_span("rebuild_vector_index", property_name)
+            .entered();
+        let indexed = self
+            .current
+            .rebuild_vector_index(property_name, config)
+            .record_error_metric()?;
+        // Mark the vector indexes dirty so the background persistence worker
+        // saves the rebuilt index (otherwise it would only be persisted after
+        // the next vector write or on shutdown/persist_indexes).
+        if let Some(ref tracker) = self.persistence_tracker {
+            tracker.record_vector_mutation();
+        }
+        Ok(indexed)
+    }
+
     /// Check if vector indexing is enabled.
     pub fn is_vector_index_enabled(&self) -> bool {
         self.current.is_vector_index_enabled()

--- a/src/index/vector/hnsw/mod.rs
+++ b/src/index/vector/hnsw/mod.rs
@@ -69,6 +69,14 @@ impl Drop for FilterCallbackGuard {
 /// Maximum number of results that can be requested in a search.
 const MAX_K: usize = 100_000;
 
+/// Maximum valid usearch key.
+///
+/// Keys above this cap are rejected both when allocating new keys (overflow
+/// protection in `add`) and when restoring persisted mappings
+/// (`restore_mapping`), so a corrupted `mappings.idx` containing a huge key
+/// can never overflow `usearch_key + 1` or poison `next_key`.
+pub(crate) const MAX_VALID_KEY: u64 = u64::MAX - 1000;
+
 /// Number of sharded locks for entry updates.
 const NUM_ENTRY_LOCKS: usize = 64;
 
@@ -489,10 +497,32 @@ impl HnswIndex {
             .collect()
     }
 
-    pub(crate) fn restore_mapping(&self, node_id: crate::core::id::NodeId, usearch_key: u64) {
+    /// Restore a persisted `NodeId` <-> usearch key mapping (Issue #451).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `usearch_key` exceeds [`MAX_VALID_KEY`]: such a
+    /// key can only come from a corrupted or malicious `mappings.idx` (the
+    /// key allocator in `add` never hands them out), and accepting it would
+    /// overflow `usearch_key + 1` or poison `next_key` so every later insert
+    /// fails with key-overflow protection.
+    pub(crate) fn restore_mapping(
+        &self,
+        node_id: crate::core::id::NodeId,
+        usearch_key: u64,
+    ) -> Result<()> {
+        if usearch_key > MAX_VALID_KEY {
+            return Err(Error::Vector(VectorError::IndexError(format!(
+                "Refusing to restore mapping for node {}: usearch key {} exceeds maximum valid key {}",
+                node_id.as_u64(),
+                usearch_key,
+                MAX_VALID_KEY
+            ))));
+        }
         self.id_mapping.insert(node_id, usearch_key);
         self.reverse_mapping.insert(usearch_key, node_id);
         self.next_key.fetch_max(usearch_key + 1, Ordering::SeqCst);
+        Ok(())
     }
 
     /// Load a persisted index from disk into memory.
@@ -996,7 +1026,6 @@ impl VectorIndex for HnswIndex {
                     Ok(())
                 }
                 dashmap::mapref::entry::Entry::Vacant(entry) => {
-                    const MAX_VALID_KEY: u64 = u64::MAX - 1000;
                     drop(entry);
 
                     let key = loop {

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -313,6 +313,74 @@ impl CurrentStorage {
         );
     }
 
+    /// Rebuild a vector index from the vector properties of current nodes.
+    ///
+    /// This is the recovery path for a vector index that was skipped at
+    /// startup because its persisted files were corrupted or unreadable
+    /// (Issue #451): it enables the index with `config` if it is not
+    /// registered, then scans every current node and (re-)indexes the
+    /// node's `property_name` vector.
+    ///
+    /// If an index is already registered for `property_name`, `config` is
+    /// ignored and the backfill runs against the existing index (existing
+    /// entries for a node are updated in place, so the call is idempotent).
+    /// The rebuild covers **current state only** — temporal vector indexes
+    /// are not touched.
+    ///
+    /// Returns the number of node vectors indexed by the backfill.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the index cannot be created (e.g. the maximum
+    /// number of vector-indexed properties is reached) or if indexing a
+    /// node's vector fails (e.g. dimension mismatch with `config`).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn rebuild_vector_index(&self, property_name: &str, config: HnswConfig) -> Result<usize> {
+        // Ensure an index is registered for the property, creating one from
+        // `config` if absent. A concurrent enable between the check and the
+        // call is benign: the index exists afterwards either way, and the
+        // backfill proceeds against whichever index won.
+        if !self.is_vector_index_enabled_for(property_name) {
+            match self.enable_vector_index(property_name, config) {
+                Ok(()) => {}
+                Err(_) if self.is_vector_index_enabled_for(property_name) => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        // Clone the Arc so no DashMap shard guard is held while scanning
+        // nodes (only the vector index map and node storage reads are
+        // involved; no other synchronization primitive is acquired).
+        let index = self
+            .vector_indexes
+            .get(property_name)
+            .map(|entry| Arc::clone(&entry.value().index))
+            .ok_or_else(|| {
+                crate::core::error::Error::Vector(crate::core::error::VectorError::IndexError(
+                    format!(
+                        "Vector index for property '{}' disappeared during rebuild",
+                        property_name
+                    ),
+                ))
+            })?;
+
+        // Backfill: registering the index BEFORE scanning means nodes created
+        // concurrently are indexed by the normal write path; `add` updates
+        // an existing entry in place, so double-indexing is harmless.
+        let mut indexed = 0usize;
+        for node in self.all_nodes() {
+            if let Some(vector) = node
+                .properties
+                .get(property_name)
+                .and_then(|v| v.as_vector())
+            {
+                index.add(node.id, vector)?;
+                indexed += 1;
+            }
+        }
+        Ok(indexed)
+    }
+
     /// Get a reference to the HNSW index and its config for a specific property.
     ///
     /// Used for persistence operations. Returns (index, config, vector_count, mappings).

--- a/src/storage/current/tests.rs
+++ b/src/storage/current/tests.rs
@@ -472,6 +472,126 @@ fn test_enable_vector_index_twice_fails() {
     assert!(result.is_err());
 }
 
+/// Issue #451: rebuilding an ALREADY-ENABLED index must not error — the
+/// supplied config is ignored and the backfill runs against the existing
+/// index, updating entries in place, so the call is idempotent. Nodes
+/// without the property, or whose property is not a vector, are skipped.
+#[test]
+fn test_rebuild_vector_index_on_already_enabled_index_is_idempotent_backfill() {
+    use crate::index::vector::{DistanceMetric, VectorIndex};
+    let storage = CurrentStorage::new();
+
+    let config = HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100);
+    storage.enable_vector_index("embedding", config).unwrap();
+
+    // Two nodes with the vector (auto-indexed at create), one without the
+    // property at all, and one whose "embedding" property is not a vector.
+    for v in [[1.0f32, 0.0, 0.0, 0.0], [0.9f32, 0.1, 0.0, 0.0]] {
+        storage
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("embedding", &v)
+                    .build(),
+            )
+            .unwrap();
+    }
+    storage
+        .create_node(
+            "Doc",
+            PropertyMapBuilder::new()
+                .insert("name", "no-vector")
+                .build(),
+        )
+        .unwrap();
+    storage
+        .create_node(
+            "Doc",
+            PropertyMapBuilder::new()
+                .insert("embedding", "not a vector")
+                .build(),
+        )
+        .unwrap();
+
+    // The config passed here (different dimensions) must be ignored because
+    // the index is already registered.
+    let other_config = HnswConfig::new(8, DistanceMetric::Euclidean);
+    let indexed = storage
+        .rebuild_vector_index("embedding", other_config.clone())
+        .expect("rebuild on an already-enabled index must succeed");
+    assert_eq!(indexed, 2, "only nodes with the vector property count");
+
+    // Idempotent: a second rebuild re-indexes the same vectors in place.
+    let indexed_again = storage
+        .rebuild_vector_index("embedding", other_config)
+        .expect("rebuild must be idempotent");
+    assert_eq!(indexed_again, 2);
+
+    let (index, config, _, _) = storage
+        .get_vector_index_for_persistence("embedding")
+        .expect("index must still be registered");
+    assert_eq!(index.len(), 2, "no duplicate entries after double rebuild");
+    assert_eq!(config.dimensions, 4, "original config must be kept");
+}
+
+/// Issue #451: rebuilding an index for a NEW property when the maximum
+/// number of vector-indexed properties is already reached must propagate the
+/// enable error instead of registering anything.
+#[test]
+fn test_rebuild_vector_index_errors_when_property_limit_reached() {
+    use crate::index::vector::DistanceMetric;
+    let storage = CurrentStorage::new();
+
+    for i in 0..DEFAULT_MAX_VECTOR_PROPERTIES {
+        storage
+            .enable_vector_index(
+                &format!("embedding_{i}"),
+                HnswConfig::new(4, DistanceMetric::Cosine),
+            )
+            .unwrap();
+    }
+
+    let result = storage.rebuild_vector_index(
+        "one_property_too_many",
+        HnswConfig::new(4, DistanceMetric::Cosine),
+    );
+    assert!(
+        result.is_err(),
+        "rebuild must fail when no index slot is available"
+    );
+    assert!(
+        !storage.is_vector_index_enabled_for("one_property_too_many"),
+        "the failed rebuild must not register an index"
+    );
+}
+
+/// Issue #451: a stored vector whose dimensionality does not match the
+/// rebuild config must fail the rebuild (the `add` error propagates).
+#[test]
+fn test_rebuild_vector_index_errors_on_dimension_mismatch() {
+    use crate::index::vector::DistanceMetric;
+    let storage = CurrentStorage::new();
+
+    // Store a 2-dimensional vector with NO index enabled, so it is accepted.
+    storage
+        .create_node(
+            "Doc",
+            PropertyMapBuilder::new()
+                .insert_vector("embedding", &[1.0f32, 0.0])
+                .build(),
+        )
+        .unwrap();
+
+    // Rebuilding with a 4-dimensional config enables the index but fails to
+    // backfill the mismatched vector.
+    let result =
+        storage.rebuild_vector_index("embedding", HnswConfig::new(4, DistanceMetric::Cosine));
+    assert!(
+        result.is_err(),
+        "a dimension mismatch during backfill must surface as an error"
+    );
+}
+
 #[test]
 fn test_auto_index_on_create() {
     use crate::index::vector::DistanceMetric;

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -225,6 +225,23 @@ fn load_single_vector_index(
         }
     };
 
+    // Test-only panic injection. The catch_unwind panic-isolation arm in
+    // `load_vector_indexes` is unreachable with well-formed inputs (every
+    // parser below returns `Err` instead of panicking), so tests inject a
+    // panic via magic directory names to prove a panicking load is isolated
+    // to a skip and cannot abort startup or its sibling loads. The three
+    // names exercise the three panic-payload downcasts (&str, String, other).
+    // Compiled out of production builds entirely.
+    #[cfg(test)]
+    match property_name.as_str() {
+        "__panic_injection_str__" => panic!("injected &str panic (test-only)"),
+        "__panic_injection_string__" => {
+            panic!("injected String panic for '{property_name}' (test-only)")
+        }
+        "__panic_injection_other__" => std::panic::panic_any(42_u32),
+        _ => {}
+    }
+
     // Load metadata
     let meta_path = vec_path.join("meta.idx");
     if !meta_path.exists() {

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -175,50 +175,69 @@ struct LoadedVectorIndex {
     index: crate::index::vector::HnswIndex,
     config: crate::index::vector::HnswConfig,
     dimensions: u32,
-    vector_count: u64,
+    /// Vector count recorded in `meta.idx` (may disagree with what was
+    /// actually restored, e.g. when `current.usearch` is missing).
+    meta_vector_count: u64,
+    /// Non-fatal warnings collected during the (parallel) load, emitted
+    /// later by the sequential registration phase so logging stays
+    /// deterministic.
+    warnings: Vec<String>,
+}
+
+/// Why a per-property vector index directory was skipped instead of loaded.
+struct SkippedVectorIndex {
+    /// Directory/property name (lossy if the name is not valid UTF-8).
+    property_name: String,
+    reason: String,
 }
 
 /// Load a single per-property vector index from its directory.
 ///
-/// Returns `None` (after logging a warning) if the directory does not contain
-/// a loadable index: missing/corrupted metadata, unknown distance metric,
-/// corrupted HNSW file or mappings, or an invalid directory name. Errors here
-/// are intentionally non-fatal so one bad index never prevents its siblings
-/// from loading (a skipped index can be rebuilt from node properties via
-/// `rebuild_vector_index`).
-fn load_single_vector_index(vec_path: &std::path::Path) -> Option<LoadedVectorIndex> {
+/// Returns `Err(SkippedVectorIndex)` (with the skip reason) if the directory
+/// does not contain a loadable index: missing/corrupted metadata, unknown
+/// distance metric, corrupted HNSW file or mappings (including a mapping key
+/// beyond the maximum valid usearch key), or an invalid directory name.
+/// Errors here are intentionally non-fatal so one bad index never prevents
+/// its siblings from loading — a skipped index can be rebuilt from node
+/// properties via [`crate::db::AletheiaDB::rebuild_vector_index`].
+///
+/// This function performs no logging itself; warnings and skip reasons are
+/// reported by the sequential registration phase in [`load_vector_indexes`]
+/// so output stays deterministic even though loads run in parallel.
+fn load_single_vector_index(
+    vec_path: &std::path::Path,
+) -> std::result::Result<LoadedVectorIndex, SkippedVectorIndex> {
     use crate::index::vector::{DistanceMetric, HnswConfig, HnswIndex};
     use crate::storage::index_persistence::vector::{load_vector_mappings, load_vector_meta};
+
+    let skipped = |property_name: &str, reason: String| SkippedVectorIndex {
+        property_name: property_name.to_string(),
+        reason,
+    };
 
     let property_name = match vec_path.file_name().and_then(|n| n.to_str()) {
         Some(name) => name.to_string(),
         None => {
-            eprintln!(
-                "Warning: Skipping vector index at {:?}: invalid directory name",
-                vec_path
-            );
-            return None;
+            return Err(SkippedVectorIndex {
+                property_name: vec_path.to_string_lossy().into_owned(),
+                reason: "invalid directory name".to_string(),
+            });
         }
     };
 
     // Load metadata
     let meta_path = vec_path.join("meta.idx");
     if !meta_path.exists() {
-        eprintln!(
-            "Warning: Skipping vector index '{}': metadata not found",
-            property_name
-        );
-        return None;
+        return Err(skipped(&property_name, "metadata not found".to_string()));
     }
 
     let meta = match load_vector_meta(&meta_path) {
         Ok(meta) => meta,
         Err(e) => {
-            eprintln!(
-                "Warning: Skipping vector index '{}': failed to load metadata: {}",
-                property_name, e
-            );
-            return None;
+            return Err(skipped(
+                &property_name,
+                format!("failed to load metadata: {}", e),
+            ));
         }
     };
 
@@ -226,11 +245,10 @@ fn load_single_vector_index(vec_path: &std::path::Path) -> Option<LoadedVectorIn
     let metric = match DistanceMetric::from_u8(meta.metric) {
         Ok(m) => m,
         Err(_) => {
-            eprintln!(
-                "Warning: Skipping vector index '{}': unknown metric {}",
-                property_name, meta.metric
-            );
-            return None;
+            return Err(skipped(
+                &property_name,
+                format!("unknown metric {}", meta.metric),
+            ));
         }
     };
 
@@ -252,25 +270,24 @@ fn load_single_vector_index(vec_path: &std::path::Path) -> Option<LoadedVectorIn
     let index = match index_result {
         Ok(index) => index,
         Err(e) => {
-            eprintln!(
-                "Warning: Skipping vector index '{}': failed to load HNSW index: {}",
-                property_name, e
-            );
-            return None;
+            return Err(skipped(
+                &property_name,
+                format!("failed to load HNSW index: {}", e),
+            ));
         }
     };
 
     // Load mappings and restore them to the index
+    let mut warnings = Vec::new();
     let mappings_path = vec_path.join("mappings.idx");
     if mappings_path.exists() {
         let mappings_data = match load_vector_mappings(&mappings_path) {
             Ok(data) => data,
             Err(e) => {
-                eprintln!(
-                    "Warning: Skipping vector index '{}': failed to load mappings: {}",
-                    property_name, e
-                );
-                return None;
+                return Err(skipped(
+                    &property_name,
+                    format!("failed to load mappings: {}", e),
+                ));
             }
         };
 
@@ -281,24 +298,33 @@ fn load_single_vector_index(vec_path: &std::path::Path) -> Option<LoadedVectorIn
         for mapping in &mappings_data.mappings {
             match NodeId::new(mapping.node_id) {
                 Ok(node_id) => {
-                    index.restore_mapping(node_id, mapping.usearch_key);
+                    // An out-of-range usearch key means the mappings file is
+                    // corrupted: skip the whole index rather than restore a
+                    // key that would poison the index's key allocator.
+                    if let Err(e) = index.restore_mapping(node_id, mapping.usearch_key) {
+                        return Err(skipped(
+                            &property_name,
+                            format!("corrupted mappings: {}", e),
+                        ));
+                    }
                 }
                 Err(e) => {
-                    eprintln!(
-                        "Warning: Skipping invalid NodeId {} in vector index '{}': {}",
+                    warnings.push(format!(
+                        "Skipping invalid NodeId {} in vector index '{}': {}",
                         mapping.node_id, property_name, e
-                    );
+                    ));
                 }
             }
         }
     }
 
-    Some(LoadedVectorIndex {
+    Ok(LoadedVectorIndex {
         property_name,
         index,
         config,
         dimensions: meta.dimensions,
-        vector_count: meta.vector_count,
+        meta_vector_count: meta.vector_count,
+        warnings,
     })
 }
 
@@ -352,26 +378,75 @@ pub(crate) fn load_vector_indexes(
 
     // Load every per-property index in parallel. Each load is independent
     // (separate files, separate in-memory structures), so loading scales with
-    // the number of vector-indexed properties.
-    let staged: Vec<Option<LoadedVectorIndex>> = index_dirs
+    // the number of vector-indexed properties. A panic inside one load task
+    // (e.g. a bug tripped by adversarial file contents) is caught and counted
+    // as a skip: all state touched by the task is task-local and the
+    // parking_lot locks used by `HnswIndex` do not poison, so unwinding is
+    // safe and must not abort startup or kill the sibling loads (rayon would
+    // otherwise propagate the panic through `collect`).
+    let staged: Vec<std::result::Result<LoadedVectorIndex, SkippedVectorIndex>> = index_dirs
         .par_iter()
-        .map(|path| load_single_vector_index(path))
+        .map(|path| {
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                load_single_vector_index(path)
+            }))
+            .unwrap_or_else(|payload| {
+                let panic_msg = if let Some(s) = payload.downcast_ref::<&str>() {
+                    (*s).to_string()
+                } else if let Some(s) = payload.downcast_ref::<String>() {
+                    s.clone()
+                } else {
+                    "non-string panic payload".to_string()
+                };
+                Err(SkippedVectorIndex {
+                    property_name: path
+                        .file_name()
+                        .map(|n| n.to_string_lossy().into_owned())
+                        .unwrap_or_else(|| path.to_string_lossy().into_owned()),
+                    reason: format!("panicked during load: {}", panic_msg),
+                })
+            })
+        })
         .collect();
 
     // Register the successfully loaded indexes sequentially (cheap: a DashMap
-    // insert per index) so registration and logging stay deterministic.
+    // insert per index). All logging happens here, in directory-scan order,
+    // rather than inside the parallel workers, so output is deterministic.
     let mut summary = VectorIndexLoadSummary::default();
-    for loaded in staged {
-        match loaded {
-            Some(loaded) => {
+    for staged_result in staged {
+        match staged_result {
+            Ok(loaded) => {
+                for warning in &loaded.warnings {
+                    eprintln!("Warning: {}", warning);
+                }
+                // Report the number of vectors actually restored, which can
+                // legitimately differ from the metadata's count (e.g. when
+                // `current.usearch` is missing an empty index is registered).
+                use crate::index::vector::VectorIndex;
+                let restored_count = loaded.index.len();
+                if loaded.meta_vector_count > 0 && restored_count == 0 {
+                    eprintln!(
+                        "Warning: vector index '{}' metadata records {} vectors but 0 were \
+                         restored (current.usearch missing or empty); the index was registered \
+                         empty — rebuild it from node properties via rebuild_vector_index to \
+                         restore searchability",
+                        loaded.property_name, loaded.meta_vector_count
+                    );
+                }
                 current.register_vector_index(&loaded.property_name, loaded.index, loaded.config);
                 eprintln!(
                     "✓ Loaded vector index '{}': {} dimensions, {} vectors",
-                    loaded.property_name, loaded.dimensions, loaded.vector_count
+                    loaded.property_name, loaded.dimensions, restored_count
                 );
                 summary.loaded += 1;
             }
-            None => summary.skipped += 1,
+            Err(skipped) => {
+                eprintln!(
+                    "Warning: Skipping vector index '{}': {}",
+                    skipped.property_name, skipped.reason
+                );
+                summary.skipped += 1;
+            }
         }
     }
 
@@ -1039,7 +1114,13 @@ pub(crate) fn load_indexes_startup(
             if summary.skipped > 0 {
                 eprintln!(
                     "Warning: Skipped {} corrupted/unreadable vector index(es); {} loaded. \
-                     Skipped indexes can be re-enabled and rebuilt from node properties.",
+                     Recover each skipped index with \
+                     AletheiaDB::rebuild_vector_index(property, config), which re-enables \
+                     it and backfills it from node properties. Do NOT just re-enable it: \
+                     enable_vector_index creates an empty index that the next persistence \
+                     cycle writes over the on-disk files, permanently losing the vectors. \
+                     The skipped directory is left in place and this warning repeats on \
+                     every startup until the index is rebuilt (and re-persisted).",
                     summary.skipped, summary.loaded
                 );
             }

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -158,146 +158,224 @@ pub(crate) fn persist_vector_indexes(
     Ok(())
 }
 
-/// Load vector indexes from disk.
+/// Outcome of [`load_vector_indexes`]: how many per-property vector indexes
+/// were restored and how many were skipped because of per-index errors
+/// (corrupted or missing files, unknown metric, invalid directory name).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct VectorIndexLoadSummary {
+    /// Number of vector indexes successfully loaded and registered.
+    pub loaded: usize,
+    /// Number of vector index directories skipped due to errors.
+    pub skipped: usize,
+}
+
+/// A vector index staged in memory, ready to be registered with `CurrentStorage`.
+struct LoadedVectorIndex {
+    property_name: String,
+    index: crate::index::vector::HnswIndex,
+    config: crate::index::vector::HnswConfig,
+    dimensions: u32,
+    vector_count: u64,
+}
+
+/// Load a single per-property vector index from its directory.
+///
+/// Returns `None` (after logging a warning) if the directory does not contain
+/// a loadable index: missing/corrupted metadata, unknown distance metric,
+/// corrupted HNSW file or mappings, or an invalid directory name. Errors here
+/// are intentionally non-fatal so one bad index never prevents its siblings
+/// from loading (a skipped index can be rebuilt from node properties via
+/// `rebuild_vector_index`).
+fn load_single_vector_index(vec_path: &std::path::Path) -> Option<LoadedVectorIndex> {
+    use crate::index::vector::{DistanceMetric, HnswConfig, HnswIndex};
+    use crate::storage::index_persistence::vector::{load_vector_mappings, load_vector_meta};
+
+    let property_name = match vec_path.file_name().and_then(|n| n.to_str()) {
+        Some(name) => name.to_string(),
+        None => {
+            eprintln!(
+                "Warning: Skipping vector index at {:?}: invalid directory name",
+                vec_path
+            );
+            return None;
+        }
+    };
+
+    // Load metadata
+    let meta_path = vec_path.join("meta.idx");
+    if !meta_path.exists() {
+        eprintln!(
+            "Warning: Skipping vector index '{}': metadata not found",
+            property_name
+        );
+        return None;
+    }
+
+    let meta = match load_vector_meta(&meta_path) {
+        Ok(meta) => meta,
+        Err(e) => {
+            eprintln!(
+                "Warning: Skipping vector index '{}': failed to load metadata: {}",
+                property_name, e
+            );
+            return None;
+        }
+    };
+
+    // Convert metric from u8 to DistanceMetric using from_u8()
+    let metric = match DistanceMetric::from_u8(meta.metric) {
+        Ok(m) => m,
+        Err(_) => {
+            eprintln!(
+                "Warning: Skipping vector index '{}': unknown metric {}",
+                property_name, meta.metric
+            );
+            return None;
+        }
+    };
+
+    // Create config from metadata
+    let config = HnswConfig::new(meta.dimensions as usize, metric)
+        .with_m(meta.hnsw_config.m as usize)
+        .with_ef_construction(meta.hnsw_config.ef_construction as usize)
+        .with_ef_search(meta.hnsw_config.ef_search as usize);
+
+    // Load or create index
+    let usearch_path = vec_path.join("current.usearch");
+    let index_result = if usearch_path.exists() {
+        // Load existing index
+        HnswIndex::load(&usearch_path, config.clone())
+    } else {
+        // Create new empty index
+        HnswIndex::new(config.clone())
+    };
+    let index = match index_result {
+        Ok(index) => index,
+        Err(e) => {
+            eprintln!(
+                "Warning: Skipping vector index '{}': failed to load HNSW index: {}",
+                property_name, e
+            );
+            return None;
+        }
+    };
+
+    // Load mappings and restore them to the index
+    let mappings_path = vec_path.join("mappings.idx");
+    if mappings_path.exists() {
+        let mappings_data = match load_vector_mappings(&mappings_path) {
+            Ok(data) => data,
+            Err(e) => {
+                eprintln!(
+                    "Warning: Skipping vector index '{}': failed to load mappings: {}",
+                    property_name, e
+                );
+                return None;
+            }
+        };
+
+        // Restore ID mappings
+        // Note: The usearch index already has the vectors loaded from disk,
+        // but we need to restore the NodeId <-> usearch_key mappings
+        use crate::core::id::NodeId;
+        for mapping in &mappings_data.mappings {
+            match NodeId::new(mapping.node_id) {
+                Ok(node_id) => {
+                    index.restore_mapping(node_id, mapping.usearch_key);
+                }
+                Err(e) => {
+                    eprintln!(
+                        "Warning: Skipping invalid NodeId {} in vector index '{}': {}",
+                        mapping.node_id, property_name, e
+                    );
+                }
+            }
+        }
+    }
+
+    Some(LoadedVectorIndex {
+        property_name,
+        index,
+        config,
+        dimensions: meta.dimensions,
+        vector_count: meta.vector_count,
+    })
+}
+
+/// Load vector indexes from disk (Issue #451).
 ///
 /// This function:
-/// 1. Scans the vector index directory.
-/// 2. For each subdirectory (representing a property), loads metadata and mappings.
-/// 3. Reconstructs the HNSW index using `usearch`.
-/// 4. Restores the `NodeId` <-> `u64` key mappings.
-/// 5. Registers the index with `CurrentStorage`, making it immediately available for search.
+/// 1. Scans the vector index directory for per-property subdirectories.
+/// 2. Loads each property's index **in parallel** (rayon): metadata,
+///    mappings, and the HNSW graph via `usearch`.
+/// 3. Restores the `NodeId` <-> `u64` key mappings.
+/// 4. Registers each index with `CurrentStorage`, making it immediately
+///    available for search.
 ///
-/// Errors during loading of individual indexes are logged but do not abort the process,
-/// allowing valid indexes to be loaded even if some are corrupted.
+/// # Error Isolation
+///
+/// Errors while loading an individual index (corrupted metadata, HNSW file,
+/// or mappings; unknown metric) are logged and that index is skipped — they
+/// never abort loading of the remaining indexes. The returned
+/// [`VectorIndexLoadSummary`] reports how many indexes loaded vs. were
+/// skipped. Only infrastructure failures (the vector directory itself is
+/// unreadable) return `Err`.
 pub(crate) fn load_vector_indexes(
     current: &Arc<CurrentStorage>,
     manager: &IndexPersistenceManager,
-) -> Result<()> {
-    use crate::index::vector::{DistanceMetric, HnswConfig, HnswIndex};
-    use crate::storage::index_persistence::vector::{load_vector_mappings, load_vector_meta};
+) -> Result<VectorIndexLoadSummary> {
+    use rayon::prelude::*;
 
     // Get vector directory
     let vector_base = manager.indexes_path().join("vector");
     if !vector_base.exists() {
-        return Ok(()); // No vector indexes to load
+        return Ok(VectorIndexLoadSummary::default()); // No vector indexes to load
     }
 
-    // Iterate through all subdirectories (one per property)
+    // Collect per-property subdirectories first so the (potentially
+    // expensive) HNSW loads can run in parallel afterwards.
     let entries = std::fs::read_dir(&vector_base).map_err(|e| {
         StorageError::PersistenceError(format!("Failed to read vector directory: {}", e))
     })?;
 
+    let mut index_dirs = Vec::new();
     for entry in entries {
         let entry = entry.map_err(|e| {
             StorageError::PersistenceError(format!("Failed to read directory entry: {}", e))
         })?;
 
         let vec_path = entry.path();
-        if !vec_path.is_dir() {
-            continue;
+        if vec_path.is_dir() {
+            index_dirs.push(vec_path);
         }
-
-        let property_name = vec_path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .ok_or_else(|| {
-                StorageError::PersistenceError("Invalid vector directory name".to_string())
-            })?;
-
-        // Load metadata
-        let meta_path = vec_path.join("meta.idx");
-        if !meta_path.exists() {
-            eprintln!(
-                "Warning: Skipping vector index '{}': metadata not found",
-                property_name
-            );
-            continue;
-        }
-
-        let meta = load_vector_meta(&meta_path).map_err(|e| {
-            StorageError::PersistenceError(format!(
-                "Failed to load vector metadata for {}: {}",
-                property_name, e
-            ))
-        })?;
-
-        // Convert metric from u8 to DistanceMetric using from_u8()
-        let metric = match DistanceMetric::from_u8(meta.metric) {
-            Ok(m) => m,
-            Err(_) => {
-                eprintln!(
-                    "Warning: Skipping vector index '{}': unknown metric {}",
-                    property_name, meta.metric
-                );
-                continue;
-            }
-        };
-
-        // Create config from metadata
-        let config = HnswConfig::new(meta.dimensions as usize, metric)
-            .with_m(meta.hnsw_config.m as usize)
-            .with_ef_construction(meta.hnsw_config.ef_construction as usize)
-            .with_ef_search(meta.hnsw_config.ef_search as usize);
-
-        // Load or create index
-        let usearch_path = vec_path.join("current.usearch");
-        let index = if usearch_path.exists() {
-            // Load existing index
-            HnswIndex::load(&usearch_path, config.clone()).map_err(|e| {
-                StorageError::PersistenceError(format!(
-                    "Failed to load usearch index for {}: {}",
-                    property_name, e
-                ))
-            })?
-        } else {
-            // Create new empty index
-            HnswIndex::new(config.clone()).map_err(|e| {
-                StorageError::PersistenceError(format!(
-                    "Failed to create HNSW index for {}: {}",
-                    property_name, e
-                ))
-            })?
-        };
-
-        // Load mappings and restore them to the index
-        let mappings_path = vec_path.join("mappings.idx");
-        if mappings_path.exists() {
-            let mappings_data = load_vector_mappings(&mappings_path).map_err(|e| {
-                StorageError::PersistenceError(format!(
-                    "Failed to load vector mappings for {}: {}",
-                    property_name, e
-                ))
-            })?;
-
-            // Restore ID mappings
-            // Note: The usearch index already has the vectors loaded from disk,
-            // but we need to restore the NodeId <-> usearch_key mappings
-            use crate::core::id::NodeId;
-            for mapping in &mappings_data.mappings {
-                match NodeId::new(mapping.node_id) {
-                    Ok(node_id) => {
-                        index.restore_mapping(node_id, mapping.usearch_key);
-                    }
-                    Err(e) => {
-                        eprintln!(
-                            "Warning: Skipping invalid NodeId {} in vector index '{}': {}",
-                            mapping.node_id, property_name, e
-                        );
-                    }
-                }
-            }
-        }
-
-        // Register index with CurrentStorage
-        current.register_vector_index(property_name, index, config);
-
-        eprintln!(
-            "✓ Loaded vector index '{}': {} dimensions, {} vectors",
-            property_name, meta.dimensions, meta.vector_count
-        );
     }
 
-    Ok(())
+    // Load every per-property index in parallel. Each load is independent
+    // (separate files, separate in-memory structures), so loading scales with
+    // the number of vector-indexed properties.
+    let staged: Vec<Option<LoadedVectorIndex>> = index_dirs
+        .par_iter()
+        .map(|path| load_single_vector_index(path))
+        .collect();
+
+    // Register the successfully loaded indexes sequentially (cheap: a DashMap
+    // insert per index) so registration and logging stay deterministic.
+    let mut summary = VectorIndexLoadSummary::default();
+    for loaded in staged {
+        match loaded {
+            Some(loaded) => {
+                current.register_vector_index(&loaded.property_name, loaded.index, loaded.config);
+                eprintln!(
+                    "✓ Loaded vector index '{}': {} dimensions, {} vectors",
+                    loaded.property_name, loaded.dimensions, loaded.vector_count
+                );
+                summary.loaded += 1;
+            }
+            None => summary.skipped += 1,
+        }
+    }
+
+    Ok(summary)
 }
 
 /// Persist graph index to disk.
@@ -955,9 +1033,20 @@ pub(crate) fn load_indexes_startup(
         }
     }
 
-    // Load vector indexes
-    if let Err(e) = load_vector_indexes(current, manager) {
-        eprintln!("Warning: Failed to load vector indexes: {}", e);
+    // Load vector indexes (parallel, per-index error isolation; Issue #451)
+    match load_vector_indexes(current, manager) {
+        Ok(summary) => {
+            if summary.skipped > 0 {
+                eprintln!(
+                    "Warning: Skipped {} corrupted/unreadable vector index(es); {} loaded. \
+                     Skipped indexes can be re-enabled and rebuilt from node properties.",
+                    summary.skipped, summary.loaded
+                );
+            }
+        }
+        Err(e) => {
+            eprintln!("Warning: Failed to load vector indexes: {}", e);
+        }
     }
 
     // Load temporal adjacency index

--- a/src/storage/index_persistence/operations_tests.rs
+++ b/src/storage/index_persistence/operations_tests.rs
@@ -458,7 +458,11 @@ fn test_load_vector_indexes_skips_non_utf8_directory_name() {
     // 0xFF is never valid in UTF-8, so this directory name has no &str form.
     let non_utf8_name = OsStr::from_bytes(b"bad_\xff\xfe_embedding");
     let non_utf8_dir = manager.indexes_path().join("vector").join(non_utf8_name);
-    std::fs::create_dir_all(&non_utf8_dir).unwrap();
+    if std::fs::create_dir_all(&non_utf8_dir).is_err() {
+        // Filesystem (e.g. APFS on macOS) rejects non-UTF-8 names with EILSEQ;
+        // the non-UTF-8-directory scenario cannot exist here.
+        return;
+    }
 
     let fresh = Arc::new(CurrentStorage::new());
     let summary = load_vector_indexes(&fresh, &manager)

--- a/src/storage/index_persistence/operations_tests.rs
+++ b/src/storage/index_persistence/operations_tests.rs
@@ -154,6 +154,7 @@ fn test_load_vector_indexes_multi_property_round_trip() {
     ];
 
     let current = Arc::new(CurrentStorage::new());
+    let mut created_nodes = std::collections::HashMap::new();
     for (property, dims, metric) in specs {
         current
             .enable_vector_index(property, HnswConfig::new(dims, metric))
@@ -162,9 +163,10 @@ fn test_load_vector_indexes_multi_property_round_trip() {
         let mut embedding = vec![0.0f32; dims];
         embedding[0] = 1.0;
         builder = builder.insert_vector(property, &embedding);
-        current
+        let node_id = current
             .create_node("Doc", builder.build())
             .unwrap_or_else(|e| panic!("failed to create node for {property}: {e}"));
+        created_nodes.insert(property, node_id);
     }
     persist_vector_indexes(&current, &manager, None, 0).expect("failed to persist vector indexes");
 
@@ -186,8 +188,190 @@ fn test_load_vector_indexes_multi_property_round_trip() {
             .unwrap_or_else(|| panic!("index for {property} must be registered"));
         assert_eq!(count, 1, "vector count for {property}");
         assert_eq!(mappings.len(), 1, "id mappings for {property}");
+        let created_id = created_nodes[property];
+        assert!(
+            mappings
+                .iter()
+                .any(|(node_id, _)| *node_id == created_id.as_u64()),
+            "restored mappings for {property} must contain the created node id \
+             {created_id:?}, got: {mappings:?}"
+        );
         assert_eq!(index.len(), 1, "HNSW length for {property}");
     }
+}
+
+/// Issue #451: every per-index skip branch must skip ONLY the broken index
+/// and still load a valid sibling. Parameterized over the corruption modes
+/// so each error path in `load_single_vector_index` has direct coverage.
+#[test]
+fn test_load_vector_indexes_skip_branches_per_corruption_mode() {
+    use crate::index::vector::{DistanceMetric, HnswConfig};
+    use crate::storage::index_persistence::formats::PersistedHnswConfig;
+    use crate::storage::index_persistence::vector::{new_vector_meta, save_vector_meta};
+    use std::path::Path;
+
+    fn truncate_file(path: &Path) {
+        let data = std::fs::read(path).unwrap();
+        assert!(
+            data.len() > 8,
+            "file {path:?} too small ({} bytes) to truncate meaningfully",
+            data.len()
+        );
+        std::fs::write(path, &data[..data.len() / 2]).unwrap();
+    }
+
+    // Each corruption is applied to the persisted "bad_embedding" directory
+    // while its sibling "valid_embedding" stays untouched.
+    #[allow(clippy::type_complexity)]
+    let modes: Vec<(&str, Box<dyn Fn(&Path)>)> = vec![
+        (
+            "missing meta.idx",
+            Box::new(|dir: &Path| std::fs::remove_file(dir.join("meta.idx")).unwrap()),
+        ),
+        (
+            "truncated meta.idx",
+            Box::new(|dir: &Path| truncate_file(&dir.join("meta.idx"))),
+        ),
+        (
+            "valid meta with unknown metric byte",
+            Box::new(|dir: &Path| {
+                // Structurally valid (magic, version, CRC all pass) but the
+                // metric byte 99 maps to no DistanceMetric.
+                let meta = new_vector_meta(
+                    "bad_embedding",
+                    4,
+                    99,
+                    PersistedHnswConfig {
+                        m: 16,
+                        ef_construction: 200,
+                        ef_search: 50,
+                    },
+                );
+                save_vector_meta(&meta, &dir.join("meta.idx")).unwrap();
+            }),
+        ),
+        (
+            "garbage mappings.idx",
+            Box::new(|dir: &Path| {
+                std::fs::write(dir.join("mappings.idx"), b"garbage, not bitcode").unwrap()
+            }),
+        ),
+        (
+            "garbage current.usearch",
+            Box::new(|dir: &Path| {
+                std::fs::write(dir.join("current.usearch"), b"garbage, not usearch").unwrap()
+            }),
+        ),
+        (
+            "truncated current.usearch",
+            Box::new(|dir: &Path| truncate_file(&dir.join("current.usearch"))),
+        ),
+        (
+            "garbage current.usearch.mappings sidecar",
+            Box::new(|dir: &Path| {
+                std::fs::write(dir.join("current.usearch.mappings"), b"garbage sidecar").unwrap()
+            }),
+        ),
+    ];
+
+    for (mode, corrupt) in modes {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let manager = Arc::new(IndexPersistenceManager::new(temp_dir.path()));
+        manager.ensure_directories().unwrap();
+
+        // Persist two healthy indexes over one node.
+        let current = Arc::new(CurrentStorage::new());
+        for property in ["bad_embedding", "valid_embedding"] {
+            current
+                .enable_vector_index(property, HnswConfig::new(4, DistanceMetric::Cosine))
+                .unwrap_or_else(|e| panic!("[{mode}] failed to enable {property}: {e}"));
+        }
+        current
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("bad_embedding", &[1.0f32, 0.0, 0.0, 0.0])
+                    .insert_vector("valid_embedding", &[1.0f32, 0.0, 0.0, 0.0])
+                    .build(),
+            )
+            .unwrap_or_else(|e| panic!("[{mode}] failed to create node: {e}"));
+        persist_vector_indexes(&current, &manager, None, 0)
+            .unwrap_or_else(|e| panic!("[{mode}] failed to persist: {e}"));
+
+        // Apply this mode's corruption to the bad index's directory.
+        corrupt(&manager.vector_path("bad_embedding"));
+
+        // Load into a fresh storage: exactly the corrupted index is skipped.
+        let fresh = Arc::new(CurrentStorage::new());
+        let summary = load_vector_indexes(&fresh, &manager)
+            .unwrap_or_else(|e| panic!("[{mode}] per-index corruption must not abort load: {e}"));
+        assert_eq!(summary.skipped, 1, "[{mode}] skipped count");
+        assert_eq!(summary.loaded, 1, "[{mode}] loaded count");
+        assert!(
+            fresh.is_vector_index_enabled_for("valid_embedding"),
+            "[{mode}] the valid sibling must load"
+        );
+        assert!(
+            !fresh.is_vector_index_enabled_for("bad_embedding"),
+            "[{mode}] the corrupted index must not be registered"
+        );
+    }
+}
+
+/// Issue #451: a `mappings.idx` that decodes cleanly but contains a usearch
+/// key beyond `MAX_VALID_KEY` (only possible via corruption) must cause the
+/// index to be SKIPPED — not panic, and not poison the index's key
+/// allocator via `usearch_key + 1` — while the valid sibling still loads.
+#[test]
+fn test_load_vector_indexes_skips_index_with_out_of_range_usearch_key() {
+    use crate::index::vector::{DistanceMetric, HnswConfig};
+    use crate::storage::index_persistence::formats::VectorMapping;
+    use crate::storage::index_persistence::vector::{new_vector_mappings, save_vector_mappings};
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let manager = Arc::new(IndexPersistenceManager::new(temp_dir.path()));
+    manager.ensure_directories().unwrap();
+
+    let current = Arc::new(CurrentStorage::new());
+    for property in ["huge_key_embedding", "valid_embedding"] {
+        current
+            .enable_vector_index(property, HnswConfig::new(4, DistanceMetric::Cosine))
+            .expect("failed to enable vector index");
+    }
+    current
+        .create_node(
+            "Doc",
+            PropertyMapBuilder::new()
+                .insert_vector("huge_key_embedding", &[1.0f32, 0.0, 0.0, 0.0])
+                .insert_vector("valid_embedding", &[1.0f32, 0.0, 0.0, 0.0])
+                .build(),
+        )
+        .expect("failed to create node");
+    persist_vector_indexes(&current, &manager, None, 0).expect("failed to persist");
+
+    // Overwrite the mappings with a structurally valid file holding a key
+    // beyond MAX_VALID_KEY (u64::MAX - 1000).
+    let mut mappings = new_vector_mappings();
+    mappings.count = 1;
+    mappings.mappings = vec![VectorMapping {
+        node_id: 1,
+        usearch_key: u64::MAX,
+    }];
+    save_vector_mappings(
+        &mappings,
+        &manager
+            .vector_path("huge_key_embedding")
+            .join("mappings.idx"),
+    )
+    .expect("failed to write huge-key mappings");
+
+    let fresh = Arc::new(CurrentStorage::new());
+    let summary = load_vector_indexes(&fresh, &manager)
+        .expect("an out-of-range usearch key must be skipped, not abort or panic");
+    assert_eq!(summary.skipped, 1, "the huge-key index must be skipped");
+    assert_eq!(summary.loaded, 1, "the valid sibling must still load");
+    assert!(fresh.is_vector_index_enabled_for("valid_embedding"));
+    assert!(!fresh.is_vector_index_enabled_for("huge_key_embedding"));
 }
 
 #[test]

--- a/src/storage/index_persistence/operations_tests.rs
+++ b/src/storage/index_persistence/operations_tests.rs
@@ -63,6 +63,133 @@ fn test_persist_vector_indexes_with_tracker() {
     // This test mainly verifies signature compatibility.
 }
 
+/// Issue #451: a corrupted vector index on disk must not abort loading of the
+/// remaining (valid) vector indexes. `load_vector_indexes` documents that
+/// "errors during loading of individual indexes are logged but do not abort
+/// the process", so a single corrupt `meta.idx` must be skipped while every
+/// valid sibling index is still registered with `CurrentStorage`.
+#[test]
+fn test_load_vector_indexes_skips_corrupt_and_loads_valid() {
+    use crate::index::vector::{DistanceMetric, HnswConfig};
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let manager = Arc::new(IndexPersistenceManager::new(temp_dir.path()));
+    manager.ensure_directories().unwrap();
+
+    // Build and persist a valid vector index with one indexed node.
+    let current = Arc::new(CurrentStorage::new());
+    current
+        .enable_vector_index("embedding", HnswConfig::new(4, DistanceMetric::Cosine))
+        .expect("failed to enable vector index");
+    current
+        .create_node(
+            "Doc",
+            PropertyMapBuilder::new()
+                .insert_vector("embedding", &[1.0f32, 0.0, 0.0, 0.0])
+                .build(),
+        )
+        .expect("failed to create node with embedding");
+    persist_vector_indexes(&current, &manager, None, 0).expect("failed to persist vector indexes");
+
+    // Fabricate a corrupted sibling vector index directory.
+    let corrupt_dir = manager.vector_path("corrupt_embedding");
+    std::fs::create_dir_all(&corrupt_dir).unwrap();
+    std::fs::write(corrupt_dir.join("meta.idx"), b"not a valid meta file").unwrap();
+
+    // Load into a fresh storage: the corrupt index must be skipped, the
+    // valid one must load.
+    let fresh = Arc::new(CurrentStorage::new());
+    let result = load_vector_indexes(&fresh, &manager);
+    let summary = match result {
+        Ok(summary) => summary,
+        Err(e) => {
+            panic!("a corrupt vector index must be skipped, not abort all vector loading: {e}")
+        }
+    };
+    assert_eq!(summary.loaded, 1, "exactly one valid index should load");
+    assert_eq!(
+        summary.skipped, 1,
+        "exactly one corrupt index should be skipped"
+    );
+    assert!(
+        fresh.is_vector_index_enabled_for("embedding"),
+        "the valid vector index must still be loaded when a sibling is corrupt"
+    );
+    assert!(
+        !fresh.is_vector_index_enabled_for("corrupt_embedding"),
+        "the corrupt vector index must not be registered"
+    );
+}
+
+/// Issue #451: loading from a directory tree with no vector indexes must
+/// succeed with an all-zero summary (fresh database startup path).
+#[test]
+fn test_load_vector_indexes_no_vector_dir_returns_empty_summary() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let manager = Arc::new(IndexPersistenceManager::new(temp_dir.path()));
+
+    let fresh = Arc::new(CurrentStorage::new());
+    let summary = load_vector_indexes(&fresh, &manager).expect("empty data dir must load cleanly");
+    assert_eq!(summary.loaded, 0);
+    assert_eq!(summary.skipped, 0);
+    assert!(!fresh.is_vector_index_enabled());
+}
+
+/// Issue #451: multiple per-property vector indexes are loaded (in parallel)
+/// in one pass, each restored with its persisted configuration (dimensions,
+/// distance metric) and its indexed vectors.
+#[test]
+fn test_load_vector_indexes_multi_property_round_trip() {
+    use crate::index::vector::{DistanceMetric, HnswConfig, VectorIndex};
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let manager = Arc::new(IndexPersistenceManager::new(temp_dir.path()));
+    manager.ensure_directories().unwrap();
+
+    // Three properties with distinct dimensions and metrics.
+    let specs: [(&str, usize, DistanceMetric); 3] = [
+        ("title_embedding", 4, DistanceMetric::Cosine),
+        ("body_embedding", 8, DistanceMetric::Euclidean),
+        ("summary_embedding", 6, DistanceMetric::DotProduct),
+    ];
+
+    let current = Arc::new(CurrentStorage::new());
+    for (property, dims, metric) in specs {
+        current
+            .enable_vector_index(property, HnswConfig::new(dims, metric))
+            .unwrap_or_else(|e| panic!("failed to enable index for {property}: {e}"));
+        let mut builder = PropertyMapBuilder::new();
+        let mut embedding = vec![0.0f32; dims];
+        embedding[0] = 1.0;
+        builder = builder.insert_vector(property, &embedding);
+        current
+            .create_node("Doc", builder.build())
+            .unwrap_or_else(|e| panic!("failed to create node for {property}: {e}"));
+    }
+    persist_vector_indexes(&current, &manager, None, 0).expect("failed to persist vector indexes");
+
+    // Load into a fresh storage and verify every index round-tripped.
+    let fresh = Arc::new(CurrentStorage::new());
+    let summary = load_vector_indexes(&fresh, &manager).expect("load must succeed");
+    assert_eq!(summary.loaded, 3, "all three indexes must load");
+    assert_eq!(summary.skipped, 0);
+
+    for (property, dims, metric) in specs {
+        let config = fresh
+            .get_hnsw_config_for(property)
+            .unwrap_or_else(|| panic!("index config for {property} must survive the round trip"));
+        assert_eq!(config.dimensions, dims, "dimensions for {property}");
+        assert_eq!(config.metric, metric, "metric for {property}");
+
+        let (index, _, count, mappings) = fresh
+            .get_vector_index_for_persistence(property)
+            .unwrap_or_else(|| panic!("index for {property} must be registered"));
+        assert_eq!(count, 1, "vector count for {property}");
+        assert_eq!(mappings.len(), 1, "id mappings for {property}");
+        assert_eq!(index.len(), 1, "HNSW length for {property}");
+    }
+}
+
 #[test]
 fn test_graph_persist_keeps_interner_consistent_with_graph_string_ids() {
     let temp_dir = tempfile::tempdir().unwrap();

--- a/src/storage/index_persistence/operations_tests.rs
+++ b/src/storage/index_persistence/operations_tests.rs
@@ -374,6 +374,249 @@ fn test_load_vector_indexes_skips_index_with_out_of_range_usearch_key() {
     assert!(!fresh.is_vector_index_enabled_for("huge_key_embedding"));
 }
 
+/// Helper: persist one healthy "valid_embedding" index over a single node so
+/// corruption tests have an intact sibling to assert isolation against.
+/// Returns the manager rooted at `base` (directories already created).
+fn persist_one_valid_vector_index(base: &std::path::Path) -> Arc<IndexPersistenceManager> {
+    use crate::index::vector::{DistanceMetric, HnswConfig};
+
+    let manager = Arc::new(IndexPersistenceManager::new(base));
+    manager.ensure_directories().unwrap();
+
+    let current = Arc::new(CurrentStorage::new());
+    current
+        .enable_vector_index(
+            "valid_embedding",
+            HnswConfig::new(4, DistanceMetric::Cosine),
+        )
+        .expect("failed to enable vector index");
+    current
+        .create_node(
+            "Doc",
+            PropertyMapBuilder::new()
+                .insert_vector("valid_embedding", &[1.0f32, 0.0, 0.0, 0.0])
+                .build(),
+        )
+        .expect("failed to create node with embedding");
+    persist_vector_indexes(&current, &manager, None, 0).expect("failed to persist vector indexes");
+    manager
+}
+
+/// Issue #451: a panic inside one per-index load task must be caught by the
+/// `catch_unwind` isolation in `load_vector_indexes` and converted into a
+/// skip — never abort startup or the sibling loads. Panics are injected via
+/// the test-only magic directory names consulted by
+/// `load_single_vector_index`; the three names exercise the three
+/// panic-payload downcast arms (&str, String, non-string).
+#[test]
+fn test_load_vector_indexes_panicking_load_is_isolated_to_a_skip() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let manager = persist_one_valid_vector_index(temp_dir.path());
+
+    let vector_base = manager.indexes_path().join("vector");
+    for magic in [
+        "__panic_injection_str__",
+        "__panic_injection_string__",
+        "__panic_injection_other__",
+    ] {
+        std::fs::create_dir_all(vector_base.join(magic)).unwrap();
+    }
+
+    let fresh = Arc::new(CurrentStorage::new());
+    let summary = load_vector_indexes(&fresh, &manager)
+        .expect("a panicking per-index load must be isolated, not abort all vector loading");
+    assert_eq!(
+        summary.skipped, 3,
+        "every panicking load must be counted as a skip"
+    );
+    assert_eq!(summary.loaded, 1, "the valid sibling must still load");
+    assert!(fresh.is_vector_index_enabled_for("valid_embedding"));
+    for magic in [
+        "__panic_injection_str__",
+        "__panic_injection_string__",
+        "__panic_injection_other__",
+    ] {
+        assert!(
+            !fresh.is_vector_index_enabled_for(magic),
+            "a panicked index '{magic}' must not be registered"
+        );
+    }
+}
+
+/// Issue #451: a vector index directory whose name is not valid UTF-8 cannot
+/// name a property, so it is skipped (with the lossy path as the reported
+/// name) while valid siblings still load.
+#[cfg(unix)]
+#[test]
+fn test_load_vector_indexes_skips_non_utf8_directory_name() {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let manager = persist_one_valid_vector_index(temp_dir.path());
+
+    // 0xFF is never valid in UTF-8, so this directory name has no &str form.
+    let non_utf8_name = OsStr::from_bytes(b"bad_\xff\xfe_embedding");
+    let non_utf8_dir = manager.indexes_path().join("vector").join(non_utf8_name);
+    std::fs::create_dir_all(&non_utf8_dir).unwrap();
+
+    let fresh = Arc::new(CurrentStorage::new());
+    let summary = load_vector_indexes(&fresh, &manager)
+        .expect("a non-UTF-8 directory name must be skipped, not abort all vector loading");
+    assert_eq!(
+        summary.skipped, 1,
+        "the non-UTF-8 directory must be skipped"
+    );
+    assert_eq!(summary.loaded, 1, "the valid sibling must still load");
+    assert!(fresh.is_vector_index_enabled_for("valid_embedding"));
+}
+
+/// Issue #451: when `meta.idx` is intact but `current.usearch` is missing,
+/// the index is registered EMPTY (a fresh HNSW index) and the hollow-index
+/// warning branch fires (metadata records N > 0 vectors but 0 were
+/// restored). The load must still succeed so the caller can recover via
+/// `rebuild_vector_index`.
+#[test]
+fn test_load_vector_indexes_registers_empty_index_when_usearch_missing() {
+    use crate::index::vector::VectorIndex;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let manager = persist_one_valid_vector_index(temp_dir.path());
+
+    // Remove the HNSW graph file (and its sidecar) but keep meta.idx, whose
+    // vector_count is 1 — the hollow-index condition.
+    let index_dir = manager.vector_path("valid_embedding");
+    std::fs::remove_file(index_dir.join("current.usearch")).unwrap();
+    let sidecar = index_dir.join("current.usearch.mappings");
+    if sidecar.exists() {
+        std::fs::remove_file(sidecar).unwrap();
+    }
+
+    let fresh = Arc::new(CurrentStorage::new());
+    let summary = load_vector_indexes(&fresh, &manager)
+        .expect("a missing current.usearch must register an empty index, not fail the load");
+    assert_eq!(summary.loaded, 1, "the hollow index must still be loaded");
+    assert_eq!(summary.skipped, 0);
+    assert!(
+        fresh.is_vector_index_enabled_for("valid_embedding"),
+        "the hollow index must be registered so rebuild_vector_index can recover it"
+    );
+    let (index, _, _, _) = fresh
+        .get_vector_index_for_persistence("valid_embedding")
+        .expect("hollow index must be registered");
+    assert_eq!(
+        index.len(),
+        0,
+        "no vectors can be restored without current.usearch"
+    );
+}
+
+/// Issue #451: a mapping whose node id exceeds `MAX_VALID_ID` is skipped
+/// with a warning while the rest of the index still loads — an invalid node
+/// id poisons only that one mapping, not the whole index (unlike an
+/// out-of-range usearch key, which would poison the key allocator).
+#[test]
+fn test_load_vector_indexes_warns_on_invalid_node_id_in_mappings_but_loads() {
+    use crate::storage::index_persistence::formats::VectorMapping;
+    use crate::storage::index_persistence::vector::{new_vector_mappings, save_vector_mappings};
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let manager = persist_one_valid_vector_index(temp_dir.path());
+
+    // Rewrite the mappings with one valid entry and one whose node id is
+    // beyond MAX_VALID_ID (u64::MAX - 1000), which NodeId::new rejects.
+    let mut mappings = new_vector_mappings();
+    mappings.count = 2;
+    mappings.mappings = vec![
+        VectorMapping {
+            node_id: 1,
+            usearch_key: 0,
+        },
+        VectorMapping {
+            node_id: u64::MAX - 100,
+            usearch_key: 1,
+        },
+    ];
+    save_vector_mappings(
+        &mappings,
+        &manager.vector_path("valid_embedding").join("mappings.idx"),
+    )
+    .expect("failed to write mappings with invalid node id");
+
+    let fresh = Arc::new(CurrentStorage::new());
+    let summary = load_vector_indexes(&fresh, &manager)
+        .expect("an invalid node id in mappings must be a per-mapping warning, not a failure");
+    assert_eq!(
+        summary.loaded, 1,
+        "the index must load despite the invalid mapping"
+    );
+    assert_eq!(summary.skipped, 0);
+    let (_, _, _, restored_mappings) = fresh
+        .get_vector_index_for_persistence("valid_embedding")
+        .expect("index must be registered");
+    assert!(
+        restored_mappings.iter().any(|(node_id, _)| *node_id == 1),
+        "the valid mapping must be restored, got: {restored_mappings:?}"
+    );
+    assert!(
+        !restored_mappings
+            .iter()
+            .any(|(node_id, _)| *node_id == u64::MAX - 100),
+        "the invalid mapping must be dropped, got: {restored_mappings:?}"
+    );
+}
+
+/// Issue #451: an unreadable vector directory (here: `vector` is a file, so
+/// `read_dir` fails) is an infrastructure error for `load_vector_indexes`,
+/// but `load_indexes_startup` must degrade it to a warning — vector indexes
+/// are auxiliary and their loss must never abort database startup.
+#[test]
+fn test_load_indexes_startup_survives_unreadable_vector_directory() {
+    use crate::core::id::IdGenerator;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let manager = Arc::new(IndexPersistenceManager::new(temp_dir.path()));
+    manager.ensure_directories().unwrap();
+
+    // Replace the vector directory with a regular file: it "exists" but
+    // read_dir on it fails, which is the only Err path out of
+    // load_vector_indexes.
+    let vector_base = manager.indexes_path().join("vector");
+    if vector_base.exists() {
+        std::fs::remove_dir_all(&vector_base).unwrap();
+    }
+    std::fs::write(&vector_base, b"not a directory").unwrap();
+
+    let current = Arc::new(CurrentStorage::new());
+    assert!(
+        load_vector_indexes(&current, &manager).is_err(),
+        "read_dir on a file must surface as an infrastructure error"
+    );
+
+    // Startup loading must swallow that error with a warning, not panic or
+    // abort.
+    let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
+    let node_id_gen = Arc::new(IdGenerator::new());
+    let edge_id_gen = Arc::new(IdGenerator::new());
+    let version_id_gen = Arc::new(IdGenerator::new());
+    let manifest_lsn = load_indexes_startup(
+        &manager,
+        &current,
+        &historical,
+        &node_id_gen,
+        &edge_id_gen,
+        &version_id_gen,
+    );
+    assert!(
+        manifest_lsn.is_none(),
+        "no manifest was persisted, so no LSN should be reported"
+    );
+    assert!(
+        !current.is_vector_index_enabled(),
+        "no vector index can load from an unreadable vector directory"
+    );
+}
+
 #[test]
 fn test_graph_persist_keeps_interner_consistent_with_graph_string_ids() {
     let temp_dir = tempfile::tempdir().unwrap();

--- a/tests/index_persistence.rs
+++ b/tests/index_persistence.rs
@@ -3016,6 +3016,11 @@ fn test_vector_index_persistence_multi_property_restart() {
             similar_to_c.iter().any(|(id, _)| *id == node_a),
             "post-restart node must be searchable and close to node_a, got: {similar_to_c:?}"
         );
+        assert!(
+            similar_to_c.iter().any(|(id, _)| *id == node_b),
+            "restored node_b must still be reachable (k=3 covers all nodes) after \
+             the post-restart insert, got: {similar_to_c:?}"
+        );
 
         // Second save (save → load → save).
         db.persist_indexes().unwrap();
@@ -3033,9 +3038,18 @@ fn test_vector_index_persistence_multi_property_restart() {
     }
 }
 
-/// Issue #451: a corrupted vector index file must not prevent the database
+/// Issue #451: corrupted vector index files must not prevent the database
 /// from starting, and every OTHER vector index must still be loaded and
 /// searchable (per-index error isolation on the startup path).
+///
+/// TWO corrupt sibling indexes are used, named so their directories bracket
+/// the good one in sorted order (`aaa_bad_embedding` < `good_embedding` <
+/// `zzz_bad_embedding`). With a single corrupt sibling the test is
+/// order-dependent: a trunk-style abort-on-first-error loader would still
+/// pass whenever directory iteration happens to visit the good index first
+/// (verified empirically during review). Bracketing guarantees that in any
+/// sorted iteration direction a corrupt index is encountered BEFORE the good
+/// one, so an abort-on-first-error regression always fails this test.
 #[test]
 fn test_vector_index_persistence_corrupt_index_degrades_gracefully() {
     let _guard = INTERNER_TEST_MUTEX.lock().unwrap();
@@ -3059,10 +3073,108 @@ fn test_vector_index_persistence_corrupt_index_degrades_gracefully() {
             .build()
     };
 
-    // ---- Phase 1: persist two vector indexes ----
+    // ---- Phase 1: persist three vector indexes ----
     let (node_a, node_b) = {
         let db = AletheiaDB::with_unified_config(make_config(false)).unwrap();
-        for property in ["good_embedding", "bad_embedding"] {
+        for property in ["aaa_bad_embedding", "good_embedding", "zzz_bad_embedding"] {
+            db.vector_index(property)
+                .hnsw(HnswConfig::new(4, DistanceMetric::Cosine))
+                .enable()
+                .unwrap();
+        }
+        let node_a = db
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("aaa_bad_embedding", &[1.0f32, 0.0, 0.0, 0.0])
+                    .insert_vector("good_embedding", &[1.0f32, 0.0, 0.0, 0.0])
+                    .insert_vector("zzz_bad_embedding", &[1.0f32, 0.0, 0.0, 0.0])
+                    .build(),
+            )
+            .unwrap();
+        let node_b = db
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("aaa_bad_embedding", &[0.9f32, 0.1, 0.0, 0.0])
+                    .insert_vector("good_embedding", &[0.9f32, 0.1, 0.0, 0.0])
+                    .insert_vector("zzz_bad_embedding", &[0.9f32, 0.1, 0.0, 0.0])
+                    .build(),
+            )
+            .unwrap();
+        db.persist_indexes().unwrap();
+        (node_a, node_b)
+    };
+
+    // ---- Corrupt the bracketing indexes' metadata on disk ----
+    let manager = IndexPersistenceManager::new(&data_dir);
+    for property in ["aaa_bad_embedding", "zzz_bad_embedding"] {
+        let corrupt_meta = manager.vector_path(property).join("meta.idx");
+        assert!(corrupt_meta.exists(), "persisted meta.idx must exist");
+        std::fs::write(&corrupt_meta, b"garbage bytes, definitely not bitcode").unwrap();
+    }
+
+    // ---- Phase 2: reopen; startup must succeed and the good index must work ----
+    {
+        let db = AletheiaDB::with_unified_config(make_config(true))
+            .expect("database startup must not fail because sibling vector indexes are corrupt");
+
+        assert!(
+            db.is_vector_index_enabled_for("good_embedding"),
+            "the intact vector index must load despite corrupt siblings on both sides"
+        );
+        for property in ["aaa_bad_embedding", "zzz_bad_embedding"] {
+            assert!(
+                !db.is_vector_index_enabled_for(property),
+                "the corrupt vector index '{property}' must be skipped, not half-loaded"
+            );
+        }
+
+        let similar = db.find_similar_in("good_embedding", node_a, 2).unwrap();
+        assert!(
+            similar.iter().any(|(id, _)| *id == node_b),
+            "search on the intact index must work after restart, got: {similar:?}"
+        );
+    }
+}
+
+/// Issue #451: a vector index skipped at startup (corrupted on disk) must be
+/// recoverable via `AletheiaDB::rebuild_vector_index`, which re-enables the
+/// index and backfills it from the vector properties of current nodes.
+///
+/// This is the documented recovery path for per-index error isolation:
+/// merely re-enabling the index (`enable_vector_index`) creates an EMPTY
+/// index that the persistence worker then writes over the on-disk files,
+/// permanently losing the vectors. `rebuild_vector_index` must restore
+/// searchability for pre-existing nodes AND survive a subsequent
+/// persist + reopen cycle.
+#[test]
+fn test_rebuild_vector_index_recovers_skipped_index() {
+    let _guard = INTERNER_TEST_MUTEX.lock().unwrap();
+
+    use aletheiadb::AletheiaDB;
+    use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
+
+    let dir = tempdir().unwrap();
+    let data_dir = dir.path().to_path_buf();
+    let wal_dir = dir.path().join("wal");
+
+    let make_config = |load_on_startup: bool| {
+        AletheiaDBConfig::builder()
+            .wal(WalConfigBuilder::new().wal_dir(wal_dir.clone()).build())
+            .persistence(PersistenceConfig {
+                enabled: true,
+                data_dir: data_dir.clone(),
+                load_on_startup,
+                ..Default::default()
+            })
+            .build()
+    };
+
+    // ---- Phase 1: persist two vector indexes over two nodes ----
+    let (node_a, node_b) = {
+        let db = AletheiaDB::with_unified_config(make_config(false)).unwrap();
+        for property in ["good_embedding", "broken_embedding"] {
             db.vector_index(property)
                 .hnsw(HnswConfig::new(4, DistanceMetric::Cosine))
                 .enable()
@@ -3073,7 +3185,7 @@ fn test_vector_index_persistence_corrupt_index_degrades_gracefully() {
                 "Doc",
                 PropertyMapBuilder::new()
                     .insert_vector("good_embedding", &[1.0f32, 0.0, 0.0, 0.0])
-                    .insert_vector("bad_embedding", &[1.0f32, 0.0, 0.0, 0.0])
+                    .insert_vector("broken_embedding", &[1.0f32, 0.0, 0.0, 0.0])
                     .build(),
             )
             .unwrap();
@@ -3082,7 +3194,7 @@ fn test_vector_index_persistence_corrupt_index_degrades_gracefully() {
                 "Doc",
                 PropertyMapBuilder::new()
                     .insert_vector("good_embedding", &[0.9f32, 0.1, 0.0, 0.0])
-                    .insert_vector("bad_embedding", &[0.9f32, 0.1, 0.0, 0.0])
+                    .insert_vector("broken_embedding", &[0.9f32, 0.1, 0.0, 0.0])
                     .build(),
             )
             .unwrap();
@@ -3092,28 +3204,114 @@ fn test_vector_index_persistence_corrupt_index_degrades_gracefully() {
 
     // ---- Corrupt one index's metadata on disk ----
     let manager = IndexPersistenceManager::new(&data_dir);
-    let corrupt_meta = manager.vector_path("bad_embedding").join("meta.idx");
+    let corrupt_meta = manager.vector_path("broken_embedding").join("meta.idx");
     assert!(corrupt_meta.exists(), "persisted meta.idx must exist");
     std::fs::write(&corrupt_meta, b"garbage bytes, definitely not bitcode").unwrap();
 
-    // ---- Phase 2: reopen; startup must succeed and the good index must work ----
+    // ---- Phase 2: reopen (sibling loads, corrupt one skipped), then rebuild ----
     {
-        let db = AletheiaDB::with_unified_config(make_config(true))
-            .expect("database startup must not fail because one vector index is corrupt");
-
+        let db = AletheiaDB::with_unified_config(make_config(true)).unwrap();
         assert!(
             db.is_vector_index_enabled_for("good_embedding"),
             "the intact vector index must load despite a corrupt sibling"
         );
         assert!(
-            !db.is_vector_index_enabled_for("bad_embedding"),
-            "the corrupt vector index must be skipped, not half-loaded"
+            !db.is_vector_index_enabled_for("broken_embedding"),
+            "the corrupt vector index must be skipped at startup"
         );
 
-        let similar = db.find_similar_in("good_embedding", node_a, 2).unwrap();
+        let rebuilt = db
+            .rebuild_vector_index(
+                "broken_embedding",
+                HnswConfig::new(4, DistanceMetric::Cosine),
+            )
+            .expect("rebuild_vector_index must recover a skipped index");
+        assert_eq!(
+            rebuilt, 2,
+            "both pre-existing nodes' vectors must be re-indexed"
+        );
+
+        assert!(
+            db.is_vector_index_enabled_for("broken_embedding"),
+            "the rebuilt vector index must be enabled again"
+        );
+        let similar = db.find_similar_in("broken_embedding", node_a, 2).unwrap();
         assert!(
             similar.iter().any(|(id, _)| *id == node_b),
-            "search on the intact index must work after restart, got: {similar:?}"
+            "pre-existing nodes' vectors must be searchable after rebuild, got: {similar:?}"
+        );
+
+        db.persist_indexes().unwrap();
+    }
+
+    // ---- Phase 3: a subsequent persist + reopen keeps the rebuilt index ----
+    {
+        let db = AletheiaDB::with_unified_config(make_config(true)).unwrap();
+        assert!(
+            db.is_vector_index_enabled_for("broken_embedding"),
+            "the rebuilt vector index must survive persist + reopen"
+        );
+        let similar = db.find_similar_in("broken_embedding", node_a, 2).unwrap();
+        assert!(
+            similar.iter().any(|(id, _)| *id == node_b),
+            "the rebuilt index must stay searchable after persist + reopen, got: {similar:?}"
+        );
+    }
+}
+
+/// Issue #451: vector index persistence must work through the documented
+/// one-line entry point `AletheiaDB::open(path)` plus `Drop` shutdown
+/// persistence — no explicit `persist_indexes()` call. This exercises the
+/// exact lifecycle the persistence guide promises users: open, enable an
+/// index, insert, drop the handle, reopen, search.
+#[test]
+fn test_vector_index_persistence_via_open_and_drop() {
+    let _guard = INTERNER_TEST_MUTEX.lock().unwrap();
+
+    use aletheiadb::AletheiaDB;
+    use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
+
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("open-drop-db");
+
+    // ---- Phase 1: open, enable index, insert, and drop (shutdown persist) ----
+    let (node_a, node_b) = {
+        let db = AletheiaDB::open(&db_path).expect("open must create a durable database");
+        db.vector_index("embedding")
+            .hnsw(HnswConfig::new(4, DistanceMetric::Cosine))
+            .enable()
+            .unwrap();
+        let node_a = db
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("embedding", &[1.0f32, 0.0, 0.0, 0.0])
+                    .build(),
+            )
+            .unwrap();
+        let node_b = db
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("embedding", &[0.9f32, 0.1, 0.0, 0.0])
+                    .build(),
+            )
+            .unwrap();
+        drop(db); // Drop joins the persistence worker, which persists on shutdown
+        (node_a, node_b)
+    };
+
+    // ---- Phase 2: reopen through open() and search ----
+    {
+        let db = AletheiaDB::open(&db_path).expect("reopen must load persisted state");
+        assert!(
+            db.is_vector_index_enabled_for("embedding"),
+            "vector index must be re-enabled after open() + Drop shutdown persistence"
+        );
+        let similar = db.find_similar_in("embedding", node_a, 2).unwrap();
+        assert!(
+            similar.iter().any(|(id, _)| *id == node_b),
+            "similarity search must work after open() + Drop + open(), got: {similar:?}"
         );
     }
 }

--- a/tests/index_persistence.rs
+++ b/tests/index_persistence.rs
@@ -2867,3 +2867,253 @@ fn test_parallel_loading_graph_error() {
 
     println!("✓ Parallel loading graph error test passed");
 }
+
+/// Issue #451: multi-property vector indexes survive a full restart cycle.
+///
+/// Verifies that after `persist_indexes()` + reopen with `load_on_startup`:
+/// - every per-property vector index is re-enabled with its persisted
+///   configuration (dimensions, distance metric),
+/// - similarity search works on every property,
+/// - vectors added AFTER the restart are indexed correctly (no usearch key
+///   collisions with restored mappings),
+/// - a second persist/reopen cycle works (save → load → save → load).
+#[test]
+fn test_vector_index_persistence_multi_property_restart() {
+    let _guard = INTERNER_TEST_MUTEX.lock().unwrap();
+
+    use aletheiadb::AletheiaDB;
+    use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
+
+    let dir = tempdir().unwrap();
+    let data_dir = dir.path().to_path_buf();
+    let wal_dir = dir.path().join("wal");
+
+    let make_config = |load_on_startup: bool| {
+        AletheiaDBConfig::builder()
+            .wal(WalConfigBuilder::new().wal_dir(wal_dir.clone()).build())
+            .persistence(PersistenceConfig {
+                enabled: true,
+                data_dir: data_dir.clone(),
+                load_on_startup,
+                ..Default::default()
+            })
+            .build()
+    };
+
+    let title_emb_a = {
+        let mut v = vec![0.0f32; 4];
+        v[0] = 1.0;
+        v
+    };
+    let title_emb_b = {
+        let mut v = vec![0.0f32; 4];
+        v[1] = 1.0;
+        v
+    };
+    let body_emb_a = {
+        let mut v = vec![0.0f32; 8];
+        v[0] = 1.0;
+        v
+    };
+    let body_emb_b = {
+        let mut v = vec![0.0f32; 8];
+        v[1] = 1.0;
+        v
+    };
+
+    // ---- Phase 1: create, index, persist ----
+    let (node_a, node_b) = {
+        let db = AletheiaDB::with_unified_config(make_config(false)).unwrap();
+
+        db.vector_index("title_embedding")
+            .hnsw(HnswConfig::new(4, DistanceMetric::Cosine))
+            .enable()
+            .unwrap();
+        db.vector_index("body_embedding")
+            .hnsw(HnswConfig::new(8, DistanceMetric::Euclidean))
+            .enable()
+            .unwrap();
+
+        let node_a = db
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("title_embedding", &title_emb_a)
+                    .insert_vector("body_embedding", &body_emb_a)
+                    .build(),
+            )
+            .unwrap();
+        let node_b = db
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("title_embedding", &title_emb_b)
+                    .insert_vector("body_embedding", &body_emb_b)
+                    .build(),
+            )
+            .unwrap();
+
+        db.persist_indexes().unwrap();
+        (node_a, node_b)
+    };
+
+    // ---- Phase 2: reopen and verify both properties ----
+    let node_c = {
+        let db = AletheiaDB::with_unified_config(make_config(true)).unwrap();
+
+        for property in ["title_embedding", "body_embedding"] {
+            assert!(
+                db.is_vector_index_enabled_for(property),
+                "vector index '{property}' must be re-enabled after restart"
+            );
+        }
+
+        // Config must survive: dimensions + metric per property.
+        let indexes = db.list_vector_indexes();
+        let title_info = indexes
+            .iter()
+            .find(|info| info.property_name == "title_embedding")
+            .expect("title_embedding config must survive restart");
+        assert_eq!(title_info.dimensions, 4);
+        assert_eq!(title_info.distance_metric, DistanceMetric::Cosine);
+        let body_info = indexes
+            .iter()
+            .find(|info| info.property_name == "body_embedding")
+            .expect("body_embedding config must survive restart");
+        assert_eq!(body_info.dimensions, 8);
+        assert_eq!(body_info.distance_metric, DistanceMetric::Euclidean);
+
+        // Similarity search must work per property after restart.
+        let title_similar = db.find_similar_in("title_embedding", node_a, 2).unwrap();
+        assert!(
+            title_similar.iter().any(|(id, _)| *id == node_b),
+            "title_embedding search must find node_b after restart, got: {title_similar:?}"
+        );
+        let body_similar = db.find_similar_in("body_embedding", node_a, 2).unwrap();
+        assert!(
+            body_similar.iter().any(|(id, _)| *id == node_b),
+            "body_embedding search must find node_b after restart, got: {body_similar:?}"
+        );
+
+        // Vectors added AFTER the restart must be indexed (fresh usearch keys
+        // must not collide with restored mappings).
+        let title_emb_c = {
+            let mut v = vec![0.0f32; 4];
+            v[0] = 0.9;
+            v[1] = 0.1;
+            v
+        };
+        let node_c = db
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("title_embedding", &title_emb_c)
+                    .build(),
+            )
+            .unwrap();
+        let similar_to_c = db.find_similar_in("title_embedding", node_c, 3).unwrap();
+        assert!(
+            similar_to_c.iter().any(|(id, _)| *id == node_a),
+            "post-restart node must be searchable and close to node_a, got: {similar_to_c:?}"
+        );
+
+        // Second save (save → load → save).
+        db.persist_indexes().unwrap();
+        node_c
+    };
+
+    // ---- Phase 3: second reopen (…→ load) ----
+    {
+        let db = AletheiaDB::with_unified_config(make_config(true)).unwrap();
+        let similar = db.find_similar_in("title_embedding", node_c, 3).unwrap();
+        assert!(
+            similar.iter().any(|(id, _)| *id == node_a),
+            "vector index must survive a second persist/reopen cycle, got: {similar:?}"
+        );
+    }
+}
+
+/// Issue #451: a corrupted vector index file must not prevent the database
+/// from starting, and every OTHER vector index must still be loaded and
+/// searchable (per-index error isolation on the startup path).
+#[test]
+fn test_vector_index_persistence_corrupt_index_degrades_gracefully() {
+    let _guard = INTERNER_TEST_MUTEX.lock().unwrap();
+
+    use aletheiadb::AletheiaDB;
+    use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
+
+    let dir = tempdir().unwrap();
+    let data_dir = dir.path().to_path_buf();
+    let wal_dir = dir.path().join("wal");
+
+    let make_config = |load_on_startup: bool| {
+        AletheiaDBConfig::builder()
+            .wal(WalConfigBuilder::new().wal_dir(wal_dir.clone()).build())
+            .persistence(PersistenceConfig {
+                enabled: true,
+                data_dir: data_dir.clone(),
+                load_on_startup,
+                ..Default::default()
+            })
+            .build()
+    };
+
+    // ---- Phase 1: persist two vector indexes ----
+    let (node_a, node_b) = {
+        let db = AletheiaDB::with_unified_config(make_config(false)).unwrap();
+        for property in ["good_embedding", "bad_embedding"] {
+            db.vector_index(property)
+                .hnsw(HnswConfig::new(4, DistanceMetric::Cosine))
+                .enable()
+                .unwrap();
+        }
+        let node_a = db
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("good_embedding", &[1.0f32, 0.0, 0.0, 0.0])
+                    .insert_vector("bad_embedding", &[1.0f32, 0.0, 0.0, 0.0])
+                    .build(),
+            )
+            .unwrap();
+        let node_b = db
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("good_embedding", &[0.9f32, 0.1, 0.0, 0.0])
+                    .insert_vector("bad_embedding", &[0.9f32, 0.1, 0.0, 0.0])
+                    .build(),
+            )
+            .unwrap();
+        db.persist_indexes().unwrap();
+        (node_a, node_b)
+    };
+
+    // ---- Corrupt one index's metadata on disk ----
+    let manager = IndexPersistenceManager::new(&data_dir);
+    let corrupt_meta = manager.vector_path("bad_embedding").join("meta.idx");
+    assert!(corrupt_meta.exists(), "persisted meta.idx must exist");
+    std::fs::write(&corrupt_meta, b"garbage bytes, definitely not bitcode").unwrap();
+
+    // ---- Phase 2: reopen; startup must succeed and the good index must work ----
+    {
+        let db = AletheiaDB::with_unified_config(make_config(true))
+            .expect("database startup must not fail because one vector index is corrupt");
+
+        assert!(
+            db.is_vector_index_enabled_for("good_embedding"),
+            "the intact vector index must load despite a corrupt sibling"
+        );
+        assert!(
+            !db.is_vector_index_enabled_for("bad_embedding"),
+            "the corrupt vector index must be skipped, not half-loaded"
+        );
+
+        let similar = db.find_similar_in("good_embedding", node_a, 2).unwrap();
+        assert!(
+            similar.iter().any(|(id, _)| *id == node_b),
+            "search on the intact index must work after restart, got: {similar:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #451

## Before

If any single persisted vector index on disk was corrupted (a bad `meta.idx`, `mappings.idx`, or `current.usearch` file, or an unknown distance metric), restarting the database silently dropped **every** vector index that hadn't been processed yet: the first corrupt index aborted the whole vector-loading pass. A user restarting their DB after minor disk corruption of one embedding index would find `find_similar` failing for *all* of their vector-indexed properties — with only a generic warning in the logs — even though the other indexes' files were perfectly intact. Loading was also strictly sequential: with several vector-indexed properties, cold-start time grew linearly with the number of properties, working against the whole point of index persistence (6-30x faster cold starts).

## After

Restarting the database now restores every intact vector index regardless of what else is broken:

- A corrupted or unreadable vector index is **skipped with a specific warning** naming the property and the reason; all sibling indexes still load and are immediately searchable. A skipped index is recovered with the new `AletheiaDB::rebuild_vector_index(property, config)`, which re-enables it and backfills it from node properties.
- All per-property HNSW indexes load **in parallel** (one rayon task per property), so cold-start time no longer scales linearly with the number of vector-indexed properties. A panic inside one load task is caught and counted as a skip instead of aborting startup.
- Startup logs a `loaded/skipped` summary whenever anything was skipped, so degradation is visible instead of silent, and each loaded index reports the vector count that was **actually restored** (not the metadata's claim).

## How

- `src/storage/index_persistence/operations.rs`:
  - Extracted per-directory loading into `load_single_vector_index(&Path) -> Result`: every per-index failure (missing/corrupt metadata, unknown metric, corrupt HNSW file or mappings, out-of-range mapping key, invalid dir name) returns a structured skip **reason** instead of propagating `Err` — matching the graceful-degradation contract the function's doc comment always claimed. The function itself does no logging.
  - `load_vector_indexes` collects the per-property subdirectories, loads them via rayon `par_iter` (each task wrapped in `catch_unwind` — task state is task-local and parking_lot locks don't poison, so a panicking load becomes a skip rather than propagating through rayon's `collect`), then registers the staged indexes sequentially (a cheap DashMap insert each). **All warnings and skip reasons are emitted in this sequential phase**, so logging is deterministic even though loads run concurrently. It returns a `VectorIndexLoadSummary { loaded, skipped }`; `Err` is reserved for infrastructure failures (the `vector/` directory itself unreadable). The per-index "Loaded" line reports `index.len()` (actually restored vectors), and a mismatch (metadata records N > 0 but 0 restored, e.g. `current.usearch` missing) gets an explicit warning.
  - `load_indexes_startup` consumes the summary and warns with loaded/skipped counts when anything was skipped, pointing at `rebuild_vector_index` and warning against bare re-enable.
- **New recovery API — `AletheiaDB::rebuild_vector_index(property_name, config) -> Result`** (`src/db/vector.rs`, delegating to `CurrentStorage::rebuild_vector_index` in `src/storage/current/mod.rs`): enables the index with `config` if absent, then backfills it by scanning current nodes and indexing each node's vector for that property (returns the number indexed; idempotent — existing entries update in place; non-temporal indexes only, matching this PR's scope; marks the persistence tracker dirty so the background worker re-persists the rebuilt index). This is the documented recovery path for a skipped index: plain `enable_vector_index` creates an **empty** index that the next persistence cycle writes over the on-disk files, permanently losing the vectors — the guide, CHANGELOG, and startup warning all now spell out that hazard.
- `HnswIndex::restore_mapping` (`src/index/vector/hnsw/mod.rs`) now bound-checks the persisted usearch key against `MAX_VALID_KEY` (`u64::MAX - 1000`, hoisted to a module const shared with `add`'s key-overflow protection) and returns `Err` instead of allowing `usearch_key + 1` overflow / a poisoned `next_key`; the loader turns that into a per-index skip.
- **On-disk format unchanged**: the existing hybrid format (bitcode + CRC32 `meta.idx` / `mappings.idx` with `GVEC` magic + version byte, usearch-native `current.usearch` + its `current.usearch.mappings` sidecar) is kept as-is — save path untouched, no migration needed.
- Tests (TDD — the corrupt-sibling unit test was written first and failed on trunk with `Err(PersistenceError("Failed to load vector metadata for corrupt_embedding: Index file corrupted: ..."))`; the rebuild integration test was likewise written first and failed with `no method named rebuild_vector_index found for struct AletheiaDB`):
  - Unit (`operations_tests.rs`): corrupt sibling skipped while valid index loads (summary `loaded=1, skipped=1`); no vector dir → zero summary; 3-property round trip preserving dimensions/metric/mappings per property (including that the created node's id is present in the restored mappings); a parameterized test iterating every corruption mode (missing `meta.idx`, truncated `meta.idx`, structurally valid meta with unknown metric byte 99, garbage `mappings.idx`, garbage `current.usearch`, truncated `current.usearch`, garbage `current.usearch.mappings` sidecar) asserting each skips exactly the broken index while the sibling loads; a `mappings.idx` with an out-of-range usearch key → index skipped, not a panic.
  - Integration (`tests/index_persistence.rs`): multi-property full restart cycle (config survives, `find_similar_in` works per property, vectors added *after* restart are indexed without key collisions and previously restored nodes stay reachable, second persist/reopen cycle works); corrupted indexes on disk → DB startup succeeds, intact index searchable, corrupt ones not registered — the corrupt test uses **two** corrupt siblings bracketing the good index in sorted order so an abort-on-first-error regression can never pass by iteration-order luck; skipped-index recovery via `rebuild_vector_index` (rebuild → search works for pre-existing nodes → persist → reopen → still works); vector persistence through the documented `AletheiaDB::open(path)` entry point + `Drop` shutdown persistence.
- Docs: new "Vector Index Persistence" section in `docs/guides/index-persistence-guide.md` (file layout — all **four** per-property files including the `current.usearch.mappings` sidecar; save/load lifecycle; error-isolation semantics; the `rebuild_vector_index` recovery flow and the empty-index overwrite hazard; skipped directories are left in place and re-warned on every startup), a corrected directory tree showing the real `indexes/indexes/` doubled layout `open()` produces, and a CHANGELOG entry under Unreleased.

## Notes for reviewers / follow-ups

- Scope decision: **temporal** vector indexes are not persisted by index persistence today (only the non-temporal per-property HNSW indexes are); making them persistent is a separate feature and left as a follow-up (pre-existing scope gap). `rebuild_vector_index` correspondingly rebuilds only the non-temporal index.
- Hollow-index case: when `meta.idx` is present but `current.usearch` is missing, an **empty** index is registered and counted as *loaded* (with a warning about the metadata/restored-count mismatch). Reclassifying that case as a skip is deliberately not done in this PR — follow-up.
- Quarantine-rename of skipped index directories (so they stop re-warning on every startup and can't be silently overwritten) — follow-up.
- ~~A panic-injection test hook for the `catch_unwind` path — follow-up.~~ **Done (b1ba623)**: `load_single_vector_index` consults three `#[cfg(test)]`-only magic directory names (compiled out of production builds) that panic with `&str`, `String`, and non-string payloads; a unit test asserts all three panicking loads are isolated to skips while a valid sibling still loads.
- **Codecov patch coverage (b1ba623)**: targeted tests added for the previously uncovered diff branches — hollow-index warning (missing `current.usearch` registers an empty index), invalid-`NodeId`-in-mappings warning, non-UTF-8 index directory name skip (unix), `load_indexes_startup` degrading an unreadable `vector/` dir (a file in its place) to a warning, and `rebuild_vector_index` edge cases (already-enabled idempotent backfill ignoring the passed config and skipping nodes without/with-non-vector property, property-limit exhaustion error, dimension-mismatch backfill error).
- **Accepted uncovered lines** (defensive/race-only, not chased): in `CurrentStorage::rebuild_vector_index`, the concurrent-enable race arm (`Err(_) if is_vector_index_enabled_for(...)`) and the "index disappeared during rebuild" `ok_or_else` closure — both require a racing writer between two adjacent statements; in `load_vector_indexes`, the per-entry `read_dir` error arm and the `file_name() == None` lossy-path fallback inside the panic handler (infrastructure-only on this filesystem).
- That loading actually happens in parallel is not verified by tests (accepted; the tests verify behavior, not scheduling).
- The manifest's `vector_indexes` field remains unpopulated (pre-existing); loading discovers indexes by scanning `indexes/vector/`, same as before. Populating the manifest is a possible follow-up.
- No overlap with PR #3396 (it touches only the temporal vector index paths in `src/storage/current/mod.rs`; this PR adds a separate non-temporal `rebuild_vector_index` method there).
- Known-failing fault-injection targets `havoc` / `regression_flush_corruption` fail identically on trunk (uid-0 environment issue, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sdwKjsymRSQYXDHAXYhYF

---
_Generated by [Claude Code](https://claude.ai/code/session_014sdwKjsymRSQYXDHAXYhYF)_