### PR TITLE
Add 60-second guided quickstart demo, docs, and CI TTFQ gate (#3380)

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -1,0 +1,88 @@
+name: Quickstart TTFQ
+
+# Enforces Issue #3380: the 60-second guided quickstart must keep working.
+# Runs the full scripted demo sequence and fails if any printed query errors
+# or if time-to-first-query (TTFQ, run-time only — the one-time build is not
+# counted) exceeds the 60-second budget.
+
+on:
+  push:
+    branches: [ main, trunk, develop ]
+  pull_request:
+    branches: [ main, trunk, develop ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  # Run-time budget for the demo, in seconds (the build is timed separately
+  # below and excluded from this gate).
+  TTFQ_BUDGET_SECONDS: 60
+
+jobs:
+  quickstart:
+    name: 60-second demo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v5
+        with:
+          path: target
+          key: ${{ runner.os }}-v2-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      # One-time build cost, reported but NOT part of the TTFQ gate.
+      - name: Build the demo (one-time, not counted toward TTFQ)
+        run: |
+          build_start=$(date +%s)
+          cargo build --example demo
+          build_end=$(date +%s)
+          echo "Cold/warm build wall-clock: $((build_end - build_start)) s (excluded from TTFQ)"
+
+      # The scripted sequence: run the demo, enforce the run-time budget, and
+      # assert every guided query produced its expected line.
+      - name: Run the guided demo and enforce TTFQ budget
+        run: |
+          run_start=$(date +%s%3N)
+          ./target/debug/examples/demo | tee demo_output.txt
+          status=${PIPESTATUS[0]}
+          run_end=$(date +%s%3N)
+          elapsed_ms=$((run_end - run_start))
+          echo "----------------------------------------------------------"
+          echo "Demo exit status: ${status}"
+          echo "Demo run wall-clock: ${elapsed_ms} ms (budget: ${TTFQ_BUDGET_SECONDS}000 ms)"
+
+          if [ "${status}" -ne 0 ]; then
+            echo "::error::demo exited non-zero — a guided query errored"
+            exit 1
+          fi
+
+          budget_ms=$((TTFQ_BUDGET_SECONDS * 1000))
+          if [ "${elapsed_ms}" -gt "${budget_ms}" ]; then
+            echo "::error::TTFQ ${elapsed_ms} ms exceeded budget ${budget_ms} ms"
+            exit 1
+          fi
+
+      - name: Assert every guided query printed its result verbatim
+        run: |
+          set -e
+          grep -q "Alice is currently: CTO" demo_output.txt
+          grep -q "Alice KNOWS Bob" demo_output.txt
+          grep -q "On founding day, Alice was: Engineer" demo_output.txt
+          grep -q '"Engineer" then vs "CTO" now' demo_output.txt
+          grep -q "v3: title = CTO" demo_output.txt
+          echo "All guided queries produced their expected output."

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -11,6 +11,12 @@ on:
   pull_request:
     branches: [ main, trunk, develop ]
 
+# Least-privilege GITHUB_TOKEN: the jobs only check out the repo and run the
+# demo — no writes to PRs, issues, pages, or the repo — so read-only contents
+# access is sufficient.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,33 @@ one query. [Why that matters →](docs/guides/why-aletheiadb.md)
 
 ---
 
+## 60-Second Quickstart
+
+One command seeds a small, story-driven **bi-temporal** dataset and walks you
+through a guided sequence of queries — including a **time-travel (`AS OF`)**
+query whose answer visibly differs from the current state. It is ephemeral
+(nothing written to disk) and needs no server and no API key:
+
+```bash
+cargo run --example demo
+```
+
+Time-to-first-query is a few seconds (the one-time `cargo build` is separate).
+The three entry channels, each with its exact commands:
+
+| Channel | Command | Server? | API key? |
+|---------|---------|---------|----------|
+| **Embedded (Rust)** | `cargo run --example demo` | No | No |
+| **MCP (agent-issued)** | `export ALETHEIADB_BOOTSTRAP_ADMIN_KEY="$(openssl rand -base64 32)"`<br>`cargo run --bin aletheia-mcp --features mcp-server` | Yes (stdio) | Yes |
+| **HTTP server** | `export ALETHEIADB_BOOTSTRAP_ADMIN_KEY="$(openssl rand -base64 32)"`<br>`cargo run --bin aletheia-server --features http-server` | Yes | Yes |
+
+Authentication is **on by default** for both servers — see the
+[Security Quickstart](docs/guides/security-quickstart.md) for key setup and the
+explicit anonymous opt-in. Full walkthrough, sample output, and measured
+timings: **[60-Second Quickstart guide →](docs/guides/quickstart.md)**
+
+---
+
 ## Install
 
 ```toml
@@ -139,6 +166,7 @@ aletheiadb = { version = "0.1", features = ["nova", "semantic-search"] }
 
 | Guide | Description |
 |-------|-------------|
+| [60-Second Quickstart](docs/guides/quickstart.md) | Fastest path to your first (time-travel) query, across all channels |
 | [Why AletheiaDB](docs/guides/why-aletheiadb.md) | The problem it solves; when to use it |
 | [Core Concepts](docs/guides/core-concepts.md) | Bi-temporal model, nodes, edges, WAL, vector search |
 | [Installation](docs/guides/installation.md) | Prerequisites, feature flags, building from source |

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -1,0 +1,196 @@
+# 60-Second Quickstart
+
+Go from zero to your first **time-travel query** in under a minute. This is the
+top of the funnel — the goal is a successful current-state query *and* a
+successful `AS OF` query within 60 seconds of deciding to try AletheiaDB
+(Issue #3380).
+
+There are three entry channels. Pick the one that matches how you'll use
+AletheiaDB:
+
+| Channel | For | Needs a server? | Needs an API key? |
+|---------|-----|-----------------|-------------------|
+| [Embedded (Rust)](#embedded-rust--fastest-path) | Rust apps, evaluation | No | No |
+| [MCP (agent-issued)](#mcp--let-an-agent-issue-the-first-query) | LLM / Claude tooling | Yes (stdio) | Yes (bootstrap in seconds) |
+| [HTTP server](#http-server) | Language-agnostic clients | Yes | Yes |
+
+> **What counts toward the 60 seconds?** Time-to-first-query (TTFQ) is
+> measured from invoking the command to the first successful query response.
+> The **one-time `cargo build`** (or download) is a separate, up-front cost and
+> is *not* counted — a cold build takes minutes; the demo run itself is a
+> few seconds. Both numbers are reported honestly below.
+
+---
+
+## Embedded (Rust) — fastest path
+
+One command seeds a small, story-driven **bi-temporal** dataset and walks you
+through a guided sequence of queries. It is ephemeral (in-memory; nothing is
+written to your working directory) and needs no server and no API key:
+
+```bash
+cargo run --example demo
+```
+
+You'll see four guided queries, each with a one-line "what you just saw":
+
+```text
+Seeded 204 nodes and 404 edges with genuine version history.
+
+── Query 1 of 4: Current-state lookup ──
+  let alice = db.get_node(alice_id)?;
+  → Alice is currently: CTO
+
+── Query 2 of 4: Traversal (who does Alice know?) ──
+  → Alice KNOWS Bob (Engineer)
+
+── Query 3 of 4: Time-travel — AS OF the founding day ──
+  let past = db.get_node_at_time(alice_id, t_founding, t_founding)?;
+  → On founding day, Alice was: Engineer
+  what you just saw: the SAME node, a different answer — "Engineer" then vs "CTO" now.
+
+── Query 4 of 4: History — every version of a fact ──
+  → v1: title = Engineer
+  → v2: title = Staff Engineer
+  → v3: title = CTO
+```
+
+Query 3 is the differentiator: the *same* node returns a *different* answer as
+of the founding day than it does now — a time-travel result no current-state
+graph database can show you.
+
+### Measured timing (reference: this repo's CI-class runner)
+
+| Phase | Wall-clock |
+|-------|-----------|
+| One-time `cargo build --example demo` (cold) | ~135 s |
+| Demo run — seed + first query (TTFQ) | ~3.1 s |
+| Demo run — full 4-query guided sequence | ~3.1 s |
+
+TTFQ is **~3 seconds**, comfortably inside the 60-second budget. The demo's
+run-time and zero-error path are enforced on every push by
+[`.github/workflows/quickstart.yml`](../../.github/workflows/quickstart.yml)
+and by `tests/quickstart_demo.rs`, so this page can never silently drift.
+
+### Drop it into your own project
+
+The demo is ordinary AletheiaDB API. Here is the whole story in ~20 lines:
+
+```rust
+use aletheiadb::prelude::*;
+use aletheiadb::time;
+
+fn main() -> Result<()> {
+    // Ephemeral (in-memory). Use AletheiaDB::open("./mydb") to persist.
+    let db = AletheiaDB::new()?;
+
+    // Hire Alice as an Engineer, then snapshot "the founding day".
+    let alice = db.create_node("Person", properties! { "name" => "Alice", "title" => "Engineer" })?;
+    let bob   = db.create_node("Person", properties! { "name" => "Bob",   "title" => "Engineer" })?;
+    db.create_edge(alice, bob, "KNOWS", properties! {})?;
+    let t_founding = time::now();
+
+    // Facts change over time: Alice is promoted twice (two new versions).
+    db.write(|tx| tx.update_node(alice, properties! { "name" => "Alice", "title" => "Staff Engineer" }))?;
+    db.write(|tx| tx.update_node(alice, properties! { "name" => "Alice", "title" => "CTO" }))?;
+
+    // 1) Current-state lookup.
+    let now = db.get_node(alice)?;
+    assert_eq!(now.properties.get("title").and_then(|v| v.as_str()), Some("CTO"));
+
+    // 2) Time-travel: who was Alice on the founding day?
+    let past = db.get_node_at_time(alice, t_founding, t_founding)?;
+    assert_eq!(past.properties.get("title").and_then(|v| v.as_str()), Some("Engineer"));
+
+    Ok(())
+}
+```
+
+For a fuller walkthrough (CRUD, edges, hybrid queries), see
+[Getting Started](getting-started.md).
+
+---
+
+## MCP — let an agent issue the first query
+
+An LLM-tooling evaluator's "first query" should be issued *by their agent*.
+AletheiaDB speaks the Model Context Protocol over stdio, exposing `get_schema`,
+`traverse`, `get_node_at_time`, and more as MCP tools.
+
+**Authentication is on by default** — the server refuses to start without a
+credential. Bootstrap one in seconds (this is the whole ceremony):
+
+```bash
+# One high-entropy admin key, memory-only (never written to disk).
+export ALETHEIADB_BOOTSTRAP_ADMIN_KEY="$(openssl rand -base64 32)"
+
+cargo run --bin aletheia-mcp --features mcp-server
+```
+
+Point an MCP client (Claude Desktop, Claude Code, or any MCP host) at it. A
+Claude Desktop `mcpServers` entry looks like:
+
+```json
+{
+  "mcpServers": {
+    "aletheiadb": {
+      "command": "cargo",
+      "args": ["run", "--bin", "aletheia-mcp", "--features", "mcp-server"],
+      "env": {
+        "ALETHEIADB_MCP_API_KEY": "aletheia_sk_...your_key..."
+      }
+    }
+  }
+}
+```
+
+The session key (`ALETHEIADB_MCP_API_KEY`) is re-verified on every tool call.
+For minting role-scoped keys, the anonymous-mode opt-in for local development
+(`ALETHEIADB_AUTH_MODE=anonymous`), and the full RBAC model, see the
+[Security Quickstart](security-quickstart.md).
+
+> **Seeding data for an agent session:** the guided dataset above is created by
+> the embedded Rust demo. To let an agent explore a *seeded* graph today, run
+> the demo's seed logic against a durable `AletheiaDB::open(path)` database and
+> start the MCP server with the same `ALETHEIADB_DATA_DIR`. A one-command
+> `aletheia demo` binary subcommand that boots a seeded, agent-reachable
+> instance directly is tracked as follow-up (see
+> [Known gaps](#known-gaps--follow-ups)).
+
+---
+
+## HTTP server
+
+For language-agnostic clients, run the HTTP server. It is also authenticated by
+default:
+
+```bash
+export ALETHEIADB_BOOTSTRAP_ADMIN_KEY="$(openssl rand -base64 32)"
+ALETHEIADB_DATA_DIR=/var/lib/aletheiadb \
+  cargo run --bin aletheia-server --features http-server
+```
+
+Then create a node and issue queries with `curl`. The complete key lifecycle
+(mint writer/reader/metrics keys, use them, audit, revoke) is documented in the
+[Security Quickstart](security-quickstart.md#step-2--mint-role-scoped-keys-over-the-admin-api).
+
+---
+
+## Known gaps / follow-ups
+
+- **Non-Rust binary / container channel.** The fastest non-Rust path — a
+  published binary or container that runs a seeded demo with **no toolchain** —
+  depends on an `aletheia demo` CLI subcommand and the container packaging
+  (owned by the deployment spec). Until it lands, the Rust-native
+  `cargo run --example demo` is the canonical guided demo, and the MCP/HTTP
+  sections above cover the server paths.
+- **Seeded agent session in one command.** See the note in the MCP section.
+
+---
+
+## Safety notes
+
+- The embedded demo is **ephemeral** and clearly labeled as demo data — it
+  writes nothing to your working directory and needs no cleanup.
+- The MCP and HTTP servers never start unauthenticated by accident; anonymous
+  mode is an explicit, loudly-warned opt-in.

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,0 +1,243 @@
+//! AletheiaDB 60-second guided demo (Issue #3380).
+//!
+//! A single command that seeds a small, story-driven **bi-temporal** dataset
+//! and walks you through a guided sequence of queries — including a time-travel
+//! (`AS OF`) query whose answer visibly differs from the current state.
+//!
+//! Run it (nothing is written to disk — the database is ephemeral):
+//!
+//! ```bash
+//! cargo run --example demo
+//! ```
+//!
+//! This is the Rust-native quickstart path. It needs no server and no API key.
+//! For the MCP (agent-issued) and HTTP (authenticated) paths, see
+//! `docs/guides/quickstart.md`.
+//!
+//! The demo is intentionally deterministic: every query printed below succeeds
+//! verbatim against the seeded data, and the flow is exercised in CI
+//! (`tests/quickstart_demo.rs`) so it can never silently drift.
+
+use std::time::Instant;
+
+use aletheiadb::prelude::*;
+use aletheiadb::time;
+
+/// Convenience alias for the example's fallible functions. We spell out
+/// `std::result::Result` because `aletheiadb::prelude` re-exports its own
+/// `Result`/`Error`, which would otherwise shadow the std trait object.
+type DemoResult = std::result::Result<(), Box<dyn std::error::Error>>;
+
+/// Named core cast so the guided queries are legible and deterministic. The
+/// wider org (a few hundred filler nodes/edges) is generated around them so the
+/// dataset is "on the order of hundreds of nodes/edges", per the issue.
+const FILLER_ENGINEERS: usize = 200;
+
+fn main() -> DemoResult {
+    let started = Instant::now();
+
+    banner();
+
+    // ── Seed a story-driven, bi-temporal dataset ────────────────────────────
+    // Ephemeral: AletheiaDB::new() is a tempdir-backed database that leaves
+    // nothing in your working directory. Use AletheiaDB::open("./path") when
+    // you want durability.
+    let db = AletheiaDB::new()?;
+
+    // t_founding: the moment the company is founded and Alice is hired as an
+    // Engineer. We capture this timestamp so we can time-travel back to it.
+    let company = db.create_node("Company", properties! { "name" => "Aletheia Labs" })?;
+
+    let alice = db.create_node(
+        "Person",
+        properties! { "name" => "Alice", "title" => "Engineer" },
+    )?;
+    let bob = db.create_node(
+        "Person",
+        properties! { "name" => "Bob", "title" => "Engineer" },
+    )?;
+    let carol = db.create_node(
+        "Person",
+        properties! { "name" => "Carol", "title" => "Designer" },
+    )?;
+
+    db.create_edge(alice, company, "WORKS_AT", properties! {})?;
+    db.create_edge(bob, company, "WORKS_AT", properties! {})?;
+    db.create_edge(carol, company, "WORKS_AT", properties! {})?;
+    db.create_edge(alice, bob, "KNOWS", properties! {})?;
+    db.create_edge(bob, carol, "KNOWS", properties! {})?;
+
+    // The wider org: a few hundred colleagues, so temporal/graph queries run
+    // against a realistically sized graph rather than a toy of three nodes.
+    seed_wider_org(&db, company)?;
+
+    // Snapshot the founding moment *after* the initial hire so a query "as of
+    // founding" sees Alice as an Engineer.
+    let t_founding = time::now();
+
+    // ── The story unfolds: facts change over time ───────────────────────────
+    // Alice is promoted twice. Each update creates a new bi-temporal version;
+    // the old versions are preserved and remain queryable forever.
+    settle(); // guarantee a distinct transaction timestamp for the next version
+    db.write(|tx| {
+        tx.update_node(
+            alice,
+            properties! { "name" => "Alice", "title" => "Staff Engineer" },
+        )
+    })?;
+    settle();
+    db.write(|tx| tx.update_node(alice, properties! { "name" => "Alice", "title" => "CTO" }))?;
+
+    println!(
+        "Seeded {} nodes and {} edges with genuine version history.\n",
+        db.node_count(),
+        db.edge_count()
+    );
+
+    // ── Guided query 1: current-state lookup ────────────────────────────────
+    section(
+        1,
+        "Current-state lookup",
+        "let alice = db.get_node(alice_id)?;",
+    );
+    let alice_now = db.get_node(alice)?;
+    let title_now = prop_str(&alice_now, "title");
+    println!("  → Alice is currently: {title_now}");
+    println!("  what you just saw: the *latest* fact — sub-microsecond, no temporal overhead.\n");
+
+    // This is the "time to first query" mark the issue defines.
+    let ttfq = started.elapsed();
+
+    // ── Guided query 2: a traversal ─────────────────────────────────────────
+    section(
+        2,
+        "Traversal (who does Alice know?)",
+        "for e in db.get_outgoing_edges_with_label(alice_id, \"KNOWS\") { .. }",
+    );
+    for edge_id in db.get_outgoing_edges_with_label(alice, "KNOWS") {
+        let target = db.get_edge_target(edge_id)?;
+        let person = db.get_node(target)?;
+        println!(
+            "  → Alice KNOWS {} ({})",
+            prop_str(&person, "name"),
+            prop_str(&person, "title")
+        );
+    }
+    println!("  what you just saw: a single-hop graph traversal over the current graph.\n");
+
+    // ── Guided query 3: AS OF time-travel (the differentiator) ──────────────
+    section(
+        3,
+        "Time-travel — AS OF the founding day",
+        "let past = db.get_node_at_time(alice_id, t_founding, t_founding)?;",
+    );
+    let alice_founding = db.get_node_at_time(alice, t_founding, t_founding)?;
+    let title_founding = prop_str(&alice_founding, "title");
+    println!("  → On founding day, Alice was: {title_founding}");
+    println!(
+        "  what you just saw: the SAME node, a different answer — \"{title_founding}\" then vs \"{title_now}\" now."
+    );
+    assert_ne!(
+        title_founding, title_now,
+        "the time-travel query must differ from current state"
+    );
+    println!("  (No incumbent graph DB can show you this in its 60-second demo.)\n");
+
+    // ── Guided query 4: full history / provenance ───────────────────────────
+    section(
+        4,
+        "History — every version of a fact",
+        "for v in db.get_node_history(alice_id)?.versions { .. }",
+    );
+    let history = db.get_node_history(alice)?;
+    for v in &history.versions {
+        println!(
+            "  → v{}: title = {}",
+            v.version_number,
+            v.properties
+                .get("title")
+                .map(display_value)
+                .unwrap_or_else(|| "<none>".to_string())
+        );
+    }
+    println!(
+        "  what you just saw: {} preserved versions of one node — the audit trail is free.\n",
+        history.versions.len()
+    );
+
+    // ── Timing summary (honest: run-time only; build is one-time) ───────────
+    let total = started.elapsed();
+    println!("────────────────────────────────────────────────────────");
+    println!(
+        "Time to first query (seed + current-state lookup): {} ms",
+        ttfq.as_millis()
+    );
+    println!(
+        "Full guided sequence (4 queries):                  {} ms",
+        total.as_millis()
+    );
+    println!("Target: < 60_000 ms. (One-time `cargo build` is separate and not counted.)");
+    println!("────────────────────────────────────────────────────────");
+    println!("\nNext: open a durable database with `AletheiaDB::open(\"./mydb\")`,");
+    println!("or point an MCP client at AletheiaDB — see docs/guides/quickstart.md.");
+
+    Ok(())
+}
+
+/// Prints the demo banner. Loudly labels the data as an ephemeral demo.
+fn banner() {
+    println!("════════════════════════════════════════════════════════");
+    println!("  AletheiaDB — 60-second bi-temporal demo");
+    println!("  Ephemeral demo data (in-memory; nothing written to disk)");
+    println!("════════════════════════════════════════════════════════\n");
+}
+
+/// Prints a guided-query section header plus the copy-paste snippet.
+fn section(n: u8, title: &str, snippet: &str) {
+    println!("── Query {n} of 4: {title} ──");
+    println!("  {snippet}");
+}
+
+/// Generates a few hundred colleague nodes/edges around the named cast so the
+/// dataset is realistically sized. Kept deterministic (no randomness).
+fn seed_wider_org(db: &AletheiaDB, company: NodeId) -> DemoResult {
+    let mut previous: Option<NodeId> = None;
+    for i in 0..FILLER_ENGINEERS {
+        let person = db.create_node(
+            "Person",
+            properties! { "name" => format!("Engineer {i}"), "title" => "Engineer" },
+        )?;
+        db.create_edge(person, company, "WORKS_AT", properties! {})?;
+        if let Some(prev) = previous {
+            db.create_edge(prev, person, "KNOWS", properties! {})?;
+        }
+        previous = Some(person);
+    }
+    Ok(())
+}
+
+/// Ensures the next write lands on a strictly later transaction timestamp than
+/// the previous one, so point-in-time reads resolve to distinct versions even
+/// on very fast machines.
+fn settle() {
+    std::thread::sleep(std::time::Duration::from_millis(2));
+}
+
+/// Extracts a string-valued property, or a placeholder if missing.
+fn prop_str(node: &aletheiadb::Node, key: &str) -> String {
+    node.properties
+        .get(key)
+        .map(display_value)
+        .unwrap_or_else(|| "<none>".to_string())
+}
+
+/// Renders a `PropertyValue` for display without leaking Debug formatting.
+fn display_value(value: &PropertyValue) -> String {
+    match value {
+        PropertyValue::String(s) => s.to_string(),
+        PropertyValue::Int(i) => i.to_string(),
+        PropertyValue::Float(f) => f.to_string(),
+        PropertyValue::Bool(b) => b.to_string(),
+        other => format!("{other:?}"),
+    }
+}

--- a/tests/quickstart_demo.rs
+++ b/tests/quickstart_demo.rs
@@ -1,0 +1,177 @@
+//! CI guard for the 60-second quickstart (Issue #3380).
+//!
+//! This test mirrors the guided sequence in `examples/demo.rs` and the
+//! copy-paste blocks in `docs/guides/quickstart.md`, asserting that:
+//!
+//! 1. every guided query succeeds against the seeded data (zero-error path),
+//! 2. the `AS OF` time-travel answer visibly differs from current state,
+//! 3. the whole seed-plus-query flow completes well under the 60-second
+//!    time-to-first-query (TTFQ) budget the project targets.
+//!
+//! `examples/demo.rs` itself is compiled by CI's `clippy --all-targets` step
+//! and run end-to-end by `.github/workflows/quickstart.yml`; this test locks
+//! the *behavior* those surfaces promise so the funnel's first page can never
+//! silently drift.
+
+use std::time::Instant;
+
+use aletheiadb::prelude::*;
+use aletheiadb::time;
+
+/// The TTFQ budget from the project brief and Issue #3380.
+const TTFQ_BUDGET_MS: u128 = 60_000;
+
+/// Mirror of the demo's wider-org filler count so the graph is realistically
+/// sized ("on the order of hundreds of nodes/edges").
+const FILLER_ENGINEERS: usize = 200;
+
+/// Extracts a string-valued property, or `<none>` if absent.
+fn prop_str(node: &aletheiadb::Node, key: &str) -> String {
+    match node.properties.get(key) {
+        Some(PropertyValue::String(s)) => s.to_string(),
+        Some(other) => format!("{other:?}"),
+        None => "<none>".to_string(),
+    }
+}
+
+#[test]
+fn quickstart_guided_sequence_succeeds_within_budget() {
+    let started = Instant::now();
+
+    // ── Seed the same story-driven, bi-temporal dataset as the demo ─────────
+    let db = AletheiaDB::new().expect("ephemeral database should open");
+
+    let company = db
+        .create_node("Company", properties! { "name" => "Aletheia Labs" })
+        .expect("create company");
+    let alice = db
+        .create_node(
+            "Person",
+            properties! { "name" => "Alice", "title" => "Engineer" },
+        )
+        .expect("create Alice");
+    let bob = db
+        .create_node(
+            "Person",
+            properties! { "name" => "Bob", "title" => "Engineer" },
+        )
+        .expect("create Bob");
+    let carol = db
+        .create_node(
+            "Person",
+            properties! { "name" => "Carol", "title" => "Designer" },
+        )
+        .expect("create Carol");
+
+    db.create_edge(alice, company, "WORKS_AT", properties! {})
+        .expect("Alice WORKS_AT");
+    db.create_edge(bob, company, "WORKS_AT", properties! {})
+        .expect("Bob WORKS_AT");
+    db.create_edge(carol, company, "WORKS_AT", properties! {})
+        .expect("Carol WORKS_AT");
+    db.create_edge(alice, bob, "KNOWS", properties! {})
+        .expect("Alice KNOWS Bob");
+    db.create_edge(bob, carol, "KNOWS", properties! {})
+        .expect("Bob KNOWS Carol");
+
+    let mut previous: Option<NodeId> = None;
+    for i in 0..FILLER_ENGINEERS {
+        let person = db
+            .create_node(
+                "Person",
+                properties! { "name" => format!("Engineer {i}"), "title" => "Engineer" },
+            )
+            .expect("create filler engineer");
+        db.create_edge(person, company, "WORKS_AT", properties! {})
+            .expect("filler WORKS_AT");
+        if let Some(prev) = previous {
+            db.create_edge(prev, person, "KNOWS", properties! {})
+                .expect("filler KNOWS");
+        }
+        previous = Some(person);
+    }
+
+    // Capture the founding moment, then let facts change over time.
+    let t_founding = time::now();
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    db.write(|tx| {
+        tx.update_node(
+            alice,
+            properties! { "name" => "Alice", "title" => "Staff Engineer" },
+        )
+    })
+    .expect("promote Alice to Staff Engineer");
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    db.write(|tx| tx.update_node(alice, properties! { "name" => "Alice", "title" => "CTO" }))
+        .expect("promote Alice to CTO");
+
+    // Dataset is realistically sized.
+    assert!(
+        db.node_count() >= 200,
+        "expected hundreds of nodes, got {}",
+        db.node_count()
+    );
+    assert!(
+        db.edge_count() >= 200,
+        "expected hundreds of edges, got {}",
+        db.edge_count()
+    );
+
+    // ── Query 1: current-state lookup ───────────────────────────────────────
+    let alice_now = db.get_node(alice).expect("get current Alice");
+    let title_now = prop_str(&alice_now, "title");
+    assert_eq!(title_now, "CTO", "current title should be the latest fact");
+
+    // ── Query 2: traversal ──────────────────────────────────────────────────
+    let mut known: Vec<String> = Vec::new();
+    for edge_id in db.get_outgoing_edges_with_label(alice, "KNOWS") {
+        let target = db.get_edge_target(edge_id).expect("resolve KNOWS target");
+        let person = db.get_node(target).expect("load known person");
+        known.push(prop_str(&person, "name"));
+    }
+    assert!(
+        known.contains(&"Bob".to_string()),
+        "Alice should KNOW Bob, got {known:?}"
+    );
+
+    // ── Query 3: AS OF time-travel — must differ from current state ──────────
+    let alice_founding = db
+        .get_node_at_time(alice, t_founding, t_founding)
+        .expect("time-travel to founding day");
+    let title_founding = prop_str(&alice_founding, "title");
+    assert_eq!(
+        title_founding, "Engineer",
+        "on founding day Alice was an Engineer"
+    );
+    assert_ne!(
+        title_founding, title_now,
+        "the AS OF answer must visibly differ from current state"
+    );
+
+    // ── Query 4: full version history ───────────────────────────────────────
+    let history = db.get_node_history(alice).expect("load Alice history");
+    let titles: Vec<String> = history
+        .versions
+        .iter()
+        .map(|v| match v.properties.get("title") {
+            Some(PropertyValue::String(s)) => s.to_string(),
+            _ => "<none>".to_string(),
+        })
+        .collect();
+    assert_eq!(
+        titles,
+        vec![
+            "Engineer".to_string(),
+            "Staff Engineer".to_string(),
+            "CTO".to_string()
+        ],
+        "history should preserve every version of the title"
+    );
+
+    // ── TTFQ budget gate ────────────────────────────────────────────────────
+    let elapsed_ms = started.elapsed().as_millis();
+    assert!(
+        elapsed_ms < TTFQ_BUDGET_MS,
+        "quickstart flow took {elapsed_ms} ms, exceeding the {TTFQ_BUDGET_MS} ms TTFQ budget"
+    );
+}


### PR DESCRIPTION
Closes part of #3380 (time-to-first-query < 60s guided quickstart).

## What & why

Adoption leaks at the top of the funnel: the stated TTFQ target is < 60s, but nothing measured it and the first-run path made a newcomer read a Rust-centric README, choose among four persistence stories, and only then discover the temporal features. This PR delivers a single-command, story-driven bi-temporal demo, a canonical multi-channel quickstart, and a CI gate so the number can't silently regress.

## Plan (brainstorm / reverse-brainstorm / six-hats, condensed)

- **How could this quickstart fail a new user?** (reverse brainstorm) → server won't boot because auth is on by default (#3421); build time mistaken for query time; demo litters the working dir; the "interesting" temporal answer is an empty set; copy-paste blocks drift from reality. Each became a design constraint or a test.
- **Approaches considered:** (A) embedded-Rust-only; (B) embedded + MCP; (C) embedded + MCP + HTTP. **Chose C for docs coverage, with the embedded path as the executable, CI-gated demo** — it needs no server and no key, so it can't be broken by the auth-on-by-default default, and it's the only path that runs verbatim in CI today.
- **Risks turned into test cases:** AS OF answer must differ from current state; every printed line must appear verbatim; whole flow must finish < 60s; dataset must be realistically sized (hundreds of nodes/edges).

## Changes

- **`examples/demo.rs`** — `cargo run --example demo`: ephemeral (in-memory, no disk litter), seeds 204 nodes / 404 edges with genuine version history, and walks through 4 guided queries, each with a "what you just saw" line and an honest run-time/TTFQ summary:
  1. current-state lookup (Alice → CTO)
  2. traversal (Alice KNOWS Bob)
  3. **AS OF time-travel** — same node, different answer: *Engineer then vs CTO now*
  4. full version history (3 preserved versions)
- **`docs/guides/quickstart.md`** — canonical quickstart across all three channels (embedded Rust, MCP agent-issued, HTTP) with sample output, measured timings, MCP client config, and the auth bootstrap for server paths (links the merged security-quickstart rather than duplicating it).
- **`README.md`** — 60-Second Quickstart section at the top with per-channel commands; guide added to the docs table.
- **`tests/quickstart_demo.rs`** — mirrors the guided sequence, asserts every result verbatim, and enforces a < 60s TTFQ budget (runs in the existing `cargo test` job).
- **`.github/workflows/quickstart.yml`** — runs the demo end-to-end; fails if any query errors or if run-time TTFQ exceeds 60s (one-time build cost reported but excluded).

## Verified (measured on this CI-class runner)

| Phase | Wall-clock |
|-------|-----------|
| One-time `cargo build --example demo` (cold) | ~135 s (excluded from TTFQ) |
| Demo run — seed + first query (TTFQ) | ~1.9–3.1 s |
| `cargo test --test quickstart_demo` | pass (1.92 s) |
| `cargo clippy --all-targets … -D warnings` | clean |
| `cargo fmt --all` | clean |

## Security

No default credentials and no anonymous-by-default drift: the embedded demo needs no key; the MCP/HTTP snippets bootstrap a key with `openssl rand` and link the security quickstart. Authentication stays on by default (#3421).

## Known gaps / follow-ups

- **Non-Rust binary/container channel** (AC 3): the toolchain-free path needs an `aletheia demo` CLI subcommand (a `src/bin` change) plus container packaging (owned by the deployment spec). This PR delivers the Rust-native executable demo + the server-path docs; the binary subcommand is called out as follow-up in the guide.
- **One-command seeded agent session**: documented interim recipe (seed a durable DB, share `ALETHEIADB_DATA_DIR` with the MCP server); a direct `aletheia demo` server mode is the same follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uw8akeT6Dw7YTPCFsMWy3x

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uw8akeT6Dw7YTPCFsMWy3x)_