### PR TITLE
Add per-query resource limits to HTTP /query surface (#3368)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -455,6 +455,13 @@ harness = false
 path = "benches/uniqueness_constraints.rs"
 required-features = []
 
+# Per-query resource limits on the HTTP /query surface (Issue #3368)
+[[bench]]
+name = "http_query_limits"
+harness = false
+path = "benches/http_query_limits.rs"
+required-features = ["http-server"]
+
 # Unified CLI binary for local operations + daemon management
 [[bin]]
 name = "aletheia"

--- a/benches/http_query_limits.rs
+++ b/benches/http_query_limits.rs
@@ -1,0 +1,142 @@
+//! Benchmarks for per-query resource-limit enforcement on the HTTP `/query`
+//! surface (Issue #3368, review P5 / AC "fast queries are not taxed").
+//!
+//! Quantifies the enforcement overhead on the **under-limit** happy path, so a
+//! regression that makes ordinary reads pay a limit tax is visible:
+//!
+//! - `limit_resolution` — the per-request cost of folding server defaults +
+//!   override + ceilings into `EffectiveQueryLimits`, with limits enabled
+//!   (`QueryLimitsConfig::default`) vs disabled (`::disabled`).
+//! - `query_response_path` — the true end-to-end `/query` response path for a
+//!   representative under-limit read, enabled vs disabled, driven through the
+//!   real router (so the extra serialize-once + byte-cap check is included).
+//! - `envelope_vs_request_deser` — deserializing a representative bulk body
+//!   into the wrapping `QueryEnvelope` vs the bare `QueryRequest`, isolating
+//!   the cost the `#[serde(flatten)]` envelope adds to request parsing.
+//!
+//! Gated on `feature = "http-server"`. Build check:
+//! `cargo bench --features http-server --no-run`.
+
+#![cfg(feature = "http-server")]
+
+use std::sync::Arc;
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::auth::AuthMode;
+use aletheiadb::core::PropertyMapBuilder;
+use aletheiadb::http::handlers::{QueryEnvelope, QueryRequest};
+use aletheiadb::http::{AppState, QueryLimitsConfig, ServerConfig, build_test_router};
+use autumn_web::test::{TestApp, TestClient};
+use criterion::{Criterion, criterion_group, criterion_main};
+use serde_json::{Value, json};
+use std::hint::black_box;
+
+/// Build an anonymous-mode `/query` client with the given limits, seeded with
+/// `n` `Person` nodes so an under-limit read returns a representative payload.
+fn client_with_limits(limits: QueryLimitsConfig, n: usize) -> TestClient {
+    let db = Arc::new(AletheiaDB::new().expect("create DB"));
+    for i in 0..n {
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("idx", i as i64).build(),
+        )
+        .expect("seed node");
+    }
+    let state = AppState::new(db);
+    let config = ServerConfig::builder()
+        .auth_mode(AuthMode::Anonymous)
+        .query_limits(limits)
+        .build();
+    let router = build_test_router(state, &config).expect("build router");
+    TestApp::from_router(router)
+}
+
+/// A representative bulk request body used to compare envelope vs bare-request
+/// deserialization cost.
+fn bulk_body(n: usize) -> Value {
+    let nodes: Vec<Value> = (0..n)
+        .map(|i| json!({ "label": "Person", "properties": { "idx": i } }))
+        .collect();
+    json!({ "operation": "bulk_create_nodes", "nodes": nodes })
+}
+
+fn bench_limit_resolution(c: &mut Criterion) {
+    let enabled = QueryLimitsConfig::default();
+    let disabled = QueryLimitsConfig::disabled();
+
+    let mut group = c.benchmark_group("limit_resolution");
+    group.bench_function("enabled_default", |b| {
+        b.iter(|| black_box(enabled.effective(black_box(None)).unwrap()));
+    });
+    group.bench_function("disabled", |b| {
+        b.iter(|| black_box(disabled.effective(black_box(None)).unwrap()));
+    });
+    group.finish();
+}
+
+fn bench_query_response_path(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    // An under-limit read: 20 rows, well below the generous defaults.
+    let enabled_client = client_with_limits(QueryLimitsConfig::default(), 20);
+    let disabled_client = client_with_limits(QueryLimitsConfig::disabled(), 20);
+    let body = json!({ "operation": "find_node", "label": "Person" });
+
+    async fn run(client: &TestClient, body: &Value) -> u16 {
+        client
+            .post("/query")
+            .json(body)
+            .send()
+            .await
+            .status
+            .as_u16()
+    }
+
+    let mut group = c.benchmark_group("query_response_path");
+    group.bench_function("enabled_default", |b| {
+        b.iter(|| {
+            let status = rt.block_on(run(&enabled_client, &body));
+            assert_eq!(status, 200);
+        });
+    });
+    group.bench_function("disabled", |b| {
+        b.iter(|| {
+            let status = rt.block_on(run(&disabled_client, &body));
+            assert_eq!(status, 200);
+        });
+    });
+    group.finish();
+}
+
+fn bench_envelope_vs_request_deser(c: &mut Criterion) {
+    let body = bulk_body(50);
+    let bytes = serde_json::to_vec(&body).expect("serialize body");
+
+    let mut group = c.benchmark_group("envelope_vs_request_deser");
+    group.bench_function("query_envelope", |b| {
+        b.iter(|| {
+            let env: QueryEnvelope =
+                serde_json::from_slice(black_box(&bytes)).expect("deserialize envelope");
+            black_box(env);
+        });
+    });
+    group.bench_function("bare_request", |b| {
+        b.iter(|| {
+            let req: QueryRequest =
+                serde_json::from_slice(black_box(&bytes)).expect("deserialize request");
+            black_box(req);
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_limit_resolution,
+    bench_query_response_path,
+    bench_envelope_vs_request_deser
+);
+criterion_main!(benches);

--- a/docs/guides/access-control-matrix.md
+++ b/docs/guides/access-control-matrix.md
@@ -39,6 +39,20 @@ Defined by `Role::allows(AccessClass)` in `src/auth/role.rs`.
 Both codes are additive to the #3234 enum and are never retriable: obtain a
 valid credential / a sufficient role, then re-issue.
 
+- **Resource limit exceeded** (per-query limits, HTTP `/query`, Issue #3368):
+  authentication and authorization run **first**, so these are only reachable
+  by an already-authorized caller.
+  - HTTP `429`, `code:"RESOURCE_EXHAUSTED"`, `retriable:true`,
+    `details:{dimension:"wall_clock_timeout", limit_ms}` — wall-clock timeout.
+  - HTTP `413`, `code:"RESOURCE_EXHAUSTED"`, `retriable:false`,
+    `details:{dimension:"result_rows"|"result_bytes", limit, consumed}` — result
+    too large (row `Reject` policy / byte cap).
+  - HTTP `422`, `code:"INVALID_ARGUMENT"`, `retriable:false`,
+    `details:{dimension, requested, ceiling}` — a per-call `limits` override
+    exceeded the operator ceiling.
+  - See [HTTP Per-Query Resource Limits](http-query-limits.md) for the full
+    contract. (MCP parity is deferred to the MCP lane.)
+
 ## MCP tools
 
 The MCP transport is stdio, so the credential is session-scoped (supplied at

--- a/docs/guides/http-query-limits.md
+++ b/docs/guides/http-query-limits.md
@@ -16,9 +16,34 @@ and an **operator hard ceiling**.
 
 | Dimension | What it bounds | Over-limit result |
 |-----------|----------------|-------------------|
-| **Wall-clock timeout** | How long the handler waits for the query before returning to the client | `429 RESOURCE_EXHAUSTED`, `retriable: true` |
-| **Result-row cap** | Number of rows/entities in the result | `Truncate` → `200` + `truncated: true`; `Reject` → `413 RESOURCE_EXHAUSTED` |
-| **Result-byte cap** | Serialized byte size of the result | `413 RESOURCE_EXHAUSTED`, `retriable: false` |
+| **Wall-clock timeout** | How long the handler waits for the query before returning to the client | `429 RESOURCE_EXHAUSTED` + `Retry-After: 1`; `retriable: true` for reads, `retriable: false` for writes |
+| **Result-row cap** | Number of rows/entities in the result (**reads only**) | `Truncate` → `200` + `truncated: true`; `Reject` → `413 RESOURCE_EXHAUSTED` |
+| **Result-byte cap** | Serialized byte size of the response envelope (**reads only**) | `413 RESOURCE_EXHAUSTED`, `retriable: false` |
+
+### Write operations are exempt from the result caps
+
+The **result-row cap** and **result-byte cap** apply to **read-class**
+operations only. A write (`create_node`, `bulk_create_nodes`,
+`bulk_update_nodes`, `bulk_delete_nodes`, and mutating `execute_query` /
+`bulk_execute_query` statements) has already committed by the time its
+acknowledgement is shaped, so truncating or `413`-ing that acknowledgement would
+misrepresent durability — the write took effect but the caller would read a
+failure. Writes therefore always return their full acknowledgement (ids /
+version ids), never flagged `truncated` and never `413`'d for size.
+
+The **wall-clock timeout still applies to writes** (it bounds the client's
+wait), but a write timeout is reported **`retriable: false`**. The synchronous
+write may already have committed on the blocking pool even though the client's
+response deadline elapsed; a naive retry would duplicate it. A read timeout, by
+contrast, is `retriable: true` — re-running a read is safe. In both cases the
+`429` carries a `Retry-After: 1` header; for the write case the flag tells a
+disciplined client to reconcile (re-read) rather than blindly retry.
+
+The byte cap is measured on the **fully-serialized response envelope** (the
+`{success, data, truncated?}` wire body), not the inner `data`, so
+`details.consumed` reports the real number of bytes that would have gone on the
+wire. The response is serialized exactly once — there is no double-serialization
+tax on the happy path.
 
 ### Wall-clock timeout — what it does and does not do
 
@@ -31,6 +56,12 @@ engine-level cancellation is tracked in the query-executor lane. In practice the
 HTTP timeout protects the client and the connection; pair it with the
 request-body-size limit (below) and a reverse-proxy connection cap for
 end-to-end protection.
+
+Every timeout `429` carries a `Retry-After: 1` header (a conservative one-second
+back-off hint). For a **read** the timeout is `retriable: true` and a client may
+back off and retry directly. For a **write** it is `retriable: false` (the write
+may already have committed — see [above](#write-operations-are-exempt-from-the-result-caps));
+a client should reconcile by re-reading rather than blindly re-issuing the write.
 
 ## Configuration
 
@@ -75,6 +106,17 @@ trusted embedded deployments and tests.
 | `max_response_bytes` | Ceiling for a per-call byte override | no ceiling |
 | `row_overflow` | `Truncate` (cap + flag) or `Reject` (413) when the row cap is hit | — |
 
+> ⚠️ **`ceiling == 0` footgun.** A ceiling of `0` means **"no ceiling"**, not
+> "zero". With a ceiling of `0`, a per-call override may set that dimension to
+> **any** value — including `0` (unlimited) — overriding whatever finite default
+> you configured. For example, `default_timeout_ms: 30_000` with
+> `max_timeout_ms: 0` lets any caller send `"limits": {"timeout_ms": 0}` and run
+> with **no** timeout at all. If you rely on a finite default as a real bound,
+> set an explicit **non-zero** ceiling for that dimension so over-ceiling and
+> unlimited (`0`) overrides are rejected `422`. Leave a ceiling at `0` only for
+> dimensions you deliberately allow callers to uncap. `QueryLimitsConfig::default()`
+> ships finite ceilings on every dimension for exactly this reason.
+
 ## Per-call overrides
 
 A request may carry an optional `limits` object. Every field is optional and
@@ -113,6 +155,10 @@ All limit errors keep the existing `{success:false, error:"…"}` body and add t
 `#3234` contract). Existing non-limit error bodies are unchanged.
 
 ### `429` — wall-clock timeout
+
+Carries a `Retry-After: 1` response header. `retriable` is `true` for a read
+timeout and `false` for a write timeout (a committed write must not be
+duplicated — see [Write operations are exempt](#write-operations-are-exempt-from-the-result-caps)).
 
 ```json
 {
@@ -189,9 +235,9 @@ Honest breakdown of #3368 across lanes:
 
 | Dimension | Default | Per-call override | Operator ceiling | Status |
 |-----------|:-------:|:-----------------:|:----------------:|--------|
-| Wall-clock timeout (HTTP response deadline) | ✅ | ✅ | ✅ | **Covered (this lane)** |
-| Result-row cap | ✅ | ✅ | ✅ | **Covered (this lane)** |
-| Result-byte cap | ✅ | ✅ | ✅ | **Covered (this lane)** |
+| Wall-clock timeout (HTTP response deadline) | ✅ | ✅ | ✅ | **Covered (this lane)** — all ops; write timeout `retriable: false` |
+| Result-row cap | ✅ | ✅ | ✅ | **Covered (this lane)** — reads only (writes exempt) |
+| Result-byte cap (measured on the response envelope) | ✅ | ✅ | ✅ | **Covered (this lane)** — reads only (writes exempt) |
 | Request body-size (input memory) | ✅ | n/a | ✅ | Covered previously (#3424) |
 | Engine-level cancellation of in-flight CPU work | — | — | — | **Deferred** → query-executor lane |
 | Query **memory budget** | — | — | — | **Deferred** → query-executor lane |
@@ -207,9 +253,18 @@ The HTTP timeout is a response-deadline bound, not a compute bound — see
   (all branches), the `disabled()` escape hatch, and dimension tokens.
 - `src/http/error.rs` — unit tests for the `429`/`413`/`422` status +
   `{code, retriable, details}` body mapping.
-- `src/http/handlers.rs` — unit tests for the enforcement helper: deterministic
-  timeout (a sleeping future), row truncate/reject, byte cap, and the
-  `QueryEnvelope` flatten (operation + optional `limits`).
+- `src/http/handlers.rs` — unit tests for the enforcement helper (deterministic
+  timeout under paused tokio time; read timeout `retriable: true` vs write
+  timeout `retriable: false`; row truncate/reject; write exemption from the row
+  cap; the envelope-serialization byte-cap step; and the `QueryEnvelope` flatten
+  of operation + optional `limits`).
+- `src/http/error.rs` — includes `write_timeout_maps_to_429_not_retriable` and
+  the `Retry-After` header on the timeout `429`.
 - `tests/http_query_limits.rs` — end-to-end integration: row cap
   truncate/reject, byte cap, override within/above ceiling, disabled config,
-  concurrency isolation, and auth-before-limits ordering.
+  `"limits": null` and malformed-limits handling, write-op exemption (with
+  persistence assertions), concurrency isolation across distinct per-call
+  overrides, and auth-before-limits ordering (401/403 precede 413/422).
+- `benches/http_query_limits.rs` — criterion benchmark of the under-limit
+  enforcement overhead (limit resolution, end-to-end response path, and
+  envelope-vs-request deserialization), enabled vs disabled.

--- a/docs/guides/http-query-limits.md
+++ b/docs/guides/http-query-limits.md
@@ -1,0 +1,215 @@
+# HTTP Per-Query Resource Limits (Issue #3368)
+
+The HTTP `/query` surface enforces per-query resource limits so a single
+request can neither hold a connection open indefinitely nor force the server to
+materialize an unbounded response. Three dimensions are enforceable at the HTTP
+layer, each with a **server-level default**, an optional **per-call override**,
+and an **operator hard ceiling**.
+
+> Scope note. This guide documents the **HTTP lane** of #3368. Engine-level
+> cancellation of in-flight CPU work and a query **memory budget** are separate
+> dimensions owned by the query-executor lane; the MCP surface is a separate
+> lane. See the [coverage matrix](#coverage-matrix) below for an honest
+> breakdown of what is and is not covered here.
+
+## The three dimensions
+
+| Dimension | What it bounds | Over-limit result |
+|-----------|----------------|-------------------|
+| **Wall-clock timeout** | How long the handler waits for the query before returning to the client | `429 RESOURCE_EXHAUSTED`, `retriable: true` |
+| **Result-row cap** | Number of rows/entities in the result | `Truncate` → `200` + `truncated: true`; `Reject` → `413 RESOURCE_EXHAUSTED` |
+| **Result-byte cap** | Serialized byte size of the result | `413 RESOURCE_EXHAUSTED`, `retriable: false` |
+
+### Wall-clock timeout — what it does and does not do
+
+The timeout wraps query execution in `tokio::time::timeout`. It bounds the HTTP
+**response deadline**: once the budget elapses the client promptly receives a
+structured `429`. It does **not** cancel the underlying computation — AletheiaDB
+runs synchronous query work on a blocking thread pool, and that work may run to
+completion in the background even after the client has been answered. True
+engine-level cancellation is tracked in the query-executor lane. In practice the
+HTTP timeout protects the client and the connection; pair it with the
+request-body-size limit (below) and a reverse-proxy connection cap for
+end-to-end protection.
+
+## Configuration
+
+Limits are configured through `ServerConfig::builder().query_limits(...)` with a
+`QueryLimitsConfig`:
+
+```rust
+use aletheiadb::http::{QueryLimitsConfig, RowOverflowPolicy, ServerConfig};
+
+let config = ServerConfig::builder()
+    .query_limits(QueryLimitsConfig {
+        enabled: true,
+        // Wall-clock timeout: default 30s, ceiling 5min.
+        default_timeout_ms: 30_000,
+        max_timeout_ms: 300_000,
+        // Result rows: default 10k, ceiling 100k.
+        default_max_result_rows: 10_000,
+        max_result_rows: 100_000,
+        // Response bytes: default 8 MiB, ceiling 64 MiB.
+        default_max_response_bytes: 8 * 1024 * 1024,
+        max_response_bytes: 64 * 1024 * 1024,
+        row_overflow: RowOverflowPolicy::Truncate,
+    })
+    .build();
+```
+
+`QueryLimitsConfig::default()` is the above (enabled, generous — chosen so no
+pre-#3368 request behavior changes). `QueryLimitsConfig::disabled()` turns off
+all enforcement (unlimited on every dimension, per-call overrides ignored) for
+trusted embedded deployments and tests.
+
+### Field reference
+
+| Field | Meaning | `0` means |
+|-------|---------|-----------|
+| `enabled` | Master switch; `false` ⇒ no enforcement | — |
+| `default_timeout_ms` | Applied when the request supplies no `timeout_ms` | unlimited |
+| `max_timeout_ms` | Ceiling for a per-call `timeout_ms` | no ceiling |
+| `default_max_result_rows` | Applied when no `max_result_rows` override | unlimited |
+| `max_result_rows` | Ceiling for a per-call row override | no ceiling |
+| `default_max_response_bytes` | Applied when no `max_response_bytes` override | unlimited |
+| `max_response_bytes` | Ceiling for a per-call byte override | no ceiling |
+| `row_overflow` | `Truncate` (cap + flag) or `Reject` (413) when the row cap is hit | — |
+
+## Per-call overrides
+
+A request may carry an optional `limits` object. Every field is optional and
+additive — a body with no `limits` key parses and behaves exactly as before:
+
+```json
+{
+  "operation": "find_node",
+  "label": "Person",
+  "limits": {
+    "timeout_ms": 5000,
+    "max_result_rows": 50,
+    "max_response_bytes": 262144
+  }
+}
+```
+
+Merge semantics (the effective limit for each dimension):
+
+- **Override present, within ceiling** → the override wins. It may be *smaller*
+  than the server default (a caller self-limiting tighter is always allowed).
+- **Override present, above the ceiling** (or requesting unlimited `0` under a
+  finite ceiling) → **rejected** `422 INVALID_ARGUMENT` before any DB work. An
+  explicit over-ceiling request is never silently clamped.
+- **Override absent** → the server default, silently clamped down to the ceiling
+  if the default itself is unlimited or above the ceiling.
+
+The merge is a single tested function
+(`QueryLimitsConfig::effective`), covered per-branch by unit tests in
+`src/http/config.rs`.
+
+## Error contract
+
+All limit errors keep the existing `{success:false, error:"…"}` body and add the
+`code` / `retriable` / `details` fields (aligning the HTTP surface toward the MCP
+`#3234` contract). Existing non-limit error bodies are unchanged.
+
+### `429` — wall-clock timeout
+
+```json
+{
+  "success": false,
+  "error": "query exceeded the wall-clock timeout of 30000 ms",
+  "code": "RESOURCE_EXHAUSTED",
+  "retriable": true,
+  "details": { "dimension": "wall_clock_timeout", "limit_ms": 30000 }
+}
+```
+
+### `413` — result too large (row `Reject` policy, or byte cap)
+
+```json
+{
+  "success": false,
+  "error": "query response exceeded the byte limit of 1048576 (serialized 2400512)",
+  "code": "RESOURCE_EXHAUSTED",
+  "retriable": false,
+  "details": { "dimension": "result_bytes", "limit": 1048576, "consumed": 2400512 }
+}
+```
+
+For the row-cap `Reject` policy, `details.dimension` is `"result_rows"` and
+`details` carries `limit` + `consumed` (the row count produced).
+
+### `200` — result truncated (row `Truncate` policy, the default)
+
+```json
+{
+  "success": true,
+  "data": [ /* first max_result_rows rows */ ],
+  "truncated": true
+}
+```
+
+`truncated` is present and `true` only when rows were actually dropped; it is
+omitted otherwise, so responses that fit under the cap are byte-identical to
+pre-#3368 responses.
+
+### `422` — per-call override exceeds the ceiling
+
+```json
+{
+  "success": false,
+  "error": "limit override for 'result_rows' (1000) exceeds the maximum allowed (100)",
+  "code": "INVALID_ARGUMENT",
+  "retriable": false,
+  "details": { "dimension": "result_rows", "requested": 1000, "ceiling": 100 }
+}
+```
+
+### Ordering: authentication first
+
+Authentication and authorization run **before** any limit logic. An
+unauthenticated request that also breaches a limit gets `401 UNAUTHENTICATED`
+(never a `422`/`413`), and an authenticated-but-unauthorized request gets
+`403 PERMISSION_DENIED`. Limits are then evaluated identically in anonymous and
+required-auth modes.
+
+## Related HTTP-layer guard: request body size
+
+The already-merged request **body-size** limit (#3424,
+`DefaultBodyLimit` / `ServerConfig::max_request_body_bytes`, default 2 MiB) is
+the HTTP-layer *input* memory guard: it rejects an oversized request body with
+`413` before it is buffered or deserialized. That bounds the memory a single
+*request* can force the server to allocate; the per-query limits here bound the
+*response* and the *time*. Together they cover the HTTP layer's input/output/time
+axes.
+
+## Coverage matrix
+
+Honest breakdown of #3368 across lanes:
+
+| Dimension | Default | Per-call override | Operator ceiling | Status |
+|-----------|:-------:|:-----------------:|:----------------:|--------|
+| Wall-clock timeout (HTTP response deadline) | ✅ | ✅ | ✅ | **Covered (this lane)** |
+| Result-row cap | ✅ | ✅ | ✅ | **Covered (this lane)** |
+| Result-byte cap | ✅ | ✅ | ✅ | **Covered (this lane)** |
+| Request body-size (input memory) | ✅ | n/a | ✅ | Covered previously (#3424) |
+| Engine-level cancellation of in-flight CPU work | — | — | — | **Deferred** → query-executor lane |
+| Query **memory budget** | — | — | — | **Deferred** → query-executor lane |
+| Same limits on the **MCP** surface | — | — | — | **Deferred** → MCP lane |
+| Rust-API builder ergonomics for limits | partial | — | — | Config type is public; a fluent builder is a follow-up |
+
+The HTTP timeout is a response-deadline bound, not a compute bound — see
+[the timeout note](#wall-clock-timeout--what-it-does-and-does-not-do).
+
+## Tests
+
+- `src/http/config.rs` — unit tests for the default/override/ceiling merge
+  (all branches), the `disabled()` escape hatch, and dimension tokens.
+- `src/http/error.rs` — unit tests for the `429`/`413`/`422` status +
+  `{code, retriable, details}` body mapping.
+- `src/http/handlers.rs` — unit tests for the enforcement helper: deterministic
+  timeout (a sleeping future), row truncate/reject, byte cap, and the
+  `QueryEnvelope` flatten (operation + optional `limits`).
+- `tests/http_query_limits.rs` — end-to-end integration: row cap
+  truncate/reject, byte cap, override within/above ceiling, disabled config,
+  concurrency isolation, and auth-before-limits ordering.

--- a/docs/guides/http-state-management.md
+++ b/docs/guides/http-state-management.md
@@ -46,17 +46,26 @@ This pattern is proven in production use.
 ```rust
 pub struct AppState {
     db: Arc<AletheiaDB>,
+    query_limits: Arc<QueryLimitsConfig>, // Issue #3368
 }
 
 impl AppState {
-    pub fn new(db: Arc<AletheiaDB>) -> Self { Self { db } }
+    pub fn new(db: Arc<AletheiaDB>) -> Self { /* default query limits */ }
+    pub fn with_query_limits(self, limits: QueryLimitsConfig) -> Self { /* ... */ }
     pub fn db(&self) -> &AletheiaDB { &self.db }
     pub fn db_arc(&self) -> Arc<AletheiaDB> { self.db.clone() }
+    pub fn query_limits(&self) -> &QueryLimitsConfig { &self.query_limits }
 }
 ```
 
 `AppState: Clone` — a cheap `Arc` bump. It is installed once per process and
-read on every request.
+read on every request. Alongside the database it carries the per-query
+resource-limit configuration (wall-clock timeout, result-row cap, result-byte
+cap), delivered from `ServerConfig::query_limits()` when the router is wired —
+exactly as the request-body-size limit is delivered into the layer stack. The
+`/query` handler reads it via `state.query_limits()`. See
+[HTTP Per-Query Resource Limits](http-query-limits.md) for the full contract,
+the per-call override shape, and the `429`/`413`/`422` error responses.
 
 ## Wiring
 

--- a/src/http/config.rs
+++ b/src/http/config.rs
@@ -17,6 +17,301 @@
 pub const DEFAULT_MAX_REQUEST_BODY_BYTES: usize = 2 * 1024 * 1024;
 
 use crate::auth::{AuthMode, SecretString};
+use serde::Deserialize;
+
+// ============================================================================
+// Per-query resource limits (Issue #3368)
+// ============================================================================
+
+/// Default per-query wall-clock timeout, in milliseconds (30 s).
+///
+/// Bounds how long the HTTP `/query` handler waits for the underlying
+/// computation before returning a prompt `429` to the client. See
+/// [`QueryLimitsConfig`].
+pub const DEFAULT_QUERY_TIMEOUT_MS: u64 = 30_000;
+
+/// Operator hard ceiling for a per-call timeout override, in milliseconds
+/// (5 min). A per-call `timeout_ms` above this is rejected with `422`.
+pub const DEFAULT_MAX_QUERY_TIMEOUT_MS: u64 = 300_000;
+
+/// Default cap on the number of rows/entities returned by a single query.
+///
+/// Deliberately aligned with the pre-existing hardcoded result caps in the
+/// `/query` handlers (e.g. `MAX_EXEC_RESULTS`) so enabling limits by default
+/// changes no existing behavior.
+pub const DEFAULT_MAX_RESULT_ROWS: usize = 10_000;
+
+/// Operator hard ceiling for a per-call `max_result_rows` override.
+pub const DEFAULT_MAX_RESULT_ROWS_CEILING: usize = 100_000;
+
+/// Default cap on the serialized response size of a single query, in bytes
+/// (8 MiB). Generous: bounds pathological large responses without affecting
+/// ordinary reads.
+pub const DEFAULT_MAX_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+/// Operator hard ceiling for a per-call `max_response_bytes` override (64 MiB).
+pub const DEFAULT_MAX_RESPONSE_BYTES_CEILING: usize = 64 * 1024 * 1024;
+
+/// Which per-query resource-limit dimension a value applies to (Issue #3368).
+///
+/// The [`as_str`](Self::as_str) token is the stable `details.dimension` value
+/// in the structured error body, so callers can branch on it without string
+/// matching the human message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LimitDimension {
+    /// The wall-clock time budget for producing the HTTP response.
+    WallClockTimeout,
+    /// The number of rows/entities in the result.
+    ResultRows,
+    /// The serialized byte size of the result.
+    ResultBytes,
+}
+
+impl LimitDimension {
+    /// Stable snake_case token used in `error.details.dimension`.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::WallClockTimeout => "wall_clock_timeout",
+            Self::ResultRows => "result_rows",
+            Self::ResultBytes => "result_bytes",
+        }
+    }
+}
+
+/// Behavior when a result exceeds the effective row cap (Issue #3368).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RowOverflowPolicy {
+    /// Return the first `max_result_rows` rows and flag the response
+    /// `truncated: true`. Safe default for list-like reads.
+    #[default]
+    Truncate,
+    /// Reject the whole response with a structured `413` error.
+    Reject,
+}
+
+/// Per-call limit override carried on a `/query` request under `"limits"`.
+///
+/// Every field is optional and additive (`#[serde(default)]`), so existing
+/// request bodies that omit `"limits"` parse and behave exactly as before.
+/// An override present but *larger* than the operator ceiling is rejected
+/// (`422`); an override *smaller* than the server default is honored (a caller
+/// self-limiting tighter). A value of `0` means "unlimited" for that dimension
+/// and is only accepted when the operator ceiling is itself unbounded.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+pub struct QueryLimitsOverride {
+    /// Per-call wall-clock timeout in milliseconds (`0` = unlimited).
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+    /// Per-call maximum result rows (`0` = unlimited).
+    #[serde(default)]
+    pub max_result_rows: Option<usize>,
+    /// Per-call maximum serialized response bytes (`0` = unlimited).
+    #[serde(default)]
+    pub max_response_bytes: Option<usize>,
+}
+
+impl QueryLimitsOverride {
+    /// True when no override fields are set (equivalent to no `"limits"` key).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.timeout_ms.is_none()
+            && self.max_result_rows.is_none()
+            && self.max_response_bytes.is_none()
+    }
+}
+
+/// A per-call override that exceeded the operator hard ceiling (Issue #3368).
+///
+/// Maps to `422 INVALID_ARGUMENT` with
+/// `details: {dimension, requested, ceiling}`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LimitOverrideError {
+    /// The dimension whose override was rejected.
+    pub dimension: LimitDimension,
+    /// The value the caller requested.
+    pub requested: u64,
+    /// The operator ceiling it exceeded.
+    pub ceiling: u64,
+}
+
+/// The concrete limits in force for a single query, after folding the
+/// server defaults, the per-call override, and the operator ceilings
+/// (Issue #3368). A value of `0` on any dimension means "unlimited".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EffectiveQueryLimits {
+    /// Wall-clock timeout in milliseconds (`0` = unlimited).
+    pub timeout_ms: u64,
+    /// Maximum result rows (`0` = unlimited).
+    pub max_result_rows: usize,
+    /// Maximum serialized response bytes (`0` = unlimited).
+    pub max_response_bytes: usize,
+    /// What to do when the row cap is exceeded.
+    pub row_overflow: RowOverflowPolicy,
+}
+
+impl EffectiveQueryLimits {
+    /// No enforcement on any dimension.
+    #[must_use]
+    pub fn unlimited() -> Self {
+        Self {
+            timeout_ms: 0,
+            max_result_rows: 0,
+            max_response_bytes: 0,
+            row_overflow: RowOverflowPolicy::Truncate,
+        }
+    }
+}
+
+/// Fold one dimension's server default, operator ceiling, and per-call
+/// override into a single effective value.
+///
+/// Semantics (all in the dimension's native unit; `0` = unlimited, a ceiling
+/// of `0` = no ceiling):
+///
+/// - **Override present**: rejected when a ceiling exists and the override
+///   either requests unlimited (`0`) or exceeds the ceiling; otherwise the
+///   override wins (it may be *below* the default — a tighter self-limit).
+/// - **Override absent**: the server default, silently clamped down to the
+///   ceiling if the default is unlimited or above it.
+fn merge_dimension(
+    default_v: u64,
+    ceiling: u64,
+    override_v: Option<u64>,
+    dimension: LimitDimension,
+) -> Result<u64, LimitOverrideError> {
+    match override_v {
+        Some(requested) => {
+            if ceiling != 0 && (requested == 0 || requested > ceiling) {
+                return Err(LimitOverrideError {
+                    dimension,
+                    requested,
+                    ceiling,
+                });
+            }
+            Ok(requested)
+        }
+        None => {
+            let mut effective = default_v;
+            if ceiling != 0 && (effective == 0 || effective > ceiling) {
+                effective = ceiling;
+            }
+            Ok(effective)
+        }
+    }
+}
+
+/// Server-level configuration for per-query resource limits (Issue #3368).
+///
+/// Each dimension has a **default** (applied when the request supplies no
+/// override), a **ceiling** (the largest value a per-call override may
+/// request; `0` = no ceiling), and — for rows — an overflow **policy**. A
+/// value of `0` on a default/override means "unlimited" for that dimension.
+///
+/// The master [`enabled`](Self::enabled) switch disables all enforcement when
+/// `false` (see [`disabled`](Self::disabled)): the effective limits are then
+/// unconditionally unlimited and per-call overrides are ignored.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryLimitsConfig {
+    /// Master switch. When `false`, no limit is enforced.
+    pub enabled: bool,
+    /// Default wall-clock timeout in milliseconds (`0` = unlimited).
+    pub default_timeout_ms: u64,
+    /// Operator ceiling for a per-call timeout override (`0` = no ceiling).
+    pub max_timeout_ms: u64,
+    /// Default maximum result rows (`0` = unlimited).
+    pub default_max_result_rows: usize,
+    /// Operator ceiling for a per-call row override (`0` = no ceiling).
+    pub max_result_rows: usize,
+    /// Default maximum serialized response bytes (`0` = unlimited).
+    pub default_max_response_bytes: usize,
+    /// Operator ceiling for a per-call byte override (`0` = no ceiling).
+    pub max_response_bytes: usize,
+    /// What to do when a result exceeds the effective row cap.
+    pub row_overflow: RowOverflowPolicy,
+}
+
+impl QueryLimitsConfig {
+    /// A config that enforces nothing: every dimension unlimited, overrides
+    /// ignored. Useful for trusted embedded deployments and tests.
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            default_timeout_ms: 0,
+            max_timeout_ms: 0,
+            default_max_result_rows: 0,
+            max_result_rows: 0,
+            default_max_response_bytes: 0,
+            max_response_bytes: 0,
+            row_overflow: RowOverflowPolicy::Truncate,
+        }
+    }
+
+    /// Fold this config and an optional per-call override into the concrete
+    /// [`EffectiveQueryLimits`] for one query.
+    ///
+    /// Returns the effective limits, or a [`LimitOverrideError`] when a
+    /// supplied override exceeds an operator ceiling. When
+    /// [`enabled`](Self::enabled) is `false`, this always returns
+    /// [`EffectiveQueryLimits::unlimited`] and never errors (overrides are
+    /// ignored).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LimitOverrideError`] if `override_` requests a value above the
+    /// corresponding ceiling (or requests unlimited under a finite ceiling).
+    pub fn effective(
+        &self,
+        override_: Option<&QueryLimitsOverride>,
+    ) -> Result<EffectiveQueryLimits, LimitOverrideError> {
+        if !self.enabled {
+            return Ok(EffectiveQueryLimits::unlimited());
+        }
+        let ov = override_.filter(|o| !o.is_empty());
+        let timeout_ms = merge_dimension(
+            self.default_timeout_ms,
+            self.max_timeout_ms,
+            ov.and_then(|o| o.timeout_ms),
+            LimitDimension::WallClockTimeout,
+        )?;
+        let max_result_rows = merge_dimension(
+            self.default_max_result_rows as u64,
+            self.max_result_rows as u64,
+            ov.and_then(|o| o.max_result_rows).map(|v| v as u64),
+            LimitDimension::ResultRows,
+        )? as usize;
+        let max_response_bytes = merge_dimension(
+            self.default_max_response_bytes as u64,
+            self.max_response_bytes as u64,
+            ov.and_then(|o| o.max_response_bytes).map(|v| v as u64),
+            LimitDimension::ResultBytes,
+        )? as usize;
+        Ok(EffectiveQueryLimits {
+            timeout_ms,
+            max_result_rows,
+            max_response_bytes,
+            row_overflow: self.row_overflow,
+        })
+    }
+}
+
+impl Default for QueryLimitsConfig {
+    /// Enabled by default, but with generous limits chosen so no existing
+    /// request behavior changes (Issue #3368).
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            default_timeout_ms: DEFAULT_QUERY_TIMEOUT_MS,
+            max_timeout_ms: DEFAULT_MAX_QUERY_TIMEOUT_MS,
+            default_max_result_rows: DEFAULT_MAX_RESULT_ROWS,
+            max_result_rows: DEFAULT_MAX_RESULT_ROWS_CEILING,
+            default_max_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
+            max_response_bytes: DEFAULT_MAX_RESPONSE_BYTES_CEILING,
+            row_overflow: RowOverflowPolicy::Truncate,
+        }
+    }
+}
 
 /// CORS (Cross-Origin Resource Sharing) configuration.
 #[derive(Debug, Clone)]
