### PR TITLE
Introduce a unified `serde` feature flag to replace per-feature cfg gates on derives (#3390)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,3 +148,39 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ignore: "RUSTSEC-2026-0104, RUSTSEC-2024-0436"
+
+  feature-matrix:
+    name: Feature Matrix
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v5
+        with:
+          path: target
+          key: ${{ runner.os }}-v2-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Verify feature flags compile standalone
+        run: just check-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,8 +182,16 @@ default = ["config-toml"]
 # Async runtime support
 tokio = ["dep:tokio"]
 
+# Unified serde support (Issue #3390).
+# Single flag that pulls in the optional `serde` dependency and gates every
+# `#[derive(Serialize, Deserialize)]` / serde attribute in the crate. Any
+# feature that needs serde derives depends on this rather than `dep:serde`
+# directly, so serde-enabled code compiles identically regardless of which
+# high-level feature turned it on.
+serde = ["dep:serde"]
+
 # Configuration file support (TOML)
-config-toml = ["dep:serde", "dep:toml"]
+config-toml = ["serde", "dep:toml"]
 
 # Embedding generation via embed_anything.
 embeddings = [
@@ -198,10 +206,10 @@ embeddings = [
 embeddings-onnx = ["embeddings", "embed_anything/ort"]
 
 # MCP server support
-mcp-server = ["dep:rmcp", "dep:tokio", "dep:serde", "dep:base64"]
+mcp-server = ["dep:rmcp", "dep:tokio", "serde", "dep:base64"]
 
 # Sharding RPC client support (uses blocking reqwest)
-sharding-rpc = ["dep:reqwest", "dep:serde", "dep:native-tls"]
+sharding-rpc = ["dep:reqwest", "serde", "dep:native-tls"]
 
 # SQL:2011 temporal syntax support
 sql = ["dep:sqlparser"]
@@ -221,7 +229,7 @@ http-server = [
     "dep:tower",
     "dep:tower-http",
     "dep:tokio",
-    "dep:serde",
+    "serde",
     "dep:base64",
     "dep:tracing",
 ]
@@ -230,7 +238,7 @@ http-server = [
 mvcc-snapshots-tdd = []
 
 # Encryption at rest (ADR-0028)
-encryption = ["dep:serde"]
+encryption = ["serde"]
 
 # AWS KMS key provider (optional)
 encryption-aws-kms = ["encryption", "dep:tokio"]

--- a/justfile
+++ b/justfile
@@ -59,6 +59,16 @@ check-features:
     @echo "=== semantic-characterization ===" && cargo check --features semantic-characterization
     @echo "=== nova umbrella ===" && cargo check --features nova
     @echo "=== nova + semantic-search ===" && cargo check --features nova,semantic-search
+    # Serde-enabling features (Issue #3390): each must compile standalone
+    # against the unified `serde` flag with no default features.
+    @echo "=== serde (standalone) ===" && cargo check --no-default-features --tests --features serde
+    @echo "=== config-toml (standalone) ===" && cargo check --no-default-features --tests --features config-toml
+    @echo "=== mcp-server (standalone) ===" && cargo check --no-default-features --tests --features mcp-server
+    @echo "=== sharding-rpc (standalone) ===" && cargo check --no-default-features --tests --features sharding-rpc
+    @echo "=== http-server (standalone) ===" && cargo check --no-default-features --tests --features http-server
+    @echo "=== encryption (standalone) ===" && cargo check --no-default-features --tests --features encryption
+    @echo "=== encryption-vault (standalone) ===" && cargo check --no-default-features --tests --features encryption-vault
+    @echo "=== encryption-aws-kms (standalone) ===" && cargo check --no-default-features --tests --features encryption-aws-kms
 
 # Format code
 fmt:

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,7 +36,7 @@
 //! let db = AletheiaDB::with_unified_config(config);
 //! ```
 
-#[cfg(feature = "config-toml")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "config-toml")]
 use std::fs;
@@ -57,8 +57,8 @@ use crate::storage::version::AnchorConfig;
 /// its behavior, such as concurrency (stripes), sync intervals, and directory paths,
 /// to balance between latency and throughput.
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "config-toml", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "config-toml", serde(default))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 #[non_exhaustive]
 pub struct WalConfig {
     /// Number of stripes for concurrent appends (must be power of 2).
@@ -327,8 +327,8 @@ impl Default for WalConfigBuilder {
 /// This configuration dictates how those versions are managed, including pruning
 /// thresholds and the directory where historical data is stored on disk.
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "config-toml", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "config-toml", serde(default))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 #[non_exhaustive]
 pub struct HistoricalConfig {
     /// Maximum versions to retain per entity before pruning.
@@ -667,8 +667,8 @@ impl Default for HistoricalConfigBuilder {
 /// configure parameters like the number of layers, connections per node, and memory
 /// limits to optimize the recall-vs-latency tradeoff.
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "config-toml", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "config-toml", serde(default))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 #[non_exhaustive]
 pub struct VectorIndexConfig {
     /// Maximum value of k for k-NN queries.
@@ -771,8 +771,8 @@ impl Default for VectorIndexConfigBuilder {
 /// (WAL, Historical, Vector, Persistence). It acts as the single source of truth
 /// when bootstrapping a new database instance.
 #[derive(Debug, Clone, PartialEq, Default)]
-#[cfg_attr(feature = "config-toml", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "config-toml", serde(default))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 #[non_exhaustive]
 pub struct AletheiaDBConfig {
     /// WAL configuration

--- a/src/core/provenance.rs
+++ b/src/core/provenance.rs
@@ -31,45 +31,31 @@ pub enum ProvenanceError {
 /// Constructed via [`Provenance::builder`], which validates `confidence`
 /// against `[0.0, 1.0]` (NaN is rejected).
 ///
-/// Serde support is feature-gated because `serde` is an optional dependency
-/// (enabled by `config-toml` — a default feature — and `mcp-server`, whose
-/// response types embed [`Provenance`] directly); `--no-default-features`
-/// builds must still compile without it.
+/// Serde support is feature-gated behind the unified `serde` flag (Issue
+/// #3390), which is pulled in by any serde-enabling feature — e.g.
+/// `config-toml` (a default feature) and `mcp-server`, whose response types
+/// embed [`Provenance`] directly; `--no-default-features` builds must still
+/// compile without it.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(
-    any(feature = "config-toml", feature = "mcp-server"),
+    feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(try_from = "ProvenanceRaw")
 )]
 pub struct Provenance {
-    #[cfg_attr(
-        any(feature = "config-toml", feature = "mcp-server"),
-        serde(skip_serializing_if = "Option::is_none")
-    )]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     source: Option<String>,
-    #[cfg_attr(
-        any(feature = "config-toml", feature = "mcp-server"),
-        serde(skip_serializing_if = "Option::is_none")
-    )]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     confidence: Option<f64>,
-    #[cfg_attr(
-        any(feature = "config-toml", feature = "mcp-server"),
-        serde(skip_serializing_if = "Option::is_none")
-    )]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     note: Option<String>,
-    #[cfg_attr(
-        any(feature = "config-toml", feature = "mcp-server"),
-        serde(skip_serializing_if = "Option::is_none")
-    )]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     correlation_id: Option<String>,
     /// The authenticated principal (API-key identity) that made this write,
     /// if the write arrived through an authenticated server surface
     /// (Issue #3350). Server-stamped -- never caller-supplied -- and
     /// composes with `source` (which remains whatever the caller declared).
