### PR TITLE
🎻 Bard: Fix rustdoc intra-doc link warnings

### DIFF
--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -1447,7 +1447,7 @@ impl WriteTransaction {
     ///   (`valid_to == valid_from` is allowed and yields an empty interval).
     /// - [`TemporalError::ValidTimeTooFarInFuture`](crate::core::error::TemporalError::ValidTimeTooFarInFuture)
     ///   if `valid_to` is more than one year in the future.
-    /// - [`StorageError::NodeNotFound`](crate::core::error::StorageError::NodeNotFound)
+    /// - [`StorageError::NodeNotFound`]
     ///   if the node never existed.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn retract_node(
@@ -1552,7 +1552,7 @@ impl WriteTransaction {
     ///
     /// See [`retract_node`](Self::retract_node) for the bi-temporal
     /// semantics, idempotency contract, and errors (with
-    /// [`StorageError::EdgeNotFound`](crate::core::error::StorageError::EdgeNotFound)
+    /// [`StorageError::EdgeNotFound`]
     /// for a never-existing edge).
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn retract_edge(

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -473,7 +473,7 @@ impl AletheiaDB {
     }
 
     /// Create a node with an optional [`WriteRequestOptions`](crate::api::transaction::WriteRequestOptions)
-    /// bundle: a backdated `valid_from` and/or a write-time [`Provenance`] bundle (Issue #3224).
+    /// bundle: a backdated `valid_from` and/or a write-time [`Provenance`](crate::core::provenance::Provenance) bundle (Issue #3224).
     ///
     /// Passing `WriteRequestOptions::default()` is identical to [`create_node`](Self::create_node).
     ///
@@ -813,7 +813,7 @@ impl AletheiaDB {
     /// decide whether a detach/cascade delete is required to avoid orphaning
     /// edges.
     ///
-    /// Returns [`StorageError::NodeNotFound`](crate::storage::StorageError::NodeNotFound)
+    /// Returns [`StorageError::NodeNotFound`](crate::core::error::StorageError::NodeNotFound)
     /// if the node does not exist in the current state, so callers never receive
     /// a misleading zero count for a missing node.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -506,7 +506,7 @@ impl AletheiaDB {
     ///
     /// This is the *discovery* counterpart to the per-entity history/diff APIs: it answers
     /// "**which** entities were created, modified, or deleted between T1 and T2?" without the
-    /// caller already knowing any IDs. Each returned [`ChangeRecord`](crate::core::ChangeRecord)
+    /// caller already knowing any IDs. Each returned [`ChangeRecord`]
     /// carries the entity id, kind, change type, and the version's transaction- and valid-time
     /// bounds, so a caller can then drill in with `get_node_history` / `diff_node_versions`.
     ///

--- a/src/storage/backup/mod.rs
+++ b/src/storage/backup/mod.rs
@@ -53,8 +53,8 @@ pub const BACKUP_MAGIC: [u8; 4] = *b"ALBK";
 ///   (transaction-time closure) and `prev_version`/`next_version` (version
 ///   chain links).
 ///
-/// Older artifacts are still restorable -- see [`BackupPayloadV1`],
-/// [`BackupPayloadV2`], [`BackupPayloadV3`] and `read_artifact`.
+/// Older artifacts are still restorable -- see `` `BackupPayloadV1` ``,
+/// `` `BackupPayloadV2` ``, `` `BackupPayloadV3` `` and `read_artifact`.
 pub const BACKUP_FORMAT_VERSION: u16 = 4;
 
 /// Maximum allowed decompressed payload size (5 GiB).

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -553,7 +553,7 @@ impl HistoricalStorage {
     }
 
     /// Add a new version of a node, optionally attaching a write-time
-    /// [`Provenance`](crate::core::provenance::Provenance) bundle (Issue #3224).
+    /// [`Provenance`] bundle (Issue #3224).
     ///
     /// Behaves identically to [`add_node_version`](Self::add_node_version) other
     /// than persisting `provenance` on the created version (anchor or delta).
@@ -828,7 +828,7 @@ impl HistoricalStorage {
     }
 
     /// Add a new version of an edge, optionally attaching a write-time
-    /// [`Provenance`](crate::core::provenance::Provenance) bundle (Issue #3224).
+    /// [`Provenance`] bundle (Issue #3224).
     ///
     /// Behaves identically to [`add_edge_version`](Self::add_edge_version) other
     /// than persisting `provenance` on the created version (anchor or delta).


### PR DESCRIPTION
📖 Chapter: Intra-doc links
🔦 Insight: Fixed unresolved, private, and redundant links that caused warnings during `cargo rustdoc --lib -- -W missing_docs`.
🧪 Example: Ensured `cargo test --doc` tests pass and `rustdoc` warnings are gone.
🖼️ Preview: No visual changes, just cleaner docs output.

---
*PR created automatically by Jules for task [4241310713480354967](https://jules.google.com/task/4241310713480354967) started by @madmax983*