### PR TITLE
Deflake find_nodes_at_time_tests: derive anchors from the HLC commit frontier

### DIFF
--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -2625,6 +2625,7 @@ mod tests {
     /// transaction_time)`.
     mod find_nodes_at_time_tests {
         use super::*;
+        use crate::AletheiaDB;
         use crate::core::id::NodeId;
         use crate::core::property::PropertyValue;
         use crate::core::temporal::time;
@@ -2638,14 +2639,47 @@ mod tests {
         }
 
         /// Capture a bi-temporal anchor strictly after every previously
-        /// committed write. A bare `time::now()` carries logical component 0,
-        /// while an HLC commit stamp in the *same microsecond* carries a
-        /// logical component > 0 and therefore orders *after* the anchor;
-        /// sleeping past the microsecond boundary first makes the anchor's
-        /// wallclock strictly greater than all prior commit wallclocks.
-        fn anchor_after_commits() -> crate::core::temporal::Timestamp {
-            std::thread::sleep(std::time::Duration::from_millis(2));
-            time::now()
+        /// committed write and strictly before every subsequent one.
+        ///
+        /// A fixed wallclock sleep is NOT sufficient (issue #3405): the HLC
+        /// commit frontier can run ahead of wallclock (logical-counter
+        /// increments within a stalled microsecond, coarse Windows clock
+        /// granularity, `cargo llvm-cov` instrumentation overhead), so a
+        /// bare `time::now()` taken "2ms later" may still order at or before
+        /// an already-committed stamp. Instead, derive the anchor from the
+        /// committed state itself:
+        ///
+        /// 1. Read the database's HLC commit frontier (the maximum
+        ///    transaction stamp issued so far) and loop-sleep until a bare
+        ///    `time::now()` reading orders strictly AFTER it. That reading
+        ///    is the anchor: it is deterministically after every prior
+        ///    commit, regardless of how far the frontier ran ahead.
+        /// 2. Loop-sleep until `time::now()` orders strictly after the
+        ///    anchor before returning, so any write committed after this
+        ///    call reads a wallclock strictly greater than the anchor's and
+        ///    therefore receives a strictly later commit stamp (a bare
+        ///    anchor has logical component 0, so an equal-microsecond commit
+        ///    stamp would otherwise compare equal, not greater).
+        ///
+        /// These tests are single-threaded, so no commit can slip between
+        /// the two phases.
+        fn anchor_after_commits(db: &AletheiaDB) -> crate::core::temporal::Timestamp {
+            let committed = *db
+                .current_timestamp
+                .lock()
+                .expect("current_timestamp mutex poisoned");
+            // Phase 1: anchor strictly after every committed stamp.
+            let mut anchor = time::now();
+            while anchor <= committed {
+                std::thread::sleep(std::time::Duration::from_micros(100));
+                anchor = time::now();
+            }
+            // Phase 2: return only once wallclock has moved strictly past
+            // the anchor, so later commits stamp strictly after it.
+            while time::now() <= anchor {
+                std::thread::sleep(std::time::Duration::from_micros(100));
+            }
+            anchor
         }
 
         #[test]
@@ -2655,10 +2689,10 @@ mod tests {
             let bob = PropertyValue::from("Bob");
 
             let id = db.create_node("Person", name_props("Alice")).unwrap();
-            let t1 = anchor_after_commits();
+            let t1 = anchor_after_commits(&db);
             db.update_node_with_valid_time(id, name_props("Bob"), None)
                 .unwrap();
-            let t2 = anchor_after_commits();
+            let t2 = anchor_after_commits(&db);
 
             // At (t1, t1) the name was still "Alice"...
             let found = db
@@ -2695,9 +2729,9 @@ mod tests {
             let (_tmp, db) = create_test_db().unwrap();
             let alice = PropertyValue::from("Alice");
 
-            let t0 = anchor_after_commits();
+            let t0 = anchor_after_commits(&db);
             let id = db.create_node("Person", name_props("Alice")).unwrap();
-            let t1 = anchor_after_commits();
+            let t1 = anchor_after_commits(&db);
 
             assert!(
                 db.find_nodes_by_property_at("Person", "name", &alice, t0, t0)
@@ -2720,9 +2754,9 @@ mod tests {
             let alice = PropertyValue::from("Alice");
 
             let id = db.create_node("Person", name_props("Alice")).unwrap();
-            let t_before = anchor_after_commits();
+            let t_before = anchor_after_commits(&db);
             db.delete_node_with_valid_time(id, None).unwrap();
-            let t_after = anchor_after_commits();
+            let t_after = anchor_after_commits(&db);
 
             // Anchoring both dimensions before the deletion recalls the node
             // -- this is the case a current-state label index alone would
@@ -2754,9 +2788,9 @@ mod tests {
             let alice = PropertyValue::from("Alice");
 
             let _id = db.create_node("Person", name_props("Alice")).unwrap();
-            let v_before = anchor_after_commits();
+            let v_before = anchor_after_commits(&db);
             db.delete_node_with_valid_time(_id, None).unwrap();
-            let tx_now = anchor_after_commits();
+            let tx_now = anchor_after_commits(&db);
 
             assert!(
                 db.find_nodes_by_property_at("Person", "name", &alice, v_before, tx_now)
@@ -2774,9 +2808,9 @@ mod tests {
             let a = db.create_node("Person", name_props("Alice")).unwrap();
             let b = db.create_node("Person", name_props("Bob")).unwrap();
             let c = db.create_node("Company", name_props("Acme")).unwrap();
-            let t1 = anchor_after_commits();
+            let t1 = anchor_after_commits(&db);
             db.delete_node_with_valid_time(b, None).unwrap();
-            let t2 = anchor_after_commits();
+            let t2 = anchor_after_commits(&db);
 
             // Before the deletion both Person nodes are visible (sorted by id).
             assert_eq!(
@@ -2806,7 +2840,7 @@ mod tests {
             let d = db.create_node("Person", name_props("Alice")).unwrap();
             db.delete_node_with_valid_time(d, None).unwrap();
 
-            let now = anchor_after_commits();
+            let now = anchor_after_commits(&db);
             let mut current = db.find_nodes_by_property("Person", "name", &alice);
             current.sort_unstable();
             let at_now = ids(&db
@@ -2836,7 +2870,7 @@ mod tests {
             let id = db
                 .create_node_with_valid_time("Person", name_props("FutureAlice"), Some(future))
                 .unwrap();
-            let now = anchor_after_commits();
+            let now = anchor_after_commits(&db);
 
             // Current-state lookup sees the future-dated node...
             assert_eq!(
@@ -2881,11 +2915,11 @@ mod tests {
             );
             // A wall-clock instant after v0 but strictly before the write is
             // recorded: inside the valid interval, outside the tx interval.
-            let t_mid = anchor_after_commits();
+            let t_mid = anchor_after_commits(&db);
             let id = db
                 .create_node_with_valid_time("Person", name_props("BackdatedAlice"), Some(v0))
                 .unwrap();
-            let t_now = anchor_after_commits();
+            let t_now = anchor_after_commits(&db);
 
             // (valid = t_mid, tx = t_now): valid interval [v0, inf) contains
             // t_mid and the write is recorded by t_now -> FOUND. With the
@@ -2927,7 +2961,7 @@ mod tests {
         fn unknown_label_or_property_key_returns_empty_not_error() {
             let (_tmp, db) = create_test_db().unwrap();
             let _ = db.create_node("Person", name_props("Alice")).unwrap();
-            let now = anchor_after_commits();
+            let now = anchor_after_commits(&db);
 
             assert!(
                 db.find_nodes_at_time("NeverInternedLabel3236", now, now)
@@ -2977,7 +3011,7 @@ mod tests {
             }
             expected.sort_unstable();
 
-            let now = anchor_after_commits();
+            let now = anchor_after_commits(&db);
             let found = ids(&db.find_nodes_at_time("Person", now, now).unwrap());
             assert_eq!(found, expected, "results must be sorted by node id");
         }
@@ -3012,7 +3046,7 @@ mod tests {
                 created.push(db.create_node("Person", name_props("Alice")).unwrap());
             }
             created.sort_unstable();
-            let now = anchor_after_commits();
+            let now = anchor_after_commits(&db);
 
             let found = db.find_nodes_at_time("Person", now, now).unwrap();
             assert!(
@@ -3038,8 +3072,7 @@ mod tests {
             // A db whose history fits under the cap never reports sampling.
             let (_tmp2, small_db) = create_test_db().unwrap();
             let id = small_db.create_node("Person", name_props("Alice")).unwrap();
-            std::thread::sleep(std::time::Duration::from_millis(2));
-            let now2 = time::now();
+            let now2 = anchor_after_commits(&small_db);
             let small = small_db.find_nodes_at_time("Person", now2, now2).unwrap();
             assert!(!small.sampled);
             assert_eq!(ids(&small), vec![id]);


### PR DESCRIPTION
Closes #3405

## Before

The shared test helper `anchor_after_commits()` in `src/db/ops.rs` captured a bi-temporal anchor with a fixed 2ms wallclock sleep followed by a bare `time::now()`:

```rust
fn anchor_after_commits() -> crate::core::temporal::Timestamp {
    std::thread::sleep(std::time::Duration::from_millis(2));
    time::now()
}
```

This relies on wallclock ordering against HLC commit stamps. When the HLC commit frontier runs ahead of wallclock — logical-counter increments within a stalled microsecond, coarse Windows clock granularity, `cargo llvm-cov` instrumentation overhead — the anchor can land at or before an already-committed stamp (or at the same microsecond as a subsequent one), so point-in-time assertions flake on CI.

## After

The helper now takes `&AletheiaDB` and derives the anchor from committed state instead of a fixed sleep:

1. Read the database's HLC commit frontier (`current_timestamp`, the maximum transaction stamp issued so far) and loop-sleep until a bare `time::now()` reading orders **strictly after** it — the anchor is deterministically after every prior commit regardless of how far the frontier ran ahead of wallclock.
2. Loop-sleep until `time::now()` orders strictly past the anchor before returning, so any write committed after the call reads a wallclock strictly greater than the anchor's and receives a **strictly later** commit stamp (a bare anchor carries logical component 0, so an equal-microsecond commit stamp would otherwise compare equal, not greater).

All 14 call sites in `find_nodes_at_time_tests` are updated, and the one raw 2ms sleep that bypassed the helper (the `small_db` block in `candidate_cap_truncates_deterministically_and_discloses_sampling`) now goes through the helper too — no test in the family anchors via wallclock sleeps anymore.

**Test-only change; no production code touched.**

## Observed failures this fixes (all 2026-07-08)

- **trunk** run 6937 (28924569842 @ `0cf4435`) — `label_only_as_of_scan_without_property_filter` (Code Coverage)
- **trunk** run 6942 (28957000897 @ `d54eb25`) — `node_deleted_before_t_found_when_both_dimensions_anchor_before_deletion` (Code Coverage)
- **PR #3392** — Code Coverage
- **PR #3396** run 28964218939 attempt 1 — `label_only_as_of_scan_without_property_filter` on Test Suite (windows-latest, nightly)
- **PR #3396** run 28964218939 attempt 2 — `label_only_as_of_scan_without_property_filter` on Test Suite (ubuntu-latest, nightly) (`left: [NodeId(0)]`, `right: [NodeId(0), NodeId(1)]` at src/db/ops.rs:2782); fail-fast also cancelled the ubuntu-stable sibling job
- **PR #3399** (28964151073 @ `1f439b0`) — `node_deleted_before_t_found_when_both_dimensions_anchor_before_deletion` (Code Coverage)
- **PR #3402** — Code Coverage
- **PR #3394** (@ `c9926f8`, per #3405 comment) — killed Mutants baseline, Code Coverage, and Test Suite (ubuntu-latest, nightly)

## Verification

- Stability loop: **40/40** consecutive runs of `cargo test --lib find_nodes_at_time` pass (11 tests per run)
- `cargo test --lib`: 3404 passed, 0 failed, 2 ignored
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --all`: applied

---
_Generated by [Claude Code](https://claude.ai/code/session_014sdwKjsymRSQYXDHAXYhYF)_