### PR TITLE
Fix stack overflow in PropertyValue equality on deeply nested arrays

### DIFF
--- a/src/core/property/value.rs
+++ b/src/core/property/value.rs
@@ -63,67 +63,64 @@ pub enum PropertyValue {
 
 impl PartialEq for PropertyValue {
     fn eq(&self, other: &Self) -> bool {
-        // Compare iteratively using an explicit work stack rather than recursing
-        // one stack frame per nesting level. Deeply nested `Array` values (which
-        // can be built programmatically well past the serialization
-        // `MAX_RECURSION_DEPTH` guard) would otherwise overflow the thread stack
-        // and abort the process. This mirrors the iterative `Drop` impl below.
-        let mut stack: Vec<(&PropertyValue, &PropertyValue)> = vec![(self, other)];
-
+        // Compare the root pair directly and only allocate a work stack when we
+        // actually descend into nested `Array` values (the sole recursive
+        // variant). Scalar-vs-scalar and shallow comparisons therefore perform
+        // zero heap allocations, while deeply nested `Array`s -- which can be
+        // built programmatically well past the serialization
+        // `MAX_RECURSION_DEPTH` guard -- are still walked iteratively rather
+        // than recursing one stack frame per level (which would overflow the
+        // thread stack and abort the process). This mirrors the iterative
+        // `Drop` impl below.
+        let mut stack: Vec<(&PropertyValue, &PropertyValue)> = Vec::new();
+        if !Self::eq_pair(self, other, &mut stack) {
+            return false;
+        }
         while let Some((a, b)) = stack.pop() {
-            match (a, b) {
-                (PropertyValue::Null, PropertyValue::Null) => {}
-                (PropertyValue::Bool(a), PropertyValue::Bool(b)) => {
-                    if a != b {
-                        return false;
-                    }
-                }
-                (PropertyValue::Int(a), PropertyValue::Int(b)) => {
-                    if a != b {
-                        return false;
-                    }
-                }
-                (PropertyValue::Float(a), PropertyValue::Float(b)) => {
-                    if a != b {
-                        return false;
-                    }
-                }
-                (PropertyValue::String(a), PropertyValue::String(b)) => {
-                    if !(Arc::ptr_eq(a, b) || a == b) {
-                        return false;
-                    }
-                }
-                (PropertyValue::Bytes(a), PropertyValue::Bytes(b)) => {
-                    if !(Arc::ptr_eq(a, b) || a == b) {
-                        return false;
-                    }
-                }
-                (PropertyValue::Vector(a), PropertyValue::Vector(b)) => {
-                    if !(Arc::ptr_eq(a, b) || a == b) {
-                        return false;
-                    }
-                }
-                (PropertyValue::SparseVector(a), PropertyValue::SparseVector(b)) => {
-                    if !(Arc::ptr_eq(a, b) || a == b) {
-                        return false;
-                    }
-                }
-                (PropertyValue::Array(a), PropertyValue::Array(b)) => {
-                    // Same allocation => structurally identical, skip element walk.
-                    if Arc::ptr_eq(a, b) {
-                        continue;
-                    }
-                    if a.len() != b.len() {
-                        return false;
-                    }
-                    stack.extend(a.iter().zip(b.iter()));
-                }
-                // Variant mismatch between the two sides.
-                _ => return false,
+            if !Self::eq_pair(a, b, &mut stack) {
+                return false;
             }
         }
-
         true
+    }
+}
+
+impl PropertyValue {
+    /// Compare a single `PartialEq` pair, enqueuing element pairs when both
+    /// sides are equal-length `Array`s (deferred to the caller's work stack)
+    /// instead of recursing. Returns `false` on any inequality or variant
+    /// mismatch. `Array` children are the only values ever pushed, so no
+    /// allocation happens unless a nested array is actually encountered.
+    fn eq_pair<'a>(
+        a: &'a PropertyValue,
+        b: &'a PropertyValue,
+        stack: &mut Vec<(&'a PropertyValue, &'a PropertyValue)>,
+    ) -> bool {
+        match (a, b) {
+            (PropertyValue::Null, PropertyValue::Null) => true,
+            (PropertyValue::Bool(a), PropertyValue::Bool(b)) => a == b,
+            (PropertyValue::Int(a), PropertyValue::Int(b)) => a == b,
+            (PropertyValue::Float(a), PropertyValue::Float(b)) => a == b,
+            (PropertyValue::String(a), PropertyValue::String(b)) => Arc::ptr_eq(a, b) || a == b,
+            (PropertyValue::Bytes(a), PropertyValue::Bytes(b)) => Arc::ptr_eq(a, b) || a == b,
+            (PropertyValue::Vector(a), PropertyValue::Vector(b)) => Arc::ptr_eq(a, b) || a == b,
+            (PropertyValue::SparseVector(a), PropertyValue::SparseVector(b)) => {
+                Arc::ptr_eq(a, b) || a == b
+            }
+            (PropertyValue::Array(a), PropertyValue::Array(b)) => {
+                // Same allocation => structurally identical, skip element walk.
+                if Arc::ptr_eq(a, b) {
+                    return true;
+                }
+                if a.len() != b.len() {
+                    return false;
+                }
+                stack.extend(a.iter().zip(b.iter()));
+                true
+            }
+            // Variant mismatch between the two sides.
+            _ => false,
+        }
     }
 }
 
@@ -445,56 +442,67 @@ impl PropertyValue {
     /// - `Vector` containing `NaN` at index `i` is equal to `Vector` containing `NaN` at index `i`
     /// - `SparseVector`: Guaranteed not to contain `NaN` (enforced at construction), so standard equality applies.
     pub fn semantically_equal(&self, other: &Self) -> bool {
-        // Iterative (explicit-stack) walk so deeply nested `Array` values do not
-        // overflow the thread stack, matching the iterative `PartialEq` impl.
-        // Element pairs are pushed back onto the stack, preserving the recursive
-        // NaN-aware semantics (nested floats keep NaN==NaN treatment).
-        let mut stack: Vec<(&PropertyValue, &PropertyValue)> = vec![(self, other)];
-
+        // Compare the root pair directly and only allocate a work stack when we
+        // descend into nested `Array` values, so scalar/shallow comparisons on
+        // this delta-computation hot path perform zero heap allocations. Deeply
+        // nested `Array`s are still walked iteratively (matching `PartialEq`) so
+        // they cannot overflow the thread stack, and the NaN-aware semantics are
+        // preserved because nested floats are compared through the same helper.
+        let mut stack: Vec<(&PropertyValue, &PropertyValue)> = Vec::new();
+        if !Self::semantically_eq_pair(self, other, &mut stack) {
+            return false;
+        }
         while let Some((a, b)) = stack.pop() {
-            match (a, b) {
-                (PropertyValue::Float(a), PropertyValue::Float(b)) => {
-                    let eq = if a.is_nan() { b.is_nan() } else { a == b };
-                    if !eq {
-                        return false;
-                    }
-                }
-                (PropertyValue::Vector(a), PropertyValue::Vector(b)) => {
-                    // Optimization: If they point to the same allocation, they must be equal.
-                    if Arc::ptr_eq(a, b) {
-                        continue;
-                    }
-                    if a.len() != b.len() {
-                        return false;
-                    }
-                    let all_eq = a
-                        .iter()
-                        .zip(b.iter())
-                        .all(|(x, y)| if x.is_nan() { y.is_nan() } else { x == y });
-                    if !all_eq {
-                        return false;
-                    }
-                }
-                (PropertyValue::Array(a), PropertyValue::Array(b)) => {
-                    // Optimization: If they point to the same allocation, they must be equal.
-                    if Arc::ptr_eq(a, b) {
-                        continue;
-                    }
-                    if a.len() != b.len() {
-                        return false;
-                    }
-                    stack.extend(a.iter().zip(b.iter()));
-                }
-                // For other types, fall back to PartialEq (itself iterative).
-                (a, b) => {
-                    if a != b {
-                        return false;
-                    }
-                }
+            if !Self::semantically_eq_pair(a, b, &mut stack) {
+                return false;
             }
         }
-
         true
+    }
+
+    /// Compare a single `semantically_equal` pair (NaN treated as equal),
+    /// enqueuing element pairs when both sides are equal-length `Array`s
+    /// instead of recursing. `Array` children are the only values ever pushed,
+    /// so no allocation happens unless a nested array is actually encountered.
+    fn semantically_eq_pair<'a>(
+        a: &'a PropertyValue,
+        b: &'a PropertyValue,
+        stack: &mut Vec<(&'a PropertyValue, &'a PropertyValue)>,
+    ) -> bool {
+        match (a, b) {
+            (PropertyValue::Float(a), PropertyValue::Float(b)) => {
+                if a.is_nan() {
+                    b.is_nan()
+                } else {
+                    a == b
+                }
+            }
+            (PropertyValue::Vector(a), PropertyValue::Vector(b)) => {
+                // Optimization: If they point to the same allocation, they must be equal.
+                if Arc::ptr_eq(a, b) {
+                    return true;
+                }
+                if a.len() != b.len() {
+                    return false;
+                }
+                a.iter()
+                    .zip(b.iter())
+                    .all(|(x, y)| if x.is_nan() { y.is_nan() } else { x == y })
+            }
+            (PropertyValue::Array(a), PropertyValue::Array(b)) => {
+                // Optimization: If they point to the same allocation, they must be equal.
+                if Arc::ptr_eq(a, b) {
+                    return true;
+                }
+                if a.len() != b.len() {
+                    return false;
+                }
+                stack.extend(a.iter().zip(b.iter()));
+                true
+            }
+            // For other types, fall back to PartialEq (itself iterative).
+            (a, b) => a == b,
+        }
     }
 
     // ========================================================================

--- a/src/core/property/value.rs
+++ b/src/core/property/value.rs
@@ -63,20 +63,67 @@ pub enum PropertyValue {
 
 impl PartialEq for PropertyValue {
     fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (PropertyValue::Null, PropertyValue::Null) => true,
-            (PropertyValue::Bool(a), PropertyValue::Bool(b)) => a == b,
-            (PropertyValue::Int(a), PropertyValue::Int(b)) => a == b,
-            (PropertyValue::Float(a), PropertyValue::Float(b)) => a == b,
-            (PropertyValue::String(a), PropertyValue::String(b)) => Arc::ptr_eq(a, b) || a == b,
-            (PropertyValue::Bytes(a), PropertyValue::Bytes(b)) => Arc::ptr_eq(a, b) || a == b,
-            (PropertyValue::Array(a), PropertyValue::Array(b)) => Arc::ptr_eq(a, b) || a == b,
-            (PropertyValue::Vector(a), PropertyValue::Vector(b)) => Arc::ptr_eq(a, b) || a == b,
-            (PropertyValue::SparseVector(a), PropertyValue::SparseVector(b)) => {
-                Arc::ptr_eq(a, b) || a == b
+        // Compare iteratively using an explicit work stack rather than recursing
+        // one stack frame per nesting level. Deeply nested `Array` values (which
+        // can be built programmatically well past the serialization
+        // `MAX_RECURSION_DEPTH` guard) would otherwise overflow the thread stack
+        // and abort the process. This mirrors the iterative `Drop` impl below.
+        let mut stack: Vec<(&PropertyValue, &PropertyValue)> = vec![(self, other)];
+
+        while let Some((a, b)) = stack.pop() {
+            match (a, b) {
+                (PropertyValue::Null, PropertyValue::Null) => {}
+                (PropertyValue::Bool(a), PropertyValue::Bool(b)) => {
+                    if a != b {
+                        return false;
+                    }
+                }
+                (PropertyValue::Int(a), PropertyValue::Int(b)) => {
+                    if a != b {
+                        return false;
+                    }
+                }
+                (PropertyValue::Float(a), PropertyValue::Float(b)) => {
+                    if a != b {
+                        return false;
+                    }
+                }
+                (PropertyValue::String(a), PropertyValue::String(b)) => {
+                    if !(Arc::ptr_eq(a, b) || a == b) {
+                        return false;
+                    }
+                }
+                (PropertyValue::Bytes(a), PropertyValue::Bytes(b)) => {
+                    if !(Arc::ptr_eq(a, b) || a == b) {
+                        return false;
+                    }
+                }
+                (PropertyValue::Vector(a), PropertyValue::Vector(b)) => {
+                    if !(Arc::ptr_eq(a, b) || a == b) {
+                        return false;
+                    }
+                }
+                (PropertyValue::SparseVector(a), PropertyValue::SparseVector(b)) => {
+                    if !(Arc::ptr_eq(a, b) || a == b) {
+                        return false;
+                    }
+                }
+                (PropertyValue::Array(a), PropertyValue::Array(b)) => {
+                    // Same allocation => structurally identical, skip element walk.
+                    if Arc::ptr_eq(a, b) {
+                        continue;
+                    }
+                    if a.len() != b.len() {
+                        return false;
+                    }
+                    stack.extend(a.iter().zip(b.iter()));
+                }
+                // Variant mismatch between the two sides.
+                _ => return false,
             }
-            _ => false,
         }
+
+        true
     }
 }
 
@@ -398,39 +445,56 @@ impl PropertyValue {
     /// - `Vector` containing `NaN` at index `i` is equal to `Vector` containing `NaN` at index `i`
     /// - `SparseVector`: Guaranteed not to contain `NaN` (enforced at construction), so standard equality applies.
     pub fn semantically_equal(&self, other: &Self) -> bool {
-        match (self, other) {
-            (PropertyValue::Float(a), PropertyValue::Float(b)) => {
-                if a.is_nan() {
-                    b.is_nan()
-                } else {
-                    a == b
+        // Iterative (explicit-stack) walk so deeply nested `Array` values do not
+        // overflow the thread stack, matching the iterative `PartialEq` impl.
+        // Element pairs are pushed back onto the stack, preserving the recursive
+        // NaN-aware semantics (nested floats keep NaN==NaN treatment).
+        let mut stack: Vec<(&PropertyValue, &PropertyValue)> = vec![(self, other)];
+
+        while let Some((a, b)) = stack.pop() {
+            match (a, b) {
+                (PropertyValue::Float(a), PropertyValue::Float(b)) => {
+                    let eq = if a.is_nan() { b.is_nan() } else { a == b };
+                    if !eq {
+                        return false;
+                    }
+                }
+                (PropertyValue::Vector(a), PropertyValue::Vector(b)) => {
+                    // Optimization: If they point to the same allocation, they must be equal.
+                    if Arc::ptr_eq(a, b) {
+                        continue;
+                    }
+                    if a.len() != b.len() {
+                        return false;
+                    }
+                    let all_eq = a
+                        .iter()
+                        .zip(b.iter())
+                        .all(|(x, y)| if x.is_nan() { y.is_nan() } else { x == y });
+                    if !all_eq {
+                        return false;
+                    }
+                }
+                (PropertyValue::Array(a), PropertyValue::Array(b)) => {
+                    // Optimization: If they point to the same allocation, they must be equal.
+                    if Arc::ptr_eq(a, b) {
+                        continue;
+                    }
+                    if a.len() != b.len() {
+                        return false;
+                    }
+                    stack.extend(a.iter().zip(b.iter()));
+                }
+                // For other types, fall back to PartialEq (itself iterative).
+                (a, b) => {
+                    if a != b {
+                        return false;
+                    }
                 }
             }
-            (PropertyValue::Vector(a), PropertyValue::Vector(b)) => {
-                // Optimization: If they point to the same allocation, they must be equal.
-                if Arc::ptr_eq(a, b) {
-                    return true;
-                }
-                if a.len() != b.len() {
-                    return false;
-                }
-                a.iter()
-                    .zip(b.iter())
-                    .all(|(x, y)| if x.is_nan() { y.is_nan() } else { x == y })
-            }
-            (PropertyValue::Array(a), PropertyValue::Array(b)) => {
-                // Optimization: If they point to the same allocation, they must be equal.
-                if Arc::ptr_eq(a, b) {
-                    return true;
-                }
-                if a.len() != b.len() {
-                    return false;
-                }
-                a.iter().zip(b.iter()).all(|(x, y)| x.semantically_equal(y))
-            }
-            // For other types, fallback to PartialEq
-            _ => self == other,
         }
+
+        true
     }
 
     // ========================================================================

--- a/tests/property_value_deep_recursion_eq.rs
+++ b/tests/property_value_deep_recursion_eq.rs
@@ -59,3 +59,81 @@ fn deeply_nested_arrays_semantically_equal_without_overflow() {
         "NaN != NaN under PartialEq, even when deeply nested"
     );
 }
+
+#[test]
+fn deeply_nested_arrays_semantically_unequal_without_overflow() {
+    // Complements the deep-equal case above: a deeply nested value that differs
+    // only at the leaf must be reported unequal by `semantically_equal` (still
+    // NaN-aware) without overflowing the stack.
+    let a = nest(PropertyValue::Float(1.0), DEEP);
+    let b = nest(PropertyValue::Float(2.0), DEEP);
+    assert!(
+        !a.semantically_equal(&b),
+        "deep arrays differing at the leaf must be semantically unequal"
+    );
+
+    // Also exercise a NaN-vs-number leaf mismatch: NaN is only equal to NaN.
+    let nan = nest(PropertyValue::Float(f64::NAN), DEEP);
+    let num = nest(PropertyValue::Float(1.0), DEEP);
+    assert!(
+        !nan.semantically_equal(&num),
+        "NaN leaf must not be semantically equal to a numeric leaf"
+    );
+}
+
+/// Branching depth for the wide+deep tree. Kept modest because the node count
+/// grows as `BRANCH^WIDE_DEEP`; the point is to exercise the work stack holding
+/// many pending pairs at once (multiple children pushed per level), not raw
+/// depth (already covered by the single-chain `DEEP` tests above).
+const BRANCH: usize = 3;
+const WIDE_DEEP: usize = 10;
+
+/// Build a balanced tree where every internal node is an `Array` of `BRANCH`
+/// children, `depth` levels deep, with every leaf equal to `leaf`.
+fn wide_nest(leaf: &PropertyValue, depth: usize) -> PropertyValue {
+    if depth == 0 {
+        return leaf.clone();
+    }
+    let child = wide_nest(leaf, depth - 1);
+    PropertyValue::Array(Arc::new(vec![child; BRANCH]))
+}
+
+#[test]
+fn wide_and_deep_arrays_compare_equal_without_overflow() {
+    // A branching tree forces the iterative work stack to actually grow with
+    // multiple pending element pairs per level (unlike the depth-1 chain in the
+    // other tests, which never holds more than one pending pair).
+    let a = wide_nest(&PropertyValue::Int(7), WIDE_DEEP);
+    let b = wide_nest(&PropertyValue::Int(7), WIDE_DEEP);
+    assert!(a == b, "identical wide+deep trees must be equal");
+    assert!(
+        a.semantically_equal(&b),
+        "identical wide+deep trees must be semantically equal"
+    );
+}
+
+#[test]
+fn wide_and_deep_arrays_detect_inequality_without_overflow() {
+    // Differ at a single leaf buried in one branch: the comparison must still
+    // return `false` cleanly while the work stack holds many pending pairs.
+    let a = wide_nest(&PropertyValue::Int(7), WIDE_DEEP);
+
+    // Build a same-shaped tree whose top level mixes identical subtrees with a
+    // differing one, so the walk descends several branches (the work stack
+    // holds many pending pairs) before finding the buried leaf difference.
+    let identical_subtree = wide_nest(&PropertyValue::Int(7), WIDE_DEEP - 1);
+    let differing_leaf_tree = PropertyValue::Array(Arc::new(vec![
+        identical_subtree.clone(),
+        identical_subtree,
+        wide_nest(&PropertyValue::Int(8), WIDE_DEEP - 1),
+    ]));
+
+    assert!(
+        a != differing_leaf_tree,
+        "wide+deep trees differing at a buried leaf must be unequal"
+    );
+    assert!(
+        !a.semantically_equal(&differing_leaf_tree),
+        "wide+deep trees differing at a buried leaf must be semantically unequal"
+    );
+}

--- a/tests/property_value_deep_recursion_eq.rs
+++ b/tests/property_value_deep_recursion_eq.rs
@@ -1,0 +1,61 @@
+//! Regression tests for stack-overflow-safe equality on deeply nested
+//! `PropertyValue::Array` values (supersedes PR #3098).
+//!
+//! A `PropertyValue::Array` can be nested arbitrarily deeply when constructed
+//! programmatically (serialization enforces `MAX_RECURSION_DEPTH`, but in-memory
+//! construction does not). A naive recursive `PartialEq` / `semantically_equal`
+//! walks one stack frame per nesting level, so comparing two deeply nested
+//! values overflows the thread stack and aborts the process (SIGABRT/SIGSEGV) —
+//! an uncatchable crash that a malicious or accidental deep value can trigger.
+//!
+//! These tests construct values far deeper than any reasonable call stack can
+//! handle and assert the comparison returns cleanly. Without the iterative
+//! (explicit-stack) equality implementations they abort the test process; with
+//! them they pass. `PropertyValue::Drop` is already iterative, so tearing the
+//! values down at end of scope is also overflow-safe.
+
+use aletheiadb::core::property::PropertyValue;
+use std::sync::Arc;
+
+/// Nesting depth that comfortably exceeds the default test-thread stack for a
+/// per-level-recursive comparison, guaranteeing an overflow without the fix.
+const DEEP: usize = 200_000;
+
+/// Wrap `leaf` in `depth` layers of single-element `Array`.
+fn nest(leaf: PropertyValue, depth: usize) -> PropertyValue {
+    let mut v = leaf;
+    for _ in 0..depth {
+        v = PropertyValue::Array(Arc::new(vec![v]));
+    }
+    v
+}
+
+#[test]
+fn deeply_nested_arrays_compare_equal_without_overflow() {
+    let a = nest(PropertyValue::Int(1), DEEP);
+    let b = nest(PropertyValue::Int(1), DEEP);
+    assert!(a == b, "structurally identical deep arrays must be equal");
+}
+
+#[test]
+fn deeply_nested_arrays_detect_inequality_without_overflow() {
+    let a = nest(PropertyValue::Int(1), DEEP);
+    let b = nest(PropertyValue::Int(2), DEEP);
+    assert!(a != b, "deep arrays differing at the leaf must be unequal");
+}
+
+#[test]
+fn deeply_nested_arrays_semantically_equal_without_overflow() {
+    // `semantically_equal` (NaN-aware) also recurses on `Array` and must be
+    // overflow-safe too. Use a NaN leaf so we exercise the NaN-aware path.
+    let a = nest(PropertyValue::Float(f64::NAN), DEEP);
+    let b = nest(PropertyValue::Float(f64::NAN), DEEP);
+    assert!(
+        a.semantically_equal(&b),
+        "deeply nested NaN arrays must be semantically equal"
+    );
+    assert!(
+        a != b,
+        "NaN != NaN under PartialEq, even when deeply nested"
+    );
+}


### PR DESCRIPTION
Supersedes #3098 (rebased onto current trunk; the original branch went stale and its fix never reached trunk).

## Before

Comparing two `PropertyValue`s for equality walked one call-stack frame per `Array` nesting level. A `PropertyValue::Array` can be nested arbitrarily deep when built in memory — the `MAX_RECURSION_DEPTH` guard only applies at serialization/deserialization time, not to programmatic construction. Comparing two such deeply nested values overflowed the thread stack and aborted the whole process:

```
thread '...' has overflowed its stack
fatal runtime error: stack overflow, aborting
(signal: 6, SIGABRT)
```

A stack overflow is an uncatchable crash (it aborts the process, it is not a catchable panic), so a single deep value passing through an `==` — an `assert_eq!`, a change-detection diff, a dedup check — could take the database down.

## After

Equality now runs in constant stack space. Deeply nested values compare cleanly and return a normal `true`/`false` instead of crashing.

## How

- `impl PartialEq for PropertyValue` (`eq`) now compares **iteratively** using an explicit work stack of `(&a, &b)` pairs instead of recursing per level. Scalars/leaves compare in place; matching `Array` pairs push their zipped element pairs back onto the stack (short-circuiting on `Arc::ptr_eq` and on length mismatch). Semantics are unchanged for every existing case.
- `PropertyValue::semantically_equal` (the NaN-aware variant) recursed the same way and had the same latent overflow, so it received the identical explicit-stack treatment. NaN-aware handling of nested floats/vectors is preserved because element pairs are pushed back through the same loop.
- This mirrors the pattern already used by the iterative `Drop` impl on this type, which linearizes teardown of deep arrays for the same reason.

No `Hash`/`Ord`/`Eq` impls exist on `PropertyValue` (the enum derives only `Clone`), so there is no equal-values-must-hash-equal consistency concern; `PartialEq` and `semantically_equal` were the only unbounded-recursion equality paths. The other recursive methods on the type (`serialize`/`serialized_size`/`estimated_heap_size`) already carry a `MAX_RECURSION_DEPTH` guard, and `Display`/`Debug` cap at depth 50.

## Tests

New deterministic regression test `tests/property_value_deep_recursion_eq.rs` nests 200,000 levels deep and asserts:
- structurally identical deep arrays compare equal,
- deep arrays differing only at the leaf compare unequal,
- deeply nested NaN arrays are `semantically_equal` (and `!=` under `PartialEq`, since NaN != NaN).

Verified red→green: the equality test aborts with `signal: 6, SIGABRT` (stack overflow) on the pre-fix code and passes with the fix. Existing `core::property` unit tests (112) pass; `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --all --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019A1QFtHuvYNhd39s7RidLj

---
_Generated by [Claude Code](https://claude.ai/code/session_019A1QFtHuvYNhd39s7RidLj)_