@@ -196,6 +491,9 @@ pub struct ServerConfig {
     /// [`data_dir`](Self::data_dir) is set, defaults to
     /// `{data_dir}/auth/keys.json`.
     auth_persist_path: Option<std::path::PathBuf>,
+    /// Per-query resource limits (timeout / result rows / response bytes)
+    /// enforced by the `/query` handler (Issue #3368).
+    query_limits: QueryLimitsConfig,
 }
 
 impl ServerConfig {
@@ -215,6 +513,7 @@ impl ServerConfig {
             auth_mode: AuthMode::default(),
             bootstrap_admin_key: None,
             auth_persist_path: None,
+            query_limits: QueryLimitsConfig::default(),
         }
     }
 
@@ -244,6 +543,11 @@ impl ServerConfig {
     /// Large` before the JSON payload is buffered or deserialized.
     pub fn max_request_body_bytes(&self) -> usize {
         self.max_request_body_bytes
+    }
+
+    /// Get the per-query resource limits configuration (Issue #3368).
+    pub fn query_limits(&self) -> &QueryLimitsConfig {
+        &self.query_limits
     }
 
     /// Get the configured data directory, if any.
@@ -327,6 +631,7 @@ impl Default for ServerConfig {
             auth_mode: AuthMode::default(),
             bootstrap_admin_key: None,
             auth_persist_path: None,
+            query_limits: QueryLimitsConfig::default(),
         }
     }
 }
