### PR TITLE
🎻 Bard: Fix intra-doc links across project

### DIFF
--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -1399,7 +1399,7 @@ impl WriteTransaction {
     ///   (`valid_to == valid_from` is allowed and yields an empty interval).
     /// - [`TemporalError::ValidTimeTooFarInFuture`](crate::core::error::TemporalError::ValidTimeTooFarInFuture)
     ///   if `valid_to` is more than one year in the future.
-    /// - [`StorageError::NodeNotFound`](crate::core::error::StorageError::NodeNotFound)
+    /// - [`StorageError::NodeNotFound`]
     ///   if the node never existed.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn retract_node(
@@ -1504,7 +1504,7 @@ impl WriteTransaction {
     ///
     /// See [`retract_node`](Self::retract_node) for the bi-temporal
     /// semantics, idempotency contract, and errors (with
-    /// [`StorageError::EdgeNotFound`](crate::core::error::StorageError::EdgeNotFound)
+    /// [`StorageError::EdgeNotFound`]
     /// for a never-existing edge).
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn retract_edge(

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -469,7 +469,7 @@ impl AletheiaDB {
     }
 
     /// Create a node with an optional [`WriteRequestOptions`](crate::api::transaction::WriteRequestOptions)
-    /// bundle: a backdated `valid_from` and/or a write-time [`Provenance`] bundle (Issue #3224).
+    /// bundle: a backdated `valid_from` and/or a write-time [`Provenance`](crate::core::provenance::Provenance) bundle (Issue #3224).
     ///
     /// Passing `WriteRequestOptions::default()` is identical to [`create_node`](Self::create_node).
     ///
@@ -809,7 +809,7 @@ impl AletheiaDB {
     /// decide whether a detach/cascade delete is required to avoid orphaning
     /// edges.
     ///
-    /// Returns [`StorageError::NodeNotFound`](crate::storage::StorageError::NodeNotFound)
+    /// Returns [`StorageError::NodeNotFound`](crate::core::error::StorageError::NodeNotFound)
     /// if the node does not exist in the current state, so callers never receive
     /// a misleading zero count for a missing node.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -506,7 +506,7 @@ impl AletheiaDB {
     ///
     /// This is the *discovery* counterpart to the per-entity history/diff APIs: it answers
     /// "**which** entities were created, modified, or deleted between T1 and T2?" without the
-    /// caller already knowing any IDs. Each returned [`ChangeRecord`](crate::core::ChangeRecord)
+    /// caller already knowing any IDs. Each returned [`ChangeRecord`]
     /// carries the entity id, kind, change type, and the version's transaction- and valid-time
     /// bounds, so a caller can then drill in with `get_node_history` / `diff_node_versions`.
     ///

--- a/src/storage/backup/mod.rs
+++ b/src/storage/backup/mod.rs
@@ -46,7 +46,7 @@ pub const BACKUP_MAGIC: [u8; 4] = *b"ALBK";
 /// Bumped to 2 for write-time provenance on temporal versions (Issue #3224):
 /// the embedded `TemporalIndexData`'s `NodeVersionEntry`/`EdgeVersionEntry`
 /// gained an optional `provenance` field. Version 1 artifacts are still
-/// restorable -- see [`BackupPayloadV1`] and `read_artifact`.
+/// restorable -- see `BackupPayloadV1` and `read_artifact`.
 pub const BACKUP_FORMAT_VERSION: u16 = 2;
 
 /// Maximum allowed decompressed payload size (5 GiB).

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -545,7 +545,7 @@ impl HistoricalStorage {
     }
 
     /// Add a new version of a node, optionally attaching a write-time
-    /// [`Provenance`](crate::core::provenance::Provenance) bundle (Issue #3224).
+    /// [`Provenance`] bundle (Issue #3224).
     ///
     /// Behaves identically to [`add_node_version`](Self::add_node_version) other
     /// than persisting `provenance` on the created version (anchor or delta).
@@ -820,7 +820,7 @@ impl HistoricalStorage {
     }
 
     /// Add a new version of an edge, optionally attaching a write-time
-    /// [`Provenance`](crate::core::provenance::Provenance) bundle (Issue #3224).
+    /// [`Provenance`] bundle (Issue #3224).
     ///
     /// Behaves identically to [`add_edge_version`](Self::add_edge_version) other
     /// than persisting `provenance` on the created version (anchor or delta).


### PR DESCRIPTION
📖 Chapter: Storage and DB modules (`src/db/ops.rs`, `src/storage/backup/mod.rs`, `src/api/transaction/write/mod.rs`, `src/db/temporal.rs`, `src/storage/historical/mod.rs`)

🔦 Insight: Fixed numerous unresolved and redundant explicit intra-doc links to satisfy `cargo rustdoc --lib -- -W missing_docs`. Fixed links for `Provenance`, `StorageError::NodeNotFound`, `StorageError::EdgeNotFound`, `ChangeRecord`, and `BackupPayloadV1`.

🧪 Example: n/a

🖼️ Preview: n/a

---
*PR created automatically by Jules for task [11324418428610693963](https://jules.google.com/task/11324418428610693963) started by @madmax983*