### PR TITLE
⚔️ Elenchus: query::planner::rules Test Quality Audit

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -346,3 +346,10 @@
 **Finding:** The `LimitPushdown` tests originally missed several behavioral edge cases and logic checks, particularly regarding the propagation limits in BinaryOp combinations (`||`), updating limit values correctly against child bounds, and setting vector rank limits.
 **Evidence:** `cargo mutants` caught mutants in `LimitPushdown::push_down` specifically targeting the changed boolean condition logic and bounds assignment.
 **Recommendation:** Added `sentry_tests` to `LimitPushdown` that explicitly trigger tests enforcing the boolean change propagation, verifying that updated properties reflect correct nested limits, and vector bounds assignment. Tests now prevent `||` to `&&` mutations and correct top-k modifications.
+
+**[AST Visitor Boolean Optimization Bugs]**
+**Module:** `src::query::planner::rules`
+**Severity:** 🟡 Suspect
+**Finding:** Multiple planner rules (`FilterScanFusion`, `LimitPushdown`, `OperationReordering`, `PredicatePushdown`) used weak boolean ORs (`||`) instead of boolean ANDs (`&&`) to bubble up `changed = true` status during AST visitor walks (e.g. `left_changed || right_changed`). Original test suites only triggered the `changed` state symmetrically (e.g. both sides changing, or the left side changing), masking `|| to &&` mutation escapes.
+**Evidence:** Cargo mutants revealed replacing `||` with `&&` caused zero test failures in `FilterScanFusion::fuse`, `LimitPushdown::push_down`, `OperationReordering::reorder`, and `PredicatePushdown::push_down`.
+**Recommendation:** Refactored tests across all four rules to include `sentry_tests` specifically targeting asymmetric AST branches (where only `left` or only `right` undergoes optimization, or when `changed` propagates through `Project` nodes), locking in the `changed || ...` logic to ensure partial optimizations always return `changed = true`.

--- a/src/query/planner/rules/filter_scan_fusion.rs
+++ b/src/query/planner/rules/filter_scan_fusion.rs
@@ -243,3 +243,52 @@ mod tests {
         assert!(result.unwrap().temporal_context.is_some());
     }
 }
+
+#[cfg(test)]
+mod sentry_tests {
+    use super::*;
+    use crate::core::NodeId;
+    use crate::query::plan::{BinaryOp, ScanOp};
+
+    fn test_stats() -> Statistics {
+        Statistics::default()
+    }
+
+    #[test]
+    fn test_fuse_binary_partial_change() {
+        let rule = FilterScanFusion;
+        let stats = test_stats();
+
+        // Left branch: Filter(Eq) over NodeScan (Will change)
+        let left = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("name", "Alice")),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: None,
+            }),
+        );
+
+        // Right branch: Simple NodeLookup (Will NOT change)
+        let right = LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()]));
+
+        let plan = LogicalPlan::new(LogicalOp::binary(BinaryOp::Union, left, right));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+
+        let expected_plan = LogicalPlan::new(LogicalOp::binary(
+            BinaryOp::Union,
+            LogicalOp::Scan(ScanOp::PropertyScan {
+                label: "Person".to_string(),
+                key: "name".to_string(),
+                value: crate::query::ir::PredicateValue::String("Alice".to_string()),
+            }),
+            LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()])),
+        ));
+
+        assert_eq!(
+            result,
+            Some(expected_plan),
+            "Partial optimization in left branch should propagate change = true"
+        );
+    }
+}

--- a/src/query/planner/rules/limit_pushdown.rs
+++ b/src/query/planner/rules/limit_pushdown.rs
@@ -542,4 +542,77 @@ mod sentry_tests {
             panic!("Expected VectorRank");
         }
     }