@@ -343,6 +648,7 @@ pub struct ServerConfigBuilder {
     auth_mode: Option<AuthMode>,
     bootstrap_admin_key: Option<SecretString>,
     auth_persist_path: Option<std::path::PathBuf>,
+    query_limits: Option<QueryLimitsConfig>,
 }
 
 impl ServerConfigBuilder {
@@ -410,6 +716,17 @@ impl ServerConfigBuilder {
         self
     }
 
+    /// Set the per-query resource limits (Issue #3368).
+    ///
+    /// Controls the `/query` handler's wall-clock timeout, result-row cap, and
+    /// response-byte cap, plus their per-call override ceilings. Defaults to
+    /// [`QueryLimitsConfig::default`] (enabled, generous). Pass
+    /// [`QueryLimitsConfig::disabled`] to turn all enforcement off.
+    pub fn query_limits(mut self, limits: QueryLimitsConfig) -> Self {
+        self.query_limits = Some(limits);
+        self
+    }
+
     /// Set the authentication mode.
     ///
     /// Defaults to [`AuthMode::Required`]. [`AuthMode::Anonymous`] disables
@@ -449,6 +766,7 @@ impl ServerConfigBuilder {
             auth_mode: self.auth_mode.unwrap_or_default(),
             bootstrap_admin_key: self.bootstrap_admin_key,
             auth_persist_path: self.auth_persist_path,
+            query_limits: self.query_limits.unwrap_or_default(),
         }
     }
 }
@@ -594,6 +912,190 @@ mod tests {
             .build();
         let debug = format!("{config:?}");
         assert!(!debug.contains("super-secret-bootstrap"));
+    }
+
+    // ------------------------------------------------------------------
+    // Per-query resource limits (Issue #3368)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn query_limits_default_is_enabled_and_generous() {
+        let limits = QueryLimitsConfig::default();
+        assert!(limits.enabled);
+        assert_eq!(limits.default_timeout_ms, DEFAULT_QUERY_TIMEOUT_MS);
+        assert_eq!(limits.max_timeout_ms, DEFAULT_MAX_QUERY_TIMEOUT_MS);
+        assert_eq!(limits.default_max_result_rows, DEFAULT_MAX_RESULT_ROWS);
+        assert_eq!(limits.row_overflow, RowOverflowPolicy::Truncate);
+
+        // ServerConfig wires the default through.
+        let config = ServerConfig::default();
+        assert_eq!(config.query_limits(), &QueryLimitsConfig::default());
+    }
+
+    #[test]
+    fn query_limits_builder_setter_overrides_default() {
+        let limits = QueryLimitsConfig::disabled();
+        let config = ServerConfig::builder().query_limits(limits.clone()).build();
+        assert_eq!(config.query_limits(), &limits);
+        assert!(!config.query_limits().enabled);
+    }
+
+    #[test]
+    fn disabled_limits_ignore_overrides_and_never_error() {
+        let limits = QueryLimitsConfig::disabled();
+        // Even a wildly-over-ceiling override yields unlimited, no error.
+        let over = QueryLimitsOverride {
+            timeout_ms: Some(u64::MAX),
+            max_result_rows: Some(usize::MAX),
+            max_response_bytes: Some(usize::MAX),
+        };
+        let eff = limits
+            .effective(Some(&over))
+            .expect("disabled never errors");
+        assert_eq!(eff, EffectiveQueryLimits::unlimited());
+    }
+
+    #[test]
+    fn effective_uses_defaults_when_no_override() {
+        let limits = QueryLimitsConfig::default();
+        let eff = limits.effective(None).expect("defaults are valid");
+        assert_eq!(eff.timeout_ms, DEFAULT_QUERY_TIMEOUT_MS);
+        assert_eq!(eff.max_result_rows, DEFAULT_MAX_RESULT_ROWS);
+        assert_eq!(eff.max_response_bytes, DEFAULT_MAX_RESPONSE_BYTES);
+    }
+
+    #[test]
+    fn effective_empty_override_is_treated_as_absent() {
+        let limits = QueryLimitsConfig::default();
+        let empty = QueryLimitsOverride::default();
+        assert!(empty.is_empty());
+        let eff = limits.effective(Some(&empty)).expect("empty override ok");
+        assert_eq!(eff.timeout_ms, DEFAULT_QUERY_TIMEOUT_MS);
+    }
+
+    #[test]
+    fn override_within_ceiling_is_honored() {
+        let limits = QueryLimitsConfig::default();
+        let over = QueryLimitsOverride {
+            timeout_ms: Some(5_000),
+            max_result_rows: Some(50),
+            max_response_bytes: Some(1024),
+        };
+        let eff = limits.effective(Some(&over)).expect("within ceiling");
+        assert_eq!(eff.timeout_ms, 5_000);
+        assert_eq!(eff.max_result_rows, 50);
+        assert_eq!(eff.max_response_bytes, 1024);
+    }
+
+    #[test]
+    fn override_below_default_is_honored_tighter() {
+        // Default rows is 10_000; a caller may self-limit to 5.
+        let limits = QueryLimitsConfig::default();
+        let over = QueryLimitsOverride {
+            max_result_rows: Some(5),
+            ..Default::default()
+        };
+        let eff = limits.effective(Some(&over)).expect("tighter self-limit");
+        assert_eq!(eff.max_result_rows, 5);
+        // Untouched dimensions keep their defaults.
+        assert_eq!(eff.timeout_ms, DEFAULT_QUERY_TIMEOUT_MS);
+    }
+
+    #[test]
+    fn override_above_ceiling_is_rejected_per_dimension() {
+        let limits = QueryLimitsConfig::default();
+
+        let too_slow = QueryLimitsOverride {
+            timeout_ms: Some(DEFAULT_MAX_QUERY_TIMEOUT_MS + 1),
+            ..Default::default()
+        };
+        let err = limits.effective(Some(&too_slow)).unwrap_err();
+        assert_eq!(err.dimension, LimitDimension::WallClockTimeout);
+        assert_eq!(err.requested, DEFAULT_MAX_QUERY_TIMEOUT_MS + 1);
+        assert_eq!(err.ceiling, DEFAULT_MAX_QUERY_TIMEOUT_MS);
+
+        let too_many_rows = QueryLimitsOverride {
+            max_result_rows: Some(DEFAULT_MAX_RESULT_ROWS_CEILING + 1),
+            ..Default::default()
+        };
+        let err = limits.effective(Some(&too_many_rows)).unwrap_err();
+        assert_eq!(err.dimension, LimitDimension::ResultRows);
+
+        let too_big = QueryLimitsOverride {
+            max_response_bytes: Some(DEFAULT_MAX_RESPONSE_BYTES_CEILING + 1),
+            ..Default::default()
+        };
+        let err = limits.effective(Some(&too_big)).unwrap_err();
+        assert_eq!(err.dimension, LimitDimension::ResultBytes);
+    }
+
+    #[test]
+    fn override_requesting_unlimited_under_finite_ceiling_is_rejected() {
+        let limits = QueryLimitsConfig::default();
+        let unlimited = QueryLimitsOverride {
+            timeout_ms: Some(0), // 0 = unlimited, but a finite ceiling exists
+            ..Default::default()
+        };
+        let err = limits.effective(Some(&unlimited)).unwrap_err();
+        assert_eq!(err.dimension, LimitDimension::WallClockTimeout);
+        assert_eq!(err.requested, 0);
+    }
+
+    #[test]
+    fn absent_override_clamps_unlimited_default_to_ceiling() {
+        // Default unlimited (0) but a finite ceiling → clamped down silently.
+        let limits = QueryLimitsConfig {
+            default_timeout_ms: 0,
+            max_timeout_ms: 1_000,
+            ..QueryLimitsConfig::default()
+        };
+        let eff = limits.effective(None).expect("clamped, not rejected");
+        assert_eq!(eff.timeout_ms, 1_000);
+    }
+
+    #[test]
+    fn absent_override_clamps_default_above_ceiling() {
+        let limits = QueryLimitsConfig {
+            default_timeout_ms: 90_000,
+            max_timeout_ms: 60_000,
+            ..QueryLimitsConfig::default()
+        };
+        let eff = limits.effective(None).expect("clamped");
+        assert_eq!(eff.timeout_ms, 60_000);
+    }
+
+    #[test]
+    fn no_ceiling_allows_any_override_including_unlimited() {
+        let limits = QueryLimitsConfig {
+            max_timeout_ms: 0, // no ceiling
+            ..QueryLimitsConfig::default()
+        };
+        let over = QueryLimitsOverride {
+            timeout_ms: Some(0), // unlimited, allowed when ceiling is 0
+            ..Default::default()
+        };
+        let eff = limits.effective(Some(&over)).expect("no ceiling");
+        assert_eq!(eff.timeout_ms, 0);
+    }
+
+    #[test]
+    fn limit_dimension_tokens_are_stable() {
+        assert_eq!(
+            LimitDimension::WallClockTimeout.as_str(),
+            "wall_clock_timeout"
+        );
+        assert_eq!(LimitDimension::ResultRows.as_str(), "result_rows");
+        assert_eq!(LimitDimension::ResultBytes.as_str(), "result_bytes");
+    }
+
+    #[test]
+    fn query_limits_override_deserializes_partial() {
+        // Only one field present; the rest default to None.
+        let ov: QueryLimitsOverride =
+            serde_json::from_value(serde_json::json!({ "timeout_ms": 1234 })).unwrap();
+        assert_eq!(ov.timeout_ms, Some(1234));
+        assert_eq!(ov.max_result_rows, None);
+        assert_eq!(ov.max_response_bytes, None);
     }
 
     #[test]

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -4,10 +4,65 @@
 //! `Result<Json<ApiResponse>, AletheiaHttpError>` and get the right status
 //! code + JSON error body for free.
 
+use crate::http::config::{LimitDimension, LimitOverrideError};
 use axum::Json;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use serde_json::json;
