### PR TITLE
fix: reserve read-snapshot HLC tick so a same-tick commit can't hide a live node (macOS trunk CI fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           key: ${{ runner.os }}-v2-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run tests
-        run: cargo test --verbose --features "config-toml,mcp-server,sharding-rpc"
+        run: cargo test --verbose --features "config-toml,mcp-server,sharding-rpc,simulation"
 
       - name: Run doc tests
         run: cargo test --doc --verbose
@@ -131,7 +131,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run clippy
-        run: cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc" -- -D warnings
+        run: cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings
 
   security:
     name: Security Audit

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -41,16 +41,19 @@ impl AletheiaDB {
     ///
     /// Reservation is load-bearing for snapshot isolation, not a mere optimization.
     /// The snapshot `S` we hand out is always strictly greater than the prior
-    /// frontier in *both* branches, so we advance the frontier to `S` under the
-    /// same lock guard (compare-and-advance). This guarantees any *subsequent*
-    /// commit's HLC `send()` yields a stamp strictly greater than `S` — even when
-    /// it lands in the same wallclock tick. Without the reservation, a commit in
-    /// the same tick would recompute the identical stamp `S`, closing a superseded
-    /// version's transaction-time interval at exactly `[C1, S)`; the half-open
-    /// upper bound (`TimeRange::contains` uses `< end`) then excludes `S`, so the
-    /// historical fallback misses the version and returns `NodeNotFound` — a
-    /// snapshot-isolation violation. Reserving `S` sorts every later commit
-    /// strictly after this read, keeping it invisible to the snapshot as required.
+    /// frontier in *both* branches, so in *both* branches we advance the frontier
+    /// to `S` under the same lock guard (compare-and-advance) — the reservation is
+    /// unconditional, not limited to the same-tick case. In the wallclock-advanced
+    /// branch `now()` becomes the new frontier; in the same-tick branch the
+    /// logical-incremented stamp does. Either way this guarantees any *subsequent*
+    /// commit's HLC `send()` yields a stamp strictly greater than `S`. That matters
+    /// most when a commit lands in the same wallclock tick as the read: without the
+    /// reservation, its `send()` would recompute the identical stamp `S`, closing a
+    /// superseded version's transaction-time interval at exactly `[C1, S)`; the
+    /// half-open upper bound (`TimeRange::contains` uses `< end`) then excludes `S`,
+    /// so the historical fallback misses the version and returns `NodeNotFound` — a
+    /// snapshot-isolation violation. Reserving `S` sorts every later commit strictly
+    /// after this read, keeping it invisible to the snapshot as required.
     ///
     /// Lock discipline: `current_timestamp` is first in the project lock order, and
     /// this method holds only that guard and calls into no other subsystem while

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -30,51 +30,73 @@ fn record_tx_mutations(tracker: Option<&Arc<PersistenceTracker>>, tx: &WriteTran
 
 impl AletheiaDB {
     /// Compute a snapshot timestamp that is strictly greater than the last commit
-    /// timestamp, ensuring all previously committed transactions are visible.
+    /// timestamp, ensuring all previously committed transactions are visible, and
+    /// **reserve** it by advancing the HLC frontier to that value.
     ///
     /// The MVCC visibility check uses strict less-than (`commit_ts < snapshot_ts`),
     /// so the snapshot must be strictly greater than the most recent commit to see it.
     /// When the system clock advances past the last commit, `now()` is sufficient.
     /// When it hasn't (e.g., multiple operations within the same clock tick), we
     /// advance one logical tick past the last commit.
+    ///
+    /// Reservation is load-bearing for snapshot isolation, not a mere optimization.
+    /// The snapshot `S` we hand out is always strictly greater than the prior
+    /// frontier in *both* branches, so we advance the frontier to `S` under the
+    /// same lock guard (compare-and-advance). This guarantees any *subsequent*
+    /// commit's HLC `send()` yields a stamp strictly greater than `S` — even when
+    /// it lands in the same wallclock tick. Without the reservation, a commit in
+    /// the same tick would recompute the identical stamp `S`, closing a superseded
+    /// version's transaction-time interval at exactly `[C1, S)`; the half-open
+    /// upper bound (`TimeRange::contains` uses `< end`) then excludes `S`, so the
+    /// historical fallback misses the version and returns `NodeNotFound` — a
+    /// snapshot-isolation violation. Reserving `S` sorts every later commit
+    /// strictly after this read, keeping it invisible to the snapshot as required.
+    ///
+    /// Lock discipline: `current_timestamp` is first in the project lock order, and
+    /// this method holds only that guard and calls into no other subsystem while
+    /// held, so the read-compute-write sequence is atomic and lock-order-safe.
     fn snapshot_timestamp_for_read(&self) -> Result<Timestamp> {
-        // Capture current time before acquiring lock to minimize lock contention
+        // Capture current time before acquiring lock to minimize lock contention.
         let now = crate::core::temporal::time::now();
 
-        let last_commit =
-            *self
-                .current_timestamp
+        // Hold the frontier guard across read + compute + write so the
+        // reservation is atomic against concurrent snapshots and commits.
+        let mut frontier =
+            self.current_timestamp
                 .lock()
                 .map_err(|_| TransactionError::LockPoisoned {
                     resource: "current_timestamp".to_string(),
                 })?;
+        let last_commit = *frontier;
 
-        if now > last_commit {
-            // Wallclock advanced past the last commit — now is sufficient
-            Ok(now)
-        } else {
-            // Wallclock hasn't advanced — advance one logical tick past the last
-            // commit so that `commit_ts < snapshot_ts` holds for all committed txns.
-            // Use checked_add to handle potential overflow (theoretically requires
-            // 4B+ events per microsecond, but we handle it for correctness).
-            let next_logical =
-                last_commit
-                    .logical()
-                    .checked_add(1)
-                    .ok_or(crate::core::error::Error::Temporal(
+        let snapshot =
+            if now > last_commit {
+                // Wallclock advanced past the last commit — now is sufficient.
+                now
+            } else {
+                // Wallclock hasn't advanced — advance one logical tick past the last
+                // commit so that `commit_ts < snapshot_ts` holds for all committed txns.
+                // Use checked_add to handle potential overflow (theoretically requires
+                // 4B+ events per microsecond, but we handle it for correctness).
+                let next_logical = last_commit.logical().checked_add(1).ok_or(
+                    crate::core::error::Error::Temporal(
                         crate::core::error::TemporalError::LogicalCounterOverflow {
                             wallclock: last_commit.wallclock(),
                             current_logical: last_commit.logical(),
                         },
-                    ))?;
+                    ),
+                )?;
 
-            // SAFETY: wallclock is copied from an existing valid HybridTimestamp,
-            // and next_logical is bounded by u32::MAX via checked_add above.
-            Ok(HybridTimestamp::new_unchecked(
-                last_commit.wallclock(),
-                next_logical,
-            ))
-        }
+                // SAFETY: wallclock is copied from an existing valid HybridTimestamp,
+                // and next_logical is bounded by u32::MAX via checked_add above.
+                HybridTimestamp::new_unchecked(last_commit.wallclock(), next_logical)
+            };
+
+        // Reserve the snapshot tick: `snapshot` is strictly greater than
+        // `last_commit` in both branches, so this only ever advances the frontier.
+        // No future commit can now reuse or land on this exact stamp.
+        *frontier = snapshot;
+        Ok(snapshot)
     }
 
     /// Create a new read-only transaction.

--- a/tests/readops_snapshot_isolation.rs
+++ b/tests/readops_snapshot_isolation.rs
@@ -90,3 +90,59 @@ fn read_tx_edge_listing_ok_for_node_deleted_after_snapshot() {
         "a fresh snapshot must not see the deleted node"
     );
 }
+
+/// Regression for the macOS-only trunk CI failure: a read snapshot and a
+/// subsequent delete commit that land in the *same wallclock tick* must not
+/// break snapshot isolation.
+///
+/// Root cause: `snapshot_timestamp_for_read` peeked the HLC frontier to compute
+/// a snapshot `S` but never reserved it. When the delete commit happened in the
+/// same tick, its `send()` recomputed the identical stamp `S`, closing the
+/// superseded version's transaction-time interval at exactly `[C1, S)`. The
+/// half-open upper bound (`TimeRange::contains` uses `< end`) then excluded the
+/// snapshot `S`, so the historical fallback returned `NodeNotFound` — a genuine
+/// snapshot-isolation violation reachable in production whenever a read snapshot
+/// and a later commit share a wallclock tick.
+///
+/// A frozen [`SimulatedClock`] makes the single-tick collision deterministic
+/// (on a normally-advancing clock it is a rare race). The clock is injected
+/// *before* the database is constructed so the startup frontier is seeded at the
+/// frozen instant and every subsequent timestamp differs only in its logical
+/// counter, guaranteeing the collision.
+#[cfg(feature = "simulation")]
+#[test]
+fn read_tx_edge_listing_ok_for_node_deleted_in_same_clock_tick() {
+    use aletheiadb::simulation::SimulatedClock;
+
+    // Freeze the clock so the read snapshot and the delete commit share a tick.
+    let clock = SimulatedClock::new(1_700_000_000_000_000);
+    let _guard = clock.inject();
+
+    let db = AletheiaDB::new().unwrap();
+
+    let node = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // Snapshot taken while the node is alive (same frozen tick).
+    let read_tx = db.read_transaction().unwrap();
+    assert!(read_tx.get_node(node).is_ok());
+
+    // A later transaction commits a delete — in the SAME wallclock tick.
+    db.write(|tx| tx.delete_node(node)).unwrap();
+
+    // The old snapshot must still see the node via the historical fallback.
+    // Before the fix the snapshot stamp collided with the delete's commit stamp,
+    // so the superseded version's tx-interval excluded the snapshot →
+    // NodeNotFound. Reserving the snapshot tick sorts the delete strictly after
+    // the read, restoring visibility.
+    let outgoing = read_tx.get_outgoing_edges(node);
+    assert!(
+        outgoing.is_ok(),
+        "node visible at snapshot time must stay visible even when the delete \
+         commits in the same wallclock tick, got {outgoing:?}"
+    );
+    assert!(outgoing.unwrap().is_empty());
+    assert!(read_tx.get_incoming_edges(node).is_ok());
+    assert!(read_tx.get_outgoing_edges_with_label(node, "KNOWS").is_ok());
+}

--- a/tests/readops_snapshot_isolation.rs
+++ b/tests/readops_snapshot_isolation.rs
@@ -145,4 +145,119 @@ fn read_tx_edge_listing_ok_for_node_deleted_in_same_clock_tick() {
     assert!(outgoing.unwrap().is_empty());
     assert!(read_tx.get_incoming_edges(node).is_ok());
     assert!(read_tx.get_outgoing_edges_with_label(node, "KNOWS").is_ok());
+
+    // Pin the historical fallback directly: get_node must still resolve the
+    // pre-delete version at the old snapshot even after the same-tick delete.
+    assert!(
+        read_tx.get_node(node).is_ok(),
+        "get_node must resolve the pre-delete version via the historical \
+         fallback after a same-tick delete, got {:?}",
+        read_tx.get_node(node)
+    );
+}
+
+/// Companion to the same-tick delete test for the *superseded-not-deleted* path:
+/// a node **updated** in the same clock tick as the read snapshot must remain
+/// visible to that snapshot as its pre-update version. An update leaves a new
+/// (updated) version in current storage whose commit stamp equals the snapshot
+/// under the pre-fix collision, so the visibility check falls through to the
+/// historical fallback — which, before the reservation fix, closed the
+/// pre-update version's tx-interval at `[C1, S)` and excluded `S`, yielding
+/// `NodeNotFound`. Reserving the snapshot tick keeps the pre-update version
+/// visible.
+#[cfg(feature = "simulation")]
+#[test]
+fn read_tx_sees_pre_update_version_for_node_updated_in_same_clock_tick() {
+    use aletheiadb::simulation::SimulatedClock;
+
+    let clock = SimulatedClock::new(1_700_000_000_000_000);
+    let _guard = clock.inject();
+
+    let db = AletheiaDB::new().unwrap();
+
+    let node = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("v", 1_i64).build(),
+        )
+        .unwrap();
+
+    // Snapshot taken while the pre-update version is current (same frozen tick).
+    let read_tx = db.read_transaction().unwrap();
+    let before = read_tx.get_node(node).unwrap();
+    assert_eq!(before.properties.get("v").and_then(|p| p.as_int()), Some(1));
+
+    // A later transaction updates the node — in the SAME wallclock tick.
+    db.write(|tx| tx.update_node(node, PropertyMapBuilder::new().insert("v", 2_i64).build()))
+        .unwrap();
+
+    // The old snapshot must still resolve the pre-update version (v == 1) via
+    // the historical fallback, not error out with NodeNotFound.
+    let after = read_tx.get_node(node);
+    assert!(
+        after.is_ok(),
+        "node updated in the same wallclock tick must stay visible as its \
+         pre-update version, got {after:?}"
+    );
+    assert_eq!(
+        after.unwrap().properties.get("v").and_then(|p| p.as_int()),
+        Some(1),
+        "the old snapshot must observe the pre-update value, not the update"
+    );
+    // Edge-listing existence gates must likewise still see the node.
+    assert!(read_tx.get_outgoing_edges(node).is_ok());
+    assert!(read_tx.get_incoming_edges(node).is_ok());
+    assert!(read_tx.get_outgoing_edges_with_label(node, "KNOWS").is_ok());
+}
+
+/// Edge analogue of the same-tick delete test: an **edge** deleted in the same
+/// clock tick as the read snapshot must stay readable via `get_edge`'s
+/// historical fallback (`get_edge_from_historical`), which uses the identical
+/// half-open `[C1, end)` logic. Before the reservation fix the delete's commit
+/// stamp collided with the snapshot `S`, closing the edge version at `[C1, S)`
+/// and excluding `S` → `EdgeNotFound`.
+#[cfg(feature = "simulation")]
+#[test]
+fn read_tx_edge_readable_for_edge_deleted_in_same_clock_tick() {
+    use aletheiadb::simulation::SimulatedClock;
+
+    let clock = SimulatedClock::new(1_700_000_000_000_000);
+    let _guard = clock.inject();
+
+    let db = AletheiaDB::new().unwrap();
+
+    let a = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    let b = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    let edge = db
+        .create_edge(a, b, "KNOWS", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // Snapshot taken while the edge is alive (same frozen tick).
+    let read_tx = db.read_transaction().unwrap();
+    assert!(read_tx.get_edge(edge).is_ok());
+
+    // A later transaction deletes the edge — in the SAME wallclock tick.
+    db.write(|tx| tx.delete_edge(edge)).unwrap();
+
+    // The old snapshot must still resolve the edge via the historical fallback.
+    let got = read_tx.get_edge(edge);
+    assert!(
+        got.is_ok(),
+        "edge visible at snapshot time must stay readable even when the delete \
+         commits in the same wallclock tick, got {got:?}"
+    );
+
+    // A fresh transaction (snapshot after the delete) must not see the edge.
+    let fresh_tx = db.read_transaction().unwrap();
+    assert!(
+        matches!(
+            fresh_tx.get_edge(edge),
+            Err(Error::Storage(StorageError::EdgeNotFound(id))) if id == edge
+        ),
+        "a fresh snapshot must not see the deleted edge"
+    );
 }


### PR DESCRIPTION
## Before / After
**Before:** On macOS, trunk CI deterministically failed `read_tx_edge_listing_ok_for_node_deleted_after_snapshot` (tests/readops_snapshot_isolation.rs) with `NodeNotFound(NodeId(0))`. A read transaction that had already observed a node as live could, after a delete committed in the same wallclock microsecond, fail to list that node's edges — the node vanished from the read's own snapshot. Passed on Linux/Windows only because their finer clocks happened to advance between operations.

**After:** A read snapshot reserves the HLC timestamp it hands out, so any later commit sorts strictly after it. The pre-delete node stays visible to the snapshot; edge listing succeeds. Deterministic regression tests (frozen simulated clock) run per-commit on all three OSes.

## Root cause
`snapshot_timestamp_for_read` (src/db/transaction.rs) computed a read snapshot `S = (W, L+1)` but only *peeked* the `current_timestamp` HLC frontier — it never wrote `S` back. When a commit landed in the same wallclock tick, its HLC `send()` produced the identical stamp `S`, closing the superseded version's transaction-time interval at exactly `[C1, S)`. Transaction-time visibility is half-open `[start, end)` (`TimeRange::contains`, src/core/temporal.rs), so the upper bound `< S` **excluded** the snapshot `S` → the historical fallback (added by the edge-listing existence gate in PR #3398, issue #359) returned `None` → `NodeNotFound`.

This is a genuine **snapshot-isolation violation reachable in production**, not a test artifact: any read snapshot acquired in the same wallclock tick as a subsequent commit collides. Coarse macOS wallclocks just make the collision certain. A test-only deflake (à la #3431) was therefore rejected in favor of fixing the anchoring.

## The fix
`snapshot_timestamp_for_read` now holds the `current_timestamp` mutex guard across read-compute-write and reserves the snapshot: `*frontier = snapshot`. The snapshot is strictly greater than the prior frontier in **both** branches (wallclock-advanced and same-tick), so this only ever advances the frontier. A subsequent commit's `send()` then yields a stamp strictly greater than the snapshot, so a superseded version's interval becomes `[C1, C2)` with `C2 > S` and `contains(S)` holds — the version stays visible. This also closes a pre-existing TOCTOU where two reads in the same tick computed identical snapshots.

- Guard holds only `current_timestamp` (first in the project lock order) and calls into no other subsystem — lock-order-safe.
- `u32` logical-counter growth from per-read increments is bounded and handled by `checked_add` → clean `LogicalCounterOverflow` error (no wrap/panic); this risk class already existed for commits.

## Tests
`tests/readops_snapshot_isolation.rs`, `#[cfg(feature = "simulation")]`, frozen `SimulatedClock` forcing the single-tick collision deterministically (all verified red-without-fix / green-with-fix):
- `read_tx_edge_listing_ok_for_node_deleted_in_same_clock_tick` — the delete case across all three edge-listing methods + direct `get_node`.
- `read_tx_sees_pre_update_version_for_node_updated_in_same_clock_tick` — superseded-not-deleted node stays visible with its pre-update value.
- `read_tx_edge_readable_for_edge_deleted_in_same_clock_tick` — same fix on the edge historical path.

**CI:** the `simulation` feature is added to the per-commit `test` and `lint` jobs in `.github/workflows/ci.yml` (previously the sim-gated regression ran only in nightly/ubuntu — never per-commit, never on macOS). The feature is inert unless a clock is injected, so it does not affect other tests.

## Reviews
Reviewed from three angles — bi-temporal correctness/visibility, concurrency/lock-ordering, and test adequacy/CI coverage — all findings addressed.

Refs: fixes the macOS trunk CI failure introduced alongside the edge-listing existence gate in #3398 (issue #359); tracked as #3435; same boundary-collision family as prior-art deflake #3431.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Z7L7wWRG6XbPTYKSXqDrM)_