+
+    #[test]
+    fn test_pushdown_unary_project_partial_change() {
+        let rule = LimitPushdown;
+        let stats = test_stats();
+
+        // Limit(5, Project(["a"], Limit(10, Scan))) -> Limit(5, Project(["a"], Limit(5, Scan)))
+        let plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Limit(5),
+            LogicalOp::unary(
+                UnaryOp::Project(vec!["a".to_string()]),
+                LogicalOp::unary(
+                    UnaryOp::Limit(10),
+                    LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+                ),
+            ),
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+
+        let expected_plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Limit(5),
+            LogicalOp::unary(
+                UnaryOp::Project(vec!["a".to_string()]),
+                LogicalOp::unary(
+                    UnaryOp::Limit(5),
+                    LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+                ),
+            ),
+        ));
+
+        assert_eq!(
+            result,
+            Some(expected_plan),
+            "Limit pushdown through project should propagate changed = true"
+        );
+    }
+
+    #[test]
+    fn test_binary_partial_change_right() {
+        let rule = LimitPushdown;
+        let stats = test_stats();
+
+        // Left: Scan -> Scan [changed = false]
+        let left = LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()]));
+
+        // Right: Limit(10, Limit(20, Scan)) -> Limit(10, Scan) [changed = true]
+        let right = LogicalOp::unary(
+            UnaryOp::Limit(10),
+            LogicalOp::unary(
+                UnaryOp::Limit(20),
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()])),
+            ),
+        );
+
+        let plan = LogicalPlan::new(LogicalOp::binary(BinaryOp::Union, left, right));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        let expected_plan = LogicalPlan::new(LogicalOp::binary(
+            BinaryOp::Union,
+            LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+            LogicalOp::unary(
+                UnaryOp::Limit(10),
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()])),
+            ),
+        ));
+
+        assert_eq!(
+            result,
+            Some(expected_plan),
+            "Partial optimization in right branch should propagate changed = true"
+        );
+    }
 }

--- a/src/query/planner/rules/operation_reordering.rs
+++ b/src/query/planner/rules/operation_reordering.rs
@@ -173,10 +173,11 @@ impl OperationReordering {
 
                 if filters.len() > 1 {
                     // Reorder filters by selectivity (most selective first = deepest)
-                    let reordered = self.reorder_filters(filters, base, stats)?;
+                    let (new_base, base_changed) = self.reorder(&base, stats)?;
+                    let reordered = self.reorder_filters(filters, new_base, stats)?;
                     // Check if order actually changed
-                    let changed = !self.filters_equal(op, &reordered);
-                    Ok((reordered, changed))
+                    let order_changed = !self.filters_equal(op, &reordered);
+                    Ok((reordered, base_changed || order_changed))
                 } else {
                     // Single filter or no filter - just recurse
                     if let LogicalOp::Unary {
@@ -1183,6 +1184,108 @@ mod tests {
         assert_ne!(
             Predicate::Or(vec![Predicate::eq("a", 1)]),
             Predicate::Or(vec![Predicate::eq("a", 1), Predicate::eq("b", 2)])
+        );
+    }
+}
+
+#[cfg(test)]
+mod sentry_tests {
+    use super::*;
+    use crate::core::NodeId;
+    use crate::query::plan::ScanOp;
+
+    fn test_stats() -> Statistics {
+        Statistics::default()
+    }
+
+    #[test]
+    fn test_reorder_binary_partial_change() {
+        let rule = OperationReordering;
+        let stats = test_stats();
+
+        // Left branch: Filter(Age > 30) -> Filter(Id == 1) -> Scan (Will be reordered because Eq is more selective)
+        let left = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("id", 1)),
+            LogicalOp::unary(
+                UnaryOp::Filter(Predicate::gt("age", 30)),
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+            ),
+        );
+
+        // Right branch: Simple Scan (Will NOT change)
+        let right = LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()]));
+
+        let plan = LogicalPlan::new(LogicalOp::binary(
+            BinaryOp::Union,
+            left.clone(),
+            right.clone(),
+        ));
+
+        // We know that `rule.reorder(left)` should return `(optimized, true)`
+        // because filters are out of order (gt before eq).
+        // `rule.reorder(right)` should return `(right, false)`.
+        let result = rule.apply(&plan, &stats).unwrap();
+
+        let expected_plan = LogicalPlan::new(LogicalOp::binary(
+            BinaryOp::Union,
+            LogicalOp::unary(
+                UnaryOp::Filter(Predicate::gt("age", 30)),
+                LogicalOp::unary(
+                    UnaryOp::Filter(Predicate::eq("id", 1)),
+                    LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+                ),
+            ),
+            LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()])),
+        ));
+
+        assert_eq!(
+            result,
+            Some(expected_plan),
+            "Partial optimization in left branch should propagate change = true"
+        );
+    }
+
+    #[test]
+    fn test_reorder_unary_partial_change() {
+        let rule = OperationReordering;
+        let stats = test_stats();
+
+        // Nested inside Unary(Limit): Binary(Union, Left, Right)
+        let left = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("id", 1)),
+            LogicalOp::unary(
+                UnaryOp::Filter(Predicate::gt("age", 30)),
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+            ),
+        );
+        let right = LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()]));
+
+        let plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Limit(10),
+            LogicalOp::binary(BinaryOp::Union, left, right),
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+
+        let expected_plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Limit(10),
+            LogicalOp::binary(
+                BinaryOp::Union,
+                LogicalOp::unary(
+                    UnaryOp::Filter(Predicate::gt("age", 30)),
+                    LogicalOp::unary(
+                        UnaryOp::Filter(Predicate::eq("id", 1)),
+                        LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+                    ),
+                ),
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()])),
+            ),
+        ));
+
+        assert_eq!(
+            result,
+            Some(expected_plan),
+            "Partial optimization inside Unary should propagate change = true"
         );
     }
 }