+use serde_json::{Value, json};
+
+/// A per-query resource limit was exceeded at the HTTP layer (Issue #3368).
+///
+/// Carries enough structure to render the `{code, retriable, details}` body:
+/// the [`LimitDimension`], the effective `limit`, and (for the byte/row caps)
+/// how much was `consumed`. The HTTP status and `retriable` flag are derived
+/// from the dimension:
+///
+/// - [`LimitDimension::WallClockTimeout`] → `429`, `retriable: true`
+/// - [`LimitDimension::ResultBytes`] / [`LimitDimension::ResultRows`] → `413`,
+///   `retriable: false`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResourceLimitExceeded {
+    /// Which dimension's cap was hit.
+    pub dimension: LimitDimension,
+    /// The effective limit that was exceeded (ms for timeout, else count/bytes).
+    pub limit: u64,
+    /// How much was consumed, when known (row count / byte size).
+    pub consumed: Option<u64>,
+}
+
+impl std::fmt::Display for ResourceLimitExceeded {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.dimension {
+            LimitDimension::WallClockTimeout => {
+                write!(
+                    f,
+                    "query exceeded the wall-clock timeout of {} ms",
+                    self.limit
+                )
+            }
+            LimitDimension::ResultRows => match self.consumed {
+                Some(c) => write!(
+                    f,
+                    "query result exceeded the row limit of {} (produced {})",
+                    self.limit, c
+                ),
+                None => write!(f, "query result exceeded the row limit of {}", self.limit),
+            },
+            LimitDimension::ResultBytes => match self.consumed {
+                Some(c) => write!(
+                    f,
+                    "query response exceeded the byte limit of {} (serialized {})",
+                    self.limit, c
+                ),
+                None => write!(
+                    f,
+                    "query response exceeded the byte limit of {} bytes",
+                    self.limit
+                ),
+            },
+        }
+    }
+}
 
 /// Errors raised by AletheiaDB's HTTP handlers.
 #[derive(Debug, thiserror::Error)]
@@ -46,6 +101,19 @@ pub enum AletheiaHttpError {
     /// The authenticated principal's role does not allow this operation.
     #[error("{0}")]
     PermissionDenied(String),
+
+    /// A per-query resource limit (timeout / rows / bytes) was exceeded
+    /// (Issue #3368). Renders `429` (timeout) or `413` (rows/bytes).
+    #[error("{0}")]
+    ResourceLimitExceeded(ResourceLimitExceeded),
+
+    /// A per-call limit override exceeded the operator ceiling (Issue #3368).
+    /// Renders `422 INVALID_ARGUMENT`.
+    #[error(
+        "limit override for '{}' ({}) exceeds the maximum allowed ({})",
+        .0.dimension.as_str(), .0.requested, .0.ceiling
+    )]
+    InvalidLimitOverride(LimitOverrideError),
 }
 
 impl AletheiaHttpError {
@@ -56,14 +124,66 @@ impl AletheiaHttpError {
             Self::Internal(_) | Self::StateMissing => StatusCode::INTERNAL_SERVER_ERROR,
             Self::Unauthorized => StatusCode::UNAUTHORIZED,
             Self::PermissionDenied(_) => StatusCode::FORBIDDEN,
+            Self::InvalidLimitOverride(_) => StatusCode::UNPROCESSABLE_ENTITY,
+            Self::ResourceLimitExceeded(e) => match e.dimension {
+                // Timeout is transient → 429 Too Many Requests.
+                LimitDimension::WallClockTimeout => StatusCode::TOO_MANY_REQUESTS,
+                // Result too large → 413 Payload Too Large.
+                LimitDimension::ResultRows | LimitDimension::ResultBytes => {
+                    StatusCode::PAYLOAD_TOO_LARGE
+                }
+            },
         }
     }
 
-    /// Stable machine-readable code, present only for auth errors (additive).
+    /// Stable machine-readable code (additive: present for auth errors since
+    /// Issue #3350 and for resource-limit errors since Issue #3368).
     fn code(&self) -> Option<&'static str> {
         match self {
             Self::Unauthorized => Some("UNAUTHENTICATED"),
             Self::PermissionDenied(_) => Some("PERMISSION_DENIED"),
+            Self::ResourceLimitExceeded(_) => Some("RESOURCE_EXHAUSTED"),
+            Self::InvalidLimitOverride(_) => Some("INVALID_ARGUMENT"),
+            _ => None,
+        }
+    }
+
+    /// Whether a caller may usefully retry (additive; Issue #3368). Only the
+    /// wall-clock timeout is transient. `None` where the flag does not apply
+    /// (existing variants keep their pre-#3368 body shape).
+    fn retriable(&self) -> Option<bool> {
+        match self {
+            Self::ResourceLimitExceeded(e) => Some(e.dimension == LimitDimension::WallClockTimeout),
+            Self::InvalidLimitOverride(_) => Some(false),
+            _ => None,
+        }
+    }
+
+    /// Structured, per-code metadata (additive; Issue #3368).
+    fn details(&self) -> Option<Value> {
+        match self {
+            Self::ResourceLimitExceeded(e) => {
+                let mut d = json!({
+                    "dimension": e.dimension.as_str(),
+                });
+                match e.dimension {
+                    LimitDimension::WallClockTimeout => {
+                        d["limit_ms"] = json!(e.limit);
+                    }
+                    LimitDimension::ResultRows | LimitDimension::ResultBytes => {
+                        d["limit"] = json!(e.limit);
+                        if let Some(c) = e.consumed {
+                            d["consumed"] = json!(c);
+                        }
+                    }
+                }
+                Some(d)
+            }
+            Self::InvalidLimitOverride(e) => Some(json!({
+                "dimension": e.dimension.as_str(),
+                "requested": e.requested,
+                "ceiling": e.ceiling,
+            })),
             _ => None,
         }
     }
@@ -72,18 +192,22 @@ impl AletheiaHttpError {
 impl IntoResponse for AletheiaHttpError {
     fn into_response(self) -> Response {
         let status = self.status();
-        let body = match self.code() {
-            // Auth errors additively carry a stable `code` field.
-            Some(code) => json!({
-                "success": false,
-                "error": self.to_string(),
-                "code": code,
-            }),
-            None => json!({
-                "success": false,
-                "error": self.to_string(),
-            }),
-        };
+        let mut body = json!({
+            "success": false,
+            "error": self.to_string(),
+        });
+        // Additive fields — only inserted when the variant defines them, so
+        // existing error bodies (bad-request, not-found, internal) are byte
+        // identical to their pre-#3368 shape.
+        if let Some(code) = self.code() {
+            body["code"] = json!(code);
+        }
+        if let Some(retriable) = self.retriable() {
+            body["retriable"] = json!(retriable);
+        }
+        if let Some(details) = self.details() {
+            body["details"] = details;
+        }
         let mut response = (status, Json(body)).into_response();
         if matches!(self, Self::Unauthorized) {
             response.headers_mut().insert(
@@ -92,5 +216,110 @@ impl IntoResponse for AletheiaHttpError {
             );
         }
         response
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+
+    async fn body_json(err: AletheiaHttpError) -> (StatusCode, Value) {
+        let resp = err.into_response();
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        (status, serde_json::from_slice(&bytes).unwrap())
+    }
+
+    #[tokio::test]
+    async fn timeout_maps_to_429_retriable_with_details() {
+        let (status, body) = body_json(AletheiaHttpError::ResourceLimitExceeded(
+            ResourceLimitExceeded {
+                dimension: LimitDimension::WallClockTimeout,
+                limit: 100,
+                consumed: None,
+            },
+        ))
+        .await;
+        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(body["success"], false);
+        assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
+        assert_eq!(body["retriable"], true);
+        assert_eq!(body["details"]["dimension"], "wall_clock_timeout");
+        assert_eq!(body["details"]["limit_ms"], 100);
+        assert!(body["error"].as_str().unwrap().contains("timeout"));
+    }
+
+    #[tokio::test]
+    async fn byte_cap_maps_to_413_not_retriable_with_consumed() {
+        let (status, body) = body_json(AletheiaHttpError::ResourceLimitExceeded(
+            ResourceLimitExceeded {
+                dimension: LimitDimension::ResultBytes,
+                limit: 1024,
+                consumed: Some(4096),
+            },
+        ))
+        .await;
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
+        assert_eq!(body["retriable"], false);
+        assert_eq!(body["details"]["dimension"], "result_bytes");
+        assert_eq!(body["details"]["limit"], 1024);
+        assert_eq!(body["details"]["consumed"], 4096);
+    }
+
+    #[tokio::test]
+    async fn row_reject_maps_to_413() {
+        let (status, body) = body_json(AletheiaHttpError::ResourceLimitExceeded(
+            ResourceLimitExceeded {
+                dimension: LimitDimension::ResultRows,
+                limit: 10,
+                consumed: Some(25),
+            },
+        ))
+        .await;
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(body["details"]["dimension"], "result_rows");
+        assert_eq!(body["details"]["consumed"], 25);
+    }
+
+    #[tokio::test]
+    async fn invalid_override_maps_to_422_invalid_argument() {
+        let (status, body) = body_json(AletheiaHttpError::InvalidLimitOverride(
+            LimitOverrideError {
+                dimension: LimitDimension::WallClockTimeout,
+                requested: 999,
+                ceiling: 100,
+            },
+        ))
+        .await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(body["code"], "INVALID_ARGUMENT");
+        assert_eq!(body["retriable"], false);
+        assert_eq!(body["details"]["dimension"], "wall_clock_timeout");
+        assert_eq!(body["details"]["requested"], 999);
+        assert_eq!(body["details"]["ceiling"], 100);
+    }
+
+    #[tokio::test]
+    async fn existing_variants_keep_minimal_body_shape() {
+        // No `code`/`retriable`/`details` for a plain bad-request (unchanged).
+        let (status, body) = body_json(AletheiaHttpError::BadRequest("nope".into())).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["success"], false);
+        assert_eq!(body["error"], "nope");
+        assert!(body.get("code").is_none());
+        assert!(body.get("retriable").is_none());
+        assert!(body.get("details").is_none());
+    }
+
+    #[tokio::test]
+    async fn auth_error_body_unchanged_still_has_code_only() {
+        let (status, body) = body_json(AletheiaHttpError::Unauthorized).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(body["code"], "UNAUTHENTICATED");
+        // Auth variants deliberately keep their pre-#3368 shape (no retriable).
+        assert!(body.get("retriable").is_none());
+        assert!(body.get("details").is_none());
     }
 }

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -13,13 +13,20 @@ use serde_json::{Value, json};
 /// A per-query resource limit was exceeded at the HTTP layer (Issue #3368).
 ///
 /// Carries enough structure to render the `{code, retriable, details}` body:
-/// the [`LimitDimension`], the effective `limit`, and (for the byte/row caps)
-/// how much was `consumed`. The HTTP status and `retriable` flag are derived
-/// from the dimension:
+/// the [`LimitDimension`], the effective `limit`, (for the byte/row caps) how
+/// much was `consumed`, and whether a retry could usefully succeed. The HTTP
+/// status is derived from the dimension:
 ///
-/// - [`LimitDimension::WallClockTimeout`] → `429`, `retriable: true`
-/// - [`LimitDimension::ResultBytes`] / [`LimitDimension::ResultRows`] → `413`,
-///   `retriable: false`
+/// - [`LimitDimension::WallClockTimeout`] → `429`
+/// - [`LimitDimension::ResultBytes`] / [`LimitDimension::ResultRows`] → `413`
+///
+/// The [`retriable`](Self::retriable) flag is carried explicitly rather than
+/// derived from the dimension: a wall-clock timeout is transient and normally
+/// `retriable: true`, **but** a timeout on a *write*-class operation is
+/// `retriable: false` — the write may already have committed on the blocking
+/// pool, so a naive retry would duplicate it (Issue #3368 review). Result-row
+/// and result-byte caps are always `retriable: false`, and (post-review) only
+/// ever apply to read-class operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResourceLimitExceeded {
     /// Which dimension's cap was hit.
@@ -28,6 +35,10 @@ pub struct ResourceLimitExceeded {
     pub limit: u64,
     /// How much was consumed, when known (row count / byte size).
     pub consumed: Option<u64>,
+    /// Whether a retry could usefully succeed. `true` only for a read-class
+    /// wall-clock timeout; `false` for a write-class timeout and for every
+    /// row/byte cap.
+    pub retriable: bool,
 }
 
 impl std::fmt::Display for ResourceLimitExceeded {
@@ -148,12 +159,15 @@ impl AletheiaHttpError {
         }
     }
 
-    /// Whether a caller may usefully retry (additive; Issue #3368). Only the
-    /// wall-clock timeout is transient. `None` where the flag does not apply
-    /// (existing variants keep their pre-#3368 body shape).
+    /// Whether a caller may usefully retry (additive; Issue #3368). The flag is
+    /// carried on the [`ResourceLimitExceeded`] itself: a read-class wall-clock
+    /// timeout is transient (`true`), a write-class timeout is not (a committed
+    /// write must not be duplicated), and row/byte caps are never retriable.
+    /// `None` where the flag does not apply (existing variants keep their
+    /// pre-#3368 body shape).
     fn retriable(&self) -> Option<bool> {
         match self {
-            Self::ResourceLimitExceeded(e) => Some(e.dimension == LimitDimension::WallClockTimeout),
+            Self::ResourceLimitExceeded(e) => Some(e.retriable),
             Self::InvalidLimitOverride(_) => Some(false),
             _ => None,
         }
@@ -215,6 +229,17 @@ impl IntoResponse for AletheiaHttpError {
                 axum::http::HeaderValue::from_static("Bearer"),
             );
         }
+        // A wall-clock timeout is a transient 429; hint clients to back off
+        // briefly before retrying (Issue #3368 review). Fixed conservative 1 s.
+        if matches!(
+            &self,
+            Self::ResourceLimitExceeded(e) if e.dimension == LimitDimension::WallClockTimeout
+        ) {
+            response.headers_mut().insert(
+                axum::http::header::RETRY_AFTER,
+                axum::http::HeaderValue::from_static("1"),
+            );
+        }
         response
     }
 }
@@ -238,6 +263,7 @@ mod tests {
                 dimension: LimitDimension::WallClockTimeout,
                 limit: 100,
                 consumed: None,
+                retriable: true,
             },
         ))
         .await;
@@ -257,6 +283,7 @@ mod tests {
                 dimension: LimitDimension::ResultBytes,
                 limit: 1024,
                 consumed: Some(4096),
+                retriable: false,
             },
         ))
         .await;
@@ -275,12 +302,36 @@ mod tests {
                 dimension: LimitDimension::ResultRows,
                 limit: 10,
                 consumed: Some(25),
+                retriable: false,
             },
         ))
         .await;
         assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
         assert_eq!(body["details"]["dimension"], "result_rows");
         assert_eq!(body["details"]["consumed"], 25);
+    }
+
+    /// A write-class wall-clock timeout renders `429` but `retriable: false`
+    /// (the write may already have committed; a retry could duplicate it —
+    /// Issue #3368 review MUST-FIX 1).
+    #[tokio::test]
+    async fn write_timeout_maps_to_429_not_retriable() {
+        let (status, body) = body_json(AletheiaHttpError::ResourceLimitExceeded(
+            ResourceLimitExceeded {
+                dimension: LimitDimension::WallClockTimeout,
+                limit: 100,
+                consumed: None,
+                retriable: false,
+            },
+        ))
+        .await;
+        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
+        assert_eq!(
+            body["retriable"], false,
+            "a write timeout must not invite a duplicate retry"
+        );
+        assert_eq!(body["details"]["dimension"], "wall_clock_timeout");
     }
 
     #[tokio::test]

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -35,6 +35,8 @@ use crate::query::read_only::detect_mutating_clause;
 use autumn_web::Route;
 use autumn_web::prelude::{get, post, routes};
 use axum::Json;
