### PR TITLE
Bound Cypher expression recursion to prevent stack-overflow aborts (#3404)

### DIFF
--- a/src/cypher/converter.rs
+++ b/src/cypher/converter.rs
@@ -520,15 +520,31 @@ impl CypherConverter {
     fn convert_expr_to_predicate(&self, expr: &CypherExpr) -> Result<Predicate, CypherError> {
         match expr {
             CypherExpr::Comparison { left, op, right } => self.convert_comparison(left, *op, right),
-            CypherExpr::And(left, right) => {
-                let left_pred = self.convert_expr_to_predicate(left)?;
-                let right_pred = self.convert_expr_to_predicate(right)?;
-                Ok(Predicate::And(vec![left_pred, right_pred]))
+            CypherExpr::And(_, _) => {
+                // Iteratively flatten the (possibly deeply left-nested) AND
+                // spine so that a long `a AND b AND c ...` chain lowers to a
+                // single n-ary predicate without recursing per operator.
+                let operands = flatten_logical_operands(expr, |e| match e {
+                    CypherExpr::And(left, right) => Some((left, right)),
+                    _ => None,
+                });
+                let preds = operands
+                    .into_iter()
+                    .map(|operand| self.convert_expr_to_predicate(operand))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Predicate::And(preds))
             }
-            CypherExpr::Or(left, right) => {
-                let left_pred = self.convert_expr_to_predicate(left)?;
-                let right_pred = self.convert_expr_to_predicate(right)?;
-                Ok(Predicate::Or(vec![left_pred, right_pred]))
+            CypherExpr::Or(_, _) => {
+                // Same iterative flattening for the OR spine.
+                let operands = flatten_logical_operands(expr, |e| match e {
+                    CypherExpr::Or(left, right) => Some((left, right)),
+                    _ => None,
+                });
+                let preds = operands
+                    .into_iter()
+                    .map(|operand| self.convert_expr_to_predicate(operand))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Predicate::Or(preds))
             }
             CypherExpr::Not(inner) => {
                 let inner_pred = self.convert_expr_to_predicate(inner)?;
@@ -842,6 +858,42 @@ impl CypherConverter {
 
         Ok((property_key, embedding))
     }
+}
+
+// ---------------------------------------------------------------------------
+// Logical-operator flattening
+// ---------------------------------------------------------------------------
+
+/// Flatten a left-nested chain of a single logical operator (`AND` or `OR`, as
+/// built by the parser's `parse_and_expr` / `parse_or_expr`) into its ordered
+/// operand list, iteratively — without recursing down the operator spine.
+///
+/// `split` returns `Some((left, right))` for a node of the operator being
+/// flattened and `None` for any other node. Nodes for which `split` returns
+/// `None` (including a sub-tree of the *other* logical operator) are returned
+/// as opaque operands, to be converted individually by the caller. Operand
+/// order is preserved left-to-right.
+///
+/// This keeps converting an arbitrarily long `a AND b AND c ...` (or `OR`)
+/// chain from overflowing the stack (issue #3404): the spine is walked with an
+/// explicit heap stack instead of one call frame per operator.
+fn flatten_logical_operands<'a>(
+    root: &'a CypherExpr,
+    split: impl Fn(&'a CypherExpr) -> Option<(&'a CypherExpr, &'a CypherExpr)>,
+) -> Vec<&'a CypherExpr> {
+    let mut operands = Vec::new();
+    let mut stack = vec![root];
+    // Pushing right-then-left means the left operand is popped first, so leaves
+    // are collected in source (left-to-right) order.
+    while let Some(node) = stack.pop() {
+        if let Some((left, right)) = split(node) {
+            stack.push(right);
+            stack.push(left);
+        } else {
+            operands.push(node);
+        }
+    }
+    operands
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cypher/converter.rs
+++ b/src/cypher/converter.rs
@@ -44,6 +44,16 @@ use crate::query::builder::Query;
 use crate::query::ir::{Predicate, PredicateValue, QueryOp, SortKey, TraversalDepth};
 use crate::query::plan::{QueryHints, TemporalContext};
 
+/// Defensive recursion bound for expression → predicate conversion.
+///
+/// The parser already caps expression nesting at 128, so for any AST it
+/// produces this never fires. It exists solely because `convert` is `pub`: a
+/// caller constructing a `CypherExpr` by hand (bypassing the parser) could nest
+/// `Not`/`Grouped` arbitrarily deep and overflow the stack during conversion.
+/// Kept clearly above the parser's cap so it only ever rejects such hand-built
+/// pathological input, never a legitimately parsed query.
+const MAX_CONVERT_DEPTH: usize = 256;
+
 // ---------------------------------------------------------------------------
 // Parameter values
 // ---------------------------------------------------------------------------
@@ -518,6 +528,26 @@ impl CypherConverter {
     ///
     /// This handles comparisons, logical operators, string predicates, etc.
     fn convert_expr_to_predicate(&self, expr: &CypherExpr) -> Result<Predicate, CypherError> {
+        self.convert_expr_to_predicate_at(expr, 0)
+    }
+
+    /// Depth-guarded worker for [`Self::convert_expr_to_predicate`].
+    ///
+    /// The `Not` / `Grouped` arms recurse structurally; `convert` is `pub`, so
+    /// this guards against a caller handing us an AST nested past the parser's
+    /// own [`MAX_EXPRESSION_DEPTH`]. The bound is set above the parser's cap so
+    /// it never fires for parser-produced ASTs, only for hand-built ones.
+    fn convert_expr_to_predicate_at(
+        &self,
+        expr: &CypherExpr,
+        depth: usize,
+    ) -> Result<Predicate, CypherError> {
+        if depth > MAX_CONVERT_DEPTH {
+            return Err(CypherError::ParseError {
+                position: 0,
+                message: "expression nesting too deep for conversion (max 256)".to_string(),
+            });
+        }
         match expr {
             CypherExpr::Comparison { left, op, right } => self.convert_comparison(left, *op, right),
             CypherExpr::And(_, _) => {
@@ -530,7 +560,7 @@ impl CypherConverter {
                 });
                 let preds = operands
                     .into_iter()
-                    .map(|operand| self.convert_expr_to_predicate(operand))
+                    .map(|operand| self.convert_expr_to_predicate_at(operand, depth + 1))
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok(Predicate::And(preds))
             }
@@ -542,12 +572,12 @@ impl CypherConverter {
                 });
                 let preds = operands
                     .into_iter()
-                    .map(|operand| self.convert_expr_to_predicate(operand))
+                    .map(|operand| self.convert_expr_to_predicate_at(operand, depth + 1))
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok(Predicate::Or(preds))
             }
             CypherExpr::Not(inner) => {
-                let inner_pred = self.convert_expr_to_predicate(inner)?;
+                let inner_pred = self.convert_expr_to_predicate_at(inner, depth + 1)?;
                 Ok(Predicate::Not(Box::new(inner_pred)))
             }
             CypherExpr::IsNull(inner) => {
@@ -596,7 +626,7 @@ impl CypherConverter {
                     suffix: suffix.clone(),
                 })
             }
-            CypherExpr::Grouped(inner) => self.convert_expr_to_predicate(inner),
+            CypherExpr::Grouped(inner) => self.convert_expr_to_predicate_at(inner, depth + 1),
             CypherExpr::Value(CypherValue::Bool(true)) => Ok(Predicate::True),
             CypherExpr::Value(CypherValue::Bool(false)) => Ok(Predicate::False),
             _ => Err(CypherError::UnsupportedFeature(format!(

--- a/src/cypher/parser.rs
+++ b/src/cypher/parser.rs
@@ -47,7 +47,26 @@ use super::lexer::{CypherLexer, Token, TokenKind};
 /// further. Without the cap, a pathological input such as thousands of nested
 /// parentheses or `NOT`s overflows the stack and aborts the whole process
 /// (issue #3404). Legitimate queries nest far below this limit.
+///
+/// Note: the bound is *cumulative* across all nesting constructs
+/// (parentheses, `NOT`, `IN [...]` element lists, and function arguments), not
+/// a separate budget per construct -- e.g. deeply nested parens inside an
+/// `IN`-list share the same counter.
 const MAX_EXPRESSION_DEPTH: usize = 128;
+
+/// Maximum number of operands in a single contiguous `AND` / `OR` chain.
+///
+/// The parser builds a left-nested `Box<CypherExpr>` spine for a flat
+/// `a AND b AND c ...` (or `OR`) chain, which is intentionally *not* bounded by
+/// [`MAX_EXPRESSION_DEPTH`] (the chain has no per-operand nesting). That spine
+/// is walked iteratively at conversion time, but the derived recursive `Drop`
+/// for `CypherExpr` still unwinds it one stack frame per node when the AST is
+/// dropped -- so an unbounded chain (tens of thousands of terms) would
+/// stack-overflow on teardown, relocating the very SIGABRT issue #3404 targets
+/// to destruction. Capping the operand count keeps that drop depth bounded
+/// while staying far beyond any realistic query; it doubles as an in-lane
+/// query-complexity guard.
+const MAX_EXPRESSION_TERMS: usize = 4096;
 
 /// Recursive descent parser for Cypher queries.
 ///
@@ -472,7 +491,13 @@ impl CypherParser {
     /// ```
     fn parse_or_expr(&mut self, depth: usize) -> Result<CypherExpr, CypherError> {
         let mut left = self.parse_and_expr(depth)?;
+        // Operand count for this contiguous OR chain (starts at 1 for `left`).
+        let mut terms: usize = 1;
         while self.eat(TokenKind::Or) {
+            terms += 1;
+            if terms > MAX_EXPRESSION_TERMS {
+                return Err(self.error("expression has too many AND/OR terms (max 4096)"));
+            }
             let right = self.parse_and_expr(depth)?;
             left = CypherExpr::Or(Box::new(left), Box::new(right));
         }
@@ -484,7 +509,13 @@ impl CypherParser {
     /// ```
     fn parse_and_expr(&mut self, depth: usize) -> Result<CypherExpr, CypherError> {
         let mut left = self.parse_not_expr(depth)?;
+        // Operand count for this contiguous AND chain (starts at 1 for `left`).
+        let mut terms: usize = 1;
         while self.eat(TokenKind::And) {
+            terms += 1;
+            if terms > MAX_EXPRESSION_TERMS {
+                return Err(self.error("expression has too many AND/OR terms (max 4096)"));
+            }
             let right = self.parse_not_expr(depth)?;
             left = CypherExpr::And(Box::new(left), Box::new(right));
         }

--- a/src/cypher/parser.rs
+++ b/src/cypher/parser.rs
@@ -37,6 +37,18 @@ use super::ast::*;
 use super::error::CypherError;
 use super::lexer::{CypherLexer, Token, TokenKind};
 
+/// Maximum nesting depth allowed while parsing an expression.
+///
+/// The expression grammar recurses at three points: a parenthesised
+/// sub-expression (`'(' expr ')'`), a `NOT` chain (`NOT not_expr`), and the
+/// element expressions of an `IN [ ... ]` / function-argument list. Each of
+/// these threads and increments a `depth` counter; when it exceeds this bound
+/// the parser returns a [`CypherError::ParseError`] instead of recursing
+/// further. Without the cap, a pathological input such as thousands of nested
+/// parentheses or `NOT`s overflows the stack and aborts the whole process
+/// (issue #3404). Legitimate queries nest far below this limit.
+const MAX_EXPRESSION_DEPTH: usize = 128;
+
 /// Recursive descent parser for Cypher queries.
 ///
 /// Created internally by [`CypherParser::parse`]; callers never need to
@@ -434,25 +446,34 @@ impl CypherParser {
     /// ```
     fn parse_where(&mut self) -> Result<CypherExpr, CypherError> {
         self.expect(TokenKind::Where)?;
-        self.parse_expression()
+        self.parse_expression(0)
     }
 
     /// Entry point for expression parsing.
     ///
+    /// `depth` is the current expression nesting level; it is incremented only
+    /// at genuine recursion re-entry points (parenthesised sub-expression,
+    /// `NOT`, and `IN`/argument element lists) and passed through unchanged by
+    /// the operator-precedence layers. Exceeding [`MAX_EXPRESSION_DEPTH`]
+    /// returns a [`CypherError::ParseError`] rather than overflowing the stack.
+    ///
     /// ```text
     /// expr := or_expr
     /// ```
-    fn parse_expression(&mut self) -> Result<CypherExpr, CypherError> {
-        self.parse_or_expr()
+    fn parse_expression(&mut self, depth: usize) -> Result<CypherExpr, CypherError> {
+        if depth > MAX_EXPRESSION_DEPTH {
+            return Err(self.error("expression nesting too deep (max 128)"));
+        }
+        self.parse_or_expr(depth)
     }
 
     /// ```text
     /// or_expr := and_expr (OR and_expr)*
     /// ```
-    fn parse_or_expr(&mut self) -> Result<CypherExpr, CypherError> {
-        let mut left = self.parse_and_expr()?;
+    fn parse_or_expr(&mut self, depth: usize) -> Result<CypherExpr, CypherError> {
+        let mut left = self.parse_and_expr(depth)?;
         while self.eat(TokenKind::Or) {
-            let right = self.parse_and_expr()?;
+            let right = self.parse_and_expr(depth)?;
             left = CypherExpr::Or(Box::new(left), Box::new(right));
         }
         Ok(left)
@@ -461,10 +482,10 @@ impl CypherParser {
     /// ```text
     /// and_expr := not_expr (AND not_expr)*
     /// ```
-    fn parse_and_expr(&mut self) -> Result<CypherExpr, CypherError> {
-        let mut left = self.parse_not_expr()?;
+    fn parse_and_expr(&mut self, depth: usize) -> Result<CypherExpr, CypherError> {
+        let mut left = self.parse_not_expr(depth)?;
         while self.eat(TokenKind::And) {
-            let right = self.parse_not_expr()?;
+            let right = self.parse_not_expr(depth)?;
             left = CypherExpr::And(Box::new(left), Box::new(right));
         }
         Ok(left)
@@ -473,12 +494,15 @@ impl CypherParser {
     /// ```text
     /// not_expr := NOT not_expr | comparison
     /// ```
-    fn parse_not_expr(&mut self) -> Result<CypherExpr, CypherError> {
+    fn parse_not_expr(&mut self, depth: usize) -> Result<CypherExpr, CypherError> {
+        if depth > MAX_EXPRESSION_DEPTH {
+            return Err(self.error("expression nesting too deep (max 128)"));
+        }
         if self.eat(TokenKind::Not) {
-            let inner = self.parse_not_expr()?;
+            let inner = self.parse_not_expr(depth + 1)?;
             Ok(CypherExpr::Not(Box::new(inner)))
         } else {
-            self.parse_comparison()
+            self.parse_comparison(depth)
         }
     }
 
@@ -486,8 +510,8 @@ impl CypherParser {
     /// comparison := primary (comp_op primary | IS [NOT] NULL | IN '[' expr_list ']'
     ///            | CONTAINS string | STARTS WITH string | ENDS WITH string)?
     /// ```
-    fn parse_comparison(&mut self) -> Result<CypherExpr, CypherError> {
-        let left = self.parse_primary_expr()?;
+    fn parse_comparison(&mut self, depth: usize) -> Result<CypherExpr, CypherError> {
+        let left = self.parse_primary_expr(depth)?;
 
         // Standard comparison operators
         let op = match self.peek().kind {
@@ -502,7 +526,7 @@ impl CypherParser {
 
         if let Some(op) = op {
             self.advance();
-            let right = self.parse_primary_expr()?;
+            let right = self.parse_primary_expr(depth)?;
             return Ok(CypherExpr::Comparison {
                 left: Box::new(left),
                 op,
@@ -527,9 +551,9 @@ impl CypherParser {
             self.expect(TokenKind::LBracket)?;
             let mut values = vec![];
             if !self.at(TokenKind::RBracket) {
-                values.push(self.parse_expression()?);
+                values.push(self.parse_expression(depth + 1)?);
                 while self.eat(TokenKind::Comma) {
-                    values.push(self.parse_expression()?);
+                    values.push(self.parse_expression(depth + 1)?);
                 }
             }
             self.expect(TokenKind::RBracket)?;
@@ -542,7 +566,7 @@ impl CypherParser {
         // CONTAINS string
         if self.at(TokenKind::Contains) {
             self.advance();
-            let right = self.parse_primary_expr()?;
+            let right = self.parse_primary_expr(depth)?;
             if let CypherExpr::Value(CypherValue::String(s)) = right {
                 return Ok(CypherExpr::Contains {
                     expr: Box::new(left),
@@ -556,7 +580,7 @@ impl CypherParser {
         if self.at(TokenKind::StartsWith) {
             self.advance(); // consume STARTS
             self.expect(TokenKind::With)?; // consume WITH
-            let right = self.parse_primary_expr()?;
+            let right = self.parse_primary_expr(depth)?;
             if let CypherExpr::Value(CypherValue::String(s)) = right {
                 return Ok(CypherExpr::StartsWith {
                     expr: Box::new(left),
@@ -570,7 +594,7 @@ impl CypherParser {
         if self.at(TokenKind::EndsWith) {
             self.advance(); // consume ENDS
             self.expect(TokenKind::With)?; // consume WITH
-            let right = self.parse_primary_expr()?;
+            let right = self.parse_primary_expr(depth)?;
             if let CypherExpr::Value(CypherValue::String(s)) = right {
                 return Ok(CypherExpr::EndsWith {
                     expr: Box::new(left),
@@ -586,12 +610,12 @@ impl CypherParser {
     /// ```text
     /// primary := value | var '.' prop | '(' expr ')' | func_call | var
     /// ```
-    fn parse_primary_expr(&mut self) -> Result<CypherExpr, CypherError> {
+    fn parse_primary_expr(&mut self, depth: usize) -> Result<CypherExpr, CypherError> {
         match self.peek().kind.clone() {
             // Parenthesized sub-expression
             TokenKind::LParen => {
                 self.advance();
-                let inner = self.parse_expression()?;
+                let inner = self.parse_expression(depth + 1)?;
                 self.expect(TokenKind::RParen)?;
                 Ok(CypherExpr::Grouped(Box::new(inner)))
             }
@@ -612,7 +636,7 @@ impl CypherParser {
                         // Dot-qualified function call: namespace.func(args...)
                         // e.g., vector.similarity(d.embedding, $query)
                         self.advance(); // consume '('
-                        let args = self.parse_function_args()?;
+                        let args = self.parse_function_args(depth)?;
                         self.expect(TokenKind::RParen)?;
                         let qualified_name = format!("{name}.{}", next_tok.text);
                         Ok(CypherExpr::FunctionCall {
@@ -629,7 +653,7 @@ impl CypherParser {
                 } else if self.at(TokenKind::LParen) {
                     // Function call: name(args...)
                     self.advance();
-                    let args = self.parse_function_args()?;
+                    let args = self.parse_function_args(depth)?;
                     self.expect(TokenKind::RParen)?;
                     Ok(CypherExpr::FunctionCall { name, args })
                 } else {
@@ -648,7 +672,7 @@ impl CypherParser {
                 let name_tok = self.advance().clone();
                 let name = name_tok.text.to_uppercase();
                 self.expect(TokenKind::LParen)?;
-                let args = self.parse_function_args()?;
+                let args = self.parse_function_args(depth)?;
                 self.expect(TokenKind::RParen)?;
                 Ok(CypherExpr::FunctionCall { name, args })
             }
@@ -673,12 +697,15 @@ impl CypherParser {
     }
 
     /// Parse comma-separated function arguments (may be empty).
-    fn parse_function_args(&mut self) -> Result<Vec<CypherExpr>, CypherError> {
+    ///
+    /// Each argument is a fresh expression nested one level below the call, so
+    /// `depth` is incremented to bound deeply nested `f(g(h(...)))` chains.
+    fn parse_function_args(&mut self, depth: usize) -> Result<Vec<CypherExpr>, CypherError> {
         let mut args = Vec::new();
         if !self.at(TokenKind::RParen) {
-            args.push(self.parse_expression()?);
+            args.push(self.parse_expression(depth + 1)?);
             while self.eat(TokenKind::Comma) {
-                args.push(self.parse_expression()?);
+                args.push(self.parse_expression(depth + 1)?);
             }
         }
         Ok(args)
@@ -766,7 +793,7 @@ impl CypherParser {
     /// return_item := expr [AS identifier]
     /// ```
     fn parse_return_item(&mut self) -> Result<CypherReturnItem, CypherError> {
-        let expr = self.parse_expression()?;
+        let expr = self.parse_expression(0)?;
 
         let alias = if self.eat(TokenKind::As) {
             let alias_tok = self.expect(TokenKind::Identifier)?;
@@ -796,7 +823,7 @@ impl CypherParser {
     /// order_item := expr [ASC | DESC]
     /// ```
     fn parse_order_item(&mut self) -> Result<CypherOrderItem, CypherError> {
-        let expr = self.parse_expression()?;
+        let expr = self.parse_expression(0)?;
 
         let descending = if self.eat(TokenKind::Desc) {
             true

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -966,10 +966,12 @@ fn test_execute_cypher_parse_error() {
 // ============================================================================
 // Expression-recursion safety tests (Issue #3404)
 //
-// Pathologically deep expression nesting must return a `ParseError` (bounded
-// by the parser depth cap) rather than overflowing the stack and aborting the
-// process, while arbitrarily long *flat* AND/OR chains must still convert (the
-// converter flattens them iteratively, so there is no term-count cap).
+// Pathologically deep expression nesting must return a `ParseError` (bounded by
+// the parser depth cap of 128) rather than overflowing the stack and aborting
+// the process. Long *flat* AND/OR chains convert via an iterative flatten (no
+// per-operator recursion), but are still bounded by a term cap of 4096 so the
+// recursive `Drop` of the left-nested `CypherExpr` spine cannot overflow the
+// stack on teardown. Chains up to the cap must build, convert, and drop safely.
 // ============================================================================
 
 /// Nested parentheses at the boundary of the cap parse successfully.
@@ -1023,11 +1025,12 @@ fn test_parse_deep_not_chain_over_cap() {
     }
 }
 
-/// A very long *flat* AND chain converts to a single n-ary `Predicate::And`
-/// without overflowing the stack in the converter.
+/// A long *flat* AND chain (comfortably under the term cap) converts to a
+/// single n-ary `Predicate::And` without overflowing the stack in the
+/// converter; running green in debug also proves the AST drops safely.
 #[test]
 fn test_convert_large_and_chain() {
-    let terms = 5000usize;
+    let terms = 4000usize;
     let clause = vec!["n.a = 1"; terms].join(" AND ");
     let query = parse_cypher(&format!("MATCH (n) WHERE {clause} RETURN n")).unwrap();
     let and_len = query.ops.iter().find_map(|op| match op {
@@ -1041,11 +1044,11 @@ fn test_convert_large_and_chain() {
     );
 }
 
-/// A very long *flat* OR chain converts to a single n-ary `Predicate::Or`
-/// without overflowing the stack in the converter.
+/// A long *flat* OR chain (comfortably under the term cap) converts to a
+/// single n-ary `Predicate::Or` without overflowing the stack in the converter.
 #[test]
 fn test_convert_large_or_chain() {
-    let terms = 5000usize;
+    let terms = 4000usize;
     let clause = vec!["n.a = 1"; terms].join(" OR ");
     let query = parse_cypher(&format!("MATCH (n) WHERE {clause} RETURN n")).unwrap();
     let or_len = query.ops.iter().find_map(|op| match op {
@@ -1056,6 +1059,127 @@ fn test_convert_large_or_chain() {
         or_len,
         Some(terms),
         "expected a flattened n-ary OR with {terms} operands"
+    );
+}
+
+/// A flat AND chain of exactly `MAX_EXPRESSION_TERMS` (4096) operands is
+/// accepted, and builds + converts + drops without crashing.
+#[test]
+fn test_parse_and_chain_at_term_cap() {
+    let clause = vec!["n.a = 1"; 4096].join(" AND ");
+    let query = parse_cypher(&format!("MATCH (n) WHERE {clause} RETURN n"))
+        .expect("4096-term AND chain should parse and convert");
+    let and_len = query.ops.iter().find_map(|op| match op {
+        QueryOp::Filter(Predicate::And(preds)) => Some(preds.len()),
+        _ => None,
+    });
+    assert_eq!(and_len, Some(4096));
+}
+
+/// A flat AND chain of `MAX_EXPRESSION_TERMS + 1` (4097) operands is rejected
+/// with a `ParseError` before the oversized AST is built.
+#[test]
+fn test_parse_and_chain_over_term_cap() {
+    let clause = vec!["n.a = 1"; 4097].join(" AND ");
+    let result = CypherParser::parse(&format!("MATCH (n) WHERE {clause} RETURN n"));
+    assert!(
+        matches!(result, Err(CypherError::ParseError { .. })),
+        "4097-term AND chain should be a ParseError, got {result:?}"
+    );
+}
+
+/// A flat OR chain of `MAX_EXPRESSION_TERMS + 1` (4097) operands is rejected
+/// with a `ParseError` before the oversized AST is built.
+#[test]
+fn test_parse_or_chain_over_term_cap() {
+    let clause = vec!["n.a = 1"; 4097].join(" OR ");
+    let result = CypherParser::parse(&format!("MATCH (n) WHERE {clause} RETURN n"));
+    assert!(
+        matches!(result, Err(CypherError::ParseError { .. })),
+        "4097-term OR chain should be a ParseError, got {result:?}"
+    );
+}
+
+/// Flat AND/OR operand order is preserved left-to-right through the iterative
+/// flatten: `a AND b AND c` lowers to `And([Eq a, Eq b, Eq c])` in order.
+#[test]
+fn test_convert_and_chain_preserves_order() {
+    let query = parse_cypher("MATCH (n) WHERE n.a = 1 AND n.b = 2 AND n.c = 3 RETURN n").unwrap();
+    let filter = query
+        .ops
+        .iter()
+        .find_map(|op| match op {
+            QueryOp::Filter(pred) => Some(pred),
+            _ => None,
+        })
+        .expect("expected a filter predicate");
+    let Predicate::And(operands) = filter else {
+        panic!("expected top-level AND predicate, got {filter:?}");
+    };
+    assert_eq!(
+        operands.len(),
+        3,
+        "expected three AND operands: {operands:?}"
+    );
+    let keys: Vec<&str> = operands
+        .iter()
+        .map(|p| match p {
+            Predicate::Eq { key, .. } => key.as_str(),
+            other => panic!("expected Eq operand, got {other:?}"),
+        })
+        .collect();
+    assert_eq!(keys, vec!["a", "b", "c"], "operand order must be preserved");
+}
+
+/// Deeply nested parentheses inside an `IN [...]` element share the cumulative
+/// depth budget: 128 deep parses, 129 deep is a `ParseError`.
+#[test]
+fn test_parse_in_list_nesting() {
+    let ok = format!(
+        "MATCH (n) WHERE n.a IN [ {}1{} ] RETURN n",
+        "(".repeat(127),
+        ")".repeat(127)
+    );
+    assert!(
+        CypherParser::parse(&ok).is_ok(),
+        "IN-list nested 127 deep should parse"
+    );
+
+    let over = format!(
+        "MATCH (n) WHERE n.a IN [ {}1{} ] RETURN n",
+        "(".repeat(129),
+        ")".repeat(129)
+    );
+    let result = CypherParser::parse(&over);
+    assert!(
+        matches!(result, Err(CypherError::ParseError { .. })),
+        "IN-list nested 129 deep should be a ParseError, got {result:?}"
+    );
+}
+
+/// Deeply nested function-argument sub-expressions are bounded by the same
+/// cumulative depth cap: 128 deep parses, 129 deep is a `ParseError`.
+#[test]
+fn test_parse_function_arg_nesting() {
+    let ok = format!(
+        "MATCH (n) WHERE n.a = {}1{} RETURN n",
+        "f(".repeat(127),
+        ")".repeat(127)
+    );
+    assert!(
+        CypherParser::parse(&ok).is_ok(),
+        "function-arg nested 127 deep should parse"
+    );
+
+    let over = format!(
+        "MATCH (n) WHERE n.a = {}1{} RETURN n",
+        "f(".repeat(129),
+        ")".repeat(129)
+    );
+    let result = CypherParser::parse(&over);
+    assert!(
+        matches!(result, Err(CypherError::ParseError { .. })),
+        "function-arg nested 129 deep should be a ParseError, got {result:?}"
     );
 }
 
@@ -1072,21 +1196,38 @@ fn test_convert_mixed_and_or_precedence() {
             _ => None,
         })
         .expect("expected a filter predicate");
-    match filter {
-        Predicate::Or(operands) => {
-            assert_eq!(
-                operands.len(),
-                2,
-                "OR should have two operands: {operands:?}"
-            );
-            assert!(
-                matches!(operands[0], Predicate::And(_)),
-                "first OR operand should be the AND sub-expression, got {:?}",
-                operands[0]
-            );
-        }
-        other => panic!("expected top-level OR predicate, got {other:?}"),
-    }
+    let Predicate::Or(operands) = filter else {
+        panic!("expected top-level OR predicate, got {filter:?}");
+    };
+    assert_eq!(
+        operands.len(),
+        2,
+        "OR should have two operands: {operands:?}"
+    );
+
+    // operands[0] is the tighter-binding `n.a = 1 AND n.b = 2`.
+    let Predicate::And(inner) = &operands[0] else {
+        panic!("first OR operand should be the AND, got {:?}", operands[0]);
+    };
+    let inner_keys: Vec<&str> = inner
+        .iter()
+        .map(|p| match p {
+            Predicate::Eq { key, .. } => key.as_str(),
+            other => panic!("expected Eq inside AND, got {other:?}"),
+        })
+        .collect();
+    assert_eq!(
+        inner_keys,
+        vec!["a", "b"],
+        "inner AND must be [n.a=1, n.b=2] in order"
+    );
+
+    // operands[1] is the `n.c = 3` comparison.
+    assert!(
+        matches!(&operands[1], Predicate::Eq { key, .. } if key == "c"),
+        "second OR operand should be n.c = 3, got {:?}",
+        operands[1]
+    );
 }
 
 /// End-to-end MCP-reachable path: a large flat AND `WHERE` clause executes

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -964,6 +964,145 @@ fn test_execute_cypher_parse_error() {
 }
 
 // ============================================================================
+// Expression-recursion safety tests (Issue #3404)
+//
+// Pathologically deep expression nesting must return a `ParseError` (bounded
+// by the parser depth cap) rather than overflowing the stack and aborting the
+// process, while arbitrarily long *flat* AND/OR chains must still convert (the
+// converter flattens them iteratively, so there is no term-count cap).
+// ============================================================================
+
+/// Nested parentheses at the boundary of the cap parse successfully.
+#[test]
+fn test_parse_nested_parens_under_cap() {
+    // 128 parens == MAX_EXPRESSION_DEPTH: still accepted.
+    let query = format!(
+        "MATCH (n) WHERE {}n.a = 1{} RETURN n",
+        "(".repeat(128),
+        ")".repeat(128)
+    );
+    let result = CypherParser::parse(&query);
+    assert!(result.is_ok(), "128 nested parens should parse: {result:?}");
+}
+
+/// Nested parentheses over the cap return a `ParseError` (not a crash).
+#[test]
+fn test_parse_nested_parens_over_cap() {
+    for parens in [129usize, 5000usize] {
+        let query = format!(
+            "MATCH (n) WHERE {}n.a = 1{} RETURN n",
+            "(".repeat(parens),
+            ")".repeat(parens)
+        );
+        let result = CypherParser::parse(&query);
+        assert!(
+            matches!(result, Err(CypherError::ParseError { .. })),
+            "{parens} nested parens should be a ParseError, got {result:?}"
+        );
+    }
+}
+
+/// A deep `NOT` chain at the boundary of the cap parses successfully.
+#[test]
+fn test_parse_deep_not_chain_under_cap() {
+    let query = format!("MATCH (n) WHERE {}n.a = 1 RETURN n", "NOT ".repeat(128));
+    let result = CypherParser::parse(&query);
+    assert!(result.is_ok(), "128 NOT chain should parse: {result:?}");
+}
+
+/// A deep `NOT` chain over the cap returns a `ParseError` (not a crash).
+#[test]
+fn test_parse_deep_not_chain_over_cap() {
+    for nots in [129usize, 5000usize] {
+        let query = format!("MATCH (n) WHERE {}n.a = 1 RETURN n", "NOT ".repeat(nots));
+        let result = CypherParser::parse(&query);
+        assert!(
+            matches!(result, Err(CypherError::ParseError { .. })),
+            "{nots} NOT chain should be a ParseError, got {result:?}"
+        );
+    }
+}
+
+/// A very long *flat* AND chain converts to a single n-ary `Predicate::And`
+/// without overflowing the stack in the converter.
+#[test]
+fn test_convert_large_and_chain() {
+    let terms = 5000usize;
+    let clause = vec!["n.a = 1"; terms].join(" AND ");
+    let query = parse_cypher(&format!("MATCH (n) WHERE {clause} RETURN n")).unwrap();
+    let and_len = query.ops.iter().find_map(|op| match op {
+        QueryOp::Filter(Predicate::And(preds)) => Some(preds.len()),
+        _ => None,
+    });
+    assert_eq!(
+        and_len,
+        Some(terms),
+        "expected a flattened n-ary AND with {terms} operands"
+    );
+}
+
+/// A very long *flat* OR chain converts to a single n-ary `Predicate::Or`
+/// without overflowing the stack in the converter.
+#[test]
+fn test_convert_large_or_chain() {
+    let terms = 5000usize;
+    let clause = vec!["n.a = 1"; terms].join(" OR ");
+    let query = parse_cypher(&format!("MATCH (n) WHERE {clause} RETURN n")).unwrap();
+    let or_len = query.ops.iter().find_map(|op| match op {
+        QueryOp::Filter(Predicate::Or(preds)) => Some(preds.len()),
+        _ => None,
+    });
+    assert_eq!(
+        or_len,
+        Some(terms),
+        "expected a flattened n-ary OR with {terms} operands"
+    );
+}
+
+/// Mixed `AND`/`OR` precedence still lowers correctly: `a AND b OR c` becomes
+/// an `OR` whose first operand is the `AND` (AND binds tighter than OR).
+#[test]
+fn test_convert_mixed_and_or_precedence() {
+    let query = parse_cypher("MATCH (n) WHERE n.a = 1 AND n.b = 2 OR n.c = 3 RETURN n").unwrap();
+    let filter = query
+        .ops
+        .iter()
+        .find_map(|op| match op {
+            QueryOp::Filter(pred) => Some(pred),
+            _ => None,
+        })
+        .expect("expected a filter predicate");
+    match filter {
+        Predicate::Or(operands) => {
+            assert_eq!(
+                operands.len(),
+                2,
+                "OR should have two operands: {operands:?}"
+            );
+            assert!(
+                matches!(operands[0], Predicate::And(_)),
+                "first OR operand should be the AND sub-expression, got {:?}",
+                operands[0]
+            );
+        }
+        other => panic!("expected top-level OR predicate, got {other:?}"),
+    }
+}
+
+/// End-to-end MCP-reachable path: a large flat AND `WHERE` clause executes
+/// cleanly instead of aborting the process.
+#[test]
+fn test_execute_cypher_large_and_chain() {
+    let db = AletheiaDB::new().unwrap();
+    let clause = vec!["n.a = 1"; 3000].join(" AND ");
+    let results = db
+        .execute_cypher(&format!("MATCH (n) WHERE {clause} RETURN n"))
+        .expect("large AND chain should execute without crashing");
+    // No nodes in an empty DB; the point is that it returns cleanly.
+    assert_eq!(results.count(), 0);
+}
+
+// ============================================================================
 // Temporal extension tests (Task 7)
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Fixes two unbounded recursions in the Cypher pipeline that could crash the **entire process** (SIGABRT via stack overflow) on tiny pathological inputs. Both are reachable through the read-only MCP `query` tool, so an LLM/caller could take the server down with a single malformed statement.

Closes #3404.

## Before

- **Nested parens** — a `WHERE` clause with ~1,000 nested `(( ... ))` overflowed the stack **while parsing** and aborted the process.
- **`NOT` chains** — ~2,000 stacked `NOT NOT NOT ...` overflowed the parser the same way.
- **Long `AND`/`OR` chains** — a flat ~2,000-term `a AND b AND c ...` clause (no parens at all) parsed fine but then overflowed the **converter**, which recursed once per operator down the left-nested AND/OR spine while lowering to the query IR.
- **Drop teardown** — even after parse+convert were made non-recursive, a *very* long flat chain (~tens of thousands of terms) still stack-overflowed when the left-nested `Box<CypherExpr>` AST was **dropped**, because the derived recursive `Drop` unwinds the spine one frame per node. Same SIGABRT, relocated to destruction.

In every case the failure was a hard `SIGABRT` that killed the server, not a recoverable error.

## After

- The deeply-nested cases return a clean `CypherError::ParseError` ("expression nesting too deep (max 128)") instead of crashing.
- A single contiguous `AND`/`OR` chain over 4,096 operands returns `CypherError::ParseError` ("expression has too many AND/OR terms (max 4096)") **before** the oversized AST is built, so the recursive drop can never overflow.
- Flat chains up to the cap build, convert, and drop safely (n-ary predicate, no per-operator recursion).
- Normal queries are entirely unaffected.

## How

**Parser depth cap (`src/cypher/parser.rs`).** Added `const MAX_EXPRESSION_DEPTH: usize = 128` and threaded a `depth` nesting counter through the expression parse chain. `depth` is a plain function parameter (no decrement, no shared mutable state), incremented only at the genuine recursion re-entry points — a parenthesised sub-expression, a `NOT`, and `IN [...]` / function-argument element lists — and passed unchanged through the operator-precedence layers. Because it is threaded (not accumulated on a struct field), it represents true nesting level and never falsely accumulates across sibling expressions or long flat chains. The bound is *cumulative* across all nesting constructs (parens/NOT/IN-lists/function-args), not a per-construct budget. The cap is checked at the top of `parse_expression` and `parse_not_expr`; exceeding it returns a `ParseError` at the current token position.

**Flat-chain term cap / drop-recursion hardening (`src/cypher/parser.rs`).** Added `const MAX_EXPRESSION_TERMS: usize = 4096`. `parse_or_expr` / `parse_and_expr` count the operands accumulated in their `while` loop (per contiguous same-operator chain, so it never accumulates across separate chains) and return a `ParseError` once the count would exceed the cap. This bounds the depth of the left-nested `Box<CypherExpr>` spine so its recursive `Drop` cannot overflow the stack on teardown, while staying far beyond any realistic query — it doubles as an in-lane query-complexity guard.

**Iterative converter flatten (`src/cypher/converter.rs`).** Rewrote the `And`/`Or` arms of `convert_expr_to_predicate` to flatten the left-nested operator spine with an explicit heap stack (`flatten_logical_operands`) into a single `Predicate::And(Vec)` / `Predicate::Or(Vec)`, preserving left-to-right operand order. A child of the *other* operator is treated as one opaque operand and converted normally (it then flattens itself). This removes the unbounded call recursion in conversion.

**Converter defensive depth guard (`src/cypher/converter.rs`).** `convert()` is `pub`, and the `Not` / `Grouped` conversion arms recurse structurally. Threaded a depth counter through the conversion worker (`convert_expr_to_predicate_at`) that rejects nesting past `const MAX_CONVERT_DEPTH: usize = 256`. This is kept clearly above the parser's 128 cap, so it never fires for a parser-produced AST — only for a hand-built `CypherExpr` that bypasses the parser.

## Tests (all passing, in `src/cypher/tests.rs`)

- `test_parse_nested_parens_under_cap`
- `test_parse_nested_parens_over_cap`
- `test_parse_deep_not_chain_under_cap`
- `test_parse_deep_not_chain_over_cap`
- `test_parse_in_list_nesting`
- `test_parse_function_arg_nesting`
- `test_convert_large_and_chain` (4000 terms; also proves safe drop)
- `test_convert_large_or_chain` (4000 terms)
- `test_parse_and_chain_at_term_cap` (4096 → ok; build + convert + drop at the boundary)
- `test_parse_and_chain_over_term_cap` (4097 → ParseError)
- `test_parse_or_chain_over_term_cap` (4097 → ParseError)
- `test_convert_and_chain_preserves_order`
- `test_convert_mixed_and_or_precedence` (asserts exact operand identity/order)
- `test_execute_cypher_large_and_chain` (end-to-end, 3000-term AND)

## Verification

- `cargo test --features cypher` — cypher module: 152 passed, 0 failed. (The only failing test in the full run is `havoc::...test_flush_deadlock_on_io_error`, a pre-existing uid-0 I/O-injection havoc test unrelated to this change.)
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all` — applied.

## Out of scope (cross-lane follow-up)

An MCP-boundary byte-size limit on the `query` tool input lives in the MCP lane (`src/mcp/server.rs`) and is **not** implemented here. It is not required for this fix: the parser-level depth (128) and term (4096) caps already reject pathological inputs before any large AST is constructed, so a malformed statement is rejected cheaply rather than crashing. A boundary byte cap on the raw request would be defense-in-depth and is a separate cross-lane change.