-    #[cfg_attr(
-        any(feature = "config-toml", feature = "mcp-server"),
-        serde(skip_serializing_if = "Option::is_none")
-    )]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     principal: Option<String>,
 }
 
@@ -249,7 +235,7 @@ impl ProvenanceBuilder {
 /// Unvalidated wire representation used only as the `serde` deserialization
 /// target; [`Provenance`] itself has private fields so it cannot be
 /// deserialized directly without going through validation.
-#[cfg(any(feature = "config-toml", feature = "mcp-server"))]
+#[cfg(feature = "serde")]
 #[derive(Debug, serde::Deserialize)]
 struct ProvenanceRaw {
     #[serde(default)]
@@ -264,7 +250,7 @@ struct ProvenanceRaw {
     principal: Option<String>,
 }
 
-#[cfg(any(feature = "config-toml", feature = "mcp-server"))]
+#[cfg(feature = "serde")]
 impl TryFrom<ProvenanceRaw> for Provenance {
     type Error = ProvenanceError;
 
@@ -337,7 +323,7 @@ mod tests {
         assert_eq!(p.confidence(), None);
     }
 
-    #[cfg(any(feature = "config-toml", feature = "mcp-server"))]
+    #[cfg(feature = "serde")]
     #[test]
     fn test_provenance_json_omits_absent_fields() {
         let p = Provenance::builder().source("csv-import").build().unwrap();
@@ -348,7 +334,7 @@ mod tests {
         assert!(!json.contains("correlation_id"));
     }
 
-    #[cfg(any(feature = "config-toml", feature = "mcp-server"))]
+    #[cfg(feature = "serde")]
     #[test]
     fn test_provenance_deserialize_valid_round_trips() {
         let json = r#"{"source":"claude-mcp","confidence":0.8}"#;
@@ -380,7 +366,7 @@ mod tests {
         assert_eq!(p.source(), None);
     }
 
-    #[cfg(any(feature = "config-toml", feature = "mcp-server"))]
+    #[cfg(feature = "serde")]
     #[test]
     fn test_provenance_principal_json_round_trip_and_omission() {
         // Absent principal is omitted from JSON entirely.
@@ -399,7 +385,7 @@ mod tests {
         assert_eq!(legacy.principal(), None);
     }
 
-    #[cfg(any(feature = "config-toml", feature = "mcp-server"))]
+    #[cfg(feature = "serde")]
     #[test]
     fn test_provenance_deserialize_rejects_invalid_confidence() {
         let json = r#"{"confidence":2.0}"#;

--- a/src/db/stats.rs
+++ b/src/db/stats.rs
@@ -53,10 +53,7 @@ use crate::storage::wal::DurabilityMode;
 /// not a transactionally frozen view — concurrent writers may advance
 /// individual counters between reads.
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(
-    any(feature = "config-toml", feature = "mcp-server"),
-    derive(serde::Serialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[non_exhaustive]
 pub struct DatabaseStats {
     /// Current-state graph size (the hot, in-RAM tier queried by
@@ -75,10 +72,7 @@ pub struct DatabaseStats {
 
 /// Current-state (hot tier) graph size.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(
-    any(feature = "config-toml", feature = "mcp-server"),
-    derive(serde::Serialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[non_exhaustive]
 pub struct CurrentStateStats {
     /// Number of nodes in the current state. O(1) index-length read.
@@ -94,10 +88,7 @@ pub struct CurrentStateStats {
 /// maintained incrementally (Issue #212) — reading them is O(1) and never
 /// iterates versions.
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(
-    any(feature = "config-toml", feature = "mcp-server"),
-    derive(serde::Serialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[non_exhaustive]
 pub struct HistoricalDepthStats {
     /// Total node versions retained in the hot historical store.
@@ -135,27 +126,21 @@ pub struct HistoricalDepthStats {
 /// — count fields are structurally absent so they can never be misread as
 /// "zero cold versions".
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(
-    any(feature = "config-toml", feature = "mcp-server"),
-    derive(serde::Serialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[non_exhaustive]
 pub struct ColdStorageTierStats {
     /// Whether a cold-storage tier (tiered storage + Redb backend) is
     /// configured for this database.
     pub enabled: bool,
     /// Counters for the enabled tier; absent when `enabled` is false.
-    #[cfg_attr(any(feature = "config-toml", feature = "mcp-server"), serde(flatten))]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub details: Option<ColdStorageDetails>,
 }
 
 /// Counters for an enabled cold-storage tier. All values are atomic counter
 /// snapshots — O(1) reads, no disk access.
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(
-    any(feature = "config-toml", feature = "mcp-server"),
-    derive(serde::Serialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[non_exhaustive]
 pub struct ColdStorageDetails {
     /// Node versions in the cold (disk) tier. Seeded from the persisted
@@ -180,10 +165,7 @@ pub struct ColdStorageDetails {
 /// Where historical-version reads were served from. Together these reveal
 /// the hot / warm-cache / cold distribution of temporal query traffic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(
-    any(feature = "config-toml", feature = "mcp-server"),
-    derive(serde::Serialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[non_exhaustive]
 pub struct TierAccessStats {
     /// Reads served from the hot (in-RAM) tier.
@@ -203,10 +185,7 @@ pub struct TierAccessStats {
 /// still emitted explicitly so the schema contract covers any future no-WAL
 /// build and a consumer never has to infer WAL presence from other fields.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    any(feature = "config-toml", feature = "mcp-server"),
-    derive(serde::Serialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[non_exhaustive]
 pub struct WalStateStats {
     /// Whether a WAL is active. Always `true` in current builds (see type
@@ -381,7 +360,7 @@ mod tests {
 
     /// WAL counters are `u64`; extreme values must survive JSON
     /// serialization without precision loss or sign flips.
-    #[cfg(any(feature = "config-toml", feature = "mcp-server"))]
+    #[cfg(feature = "serde")]
     #[test]
     fn wal_stats_u64_max_survives_json_round_trip() {
         let stats = WalStateStats {
@@ -405,7 +384,7 @@ mod tests {
 
     /// Disabled cold storage serializes as exactly `{"enabled": false}` —
     /// no count keys an LLM could misread as "0 cold versions".
-    #[cfg(any(feature = "config-toml", feature = "mcp-server"))]
+    #[cfg(feature = "serde")]
     #[test]
     fn disabled_cold_storage_serializes_without_count_fields() {
         let value = serde_json::to_value(ColdStorageTierStats {

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -2650,7 +2650,7 @@ fn test_schema_as_of_entity_cap_is_configurable_and_discloses_sampling() {
 /// `config-toml` or `mcp-server` is enabled, so this test is gated the same
 /// way; `test_stats_populated_matches_underlying_counters` keeps the
 /// non-serde behavior covered in minimal builds.
-#[cfg(any(feature = "config-toml", feature = "mcp-server"))]
+#[cfg(feature = "serde")]
 #[test]
 fn test_stats_serialization_shape_empty_db() {
     let db = AletheiaDB::new().unwrap();
@@ -2734,7 +2734,7 @@ fn test_stats_populated_matches_underlying_counters() {
 ///
 /// Gated like `test_stats_serialization_shape_empty_db`: the serde derive
 /// this test exercises only exists under `config-toml`/`mcp-server`.
-#[cfg(any(feature = "config-toml", feature = "mcp-server"))]
+#[cfg(feature = "serde")]
 #[test]
 fn test_stats_cold_storage_enabled() {
     use crate::config::{AletheiaDBConfig, HistoricalConfigBuilder, WalConfigBuilder};

--- a/src/encryption/config.rs
+++ b/src/encryption/config.rs
@@ -12,11 +12,8 @@ use crate::encryption::factory::Algorithm;
 ///
 /// Determines where the Master Encryption Key (MEK) is sourced from at startup.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "config-toml", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    feature = "config-toml",
-    serde(tag = "type", rename_all = "snake_case")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", rename_all = "snake_case"))]
 /// Configuration options for the Master Encryption Key (MEK) provider.
 ///
 /// # Why?
@@ -50,8 +47,8 @@ impl Default for KeyProviderConfig {
 /// storage, checkpoints) is encrypted using per-component DEKs derived from a
 /// master encryption key sourced by the configured [`KeyProviderConfig`].
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "config-toml", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "config-toml", serde(default))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct EncryptionConfig {
     /// Whether encryption at rest is enabled.
     pub enabled: bool,

--- a/src/encryption/factory.rs
+++ b/src/encryption/factory.rs
@@ -13,8 +13,8 @@ use crate::encryption::cipher::{
 ///
 /// `Auto` selects the best algorithm based on hardware capabilities at runtime.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "config-toml", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "config-toml", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum Algorithm {
     /// AES-256-GCM -- preferred when AES-NI hardware acceleration is available.
     Aes256Gcm,

--- a/src/index/vector/sparse.rs
+++ b/src/index/vector/sparse.rs
@@ -97,7 +97,7 @@ const SPARSE_INDEX_VERSION: u16 = 1;
 /// - **Cosine**: Angle-based similarity, ignores magnitude
 /// - **BM25**: Best for text retrieval with term frequencies
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
-#[cfg_attr(feature = "config-toml", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ScoringMethod {
     /// Dot product (inner product) similarity.
     /// Scores can be any real number. Higher is more similar.
@@ -125,7 +125,7 @@ impl ScoringMethod {
 
 /// Configuration for sparse vector index.
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "config-toml", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SparseIndexConfig {
     /// Vector dimensionality (total dimensions including zeros).
     pub dimensions: usize,
@@ -929,7 +929,7 @@ impl SparseVectorIndex {
 
 /// Statistics about a sparse vector index.
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "config-toml", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SparseIndexStats {
     /// Number of vectors in the index
     pub num_vectors: usize,

--- a/src/storage/index_persistence/api.rs
+++ b/src/storage/index_persistence/api.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-#[cfg(feature = "config-toml")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use super::formats::PersistencePolicies;
@@ -27,8 +27,8 @@ use super::formats::PersistencePolicies;
 /// [`crate::config::durable_config_for_data_dir`], which wire this up for you
 /// under a single data-directory root.
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "config-toml", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "config-toml", serde(default))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct PersistenceConfig {
     /// Whether persistence is enabled. Defaults to `false`; always pair
     /// `enabled: true` with an explicit `data_dir`.

--- a/src/storage/index_persistence/formats.rs
+++ b/src/storage/index_persistence/formats.rs
@@ -629,8 +629,8 @@ pub enum PersistedSnapshotType {
 
 /// Persistence policies for all index types.
 #[derive(Debug, Clone, PartialEq, Default, Encode, Decode)]
-#[cfg_attr(feature = "config-toml", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "config-toml", serde(default))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct PersistencePolicies {
     /// Vector index persistence policy
     pub vector: VectorPersistencePolicy,
@@ -644,8 +644,8 @@ pub struct PersistencePolicies {
 
 /// Vector index persistence policy.
 #[derive(Debug, Clone, PartialEq, Encode, Decode)]
-#[cfg_attr(feature = "config-toml", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "config-toml", serde(default))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct VectorPersistencePolicy {
     /// Persist after N mutations
     pub mutation_threshold: u32,
@@ -664,8 +664,8 @@ impl Default for VectorPersistencePolicy {
 
 /// Graph index persistence policy.
 #[derive(Debug, Clone, PartialEq, Encode, Decode)]
-#[cfg_attr(feature = "config-toml", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "config-toml", serde(default))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct GraphPersistencePolicy {
     /// Persist after adjacency rebuild
     pub on_adjacency_rebuild: bool,
@@ -687,8 +687,8 @@ impl Default for GraphPersistencePolicy {
 
 /// Temporal index persistence policy.
 #[derive(Debug, Clone, PartialEq, Encode, Decode)]
-#[cfg_attr(feature = "config-toml", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "config-toml", serde(default))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct TemporalPersistencePolicy {
     /// Persist after N new versions
     pub version_threshold: u32,
@@ -710,8 +710,8 @@ impl Default for TemporalPersistencePolicy {
 
 /// String interner persistence policy.
 #[derive(Debug, Clone, PartialEq, Encode, Decode)]
-#[cfg_attr(feature = "config-toml", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "config-toml", serde(default))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct StringPersistencePolicy {
     /// Persist after N new strings
     pub new_strings_threshold: u32,

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -76,7 +76,7 @@ use std::sync::{Condvar, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-#[cfg(feature = "config-toml")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Interval for checking shutdown signal in the background worker.
@@ -105,8 +105,8 @@ const DROP_TIMEOUT: Duration = Duration::from_secs(5);
 /// - Check for migration every 60 seconds
 /// - Trigger if memory usage exceeds 1GB
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "config-toml", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "config-toml", serde(default))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct MigrationPolicy {
     /// Migrate versions older than this duration.
     ///

--- a/src/storage/redb_cold_storage/mod.rs
+++ b/src/storage/redb_cold_storage/mod.rs
@@ -61,7 +61,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-#[cfg(feature = "config-toml")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
@@ -119,7 +119,7 @@ impl PreparedVersionBatch {
 
 /// Compression algorithm for cold storage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[cfg_attr(feature = "config-toml", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CompressionAlgorithm {
     /// No compression (fastest, but uses more disk space)
     None,
@@ -169,8 +169,8 @@ impl CompressionAlgorithm {
 /// assert!(matches!(config.compression, CompressionAlgorithm::Zstd));
 /// ```
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "config-toml", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "config-toml", serde(default))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct ColdStorageConfig {
     /// Compression algorithm to use.
     pub compression: CompressionAlgorithm,
@@ -404,8 +404,8 @@ fn map_compaction_error(
 ///     .cache_size_bytes(1024 * 1024 * 64); // 64MB cache
 /// ```
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "config-toml", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "config-toml", serde(default))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct RedbConfig {
     /// Compression algorithm for stored values.
     pub compression: CompressionAlgorithm,

--- a/src/storage/tiered_storage.rs
+++ b/src/storage/tiered_storage.rs
@@ -55,7 +55,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-#[cfg(feature = "config-toml")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Number of latency samples to keep for percentile calculation.
@@ -63,8 +63,8 @@ const LATENCY_SAMPLE_SIZE: usize = 1000;
 
 /// Configuration for tiered storage.
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "config-toml", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "config-toml", serde(default))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct TieredStorageConfig {
     /// Size of the warm cache (number of entries per type).
     /// This cache holds recently accessed cold data to reduce disk reads.

--- a/src/storage/wal/durability.rs
+++ b/src/storage/wal/durability.rs
@@ -38,7 +38,7 @@ use std::time::Duration;
 ///     .build();
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "config-toml", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DurabilityMode {
     /// Fsync after every commit. Maximum durability, minimum throughput.
     ///


### PR DESCRIPTION
Closes #3390.

## Summary

serde derives were gated ad hoc on `feature = "config-toml"` and `any(feature = "config-toml", feature = "mcp-server")` at ~37 sites across ~10 files, while other serde-pulling features (`http-server`, `sharding-rpc`, `encryption`, `encryption-vault`) enabled `dep:serde` without those derives ever activating — some existing gates were **narrower than their real consumers**. This introduces a single unified `serde` feature and routes every serde-enabling feature through it, then migrates every serde cfg gate to `feature = "serde"`.

## Before / After

**Before** (`Cargo.toml`)
```toml
config-toml  = ["dep:serde", "dep:toml"]
mcp-server   = ["dep:rmcp", "dep:tokio", "dep:serde", "dep:base64"]
sharding-rpc = ["dep:reqwest", "dep:serde", "dep:native-tls"]
http-server  = [..., "dep:serde", ...]
encryption   = ["dep:serde"]
```
```rust
#[cfg_attr(feature = "config-toml", derive(Serialize, Deserialize))]
#[cfg_attr(any(feature = "config-toml", feature = "mcp-server"), derive(serde::Serialize))]
```

**After**
```toml
serde        = ["dep:serde"]        # new: single serde toggle
config-toml  = ["serde", "dep:toml"]
mcp-server   = ["dep:rmcp", "dep:tokio", "serde", "dep:base64"]
sharding-rpc = ["dep:reqwest", "serde", "dep:native-tls"]
http-server  = [..., "serde", ...]
encryption   = ["serde"]
```
```rust
#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
#[cfg_attr(feature = "serde", derive(serde::Serialize))]
```

## How

- Added `serde = ["dep:serde"]` to `[features]`.
- Made `config-toml`, `mcp-server`, `sharding-rpc`, `http-server`, and `encryption` depend on `serde` instead of `dep:serde` (`encryption-aws-kms` / `encryption-vault` inherit it transitively via `encryption`).
- Migrated every serde derive / serde-attribute / `use serde::…` import / serde impl / serde-only test gate from `config-toml` / `any(config-toml, mcp-server)` to `feature = "serde"` — **68 gate lines across 13 `src` files**.
- Left genuine TOML-crate functionality (`from_toml_*` / `to_toml_*`, their `std::fs` / `std::path::Path` imports, and TOML round-trip tests) gated on `config-toml` — those need the `toml` dependency, not just serde.
- Extended `just check-features` to `cargo check --no-default-features --tests --features <F>` for `serde`, `config-toml`, `mcp-server`, `sharding-rpc`, `http-server`, `encryption`, `encryption-vault`, `encryption-aws-kms`.

## Acceptance criteria

- [x] **All serde-enabling feature combos compile standalone (extend `just check-features`).**
  Recipe extended; each of `serde`, `config-toml`, `mcp-server`, `sharding-rpc`, `http-server`, `encryption`, `encryption-vault`, `encryption-aws-kms` compiles with `--no-default-features` (all exit 0), plus a bare `--no-default-features` build.
- [x] **No behavior change under default features.**
  Default features include `config-toml` → `serde`, so the same derives are active as before. `cargo test --lib`: `3551 passed; 0 failed; 2 ignored`. `cargo clippy --all-targets --all-features -- -D warnings` exits 0.
- [x] **The ~37 sites migrated in one sweep.**
  All serde derive/attr/use/impl/test gates migrated; a post-sweep grep finds zero serde derives left on `config-toml` or `any(config-toml, mcp-server)`.

## Verification

- `cargo fmt --all` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — exit 0
- `cargo test --lib` — `3551 passed; 0 failed; 2 ignored`
- extended `just check-features` — every serde-enabling feature exits 0 standalone

The only failing test in the full `cargo test` run is `havoc_flush_deadlock::test_flush_deadlock_on_io_error`, a pre-existing environment failure (I/O-error injection cannot trigger when the suite runs as uid 0 / root) unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkubkQo6gZJc9iQtzaRtED

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkubkQo6gZJc9iQtzaRtED)_