+use axum::http::{HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet};
@@ -697,11 +699,16 @@ pub struct QueryEnvelope {
 
 /// Apply the effective row cap to a result `Value` (Issue #3368).
 ///
-/// Row limits apply only to array-shaped results (list-like reads); a
-/// single-entity object result is returned unchanged. Under
-/// [`RowOverflowPolicy::Truncate`] the array is capped and `truncated` is
-/// `true`; under [`RowOverflowPolicy::Reject`] an over-cap result is a
-/// structured `413` error.
+/// Caps the **top-level array length only**: row limits apply to
+/// array-shaped results (list-like reads); a single-entity object result is
+/// returned unchanged, and nested arrays inside an object are never counted or
+/// truncated. Under [`RowOverflowPolicy::Truncate`] the array is capped and
+/// `truncated` is `true`; under [`RowOverflowPolicy::Reject`] an over-cap
+/// result is a structured `413` error (never retriable — the result is simply
+/// too large).
+///
+/// Only ever invoked for read-class operations (Issue #3368 review MUST-FIX 1):
+/// a committed write's acknowledgement is never truncated or rejected here.
 fn apply_row_cap(
     data: Value,
     limits: &EffectiveQueryLimits,
@@ -722,6 +729,7 @@ fn apply_row_cap(
                         dimension: LimitDimension::ResultRows,
                         limit: limits.max_result_rows as u64,
                         consumed: Some(consumed as u64),
+                        retriable: false,
                     },
                 )),
             }
@@ -730,27 +738,37 @@ fn apply_row_cap(
     }
 }
 
-/// Enforce the three per-query limit dimensions around an operation future
-/// (Issue #3368):
+/// Enforce the time and result-shaping limit dimensions around an operation
+/// future (Issue #3368):
 ///
-/// 1. **Wall-clock timeout** — the operation is raced against
-///    `timeout_ms`; on elapse the client gets a prompt `429`. (The underlying
-///    blocking computation is not cancelled — it runs to completion on the
-///    blocking pool — but the HTTP response deadline is bounded. True
-///    engine-level cancellation is the query-executor lane's concern.)
-/// 2. **Result-row cap** — truncate-or-reject per policy.
-/// 3. **Result-byte cap** — the serialized result size is bounded.
+/// 1. **Wall-clock timeout** — the operation is raced against `timeout_ms`; on
+///    elapse the client gets a prompt `429`. Applies to **all** operations
+///    (it bounds the client's wait). (The underlying blocking computation is
+///    not cancelled — it runs to completion on the blocking pool — but the HTTP
+///    response deadline is bounded. True engine-level cancellation is the
+///    query-executor lane's concern.) The timeout's `retriable` flag is `true`
+///    only for read-class ops: a **write** may have committed on the blocking
+///    pool, so its timeout is `retriable: false` to avoid a duplicate retry
+///    (review MUST-FIX 1).
+/// 2. **Result-row cap** — truncate-or-reject per policy, **read-class only**.
+///    A committed write's small acknowledgement (ids / version ids) is never
+///    truncated or `413`'d after the fact.
+///
+/// The **result-byte cap** is enforced by the caller ([`handle_query`]) on the
+/// fully-serialized response envelope, so it too is read-class only and is not
+/// applied here.
 ///
 /// A dimension whose effective value is `0` is unlimited and skipped. Returns
 /// the (possibly truncated) result plus a `truncated` flag.
 async fn enforce_query_limits<F>(
     limits: &EffectiveQueryLimits,
+    is_write: bool,
     op: F,
 ) -> Result<(Value, bool), AletheiaHttpError>
 where
     F: Future<Output = Result<Value, AletheiaHttpError>>,
 {
-    // 1. Wall-clock timeout.
+    // 1. Wall-clock timeout (all ops — it bounds the client's wait).
     let data = if limits.timeout_ms > 0 {
         match tokio::time::timeout(Duration::from_millis(limits.timeout_ms), op).await {
             Ok(result) => result?,
@@ -760,6 +778,9 @@ where
                         dimension: LimitDimension::WallClockTimeout,
                         limit: limits.timeout_ms,
                         consumed: None,
+                        // A write may already have committed — do not invite a
+                        // duplicate retry.
+                        retriable: !is_write,
                     },
                 ));
             }
@@ -768,24 +789,12 @@ where
         op.await?
     };
 
-    // 2. Result-row cap (arrays only).
-    let (data, truncated) = apply_row_cap(data, limits)?;
-
-    // 3. Result-byte cap.
-    if limits.max_response_bytes > 0 {
-        let serialized =
-            serde_json::to_vec(&data).map_err(|e| AletheiaHttpError::Internal(e.to_string()))?;
-        if serialized.len() > limits.max_response_bytes {
-            return Err(AletheiaHttpError::ResourceLimitExceeded(
-                ResourceLimitExceeded {
-                    dimension: LimitDimension::ResultBytes,
-                    limit: limits.max_response_bytes as u64,
-                    consumed: Some(serialized.len() as u64),
-                },
-            ));
-        }
+    // 2. Result-row cap — READ-class ops only. A write acknowledgement is never
+    // truncated or rejected after the write has committed.
+    if is_write {
+        return Ok((data, false));
     }
-
+    let (data, truncated) = apply_row_cap(data, limits)?;
     Ok((data, truncated))
 }
 
@@ -802,14 +811,21 @@ pub async fn handle_query(
     auth: AuthContext,
     state: AppState,
     Json(envelope): Json<QueryEnvelope>,
-) -> Result<Json<ApiResponse>, AletheiaHttpError> {
+) -> Result<Response, AletheiaHttpError> {
     let QueryEnvelope {
         request: req,
         limits,
     } = envelope;
 
+    // Classify the operation once. The access class drives BOTH authorization
+    // and limit semantics: a write is exempt from the result row/byte caps and
+    // its wall-clock timeout is non-retriable (the write may already have
+    // committed — Issue #3368 review MUST-FIX 1).
+    let access_class = query_access_class(&req);
+    let is_write = matches!(access_class, AccessClass::Write);
+
     // Authorization first: auth rejects (401/403) before limit logic runs.
-    auth.authorize(query_access_class(&req))?;
+    auth.authorize(access_class)?;
 
     // Resolve effective limits; an over-ceiling per-call override is a 422
     // rejected up front, before any database work.
@@ -861,8 +877,43 @@ pub async fn handle_query(
         }
     };
 
-    let (data, truncated) = enforce_query_limits(&effective, op).await?;
-    Ok(Json(ApiResponse::success_with_truncation(data, truncated)))
+    let (data, truncated) = enforce_query_limits(&effective, is_write, op).await?;
+
+    // Build and serialize the response envelope exactly ONCE (Issue #3368
+    // review perf-High: the earlier design double-serialized every response to
+    // measure the byte cap). We serialize the final wire envelope here, measure
+    // the byte cap against those real wire bytes (review correctness: the cap
+    // must count the envelope, not the inner `data`), and hand the pre-encoded
+    // bytes straight to the response — never back through `Json(..)`, which
+    // would serialize a second time. `Json` itself uses `serde_json::to_vec`,
+    // so these bytes are byte-identical to what `Json(body)` would produce.
+    let body = ApiResponse::success_with_truncation(data, truncated);
+    let bytes =
+        serde_json::to_vec(&body).map_err(|e| AletheiaHttpError::Internal(e.to_string()))?;
+
+    // Result-byte cap — READ-class only, and only when a finite cap is set. A
+    // committed write's acknowledgement has already taken effect; a post-commit
+    // 413 would lie about durability, so writes are exempt.
+    if !is_write && effective.max_response_bytes > 0 && bytes.len() > effective.max_response_bytes {
+        return Err(AletheiaHttpError::ResourceLimitExceeded(
+            ResourceLimitExceeded {
+                dimension: LimitDimension::ResultBytes,
+                limit: effective.max_response_bytes as u64,
+                consumed: Some(bytes.len() as u64),
+                retriable: false,
+            },
+        ));
+    }
+
+    Ok((
+        StatusCode::OK,
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        )],
+        bytes,
+    )
+        .into_response())
 }
 
 /// Collect the crate's HTTP routes as a `Vec<Route>`.
@@ -1042,19 +1093,45 @@ mod tests {
     }
 
     /// A future that outlives the timeout produces a 429 timeout error, with
