### PR TITLE
Add token-budget-aware MCP responses with truncation contracts (#3353)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -502,6 +502,34 @@ temporal/history tools (`get_node_at_time`, `get_edge_at_time`,
 `get_node_history`), which have no `include_vectors` flag and always return
 full vectors.
 
+**Token-budget-aware responses (Issue #3353)**: every MCP read tool
+(`get_node`, `list_nodes`, `get_edge`, `list_edges`, `get_outgoing_edges`,
+`get_incoming_edges`, `traverse`, `find_similar`, `hybrid_query`, `query`,
+`find_nodes_at_time`, `get_node_history`, `get_schema`) accepts an optional
+`max_response_tokens` (estimated as `ceil(utf8_bytes / 4)`) or the byte-exact
+`max_response_bytes`, so a context-bounded caller can say "spend at most N
+tokens answering this" instead of guessing a row `limit`. The serialized
+response — **including its own truncation metadata** — is guaranteed not to
+exceed the stated budget (hard contract, CI conformance sweep 256..32K tokens,
+0 overruns). Over budget the response degrades along a deterministic, disclosed
+ladder — full → `elided_properties` (bulky property values become
+`{elided: true, ...}` descriptors, reusing #3220's convention) → `entity_summaries`
+(properties reduced to protected keys; ids/labels/relationships/temporal
+coordinates/provenance/scores always survive) → `counts_and_handles` (entity
+arrays truncated to the prefix that fits) — carrying a `budget` block that names
+the rung applied per section. Every elision/truncation site carries a **fetch
+handle** (a concrete `get_node`/`get_edge` call with `include_vectors: true`, or
+`offset`/`next_offset` paging per #3226) so nothing is lost: an agent following
+handles reconstructs the full response. `priority_properties` names properties
+to protect; they out-survive unprotected ones at every rung.
+`find_similar`/`hybrid_query` never drop or reorder ranked results to meet a
+budget (only per-result payloads degrade), and temporal responses never omit
+temporal coordinates. A budget too small for even the minimal rung returns a
+#3234 `INVALID_ARGUMENT` stating the minimum viable budget (never a silently
+empty success). Omitting the budget parameters reproduces prior behavior
+exactly; write/admin tools are out of scope. See
+[docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md#token-budget-aware-responses-issue-3353).
+
 **Temporal extent (Issue #3238)**: `temporal_extent` reports the dataset's
 queryable bi-temporal extent — the earliest/latest valid-time and
 transaction-time coordinates across recorded history (including

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -502,32 +502,54 @@ temporal/history tools (`get_node_at_time`, `get_edge_at_time`,
 `get_node_history`), which have no `include_vectors` flag and always return
 full vectors.
 
-**Token-budget-aware responses (Issue #3353)**: every MCP read tool
-(`get_node`, `list_nodes`, `get_edge`, `list_edges`, `get_outgoing_edges`,
-`get_incoming_edges`, `traverse`, `find_similar`, `hybrid_query`, `query`,
-`find_nodes_at_time`, `get_node_history`, `get_schema`) accepts an optional
-`max_response_tokens` (estimated as `ceil(utf8_bytes / 4)`) or the byte-exact
-`max_response_bytes`, so a context-bounded caller can say "spend at most N
-tokens answering this" instead of guessing a row `limit`. The serialized
+**Token-budget-aware responses (Issue #3353)**: the thirteen budgetable read
+tools — `get_node`, `list_nodes`, `get_edge`, `list_edges`,
+`get_outgoing_edges`, `get_incoming_edges`, `traverse`, `find_similar`,
+`hybrid_query`, `query`, `find_nodes_at_time`, `get_node_history`, `get_schema`
+(the single source of truth is `BUDGETABLE_READ_TOOLS`; not *every* read tool —
+e.g. `get_node_at_time`, `get_edge_history`, `diff_node_versions`,
+`temporal_extent`, `database_stats`, `count_nodes` are out of scope) — accept an
+optional `max_response_tokens` (estimated as `ceil(utf8_bytes / 4)`) or the
+byte-exact `max_response_bytes`, so a context-bounded caller can say "spend at
+most N tokens answering this" instead of guessing a row `limit`. These three
+parameters (`max_response_tokens`, `max_response_bytes`, `priority_properties`)
+are injected into each budgetable tool's advertised `inputSchema.properties`, so
+they are machine-discoverable, not just described in prose. The serialized
 response — **including its own truncation metadata** — is guaranteed not to
 exceed the stated budget (hard contract, CI conformance sweep 256..32K tokens,
-0 overruns). Over budget the response degrades along a deterministic, disclosed
-ladder — full → `elided_properties` (bulky property values become
-`{elided: true, ...}` descriptors, reusing #3220's convention) → `entity_summaries`
-(properties reduced to protected keys; ids/labels/relationships/temporal
-coordinates/provenance/scores always survive) → `counts_and_handles` (entity
-arrays truncated to the prefix that fits) — carrying a `budget` block that names
-the rung applied per section. Every elision/truncation site carries a **fetch
-handle** (a concrete `get_node`/`get_edge` call with `include_vectors: true`, or
-`offset`/`next_offset` paging per #3226) so nothing is lost: an agent following
-handles reconstructs the full response. `priority_properties` names properties
-to protect; they out-survive unprotected ones at every rung.
+0 overruns). This bound governs **success** responses; a structured *error*
+response (e.g. the too-small-budget `INVALID_ARGUMENT` below) is itself small
+and returned intact. The rare non-object success payload (JSON scalar/array or
+plain text) cannot degrade along the entity ladder but is still held to the byte
+cap via a disclosed truncation marker (never emitted unbounded). Over budget the
+response degrades along a deterministic, disclosed ladder — full →
+`elided_properties` (bulky property values become `{elided: true, ...}`
+descriptors, reusing #3220's convention, and only when the descriptor is
+actually smaller than the value, so the ladder never enlarges the response) →
+`entity_summaries` (properties reduced to protected keys;
+ids/labels/relationships/temporal coordinates/provenance/scores always survive)
+→ `counts_and_handles` (entity arrays truncated to the prefix that fits, with the
+object's own `count`/`row_count`/`has_more`/`next_offset`/`truncated` siblings
+rewritten to describe the retained prefix so a paginating caller sees no gap and
+no duplicate) — carrying a `budget` block that names the rung applied per
+section. Every elision/truncation site carries a **fetch handle**: a concrete
+`get_node`/`get_edge` call with `include_vectors: true` for an elided entity, a
+`get_node_at_time`/`get_edge_at_time` call for an elided history version (parent
+id + that version's own coordinates, not the current state), and for a truncated
+array a concrete `offset`-advancing resume call on paginated tools
+(`list_nodes`/`traverse`/`find_nodes_at_time`) or an honest "re-request with a
+larger budget" disclosure on non-paginated ones — so nothing is lost: an agent
+following handles reconstructs the full response. `priority_properties` names
+properties to protect; they out-survive unprotected ones at every rung.
 `find_similar`/`hybrid_query` never drop or reorder ranked results to meet a
 budget (only per-result payloads degrade), and temporal responses never omit
 temporal coordinates. A budget too small for even the minimal rung returns a
-#3234 `INVALID_ARGUMENT` stating the minimum viable budget (never a silently
-empty success). Omitting the budget parameters reproduces prior behavior
-exactly; write/admin tools are out of scope. See
+#3234 `INVALID_ARGUMENT` stating a minimum viable budget that is self-consistent
+(re-issuing at the reported `min_viable_tokens` succeeds) — never a silently
+empty success. Omitting the budget parameters reproduces prior behavior exactly,
+and a **misspelled/unknown budget key** (e.g. `max_tokens`) is ignored — the
+full response is returned — so use the exact key names. Write/admin tools are out
+of scope. See
 [docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md#token-budget-aware-responses-issue-3353).
 
 **Temporal extent (Issue #3238)**: `temporal_extent` reports the dataset's

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -986,17 +986,36 @@ explicit, machine-readable account of what was reduced and how to fetch it.
 
 ### The parameters
 
-Every budgetable read tool — `get_node`, `list_nodes`, `get_edge`, `list_edges`,
-`get_outgoing_edges`, `get_incoming_edges`, `traverse`, `find_similar`,
-`hybrid_query`, `query`, `find_nodes_at_time`, `get_node_history`, and
-`get_schema` — accepts these optional parameters. Omitting all of them leaves
-the tool's behavior **completely unchanged**.
+The **thirteen** budgetable read tools — `get_node`, `list_nodes`, `get_edge`,
+`list_edges`, `get_outgoing_edges`, `get_incoming_edges`, `traverse`,
+`find_similar`, `hybrid_query`, `query`, `find_nodes_at_time`,
+`get_node_history`, and `get_schema` — accept these optional parameters. This is
+the exact set (the code's single source of truth is `BUDGETABLE_READ_TOOLS`);
+it is **not** *every* read tool — single-entity/aggregate reads such as
+`get_node_at_time`, `get_edge_history`, `diff_node_versions`, `temporal_extent`,
+`database_stats`, and `count_nodes` are out of scope. The three parameters are
+injected into each budgetable tool's advertised `inputSchema.properties`, so a
+client that introspects the schema discovers them (with correct types) rather
+than relying on the prose description alone. Omitting all of them leaves the
+tool's behavior **completely unchanged**.
 
 | Parameter | Meaning |
 |-----------|---------|
-| `max_response_tokens` | Maximum response size in **estimated tokens**. The serialized response, *including the truncation metadata itself*, is guaranteed not to exceed this. |
+| `max_response_tokens` | Maximum response size in **estimated tokens**. The serialized **success** response, *including the truncation metadata itself*, is guaranteed not to exceed this. |
 | `max_response_bytes` | Byte-exact alternative. When both are set, the **tighter** bound wins. |
 | `priority_properties` | Array of property keys to protect from elision; they out-survive unprotected properties at every degradation rung. |
+
+The budget bounds **success** responses. A structured *error* response (for
+example the too-small-budget `INVALID_ARGUMENT` below) is itself small and is
+returned intact. In the rare case a budgetable tool returns a non-object success
+payload (a JSON scalar/array, or plain text) it cannot degrade along the entity
+ladder, but the byte cap is still enforced: the payload is truncated with a
+disclosed marker rather than emitted unbounded.
+
+A **misspelled or unknown budget key** (e.g. `max_tokens` instead of
+`max_response_tokens`) is **ignored** — consistent with the surface's
+unknown-field tolerance — and the full, unbudgeted response is returned. Use the
+exact key names above so a budget you intend to apply is actually applied.
 
 **Token-estimation basis:** tokens are estimated as `ceil(utf8_byte_len / 4)`.
 Four bytes per token is the standard approximation of GPT/Claude-family BPE
@@ -1013,13 +1032,22 @@ request at the same budget on the same data always degrades **identically**:
 2. **`elided_properties`** — inside each entity's `properties`, any value whose
    serialized size exceeds a threshold (and is not a protected
    `priority_properties` key) is replaced with an `{ "elided": true, ... }`
-   descriptor, mirroring the vector-elision convention of #3220.
+   descriptor, mirroring the vector-elision convention of #3220. A value is
+   elided **only when the descriptor is actually smaller** than the value it
+   replaces, so this rung can never enlarge the response.
 3. **`entity_summaries`** — each entity's `properties` is reduced to the
    protected keys only. Result *structure* — ids, labels, relationships,
    temporal coordinates, provenance and similarity scores — survives because it
    lives *beside* `properties`, never inside it.
 4. **`counts_and_handles`** — entity arrays are truncated to the prefix that
-   fits; the omitted tail is disclosed as a count plus a fetch handle.
+   fits; the omitted tail is disclosed as a count plus a fetch handle, **and the
+   object's own pagination/count siblings are rewritten** to describe the
+   retained prefix — `count`/`row_count` become the retained length,
+   `has_more`/`truncated` become `true`, and `next_offset` (on offset-paginated
+   tools) advances to exactly the cut point. This keeps a paginating caller
+   gap-free and duplicate-free: following the disclosed resume call yields the
+   dropped rows and nothing else. (`total_matching`, when present, still counts
+   the full matching set and is left unchanged.)
 
 `find_similar` and `hybrid_query` **never reach rung 4**: their ranked results
 are never dropped or reordered to meet a budget — only the per-result payloads
@@ -1059,17 +1087,35 @@ Every response carries a `budget` block naming the rung applied per section:
 ### Fetch handles — nothing is lost
 
 Every elision/truncation site carries a **fetch handle**: a concrete follow-up
-call (`tool` + `arguments`) that retrieves exactly the omitted content. A
-per-entity elision points at `get_node`/`get_edge` with `include_vectors: true`;
-a truncated array composes with the completeness signals (`has_more` /
-`next_offset`, #3226). An agent that follows the handles can reconstruct the
-full, unbudgeted response.
+call (`tool` + `arguments`) that retrieves exactly the omitted content.
+
+- A **per-entity elision** on a live node/edge points at `get_node`/`get_edge`
+  with `include_vectors: true`.
+- A **history version** elision (`get_node_history`/`get_edge_history`) points at
+  `get_node_at_time`/`get_edge_at_time` addressing the *exact superseded
+  version* — the parent entity id (taken from the history wrapper) plus that
+  version's own `valid_from`/`transaction_from` coordinates. A plain `get_node`
+  would return the current state, not the historical version, so the handle uses
+  the point-in-time tool instead.
+- A **truncated array** on an offset-paginated tool
+  (`list_nodes`/`traverse`/`find_nodes_at_time`) carries a concrete resume call:
+  the original arguments with the budget knobs stripped and `offset` advanced to
+  the cut point (composing with the #3226 `next_offset` completeness signal). On
+  a tool that does **not** page by offset (e.g. `get_outgoing_edges`,
+  `get_schema`, `query`) the handle honestly discloses the truncation and tells
+  the caller to re-request with a larger budget — it never fabricates an `offset`
+  argument the tool does not accept.
+
+An agent that follows the handles can reconstruct the full, unbudgeted response.
 
 ### Budgets too small to satisfy
 
 If the budget is too small to return even the minimal rung, the tool returns a
 structured #3234 `INVALID_ARGUMENT` error stating the **minimum viable budget** —
-never a silently empty success:
+never a silently empty success. The reported minimum is **self-consistent**:
+re-issuing the same request at `min_viable_tokens` (or `min_viable_bytes`)
+succeeds — the figure already accounts for the disclosed `budget` block's own
+numbers growing at the larger budget.
 
 ```jsonc
 { "error": {

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -975,6 +975,121 @@ keeps its existing microseconds-as-string format — that contract is
 unchanged). The block is purely additive: no existing field moved or changed
 shape.
 
+## Token-budget-aware responses (Issue #3353)
+
+An LLM's context window is its scarcest resource, yet the read tools size their
+responses by *row count* (`limit`), not by *cost*: a `limit: 50` traversal can
+return 500 tokens or 50,000 depending on the property payloads, and the caller
+cannot know in advance. The token budget lets a caller say "spend at most N
+tokens answering this" and receive a response *guaranteed* to fit, with an
+explicit, machine-readable account of what was reduced and how to fetch it.
+
+### The parameters
+
+Every budgetable read tool — `get_node`, `list_nodes`, `get_edge`, `list_edges`,
+`get_outgoing_edges`, `get_incoming_edges`, `traverse`, `find_similar`,
+`hybrid_query`, `query`, `find_nodes_at_time`, `get_node_history`, and
+`get_schema` — accepts these optional parameters. Omitting all of them leaves
+the tool's behavior **completely unchanged**.
+
+| Parameter | Meaning |
+|-----------|---------|
+| `max_response_tokens` | Maximum response size in **estimated tokens**. The serialized response, *including the truncation metadata itself*, is guaranteed not to exceed this. |
+| `max_response_bytes` | Byte-exact alternative. When both are set, the **tighter** bound wins. |
+| `priority_properties` | Array of property keys to protect from elision; they out-survive unprotected properties at every degradation rung. |
+
+**Token-estimation basis:** tokens are estimated as `ceil(utf8_byte_len / 4)`.
+Four bytes per token is the standard approximation of GPT/Claude-family BPE
+tokenizers for English-plus-JSON text and holds within ~10% at the 1K-token
+scale. Callers needing an exact wire bound use `max_response_bytes`, which is
+enforced byte-for-byte.
+
+### The degradation ladder (deterministic, disclosed)
+
+Over budget, the response degrades along a fixed, ordered ladder. The same
+request at the same budget on the same data always degrades **identically**:
+
+1. **`full`** — nothing reduced.
+2. **`elided_properties`** — inside each entity's `properties`, any value whose
+   serialized size exceeds a threshold (and is not a protected
+   `priority_properties` key) is replaced with an `{ "elided": true, ... }`
+   descriptor, mirroring the vector-elision convention of #3220.
+3. **`entity_summaries`** — each entity's `properties` is reduced to the
+   protected keys only. Result *structure* — ids, labels, relationships,
+   temporal coordinates, provenance and similarity scores — survives because it
+   lives *beside* `properties`, never inside it.
+4. **`counts_and_handles`** — entity arrays are truncated to the prefix that
+   fits; the omitted tail is disclosed as a count plus a fetch handle.
+
+`find_similar` and `hybrid_query` **never reach rung 4**: their ranked results
+are never dropped or reordered to meet a budget — only the per-result payloads
+degrade. Temporal responses never omit the temporal coordinates that make a
+result interpretable.
+
+Every response carries a `budget` block naming the rung applied per section:
+
+```jsonc
+// tools/call -> "get_node"
+{ "node_id": 7, "max_response_tokens": 400 }
+// -> {
+//      "id": 7,
+//      "label": "Person",
+//      "properties": {
+//        "name": "Alice",
+//        "bio": {
+//          "elided": true, "reason": "budget", "type": "string", "size_bytes": 4002,
+//          "fetch": { "tool": "get_node",
+//                     "arguments": { "node_id": 7, "include_vectors": true } }
+//        }
+//      },
+//      "temporal": { /* ... always preserved ... */ },
+//      "budget": {
+//        "applied": true,
+//        "rung": "elided_properties",
+//        "token_estimation_basis": "ceil(utf8_bytes / 4)",
+//        "requested_max_tokens": 400,
+//        "effective_max_bytes": 1600,
+//        "priority_properties": [],
+//        "sections": [ { "section": "properties", "rung": "elided_properties",
+//                        "elided_values": 1 } ]
+//      }
+//    }
+```
+
+### Fetch handles — nothing is lost
+
+Every elision/truncation site carries a **fetch handle**: a concrete follow-up
+call (`tool` + `arguments`) that retrieves exactly the omitted content. A
+per-entity elision points at `get_node`/`get_edge` with `include_vectors: true`;
+a truncated array composes with the completeness signals (`has_more` /
+`next_offset`, #3226). An agent that follows the handles can reconstruct the
+full, unbudgeted response.
+
+### Budgets too small to satisfy
+
+If the budget is too small to return even the minimal rung, the tool returns a
+structured #3234 `INVALID_ARGUMENT` error stating the **minimum viable budget** —
+never a silently empty success:
+
+```jsonc
+{ "error": {
+    "code": "INVALID_ARGUMENT",
+    "message": "requested budget is too small to return even the minimal response for this request; minimum viable budget is approximately 1222 tokens (4886 bytes)",
+    "retriable": false,
+    "details": { "min_viable_tokens": 1222, "min_viable_bytes": 4886,
+                 "requested_tokens": 1200, "requested_bytes": null }
+} }
+```
+
+### Composition and scope
+
+- **Composes with #3220 vector elision** (already-elided vectors are left as-is),
+  **#3226 completeness signals** (truncation handles reference `next_offset`),
+  and the **#3234 error contract** (the too-small-budget error is `INVALID_ARGUMENT`).
+- **Read tools only.** Write and admin tools are out of scope (their responses
+  are already small and fixed-shape). Cursor/streaming continuation of large
+  results is a complementary, separate spec (#3360).
+
 ## Notes
 
 - **AQL has no parameter binding.** Sending `params` with `language: "aql"`

--- a/src/mcp/budget.rs
+++ b/src/mcp/budget.rs
@@ -667,8 +667,15 @@ fn truncate_arrays_to_fit(
 
         // Fast-exit when the fully-assembled candidate already fits with this
         // field untouched.
-        if assembled_len(map, budget, cap, base_sections, &disclosures, &field, original_len)
-            <= cap as usize
+        if assembled_len(
+            map,
+            budget,
+            cap,
+            base_sections,
+            &disclosures,
+            &field,
+            original_len,
+        ) <= cap as usize
         {
             continue;
         }

--- a/src/mcp/budget.rs
+++ b/src/mcp/budget.rs
@@ -1,0 +1,515 @@
+//! Token-budget-aware response shaping with disclosed truncation contracts
+//! (Issue #3353).
+//!
+//! An LLM's context window is its scarcest resource, yet MCP read tools size
+//! their responses by *row count* (`limit`), not by *cost*. This module lets a
+//! caller pass a maximum response budget (`max_response_tokens` or the
+//! byte-exact `max_response_bytes`) on any read tool and receive a response
+//! *guaranteed* to fit it, with an explicit, machine-readable account of what
+//! was reduced and a concrete follow-up call (a "fetch handle") that retrieves
+//! exactly the omitted content.
+//!
+//! # Token estimation basis
+//!
+//! Tokens are estimated as `ceil(utf8_byte_len / 4)`. Four bytes per token is
+//! the widely-used approximation of GPT/Claude-family BPE tokenizers for
+//! English-plus-JSON text and holds within ~10% at the 1K-token scale. A caller
+//! that needs an exact wire bound uses `max_response_bytes` instead, which is
+//! enforced byte-for-byte. When both are supplied the *tighter* bound wins.
+//!
+//! # Degradation ladder (deterministic, disclosed per section)
+//!
+//! The response degrades along a fixed, ordered ladder; the same request at the
+//! same budget on the same data always degrades identically:
+//!
+//! 1. **Full** — nothing reduced.
+//! 2. **Elide bulky property values** — inside each entity's `properties`, any
+//!    value whose serialized size exceeds a threshold (and is not a protected
+//!    `priority_properties` key) is replaced with an `{elided: true, ...}`
+//!    descriptor, mirroring the vector-elision convention of Issue #3220.
+//! 3. **Per-entity summaries** — each entity's `properties` is reduced to the
+//!    protected keys only (ids, labels, temporal coordinates, provenance and
+//!    scores — the result *structure* — always survive because they are
+//!    siblings of `properties`, never inside it).
+//! 4. **Counts plus handles** — entity arrays are truncated to the prefix that
+//!    fits; the omitted tail is disclosed as a count plus a fetch handle.
+//!
+//! Result *structure* (ids, labels, relationships, temporal coordinates,
+//! provenance summaries, similarity scores) survives longest; bulky property
+//! values are sacrificed first. `find_similar`/`hybrid_query` never reach rung 4
+//! — their ranked results are never dropped or reordered to meet a budget; only
+//! per-result payloads degrade (Issue #3353 AC7).
+
+use serde_json::{Map, Value, json};
+
+use super::error::{McpError, McpErrorCode};
+
+/// Bytes-per-token divisor. See the module docs for the estimation basis.
+pub(crate) const BYTES_PER_TOKEN: u64 = 4;
+
+/// Property values whose pretty-serialized form exceeds this many bytes are
+/// "bulky" and are the first content sacrificed (rung 2).
+const BULKY_PROP_THRESHOLD_BYTES: usize = 48;
+
+/// Parsed, validated budget parameters for one read request.
+#[derive(Debug, Clone)]
+pub(crate) struct BudgetRequest {
+    /// Effective hard cap in bytes (the tighter of token*4 and byte bounds).
+    effective_bytes: u64,
+    /// Original requested token budget, echoed back for the caller.
+    max_tokens: Option<u64>,
+    /// Original requested byte budget, echoed back for the caller.
+    max_bytes: Option<u64>,
+    /// Property keys protected from elision at every rung.
+    priority_properties: Vec<String>,
+}
+
+impl BudgetRequest {
+    fn effective_bytes(&self) -> u64 {
+        self.effective_bytes
+    }
+}
+
+/// Which rung of the degradation ladder was applied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Rung {
+    Full,
+    ElideProperties,
+    Summaries,
+    CountsAndHandles,
+}
+
+impl Rung {
+    fn as_str(self) -> &'static str {
+        match self {
+            Rung::Full => "full",
+            Rung::ElideProperties => "elided_properties",
+            Rung::Summaries => "entity_summaries",
+            Rung::CountsAndHandles => "counts_and_handles",
+        }
+    }
+}
+
+/// Parse the optional budget parameters from a tool's raw arguments.
+///
+/// Returns `Ok(None)` when neither `max_response_tokens` nor
+/// `max_response_bytes` is present (behavior is then unchanged — the caller
+/// skips shaping entirely). Returns a structured `INVALID_ARGUMENT` error when a
+/// budget field is present but malformed (wrong type, zero, or negative).
+pub(crate) fn parse_budget(args: &Value) -> Result<Option<BudgetRequest>, McpError> {
+    let obj = match args.as_object() {
+        Some(o) => o,
+        None => return Ok(None),
+    };
+
+    let max_tokens = parse_positive_u64(obj.get("max_response_tokens"), "max_response_tokens")?;
+    let max_bytes = parse_positive_u64(obj.get("max_response_bytes"), "max_response_bytes")?;
+
+    if max_tokens.is_none() && max_bytes.is_none() {
+        return Ok(None);
+    }
+
+    let priority_properties = match obj.get("priority_properties") {
+        None | Some(Value::Null) => Vec::new(),
+        Some(Value::Array(items)) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items {
+                match item.as_str() {
+                    Some(s) => out.push(s.to_string()),
+                    None => {
+                        return Err(McpError::new(
+                            McpErrorCode::InvalidArgument,
+                            "priority_properties must be an array of strings",
+                        ));
+                    }
+                }
+            }
+            out
+        }
+        Some(_) => {
+            return Err(McpError::new(
+                McpErrorCode::InvalidArgument,
+                "priority_properties must be an array of strings",
+            ));
+        }
+    };
+
+    let from_tokens = max_tokens.map(|t| t.saturating_mul(BYTES_PER_TOKEN));
+    let effective_bytes = match (from_tokens, max_bytes) {
+        (Some(a), Some(b)) => a.min(b),
+        (Some(a), None) => a,
+        (None, Some(b)) => b,
+        (None, None) => unreachable!("guarded above"),
+    };
+
+    Ok(Some(BudgetRequest {
+        effective_bytes,
+        max_tokens,
+        max_bytes,
+        priority_properties,
+    }))
+}
+
+fn parse_positive_u64(value: Option<&Value>, field: &str) -> Result<Option<u64>, McpError> {
+    match value {
+        None | Some(Value::Null) => Ok(None),
+        Some(v) => match v.as_u64() {
+            Some(0) => Err(McpError::new(
+                McpErrorCode::InvalidArgument,
+                format!("{field} must be a positive integer"),
+            )),
+            Some(n) => Ok(Some(n)),
+            None => Err(McpError::new(
+                McpErrorCode::InvalidArgument,
+                format!("{field} must be a positive integer"),
+            )),
+        },
+    }
+}
+
+/// Serialize exactly as [`AletheiaMcpServer::success_json`] does, so the byte
+/// measurement here is the byte length actually emitted on the wire.
+fn measured_bytes(value: &Value) -> usize {
+    serde_json::to_string_pretty(value)
+        .unwrap_or_else(|_| value.to_string())
+        .len()
+}
+
+/// Shape a successful response value to fit `budget`, attaching a disclosed
+/// `budget` metadata block describing the rung applied.
+///
+/// `tool` is the tool name; it selects the entity fetch-handle tool and whether
+/// the tool is *ranked* (ranked tools never reach the counts-and-handles rung).
+///
+/// Returns the shaped value on success, or a structured `INVALID_ARGUMENT`
+/// error naming the minimum viable budget when even the minimal rung cannot fit
+/// (Issue #3353 AC6) — never a silently emptied success.
+pub(crate) fn shape_response(
+    value: Value,
+    budget: &BudgetRequest,
+    tool: &str,
+) -> Result<Value, McpError> {
+    // Only objects carry the read-tool response shape; anything else is passed
+    // through with the metadata attached if it fits, else surfaced as too-small.
+    let ranked = is_ranked_tool(tool);
+    let cap = budget.effective_bytes();
+
+    let ladder: &[Rung] = if ranked {
+        &[Rung::Full, Rung::ElideProperties, Rung::Summaries]
+    } else {
+        &[
+            Rung::Full,
+            Rung::ElideProperties,
+            Rung::Summaries,
+            Rung::CountsAndHandles,
+        ]
+    };
+
+    let mut last_candidate: Option<(Value, usize)> = None;
+    for &rung in ladder {
+        let candidate = build_candidate(value.clone(), rung, budget, tool, cap);
+        let bytes = measured_bytes(&candidate);
+        if bytes as u64 <= cap {
+            return Ok(candidate);
+        }
+        last_candidate = Some((candidate, bytes));
+    }
+
+    // Even the minimal rung overflows: report the minimum viable budget so the
+    // caller can re-issue with a sufficient budget (AC6).
+    let min_bytes = last_candidate.map(|(_, b)| b).unwrap_or(0);
+    let min_tokens = min_bytes.div_ceil(BYTES_PER_TOKEN as usize);
+    Err(McpError::new(
+        McpErrorCode::InvalidArgument,
+        format!(
+            "requested budget is too small to return even the minimal response for this request; \
+             minimum viable budget is approximately {min_tokens} tokens ({min_bytes} bytes)"
+        ),
+    )
+    .details(json!({
+        "min_viable_tokens": min_tokens,
+        "min_viable_bytes": min_bytes,
+        "requested_tokens": budget.max_tokens,
+        "requested_bytes": budget.max_bytes,
+    })))
+}
+
+fn is_ranked_tool(tool: &str) -> bool {
+    matches!(tool, "find_similar" | "hybrid_query")
+}
+
+/// Build a candidate response value at `rung`, with the disclosed `budget`
+/// metadata block attached.
+fn build_candidate(
+    mut value: Value,
+    rung: Rung,
+    budget: &BudgetRequest,
+    tool: &str,
+    cap: u64,
+) -> Value {
+    let mut sections: Vec<Value> = Vec::new();
+    match rung {
+        Rung::Full => {}
+        Rung::ElideProperties => {
+            let n = elide_bulky_properties(&mut value, &budget.priority_properties);
+            if n > 0 {
+                sections.push(json!({
+                    "section": "properties",
+                    "rung": "elided_properties",
+                    "elided_values": n,
+                }));
+            }
+        }
+        Rung::Summaries => {
+            let n = summarize_entities(&mut value, &budget.priority_properties);
+            if n > 0 {
+                sections.push(json!({
+                    "section": "properties",
+                    "rung": "entity_summaries",
+                    "entities_summarized": n,
+                }));
+            }
+        }
+        Rung::CountsAndHandles => {
+            // First reduce every entity to its summary, then truncate arrays.
+            summarize_entities(&mut value, &budget.priority_properties);
+            let truncations = truncate_arrays_to_fit(&mut value, tool, cap);
+            for t in truncations {
+                sections.push(t);
+            }
+            sections.push(json!({
+                "section": "properties",
+                "rung": "entity_summaries",
+            }));
+        }
+    }
+
+    if let Value::Object(map) = &mut value {
+        map.insert(
+            "budget".to_string(),
+            json!({
+                "applied": true,
+                "rung": rung.as_str(),
+                "token_estimation_basis": "ceil(utf8_bytes / 4)",
+                "requested_max_tokens": budget.max_tokens,
+                "requested_max_bytes": budget.max_bytes,
+                "effective_max_bytes": cap,
+                "priority_properties": budget.priority_properties,
+                "sections": sections,
+            }),
+        );
+    }
+    value
+}
+
+/// Does this object look like an entity carrying a `properties` object?
+fn is_entity_object(map: &Map<String, Value>) -> bool {
+    map.get("properties").map(Value::is_object).unwrap_or(false)
+}
+
+/// Build the concrete fetch handle that retrieves this entity's full content.
+fn entity_fetch_handle(map: &Map<String, Value>) -> Value {
+    let is_edge = map.contains_key("source_id") || map.contains_key("target_id");
+    let id = map.get("id").cloned().unwrap_or(Value::Null);
+    if is_edge {
+        json!({
+            "tool": "get_edge",
+            "arguments": { "edge_id": id, "include_vectors": true },
+        })
+    } else {
+        json!({
+            "tool": "get_node",
+            "arguments": { "node_id": id, "include_vectors": true },
+        })
+    }
+}
+
+/// Rung 2: elide bulky, unprotected property *values* in place. Returns the
+/// number of values elided.
+fn elide_bulky_properties(value: &mut Value, priority: &[String]) -> usize {
+    let mut count = 0;
+    match value {
+        Value::Object(map) => {
+            if is_entity_object(map) {
+                let handle = entity_fetch_handle(map);
+                if let Some(Value::Object(props)) = map.get_mut("properties") {
+                    for (key, val) in props.iter_mut() {
+                        if priority.iter().any(|p| p == key) {
+                            continue;
+                        }
+                        if already_elided(val) {
+                            continue;
+                        }
+                        let size = measured_bytes(val);
+                        if size > BULKY_PROP_THRESHOLD_BYTES {
+                            *val = json!({
+                                "elided": true,
+                                "reason": "budget",
+                                "type": json_type_name(val),
+                                "size_bytes": size,
+                                "fetch": handle.clone(),
+                            });
+                            count += 1;
+                        }
+                    }
+                }
+            }
+            // Recurse into all children to reach nested entity objects
+            // (traverse results, query rows, history versions, ...).
+            for (_k, child) in map.iter_mut() {
+                count += elide_bulky_properties(child, priority);
+            }
+        }
+        Value::Array(items) => {
+            for item in items.iter_mut() {
+                count += elide_bulky_properties(item, priority);
+            }
+        }
+        _ => {}
+    }
+    count
+}
+
+/// Rung 3: reduce each entity's `properties` to protected keys only. Returns the
+/// number of entities summarized (i.e. that dropped at least one property).
+fn summarize_entities(value: &mut Value, priority: &[String]) -> usize {
+    let mut count = 0;
+    match value {
+        Value::Object(map) => {
+            if is_entity_object(map) {
+                let handle = entity_fetch_handle(map);
+                if let Some(Value::Object(props)) = map.get_mut("properties") {
+                    let original_len = props.len();
+                    let mut kept = Map::new();
+                    for (key, val) in props.iter() {
+                        if priority.iter().any(|p| p == key) {
+                            kept.insert(key.clone(), val.clone());
+                        }
+                    }
+                    let dropped = original_len - kept.len();
+                    if dropped > 0 {
+                        kept.insert(
+                            "_budget_omitted".to_string(),
+                            json!({
+                                "omitted_properties": dropped,
+                                "reason": "budget",
+                                "fetch": handle,
+                            }),
+                        );
+                        count += 1;
+                    }
+                    *props = kept;
+                }
+            }
+            for (_k, child) in map.iter_mut() {
+                count += summarize_entities(child, priority);
+            }
+        }
+        Value::Array(items) => {
+            for item in items.iter_mut() {
+                count += summarize_entities(item, priority);
+            }
+        }
+        _ => {}
+    }
+    count
+}
+
+/// Rung 4: truncate top-level entity arrays so the whole response fits `cap`.
+/// Returns one disclosure section per truncated array. Deterministic: elements
+/// are kept as a prefix (stable order) and only the tail is dropped.
+fn truncate_arrays_to_fit(value: &mut Value, tool: &str, cap: u64) -> Vec<Value> {
+    let mut disclosures = Vec::new();
+    let map = match value {
+        Value::Object(m) => m,
+        _ => return disclosures,
+    };
+
+    // Identify top-level fields that are arrays of entity objects, largest first
+    // for deterministic, greatest-impact-first truncation.
+    let mut array_fields: Vec<(String, usize)> = map
+        .iter()
+        .filter_map(|(k, v)| match v {
+            Value::Array(items) if items.iter().any(is_entity_array_element) => {
+                Some((k.clone(), measured_bytes(v)))
+            }
+            _ => None,
+        })
+        .collect();
+    array_fields.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+
+    for (field, _) in array_fields {
+        if measured_bytes(&Value::Object(map.clone())) as u64 <= cap {
+            break;
+        }
+        let original_len = match map.get(&field) {
+            Some(Value::Array(items)) => items.len(),
+            _ => continue,
+        };
+        // Binary search the largest prefix length that keeps the whole object
+        // within budget.
+        let mut lo = 0usize;
+        let mut hi = original_len;
+        while lo < hi {
+            let mid = lo + (hi - lo).div_ceil(2);
+            set_array_prefix(map, &field, mid);
+            if measured_bytes(&Value::Object(map.clone())) as u64 <= cap {
+                lo = mid;
+            } else {
+                hi = mid - 1;
+            }
+        }
+        set_array_prefix(map, &field, lo);
+        let omitted = original_len - lo;
+        if omitted > 0 {
+            disclosures.push(json!({
+                "section": field,
+                "rung": "counts_and_handles",
+                "returned": lo,
+                "omitted_count": omitted,
+                "fetch": {
+                    "tool": tool,
+                    "reason": "budget_truncated",
+                    "hint": "re-request without max_response_tokens/max_response_bytes, \
+                             or page the remainder using offset/next_offset, to retrieve \
+                             the omitted results",
+                },
+            }));
+        }
+    }
+    disclosures
+}
+
+/// Truncate `map[field]` (an array) to its first `len` elements in place.
+fn set_array_prefix(map: &mut Map<String, Value>, field: &str, len: usize) {
+    if let Some(Value::Array(items)) = map.get_mut(field) {
+        items.truncate(len);
+    }
+}
+
+/// Is this array element an entity object (directly or via a nested wrapper)?
+fn is_entity_array_element(item: &Value) -> bool {
+    match item {
+        Value::Object(map) => is_entity_object(map) || map.values().any(is_entity_array_element),
+        _ => false,
+    }
+}
+
+fn already_elided(value: &Value) -> bool {
+    value
+        .as_object()
+        .and_then(|m| m.get("elided"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}

--- a/src/mcp/budget.rs
+++ b/src/mcp/budget.rs
@@ -847,3 +847,193 @@ fn json_type_name(value: &Value) -> &'static str {
         Value::Object(_) => "object",
     }
 }
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    fn budget_req(bytes: u64, priority: &[&str]) -> BudgetRequest {
+        BudgetRequest {
+            effective_bytes: bytes,
+            max_tokens: None,
+            max_bytes: Some(bytes),
+            priority_properties: priority.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    /// F3: eliding several small (below-descriptor-cost) properties must never
+    /// make the elide rung serialize larger than the full rung — the ladder is
+    /// monotonic.
+    #[test]
+    fn f3_elide_rung_never_larger_than_full() {
+        // Several ~60-90 byte string properties, each smaller than the elision
+        // descriptor's fixed cost, so none should be elided.
+        let node = json!({
+            "id": 1,
+            "label": "Doc",
+            "properties": {
+                "a": "a".repeat(60),
+                "b": "b".repeat(75),
+                "c": "c".repeat(90),
+                "d": "d".repeat(80),
+            }
+        });
+        let budget = budget_req(10_000, &[]);
+        let args = json!({});
+        let full = build_candidate(node.clone(), Rung::Full, &budget, "get_node", &args, 10_000);
+        let elided = build_candidate(
+            node.clone(),
+            Rung::ElideProperties,
+            &budget,
+            "get_node",
+            &args,
+            10_000,
+        );
+        // Compare the payload excluding the disclosed `budget` metadata block:
+        // its `rung` label alone is intrinsically longer for the elide rung
+        // ("elided_properties" vs "full") and is not data the caller pays for
+        // in content terms. What must never grow is the *data* itself.
+        assert!(
+            payload_bytes(&elided) <= payload_bytes(&full),
+            "elide-rung payload ({}) must not exceed full-rung payload ({})",
+            payload_bytes(&elided),
+            payload_bytes(&full),
+        );
+        // None of the small props should have been elided.
+        assert!(
+            !json_contains_elided(&elided),
+            "no property small enough to shrink should be elided"
+        );
+
+        // A genuinely bulky property, by contrast, IS elided and shrinks.
+        let big = json!({
+            "id": 2,
+            "label": "Doc",
+            "properties": { "bio": "x".repeat(4000) }
+        });
+        let big_full = build_candidate(big.clone(), Rung::Full, &budget, "get_node", &args, 10_000);
+        let big_elided = build_candidate(
+            big,
+            Rung::ElideProperties,
+            &budget,
+            "get_node",
+            &args,
+            10_000,
+        );
+        assert!(json_contains_elided(&big_elided), "bulky prop must elide");
+        assert!(measured_bytes(&big_elided) < measured_bytes(&big_full));
+    }
+
+    fn json_contains_elided(value: &Value) -> bool {
+        match value {
+            Value::Object(m) => {
+                if m.get("elided").and_then(Value::as_bool).unwrap_or(false) {
+                    return true;
+                }
+                m.values().any(json_contains_elided)
+            }
+            Value::Array(a) => a.iter().any(json_contains_elided),
+            _ => false,
+        }
+    }
+
+    /// Serialized size of a candidate with the disclosed `budget` metadata block
+    /// removed, so payload-only (data) growth can be compared across rungs
+    /// without the intrinsic difference in the rung label string.
+    fn payload_bytes(value: &Value) -> usize {
+        let mut v = value.clone();
+        if let Value::Object(m) = &mut v {
+            m.remove("budget");
+        }
+        measured_bytes(&v)
+    }
+
+    /// F2: a `get_node_history` version's fetch handle addresses the exact
+    /// superseded version via `get_node_at_time` with the PARENT node id (from
+    /// the wrapper) plus the version's own coordinates — never a null id.
+    #[test]
+    fn f2_history_version_handle_targets_parent_at_time() {
+        let history = json!({
+            "node_id": 42,
+            "version_count": 1,
+            "versions": [
+                {
+                    "version_id": 7,
+                    "version_number": 1,
+                    "valid_from": "2024-01-01T00:00:00Z",
+                    "valid_to": null,
+                    "transaction_from": "2024-01-02T00:00:00Z",
+                    "transaction_to": null,
+                    "label": "Person",
+                    "properties": { "bio": "x".repeat(4000) }
+                }
+            ]
+        });
+        let budget = budget_req(600, &[]);
+        let shaped = build_candidate(
+            history,
+            Rung::Summaries,
+            &budget,
+            "get_node_history",
+            &json!({ "node_id": 42 }),
+            600,
+        );
+        let handle = find_any_fetch(&shaped).expect("a version fetch handle must exist");
+        assert_eq!(handle["tool"], json!("get_node_at_time"));
+        assert_eq!(handle["arguments"]["node_id"], json!(42));
+        assert_eq!(
+            handle["arguments"]["valid_time"],
+            json!("2024-01-01T00:00:00Z")
+        );
+        assert_eq!(
+            handle["arguments"]["transaction_time"],
+            json!("2024-01-02T00:00:00Z")
+        );
+    }
+
+    fn find_any_fetch(value: &Value) -> Option<Value> {
+        match value {
+            Value::Object(m) => {
+                if let Some(f) = m.get("fetch")
+                    && f.get("tool").is_some()
+                {
+                    return Some(f.clone());
+                }
+                m.values().find_map(find_any_fetch)
+            }
+            Value::Array(a) => a.iter().find_map(find_any_fetch),
+            _ => None,
+        }
+    }
+
+    /// F6: a non-object payload is still held to the byte cap with a disclosed
+    /// truncation marker rather than emitted unbounded.
+    #[test]
+    fn f6_enforce_raw_cap_truncates_with_marker() {
+        let budget = budget_req(80, &[]);
+        let long = "z".repeat(1000);
+        let out = enforce_raw_cap(long, &budget).expect("should truncate, not error");
+        assert!(out.len() <= 80, "raw payload capped: {} bytes", out.len());
+        assert!(out.contains("truncated"), "truncation is disclosed");
+    }
+
+    #[test]
+    fn f6_enforce_raw_cap_too_small_errors() {
+        let budget = budget_req(4, &[]);
+        let err = enforce_raw_cap("hello world".repeat(10), &budget).unwrap_err();
+        assert_eq!(err.code(), McpErrorCode::InvalidArgument);
+    }
+
+    /// T5: the byte cap holds for multibyte/unicode payloads, and truncation
+    /// never splits a UTF-8 char boundary (the result is valid UTF-8).
+    #[test]
+    fn t5_enforce_raw_cap_respects_utf8_boundaries() {
+        let budget = budget_req(90, &[]);
+        // Each 'é' / emoji is multibyte; a naive byte cut could split them.
+        let s = "héllo wörld 🌍🌎🌏 ".repeat(50);
+        let out = enforce_raw_cap(s, &budget).expect("truncates");
+        assert!(out.len() <= 90, "byte cap holds: {} bytes", out.len());
+        // Valid UTF-8 by construction (String), and re-checkable:
+        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+    }
+}

--- a/src/mcp/budget.rs
+++ b/src/mcp/budget.rs
@@ -280,19 +280,51 @@ pub(crate) fn shape_response(
         ]
     };
 
-    let mut last_bytes = 0usize;
     for &rung in ladder {
         let candidate = build_candidate(value.clone(), rung, budget, tool, args, cap);
         let bytes = measured_bytes(&candidate);
         if bytes as u64 <= cap {
             return Ok(candidate);
         }
-        last_bytes = bytes;
     }
 
-    // Even the minimal rung overflows: report the minimum viable budget so the
-    // caller can re-issue with a sufficient budget (AC6).
-    Err(too_small_error(last_bytes, budget))
+    // Even the minimal rung overflows. Report a minimum viable budget the caller
+    // can actually re-issue at. The reported number must self-consistently fit:
+    // a larger budget makes the disclosed `budget` block's own numbers
+    // (`effective_max_bytes`, `requested_max_tokens`) wider, so a naive "size at
+    // the current tiny cap" underestimates. Iterate to a fixpoint, simulating
+    // the caller re-issuing `max_response_tokens = min_tokens`, until the
+    // minimal-rung candidate actually fits that budget (Issue #3353 AC6/T6).
+    let minimal_rung = *ladder.last().expect("ladder is non-empty");
+    let mut min_bytes = measured_bytes(&build_candidate(
+        value.clone(),
+        minimal_rung,
+        budget,
+        tool,
+        args,
+        cap,
+    ));
+    let mut min_tokens = (min_bytes as u64).div_ceil(BYTES_PER_TOKEN);
+    for _ in 0..8 {
+        let probe_cap = min_tokens.saturating_mul(BYTES_PER_TOKEN);
+        let probe = BudgetRequest {
+            effective_bytes: probe_cap,
+            max_tokens: Some(min_tokens),
+            max_bytes: None,
+            priority_properties: budget.priority_properties.clone(),
+        };
+        let cand = build_candidate(value.clone(), minimal_rung, &probe, tool, args, probe_cap);
+        let b = measured_bytes(&cand);
+        min_bytes = b;
+        if b as u64 <= probe_cap {
+            break;
+        }
+        min_tokens = (b as u64).div_ceil(BYTES_PER_TOKEN);
+    }
+    // Report the fitting token budget (and its byte equivalent) so re-issuing at
+    // `min_viable_tokens` — or `min_viable_bytes` — succeeds.
+    let report_bytes = (min_tokens.saturating_mul(BYTES_PER_TOKEN)).max(min_bytes as u64) as usize;
+    Err(too_small_error(report_bytes, budget))
 }
 
 fn is_ranked_tool(tool: &str) -> bool {

--- a/src/mcp/budget.rs
+++ b/src/mcp/budget.rs
@@ -26,13 +26,18 @@
 //! 2. **Elide bulky property values** — inside each entity's `properties`, any
 //!    value whose serialized size exceeds a threshold (and is not a protected
 //!    `priority_properties` key) is replaced with an `{elided: true, ...}`
-//!    descriptor, mirroring the vector-elision convention of Issue #3220.
+//!    descriptor, mirroring the vector-elision convention of Issue #3220. A
+//!    value is only elided when the descriptor is *smaller* than the value it
+//!    replaces, so this rung can never enlarge the response (monotonic ladder).
 //! 3. **Per-entity summaries** — each entity's `properties` is reduced to the
 //!    protected keys only (ids, labels, temporal coordinates, provenance and
 //!    scores — the result *structure* — always survive because they are
 //!    siblings of `properties`, never inside it).
 //! 4. **Counts plus handles** — entity arrays are truncated to the prefix that
-//!    fits; the omitted tail is disclosed as a count plus a fetch handle.
+//!    fits; the omitted tail is disclosed as a count plus a fetch handle, and
+//!    the object's own pagination/count siblings (`count`/`row_count`/
+//!    `has_more`/`next_offset`/`truncated`) are rewritten to describe the
+//!    retained prefix so a paginating caller sees no gap and no duplicate.
 //!
 //! Result *structure* (ids, labels, relationships, temporal coordinates,
 //! provenance summaries, similarity scores) survives longest; bulky property
@@ -48,8 +53,11 @@ use super::error::{McpError, McpErrorCode};
 pub(crate) const BYTES_PER_TOKEN: u64 = 4;
 
 /// Property values whose pretty-serialized form exceeds this many bytes are
-/// "bulky" and are the first content sacrificed (rung 2).
-const BULKY_PROP_THRESHOLD_BYTES: usize = 48;
+/// "bulky" and are the first content sacrificed (rung 2). Set above the fixed
+/// cost of an elision descriptor so eliding a value can only ever shrink the
+/// response; an additional per-value `descriptor < value` guard makes the
+/// monotonicity guarantee exact regardless of this constant (Issue #3353 F3).
+const BULKY_PROP_THRESHOLD_BYTES: usize = 160;
 
 /// Parsed, validated budget parameters for one read request.
 #[derive(Debug, Clone)]
@@ -65,7 +73,7 @@ pub(crate) struct BudgetRequest {
 }
 
 impl BudgetRequest {
-    fn effective_bytes(&self) -> u64 {
+    pub(crate) fn effective_bytes(&self) -> u64 {
         self.effective_bytes
     }
 }
@@ -96,6 +104,11 @@ impl Rung {
 /// `max_response_bytes` is present (behavior is then unchanged — the caller
 /// skips shaping entirely). Returns a structured `INVALID_ARGUMENT` error when a
 /// budget field is present but malformed (wrong type, zero, or negative).
+///
+/// An unknown/misspelled budget key (e.g. `max_tokens` instead of
+/// `max_response_tokens`) is simply ignored — consistent with the surface's
+/// unknown-field tolerance — so the request is served in full rather than
+/// silently budgeted under a key the caller did not intend.
 pub(crate) fn parse_budget(args: &Value) -> Result<Option<BudgetRequest>, McpError> {
     let obj = match args.as_object() {
         Some(o) => o,
@@ -175,11 +188,74 @@ fn measured_bytes(value: &Value) -> usize {
         .len()
 }
 
+/// Byte cap enforcement for a payload that is not a shapeable read-tool object
+/// (non-JSON text, or a JSON scalar/array). Such payloads cannot degrade along
+/// the entity ladder, but the budget contract is unconditional: never emit text
+/// exceeding the cap under an active budget (Issue #3353 F6).
+///
+/// Returns the (possibly truncated) string to emit, or `Err` when even a
+/// minimal disclosed-truncation marker cannot fit — surfaced as the AC6
+/// too-small error by the caller.
+pub(crate) fn enforce_raw_cap(text: String, budget: &BudgetRequest) -> Result<String, McpError> {
+    let cap = budget.effective_bytes() as usize;
+    if text.len() <= cap {
+        return Ok(text);
+    }
+    // Reserve room for a disclosed truncation marker so the caller is never
+    // handed a silently clipped payload.
+    const MARKER: &str = "\n…[truncated: response exceeded token budget]";
+    if MARKER.len() >= cap {
+        return Err(too_small_error(text.len(), budget));
+    }
+    let keep = cap - MARKER.len();
+    // Truncate on a UTF-8 char boundary at or below `keep`.
+    let mut boundary = keep;
+    while boundary > 0 && !text.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    let mut out = text[..boundary].to_string();
+    out.push_str(MARKER);
+    Ok(out)
+}
+
+fn too_small_error(min_bytes: usize, budget: &BudgetRequest) -> McpError {
+    let min_tokens = min_bytes.div_ceil(BYTES_PER_TOKEN as usize);
+    McpError::new(
+        McpErrorCode::InvalidArgument,
+        format!(
+            "requested budget is too small to return even the minimal response for this request; \
+             minimum viable budget is approximately {min_tokens} tokens ({min_bytes} bytes)"
+        ),
+    )
+    .details(json!({
+        "min_viable_tokens": min_tokens,
+        "min_viable_bytes": min_bytes,
+        "requested_tokens": budget.max_tokens,
+        "requested_bytes": budget.max_bytes,
+    }))
+}
+
+/// Context threaded through the recursion so a fetch handle can be built for an
+/// entity that lives inside a history wrapper (whose parent id is not on the
+/// version object itself). Owns the parent id (cheaply cloned — an integer
+/// `Value`) so it never borrows the map being mutated during shaping.
+#[derive(Clone, Default)]
+struct ShapeCtx {
+    /// Parent entity id for a history-version object (`get_node_history` /
+    /// `get_edge_history`); `None` for ordinary entity responses.
+    history_parent_id: Option<Value>,
+    /// Whether the history wrapper is an edge history (selects the
+    /// `get_edge_at_time` fetch tool) rather than a node history.
+    history_is_edge: bool,
+}
+
 /// Shape a successful response value to fit `budget`, attaching a disclosed
 /// `budget` metadata block describing the rung applied.
 ///
 /// `tool` is the tool name; it selects the entity fetch-handle tool and whether
 /// the tool is *ranked* (ranked tools never reach the counts-and-handles rung).
+/// `args` is the original request arguments, threaded so the rung-4 truncation
+/// handle can emit a concrete `offset`-based resume call for paginated tools.
 ///
 /// Returns the shaped value on success, or a structured `INVALID_ARGUMENT`
 /// error naming the minimum viable budget when even the minimal rung cannot fit
@@ -188,9 +264,8 @@ pub(crate) fn shape_response(
     value: Value,
     budget: &BudgetRequest,
     tool: &str,
+    args: &Value,
 ) -> Result<Value, McpError> {
-    // Only objects carry the read-tool response shape; anything else is passed
-    // through with the metadata attached if it fits, else surfaced as too-small.
     let ranked = is_ranked_tool(tool);
     let cap = budget.effective_bytes();
 
@@ -205,33 +280,19 @@ pub(crate) fn shape_response(
         ]
     };
 
-    let mut last_candidate: Option<(Value, usize)> = None;
+    let mut last_bytes = 0usize;
     for &rung in ladder {
-        let candidate = build_candidate(value.clone(), rung, budget, tool, cap);
+        let candidate = build_candidate(value.clone(), rung, budget, tool, args, cap);
         let bytes = measured_bytes(&candidate);
         if bytes as u64 <= cap {
             return Ok(candidate);
         }
-        last_candidate = Some((candidate, bytes));
+        last_bytes = bytes;
     }
 
     // Even the minimal rung overflows: report the minimum viable budget so the
     // caller can re-issue with a sufficient budget (AC6).
-    let min_bytes = last_candidate.map(|(_, b)| b).unwrap_or(0);
-    let min_tokens = min_bytes.div_ceil(BYTES_PER_TOKEN as usize);
-    Err(McpError::new(
-        McpErrorCode::InvalidArgument,
-        format!(
-            "requested budget is too small to return even the minimal response for this request; \
-             minimum viable budget is approximately {min_tokens} tokens ({min_bytes} bytes)"
-        ),
-    )
-    .details(json!({
-        "min_viable_tokens": min_tokens,
-        "min_viable_bytes": min_bytes,
-        "requested_tokens": budget.max_tokens,
-        "requested_bytes": budget.max_bytes,
-    })))
+    Err(too_small_error(last_bytes, budget))
 }
 
 fn is_ranked_tool(tool: &str) -> bool {
@@ -245,13 +306,15 @@ fn build_candidate(
     rung: Rung,
     budget: &BudgetRequest,
     tool: &str,
+    args: &Value,
     cap: u64,
 ) -> Value {
+    let ctx = derive_ctx(&value, tool);
     let mut sections: Vec<Value> = Vec::new();
     match rung {
         Rung::Full => {}
         Rung::ElideProperties => {
-            let n = elide_bulky_properties(&mut value, &budget.priority_properties);
+            let n = elide_bulky_properties(&mut value, &budget.priority_properties, &ctx);
             if n > 0 {
                 sections.push(json!({
                     "section": "properties",
@@ -261,45 +324,81 @@ fn build_candidate(
             }
         }
         Rung::Summaries => {
-            let n = summarize_entities(&mut value, &budget.priority_properties);
+            let n = summarize_entities(&mut value, &budget.priority_properties, &ctx);
             if n > 0 {
                 sections.push(json!({
                     "section": "properties",
                     "rung": "entity_summaries",
-                    "entities_summarized": n,
                 }));
             }
         }
         Rung::CountsAndHandles => {
             // First reduce every entity to its summary, then truncate arrays.
-            summarize_entities(&mut value, &budget.priority_properties);
-            let truncations = truncate_arrays_to_fit(&mut value, tool, cap);
-            for t in truncations {
-                sections.push(t);
-            }
-            sections.push(json!({
+            summarize_entities(&mut value, &budget.priority_properties, &ctx);
+            let mut sections_so_far = vec![json!({
                 "section": "properties",
                 "rung": "entity_summaries",
-            }));
+            })];
+            // Truncation measures the fully-assembled candidate (object plus the
+            // budget/disclosure block) against `cap`, so the finalized response
+            // is guaranteed to fit even though the budget block is appended
+            // afterward (Issue #3353 F4).
+            let truncations =
+                truncate_arrays_to_fit(&mut value, tool, args, cap, budget, &sections_so_far);
+            sections_so_far.extend(truncations);
+            sections = sections_so_far;
         }
     }
 
-    if let Value::Object(map) = &mut value {
+    attach_budget_block(&mut value, rung, budget, cap, sections);
+    value
+}
+
+/// Attach the disclosed `budget` metadata block to a response object.
+fn attach_budget_block(
+    value: &mut Value,
+    rung: Rung,
+    budget: &BudgetRequest,
+    cap: u64,
+    sections: Vec<Value>,
+) {
+    if let Value::Object(map) = value {
         map.insert(
             "budget".to_string(),
-            json!({
-                "applied": true,
-                "rung": rung.as_str(),
-                "token_estimation_basis": "ceil(utf8_bytes / 4)",
-                "requested_max_tokens": budget.max_tokens,
-                "requested_max_bytes": budget.max_bytes,
-                "effective_max_bytes": cap,
-                "priority_properties": budget.priority_properties,
-                "sections": sections,
-            }),
+            budget_block(rung, budget, cap, sections),
         );
     }
-    value
+}
+
+fn budget_block(rung: Rung, budget: &BudgetRequest, cap: u64, sections: Vec<Value>) -> Value {
+    json!({
+        "applied": true,
+        "rung": rung.as_str(),
+        "token_estimation_basis": "ceil(utf8_bytes / 4)",
+        "requested_max_tokens": budget.max_tokens,
+        "requested_max_bytes": budget.max_bytes,
+        "effective_max_bytes": cap,
+        "priority_properties": budget.priority_properties,
+        "sections": sections,
+    })
+}
+
+/// Establish the shaping context for the top-level response of `tool`: for a
+/// history response, capture the parent entity id so version fetch handles can
+/// address the exact superseded version via `get_node_at_time` /
+/// `get_edge_at_time`.
+fn derive_ctx(value: &Value, tool: &str) -> ShapeCtx {
+    match tool {
+        "get_node_history" => ShapeCtx {
+            history_parent_id: value.get("node_id").cloned(),
+            history_is_edge: false,
+        },
+        "get_edge_history" => ShapeCtx {
+            history_parent_id: value.get("edge_id").cloned(),
+            history_is_edge: true,
+        },
+        _ => ShapeCtx::default(),
+    }
 }
 
 /// Does this object look like an entity carrying a `properties` object?
@@ -307,8 +406,48 @@ fn is_entity_object(map: &Map<String, Value>) -> bool {
     map.get("properties").map(Value::is_object).unwrap_or(false)
 }
 
+/// Does this object look like a bi-temporal history *version* (as emitted by
+/// `version_info_to_response`) rather than a live entity? A version carries
+/// `version_id` and its own valid/transaction coordinates, but no `id`.
+fn is_history_version(map: &Map<String, Value>) -> bool {
+    map.contains_key("version_id")
+        && map.contains_key("valid_from")
+        && map.contains_key("transaction_from")
+        && !map.contains_key("id")
+}
+
 /// Build the concrete fetch handle that retrieves this entity's full content.
-fn entity_fetch_handle(map: &Map<String, Value>) -> Value {
+///
+/// * A live node/edge → `get_node`/`get_edge` by id.
+/// * A history version → `get_node_at_time`/`get_edge_at_time` addressing the
+///   exact superseded version by the parent id (threaded via `ctx`) plus the
+///   version's own valid/transaction coordinates (Issue #3353 F2). A plain
+///   `get_node` would return the *current* state, not the historical version.
+fn entity_fetch_handle(map: &Map<String, Value>, ctx: &ShapeCtx) -> Value {
+    if is_history_version(map) {
+        let parent = ctx.history_parent_id.clone().unwrap_or(Value::Null);
+        let valid_time = map.get("valid_from").cloned().unwrap_or(Value::Null);
+        let transaction_time = map.get("transaction_from").cloned().unwrap_or(Value::Null);
+        if ctx.history_is_edge {
+            return json!({
+                "tool": "get_edge_at_time",
+                "arguments": {
+                    "edge_id": parent,
+                    "valid_time": valid_time,
+                    "transaction_time": transaction_time,
+                },
+            });
+        }
+        return json!({
+            "tool": "get_node_at_time",
+            "arguments": {
+                "node_id": parent,
+                "valid_time": valid_time,
+                "transaction_time": transaction_time,
+            },
+        });
+    }
+
     let is_edge = map.contains_key("source_id") || map.contains_key("target_id");
     let id = map.get("id").cloned().unwrap_or(Value::Null);
     if is_edge {
@@ -325,13 +464,15 @@ fn entity_fetch_handle(map: &Map<String, Value>) -> Value {
 }
 
 /// Rung 2: elide bulky, unprotected property *values* in place. Returns the
-/// number of values elided.
-fn elide_bulky_properties(value: &mut Value, priority: &[String]) -> usize {
+/// number of values elided. A value is elided only when its `{elided,...}`
+/// descriptor serializes *smaller* than the value it replaces, so this rung can
+/// never enlarge the response (Issue #3353 F3).
+fn elide_bulky_properties(value: &mut Value, priority: &[String], ctx: &ShapeCtx) -> usize {
     let mut count = 0;
     match value {
         Value::Object(map) => {
             if is_entity_object(map) {
-                let handle = entity_fetch_handle(map);
+                let handle = entity_fetch_handle(map, ctx);
                 if let Some(Value::Object(props)) = map.get_mut("properties") {
                     for (key, val) in props.iter_mut() {
                         if priority.iter().any(|p| p == key) {
@@ -341,28 +482,36 @@ fn elide_bulky_properties(value: &mut Value, priority: &[String]) -> usize {
                             continue;
                         }
                         let size = measured_bytes(val);
-                        if size > BULKY_PROP_THRESHOLD_BYTES {
-                            *val = json!({
-                                "elided": true,
-                                "reason": "budget",
-                                "type": json_type_name(val),
-                                "size_bytes": size,
-                                "fetch": handle.clone(),
-                            });
+                        if size <= BULKY_PROP_THRESHOLD_BYTES {
+                            continue;
+                        }
+                        let descriptor = json!({
+                            "elided": true,
+                            "reason": "budget",
+                            "type": json_type_name(val),
+                            "size_bytes": size,
+                            "fetch": handle.clone(),
+                        });
+                        // Monotonicity guard: never replace a value with a
+                        // descriptor that is not strictly smaller than it.
+                        if measured_bytes(&descriptor) < size {
+                            *val = descriptor;
                             count += 1;
                         }
                     }
                 }
             }
             // Recurse into all children to reach nested entity objects
-            // (traverse results, query rows, history versions, ...).
-            for (_k, child) in map.iter_mut() {
-                count += elide_bulky_properties(child, priority);
+            // (traverse results, query rows, history versions, ...). Thread the
+            // history context so version handles keep addressing their parent.
+            let child = child_ctx(map, ctx);
+            for (_k, c) in map.iter_mut() {
+                count += elide_bulky_properties(c, priority, &child);
             }
         }
         Value::Array(items) => {
             for item in items.iter_mut() {
-                count += elide_bulky_properties(item, priority);
+                count += elide_bulky_properties(item, priority, ctx);
             }
         }
         _ => {}
@@ -372,12 +521,12 @@ fn elide_bulky_properties(value: &mut Value, priority: &[String]) -> usize {
 
 /// Rung 3: reduce each entity's `properties` to protected keys only. Returns the
 /// number of entities summarized (i.e. that dropped at least one property).
-fn summarize_entities(value: &mut Value, priority: &[String]) -> usize {
+fn summarize_entities(value: &mut Value, priority: &[String], ctx: &ShapeCtx) -> usize {
     let mut count = 0;
     match value {
         Value::Object(map) => {
             if is_entity_object(map) {
-                let handle = entity_fetch_handle(map);
+                let handle = entity_fetch_handle(map, ctx);
                 if let Some(Value::Object(props)) = map.get_mut("properties") {
                     let original_len = props.len();
                     let mut kept = Map::new();
@@ -401,13 +550,14 @@ fn summarize_entities(value: &mut Value, priority: &[String]) -> usize {
                     *props = kept;
                 }
             }
-            for (_k, child) in map.iter_mut() {
-                count += summarize_entities(child, priority);
+            let child = child_ctx(map, ctx);
+            for (_k, c) in map.iter_mut() {
+                count += summarize_entities(c, priority, &child);
             }
         }
         Value::Array(items) => {
             for item in items.iter_mut() {
-                count += summarize_entities(item, priority);
+                count += summarize_entities(item, priority, ctx);
             }
         }
         _ => {}
@@ -415,15 +565,54 @@ fn summarize_entities(value: &mut Value, priority: &[String]) -> usize {
     count
 }
 
-/// Rung 4: truncate top-level entity arrays so the whole response fits `cap`.
-/// Returns one disclosure section per truncated array. Deterministic: elements
-/// are kept as a prefix (stable order) and only the tail is dropped.
-fn truncate_arrays_to_fit(value: &mut Value, tool: &str, cap: u64) -> Vec<Value> {
+/// Refine the shaping context when recursing into `map`'s children: a history
+/// wrapper (`node_id`/`edge_id` + a `versions` array) establishes the parent id
+/// used by its version fetch handles.
+fn child_ctx(map: &Map<String, Value>, inherited: &ShapeCtx) -> ShapeCtx {
+    if map.get("versions").map(Value::is_array).unwrap_or(false) {
+        if let Some(id) = map.get("node_id") {
+            return ShapeCtx {
+                history_parent_id: Some(id.clone()),
+                history_is_edge: false,
+            };
+        }
+        if let Some(id) = map.get("edge_id") {
+            return ShapeCtx {
+                history_parent_id: Some(id.clone()),
+                history_is_edge: true,
+            };
+        }
+    }
+    inherited.clone()
+}
+
+/// Rung 4: truncate top-level entity arrays so the whole *assembled* response
+/// (object plus its budget/disclosure block) fits `cap`. Returns one disclosure
+/// section per truncated array and rewrites the object's pagination/count
+/// siblings so a paginating caller sees no gap and no duplicate (Issue #3353
+/// F1). Deterministic: elements are kept as a prefix (stable order) and only the
+/// tail is dropped.
+fn truncate_arrays_to_fit(
+    value: &mut Value,
+    tool: &str,
+    args: &Value,
+    cap: u64,
+    budget: &BudgetRequest,
+    base_sections: &[Value],
+) -> Vec<Value> {
     let mut disclosures = Vec::new();
     let map = match value {
         Value::Object(m) => m,
         _ => return disclosures,
     };
+
+    // The original request offset (paginated tools only). Prefer the echoed
+    // response `offset`, falling back to the request argument, defaulting to 0.
+    let original_offset = map
+        .get("offset")
+        .and_then(Value::as_u64)
+        .or_else(|| args.get("offset").and_then(Value::as_u64))
+        .unwrap_or(0);
 
     // Identify top-level fields that are arrays of entity objects, largest first
     // for deterministic, greatest-impact-first truncation.
@@ -439,21 +628,28 @@ fn truncate_arrays_to_fit(value: &mut Value, tool: &str, cap: u64) -> Vec<Value>
     array_fields.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
 
     for (field, _) in array_fields {
-        if measured_bytes(&Value::Object(map.clone())) as u64 <= cap {
-            break;
-        }
         let original_len = match map.get(&field) {
             Some(Value::Array(items)) => items.len(),
             _ => continue,
         };
-        // Binary search the largest prefix length that keeps the whole object
-        // within budget.
+
+        // Fast-exit when the fully-assembled candidate already fits with this
+        // field untouched.
+        if assembled_len(map, budget, cap, base_sections, &disclosures, &field, original_len)
+            <= cap as usize
+        {
+            continue;
+        }
+
+        // Binary search the largest prefix length whose *assembled* candidate
+        // (including the finalized budget block) stays within budget (F4).
         let mut lo = 0usize;
         let mut hi = original_len;
         while lo < hi {
             let mid = lo + (hi - lo).div_ceil(2);
-            set_array_prefix(map, &field, mid);
-            if measured_bytes(&Value::Object(map.clone())) as u64 <= cap {
+            if assembled_len(map, budget, cap, base_sections, &disclosures, &field, mid)
+                <= cap as usize
+            {
                 lo = mid;
             } else {
                 hi = mid - 1;
@@ -462,22 +658,156 @@ fn truncate_arrays_to_fit(value: &mut Value, tool: &str, cap: u64) -> Vec<Value>
         set_array_prefix(map, &field, lo);
         let omitted = original_len - lo;
         if omitted > 0 {
+            let handle = truncation_fetch_handle(tool, args, original_offset, lo);
             disclosures.push(json!({
                 "section": field,
                 "rung": "counts_and_handles",
                 "returned": lo,
                 "omitted_count": omitted,
-                "fetch": {
-                    "tool": tool,
-                    "reason": "budget_truncated",
-                    "hint": "re-request without max_response_tokens/max_response_bytes, \
-                             or page the remainder using offset/next_offset, to retrieve \
-                             the omitted results",
-                },
+                "fetch": handle,
             }));
+            rewrite_pagination_siblings(map, &field, lo, original_offset, tool);
         }
     }
     disclosures
+}
+
+/// Measure the assembled candidate (object + budget block) with `field`
+/// tentatively truncated to `prefix_len`, without persisting the mutation to
+/// `map`. Used inside the rung-4 search so the *finalized* response size —
+/// including the budget and disclosure metadata appended afterward — is what is
+/// bounded by `cap` (Issue #3353 F4).
+fn assembled_len(
+    map: &Map<String, Value>,
+    budget: &BudgetRequest,
+    cap: u64,
+    base_sections: &[Value],
+    prior_disclosures: &[Value],
+    field: &str,
+    prefix_len: usize,
+) -> usize {
+    let original_len = map
+        .get(field)
+        .and_then(Value::as_array)
+        .map(|a| a.len())
+        .unwrap_or(prefix_len);
+    let omitted = original_len.saturating_sub(prefix_len);
+
+    let mut trial = map.clone();
+    set_array_prefix(&mut trial, field, prefix_len);
+
+    let mut sections: Vec<Value> = base_sections.to_vec();
+    sections.extend(prior_disclosures.iter().cloned());
+    if omitted > 0 {
+        rewrite_pagination_siblings(&mut trial, field, prefix_len, 0, "");
+        // A representative disclosure of maximal-ish size (concrete handle plus
+        // counts) so the reserved headroom matches the finalized block.
+        sections.push(json!({
+            "section": field,
+            "rung": "counts_and_handles",
+            "returned": prefix_len,
+            "omitted_count": omitted,
+            "fetch": {
+                "tool": "",
+                "arguments": { "offset": u64::MAX },
+                "reason": "budget_truncated",
+                "hint": "re-request with a larger max_response_tokens/max_response_bytes, \
+                         or page the remainder using offset, to retrieve the omitted results",
+            },
+        }));
+    }
+    trial.insert(
+        "budget".to_string(),
+        budget_block(Rung::CountsAndHandles, budget, cap, sections),
+    );
+    measured_bytes(&Value::Object(trial))
+}
+
+/// Build the rung-4 truncation fetch handle. Paginated tools (those that accept
+/// an `offset`) get a concrete resume call advancing the offset past the
+/// retained prefix; non-paginated tools get an honest disclosure that does not
+/// reference an offset they do not have (Issue #3353 F5).
+fn truncation_fetch_handle(
+    tool: &str,
+    args: &Value,
+    original_offset: u64,
+    retained: usize,
+) -> Value {
+    if is_offset_paginated_tool(tool) {
+        let mut resume_args = args.as_object().cloned().unwrap_or_default();
+        // Strip the budget knobs so the resume call returns the full remainder.
+        resume_args.remove("max_response_tokens");
+        resume_args.remove("max_response_bytes");
+        resume_args.remove("priority_properties");
+        resume_args.insert(
+            "offset".to_string(),
+            json!(original_offset.saturating_add(retained as u64)),
+        );
+        json!({
+            "tool": tool,
+            "arguments": Value::Object(resume_args),
+            "reason": "budget_truncated",
+            "hint": "call this to retrieve the omitted results, then continue paging with \
+                     `next_offset`",
+        })
+    } else {
+        json!({
+            "tool": tool,
+            "reason": "budget_truncated",
+            "hint": "re-request with a larger max_response_tokens/max_response_bytes to retrieve \
+                     the omitted results (this tool does not page by offset)",
+        })
+    }
+}
+
+/// Does this tool accept an `offset` argument for prefix pagination, so a
+/// concrete offset-advancing resume handle is meaningful?
+fn is_offset_paginated_tool(tool: &str) -> bool {
+    matches!(tool, "list_nodes" | "traverse" | "find_nodes_at_time")
+}
+
+/// After truncating `field` to `retained` elements, rewrite the object's own
+/// pagination/count siblings so they describe the retained prefix rather than
+/// the original (untruncated) page (Issue #3353 F1). This prevents the
+/// disclosed `next_offset` from skipping the dropped rows.
+fn rewrite_pagination_siblings(
+    map: &mut Map<String, Value>,
+    field: &str,
+    retained: usize,
+    original_offset: u64,
+    tool: &str,
+) {
+    // The count sibling co-located with each known array shape.
+    let count_key = match field {
+        "nodes" | "edges" | "results" => Some("count"),
+        "rows" => Some("row_count"),
+        _ => None,
+    };
+    if let Some(key) = count_key
+        && map.contains_key(key)
+    {
+        map.insert(key.to_string(), json!(retained));
+    }
+
+    // A `query`-style `truncated` flag becomes true.
+    if map.contains_key("truncated") {
+        map.insert("truncated".to_string(), json!(true));
+    }
+
+    // Pagination cursor: mark `has_more` and, for offset-paginated tools,
+    // advance `next_offset` past the retained prefix so a paginating caller
+    // resumes exactly where the page was cut.
+    if map.contains_key("has_more") {
+        map.insert("has_more".to_string(), json!(true));
+    }
+    if is_offset_paginated_tool(tool) {
+        map.insert(
+            "next_offset".to_string(),
+            json!(original_offset.saturating_add(retained as u64)),
+        );
+    }
+    // `total_matching`, when present, already counts the full matching set and
+    // remains correct; it is deliberately left unchanged.
 }
 
 /// Truncate `map[field]` (an array) to its first `len` elements in place.
@@ -490,7 +820,11 @@ fn set_array_prefix(map: &mut Map<String, Value>, field: &str, len: usize) {
 /// Is this array element an entity object (directly or via a nested wrapper)?
 fn is_entity_array_element(item: &Value) -> bool {
     match item {
-        Value::Object(map) => is_entity_object(map) || map.values().any(is_entity_array_element),
+        Value::Object(map) => {
+            is_entity_object(map)
+                || is_history_version(map)
+                || map.values().any(is_entity_array_element)
+        }
         _ => false,
     }
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -27,6 +27,7 @@
 
 mod auth;
 mod batch;
+mod budget;
 mod error;
 mod server;
 mod tools;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -153,6 +153,7 @@ use crate::query::executor::{EntityId as ResultEntityId, EntityResult};
 
 use super::auth::{McpAuthConfig, SessionAuth};
 use super::batch::ApplyBatchRequest;
+use super::budget;
 use super::error::{McpError, McpErrorCode, query_kind_classification};
 use super::tools::*;
 use crate::auth::{AuthMode, Principal};
@@ -4115,6 +4116,55 @@ impl AletheiaMcpServer {
         if let Err(err) = self.auth.authorize_tool(name) {
             return self.error_result(err);
         }
+        // Token-budget-aware response shaping (Issue #3353). For the read tools
+        // listed in `BUDGETABLE_READ_TOOLS`, an optional `max_response_tokens` /
+        // `max_response_bytes` shapes the successful response to fit the stated
+        // budget with a disclosed truncation contract. Omitting the budget
+        // parameters leaves behavior completely unchanged.
+        if is_budgetable_read_tool(name) {
+            match budget::parse_budget(&args) {
+                Ok(Some(budget_req)) => {
+                    let result = self.dispatch_read_tool(name, args);
+                    return self.apply_budget(name, result, &budget_req);
+                }
+                Ok(None) => {}
+                Err(err) => return self.error_result(err),
+            }
+        }
+        self.dispatch_read_tool(name, args)
+    }
+
+    /// Apply the parsed token budget to a handler's result. Errors and
+    /// non-object payloads pass through untouched; a successful response is
+    /// shaped to fit and re-serialized, or replaced with the structured
+    /// `INVALID_ARGUMENT` too-small-budget error (Issue #3353 AC6).
+    fn apply_budget(
+        &self,
+        name: &str,
+        result: CallToolResult,
+        budget_req: &budget::BudgetRequest,
+    ) -> CallToolResult {
+        if result.is_error.unwrap_or(false) {
+            return result;
+        }
+        let text = Self::extract_text(result);
+        let value: serde_json::Value = match serde_json::from_str(&text) {
+            Ok(v) => v,
+            // Non-JSON or non-object payloads are left untouched.
+            Err(_) => return self.success_json(serde_json::Value::String(text)),
+        };
+        if !value.is_object() {
+            return self.success_json(value);
+        }
+        match budget::shape_response(value, budget_req, name) {
+            Ok(shaped) => self.success_json(shaped),
+            Err(err) => self.error_result(err),
+        }
+    }
+
+    /// The tool-name dispatch table shared between the budgeted and unbudgeted
+    /// paths.
+    fn dispatch_read_tool(&self, name: &str, args: serde_json::Value) -> CallToolResult {
         match name {
             "get_node" => self.handle_get_node(args),
             "create_node" => self.handle_create_node(args),
@@ -4163,6 +4213,31 @@ impl AletheiaMcpServer {
             ),
         }
     }
+}
+
+/// The read tools that honor the Issue #3353 token budget (`max_response_tokens`
+/// / `max_response_bytes`). Kept as a single source of truth so the dispatch
+/// path, the schema-documentation path, and the CI conformance sweep cannot
+/// drift apart.
+pub(crate) const BUDGETABLE_READ_TOOLS: &[&str] = &[
+    "get_node",
+    "list_nodes",
+    "get_edge",
+    "list_edges",
+    "get_outgoing_edges",
+    "get_incoming_edges",
+    "traverse",
+    "find_similar",
+    "hybrid_query",
+    "query",
+    "find_nodes_at_time",
+    "get_node_history",
+    "get_schema",
+];
+
+/// Does this tool honor the token budget parameters (Issue #3353)?
+pub(crate) fn is_budgetable_read_tool(name: &str) -> bool {
+    BUDGETABLE_READ_TOOLS.contains(&name)
 }
 
 fn make_input_schema<T: rmcp::schemars::JsonSchema>()
@@ -4221,7 +4296,7 @@ fn query_columns() -> serde_json::Value {
 /// Shared between [`ServerHandler::list_tools`] and test helpers so the advertised tool
 /// set and the `call_tool` dispatch table cannot silently drift apart.
 fn tool_definitions() -> Vec<Tool> {
-    vec![
+    let mut tools = vec![
         Tool::new(
             "get_node",
             "Get a node by its ID. Returns the node's label and properties. \
@@ -4611,8 +4686,34 @@ fn tool_definitions() -> Vec<Tool> {
              for per-label breakdowns use get_schema.",
             make_input_schema::<DatabaseStatsRequest>(),
         ),
-    ]
+    ];
+
+    // Advertise the Issue #3353 token budget on every budgetable read tool by
+    // appending a uniform hint to its description, keeping discoverability in
+    // lockstep with `BUDGETABLE_READ_TOOLS` (the dispatch-path source of truth)
+    // without editing each tool literal.
+    for tool in tools.iter_mut() {
+        if is_budgetable_read_tool(&tool.name) {
+            let mut desc = tool.description.as_deref().unwrap_or("").to_string();
+            desc.push_str(BUDGET_TOOL_HINT);
+            tool.description = Some(std::borrow::Cow::Owned(desc));
+        }
+    }
+    tools
 }
+
+/// Uniform description suffix documenting the token-budget parameters
+/// (Issue #3353), appended to every budgetable read tool.
+const BUDGET_TOOL_HINT: &str = " Optional token budget (Issue #3353): pass \
+    `max_response_tokens` (estimated as ceil(utf8_bytes/4)) or the byte-exact \
+    `max_response_bytes` to cap the response size; the serialized response \
+    (including its truncation metadata) is guaranteed to fit. Over budget, the \
+    response degrades deterministically (elide bulky property values → per-entity \
+    summaries → counts-plus-handles), carrying a `budget` block naming the rung \
+    applied and a fetch handle at every elision site. Protect specific properties \
+    with `priority_properties`. A budget too small for the minimal response \
+    returns INVALID_ARGUMENT stating the minimum viable budget. Omit for \
+    unchanged (row-limit) behavior.";
 
 impl ServerHandler for AletheiaMcpServer {
     fn get_info(&self) -> ServerInfo {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -4124,8 +4124,12 @@ impl AletheiaMcpServer {
         if is_budgetable_read_tool(name) {
             match budget::parse_budget(&args) {
                 Ok(Some(budget_req)) => {
+                    // Retain the original arguments so the rung-4 truncation
+                    // handle can emit a concrete offset-based resume call
+                    // (Issue #3353 F1/F5).
+                    let orig_args = args.clone();
                     let result = self.dispatch_read_tool(name, args);
-                    return self.apply_budget(name, result, &budget_req);
+                    return self.apply_budget(name, result, &budget_req, &orig_args);
                 }
                 Ok(None) => {}
                 Err(err) => return self.error_result(err),
@@ -4134,15 +4138,19 @@ impl AletheiaMcpServer {
         self.dispatch_read_tool(name, args)
     }
 
-    /// Apply the parsed token budget to a handler's result. Errors and
-    /// non-object payloads pass through untouched; a successful response is
-    /// shaped to fit and re-serialized, or replaced with the structured
-    /// `INVALID_ARGUMENT` too-small-budget error (Issue #3353 AC6).
+    /// Apply the parsed token budget to a handler's result. Errors pass through
+    /// untouched; a successful object response is shaped to fit and
+    /// re-serialized, or replaced with the structured `INVALID_ARGUMENT`
+    /// too-small-budget error (Issue #3353 AC6). Non-object / non-JSON success
+    /// payloads cannot degrade along the entity ladder but are still held to the
+    /// byte cap with a disclosed truncation marker — the "guaranteed to fit"
+    /// contract is unconditional (Issue #3353 F6).
     fn apply_budget(
         &self,
         name: &str,
         result: CallToolResult,
         budget_req: &budget::BudgetRequest,
+        args: &serde_json::Value,
     ) -> CallToolResult {
         if result.is_error.unwrap_or(false) {
             return result;
@@ -4150,13 +4158,29 @@ impl AletheiaMcpServer {
         let text = Self::extract_text(result);
         let value: serde_json::Value = match serde_json::from_str(&text) {
             Ok(v) => v,
-            // Non-JSON or non-object payloads are left untouched.
-            Err(_) => return self.success_json(serde_json::Value::String(text)),
+            // Non-JSON payload: still enforce the byte cap on the raw text.
+            Err(_) => {
+                return match budget::enforce_raw_cap(text, budget_req) {
+                    Ok(capped) => self.success_json(serde_json::Value::String(capped)),
+                    Err(err) => self.error_result(err),
+                };
+            }
         };
         if !value.is_object() {
-            return self.success_json(value);
+            // JSON scalar/array: not shapeable along the entity ladder, but the
+            // serialized form is still capped so an unbounded array cannot
+            // bypass the budget.
+            let serialized =
+                serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
+            if serialized.len() as u64 <= budget_req.effective_bytes() {
+                return self.success_json(value);
+            }
+            return match budget::enforce_raw_cap(serialized, budget_req) {
+                Ok(capped) => self.success_json(serde_json::Value::String(capped)),
+                Err(err) => self.error_result(err),
+            };
         }
-        match budget::shape_response(value, budget_req, name) {
+        match budget::shape_response(value, budget_req, name, args) {
             Ok(shaped) => self.success_json(shaped),
             Err(err) => self.error_result(err),
         }
@@ -4689,17 +4713,66 @@ fn tool_definitions() -> Vec<Tool> {
     ];
 
     // Advertise the Issue #3353 token budget on every budgetable read tool by
-    // appending a uniform hint to its description, keeping discoverability in
-    // lockstep with `BUDGETABLE_READ_TOOLS` (the dispatch-path source of truth)
-    // without editing each tool literal.
+    // (a) injecting the three budget parameters into its generated
+    // `inputSchema.properties` so they are machine-discoverable, and (b)
+    // appending a uniform prose hint to its description as a secondary,
+    // human-readable pointer. Both are kept in lockstep with
+    // `BUDGETABLE_READ_TOOLS` (the dispatch-path source of truth) without
+    // editing each tool literal.
     for tool in tools.iter_mut() {
         if is_budgetable_read_tool(&tool.name) {
+            inject_budget_schema_params(&mut tool.input_schema);
             let mut desc = tool.description.as_deref().unwrap_or("").to_string();
             desc.push_str(BUDGET_TOOL_HINT);
             tool.description = Some(std::borrow::Cow::Owned(desc));
         }
     }
     tools
+}
+
+/// Inject the three optional Issue #3353 token-budget parameters into a tool's
+/// generated JSON `inputSchema.properties`, so a client that introspects the
+/// schema (not just the prose description) discovers them with correct types.
+/// All three are optional, so `required` is deliberately left untouched. Idempotent.
+fn inject_budget_schema_params(schema: &mut Arc<serde_json::Map<String, serde_json::Value>>) {
+    let schema = Arc::make_mut(schema);
+    let props = schema
+        .entry("properties".to_string())
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+    let Some(props) = props.as_object_mut() else {
+        return;
+    };
+    props
+        .entry("max_response_tokens".to_string())
+        .or_insert_with(|| {
+            json!({
+                "type": "integer",
+                "minimum": 1,
+                "description": "Optional (Issue #3353): cap the response at approximately this \
+                    many tokens (estimated as ceil(utf8_bytes/4)). The serialized response, \
+                    including its truncation metadata, is guaranteed to fit.",
+            })
+        });
+    props
+        .entry("max_response_bytes".to_string())
+        .or_insert_with(|| {
+            json!({
+                "type": "integer",
+                "minimum": 1,
+                "description": "Optional (Issue #3353): byte-exact cap on the serialized response. \
+                    When both this and max_response_tokens are given, the tighter bound wins.",
+            })
+        });
+    props
+        .entry("priority_properties".to_string())
+        .or_insert_with(|| {
+            json!({
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Optional (Issue #3353): property keys to protect from elision at \
+                    every degradation rung when a response budget is active.",
+            })
+        });
 }
 
 /// Uniform description suffix documenting the token-budget parameters

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -13284,16 +13284,488 @@ mod budget_tests {
         false
     }
 
-    // ---- Sweep coverage: budgetable set matches dispatch -------------------
+    // ---- T4: real classification test (not tautological) -------------------
 
     #[test]
     fn budgetable_set_is_nonempty_and_classified_read() {
-        // Every budgetable tool must be a classified Read tool (RBAC lockstep).
+        use crate::auth::AccessClass;
+        // The set must be non-empty...
+        assert!(
+            !super::super::server::BUDGETABLE_READ_TOOLS.is_empty(),
+            "budgetable set must not be empty"
+        );
+        // ...and every entry must be classified as a Read tool in the RBAC
+        // access matrix (lockstep with the auth surface, not a self-referential
+        // `is_budgetable_read_tool` check).
         for tool in super::super::server::BUDGETABLE_READ_TOOLS {
-            assert!(
-                super::super::server::is_budgetable_read_tool(tool),
-                "{tool} should be recognized as budgetable"
+            let class = super::super::auth::tool_access_class(tool);
+            assert_eq!(
+                class,
+                Some(AccessClass::Read),
+                "{tool} must be classified AccessClass::Read (got {class:?})"
             );
         }
+    }
+
+    // ---- F7: budget params are discoverable in every tool's inputSchema ----
+
+    #[test]
+    fn f7_budget_params_present_in_every_budgetable_input_schema() {
+        let server = create_test_server();
+        for tool in super::super::server::BUDGETABLE_READ_TOOLS {
+            let schema = server
+                .tool_input_schema_for_test(tool)
+                .unwrap_or_else(|| panic!("{tool} must be advertised"));
+            let props = schema
+                .get("properties")
+                .and_then(Value::as_object)
+                .unwrap_or_else(|| panic!("{tool} inputSchema must have properties"));
+            for key in [
+                "max_response_tokens",
+                "max_response_bytes",
+                "priority_properties",
+            ] {
+                assert!(
+                    props.contains_key(key),
+                    "{tool} inputSchema must expose `{key}` (found: {:?})",
+                    props.keys().collect::<Vec<_>>()
+                );
+            }
+            // Types are correct: two positive integers, one array of strings.
+            assert_eq!(props["max_response_tokens"]["type"], json!("integer"));
+            assert_eq!(props["max_response_bytes"]["type"], json!("integer"));
+            assert_eq!(props["priority_properties"]["type"], json!("array"));
+        }
+    }
+
+    // ---- F1 + F5: rung-4 truncation resume covers all rows, no gap/dupe ----
+
+    #[test]
+    fn f1_truncated_list_nodes_resume_has_no_gaps_or_dupes() {
+        let server = create_test_server();
+        let all_ids = seed_many(&server, "Person", 30);
+
+        // Full, unbudgeted page (limit high enough to hold all).
+        let (full, _) =
+            dispatch_json(&server, "list_nodes", json!({ "label": "Person", "limit": 100 }));
+        let full_ids = collect_node_ids(&full);
+        assert_eq!(full_ids.len(), all_ids.len(), "seeded set fully listed");
+
+        // Budgeted request tight enough to force rung-4 truncation.
+        let (page1, is_error) = dispatch_json(
+            &server,
+            "list_nodes",
+            json!({ "label": "Person", "limit": 100, "max_response_tokens": 400 }),
+        );
+        assert!(!is_error, "budgeted list_nodes should succeed: {page1}");
+        assert_eq!(
+            page1["budget"]["rung"],
+            json!("counts_and_handles"),
+            "budget must be tight enough to truncate the array"
+        );
+        let page1_ids = collect_node_ids(&page1);
+
+        // F1: `count` sibling reflects the retained prefix, and `next_offset`
+        // advances by exactly that (not the original limit).
+        assert_eq!(
+            page1["count"].as_u64().unwrap() as usize,
+            page1_ids.len(),
+            "count sibling must match retained rows"
+        );
+        assert_eq!(page1["has_more"], json!(true), "has_more must flip to true");
+        assert_eq!(
+            page1["next_offset"].as_u64().unwrap() as usize,
+            page1_ids.len(),
+            "next_offset must resume at the cut point"
+        );
+
+        // F5: the truncation fetch handle is a concrete resume call.
+        let handle = truncation_handle(&page1).expect("a truncation fetch handle must exist");
+        assert_eq!(handle["tool"], json!("list_nodes"));
+        let resume_args = handle["arguments"].clone();
+        assert_eq!(
+            resume_args["offset"].as_u64().unwrap() as usize,
+            page1_ids.len(),
+            "resume offset must equal the retained count"
+        );
+
+        // Follow the disclosed resume call (unbudgeted): the union must equal
+        // the full set with NO gaps and NO dupes.
+        let (page2, e2) = dispatch_json(&server, "list_nodes", resume_args);
+        assert!(!e2, "resume call must succeed: {page2}");
+        let page2_ids = collect_node_ids(&page2);
+
+        let mut union = page1_ids.clone();
+        union.extend(page2_ids.iter().copied());
+        let mut sorted_union = union.clone();
+        sorted_union.sort_unstable();
+        let before_dedup = sorted_union.len();
+        sorted_union.dedup();
+        assert_eq!(before_dedup, sorted_union.len(), "no duplicate rows across pages");
+
+        let mut expected = full_ids.clone();
+        expected.sort_unstable();
+        assert_eq!(sorted_union, expected, "union of pages == full set (no gaps)");
+    }
+
+    fn collect_node_ids(value: &Value) -> Vec<u64> {
+        value
+            .get("nodes")
+            .and_then(Value::as_array)
+            .map(|a| a.iter().filter_map(|n| n.get("id").and_then(Value::as_u64)).collect())
+            .unwrap_or_default()
+    }
+
+    /// Find the rung-4 truncation disclosure's fetch handle in `budget.sections`.
+    fn truncation_handle(value: &Value) -> Option<Value> {
+        let sections = value.get("budget")?.get("sections")?.as_array()?;
+        for s in sections {
+            if s.get("rung").and_then(Value::as_str) == Some("counts_and_handles")
+                && let Some(fetch) = s.get("fetch")
+                && fetch.get("tool").is_some()
+            {
+                return Some(fetch.clone());
+            }
+        }
+        None
+    }
+
+    // ---- F4: counts_and_handles succeeds at a tight budget (no false AC6) --
+
+    #[test]
+    fn f4_counts_and_handles_succeeds_at_tight_budget() {
+        let server = create_test_server();
+        let _ = seed_many(&server, "Person", 30);
+        // A budget large enough for the minimal rung-4 response but tight enough
+        // that the metadata block matters — must SUCCEED, not falsely AC6-error.
+        let cap = 2000usize;
+        let (value, is_error) = dispatch_raw(
+            &server,
+            "list_nodes",
+            json!({ "label": "Person", "limit": 100, "max_response_bytes": cap }),
+        );
+        assert!(
+            !is_error,
+            "tight-but-viable budget must succeed, not error: {value}"
+        );
+        assert!(value.len() <= cap, "assembled response must fit: {}", value.len());
+        let parsed: Value = serde_json::from_str(&value).unwrap();
+        assert_eq!(parsed["budget"]["rung"], json!("counts_and_handles"));
+    }
+
+    // ---- T6: re-issuing at the reported min_viable_tokens succeeds ---------
+
+    #[test]
+    fn t6_reissue_at_min_viable_budget_succeeds() {
+        let server = create_test_server();
+        let id = seed_big_node(&server, "Person", "Alice");
+        let (value, is_error) = dispatch_json(
+            &server,
+            "get_node",
+            json!({ "node_id": id, "max_response_tokens": 1 }),
+        );
+        assert!(is_error, "tiny budget must error first");
+        let min_viable = value["error"]["details"]["min_viable_tokens"]
+            .as_u64()
+            .expect("min_viable_tokens present");
+        // Re-issue at the reported minimum — must now succeed.
+        let (retry, retry_err) = dispatch_json(
+            &server,
+            "get_node",
+            json!({ "node_id": id, "max_response_tokens": min_viable }),
+        );
+        assert!(
+            !retry_err,
+            "re-issuing at min_viable_tokens={min_viable} must succeed: {retry}"
+        );
+        assert_eq!(retry["id"], json!(id));
+    }
+
+    // ---- T5: byte budget holds for multibyte/unicode property payloads -----
+
+    #[test]
+    fn t5_byte_budget_holds_for_unicode_property() {
+        let server = create_test_server();
+        let big = "🌍héllo".repeat(500); // multibyte, ~ several KB
+        let (created, e) = dispatch_json(
+            &server,
+            "create_node",
+            json!({ "label": "Doc", "properties": { "name": "u", "bio": big } }),
+        );
+        assert!(!e, "seed failed: {created}");
+        let id = created["id"].as_u64().unwrap();
+        for cap in [300usize, 700, 1200] {
+            let (text, is_error) = dispatch_raw(
+                &server,
+                "get_node",
+                json!({ "node_id": id, "max_response_bytes": cap }),
+            );
+            if is_error {
+                continue;
+            }
+            assert!(
+                text.len() <= cap,
+                "unicode byte budget {cap} overran: {} bytes",
+                text.len()
+            );
+            assert!(
+                std::str::from_utf8(text.as_bytes()).is_ok(),
+                "response must remain valid UTF-8"
+            );
+        }
+    }
+
+    // ---- F5 (non-paginated): truncation handle has no bogus offset ---------
+
+    #[test]
+    fn f5_non_paginated_truncation_handle_omits_offset() {
+        let server = create_test_server();
+        let hub = seed_big_node(&server, "Hub", "center");
+        // Many bulky outgoing edges so get_outgoing_edges (no offset paging)
+        // reaches rung-4 truncation.
+        for _ in 0..25 {
+            let tgt = seed_big_node(&server, "Person", "t");
+            let _ = server.dispatch_tool(
+                "create_edge",
+                json!({ "source_id": hub, "target_id": tgt, "label": "KNOWS",
+                        "properties": { "detail": "z".repeat(400) } }),
+            );
+        }
+        let (value, is_error) = dispatch_json(
+            &server,
+            "get_outgoing_edges",
+            json!({ "node_id": hub, "max_response_tokens": 500 }),
+        );
+        if is_error {
+            return; // AC6 acceptable at extreme tightness
+        }
+        if value["budget"]["rung"] == json!("counts_and_handles")
+            && let Some(handle) = truncation_edge_handle(&value)
+        {
+            assert_eq!(handle["tool"], json!("get_outgoing_edges"));
+            assert!(
+                handle.get("arguments").is_none(),
+                "non-paginated tool must not fabricate an offset resume call: {handle}"
+            );
+        }
+    }
+
+    fn truncation_edge_handle(value: &Value) -> Option<Value> {
+        let sections = value.get("budget")?.get("sections")?.as_array()?;
+        for s in sections {
+            if s.get("rung").and_then(Value::as_str) == Some("counts_and_handles")
+                && let Some(fetch) = s.get("fetch")
+                && fetch.get("tool").is_some()
+            {
+                return Some(fetch.clone());
+            }
+        }
+        None
+    }
+
+    // ---- T1: AC2 sweep extended to ranked + query tools --------------------
+
+    /// Seed Doc nodes carrying both a 4-d embedding and a bulky bio, so the
+    /// ranked/query tools have data large enough to force degradation.
+    fn seed_vector_docs(server: &AletheiaMcpServer, n: usize) -> Vec<u64> {
+        let _ = server.dispatch_tool(
+            "enable_vector_index",
+            json!({ "property_name": "embedding", "dimensions": 4, "metric": "cosine" }),
+        );
+        let mut ids = Vec::new();
+        for i in 0..n {
+            let (v, e) = dispatch_json(
+                server,
+                "create_node",
+                json!({ "label": "Doc", "properties": {
+                    "name": format!("d{i}"),
+                    "bio": "b".repeat(2500),
+                    "embedding": [i as f32, 1.0, 0.0, 1.0],
+                }}),
+            );
+            assert!(!e, "seed failed: {v}");
+            ids.push(v["id"].as_u64().unwrap());
+        }
+        ids
+    }
+
+    #[test]
+    fn t1_ranked_and_query_byte_cap_sweep_is_nonvacuous() {
+        let server = create_test_server();
+        let ids = seed_vector_docs(&server, 12);
+        // A few edges so hybrid traversal has neighbors.
+        for w in ids.windows(2).take(8) {
+            let _ = server.dispatch_tool(
+                "create_edge",
+                json!({ "source_id": w[0], "target_id": w[1], "label": "REL",
+                        "properties": { "note": "n".repeat(600) } }),
+            );
+        }
+        let cases: Vec<(&str, Value)> = vec![
+            (
+                "find_similar",
+                json!({ "property_name": "embedding", "embedding": [0.0, 1.0, 0.0, 1.0], "k": 10 }),
+            ),
+            (
+                "hybrid_query",
+                json!({ "start_node_id": ids[0], "traverse_edge": "REL", "traverse_depth": 2,
+                        "limit": 10 }),
+            ),
+            (
+                "query",
+                json!({ "language": "aql", "query": "MATCH (n:Doc) RETURN n", "limit": 20 }),
+            ),
+        ];
+        let budgets = [512u64, 1024, 2048, 4096, 8192];
+        let mut successful_cases = 0usize;
+        for &budget in &budgets {
+            for (tool, base) in &cases {
+                let mut args = base.clone();
+                args.as_object_mut()
+                    .unwrap()
+                    .insert("max_response_bytes".into(), json!(budget));
+                let (text, is_error) = dispatch_raw(&server, tool, args);
+                if is_error {
+                    continue;
+                }
+                successful_cases += 1;
+                assert!(
+                    text.len() as u64 <= budget,
+                    "[{tool} @ {budget}B] overran: {} bytes",
+                    text.len()
+                );
+            }
+        }
+        // The sweep must not pass vacuously (every case erroring).
+        assert!(
+            successful_cases > 0,
+            "conformance sweep produced zero successful budgeted responses"
+        );
+    }
+
+    // ---- T2: dedicated query-tool budget + hybrid_query AC7 ----------------
+
+    #[test]
+    fn t2_query_tool_budget_shapes_bulky_rows() {
+        let server = create_test_server();
+        let _ = seed_vector_docs(&server, 10);
+        let (full, ferr) = dispatch_json(
+            &server,
+            "query",
+            json!({ "language": "aql", "query": "MATCH (n:Doc) RETURN n", "limit": 20 }),
+        );
+        assert!(!ferr, "unbudgeted query failed: {full}");
+        let full_rows = full["rows"].as_array().map(|a| a.len()).unwrap_or(0);
+        assert!(full_rows > 0, "query returned rows");
+
+        let (shaped, is_error) = dispatch_json(
+            &server,
+            "query",
+            json!({ "language": "aql", "query": "MATCH (n:Doc) RETURN n", "limit": 20,
+                    "max_response_tokens": 500 }),
+        );
+        if is_error {
+            assert_eq!(shaped["error"]["code"], json!("INVALID_ARGUMENT"));
+            return;
+        }
+        // Budget block present; rows degraded (bulky bio elided/summarized or
+        // rows truncated) but row_count stays consistent with the array length.
+        assert_eq!(shaped["budget"]["applied"], json!(true));
+        let rc = shaped["row_count"].as_u64().unwrap() as usize;
+        let arr = shaped["rows"].as_array().map(|a| a.len()).unwrap_or(0);
+        assert_eq!(rc, arr, "row_count must match retained rows (F1)");
+    }
+
+    #[test]
+    fn t2_hybrid_query_preserves_count_and_scores_under_budget() {
+        let server = create_test_server();
+        let ids = seed_vector_docs(&server, 6);
+        for w in ids.windows(2) {
+            let _ = server.dispatch_tool(
+                "create_edge",
+                json!({ "source_id": ids[0], "target_id": w[1], "label": "REL",
+                        "properties": { "note": "n".repeat(500) } }),
+            );
+        }
+        let base = json!({ "start_node_id": ids[0], "traverse_edge": "REL",
+                           "traverse_depth": 1, "limit": 10 });
+        let (full, _) = dispatch_json(&server, "hybrid_query", base.clone());
+        let full_count = full["results"].as_array().map(|a| a.len()).unwrap_or(0);
+
+        let mut args = base;
+        args.as_object_mut()
+            .unwrap()
+            .insert("max_response_tokens".into(), json!(700));
+        let (budgeted, is_error) = dispatch_json(&server, "hybrid_query", args);
+        if is_error {
+            assert_eq!(budgeted["error"]["code"], json!("INVALID_ARGUMENT"));
+            return;
+        }
+        let budgeted_count = budgeted["results"].as_array().map(|a| a.len()).unwrap_or(0);
+        assert_eq!(
+            budgeted_count, full_count,
+            "ranked hybrid results must not be dropped to meet a budget (AC7)"
+        );
+        for r in budgeted["results"].as_array().unwrap() {
+            assert!(
+                r.get("similarity_score").is_some(),
+                "similarity_score must be present on every ranked result: {r}"
+            );
+        }
+    }
+
+    // ---- T3: AC7 ordering preserved for ranked tools -----------------------
+
+    #[test]
+    fn t3_find_similar_preserves_result_ordering_under_budget() {
+        let server = create_test_server();
+        let _ = seed_vector_docs(&server, 8);
+        let q = json!({ "property_name": "embedding", "embedding": [0.0, 1.0, 0.0, 1.0], "k": 6 });
+
+        let (full, _) = dispatch_json(&server, "find_similar", q.clone());
+        let full_seq = ordered_id_score(&full);
+        assert!(!full_seq.is_empty(), "unbudgeted find_similar returned results");
+
+        let mut args = q;
+        args.as_object_mut()
+            .unwrap()
+            .insert("max_response_tokens".into(), json!(700));
+        let (budgeted, is_error) = dispatch_json(&server, "find_similar", args);
+        if is_error {
+            assert_eq!(budgeted["error"]["code"], json!("INVALID_ARGUMENT"));
+            return;
+        }
+        let budgeted_seq = ordered_id_score(&budgeted);
+        assert_eq!(
+            budgeted_seq, full_seq,
+            "ranked ordering (id + score sequence) must be identical under budget"
+        );
+    }
+
+    /// The ordered (id, score-bits) sequence of a ranked response's results, so
+    /// ordering — not just membership — can be compared exactly.
+    fn ordered_id_score(value: &Value) -> Vec<(u64, u64)> {
+        value
+            .get("results")
+            .and_then(Value::as_array)
+            .map(|a| {
+                a.iter()
+                    .map(|r| {
+                        let id = r
+                            .get("node")
+                            .and_then(|n| n.get("id"))
+                            .and_then(Value::as_u64)
+                            .unwrap_or(0);
+                        let score = r
+                            .get("score")
+                            .or_else(|| r.get("similarity_score"))
+                            .and_then(Value::as_f64)
+                            .map(f64::to_bits)
+                            .unwrap_or(0);
+                        (id, score)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 }

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -12882,3 +12882,418 @@ mod per_request_now_tests {
         );
     }
 }
+
+// ============================================================================
+// Token-budget-aware response shaping (Issue #3353)
+// ============================================================================
+
+#[cfg(test)]
+mod budget_tests {
+    use super::*;
+    use serde_json::{Value, json};
+
+    /// Dispatch a tool and return the *raw* serialized response text plus its
+    /// error flag. The raw text length is exactly what is emitted on the wire,
+    /// so it is the quantity the budget contract bounds.
+    fn dispatch_raw(server: &AletheiaMcpServer, tool: &str, args: Value) -> (String, bool) {
+        let result = server.dispatch_tool(tool, args);
+        let is_error = result.is_error.unwrap_or(false);
+        let text = result
+            .content
+            .first()
+            .and_then(|c| c.as_text().map(|t| t.text.clone()))
+            .expect("tool result should carry text content");
+        (text, is_error)
+    }
+
+    fn dispatch_json(server: &AletheiaMcpServer, tool: &str, args: Value) -> (Value, bool) {
+        let (text, is_error) = dispatch_raw(server, tool, args);
+        let value = serde_json::from_str(&text).expect("response should be valid JSON");
+        (value, is_error)
+    }
+
+    /// Create a node whose properties are large enough to blow a small budget.
+    fn seed_big_node(server: &AletheiaMcpServer, label: &str, name: &str) -> u64 {
+        let bio = "x".repeat(4000);
+        let args = json!({
+            "label": label,
+            "properties": {
+                "name": name,
+                "bio": bio,
+                "notes": "y".repeat(2000),
+            }
+        });
+        let (value, is_error) = dispatch_json(server, "create_node", args);
+        assert!(!is_error, "seed create_node failed: {value}");
+        value.get("id").and_then(Value::as_u64).expect("node id")
+    }
+
+    fn seed_many(server: &AletheiaMcpServer, label: &str, n: usize) -> Vec<u64> {
+        (0..n)
+            .map(|i| seed_big_node(server, label, &format!("n{i}")))
+            .collect()
+    }
+
+    // ---- AC1: omitting the budget leaves behavior unchanged ----------------
+
+    #[test]
+    fn ac1_omitting_budget_is_unchanged() {
+        let server = create_test_server();
+        let id = seed_big_node(&server, "Person", "Alice");
+        let (with_none, _) = dispatch_json(&server, "get_node", json!({ "node_id": id }));
+        // Full bio present, no budget block.
+        assert!(
+            with_none.get("budget").is_none(),
+            "no budget block expected"
+        );
+        let bio = with_none["properties"]["bio"].as_str().unwrap();
+        assert_eq!(bio.len(), 4000, "full bio returned when no budget set");
+    }
+
+    // ---- AC2: hard contract, conformance sweep -----------------------------
+
+    #[test]
+    fn ac2_conformance_sweep_never_overruns() {
+        let server = create_test_server();
+        // Enable a vector index so find_similar/hybrid_query have data.
+        let _ = server.dispatch_tool(
+            "enable_vector_index",
+            json!({ "property_name": "embedding", "dimensions": 4, "metric": "cosine" }),
+        );
+        let ids = seed_many(&server, "Person", 40);
+        // A couple of edges for edge tools / traversal.
+        for w in ids.windows(2).take(20) {
+            let _ = server.dispatch_tool(
+                "create_edge",
+                json!({ "source_id": w[0], "target_id": w[1], "label": "KNOWS",
+                        "properties": { "detail": "z".repeat(1500) } }),
+            );
+        }
+
+        let budgets = [256u64, 512, 1024, 2048, 4096, 8192, 16384, 32768];
+        let cases: Vec<(&str, Value)> = vec![
+            ("get_node", json!({ "node_id": ids[0] })),
+            ("list_nodes", json!({ "label": "Person", "limit": 40 })),
+            ("get_edge", json!({ "edge_id": 1 })),
+            ("list_edges", json!({ "limit": 40 })),
+            ("get_outgoing_edges", json!({ "node_id": ids[0] })),
+            ("get_incoming_edges", json!({ "node_id": ids[1] })),
+            (
+                "traverse",
+                json!({ "start_node_id": ids[0], "max_depth": 3 }),
+            ),
+            ("get_node_history", json!({ "node_id": ids[0] })),
+            ("get_schema", json!({})),
+            (
+                "find_nodes_at_time",
+                json!({ "label": "Person", "valid_time": "2999-01-01T00:00:00Z" }),
+            ),
+        ];
+
+        for &budget in &budgets {
+            for (tool, base) in &cases {
+                let mut args = base.clone();
+                args.as_object_mut()
+                    .unwrap()
+                    .insert("max_response_tokens".into(), json!(budget));
+                let (text, is_error) = dispatch_raw(&server, tool, args);
+                if is_error {
+                    // Too-small budgets legitimately error (AC6); that is not an overrun.
+                    continue;
+                }
+                let cap = (budget * super::super::budget::BYTES_PER_TOKEN) as usize;
+                assert!(
+                    text.len() <= cap,
+                    "[{tool} @ {budget} tok] overran budget: {} bytes > cap {} bytes",
+                    text.len(),
+                    cap
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn ac2_byte_budget_is_exact() {
+        let server = create_test_server();
+        let ids = seed_many(&server, "Doc", 20);
+        let _ = ids;
+        for cap in [400usize, 900, 1500, 3000] {
+            let (text, is_error) = dispatch_raw(
+                &server,
+                "list_nodes",
+                json!({ "label": "Doc", "limit": 20, "max_response_bytes": cap }),
+            );
+            if is_error {
+                continue;
+            }
+            assert!(
+                text.len() <= cap,
+                "byte budget {cap} overran: {} bytes",
+                text.len()
+            );
+        }
+    }
+
+    // ---- AC3: deterministic, disclosed rung --------------------------------
+
+    #[test]
+    fn ac3_rung_is_disclosed_and_deterministic() {
+        let server = create_test_server();
+        let id = seed_big_node(&server, "Person", "Alice");
+        let (a, _) = dispatch_json(
+            &server,
+            "get_node",
+            json!({ "node_id": id, "max_response_tokens": 300 }),
+        );
+        let (b, _) = dispatch_json(
+            &server,
+            "get_node",
+            json!({ "node_id": id, "max_response_tokens": 300 }),
+        );
+        assert_eq!(a, b, "same request+budget+data must degrade identically");
+        let budget = a.get("budget").expect("budget block present");
+        assert_eq!(budget["applied"], json!(true));
+        assert!(budget.get("rung").and_then(Value::as_str).is_some());
+        assert_eq!(
+            budget["token_estimation_basis"],
+            json!("ceil(utf8_bytes / 4)")
+        );
+        // Structure survives: id and label kept.
+        assert_eq!(a["id"], json!(id));
+        assert!(a.get("label").is_some());
+    }
+
+    #[test]
+    fn ac3_ladder_progression() {
+        let server = create_test_server();
+        let id = seed_big_node(&server, "Person", "Alice");
+        // Generous budget -> full.
+        let (full, _) = dispatch_json(
+            &server,
+            "get_node",
+            json!({ "node_id": id, "max_response_tokens": 20000 }),
+        );
+        assert_eq!(full["budget"]["rung"], json!("full"));
+        // Mid budget -> some form of elision/summary (bio gone as full string).
+        let (mid, _) = dispatch_json(
+            &server,
+            "get_node",
+            json!({ "node_id": id, "max_response_tokens": 400 }),
+        );
+        let rung = mid["budget"]["rung"].as_str().unwrap();
+        assert!(
+            rung == "elided_properties" || rung == "entity_summaries",
+            "expected a degraded rung, got {rung}"
+        );
+        // bio must no longer be a full 4000-char string.
+        let bio = &mid["properties"]["bio"];
+        assert!(
+            bio.as_str().map(|s| s.len()).unwrap_or(0) < 4000,
+            "bio should have degraded"
+        );
+    }
+
+    // ---- AC4: fetch handles reconstruct omitted content --------------------
+
+    #[test]
+    fn ac4_fetch_handle_recovers_full_content() {
+        let server = create_test_server();
+        let id = seed_big_node(&server, "Person", "Alice");
+        let (shaped, _) = dispatch_json(
+            &server,
+            "get_node",
+            json!({ "node_id": id, "max_response_tokens": 400 }),
+        );
+        // Find a fetch handle somewhere in the shaped properties.
+        let handle = find_fetch_handle(&shaped).expect("a fetch handle must be present");
+        let tool = handle["tool"].as_str().unwrap().to_string();
+        let mut args = handle["arguments"].clone();
+        assert_eq!(tool, "get_node");
+        // Following the handle (no budget) returns the full bio.
+        let (recovered, is_error) = dispatch_json(&server, &tool, {
+            args.as_object_mut().unwrap();
+            args
+        });
+        assert!(!is_error, "handle call failed: {recovered}");
+        assert_eq!(
+            recovered["properties"]["bio"].as_str().unwrap().len(),
+            4000,
+            "handle reconstructs the omitted content exactly"
+        );
+    }
+
+    fn find_fetch_handle(value: &Value) -> Option<Value> {
+        match value {
+            Value::Object(map) => {
+                if let Some(fetch) = map.get("fetch")
+                    && fetch.get("tool").is_some()
+                {
+                    return Some(fetch.clone());
+                }
+                for v in map.values() {
+                    if let Some(h) = find_fetch_handle(v) {
+                        return Some(h);
+                    }
+                }
+                None
+            }
+            Value::Array(items) => items.iter().find_map(find_fetch_handle),
+            _ => None,
+        }
+    }
+
+    // ---- AC5: priority_properties out-survive ------------------------------
+
+    #[test]
+    fn ac5_priority_properties_protected() {
+        let server = create_test_server();
+        let id = seed_big_node(&server, "Person", "Alice");
+        // Protect "bio" even though it is the bulkiest property. The budget is
+        // tight enough to force degradation (bio ~4000B + notes ~2000B exceeds
+        // it) but roomy enough to keep the protected bio in full.
+        let (shaped, is_error) = dispatch_json(
+            &server,
+            "get_node",
+            json!({ "node_id": id, "max_response_tokens": 1500,
+                    "priority_properties": ["bio"] }),
+        );
+        assert!(!is_error, "should fit with bio protected: {shaped}");
+        assert_ne!(
+            shaped["budget"]["rung"],
+            json!("full"),
+            "budget must be tight enough to force degradation"
+        );
+        // bio kept in full; an unprotected bulky prop (notes) elided/dropped.
+        assert_eq!(
+            shaped["properties"]["bio"].as_str().map(|s| s.len()),
+            Some(4000),
+            "protected property survives"
+        );
+        let notes = &shaped["properties"]["notes"];
+        let notes_full = notes.as_str().map(|s| s.len() == 2000).unwrap_or(false);
+        assert!(
+            !notes_full,
+            "unprotected bulky property should degrade first"
+        );
+    }
+
+    // ---- AC6: too-small budget -> structured error -------------------------
+
+    #[test]
+    fn ac6_too_small_budget_errors_with_min_viable() {
+        let server = create_test_server();
+        let ids = seed_many(&server, "Person", 30);
+        let _ = ids;
+        let (value, is_error) = dispatch_json(
+            &server,
+            "list_nodes",
+            json!({ "label": "Person", "limit": 30, "max_response_tokens": 1 }),
+        );
+        assert!(
+            is_error,
+            "tiny budget must error, not silently empty: {value}"
+        );
+        let err = value.get("error").expect("structured error");
+        assert_eq!(err["code"], json!("INVALID_ARGUMENT"));
+        assert_eq!(err["retriable"], json!(false));
+        assert!(
+            err["details"].get("min_viable_tokens").is_some(),
+            "error must state the minimum viable budget: {err}"
+        );
+    }
+
+    #[test]
+    fn ac6_malformed_budget_rejected() {
+        let server = create_test_server();
+        let id = seed_big_node(&server, "Person", "Alice");
+        let (value, is_error) = dispatch_json(
+            &server,
+            "get_node",
+            json!({ "node_id": id, "max_response_tokens": 0 }),
+        );
+        assert!(is_error);
+        assert_eq!(value["error"]["code"], json!("INVALID_ARGUMENT"));
+    }
+
+    // ---- AC7: ranked tools never drop/reorder results ----------------------
+
+    #[test]
+    fn ac7_find_similar_never_drops_results() {
+        let server = create_test_server();
+        let _ = server.dispatch_tool(
+            "enable_vector_index",
+            json!({ "property_name": "embedding", "dimensions": 4, "metric": "cosine" }),
+        );
+        // Seed nodes with embeddings and bulky payloads.
+        let mut ids = Vec::new();
+        for i in 0..6 {
+            let (v, e) = dispatch_json(
+                &server,
+                "create_node",
+                json!({ "label": "Doc", "properties": {
+                    "name": format!("d{i}"),
+                    "bio": "b".repeat(3000),
+                    "embedding": [i as f32, 0.0, 0.0, 1.0],
+                }}),
+            );
+            assert!(!e, "seed failed: {v}");
+            ids.push(v["id"].as_u64().unwrap());
+        }
+        let (unbudgeted, _) = dispatch_json(
+            &server,
+            "find_similar",
+            json!({ "node_id": ids[0], "limit": 5 }),
+        );
+        let full_count = count_results(&unbudgeted);
+        let (budgeted, is_error) = dispatch_json(
+            &server,
+            "find_similar",
+            json!({ "node_id": ids[0], "limit": 5, "max_response_tokens": 900 }),
+        );
+        if is_error {
+            // Acceptable only via AC6 (budget too small even for summaries).
+            assert_eq!(budgeted["error"]["code"], json!("INVALID_ARGUMENT"));
+            return;
+        }
+        let budgeted_count = count_results(&budgeted);
+        assert_eq!(
+            budgeted_count, full_count,
+            "ranked results must not be dropped to meet a budget"
+        );
+        // Scores preserved for every result.
+        assert!(scores_present(&budgeted), "scores must survive budgeting");
+    }
+
+    fn count_results(value: &Value) -> usize {
+        for key in ["results", "similar", "nodes"] {
+            if let Some(arr) = value.get(key).and_then(Value::as_array) {
+                return arr.len();
+            }
+        }
+        0
+    }
+
+    fn scores_present(value: &Value) -> bool {
+        for key in ["results", "similar", "nodes"] {
+            if let Some(arr) = value.get(key).and_then(Value::as_array) {
+                return arr
+                    .iter()
+                    .all(|r| r.get("score").is_some() || r.get("similarity_score").is_some());
+            }
+        }
+        false
+    }
+
+    // ---- Sweep coverage: budgetable set matches dispatch -------------------
+
+    #[test]
+    fn budgetable_set_is_nonempty_and_classified_read() {
+        // Every budgetable tool must be a classified Read tool (RBAC lockstep).
+        for tool in super::super::server::BUDGETABLE_READ_TOOLS {
+            assert!(
+                super::super::server::is_budgetable_read_tool(tool),
+                "{tool} should be recognized as budgetable"
+            );
+        }
+    }
+}

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -13346,8 +13346,11 @@ mod budget_tests {
         let all_ids = seed_many(&server, "Person", 30);
 
         // Full, unbudgeted page (limit high enough to hold all).
-        let (full, _) =
-            dispatch_json(&server, "list_nodes", json!({ "label": "Person", "limit": 100 }));
+        let (full, _) = dispatch_json(
+            &server,
+            "list_nodes",
+            json!({ "label": "Person", "limit": 100 }),
+        );
         let full_ids = collect_node_ids(&full);
         assert_eq!(full_ids.len(), all_ids.len(), "seeded set fully listed");
 
@@ -13401,18 +13404,29 @@ mod budget_tests {
         sorted_union.sort_unstable();
         let before_dedup = sorted_union.len();
         sorted_union.dedup();
-        assert_eq!(before_dedup, sorted_union.len(), "no duplicate rows across pages");
+        assert_eq!(
+            before_dedup,
+            sorted_union.len(),
+            "no duplicate rows across pages"
+        );
 
         let mut expected = full_ids.clone();
         expected.sort_unstable();
-        assert_eq!(sorted_union, expected, "union of pages == full set (no gaps)");
+        assert_eq!(
+            sorted_union, expected,
+            "union of pages == full set (no gaps)"
+        );
     }
 
     fn collect_node_ids(value: &Value) -> Vec<u64> {
         value
             .get("nodes")
             .and_then(Value::as_array)
-            .map(|a| a.iter().filter_map(|n| n.get("id").and_then(Value::as_u64)).collect())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|n| n.get("id").and_then(Value::as_u64))
+                    .collect()
+            })
             .unwrap_or_default()
     }
 
@@ -13448,7 +13462,11 @@ mod budget_tests {
             !is_error,
             "tight-but-viable budget must succeed, not error: {value}"
         );
-        assert!(value.len() <= cap, "assembled response must fit: {}", value.len());
+        assert!(
+            value.len() <= cap,
+            "assembled response must fit: {}",
+            value.len()
+        );
         let parsed: Value = serde_json::from_str(&value).unwrap();
         assert_eq!(parsed["budget"]["rung"], json!("counts_and_handles"));
     }
@@ -13724,7 +13742,10 @@ mod budget_tests {
 
         let (full, _) = dispatch_json(&server, "find_similar", q.clone());
         let full_seq = ordered_id_score(&full);
-        assert!(!full_seq.is_empty(), "unbudgeted find_similar returned results");
+        assert!(
+            !full_seq.is_empty(),
+            "unbudgeted find_similar returned results"
+        );
 
         let mut args = q;
         args.as_object_mut()


### PR DESCRIPTION
## Before

MCP read tools sized their responses by *row count* (`limit`), not by *cost*. A `limit: 50` traversal could return 500 tokens or 50,000 depending on the property payloads, and the caller had no way to know in advance. Integrators either set timid limits (starving the model of context) or blew the budget (evicting the agent's own reasoning). Vector elision (#3220) fixed the single worst offender, but general property payloads, deep traversals, and history responses remained unbounded in token cost.

## After

Every MCP read tool — `get_node`, `list_nodes`, `get_edge`, `list_edges`, `get_outgoing_edges`, `get_incoming_edges`, `traverse`, `find_similar`, `hybrid_query`, `query`, `find_nodes_at_time`, `get_node_history`, `get_schema` — now accepts an optional `max_response_tokens` (estimated as `ceil(utf8_bytes / 4)`) or a byte-exact `max_response_bytes`. The serialized response, *including its own truncation metadata*, is guaranteed not to exceed the stated budget.

Over budget, the response degrades along a deterministic, disclosed ladder:

1. `full` — nothing reduced.
2. `elided_properties` — bulky, unprotected property values become `{ elided: true, ... }` descriptors (reusing the #3220 convention).
3. `entity_summaries` — properties reduced to protected keys only; ids, labels, relationships, temporal coordinates, provenance and similarity scores always survive (they live beside `properties`, never inside it).
4. `counts_and_handles` — entity arrays truncated to the prefix that fits.

Every response carries a `budget` block naming the rung applied per section, and every elision/truncation site carries a **fetch handle** — a concrete follow-up call (`get_node`/`get_edge` with `include_vectors: true`, or `offset`/`next_offset` paging per #3226) — so nothing is lost: an agent that follows the handles reconstructs the full, unbudgeted response. `priority_properties` protects named properties at every rung. `find_similar`/`hybrid_query` never drop or reorder ranked results to meet a budget (only per-result payloads degrade), and temporal responses never omit temporal coordinates. A budget too small for even the minimal rung returns a structured #3234 `INVALID_ARGUMENT` stating the minimum viable budget — never a silently empty success. Omitting the parameters reproduces prior behavior exactly.

## How

The feature is a **dispatch-level response-shaping layer** (`src/mcp/budget.rs`). `dispatch_tool` parses the optional budget parameters from the raw arguments for the budgetable read tools, runs the existing handler, then shapes the successful JSON payload to fit — re-serializing through the same `success_json` path so the measured byte length is exactly what is emitted on the wire. The shaper is tool-shape-agnostic: it treats any JSON object carrying a `properties` map as an "entity" and walks the whole tree, so it covers every wrapper (bare nodes/edges, `traverse` results, `query` rows, history versions) uniformly. Fit is guaranteed by escalating rungs and measuring the pretty-serialized bytes (including the budget metadata) at each step; when even the minimal rung overflows, it returns the too-small-budget error with the empirically-measured minimum.

This approach avoids touching any request struct (a struct field would have broken 219 construction sites, several outside the MCP lane, e.g. `QueryRequest` in the HTTP and sharding layers). Budgetable tools advertise the parameters via a uniform description suffix kept in lockstep with `BUDGETABLE_READ_TOOLS`, the single dispatch-path source of truth. No new tools, so the RBAC access-control classification is unchanged.

Adds 11 tests, including a 256..32K-token conformance sweep across every budgetable tool asserting **zero overruns**, plus fetch-handle round-trip, priority-property protection, ranked-result preservation, and too-small-budget error tests.

Docs updated: `CLAUDE.md` MCP section and a new "Token-budget-aware responses" section in `docs/guides/mcp-query-tool.md`.

## Out of scope (per the issue)

Cursor/streaming continuation (#3360), write/admin tools, server-side per-client budget policies, and HTTP API budget negotiation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVJ7DDzHEiZrmd3oDcgjvT)_