--- a/src/query/planner/rules/predicate_pushdown.rs
+++ b/src/query/planner/rules/predicate_pushdown.rs
@@ -703,4 +703,56 @@ mod sentry_tests {
             "Partial optimization (left branch) should trigger change"
         );
     }
+
+    #[test]
+    fn test_binary_op_partial_change_right_side() {
+        let rule = PredicatePushdown;
+        let stats = Statistics::default();
+
+        // Left: Filter(Scan) -> Should NOT change
+        let left = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("a", 1)),
+            LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+        );
+
+        // Right: Filter(Sort(Scan)) -> Should change to Sort(Filter(Scan))
+        let right = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("b", 2)),
+            LogicalOp::unary(
+                UnaryOp::Sort {
+                    key: SortKey::Property("b".to_string()),
+                    descending: false,
+                },
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()])),
+            ),
+        );
+
+        let plan = LogicalPlan::new(LogicalOp::binary(BinaryOp::Union, left, right));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+
+        let expected_plan = LogicalPlan::new(LogicalOp::binary(
+            BinaryOp::Union,
+            LogicalOp::unary(
+                UnaryOp::Filter(Predicate::eq("a", 1)),
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+            ),
+            LogicalOp::unary(
+                UnaryOp::Sort {
+                    key: SortKey::Property("b".to_string()),
+                    descending: false,
+                },
+                LogicalOp::unary(
+                    UnaryOp::Filter(Predicate::eq("b", 2)),
+                    LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()])),
+                ),
+            ),
+        ));
+
+        assert_eq!(
+            result,
+            Some(expected_plan),
+            "Partial optimization (right branch) should trigger change"
+        );
+    }
 }


### PR DESCRIPTION
Summary: AST Visitor Boolean Optimization Bugs fixed by verifying partial tree changes.
Verdict table: 4 rules acquired 🟢 Acquitted (Strengthened).
Priority fixes: Strengthen `||` operators in AST walks propagating `changed` states, specifically resolving a logic bug in `OperationReordering`.
Missing coverage: Missing tests ensuring partial AST optimizations are upward-propagated correctly have been added.

---
*PR created automatically by Jules for task [5886120934454319171](https://jules.google.com/task/5886120934454319171) started by @madmax983*