-    /// the underlying computation left running (documented caveat).
-    #[tokio::test]
+    /// the underlying computation left running (documented caveat). Read-class
+    /// op → `retriable: true`. Uses paused time for determinism.
+    #[tokio::test(start_paused = true)]
     async fn enforce_wall_clock_timeout_trips_429() {
         let limits = effective(10, 0, 0, RowOverflowPolicy::Truncate);
         let slow = async {
             tokio::time::sleep(Duration::from_millis(500)).await;
             Ok(json!([]))
         };
-        let err = enforce_query_limits(&limits, slow).await.unwrap_err();
+        let err = enforce_query_limits(&limits, false, slow)
+            .await
+            .unwrap_err();
         match err {
             AletheiaHttpError::ResourceLimitExceeded(e) => {
                 assert_eq!(e.dimension, LimitDimension::WallClockTimeout);
                 assert_eq!(e.limit, 10);
+                assert!(e.retriable, "a read-class timeout is retriable");
+            }
+            other => panic!("expected timeout, got {other:?}"),
+        }
+    }
+
+    /// A write-class op that outlives the timeout is `retriable: false` — the
+    /// write may already have committed on the blocking pool (review MUST-FIX 1).
+    #[tokio::test(start_paused = true)]
+    async fn enforce_write_timeout_is_not_retriable() {
+        let limits = effective(10, 0, 0, RowOverflowPolicy::Truncate);
+        let slow = async {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            Ok(json!({ "id": 1 }))
+        };
+        let err = enforce_query_limits(&limits, true, slow).await.unwrap_err();
+        match err {
+            AletheiaHttpError::ResourceLimitExceeded(e) => {
+                assert_eq!(e.dimension, LimitDimension::WallClockTimeout);
+                assert!(
+                    !e.retriable,
+                    "a write-class timeout must not invite a duplicate retry"
+                );
             }
             other => panic!("expected timeout, got {other:?}"),
         }
@@ -1065,20 +1142,20 @@ mod tests {
     async fn enforce_fast_op_under_timeout_succeeds() {
         let limits = effective(1_000, 0, 0, RowOverflowPolicy::Truncate);
         let fast = async { Ok(json!({ "ok": true })) };
-        let (data, truncated) = enforce_query_limits(&limits, fast).await.unwrap();
+        let (data, truncated) = enforce_query_limits(&limits, false, fast).await.unwrap();
         assert_eq!(data, json!({ "ok": true }));
         assert!(!truncated);
     }
 
     /// Zero timeout means unlimited — a slow op is not interrupted.
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn enforce_zero_timeout_is_unlimited() {
         let limits = effective(0, 0, 0, RowOverflowPolicy::Truncate);
         let op = async {
             tokio::time::sleep(Duration::from_millis(20)).await;
             Ok(json!([1, 2, 3]))
         };
-        let (data, truncated) = enforce_query_limits(&limits, op).await.unwrap();
+        let (data, truncated) = enforce_query_limits(&limits, false, op).await.unwrap();
         assert_eq!(data, json!([1, 2, 3]));
         assert!(!truncated);
     }
@@ -1087,7 +1164,7 @@ mod tests {
     async fn enforce_row_cap_truncate_flags_truncated() {
         let limits = effective(0, 2, 0, RowOverflowPolicy::Truncate);
         let op = async { Ok(json!([1, 2, 3, 4, 5])) };
-        let (data, truncated) = enforce_query_limits(&limits, op).await.unwrap();
+        let (data, truncated) = enforce_query_limits(&limits, false, op).await.unwrap();
         assert_eq!(data, json!([1, 2]));
         assert!(truncated);
     }
@@ -1096,7 +1173,7 @@ mod tests {
     async fn enforce_row_cap_reject_errors() {
         let limits = effective(0, 2, 0, RowOverflowPolicy::Reject);
         let op = async { Ok(json!([1, 2, 3])) };
-        let err = enforce_query_limits(&limits, op).await.unwrap_err();
+        let err = enforce_query_limits(&limits, false, op).await.unwrap_err();
         match err {
             AletheiaHttpError::ResourceLimitExceeded(e) => {
                 assert_eq!(e.dimension, LimitDimension::ResultRows);
@@ -1107,29 +1184,47 @@ mod tests {
         }
     }
 
+    /// A WRITE op is exempt from the row cap: an over-cap array acknowledgement
+    /// is neither truncated nor rejected (review MUST-FIX 1).
+    #[tokio::test]
+    async fn enforce_write_op_is_exempt_from_row_cap() {
+        // Reject policy with a cap of 1; a 3-element write ack must still pass.
+        let limits = effective(0, 1, 0, RowOverflowPolicy::Reject);
+        let op = async { Ok(json!([1, 2, 3])) };
+        let (data, truncated) = enforce_query_limits(&limits, true, op).await.unwrap();
+        assert_eq!(data, json!([1, 2, 3]), "write ack must not be truncated");
+        assert!(!truncated);
+    }
+
     /// Row cap only applies to arrays; a single-object result is untouched.
     #[tokio::test]
     async fn enforce_row_cap_ignores_non_arrays() {
         let limits = effective(0, 1, 0, RowOverflowPolicy::Reject);
         let op = async { Ok(json!({ "id": 1, "big": [1, 2, 3, 4] })) };
-        let (data, truncated) = enforce_query_limits(&limits, op).await.unwrap();
+        let (data, truncated) = enforce_query_limits(&limits, false, op).await.unwrap();
         assert_eq!(data, json!({ "id": 1, "big": [1, 2, 3, 4] }));
         assert!(!truncated);
     }
 
-    #[tokio::test]
-    async fn enforce_byte_cap_trips_413() {
-        let limits = effective(0, 0, 8, RowOverflowPolicy::Truncate);
-        let op = async { Ok(json!(["a very long string that exceeds eight bytes"])) };
-        let err = enforce_query_limits(&limits, op).await.unwrap_err();
-        match err {
-            AletheiaHttpError::ResourceLimitExceeded(e) => {
-                assert_eq!(e.dimension, LimitDimension::ResultBytes);
-                assert_eq!(e.limit, 8);
-                assert!(e.consumed.unwrap() > 8);
-            }
-            other => panic!("expected byte-cap, got {other:?}"),
-        }
+    /// The byte cap now lives in `handle_query`, applied to the fully-serialized
+    /// response envelope. This unit test drives that same envelope serialization
+    /// and measurement step directly (the end-to-end path is covered in the
+    /// `tests/http_query_limits.rs` integration suite).
+    #[test]
+    fn envelope_byte_cap_measures_the_wire_body() {
+        let max_response_bytes = 8usize;
+        let data = json!(["a very long string that exceeds eight bytes"]);
+        let body = ApiResponse::success_with_truncation(data, false);
+        let bytes = serde_json::to_vec(&body).unwrap();
+        // The serialized envelope wraps `data` in `{"success":true,"data":...}`,
+        // so it is strictly larger than the raw data and far exceeds 8 bytes.
+        assert!(bytes.len() > max_response_bytes);
+
+        let over_cap = bytes.len() > max_response_bytes;
+        assert!(over_cap, "envelope must trip the byte cap");
+
+        // A generous cap does not trip.
+        assert!(bytes.len() < 4096);
     }
 
     #[test]

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -19,11 +19,14 @@ use crate::api::transaction::WriteOps;
 use crate::auth::AccessClass;
 use crate::core::NodeId;
 use crate::http::auth::AuthContext;
+use crate::http::config::{
+    EffectiveQueryLimits, LimitDimension, QueryLimitsOverride, RowOverflowPolicy,
+};
 use crate::http::converters::{
     interned_to_string, json_to_parameter_map, json_to_property_map, property_map_to_json,
     query_row_to_json,
 };
-use crate::http::error::AletheiaHttpError;
+use crate::http::error::{AletheiaHttpError, ResourceLimitExceeded};
 use crate::http::state::AppState;
 use crate::query::QueryBuilder;
 use crate::query::converter::{parse_query, parse_query_with_params};
@@ -35,7 +38,9 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet};
+use std::future::Future;
 use std::sync::Arc;
+use std::time::Duration;
 
 // Resource caps to prevent DoS via deep pagination / large result sets.
 const MAX_DEEP_PAGINATION: usize = 10_000;
@@ -143,6 +148,11 @@ pub struct ApiResponse {
     data: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+    /// `truncated` is additive (Issue #3368): present and `true` only when a
+    /// result row cap under [`RowOverflowPolicy::Truncate`] dropped rows;
+    /// omitted otherwise, so existing responses are unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    truncated: Option<bool>,
 }
 
 impl ApiResponse {
@@ -151,6 +161,18 @@ impl ApiResponse {
             success: true,
             data: Some(data),
             error: None,
+            truncated: None,
+        }
+    }
+
+    /// Success response that flags `truncated: true` when the row cap dropped
+    /// rows (Issue #3368). When `truncated` is `false`, the field is omitted.
+    pub(crate) fn success_with_truncation(data: Value, truncated: bool) -> Self {
+        Self {
+            success: true,
+            data: Some(data),
+            error: None,
+            truncated: truncated.then_some(true),
         }
     }
 }
@@ -659,58 +681,188 @@ fn query_access_class(req: &QueryRequest) -> AccessClass {
     }
 }
 
+/// The `/query` request envelope (Issue #3368).
+///
+/// Wraps the polymorphic [`QueryRequest`] (flattened, so the `operation` tag
+/// and its fields stay at the top level) and an optional per-call `limits`
+/// override. Both `limits` and its inner fields are `#[serde(default)]`, so a
+/// request body with no `"limits"` key parses and behaves exactly as before.
+#[derive(Debug, Deserialize)]
+pub struct QueryEnvelope {
+    #[serde(flatten)]
+    request: QueryRequest,
+    #[serde(default)]
+    limits: Option<QueryLimitsOverride>,
+}
+
+/// Apply the effective row cap to a result `Value` (Issue #3368).
+///
+/// Row limits apply only to array-shaped results (list-like reads); a
+/// single-entity object result is returned unchanged. Under
+/// [`RowOverflowPolicy::Truncate`] the array is capped and `truncated` is
+/// `true`; under [`RowOverflowPolicy::Reject`] an over-cap result is a
+/// structured `413` error.
+fn apply_row_cap(
+    data: Value,
+    limits: &EffectiveQueryLimits,
+) -> Result<(Value, bool), AletheiaHttpError> {
+    if limits.max_result_rows == 0 {
+        return Ok((data, false));
+    }
+    match data {
+        Value::Array(mut rows) if rows.len() > limits.max_result_rows => {
+            let consumed = rows.len();
+            match limits.row_overflow {
+                RowOverflowPolicy::Truncate => {
+                    rows.truncate(limits.max_result_rows);
+                    Ok((Value::Array(rows), true))
+                }
+                RowOverflowPolicy::Reject => Err(AletheiaHttpError::ResourceLimitExceeded(
+                    ResourceLimitExceeded {
+                        dimension: LimitDimension::ResultRows,
+                        limit: limits.max_result_rows as u64,
+                        consumed: Some(consumed as u64),
+                    },
+                )),
+            }
+        }
+        other => Ok((other, false)),
+    }
+}
+
+/// Enforce the three per-query limit dimensions around an operation future
+/// (Issue #3368):
+///
+/// 1. **Wall-clock timeout** — the operation is raced against
+///    `timeout_ms`; on elapse the client gets a prompt `429`. (The underlying
+///    blocking computation is not cancelled — it runs to completion on the
+///    blocking pool — but the HTTP response deadline is bounded. True
+///    engine-level cancellation is the query-executor lane's concern.)
+/// 2. **Result-row cap** — truncate-or-reject per policy.
+/// 3. **Result-byte cap** — the serialized result size is bounded.
+///
+/// A dimension whose effective value is `0` is unlimited and skipped. Returns
+/// the (possibly truncated) result plus a `truncated` flag.
+async fn enforce_query_limits<F>(
+    limits: &EffectiveQueryLimits,
+    op: F,
+) -> Result<(Value, bool), AletheiaHttpError>
+where
+    F: Future<Output = Result<Value, AletheiaHttpError>>,
+{
+    // 1. Wall-clock timeout.
+    let data = if limits.timeout_ms > 0 {
+        match tokio::time::timeout(Duration::from_millis(limits.timeout_ms), op).await {
+            Ok(result) => result?,
+            Err(_elapsed) => {
+                return Err(AletheiaHttpError::ResourceLimitExceeded(
+                    ResourceLimitExceeded {
+                        dimension: LimitDimension::WallClockTimeout,
+                        limit: limits.timeout_ms,
+                        consumed: None,
+                    },
+                ));
+            }
+        }
+    } else {
+        op.await?
+    };
+
+    // 2. Result-row cap (arrays only).
+    let (data, truncated) = apply_row_cap(data, limits)?;
+
+    // 3. Result-byte cap.
+    if limits.max_response_bytes > 0 {
+        let serialized =
+            serde_json::to_vec(&data).map_err(|e| AletheiaHttpError::Internal(e.to_string()))?;
+        if serialized.len() > limits.max_response_bytes {
+            return Err(AletheiaHttpError::ResourceLimitExceeded(
+                ResourceLimitExceeded {
+                    dimension: LimitDimension::ResultBytes,
+                    limit: limits.max_response_bytes as u64,
+                    consumed: Some(serialized.len() as u64),
+                },
+            ));
+        }
+    }
+
+    Ok((data, truncated))
+}
+
 /// Polymorphic `/query` endpoint. Dispatches on the `operation` tag.
 ///
 /// Authorization happens *before* any database work: the request's operation
 /// is classified via [`query_access_class`] and checked against the caller's
-/// role.
+/// role. Per-query resource limits (Issue #3368) are then resolved from the
+/// server defaults + the optional per-call `limits` override (a request that
+/// asks for more than the operator ceiling is rejected `422` here, before any
+/// DB work), and enforced around execution by [`enforce_query_limits`].
 #[post("/query")]
 pub async fn handle_query(
     auth: AuthContext,
     state: AppState,
-    Json(req): Json<QueryRequest>,
+    Json(envelope): Json<QueryEnvelope>,
 ) -> Result<Json<ApiResponse>, AletheiaHttpError> {
+    let QueryEnvelope {
+        request: req,
+        limits,
+    } = envelope;
+
+    // Authorization first: auth rejects (401/403) before limit logic runs.
     auth.authorize(query_access_class(&req))?;
+
+    // Resolve effective limits; an over-ceiling per-call override is a 422
+    // rejected up front, before any database work.
+    let effective = state
+        .query_limits()
+        .effective(limits.as_ref())
+        .map_err(AletheiaHttpError::InvalidLimitOverride)?;
+
     let db = state.db_arc();
     // Verified principal name (if any) for provenance stamping on write
     // operations (Issue #3350). Anonymous mode yields None.
     let principal = auth.principal().map(|p| p.name.clone());
 
-    let data = match req {
-        QueryRequest::CreateNode { label, properties } => {
-            handle_create_node(db, label, properties, principal).await?
-        }
-        QueryRequest::GetNode { node_id } => handle_get_node(db, node_id).await?,
-        QueryRequest::BulkCreateNodes { nodes } => {
-            handle_bulk_create_nodes(db, nodes, principal).await?
-        }
-        QueryRequest::BulkGetNodes { node_ids } => handle_bulk_get_nodes(db, node_ids).await?,
-        QueryRequest::BulkUpdateNodes { updates } => {
-            handle_bulk_update_nodes(db, updates, principal).await?
-        }
-        QueryRequest::BulkDeleteNodes { node_ids, cascade } => {
-            handle_bulk_delete_nodes(db, node_ids, cascade).await?
-        }
-        QueryRequest::FindNode {
-            label,
-            properties,
-            limit,
-            offset,
-        } => handle_find_node(db, label, properties, limit, offset).await?,
-        QueryRequest::FindNeighbors {
-            node_id,
-            limit,
-            offset,
-        } => handle_find_neighbors(db, node_id, limit, offset).await?,
-        QueryRequest::ExecuteQuery { query, parameters } => {
-            handle_execute_query(db, query, parameters).await?
-        }
-        QueryRequest::BulkExecuteQuery { queries } => {
-            handle_bulk_execute_query(db, queries).await?
+    // Build (but do not yet await) the operation future so the wall-clock
+    // timeout in `enforce_query_limits` wraps the actual execution.
+    let op = async move {
+        match req {
+            QueryRequest::CreateNode { label, properties } => {
+                handle_create_node(db, label, properties, principal).await
+            }
+            QueryRequest::GetNode { node_id } => handle_get_node(db, node_id).await,
+            QueryRequest::BulkCreateNodes { nodes } => {
+                handle_bulk_create_nodes(db, nodes, principal).await
+            }
+            QueryRequest::BulkGetNodes { node_ids } => handle_bulk_get_nodes(db, node_ids).await,
+            QueryRequest::BulkUpdateNodes { updates } => {
+                handle_bulk_update_nodes(db, updates, principal).await
+            }
+            QueryRequest::BulkDeleteNodes { node_ids, cascade } => {
+                handle_bulk_delete_nodes(db, node_ids, cascade).await
+            }
+            QueryRequest::FindNode {
+                label,
+                properties,
+                limit,
+                offset,
+            } => handle_find_node(db, label, properties, limit, offset).await,
+            QueryRequest::FindNeighbors {
+                node_id,
+                limit,
+                offset,
+            } => handle_find_neighbors(db, node_id, limit, offset).await,
+            QueryRequest::ExecuteQuery { query, parameters } => {
+                handle_execute_query(db, query, parameters).await
+            }
+            QueryRequest::BulkExecuteQuery { queries } => {
+                handle_bulk_execute_query(db, queries).await
+            }
         }
     };
 
-    Ok(Json(ApiResponse::success(data)))
+    let (data, truncated) = enforce_query_limits(&effective, op).await?;
+    Ok(Json(ApiResponse::success_with_truncation(data, truncated)))
 }
 
 /// Collect the crate's HTTP routes as a `Vec<Route>`.
@@ -841,6 +993,142 @@ mod tests {
                 route.method,
                 route.path
             );
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Per-query resource limits (Issue #3368)
+    // ------------------------------------------------------------------
+
+    /// The `#[serde(flatten)]` envelope keeps `operation` at the top level and
+    /// carries the optional `limits` override — and a body with no `limits`
+    /// key still parses (backward compatible).
+    #[test]
+    fn query_envelope_flattens_operation_and_optional_limits() {
+        // With a limits override.
+        let env: QueryEnvelope = serde_json::from_value(json!({
+            "operation": "get_node",
+            "node_id": 7,
+            "limits": { "timeout_ms": 500, "max_result_rows": 3 }
+        }))
+        .expect("deserialize envelope with limits");
+        assert!(matches!(env.request, QueryRequest::GetNode { node_id: 7 }));
+        let ov = env.limits.expect("limits present");
+        assert_eq!(ov.timeout_ms, Some(500));
+        assert_eq!(ov.max_result_rows, Some(3));
+
+        // Without a limits key — unchanged legacy body.
+        let env: QueryEnvelope = serde_json::from_value(json!({
+            "operation": "get_node",
+            "node_id": 9
+        }))
+        .expect("deserialize envelope without limits");
+        assert!(matches!(env.request, QueryRequest::GetNode { node_id: 9 }));
+        assert!(env.limits.is_none());
+    }
+
+    fn effective(
+        timeout_ms: u64,
+        max_result_rows: usize,
+        max_response_bytes: usize,
+        row_overflow: RowOverflowPolicy,
+    ) -> EffectiveQueryLimits {
+        EffectiveQueryLimits {
+            timeout_ms,
+            max_result_rows,
+            max_response_bytes,
+            row_overflow,
+        }
+    }
+
+    /// A future that outlives the timeout produces a 429 timeout error, with
+    /// the underlying computation left running (documented caveat).
+    #[tokio::test]
+    async fn enforce_wall_clock_timeout_trips_429() {
+        let limits = effective(10, 0, 0, RowOverflowPolicy::Truncate);
+        let slow = async {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            Ok(json!([]))
+        };
+        let err = enforce_query_limits(&limits, slow).await.unwrap_err();
+        match err {
+            AletheiaHttpError::ResourceLimitExceeded(e) => {
+                assert_eq!(e.dimension, LimitDimension::WallClockTimeout);
+                assert_eq!(e.limit, 10);
+            }
+            other => panic!("expected timeout, got {other:?}"),
+        }
+    }
+
+    /// A fast future under the timeout passes through untouched.
+    #[tokio::test]
+    async fn enforce_fast_op_under_timeout_succeeds() {
+        let limits = effective(1_000, 0, 0, RowOverflowPolicy::Truncate);
+        let fast = async { Ok(json!({ "ok": true })) };
+        let (data, truncated) = enforce_query_limits(&limits, fast).await.unwrap();
+        assert_eq!(data, json!({ "ok": true }));
+        assert!(!truncated);
+    }
+
+    /// Zero timeout means unlimited — a slow op is not interrupted.
+    #[tokio::test]
+    async fn enforce_zero_timeout_is_unlimited() {
+        let limits = effective(0, 0, 0, RowOverflowPolicy::Truncate);
+        let op = async {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            Ok(json!([1, 2, 3]))
+        };
+        let (data, truncated) = enforce_query_limits(&limits, op).await.unwrap();
+        assert_eq!(data, json!([1, 2, 3]));
+        assert!(!truncated);
+    }
+
+    #[tokio::test]
+    async fn enforce_row_cap_truncate_flags_truncated() {
+        let limits = effective(0, 2, 0, RowOverflowPolicy::Truncate);
+        let op = async { Ok(json!([1, 2, 3, 4, 5])) };
+        let (data, truncated) = enforce_query_limits(&limits, op).await.unwrap();
+        assert_eq!(data, json!([1, 2]));
+        assert!(truncated);
+    }
+
+    #[tokio::test]
+    async fn enforce_row_cap_reject_errors() {
+        let limits = effective(0, 2, 0, RowOverflowPolicy::Reject);
+        let op = async { Ok(json!([1, 2, 3])) };
+        let err = enforce_query_limits(&limits, op).await.unwrap_err();
+        match err {
+            AletheiaHttpError::ResourceLimitExceeded(e) => {
+                assert_eq!(e.dimension, LimitDimension::ResultRows);
+                assert_eq!(e.limit, 2);
+                assert_eq!(e.consumed, Some(3));
+            }
+            other => panic!("expected row-reject, got {other:?}"),
+        }
+    }
+
+    /// Row cap only applies to arrays; a single-object result is untouched.
+    #[tokio::test]
+    async fn enforce_row_cap_ignores_non_arrays() {
+        let limits = effective(0, 1, 0, RowOverflowPolicy::Reject);
+        let op = async { Ok(json!({ "id": 1, "big": [1, 2, 3, 4] })) };
+        let (data, truncated) = enforce_query_limits(&limits, op).await.unwrap();
+        assert_eq!(data, json!({ "id": 1, "big": [1, 2, 3, 4] }));
+        assert!(!truncated);
+    }
+
+    #[tokio::test]
+    async fn enforce_byte_cap_trips_413() {
+        let limits = effective(0, 0, 8, RowOverflowPolicy::Truncate);
+        let op = async { Ok(json!(["a very long string that exceeds eight bytes"])) };
+        let err = enforce_query_limits(&limits, op).await.unwrap_err();
+        match err {
+            AletheiaHttpError::ResourceLimitExceeded(e) => {
+                assert_eq!(e.dimension, LimitDimension::ResultBytes);
+                assert_eq!(e.limit, 8);
+                assert!(e.consumed.unwrap() > 8);
+            }
+            other => panic!("expected byte-cap, got {other:?}"),
         }
     }
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -42,7 +42,9 @@ mod state;
 
 pub use auth::{AuthContext, AuthState, validate_auth_startup};
 pub use config::{
-    CorsConfig, DEFAULT_MAX_REQUEST_BODY_BYTES, RateLimitConfig, ServerConfig, ServerConfigBuilder,
+    CorsConfig, DEFAULT_MAX_REQUEST_BODY_BYTES, EffectiveQueryLimits, LimitDimension,
+    LimitOverrideError, QueryLimitsConfig, QueryLimitsOverride, RateLimitConfig, RowOverflowPolicy,
+    ServerConfig, ServerConfigBuilder,
 };
 pub use error::AletheiaHttpError;
 pub use handlers::{ApiResponse, QueryRequest, handle_query, health_check};

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -108,7 +108,10 @@ pub async fn run_server(config: ServerConfig) -> std::io::Result<()> {
     }
 
     let db = Arc::new(build_database(&config)?);
-    let our_state = AppState::new(db);
+    // Deliver the per-query resource limits (Issue #3368) to handlers via
+    // shared state, exactly as the request-body-size limit is delivered via
+    // config into the layer stack below.
+    let our_state = AppState::new(db).with_query_limits(config.query_limits().clone());
     let startup_state = our_state.clone();
     let startup_auth = auth_state.clone();
     let shutdown_state = our_state.clone();
@@ -380,6 +383,11 @@ pub fn build_test_router_with_auth(
     config: &ServerConfig,
 ) -> Result<Router, String> {
     config.rate_limit().validate()?;
+
+    // Fold the per-query resource limits (Issue #3368) from `config` into the
+    // shared state, mirroring how `run_server` wires them — so tests that pass
+    // a custom `QueryLimitsConfig` through `ServerConfig` see it enforced.
+    let state = state.with_query_limits(config.query_limits().clone());
 
     let autumn_state = AutumnAppState::detached();
     autumn_state.insert_extension(state);

--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -13,6 +13,7 @@
 //! in this module, which reads the extension out of autumn's own state.
 
 use crate::AletheiaDB;
+use crate::http::config::QueryLimitsConfig;
 use crate::http::error::AletheiaHttpError;
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
@@ -20,18 +21,35 @@ use std::sync::Arc;
 
 /// Application state shared across HTTP handlers.
 ///
-/// Holds an `Arc<AletheiaDB>` and exposes it via [`db`](Self::db) and
-/// [`db_arc`](Self::db_arc). Cheap to clone (a single `Arc` bump).
+/// Holds an `Arc<AletheiaDB>` plus the per-query resource-limit configuration
+/// (Issue #3368) and exposes them via [`db`](Self::db) / [`db_arc`](Self::db_arc)
+/// and [`query_limits`](Self::query_limits). Cheap to clone (a single `Arc`
+/// bump plus a small `Copy`-ish config).
 #[derive(Clone)]
 pub struct AppState {
     db: Arc<AletheiaDB>,
+    query_limits: Arc<QueryLimitsConfig>,
 }
 
 impl AppState {
-    /// Create new application state wrapping the given database.
+    /// Create new application state wrapping the given database, with the
+    /// default per-query limits ([`QueryLimitsConfig::default`]).
     #[must_use]
     pub fn new(db: Arc<AletheiaDB>) -> Self {
-        Self { db }
+        Self {
+            db,
+            query_limits: Arc::new(QueryLimitsConfig::default()),
+        }
+    }
+
+    /// Install the per-query resource limits this state should enforce
+    /// (Issue #3368). Builder-style; typically fed from
+    /// [`ServerConfig::query_limits`](crate::http::ServerConfig::query_limits)
+    /// when wiring the router.
+    #[must_use]
+    pub fn with_query_limits(mut self, limits: QueryLimitsConfig) -> Self {
+        self.query_limits = Arc::new(limits);
+        self
     }
 
     /// Borrow the database for direct method calls.
@@ -44,6 +62,12 @@ impl AppState {
     #[must_use]
     pub fn db_arc(&self) -> Arc<AletheiaDB> {
         self.db.clone()
+    }
+
+    /// The per-query resource limits in force (Issue #3368).
+    #[must_use]
+    pub fn query_limits(&self) -> &QueryLimitsConfig {
+        &self.query_limits
     }
 }
 

--- a/tests/http_query_limits.rs
+++ b/tests/http_query_limits.rs
@@ -425,3 +425,291 @@ async fn request_without_limits_key_uses_server_defaults() {
     assert!(body.get("truncated").is_none());
     assert_eq!(body["data"].as_array().map(Vec::len), Some(3));
 }
+
+/// A `"limits": null` field is deserialized as absent (`Option::None`) and
+/// therefore behaves exactly as no `"limits"` key at all — server defaults.
+#[tokio::test]
+async fn null_limits_behaves_as_absent() {
+    let (client, db) = client_with_limits(QueryLimitsConfig::default());
+    seed_people(&db, 3);
+
+    let (status, body) = post_query(
+        &client,
+        &json!({ "operation": "find_node", "label": "Person", "limits": null }),
+    )
+    .await;
+    assert_eq!(status, 200, "null limits must parse as absent: {body}");
+    assert_eq!(body["success"], true);
+    assert!(body.get("truncated").is_none());
+    assert_eq!(body["data"].as_array().map(Vec::len), Some(3));
+}
+
+/// A malformed `limits` field (out-of-range or wrong-typed) is a clean client
+/// error (4xx) from the JSON extractor — never a 500 (server fault).
+#[tokio::test]
+async fn malformed_limits_is_a_clean_4xx_not_500() {
+    let (client, _db) = client_with_limits(QueryLimitsConfig::default());
+
+    // `timeout_ms` is a u64; a negative value cannot deserialize.
+    let (status, _body) = post_query(
+        &client,
+        &json!({
+            "operation": "find_node",
+            "label": "Person",
+            "limits": { "timeout_ms": -1 }
+        }),
+    )
+    .await;
+    assert!(
+        (400..500).contains(&status),
+        "negative timeout_ms must be a 4xx, got {status}"
+    );
+
+    // Wrong type (string where a number is expected) is likewise a clean 4xx.
+    let (status, _body) = post_query(
+        &client,
+        &json!({
+            "operation": "find_node",
+            "label": "Person",
+            "limits": { "max_result_rows": "not-a-number" }
+        }),
+    )
+    .await;
+    assert!(
+        (400..500).contains(&status),
+        "wrong-typed override must be a 4xx, got {status}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Write operations are exempt from the result row/byte caps (Issue #3368
+// review MUST-FIX 1) — a committed write is never truncated or 413'd.
+// ---------------------------------------------------------------------------
+
+/// Under a Reject row policy with a tight per-call `max_result_rows`, a bulk
+/// WRITE that produces more acknowledgement rows than the cap must NOT 413:
+/// the write is exempt, and every node must actually persist.
+#[tokio::test]
+async fn write_op_is_exempt_from_row_reject_and_persists() {
+    // Reject policy, cap 1, no ceiling (so the per-call override is honored).
+    let limits = QueryLimitsConfig {
+        enabled: true,
+        default_timeout_ms: 0,
+        max_timeout_ms: 0,
+        default_max_result_rows: 100,
+        max_result_rows: 0,
+        default_max_response_bytes: 0,
+        max_response_bytes: 0,
+        row_overflow: RowOverflowPolicy::Reject,
+    };
+    let (client, db) = client_with_limits(limits);
+
+    let (status, body) = post_query(
+        &client,
+        &json!({
+            "operation": "bulk_create_nodes",
+            "nodes": [
+                { "label": "Person" },
+                { "label": "Person" },
+                { "label": "Person" },
+            ],
+            "limits": { "max_result_rows": 1 } // would 413 a read of 3 rows
+        }),
+    )
+    .await;
+    assert_eq!(
+        status, 200,
+        "a write must be exempt from the row Reject cap: {body}"
+    );
+    assert_eq!(body["success"], true);
+    assert!(
+        body.get("truncated").is_none(),
+        "a write ack is never flagged truncated: {body}"
+    );
+    assert_eq!(
+        body["data"].as_array().map(Vec::len),
+        Some(3),
+        "the full write acknowledgement is returned"
+    );
+    assert_eq!(db.node_count(), 3, "all three nodes must persist");
+}
+
+/// Under a Truncate policy with a tight per-call row cap, a bulk WRITE is not
+/// truncated and is not flagged `truncated` — writes bypass the row cap.
+#[tokio::test]
+async fn write_op_is_not_truncated_under_truncate_policy() {
+    let limits = QueryLimitsConfig {
+        enabled: true,
+        default_timeout_ms: 0,
+        max_timeout_ms: 0,
+        default_max_result_rows: 1, // tiny default cap
+        max_result_rows: 0,
+        default_max_response_bytes: 0,
+        max_response_bytes: 0,
+        row_overflow: RowOverflowPolicy::Truncate,
+    };
+    let (client, db) = client_with_limits(limits);
+
+    let (status, body) = post_query(
+        &client,
+        &json!({
+            "operation": "bulk_create_nodes",
+            "nodes": [
+                { "label": "Person" },
+                { "label": "Person" },
+                { "label": "Person" },
+            ]
+        }),
+    )
+    .await;
+    assert_eq!(status, 200, "{body}");
+    assert!(
+        body.get("truncated").is_none(),
+        "write ack must not be flagged truncated: {body}"
+    );
+    assert_eq!(body["data"].as_array().map(Vec::len), Some(3));
+    assert_eq!(db.node_count(), 3);
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency isolation — distinct per-call overrides yield distinct outcomes
+// on the SAME server, proving no shared-state bleed between requests.
+// ---------------------------------------------------------------------------
+
+/// Four concurrent `/query` requests against one server, each with a different
+/// per-call override, must each get its own outcome: a default truncation, a
+/// byte-cap 413, an over-ceiling 422, and an unlimited-within-ceiling 200.
+/// (The row overflow *policy* is server-wide, so the 413 case uses the byte
+/// dimension — still a genuine per-request 413.)
+#[tokio::test]
+async fn concurrent_requests_with_distinct_overrides_are_isolated() {
+    let limits = QueryLimitsConfig {
+        enabled: true,
+        default_timeout_ms: 0,
+        max_timeout_ms: 0,
+        default_max_result_rows: 2, // default cap → truncates the 5-row read
+        max_result_rows: 10,        // ceiling for row overrides
+        default_max_response_bytes: 0, // unlimited by default
+        max_response_bytes: 0,      // no byte ceiling → any byte override ok
+        row_overflow: RowOverflowPolicy::Truncate,
+    };
+    let (client, db) = client_with_limits(limits);
+    seed_people(&db, 5);
+    let client = Arc::new(client);
+
+    // A: no override → default cap 2 → truncated.
+    let a = {
+        let client = client.clone();
+        tokio::spawn(async move { post_query(&client, &find_people()).await })
+    };
+    // B: tiny byte override → the 5-row response blows past 8 bytes → 413.
+    let b = {
+        let client = client.clone();
+        tokio::spawn(async move {
+            post_query(
+                &client,
+                &json!({
+                    "operation": "find_node",
+                    "label": "Person",
+                    "limits": { "max_response_bytes": 8 }
+                }),
+            )
+            .await
+        })
+    };
+    // C: row override above the ceiling → 422.
+    let c = {
+        let client = client.clone();
+        tokio::spawn(async move {
+            post_query(
+                &client,
+                &json!({
+                    "operation": "find_node",
+                    "label": "Person",
+                    "limits": { "max_result_rows": 1000 }
+                }),
+            )
+            .await
+        })
+    };
+    // D: row override at the ceiling (10 > 5 seeded) → full result, untruncated.
+    let d = {
+        let client = client.clone();
+        tokio::spawn(async move {
+            post_query(
+                &client,
+                &json!({
+                    "operation": "find_node",
+                    "label": "Person",
+                    "limits": { "max_result_rows": 10 }
+                }),
+            )
+            .await
+        })
+    };
+
+    let (a, b, c, d) = (
+        a.await.unwrap(),
+        b.await.unwrap(),
+        c.await.unwrap(),
+        d.await.unwrap(),
+    );
+
+    // A: truncated to 2.
+    assert_eq!(a.0, 200, "A: {}", a.1);
+    assert_eq!(a.1["truncated"], true);
+    assert_eq!(a.1["data"].as_array().map(Vec::len), Some(2));
+
+    // B: byte-cap 413.
+    assert_eq!(b.0, 413, "B: {}", b.1);
+    assert_eq!(b.1["details"]["dimension"], "result_bytes");
+
+    // C: over-ceiling 422.
+    assert_eq!(c.0, 422, "C: {}", c.1);
+    assert_eq!(c.1["details"]["dimension"], "result_rows");
+
+    // D: full, untruncated.
+    assert_eq!(d.0, 200, "D: {}", d.1);
+    assert!(d.1.get("truncated").is_none());
+    assert_eq!(d.1["data"].as_array().map(Vec::len), Some(5));
+}
+
+// ---------------------------------------------------------------------------
+// Auth parity — an authenticated-but-unauthorized caller is rejected 403
+// BEFORE limit validation, even carrying an over-ceiling override.
+// ---------------------------------------------------------------------------
+
+/// A Reader (no write permission) attempting a WRITE operation while ALSO
+/// carrying an over-ceiling limit override is rejected 403 PERMISSION_DENIED —
+/// authorization runs before limit validation, so the caller never sees a 422.
+#[tokio::test]
+async fn authorized_check_precedes_limit_validation() {
+    let limits = QueryLimitsConfig {
+        enabled: true,
+        default_timeout_ms: 0,
+        max_timeout_ms: 0,
+        default_max_result_rows: 10,
+        max_result_rows: 100, // finite ceiling the override breaches
+        default_max_response_bytes: 0,
+        max_response_bytes: 0,
+        row_overflow: RowOverflowPolicy::Truncate,
+    };
+    let (client, store, _db) = auth_client_with_limits(limits);
+    let (_p, key) = store.create_key("reader", Role::Reader).expect("mint key");
+
+    let (status, body) = post_query_with_key(
+        &client,
+        &key,
+        &json!({
+            "operation": "create_node",
+            "label": "Person",
+            "limits": { "max_result_rows": 1000 } // over ceiling 100
+        }),
+    )
+    .await;
+    assert_eq!(
+        status, 403,
+        "role denial must precede limit validation: {body}"
+    );
+    assert_eq!(body["code"], "PERMISSION_DENIED");
+}

--- a/tests/http_query_limits.rs
+++ b/tests/http_query_limits.rs
@@ -1,0 +1,427 @@
+//! Integration tests for per-query resource limits on the HTTP `/query`
+//! surface (Issue #3368).
+//!
+//! Covers the three enforceable dimensions — wall-clock timeout, result-row
+//! cap, and result-byte cap — plus their server default / per-call override /
+//! operator ceiling composition, the structured `{code, retriable, details}`
+//! error contract (429 / 413 / 422), the disabled-config escape hatch,
+//! concurrency isolation, and auth-vs-limits ordering (auth rejects first).
+//!
+//! The wall-clock timeout is additionally unit-tested for determinism in
+//! `src/http/handlers.rs` (a real slow query can't be forced deterministically
+//! over the wire); these integration tests exercise the row/byte caps and the
+//! override/ceiling logic, which are deterministic end-to-end.
+//!
+//! Run with: `cargo test --test http_query_limits --features http-server`
+
+#![cfg(feature = "http-server")]
+
+use std::sync::Arc;
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::auth::{AuthMode, AuthStore, Role};
+use aletheiadb::core::PropertyMapBuilder;
+use aletheiadb::http::{
+    AppState, AuthState, QueryLimitsConfig, RowOverflowPolicy, ServerConfig, build_test_router,
+    build_test_router_with_auth,
+};
+use autumn_web::test::{TestApp, TestClient};
+use serde_json::{Value, json};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build an anonymous-mode client with the given per-query limits.
+fn client_with_limits(limits: QueryLimitsConfig) -> (TestClient, Arc<AletheiaDB>) {
+    let db = Arc::new(AletheiaDB::new().expect("create DB"));
+    let state = AppState::new(db.clone());
+    let config = ServerConfig::builder()
+        .auth_mode(AuthMode::Anonymous)
+        .query_limits(limits)
+        .build();
+    let router = build_test_router(state, &config).expect("build router");
+    (TestApp::from_router(router), db)
+}
+
+/// Build a required-auth client with the given limits, returning the shared
+/// key store so the test can mint a valid credential.
+fn auth_client_with_limits(
+    limits: QueryLimitsConfig,
+) -> (TestClient, Arc<AuthStore>, Arc<AletheiaDB>) {
+    let db = Arc::new(AletheiaDB::new().expect("create DB"));
+    let state = AppState::new(db.clone());
+    let store = Arc::new(AuthStore::new());
+    let auth = AuthState::new(store.clone(), AuthMode::Required);
+    let config = ServerConfig::builder().query_limits(limits).build();
+    let router = build_test_router_with_auth(state, auth, &config).expect("build router");
+    (TestApp::from_router(router), store, db)
+}
+
+async fn post_query(client: &TestClient, body: &Value) -> (u16, Value) {
+    let resp = client.post("/query").json(body).send().await;
+    let status = resp.status.as_u16();
+    let json = serde_json::from_slice::<Value>(&resp.body).unwrap_or(Value::Null);
+    (status, json)
+}
+
+async fn post_query_with_key(client: &TestClient, key: &str, body: &Value) -> (u16, Value) {
+    let resp = client
+        .post("/query")
+        .header("Authorization", &format!("Bearer {key}"))
+        .json(body)
+        .send()
+        .await;
+    let status = resp.status.as_u16();
+    let json = serde_json::from_slice::<Value>(&resp.body).unwrap_or(Value::Null);
+    (status, json)
+}
+
+fn seed_people(db: &AletheiaDB, count: usize) {
+    for i in 0..count {
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("idx", i as i64).build(),
+        )
+        .expect("seed node");
+    }
+}
+
+fn find_people() -> Value {
+    json!({ "operation": "find_node", "label": "Person" })
+}
+
+/// Limits with a small row cap; every other dimension unlimited.
+fn row_cap(max_rows: usize, policy: RowOverflowPolicy) -> QueryLimitsConfig {
+    QueryLimitsConfig {
+        enabled: true,
+        default_timeout_ms: 0,
+        max_timeout_ms: 0,
+        default_max_result_rows: max_rows,
+        max_result_rows: 0,
+        default_max_response_bytes: 0,
+        max_response_bytes: 0,
+        row_overflow: policy,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Result-row cap
+// ---------------------------------------------------------------------------
+
+/// Truncate policy: an over-cap result is capped and flagged `truncated: true`.
+#[tokio::test]
+async fn row_cap_truncate_caps_rows_and_flags_truncated() {
+    let (client, db) = client_with_limits(row_cap(2, RowOverflowPolicy::Truncate));
+    seed_people(&db, 5);
+
+    let (status, body) = post_query(&client, &find_people()).await;
+    assert_eq!(status, 200, "truncation is a success, not an error: {body}");
+    assert_eq!(body["success"], true);
+    assert_eq!(body["truncated"], true, "must flag truncation");
+    assert_eq!(
+        body["data"].as_array().map(Vec::len),
+        Some(2),
+        "result must be capped to the row limit"
+    );
+}
+
+/// A result at or under the cap is not flagged truncated.
+#[tokio::test]
+async fn row_cap_not_tripped_leaves_response_unflagged() {
+    let (client, db) = client_with_limits(row_cap(10, RowOverflowPolicy::Truncate));
+    seed_people(&db, 3);
+
+    let (status, body) = post_query(&client, &find_people()).await;
+    assert_eq!(status, 200);
+    assert_eq!(body["success"], true);
+    assert!(
+        body.get("truncated").is_none(),
+        "truncated must be omitted when nothing was dropped: {body}"
+    );
+    assert_eq!(body["data"].as_array().map(Vec::len), Some(3));
+}
+
+/// Reject policy: an over-cap result is a structured 413.
+#[tokio::test]
+async fn row_cap_reject_returns_413_with_details() {
+    let (client, db) = client_with_limits(row_cap(2, RowOverflowPolicy::Reject));
+    seed_people(&db, 5);
+
+    let (status, body) = post_query(&client, &find_people()).await;
+    assert_eq!(
+        status, 413,
+        "reject policy must error, not truncate: {body}"
+    );
+    assert_eq!(body["success"], false);
+    assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
+    assert_eq!(body["retriable"], false);
+    assert_eq!(body["details"]["dimension"], "result_rows");
+    assert_eq!(body["details"]["limit"], 2);
+    assert_eq!(body["details"]["consumed"], 5);
+}
+
+// ---------------------------------------------------------------------------
+// Result-byte cap
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn byte_cap_exceeded_returns_413_with_details() {
+    let limits = QueryLimitsConfig {
+        enabled: true,
+        default_timeout_ms: 0,
+        max_timeout_ms: 0,
+        default_max_result_rows: 0,
+        max_result_rows: 0,
+        default_max_response_bytes: 16, // tiny — any real result blows past it
+        max_response_bytes: 0,
+        row_overflow: RowOverflowPolicy::Truncate,
+    };
+    let (client, db) = client_with_limits(limits);
+    seed_people(&db, 3);
+
+    let (status, body) = post_query(&client, &find_people()).await;
+    assert_eq!(status, 413, "oversized response must be rejected: {body}");
+    assert_eq!(body["success"], false);
+    assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
+    assert_eq!(body["retriable"], false);
+    assert_eq!(body["details"]["dimension"], "result_bytes");
+    assert_eq!(body["details"]["limit"], 16);
+    assert!(
+        body["details"]["consumed"].as_u64().unwrap() > 16,
+        "consumed must report the actual serialized size"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Per-call override / ceiling composition
+// ---------------------------------------------------------------------------
+
+/// An override within the ceiling is honored (here: a tighter row cap than the
+/// server default triggers truncation at the lower bound).
+#[tokio::test]
+async fn override_within_ceiling_is_honored_tighter_than_default() {
+    // Default cap 100, ceiling 100. Caller self-limits to 1.
+    let limits = QueryLimitsConfig {
+        enabled: true,
+        default_timeout_ms: 0,
+        max_timeout_ms: 0,
+        default_max_result_rows: 100,
+        max_result_rows: 100,
+        default_max_response_bytes: 0,
+        max_response_bytes: 0,
+        row_overflow: RowOverflowPolicy::Truncate,
+    };
+    let (client, db) = client_with_limits(limits);
+    seed_people(&db, 5);
+
+    let (status, body) = post_query(
+        &client,
+        &json!({
+            "operation": "find_node",
+            "label": "Person",
+            "limits": { "max_result_rows": 1 }
+        }),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert_eq!(body["truncated"], true);
+    assert_eq!(body["data"].as_array().map(Vec::len), Some(1));
+}
+
+/// An override above the operator ceiling is rejected 422 INVALID_ARGUMENT
+/// before any DB work.
+#[tokio::test]
+async fn override_above_ceiling_returns_422() {
+    let limits = QueryLimitsConfig {
+        enabled: true,
+        default_timeout_ms: 0,
+        max_timeout_ms: 0,
+        default_max_result_rows: 10,
+        max_result_rows: 100, // ceiling
+        default_max_response_bytes: 0,
+        max_response_bytes: 0,
+        row_overflow: RowOverflowPolicy::Truncate,
+    };
+    let (client, _db) = client_with_limits(limits);
+
+    let (status, body) = post_query(
+        &client,
+        &json!({
+            "operation": "find_node",
+            "label": "Person",
+            "limits": { "max_result_rows": 1000 } // > ceiling 100
+        }),
+    )
+    .await;
+    assert_eq!(
+        status, 422,
+        "over-ceiling override must be rejected: {body}"
+    );
+    assert_eq!(body["success"], false);
+    assert_eq!(body["code"], "INVALID_ARGUMENT");
+    assert_eq!(body["retriable"], false);
+    assert_eq!(body["details"]["dimension"], "result_rows");
+    assert_eq!(body["details"]["requested"], 1000);
+    assert_eq!(body["details"]["ceiling"], 100);
+}
+
+/// A timeout override above the ceiling is likewise rejected 422 (dimension =
+/// wall_clock_timeout), demonstrating per-dimension ceiling enforcement.
+#[tokio::test]
+async fn timeout_override_above_ceiling_returns_422() {
+    let (client, _db) = client_with_limits(QueryLimitsConfig::default());
+
+    let (status, body) = post_query(
+        &client,
+        &json!({
+            "operation": "find_node",
+            "label": "Person",
+            "limits": { "timeout_ms": 999_999_999 }
+        }),
+    )
+    .await;
+    assert_eq!(status, 422);
+    assert_eq!(body["code"], "INVALID_ARGUMENT");
+    assert_eq!(body["details"]["dimension"], "wall_clock_timeout");
+}
+
+// ---------------------------------------------------------------------------
+// Disabled config — no enforcement
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn disabled_limits_do_not_enforce_anything() {
+    let (client, db) = client_with_limits(QueryLimitsConfig::disabled());
+    seed_people(&db, 50);
+
+    // A large result passes untouched, no truncation.
+    let (status, body) = post_query(&client, &find_people()).await;
+    assert_eq!(status, 200);
+    assert!(body.get("truncated").is_none());
+    assert_eq!(body["data"].as_array().map(Vec::len), Some(50));
+
+    // Even an absurd per-call override is ignored (not rejected) when disabled.
+    let (status, body) = post_query(
+        &client,
+        &json!({
+            "operation": "find_node",
+            "label": "Person",
+            "limits": { "max_result_rows": 999_999_999, "timeout_ms": 0 }
+        }),
+    )
+    .await;
+    assert_eq!(status, 200, "disabled config ignores overrides: {body}");
+    assert_eq!(body["data"].as_array().map(Vec::len), Some(50));
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency — limits are per-request, no shared-state poisoning
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn concurrent_queries_under_limits_all_succeed() {
+    let (client, db) = client_with_limits(row_cap(1000, RowOverflowPolicy::Truncate));
+    seed_people(&db, 10);
+    let client = Arc::new(client);
+
+    let mut handles = Vec::new();
+    for _ in 0..16 {
+        let client = client.clone();
+        handles.push(tokio::spawn(async move {
+            let (status, body) = post_query(&client, &find_people()).await;
+            assert_eq!(status, 200, "concurrent query failed: {body}");
+            assert_eq!(body["success"], true);
+            // Well under the cap → never truncated.
+            assert!(body.get("truncated").is_none());
+        }));
+    }
+    for h in handles {
+        h.await.expect("task panicked");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Auth composes with limits: auth rejects FIRST
+// ---------------------------------------------------------------------------
+
+/// Identical limit behavior applies under authenticated required-mode as under
+/// anonymous mode: an over-ceiling override is a 422 once authenticated.
+#[tokio::test]
+async fn authenticated_request_gets_same_limit_behavior() {
+    let limits = QueryLimitsConfig {
+        enabled: true,
+        default_timeout_ms: 0,
+        max_timeout_ms: 0,
+        default_max_result_rows: 10,
+        max_result_rows: 100,
+        default_max_response_bytes: 0,
+        max_response_bytes: 0,
+        row_overflow: RowOverflowPolicy::Truncate,
+    };
+    let (client, store, _db) = auth_client_with_limits(limits);
+    let (_p, key) = store.create_key("writer", Role::Writer).expect("mint key");
+
+    let (status, body) = post_query_with_key(
+        &client,
+        &key,
+        &json!({
+            "operation": "find_node",
+            "label": "Person",
+            "limits": { "max_result_rows": 1000 }
+        }),
+    )
+    .await;
+    assert_eq!(
+        status, 422,
+        "authenticated over-ceiling override → 422: {body}"
+    );
+    assert_eq!(body["code"], "INVALID_ARGUMENT");
+}
+
+/// An unauthenticated request that ALSO breaches a limit is rejected 401 —
+/// authentication runs before any limit logic, so the caller never sees a
+/// 422/413. (Required mode, no credential presented.)
+#[tokio::test]
+async fn unauthenticated_over_limit_request_is_401_not_422() {
+    let limits = QueryLimitsConfig {
+        enabled: true,
+        default_timeout_ms: 0,
+        max_timeout_ms: 0,
+        default_max_result_rows: 10,
+        max_result_rows: 100,
+        default_max_response_bytes: 0,
+        max_response_bytes: 0,
+        row_overflow: RowOverflowPolicy::Truncate,
+    };
+    let (client, _store, _db) = auth_client_with_limits(limits);
+
+    // No Authorization header + an over-ceiling override.
+    let (status, body) = post_query(
+        &client,
+        &json!({
+            "operation": "find_node",
+            "label": "Person",
+            "limits": { "max_result_rows": 1000 }
+        }),
+    )
+    .await;
+    assert_eq!(status, 401, "auth must reject before limit logic: {body}");
+    assert_eq!(body["code"], "UNAUTHENTICATED");
+}
+
+// ---------------------------------------------------------------------------
+// Backward compatibility — a body with no "limits" key behaves as before
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn request_without_limits_key_uses_server_defaults() {
+    let (client, db) = client_with_limits(QueryLimitsConfig::default());
+    seed_people(&db, 3);
+
+    let (status, body) = post_query(&client, &find_people()).await;
+    assert_eq!(status, 200);
+    assert_eq!(body["success"], true);
+    assert!(body.get("truncated").is_none());
+    assert_eq!(body["data"].as_array().map(Vec::len), Some(3));
+}


### PR DESCRIPTION
## Summary

Implements the **HTTP lane** of #3368 (per-query resource limits). The `/query` surface now enforces three per-query limit dimensions, each with a **server-level default**, an optional **per-call override**, and an **operator hard ceiling**:

| Dimension | Bounds | Over-limit result |
|-----------|--------|-------------------|
| **Wall-clock timeout** | HTTP response deadline (`tokio::time::timeout`) | `429 RESOURCE_EXHAUSTED`, `retriable:true`, `details.dimension="wall_clock_timeout"` |
| **Result-row cap** | rows/entities returned | `Truncate` → `200` + `truncated:true`; `Reject` → `413 RESOURCE_EXHAUSTED` |
| **Result-byte cap** | serialized response size | `413 RESOURCE_EXHAUSTED`, `retriable:false` |

### Before / After

**Before:** `/query` had only scattered hardcoded result caps (e.g. `MAX_EXEC_RESULTS`) and the #3424 request body-size input guard — no configurable, per-call, ceiling-bounded output/time limits, and no structured `{code,retriable,details}` error contract on the HTTP surface.

**After:** a single `QueryLimitsConfig` on `ServerConfig` (default = enabled + generous, so no existing behavior changes; `disabled()` turns enforcement off). Requests may carry an additive `"limits"` object; over-ceiling overrides are rejected `422 INVALID_ARGUMENT` **before any DB work**, defaults are silently clamped. Limits compose **after** auth (auth rejects first). The error body additively gains `code`/`retriable`/`details`, aligning HTTP toward the MCP #3234 contract; existing error bodies are unchanged.

### How

- **`src/http/config.rs`** — `QueryLimitsConfig` (+ `Default`, `disabled()`), `QueryLimitsOverride`, `EffectiveQueryLimits`, `RowOverflowPolicy`, `LimitDimension`, `LimitOverrideError`. Centralized merge logic in `QueryLimitsConfig::effective` (default/override/ceiling, `0` = unlimited, ceiling `0` = no ceiling), unit-tested per branch. Wired into `ServerConfig` (field + builder setter + getter).
- **`src/http/error.rs`** — `ResourceLimitExceeded` and `InvalidLimitOverride` variants; `IntoResponse` additively emits `code`/`retriable`/`details` (429/413/422); existing variants keep their pre-#3368 shape.
- **`src/http/handlers.rs`** — `QueryEnvelope` (`#[serde(flatten)]` operation tag + optional `limits`), `enforce_query_limits` helper (timeout → row cap → byte cap), `ApiResponse.truncated` (additive), rewired `handle_query`.
- **`src/http/state.rs` / `server.rs`** — `AppState` carries the limits config, wired from `ServerConfig::query_limits()` in both `run_server` and `build_test_router_with_auth`.
- **Docs** — new `docs/guides/http-query-limits.md` (contract, config, override, error shapes, honest coverage matrix); pointers added to `http-state-management.md` and `access-control-matrix.md`.

### Scope / deferrals (honest)

- **Wall-clock timeout bounds the HTTP response deadline, not compute.** The underlying synchronous query runs on a blocking pool and may complete in the background after the client is answered `429`. True engine-level cancellation is the **query-executor lane**.
- **Memory budget** (engine dimension) is deferred to the **query-executor lane**; the #3424 request body-size limit remains the HTTP *input* memory guard.
- **MCP-surface parity** is deferred to the **MCP lane**.

### Tests

- Unit: `config.rs` (merge branches, `disabled()`, dimension tokens), `error.rs` (429/413/422 + body mapping), `handlers.rs` (deterministic timeout via a sleeping future, row truncate/reject, byte cap, envelope flatten).
- Integration: `tests/http_query_limits.rs` (12 tests) — row cap truncate/reject, byte cap, override within/above ceiling, disabled config, concurrency isolation, auth-before-limits ordering, backward compatibility.

All HTTP unit + integration suites green; `cargo fmt --all --check` clean; `cargo clippy --all-targets --all-features -D warnings` clean.

Refs #3368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwRkYyiuAD3fzCnpJdfQKh

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwRkYyiuAD3fzCnpJdfQKh)_