### PR TITLE
Add signed audit export of entity history for compliance (#3358)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,7 @@ dependencies = [
  "crossterm",
  "csv",
  "dashmap",
+ "ed25519-dalek",
  "embed_anything",
  "hkdf",
  "lazy_static",
@@ -1978,6 +1979,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "cxx"
 version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2142,6 +2170,16 @@ name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
  "zeroize",
@@ -2399,7 +2437,31 @@ dependencies = [
  "der 0.6.1",
  "elliptic-curve",
  "rfc6979",
- "signature",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2421,7 +2483,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "pkcs8",
+ "pkcs8 0.9.0",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -2630,6 +2692,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -5159,7 +5227,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der 0.6.1",
- "spki",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.10",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -6394,7 +6472,7 @@ dependencies = [
  "base16ct",
  "der 0.6.1",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.9.0",
  "subtle",
  "zeroize",
 ]
@@ -6656,6 +6734,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6739,6 +6826,16 @@ checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
  "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.10",
 ]
 
 [[package]]
@@ -6941,7 +7038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,11 @@ aws-sdk-kms = { version = "1.106.0", optional = true }
 # Constant-time equality for API-key digest comparison (Issue #3350).
 subtle = "2.6"
 
+# Ed25519 asymmetric signatures for signed audit-export artifacts (Issue #3358).
+# Chosen over HMAC so third parties verify offline with ONLY the signer's public
+# key. Pure-Rust, RFC 8032 deterministic signatures → reproducible artifacts.
+ed25519-dalek = { version = "2", optional = true }
+
 [dev-dependencies]
 criterion = "0.8"
 proptest = "1.11"
@@ -177,7 +182,13 @@ observability = ["dep:tracing"]
 metrics-rs = ["observability", "dep:metrics"]
 
 # Default features
-default = ["config-toml"]
+default = ["config-toml", "audit-export"]
+
+# Signed audit export of entity history for compliance (Issue #3358).
+# Pulls Ed25519 (asymmetric offline-verifiable signatures) and serde (artifact
+# (de)serialization). On by default so the `aletheia` CLI ships audit-export /
+# audit-verify; cleanly excluded under --no-default-features.
+audit-export = ["dep:ed25519-dalek", "dep:serde"]
 
 # Async runtime support
 tokio = ["dep:tokio"]
@@ -197,8 +208,8 @@ embeddings = [
 # ONNX embedding support pulls in embed_anything's ort backend.
 embeddings-onnx = ["embeddings", "embed_anything/ort"]
 
-# MCP server support
-mcp-server = ["dep:rmcp", "dep:tokio", "dep:serde", "dep:base64"]
+# MCP server support (exposes the audit_export tool, so it implies audit-export)
+mcp-server = ["dep:rmcp", "dep:tokio", "dep:serde", "dep:base64", "audit-export"]
 
 # Sharding RPC client support (uses blocking reqwest)
 sharding-rpc = ["dep:reqwest", "dep:serde", "dep:native-tls"]

--- a/docs/guides/access-control-matrix.md
+++ b/docs/guides/access-control-matrix.md
@@ -82,6 +82,7 @@ is served by the HTTP admin endpoints over the shared persisted store
 | `query` | read |
 | `get_schema` | read |
 | `temporal_extent` | read |
+| `audit_export` | read |
 | `database_stats` | metrics |
 | `create_node` | write |
 | `update_node` | write |

--- a/docs/guides/audit-export.md
+++ b/docs/guides/audit-export.md
@@ -1,0 +1,261 @@
+# Signed Audit Export (Issue #3358)
+
+> Turn AletheiaDB's storage-layer trust into portable, courtroom-shaped evidence.
+
+When an auditor, regulator, or opposing counsel asks *"prove what your system knew
+about entity X, and when"*, a mutable JSON dump of `get_node_history` is worthless
+the moment it leaves the database. A **signed audit export** is a single, self-
+contained file that a third party can verify **offline** — with no AletheiaDB
+instance, no network, and no trust in the operator — establishing that:
+
+1. **Integrity** — no content in the artifact was altered after export.
+2. **Completeness** — no version was added, removed, or reordered.
+3. **Authenticity** — it was signed by the holder of a specific private key.
+
+This is the evidence packet that compliance workflows actually consume: AI-governance
+reviews, GDPR/CCPA subject-access requests, financial audits, and legal discovery.
+
+## Contents
+
+- [Quick start (CLI)](#quick-start-cli)
+- [What's in the artifact](#whats-in-the-artifact)
+- [The verification contract](#the-verification-contract)
+- [Offline verification](#offline-verification)
+- [Scope options](#scope-options)
+- [Redaction](#redaction)
+- [Rust API](#rust-api)
+- [MCP tool](#mcp-tool)
+- [Key management](#key-management)
+- [Why Ed25519 (not an HMAC)](#why-ed25519-not-an-hmac)
+- [Known limitation: delete/retract attribution (#3427)](#known-limitation-deleteretract-attribution-3427)
+- [Independently implementing a verifier](#independently-implementing-a-verifier)
+
+## Quick start (CLI)
+
+```bash
+# 1. Generate an operator signing key (written 0600). Prints the PUBLIC key —
+#    distribute that to auditors; keep the key file secret.
+aletheia audit-keygen ./audit-signing.key
+# {"ok":true,"key_file":"./audit-signing.key","public_key":"f80c…6215"}
+
+# 2. Export an entity's full bi-temporal history into a signed artifact.
+#    (Opens the database via ALETHEIADB_CONFIG or ALETHEIADB_DATA_DIR.)
+aletheia audit-export node 42 \
+    --key ./audit-signing.key \
+    --out ./evidence-node-42.audit.json \
+    --db-id prod-cluster-1 \
+    --redact ssn,dob
+
+# 3. Verify OFFLINE with only the public key — no database, no network.
+aletheia audit-verify ./evidence-node-42.audit.json \
+    --public-key f80c55f0087b9f32f17d5ad89003a4b0fb68cc2812de7508c401ebd2ba736215
+# PASS [trusted-key] db=prod-cluster-1 entities=1 versions=4 span=… root=1a12fb0d…
+
+# 4. Render a human-readable chronology for the humans in the audit.
+aletheia audit-render ./evidence-node-42.audit.json
+```
+
+`audit-verify` exits non-zero if verification fails, so it drops straight into CI.
+
+## What's in the artifact
+
+The artifact is a single JSON file. Top-level shape (`format_version: 1`):
+
+| Field | Purpose |
+|-------|---------|
+| `metadata` | Database identity, export time, tool version, **scope** (what was/wasn't included), **chain anchor** (WAL LSN at export time), redacted keys, entity/version counts, algorithm identifiers. |
+| `entities[]` | Each exported node/edge with its **complete** version list (oldest first), including superseded versions and delete tombstones. Each version carries bi-temporal coordinates, provenance (source / confidence / note / correlation_id / **principal**), and properties. |
+| `chain` | The integrity proof: a per-version `leaves[]` array of SHA-256 hashes and the folded `root`. |
+| `signature` | The Ed25519 `public_key`, the detached `signature` over `chain.root`, and a description of what was signed. |
+
+Every version records `valid_from`/`valid_to` and `transaction_from`/`transaction_to`
+(microseconds + HLC logical counter; open-ended bounds are explicit `null`), plus
+`is_current`.
+
+## The verification contract
+
+The signature is **not** computed over the JSON text. It is computed over a
+deterministic *canonical binary encoding* of the typed content, so that:
+
+- Re-pretty-printing, reordering object keys, or reformatting floats **does not**
+  break a valid signature.
+- Changing any signed value, timestamp, provenance field, entity endpoint, or the
+  order/number of versions **always** breaks it.
+
+Construction:
+
+1. **Leaf** — for each version, `leaf = SHA256("aletheiadb.audit.v1.leaf\0" ||
+   canon(version))`, where `canon` is the domain-separated, length-prefixed binary
+   encoding described [below](#independently-implementing-a-verifier). Property keys
+   are sorted; floats are hashed by their IEEE-754 bits.
+2. **Root** — fold, in order:
+   `acc = SHA256("aletheiadb.audit.v1.root\0" || canon(metadata))`; then for each
+   entity, `acc = SHA256(acc || SHA256("…header\0" || canon(header)))`, and for each
+   of its versions `acc = SHA256(acc || leaf)`. The final `acc` is `chain.root`.
+   The fold is **order- and count-dependent**, which is how reordering and truncation
+   are detected.
+3. **Signature** — `Ed25519.sign(private_key, chain.root)`.
+
+Verification recomputes the leaves and root from the content, checks them against the
+stored values, cross-checks the declared counts, and verifies the Ed25519 signature
+over the recomputed root. Descriptive/algorithm labels not folded into the root are
+pinned to their known constants, and unknown JSON fields are rejected — so no byte
+of the artifact escapes detection.
+
+### Chain anchor and #3351
+
+`metadata.chain_anchor.source_lsn` records the WAL log-sequence number at export time
+— the "chain-head position". When the global tamper-evident hash chain (#3351) lands,
+the per-version leaves can additionally be anchored to that chain's head; the format
+is designed to accommodate that additively.
+
+## Offline verification
+
+`aletheia audit-verify <file> [--public-key HEX]`:
+
+- With `--public-key`, the signature is checked against that **trusted** key **and**
+  the key embedded in the artifact must equal it — this defeats public-key
+  substitution (an attacker re-signing with their own key and swapping the embedded
+  key will fail against the trusted key).
+- Without `--public-key`, the embedded key is used and the result is marked
+  *self-asserted* with a prominent note — trust is only as good as the embedded key,
+  which is why an auditor should always supply the signer's known public key.
+
+Verification requires **no database and no network**. The Rust entry point is
+`aletheiadb::audit::verify_json_bytes(bytes, Some(&public_key))`.
+
+## Scope options
+
+Each option records in `metadata.scope` exactly what was requested, what was
+`included`, and what was `not_included` (with a reason) — so absence of data is never
+ambiguous.
+
+| Scope | CLI / API | Meaning |
+|-------|-----------|---------|
+| Single entity | `audit-export node <id>` / `AuditScope::node(id)` | One node or edge. |
+| Entity set | `AuditScope::EntitySet(vec![…])` | An explicit id list; missing entities are listed under `not_included`. |
+| Neighborhood | `AuditScope::Neighborhood { start, hops, valid_time, transaction_time }` | A node plus its N-hop neighborhood **at a stated bi-temporal coordinate**; the coordinate and hop radius are recorded, and only nodes/edges valid at that coordinate are included. Each member's *complete* history is exported. |
+
+## Redaction
+
+Redaction is **explicit and verifiable**, never silent. Redacted property keys
+(`--redact k1,k2` / `ExportOptions::redact([...])`) have their **values omitted** but
+the key and a `redacted: true` marker remain, and the redaction is folded into the
+signature. `metadata.redacted_keys` lists every redacted key. Verification still
+passes, but the redaction is visible in the artifact and in the verification report.
+
+## Rust API
+
+```rust
+use aletheiadb::AletheiaDB;
+use aletheiadb::audit::{AuditScope, AuditSigningKey, ExportOptions, verify_json_bytes};
+
+let db = AletheiaDB::open("./data")?;
+let key = AuditSigningKey::from_file("./audit-signing.key")?; // or ::generate()
+
+let export = db.audit_export(
+    AuditScope::node(node_id),
+    &key,
+    &ExportOptions::new("prod-cluster-1").redact(["ssn"]),
+)?;
+let bytes = export.to_json_bytes()?;      // the single-file artifact
+std::fs::write("evidence.audit.json", &bytes)?;
+
+// Offline verification (elsewhere, with only the public key):
+let report = verify_json_bytes(&bytes, Some(&key.public_key()))?;
+assert!(report.passed);
+println!("{}", report.summary());
+println!("{}", export.render_chronology());
+```
+
+## MCP tool
+
+The `audit_export` MCP tool lets an LLM/agent produce an evidence artifact in one
+call. Arguments: `entity_type` (`"node"`|`"edge"`), `entity_id`, optional
+`database_id`, optional `redact_keys`. It returns the artifact JSON plus `public_key`,
+`chain_root`, and entity/version counts. It is classified **read** in the
+[access-control matrix](access-control-matrix.md) (it reads history and signs it; it
+never mutates). The Ed25519 signing key is operator-provided out of band via the
+`ALETHEIADB_AUDIT_SIGNING_KEY` environment variable (a 32-byte hex seed); a missing
+key is a `FAILED_PRECONDITION` — the server never emits a silent unsigned export, and
+the secret is never returned or logged.
+
+## Key management
+
+Signing keys are operator-provided, file/env based to start (AC8), and follow the
+same handling conventions as the #3350 API-key store:
+
+- The private seed is held in a zeroizing buffer, **never logged**, and the
+  `Debug` impl prints only the public-key fingerprint.
+- `audit-keygen` writes the key file with `0600` permissions on unix from creation.
+- `AuditSigningKey::from_file` / `::from_env` / `::from_seed_hex` load a 32-byte hex
+  seed; `ALETHEIADB_AUDIT_SIGNING_KEY` is the standard env variable.
+
+**Interplay with the encryption cluster (#477–#491).** Audit signing keys are a
+distinct concern from the at-rest encryption key hierarchy: encryption keys protect
+data confidentiality on disk, while the audit signing key attests to the authenticity
+of an exported artifact. They are configured independently. An operator who manages
+encryption keys through a KMS/Vault provider can store the audit signing seed in the
+same secret manager and supply it via `ALETHEIADB_AUDIT_SIGNING_KEY`; this is a
+configuration choice, not a second key system baked into AletheiaDB. Rotating the
+audit signing key does not affect previously issued artifacts — each artifact embeds
+the public key it was signed with, and an auditor verifies against the public key that
+was current when the artifact was issued.
+
+## Why Ed25519 (not an HMAC)
+
+Verification must be possible for a party who holds **only the signer's public key**.
+A symmetric MAC (HMAC) would require the verifier to hold the same secret the signer
+holds — so the operator could forge artifacts and a third party could not
+independently trust them. Ed25519 detached signatures give offline, public-key-only
+verification; only the private-key holder can produce a valid signature, and RFC 8032
+determinism makes signatures reproducible.
+
+## Known limitation: delete/retract attribution (#3427)
+
+Delete and retract operations do **not** yet stamp an authenticated principal into
+version provenance (tracked as Issue #3427: destructive-op attribution needs a WAL
+payload extension to survive crash recovery). The audit export surfaces provenance
+**faithfully — including its absence** on delete tombstones — and never fabricates
+attribution. In a rendered chronology a delete tombstone shows
+`Provenance: (none recorded)`. This is documented honestly here rather than papered
+over; when #3427 lands, delete/retract versions will carry a principal like any other
+write, with no format change required.
+
+## Independently implementing a verifier
+
+A third party can implement a verifier from this section alone (plus SHA-256 and
+Ed25519 libraries). Canonical primitive framing — **all integers big-endian**:
+
+- `u8` tag; `u32`/`u64`/`i64` fixed-width; `f64` as its IEEE-754 `to_bits()` `u64`.
+- `bool` as one byte (`0`/`1`).
+- Length-prefixed byte strings: a `u64` length followed by the raw UTF-8/bytes.
+- `Option<T>`: a `0` byte for absent, or a `1` byte followed by `T`.
+
+**Version leaf** `canon(version)` writes, in order: entity kind (str), entity id
+(`u64`), version_number (`u64`), version_id (`u64`), label (str), valid_from micros
+(`i64`) + logical (`u32`), valid_to (opt `i64`) + logical (opt `u32`), transaction_from
+micros (`i64`) + logical (`u32`), transaction_to (opt `i64`) + logical (opt `u32`),
+is_current (bool), provenance (opt: source/confidence/note/correlation_id/principal,
+each an `Option`), then the property count (`u64`) followed by each property **sorted
+by key**: key (str), redacted (bool), value (opt, tagged by type — `0` null, `1` bool,
+`2` i64, `3` f64-bits, `4` string, `5` bytes, `6` array, `7` dense vector of f64-bits,
+`8` sparse vector). `leaf = SHA256("aletheiadb.audit.v1.leaf\0" || canon(version))`.
+
+**Entity header** `canon(header)` writes kind (str), id (`u64`), label (opt str),
+source (opt `u64`), target (opt `u64`);
+`header_hash = SHA256("aletheiadb.audit.v1.header\0" || canon(header))`.
+
+**Metadata** `canon(metadata)` writes database_id, exported_at, tool_version,
+scope_description, scope.kind, then the requested/included/not_included lists, the
+optional coordinate, hops (opt `u32`), chain_anchor.source_lsn (`u64`) + description,
+the **sorted** redacted keys, entity_count (`u64`), version_count (`u64`), and the two
+algorithm strings.
+
+**Root** — `acc = SHA256("aletheiadb.audit.v1.root\0" || canon(metadata))`; then for
+each entity `acc = SHA256(acc || header_hash)` and for each of its versions
+`acc = SHA256(acc || leaf)`. The final `acc` must equal `chain.root`.
+
+**Signature** — verify the 64-byte Ed25519 `signature` over the 32-byte root using the
+32-byte `public_key`. Also confirm `format_version == 1`, the algorithm labels, and
+the declared entity/version counts. Reject any unknown JSON fields.

--- a/src/audit/build.rs
+++ b/src/audit/build.rs
@@ -541,9 +541,5 @@ fn describe_scope(scope: &AuditScope) -> String {
 /// Format a timestamp as RFC 3339 (UTC), falling back to raw micros if it is
 /// outside chrono's representable range.
 fn format_timestamp(ts: Timestamp) -> String {
-    use chrono::{DateTime, Utc};
-    match DateTime::<Utc>::from_timestamp_micros(ts.wallclock()) {
-        Some(dt) => dt.to_rfc3339_opts(chrono::SecondsFormat::Micros, true),
-        None => format!("{}us", ts.wallclock()),
-    }
+    crate::audit::model::rfc3339_micros(ts.wallclock())
 }

--- a/src/audit/build.rs
+++ b/src/audit/build.rs
@@ -1,0 +1,549 @@
+//! Building a signed audit export from live database history (Issue #3358).
+//!
+//! This is a read-only path: it consumes the existing history reads
+//! (`get_node_history` / `get_edge_history`) plus current adjacency for the
+//! neighborhood scope, and never mutates the database — so it takes no
+//! write-path locks.
+
+use std::collections::BTreeSet;
+
+use crate::audit::canonical;
+use crate::audit::error::{AuditError, AuditResult};
+use crate::audit::model::{
+    AUDIT_FORMAT_VERSION, AuditExport, ChainAnchor, ChainProof, CoordinateRecord, EntityIdRecord,
+    ExportMetadata, ExportedEntity, ExportedProperty, ExportedProvenance, ExportedValue,
+    ExportedVersion, HASH_ALGORITHM, NotIncludedRecord, SIGNATURE_ALGORITHM, SIGNED_DESCRIPTION,
+    ScopeRecord, SignatureBlock, f64_to_token,
+};
+use crate::audit::signing::AuditSigningKey;
+use crate::core::history::{EntityHistory, VersionInfo};
+use crate::core::interning::GLOBAL_INTERNER;
+use crate::core::property::PropertyValue;
+use crate::core::temporal::{TIMESTAMP_MAX, Timestamp, time};
+use crate::core::{EdgeId, NodeId};
+use crate::db::AletheiaDB;
+
+/// A reference to a single node or edge for export.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntityRef {
+    /// A node, by id.
+    Node(NodeId),
+    /// An edge, by id.
+    Edge(EdgeId),
+}
+
+/// What to export (AC5): a single entity, an explicit set, or a neighborhood.
+#[derive(Debug, Clone)]
+pub enum AuditScope {
+    /// A single node or edge.
+    SingleEntity(EntityRef),
+    /// An explicit list of entities.
+    EntitySet(Vec<EntityRef>),
+    /// A node plus its N-hop neighborhood at a bi-temporal coordinate.
+    Neighborhood {
+        /// The entity to start from.
+        start: NodeId,
+        /// Hop radius.
+        hops: u32,
+        /// Valid-time coordinate (defaults to now when omitted).
+        valid_time: Option<Timestamp>,
+        /// Transaction-time coordinate (defaults to now when omitted).
+        transaction_time: Option<Timestamp>,
+    },
+}
+
+impl AuditScope {
+    /// Convenience: export a single node.
+    #[must_use]
+    pub fn node(id: NodeId) -> Self {
+        AuditScope::SingleEntity(EntityRef::Node(id))
+    }
+
+    /// Convenience: export a single edge.
+    #[must_use]
+    pub fn edge(id: EdgeId) -> Self {
+        AuditScope::SingleEntity(EntityRef::Edge(id))
+    }
+}
+
+/// Options controlling an export: database identity + redaction (AC6/AC8).
+#[derive(Debug, Clone)]
+pub struct ExportOptions {
+    database_id: String,
+    redact_keys: Vec<String>,
+}
+
+impl ExportOptions {
+    /// New options with the given operator-supplied database identity.
+    #[must_use]
+    pub fn new(database_id: impl Into<String>) -> Self {
+        Self {
+            database_id: database_id.into(),
+            redact_keys: Vec::new(),
+        }
+    }
+
+    /// Redact the given property keys at export (their values are omitted, but
+    /// the redaction is recorded and verifiable — never silent).
+    #[must_use]
+    pub fn redact<I, S>(mut self, keys: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.redact_keys
+            .extend(keys.into_iter().map(std::convert::Into::into));
+        self
+    }
+}
+
+impl AletheiaDB {
+    /// Produce a signed, self-contained audit export of an entity's (or a set
+    /// or neighborhood's) complete bi-temporal history (Issue #3358).
+    ///
+    /// The result verifies OFFLINE with only the signer's public key. See the
+    /// [`crate::audit`] module docs and `docs/guides/audit-export.md` for the
+    /// artifact format and verification contract.
+    ///
+    /// # Errors
+    /// Returns [`AuditError::NoHistory`] if a single requested entity has no
+    /// retrievable history, or [`AuditError::DatabaseRead`] on a read failure.
+    pub fn audit_export(
+        &self,
+        scope: AuditScope,
+        signing_key: &AuditSigningKey,
+        options: &ExportOptions,
+    ) -> AuditResult<AuditExport> {
+        let redact: BTreeSet<String> = options.redact_keys.iter().cloned().collect();
+
+        let (kind_str, requested, entities, not_included, coordinate, hops) =
+            self.resolve_scope(&scope, &redact)?;
+
+        let included: Vec<EntityIdRecord> = entities
+            .iter()
+            .map(|e| EntityIdRecord {
+                kind: e.kind.clone(),
+                id: e.id,
+            })
+            .collect();
+
+        let version_count: usize = entities.iter().map(|e| e.versions.len()).sum();
+        let mut redacted_keys: Vec<String> = redact.into_iter().collect();
+        redacted_keys.sort();
+
+        let metadata = ExportMetadata {
+            database_id: options.database_id.clone(),
+            exported_at: format_timestamp(time::now()),
+            tool_version: env!("CARGO_PKG_VERSION").to_string(),
+            scope_description: describe_scope(&scope),
+            scope: ScopeRecord {
+                kind: kind_str,
+                requested,
+                included,
+                not_included,
+                coordinate,
+                hops,
+            },
+            chain_anchor: ChainAnchor {
+                source_lsn: self.stats().wal.current_lsn,
+                description: "WAL LSN at export time (chain-head position, #3351 anchor)"
+                    .to_string(),
+            },
+            redacted_keys,
+            entity_count: entities.len(),
+            version_count,
+            hash_algorithm: HASH_ALGORITHM.to_string(),
+            signature_algorithm: SIGNATURE_ALGORITHM.to_string(),
+        };
+
+        // Integrity: per-version leaves + folded chain root, then sign the root.
+        let (leaves, root) = canonical::compute_chain(&metadata, &entities);
+        let signature = signing_key.sign_root(&root);
+        let public_key = signing_key.public_key();
+
+        Ok(AuditExport {
+            format_version: AUDIT_FORMAT_VERSION,
+            metadata,
+            entities,
+            chain: ChainProof {
+                algorithm: HASH_ALGORITHM.to_string(),
+                leaves: leaves.iter().map(canonical::to_hex).collect(),
+                root: canonical::to_hex(&root),
+            },
+            signature: SignatureBlock {
+                algorithm: SIGNATURE_ALGORITHM.to_string(),
+                public_key: public_key.to_hex(),
+                signature: crate::core::hex::encode(&signature),
+                signed: SIGNED_DESCRIPTION.to_string(),
+            },
+        })
+    }
+
+    /// Resolve a scope into the concrete entities to export plus scope metadata.
+    #[allow(clippy::type_complexity)]
+    fn resolve_scope(
+        &self,
+        scope: &AuditScope,
+        redact: &BTreeSet<String>,
+    ) -> AuditResult<(
+        String,
+        Vec<EntityIdRecord>,
+        Vec<ExportedEntity>,
+        Vec<NotIncludedRecord>,
+        Option<CoordinateRecord>,
+        Option<u32>,
+    )> {
+        match scope {
+            AuditScope::SingleEntity(entity_ref) => {
+                let kind = match entity_ref {
+                    EntityRef::Node(_) => "single_node",
+                    EntityRef::Edge(_) => "single_edge",
+                };
+                let requested = vec![entity_id_record(*entity_ref)];
+                let exported = self
+                    .export_one(*entity_ref, redact)?
+                    .ok_or_else(|| AuditError::NoHistory(describe_entity(*entity_ref)))?;
+                Ok((
+                    kind.to_string(),
+                    requested,
+                    vec![exported],
+                    Vec::new(),
+                    None,
+                    None,
+                ))
+            }
+            AuditScope::EntitySet(refs) => {
+                let requested: Vec<EntityIdRecord> =
+                    refs.iter().map(|r| entity_id_record(*r)).collect();
+                let mut entities = Vec::new();
+                let mut not_included = Vec::new();
+                for r in refs {
+                    match self.export_one(*r, redact)? {
+                        Some(e) => entities.push(e),
+                        None => {
+                            let rec = entity_id_record(*r);
+                            not_included.push(NotIncludedRecord {
+                                kind: rec.kind,
+                                id: rec.id,
+                                reason: "no_history".to_string(),
+                            });
+                        }
+                    }
+                }
+                Ok((
+                    "entity_set".to_string(),
+                    requested,
+                    entities,
+                    not_included,
+                    None,
+                    None,
+                ))
+            }
+            AuditScope::Neighborhood {
+                start,
+                hops,
+                valid_time,
+                transaction_time,
+            } => {
+                let vt = valid_time.unwrap_or_else(time::now);
+                let tt = transaction_time.unwrap_or_else(time::now);
+                let (node_ids, edge_ids) = self.collect_neighborhood(*start, *hops, vt, tt);
+
+                let mut entities = Vec::new();
+                for n in node_ids {
+                    if let Some(e) = self.export_one(EntityRef::Node(n), redact)? {
+                        entities.push(e);
+                    }
+                }
+                for ed in edge_ids {
+                    if let Some(e) = self.export_one(EntityRef::Edge(ed), redact)? {
+                        entities.push(e);
+                    }
+                }
+                let coordinate = Some(CoordinateRecord {
+                    valid_time: Some(format_timestamp(vt)),
+                    transaction_time: Some(format_timestamp(tt)),
+                });
+                Ok((
+                    "neighborhood".to_string(),
+                    vec![entity_id_record(EntityRef::Node(*start))],
+                    entities,
+                    Vec::new(),
+                    coordinate,
+                    Some(*hops),
+                ))
+            }
+        }
+    }
+
+    /// Export a single entity's full history, or `None` if it has no history.
+    fn export_one(
+        &self,
+        entity_ref: EntityRef,
+        redact: &BTreeSet<String>,
+    ) -> AuditResult<Option<ExportedEntity>> {
+        match entity_ref {
+            EntityRef::Node(id) => {
+                let history = match self.get_node_history(id) {
+                    Ok(h) => h,
+                    Err(_) => return Ok(None),
+                };
+                if history.version_count() == 0 {
+                    return Ok(None);
+                }
+                let label = history
+                    .current_version()
+                    .or_else(|| history.first_version())
+                    .map(|v| v.label.clone());
+                Ok(Some(ExportedEntity {
+                    kind: "node".to_string(),
+                    id: id.as_u64(),
+                    label,
+                    source: None,
+                    target: None,
+                    versions: convert_versions(&history, redact),
+                }))
+            }
+            EntityRef::Edge(id) => {
+                let history = match self.get_edge_history(id) {
+                    Ok(h) => h,
+                    Err(_) => return Ok(None),
+                };
+                if history.version_count() == 0 {
+                    return Ok(None);
+                }
+                let label = history
+                    .current_version()
+                    .or_else(|| history.first_version())
+                    .map(|v| v.label.clone());
+                // Endpoints are informational; recover them if the edge still
+                // resolves (deleted edges leave them unknown → None).
+                let (source, target) = match self.get_edge(id) {
+                    Ok(edge) => (Some(edge.source.as_u64()), Some(edge.target.as_u64())),
+                    Err(_) => (None, None),
+                };
+                Ok(Some(ExportedEntity {
+                    kind: "edge".to_string(),
+                    id: id.as_u64(),
+                    label,
+                    source,
+                    target,
+                    versions: convert_versions(&history, redact),
+                }))
+            }
+        }
+    }
+
+    /// BFS the current graph from `start` up to `hops`, keeping only nodes/edges
+    /// valid at the given bi-temporal coordinate. Returns `(nodes, edges)`.
+    fn collect_neighborhood(
+        &self,
+        start: NodeId,
+        hops: u32,
+        vt: Timestamp,
+        tt: Timestamp,
+    ) -> (Vec<NodeId>, Vec<EdgeId>) {
+        let mut nodes: BTreeSet<u64> = BTreeSet::new();
+        let mut edges: BTreeSet<u64> = BTreeSet::new();
+        let mut frontier: Vec<NodeId> = Vec::new();
+
+        if self.get_node_at_time(start, vt, tt).is_ok() {
+            nodes.insert(start.as_u64());
+            frontier.push(start);
+        }
+
+        for _ in 0..hops {
+            let mut next = Vec::new();
+            for node in std::mem::take(&mut frontier) {
+                for edge_id in self
+                    .get_outgoing_edges(node)
+                    .into_iter()
+                    .chain(self.get_incoming_edges(node))
+                {
+                    if self.get_edge_at_time(edge_id, vt, tt).is_err() {
+                        continue;
+                    }
+                    edges.insert(edge_id.as_u64());
+                    for endpoint in [
+                        self.get_edge_source(edge_id).ok(),
+                        self.get_edge_target(edge_id).ok(),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    {
+                        if self.get_node_at_time(endpoint, vt, tt).is_ok()
+                            && nodes.insert(endpoint.as_u64())
+                        {
+                            next.push(endpoint);
+                        }
+                    }
+                }
+            }
+            frontier = next;
+        }
+
+        let node_ids = nodes
+            .into_iter()
+            .filter_map(|id| NodeId::new(id).ok())
+            .collect();
+        let edge_ids = edges
+            .into_iter()
+            .filter_map(|id| EdgeId::new(id).ok())
+            .collect();
+        (node_ids, edge_ids)
+    }
+}
+
+/// Convert an entity's history into exported versions (oldest first).
+fn convert_versions(history: &EntityHistory, redact: &BTreeSet<String>) -> Vec<ExportedVersion> {
+    let now = time::now();
+    history
+        .versions
+        .iter()
+        .map(|v| convert_version(v, redact, now))
+        .collect()
+}
+
+fn convert_version(v: &VersionInfo, redact: &BTreeSet<String>, now: Timestamp) -> ExportedVersion {
+    let valid = v.temporal.valid_time();
+    let tx = v.temporal.transaction_time();
+
+    let (valid_to_micros, valid_to_logical) = closed_bound(valid.end());
+    let (tx_to_micros, tx_to_logical) = closed_bound(tx.end());
+    let is_current = tx.is_current() && valid.contains(now);
+
+    let mut properties: Vec<ExportedProperty> = v
+        .properties
+        .iter()
+        .map(|(key, value)| {
+            let key_str = GLOBAL_INTERNER
+                .resolve_with(*key, std::string::ToString::to_string)
+                .unwrap_or_else(|| "<unknown-key>".to_string());
+            if redact.contains(&key_str) {
+                ExportedProperty {
+                    key: key_str,
+                    value: None,
+                    redacted: true,
+                }
+            } else {
+                ExportedProperty {
+                    key: key_str,
+                    value: Some(property_value_to_exported(value)),
+                    redacted: false,
+                }
+            }
+        })
+        .collect();
+    properties.sort_by(|a, b| a.key.cmp(&b.key));
+
+    ExportedVersion {
+        version_number: v.version_number,
+        version_id: v.version_id.as_u64(),
+        label: v.label.clone(),
+        valid_from_micros: valid.start().wallclock(),
+        valid_from_logical: valid.start().logical(),
+        valid_to_micros,
+        valid_to_logical,
+        transaction_from_micros: tx.start().wallclock(),
+        transaction_from_logical: tx.start().logical(),
+        transaction_to_micros: tx_to_micros,
+        transaction_to_logical: tx_to_logical,
+        is_current,
+        provenance: v.provenance.as_ref().map(convert_provenance),
+        properties,
+    }
+}
+
+/// `None` for an open-ended (`TIMESTAMP_MAX`) bound, else its `(micros, logical)`.
+fn closed_bound(end: Timestamp) -> (Option<i64>, Option<u32>) {
+    if end == TIMESTAMP_MAX {
+        (None, None)
+    } else {
+        (Some(end.wallclock()), Some(end.logical()))
+    }
+}
+
+fn convert_provenance(p: &crate::core::provenance::Provenance) -> ExportedProvenance {
+    ExportedProvenance {
+        source: p.source().map(std::string::ToString::to_string),
+        confidence: p.confidence(),
+        note: p.note().map(std::string::ToString::to_string),
+        correlation_id: p.correlation_id().map(std::string::ToString::to_string),
+        principal: p.principal().map(std::string::ToString::to_string),
+    }
+}
+
+fn property_value_to_exported(value: &PropertyValue) -> ExportedValue {
+    match value {
+        PropertyValue::Null => ExportedValue::Null,
+        PropertyValue::Bool(b) => ExportedValue::Bool { value: *b },
+        PropertyValue::Int(i) => ExportedValue::Int { value: *i },
+        PropertyValue::Float(f) => ExportedValue::Float { value: *f },
+        PropertyValue::String(s) => ExportedValue::String {
+            value: s.to_string(),
+        },
+        PropertyValue::Bytes(b) => ExportedValue::Bytes {
+            hex: crate::core::hex::encode(b),
+        },
+        PropertyValue::Array(values) => ExportedValue::Array {
+            values: values.iter().map(property_value_to_exported).collect(),
+        },
+        PropertyValue::Vector(v) => ExportedValue::Vector {
+            values: v.iter().map(|f| f64_to_token(f64::from(*f))).collect(),
+        },
+        PropertyValue::SparseVector(sv) => ExportedValue::SparseVector {
+            dimension: sv.dimension(),
+            indices: sv.indices().to_vec(),
+            values: sv
+                .values()
+                .iter()
+                .map(|f| f64_to_token(f64::from(*f)))
+                .collect(),
+        },
+    }
+}
+
+fn entity_id_record(r: EntityRef) -> EntityIdRecord {
+    match r {
+        EntityRef::Node(id) => EntityIdRecord {
+            kind: "node".to_string(),
+            id: id.as_u64(),
+        },
+        EntityRef::Edge(id) => EntityIdRecord {
+            kind: "edge".to_string(),
+            id: id.as_u64(),
+        },
+    }
+}
+
+fn describe_entity(r: EntityRef) -> String {
+    match r {
+        EntityRef::Node(id) => format!("node {}", id.as_u64()),
+        EntityRef::Edge(id) => format!("edge {}", id.as_u64()),
+    }
+}
+
+fn describe_scope(scope: &AuditScope) -> String {
+    match scope {
+        AuditScope::SingleEntity(EntityRef::Node(id)) => {
+            format!("single_node: node {}", id.as_u64())
+        }
+        AuditScope::SingleEntity(EntityRef::Edge(id)) => {
+            format!("single_edge: edge {}", id.as_u64())
+        }
+        AuditScope::EntitySet(refs) => format!("entity_set: {} entities requested", refs.len()),
+        AuditScope::Neighborhood { start, hops, .. } => {
+            format!("neighborhood: {} hops around node {}", hops, start.as_u64())
+        }
+    }
+}
+
+/// Format a timestamp as RFC 3339 (UTC), falling back to raw micros if it is
+/// outside chrono's representable range.
+fn format_timestamp(ts: Timestamp) -> String {
+    use chrono::{DateTime, Utc};
+    match DateTime::<Utc>::from_timestamp_micros(ts.wallclock()) {
+        Some(dt) => dt.to_rfc3339_opts(chrono::SecondsFormat::Micros, true),
+        None => format!("{}us", ts.wallclock()),
+    }
+}

--- a/src/audit/canonical.rs
+++ b/src/audit/canonical.rs
@@ -1,0 +1,352 @@
+//! Deterministic canonical encoding + SHA-256 hash chain (Issue #3358).
+//!
+//! The signature is computed over a canonical *binary* encoding of the typed
+//! [`super::model`] values — NOT the JSON text — so that reformatting the JSON
+//! (whitespace, key order, float rendering) never invalidates a signature, while
+//! any change to signed content (a value, a timestamp, a provenance field, the
+//! order or count of versions) always changes a leaf hash and therefore the root.
+//!
+//! # Canonical encoding (independently implementable)
+//!
+//! Primitive framing, all integers big-endian:
+//! - `u8` tag, `u32`/`u64`/`i64` fixed-width, `f64` as its IEEE-754 `to_bits()` u64,
+//! - `bool` as one byte (`0`/`1`),
+//! - length-prefixed byte strings: `u64` length then raw UTF-8/bytes,
+//! - `Option<T>`: a `0` byte for `None`, or a `1` byte then `T`.
+//!
+//! A version leaf is `SHA256("aletheiadb.audit.v1.leaf\0" || canon(version))`.
+//! The root folds metadata then every leaf in flattened entity→version order:
+//! `acc = SHA256("aletheiadb.audit.v1.root\0" || canon(metadata))`, then for each
+//! leaf `acc = SHA256(acc || leaf)`; the final `acc` is the root the signature
+//! covers. The fold is order- and count-dependent, so reordering or truncating
+//! versions changes the root.
+
+use crate::audit::model::{
+    ExportMetadata, ExportedEntity, ExportedProperty, ExportedProvenance, ExportedValue,
+    ExportedVersion,
+};
+use crate::core::hex;
+use sha2::{Digest, Sha256};
+
+const LEAF_DOMAIN: &[u8] = b"aletheiadb.audit.v1.leaf\0";
+const ROOT_DOMAIN: &[u8] = b"aletheiadb.audit.v1.root\0";
+const HEADER_DOMAIN: &[u8] = b"aletheiadb.audit.v1.header\0";
+
+/// A tiny append-only canonical byte writer.
+#[derive(Default)]
+struct Canon {
+    buf: Vec<u8>,
+}
+
+impl Canon {
+    fn tag(&mut self, t: u8) {
+        self.buf.push(t);
+    }
+    fn u32(&mut self, v: u32) {
+        self.buf.extend_from_slice(&v.to_be_bytes());
+    }
+    fn u64(&mut self, v: u64) {
+        self.buf.extend_from_slice(&v.to_be_bytes());
+    }
+    fn i64(&mut self, v: i64) {
+        self.buf.extend_from_slice(&v.to_be_bytes());
+    }
+    fn f64(&mut self, v: f64) {
+        self.buf.extend_from_slice(&v.to_bits().to_be_bytes());
+    }
+    fn bool(&mut self, v: bool) {
+        self.buf.push(u8::from(v));
+    }
+    fn bytes(&mut self, b: &[u8]) {
+        self.u64(b.len() as u64);
+        self.buf.extend_from_slice(b);
+    }
+    fn str(&mut self, s: &str) {
+        self.bytes(s.as_bytes());
+    }
+    fn opt_i64(&mut self, v: Option<i64>) {
+        match v {
+            None => self.buf.push(0),
+            Some(x) => {
+                self.buf.push(1);
+                self.i64(x);
+            }
+        }
+    }
+    fn opt_u32(&mut self, v: Option<u32>) {
+        match v {
+            None => self.buf.push(0),
+            Some(x) => {
+                self.buf.push(1);
+                self.u32(x);
+            }
+        }
+    }
+    fn opt_str(&mut self, v: Option<&str>) {
+        match v {
+            None => self.buf.push(0),
+            Some(s) => {
+                self.buf.push(1);
+                self.str(s);
+            }
+        }
+    }
+    fn opt_f64(&mut self, v: Option<f64>) {
+        match v {
+            None => self.buf.push(0),
+            Some(x) => {
+                self.buf.push(1);
+                self.f64(x);
+            }
+        }
+    }
+
+    fn value(&mut self, v: &ExportedValue) {
+        match v {
+            ExportedValue::Null => self.tag(0),
+            ExportedValue::Bool { value } => {
+                self.tag(1);
+                self.bool(*value);
+            }
+            ExportedValue::Int { value } => {
+                self.tag(2);
+                self.i64(*value);
+            }
+            ExportedValue::Float { value } => {
+                self.tag(3);
+                self.f64(*value);
+            }
+            ExportedValue::String { value } => {
+                self.tag(4);
+                self.str(value);
+            }
+            ExportedValue::Bytes { hex } => {
+                self.tag(5);
+                // Encode the decoded bytes so an equivalent-but-recased hex still
+                // canonicalizes identically; fall back to raw string on garbage.
+                match hex::decode(hex) {
+                    Some(bytes) => self.bytes(&bytes),
+                    None => self.str(hex),
+                }
+            }
+            ExportedValue::Array { values } => {
+                self.tag(6);
+                self.u64(values.len() as u64);
+                for e in values {
+                    self.value(e);
+                }
+            }
+            ExportedValue::Vector { values } => {
+                self.tag(7);
+                self.u64(values.len() as u64);
+                for s in values {
+                    // Canonicalize via the parsed float bits.
+                    let f = crate::audit::model::token_to_f64(s).unwrap_or(f64::NAN);
+                    self.f64(f);
+                }
+            }
+            ExportedValue::SparseVector {
+                dimension,
+                indices,
+                values,
+            } => {
+                self.tag(8);
+                self.u64(*dimension as u64);
+                self.u64(indices.len() as u64);
+                for i in indices {
+                    self.u32(*i);
+                }
+                self.u64(values.len() as u64);
+                for s in values {
+                    let f = crate::audit::model::token_to_f64(s).unwrap_or(f64::NAN);
+                    self.f64(f);
+                }
+            }
+        }
+    }
+
+    fn provenance(&mut self, p: &Option<ExportedProvenance>) {
+        match p {
+            None => self.buf.push(0),
+            Some(pr) => {
+                self.buf.push(1);
+                self.opt_str(pr.source.as_deref());
+                self.opt_f64(pr.confidence);
+                self.opt_str(pr.note.as_deref());
+                self.opt_str(pr.correlation_id.as_deref());
+                self.opt_str(pr.principal.as_deref());
+            }
+        }
+    }
+
+    fn property(&mut self, p: &ExportedProperty) {
+        self.str(&p.key);
+        self.bool(p.redacted);
+        match &p.value {
+            None => self.buf.push(0),
+            Some(v) => {
+                self.buf.push(1);
+                self.value(v);
+            }
+        }
+    }
+}
+
+/// Canonical bytes for a single version leaf (bound to its entity identity).
+fn version_canonical(entity_kind: &str, entity_id: u64, v: &ExportedVersion) -> Vec<u8> {
+    let mut c = Canon::default();
+    c.str(entity_kind);
+    c.u64(entity_id);
+    c.u64(v.version_number);
+    c.u64(v.version_id);
+    c.str(&v.label);
+    c.i64(v.valid_from_micros);
+    c.u32(v.valid_from_logical);
+    c.opt_i64(v.valid_to_micros);
+    c.opt_u32(v.valid_to_logical);
+    c.i64(v.transaction_from_micros);
+    c.u32(v.transaction_from_logical);
+    c.opt_i64(v.transaction_to_micros);
+    c.opt_u32(v.transaction_to_logical);
+    c.bool(v.is_current);
+    c.provenance(&v.provenance);
+
+    // Sort properties by key so property-array ordering is not signed content.
+    let mut props: Vec<&ExportedProperty> = v.properties.iter().collect();
+    props.sort_by(|a, b| a.key.cmp(&b.key));
+    c.u64(props.len() as u64);
+    for p in props {
+        c.property(p);
+    }
+    c.buf
+}
+
+/// Canonical bytes for the export metadata (folded first into the root).
+fn metadata_canonical(m: &ExportMetadata) -> Vec<u8> {
+    let mut c = Canon::default();
+    c.str(&m.database_id);
+    c.str(&m.exported_at);
+    c.str(&m.tool_version);
+    c.str(&m.scope_description);
+    c.str(&m.scope.kind);
+    // requested + included + not_included (order as recorded, they are stable).
+    c.u64(m.scope.requested.len() as u64);
+    for e in &m.scope.requested {
+        c.str(&e.kind);
+        c.u64(e.id);
+    }
+    c.u64(m.scope.included.len() as u64);
+    for e in &m.scope.included {
+        c.str(&e.kind);
+        c.u64(e.id);
+    }
+    c.u64(m.scope.not_included.len() as u64);
+    for e in &m.scope.not_included {
+        c.str(&e.kind);
+        c.u64(e.id);
+        c.str(&e.reason);
+    }
+    match &m.scope.coordinate {
+        None => c.buf.push(0),
+        Some(co) => {
+            c.buf.push(1);
+            c.opt_str(co.valid_time.as_deref());
+            c.opt_str(co.transaction_time.as_deref());
+        }
+    }
+    c.opt_u32(m.scope.hops);
+    c.u64(m.chain_anchor.source_lsn);
+    c.str(&m.chain_anchor.description);
+    // Redacted keys folded sorted so their order is not signed content.
+    let mut rk: Vec<&String> = m.redacted_keys.iter().collect();
+    rk.sort();
+    c.u64(rk.len() as u64);
+    for k in rk {
+        c.str(k);
+    }
+    c.u64(m.entity_count as u64);
+    c.u64(m.version_count as u64);
+    c.str(&m.hash_algorithm);
+    c.str(&m.signature_algorithm);
+    c.buf
+}
+
+/// Canonical bytes for an entity header (binds label / edge endpoints).
+fn entity_header_canonical(entity: &ExportedEntity) -> Vec<u8> {
+    let mut c = Canon::default();
+    c.str(&entity.kind);
+    c.u64(entity.id);
+    c.opt_str(entity.label.as_deref());
+    match entity.source {
+        None => c.buf.push(0),
+        Some(s) => {
+            c.buf.push(1);
+            c.u64(s);
+        }
+    }
+    match entity.target {
+        None => c.buf.push(0),
+        Some(t) => {
+            c.buf.push(1);
+            c.u64(t);
+        }
+    }
+    c.buf
+}
+
+/// SHA-256 of `domain || payload`.
+fn hash_domain(domain: &[u8], payload: &[u8]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(domain);
+    h.update(payload);
+    h.finalize().into()
+}
+
+/// Compute the per-version leaf hashes AND the folded chain root in one pass.
+///
+/// Returns `(leaves, root)` where `leaves` are the per-version hashes in
+/// flattened entity→version order (stored in the artifact) and `root` is the
+/// 32-byte value the signature covers. The fold binds, in order: the metadata,
+/// then for each entity its header followed by each of its version leaves — so
+/// tampering an endpoint, reordering, or truncating any of them changes `root`.
+pub(crate) fn compute_chain(
+    metadata: &ExportMetadata,
+    entities: &[ExportedEntity],
+) -> (Vec<[u8; 32]>, [u8; 32]) {
+    let mut acc = hash_domain(ROOT_DOMAIN, &metadata_canonical(metadata));
+    let mut leaves = Vec::new();
+    for entity in entities {
+        let header = hash_domain(HEADER_DOMAIN, &entity_header_canonical(entity));
+        acc = fold(acc, &header);
+        for v in &entity.versions {
+            let leaf = hash_domain(LEAF_DOMAIN, &version_canonical(&entity.kind, entity.id, v));
+            leaves.push(leaf);
+            acc = fold(acc, &leaf);
+        }
+    }
+    (leaves, acc)
+}
+
+/// `SHA256(acc || next)`.
+fn fold(acc: [u8; 32], next: &[u8; 32]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(acc);
+    h.update(next);
+    h.finalize().into()
+}
+
+/// Hex-encode a 32-byte hash.
+pub(crate) fn to_hex(bytes: &[u8; 32]) -> String {
+    hex::encode(bytes)
+}
+
+/// Decode a 32-byte hex hash.
+pub(crate) fn hex_to_32(s: &str) -> Option<[u8; 32]> {
+    let v = hex::decode(s)?;
+    if v.len() != 32 {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&v);
+    Some(out)
+}

--- a/src/audit/error.rs
+++ b/src/audit/error.rs
@@ -1,0 +1,71 @@
+//! Error type for the signed audit-export subsystem (Issue #3358).
+
+use thiserror::Error;
+
+/// Errors from building, serializing, or verifying a signed audit export.
+///
+/// Verification failures are deliberately specific so an auditor can tell
+/// *why* an artifact was rejected (tampered content, wrong key, truncated,
+/// reordered) — completeness and integrity are distinct guarantees.
+#[derive(Debug, Error)]
+pub enum AuditError {
+    /// The requested entity had no retrievable history (does not exist).
+    #[error("entity has no exportable history: {0}")]
+    NoHistory(String),
+
+    /// A read against the database failed while building the export.
+    #[error("database read failed during export: {0}")]
+    DatabaseRead(String),
+
+    /// The signing key material was malformed (wrong length / not hex).
+    #[error("invalid signing key: {0}")]
+    InvalidKey(String),
+
+    /// The public key material was malformed.
+    #[error("invalid public key: {0}")]
+    InvalidPublicKey(String),
+
+    /// I/O failure reading or writing key material or an artifact.
+    #[error("audit I/O error: {0}")]
+    Io(String),
+
+    /// The artifact could not be serialized or parsed as JSON.
+    #[error("audit artifact (de)serialization error: {0}")]
+    Serialization(String),
+
+    /// The artifact declares a format version this build cannot verify.
+    #[error("unsupported audit artifact format version {found} (expected {expected})")]
+    UnsupportedFormat {
+        /// Version found in the artifact.
+        found: u32,
+        /// Version this build understands.
+        expected: u32,
+    },
+
+    /// A per-version integrity leaf hash did not match — content was altered.
+    #[error("content integrity check failed: {0}")]
+    ContentTampered(String),
+
+    /// The recomputed chain root did not match the embedded root — content was
+    /// altered, reordered, or truncated.
+    #[error(
+        "chain root mismatch: artifact content is inconsistent (tampered, reordered, or truncated)"
+    )]
+    ChainRootMismatch,
+
+    /// The declared version/entity count did not match the embedded records —
+    /// records were added or removed.
+    #[error("completeness check failed: {0}")]
+    CompletenessMismatch(String),
+
+    /// The signature did not verify against the expected public key.
+    #[error("signature verification failed: {0}")]
+    SignatureInvalid(String),
+
+    /// The embedded public key did not match the caller-supplied trusted key.
+    #[error("public key mismatch: artifact is signed by a different key than the trusted one")]
+    KeyMismatch,
+}
+
+/// Result alias for audit operations.
+pub type AuditResult<T> = std::result::Result<T, AuditError>;

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -1,0 +1,71 @@
+//! Signed audit export of entity history for compliance (Issue #3358).
+//!
+//! Turns AletheiaDB's storage-layer trust into portable, offline-verifiable
+//! evidence: a single-file artifact containing an entity's complete bi-temporal
+//! history plus provenance, signed so a third party with only the signer's
+//! **public key** can verify — with no database, no network, and no trust in the
+//! operator — that (a) no content was altered after export and (b) the content
+//! is complete (nothing was added, removed, or reordered).
+//!
+//! # Why Ed25519 (asymmetric) rather than an HMAC
+//!
+//! Verification must be possible for a party who has *only the signer's public
+//! key*. A symmetric MAC would require the verifier to hold the same secret the
+//! signer holds — so the operator could forge artifacts and a third party could
+//! not independently trust them. Ed25519 detached signatures over a SHA-256 hash
+//! chain give offline, public-key-only verification with reproducible signatures.
+//!
+//! # Artifact + verification contract
+//!
+//! The artifact is JSON ([`AuditExport`]). Its signature is computed over a
+//! deterministic canonical *binary* encoding of the typed content (not the JSON
+//! text), so reformatting is safe but any content change is caught. See the
+//! [`canonical`] module and `docs/guides/audit-export.md` for the fully
+//! documented, independently-implementable format.
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! use aletheiadb::AletheiaDB;
+//! use aletheiadb::audit::{AuditScope, AuditSigningKey, ExportOptions, verify_json_bytes};
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let db = AletheiaDB::new()?;
+//! let node = db.create_node("Person", aletheiadb::PropertyMap::new())?;
+//!
+//! let key = AuditSigningKey::generate();
+//! let export = db.audit_export(AuditScope::node(node), &key, &ExportOptions::new("prod-db"))?;
+//! let bytes = export.to_json_bytes()?;
+//!
+//! // Offline: only the bytes + the public key.
+//! let report = verify_json_bytes(&bytes, Some(&key.public_key()))?;
+//! assert!(report.passed);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Known limitation (#3427)
+//!
+//! Delete/retract operations do not yet stamp an authenticated principal into
+//! provenance. The export surfaces provenance faithfully — including its absence
+//! on delete tombstones — and never fabricates attribution. This is documented
+//! honestly rather than papered over.
+
+mod build;
+mod canonical;
+mod error;
+mod model;
+mod signing;
+mod verify;
+
+#[cfg(test)]
+mod tests;
+
+pub use build::{AuditScope, EntityRef, ExportOptions};
+pub use error::{AuditError, AuditResult};
+pub use model::{
+    AUDIT_FORMAT_VERSION, AuditExport, ChainAnchor, ChainProof, CoordinateRecord, EntityIdRecord,
+    ExportMetadata, ExportedEntity, ExportedProperty, ExportedProvenance, ExportedValue,
+    ExportedVersion, NotIncludedRecord, ScopeRecord, SignatureBlock,
+};
+pub use signing::{AuditPublicKey, AuditSigningKey, SIGNING_KEY_ENV};
+pub use verify::{AuditVerification, verify_json_bytes};

--- a/src/audit/model.rs
+++ b/src/audit/model.rs
@@ -304,6 +304,17 @@ pub struct SignatureBlock {
     pub signed: String,
 }
 
+/// Format microseconds-since-epoch as RFC 3339 (UTC), or `<micros>us` if the
+/// value is outside chrono's representable range. Shared by the export builder
+/// and the offline verifier so their timestamp rendering cannot drift.
+pub(crate) fn rfc3339_micros(micros: i64) -> String {
+    use chrono::{DateTime, Utc};
+    match DateTime::<Utc>::from_timestamp_micros(micros) {
+        Some(dt) => dt.to_rfc3339_opts(chrono::SecondsFormat::Micros, true),
+        None => format!("{micros}us"),
+    }
+}
+
 /// Render a finite/NaN/Inf `f64` to a lossless, parseable token.
 pub(crate) fn f64_to_token(v: f64) -> String {
     if v.is_nan() {

--- a/src/audit/model.rs
+++ b/src/audit/model.rs
@@ -1,0 +1,367 @@
+//! Serde model for the audit-export artifact — the published, compatibility
+//! bearing wire format (Issue #3358).
+//!
+//! The JSON shape here is what a third party parses; the SIGNATURE, however, is
+//! computed over a separate deterministic *canonical binary encoding* of these
+//! same typed values (see [`super::canonical`]) so that benign JSON reformatting
+//! never breaks a signature while any change to signed content always does.
+//!
+//! Floats are stored as strings (see [`float_string`]) so the artifact can carry
+//! `NaN`/`Infinity` faithfully (JSON numbers cannot) and so their textual form is
+//! unambiguous for an independent verifier.
+
+use serde::{Deserialize, Serialize};
+
+/// Format version of the artifact. Bumped only on breaking format changes.
+pub const AUDIT_FORMAT_VERSION: u32 = 1;
+
+/// Hash-chain algorithm identifier embedded in the artifact.
+pub const HASH_ALGORITHM: &str = "sha256-linked-v1";
+
+/// Signature algorithm identifier embedded in the artifact.
+pub const SIGNATURE_ALGORITHM: &str = "ed25519";
+
+/// Canonical description of what the signature covers. Checked verbatim during
+/// verification so no descriptive field escapes tamper detection.
+pub const SIGNED_DESCRIPTION: &str = "ed25519 detached signature over chain.root";
+
+/// A complete signed audit export of one or more entities' bi-temporal history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuditExport {
+    /// Artifact format version.
+    pub format_version: u32,
+    /// Export-level metadata (identity, time, scope, anchor, redaction).
+    pub metadata: ExportMetadata,
+    /// The exported entities, each with its full version history.
+    pub entities: Vec<ExportedEntity>,
+    /// Integrity proof: per-version leaf hashes and the chain root.
+    pub chain: ChainProof,
+    /// Detached signature over the chain root.
+    pub signature: SignatureBlock,
+}
+
+/// Export-level metadata (AC1 "export's own metadata").
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExportMetadata {
+    /// Operator-supplied database identity.
+    pub database_id: String,
+    /// RFC 3339 wallclock time the export was produced (UTC, `Z`).
+    pub exported_at: String,
+    /// Version of the AletheiaDB build that produced the export.
+    pub tool_version: String,
+    /// Human-readable one-line description of the scope.
+    pub scope_description: String,
+    /// Structured scope record: what was requested vs actually included.
+    pub scope: ScopeRecord,
+    /// Anchor to the database's write position at export time (chain head).
+    pub chain_anchor: ChainAnchor,
+    /// Property keys that were redacted at export (AC6), sorted, de-duplicated.
+    pub redacted_keys: Vec<String>,
+    /// Number of entities included.
+    pub entity_count: usize,
+    /// Total number of versions across all included entities.
+    pub version_count: usize,
+    /// Hash-chain algorithm identifier.
+    pub hash_algorithm: String,
+    /// Signature algorithm identifier.
+    pub signature_algorithm: String,
+}
+
+/// Structured record of the requested scope and the resolved membership so that
+/// absence of data is never ambiguous (AC5).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScopeRecord {
+    /// `single_node` | `single_edge` | `entity_set` | `neighborhood`.
+    pub kind: String,
+    /// Entities the caller explicitly asked for (empty for pure neighborhood).
+    pub requested: Vec<EntityIdRecord>,
+    /// Entities actually included in this artifact.
+    pub included: Vec<EntityIdRecord>,
+    /// Requested entities that could NOT be included, each with a reason.
+    pub not_included: Vec<NotIncludedRecord>,
+    /// Bi-temporal coordinate the neighborhood was resolved at (if any).
+    pub coordinate: Option<CoordinateRecord>,
+    /// Neighborhood hop radius (if any).
+    pub hops: Option<u32>,
+}
+
+/// A `(kind, id)` reference to a node or edge.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EntityIdRecord {
+    /// `node` | `edge`.
+    pub kind: String,
+    /// Numeric entity id.
+    pub id: u64,
+}
+
+/// A requested entity that was omitted, with the reason it was omitted.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NotIncludedRecord {
+    /// `node` | `edge`.
+    pub kind: String,
+    /// Numeric entity id.
+    pub id: u64,
+    /// Why it was not included (e.g. `no_history`).
+    pub reason: String,
+}
+
+/// A bi-temporal coordinate, both dimensions optional and RFC 3339 encoded.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CoordinateRecord {
+    /// Valid-time coordinate (RFC 3339) if pinned.
+    pub valid_time: Option<String>,
+    /// Transaction-time coordinate (RFC 3339) if pinned.
+    pub transaction_time: Option<String>,
+}
+
+/// Anchor tying the artifact to the database's write position at export time.
+///
+/// Records the current WAL LSN as the "chain head position" (AC1/AC2). When the
+/// global tamper-evident hash chain (#3351) lands, the per-version leaves here
+/// can additionally be anchored to that chain's head — documented forward-compat.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ChainAnchor {
+    /// WAL log-sequence number at export time (the chain-head position).
+    pub source_lsn: u64,
+    /// Human description of what the anchor references.
+    pub description: String,
+}
+
+/// One entity (node or edge) and its complete version history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExportedEntity {
+    /// `node` | `edge`.
+    pub kind: String,
+    /// Numeric entity id.
+    pub id: u64,
+    /// Current/last-known label (informational).
+    pub label: Option<String>,
+    /// Source node id (edges only).
+    pub source: Option<u64>,
+    /// Target node id (edges only).
+    pub target: Option<u64>,
+    /// Every version, oldest first (incl. superseded versions + tombstones).
+    pub versions: Vec<ExportedVersion>,
+}
+
+/// A single bi-temporal version of an entity (AC1).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExportedVersion {
+    /// Sequential version number (1-based).
+    pub version_number: u64,
+    /// Internal version id.
+    pub version_id: u64,
+    /// Entity label at this version.
+    pub label: String,
+    /// Valid-time start (microseconds since epoch).
+    pub valid_from_micros: i64,
+    /// Valid-time start logical counter (HLC).
+    pub valid_from_logical: u32,
+    /// Valid-time end (microseconds), `None` = open-ended.
+    pub valid_to_micros: Option<i64>,
+    /// Valid-time end logical counter, `None` = open-ended.
+    pub valid_to_logical: Option<u32>,
+    /// Transaction-time start (microseconds).
+    pub transaction_from_micros: i64,
+    /// Transaction-time start logical counter.
+    pub transaction_from_logical: u32,
+    /// Transaction-time end (microseconds), `None` = open-ended.
+    pub transaction_to_micros: Option<i64>,
+    /// Transaction-time end logical counter, `None` = open-ended.
+    pub transaction_to_logical: Option<u32>,
+    /// Whether this version is the current one (both intervals open at now).
+    pub is_current: bool,
+    /// Per-version provenance, if any (`None` = none recorded — never fabricated).
+    pub provenance: Option<ExportedProvenance>,
+    /// Properties at this version, sorted by key; redacted keys carry no value.
+    pub properties: Vec<ExportedProperty>,
+}
+
+/// Write-time provenance surfaced verbatim from the version (Issue #3224/#3421).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExportedProvenance {
+    /// Declared source system/identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// Writer confidence in `[0,1]` (string-encoded float).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(with = "float_string_opt")]
+    pub confidence: Option<f64>,
+    /// Free-text note / reason.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    /// Correlation id grouping writes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<String>,
+    /// Authenticated principal that made the write (surfaced where present).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub principal: Option<String>,
+}
+
+/// One property key/value at a version, or a redaction marker (AC6).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExportedProperty {
+    /// Property key.
+    pub key: String,
+    /// Value, or `None` when redacted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<ExportedValue>,
+    /// True when this key was redacted at export; value is then absent.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub redacted: bool,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+/// A property value in an unambiguous, self-describing, serializable form.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ExportedValue {
+    /// SQL-style null.
+    Null,
+    /// Boolean.
+    Bool {
+        /// The boolean.
+        value: bool,
+    },
+    /// 64-bit signed integer.
+    Int {
+        /// The integer.
+        value: i64,
+    },
+    /// 64-bit float (string-encoded, `NaN`/`inf` safe).
+    Float {
+        /// The float, string-encoded.
+        #[serde(with = "float_string")]
+        value: f64,
+    },
+    /// UTF-8 string.
+    String {
+        /// The string.
+        value: String,
+    },
+    /// Raw bytes (lowercase hex).
+    Bytes {
+        /// Hex-encoded bytes.
+        hex: String,
+    },
+    /// Heterogeneous array.
+    Array {
+        /// The elements.
+        values: Vec<ExportedValue>,
+    },
+    /// Dense float vector (each element string-encoded).
+    Vector {
+        /// The vector elements, string-encoded floats.
+        values: Vec<String>,
+    },
+    /// Sparse float vector.
+    SparseVector {
+        /// Full dimensionality.
+        dimension: usize,
+        /// Non-zero indices.
+        indices: Vec<u32>,
+        /// Non-zero values, string-encoded floats.
+        values: Vec<String>,
+    },
+}
+
+/// Integrity proof: per-version leaf hashes and the chain root (AC2).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ChainProof {
+    /// Algorithm identifier (`sha256-linked-v1`).
+    pub algorithm: String,
+    /// Per-version leaf hashes (hex), in flattened entity→version order.
+    pub leaves: Vec<String>,
+    /// Chain root (hex) that the signature covers.
+    pub root: String,
+}
+
+/// Detached signature over the chain root (AC2/AC3).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SignatureBlock {
+    /// Algorithm identifier (`ed25519`).
+    pub algorithm: String,
+    /// Signer's Ed25519 public key (hex, 32 bytes).
+    pub public_key: String,
+    /// Detached signature (hex, 64 bytes) over the chain root bytes.
+    pub signature: String,
+    /// What was signed, for an independent implementer.
+    pub signed: String,
+}
+
+/// Render a finite/NaN/Inf `f64` to a lossless, parseable token.
+pub(crate) fn f64_to_token(v: f64) -> String {
+    if v.is_nan() {
+        "NaN".to_string()
+    } else if v.is_infinite() {
+        if v.is_sign_positive() {
+            "Infinity".to_string()
+        } else {
+            "-Infinity".to_string()
+        }
+    } else {
+        // `{:?}` yields the shortest round-tripping decimal for f64.
+        format!("{v:?}")
+    }
+}
+
+/// Parse a token produced by [`f64_to_token`] back to an `f64`.
+pub(crate) fn token_to_f64(s: &str) -> Option<f64> {
+    match s {
+        "NaN" => Some(f64::NAN),
+        "Infinity" => Some(f64::INFINITY),
+        "-Infinity" => Some(f64::NEG_INFINITY),
+        other => other.parse::<f64>().ok(),
+    }
+}
+
+/// Serde adapter: `f64` <-> lossless string token.
+pub(crate) mod float_string {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(v: &f64, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&super::f64_to_token(*v))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<f64, D::Error> {
+        let s = String::deserialize(d)?;
+        super::token_to_f64(&s).ok_or_else(|| serde::de::Error::custom("invalid float token"))
+    }
+}
+
+/// Serde adapter for `Option<f64>` as a string token.
+pub(crate) mod float_string_opt {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(v: &Option<f64>, s: S) -> Result<S::Ok, S::Error> {
+        match v {
+            Some(f) => s.serialize_str(&super::f64_to_token(*f)),
+            None => s.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<f64>, D::Error> {
+        let opt = Option::<String>::deserialize(d)?;
+        match opt {
+            Some(s) => super::token_to_f64(&s)
+                .map(Some)
+                .ok_or_else(|| serde::de::Error::custom("invalid float token")),
+            None => Ok(None),
+        }
+    }
+}

--- a/src/audit/signing.rs
+++ b/src/audit/signing.rs
@@ -1,0 +1,195 @@
+//! Ed25519 signing / verifying key material for audit exports (Issue #3358).
+//!
+//! Design (mirrors the #3350/#3421 key-handling conventions):
+//! - The private seed is held in a [`Zeroizing`] buffer and never logged; the
+//!   [`Debug`] impl prints no key material.
+//! - Key files are written atomically and chmodded `0600` on unix.
+//! - Verification is asymmetric: a third party checks an artifact with ONLY the
+//!   public key, so the operator cannot be a trusted party in the proof.
+
+use crate::audit::error::{AuditError, AuditResult};
+use crate::core::hex;
+use ed25519_dalek::{Signature, SigningKey, VerifyingKey};
+use rand::RngCore;
+use rand::rngs::OsRng;
+use std::path::Path;
+use zeroize::Zeroizing;
+
+/// Environment variable convention for supplying a signing key seed (hex).
+pub const SIGNING_KEY_ENV: &str = "ALETHEIADB_AUDIT_SIGNING_KEY";
+
+/// An Ed25519 signing key (32-byte seed) used to sign audit exports.
+///
+/// The seed is the operator's secret. It is never logged and is zeroized on drop
+/// (via [`Zeroizing`]). Keep the corresponding [public key](AuditPublicKey) for
+/// distribution to auditors.
+pub struct AuditSigningKey {
+    inner: SigningKey,
+}
+
+impl std::fmt::Debug for AuditSigningKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Public-key fingerprint only — NEVER the secret seed.
+        f.debug_struct("AuditSigningKey")
+            .field("public_key", &self.public_key().to_hex())
+            .finish()
+    }
+}
+
+impl AuditSigningKey {
+    /// Generate a fresh random signing key from the OS CSPRNG.
+    #[must_use]
+    pub fn generate() -> Self {
+        let mut seed = Zeroizing::new([0u8; 32]);
+        OsRng.fill_bytes(seed.as_mut());
+        Self {
+            inner: SigningKey::from_bytes(&seed),
+        }
+    }
+
+    /// Construct a signing key from a raw 32-byte seed.
+    #[must_use]
+    pub fn from_seed_bytes(seed: [u8; 32]) -> Self {
+        let seed = Zeroizing::new(seed);
+        Self {
+            inner: SigningKey::from_bytes(&seed),
+        }
+    }
+
+    /// Construct a signing key from a 64-char lowercase-hex seed.
+    ///
+    /// # Errors
+    /// Returns [`AuditError::InvalidKey`] if the string is not 32 bytes of hex.
+    pub fn from_seed_hex(s: &str) -> AuditResult<Self> {
+        let bytes = hex::decode(s.trim())
+            .ok_or_else(|| AuditError::InvalidKey("seed is not valid hex".to_string()))?;
+        if bytes.len() != 32 {
+            return Err(AuditError::InvalidKey(format!(
+                "seed must be 32 bytes, got {}",
+                bytes.len()
+            )));
+        }
+        let mut seed = Zeroizing::new([0u8; 32]);
+        seed.copy_from_slice(&bytes);
+        Ok(Self {
+            inner: SigningKey::from_bytes(&seed),
+        })
+    }
+
+    /// Load a signing key from a file containing a hex seed (whitespace trimmed).
+    ///
+    /// # Errors
+    /// Returns [`AuditError::Io`] on read failure, or [`AuditError::InvalidKey`]
+    /// if the contents are not a valid 32-byte hex seed.
+    pub fn from_file(path: impl AsRef<Path>) -> AuditResult<Self> {
+        let contents = std::fs::read_to_string(path.as_ref())
+            .map_err(|e| AuditError::Io(format!("reading signing key: {e}")))?;
+        Self::from_seed_hex(&contents)
+    }
+
+    /// Load a signing key from an environment variable (hex seed).
+    ///
+    /// # Errors
+    /// Returns [`AuditError::InvalidKey`] if the variable is unset or malformed.
+    pub fn from_env(var: &str) -> AuditResult<Self> {
+        let value = std::env::var(var).map_err(|_| {
+            AuditError::InvalidKey(format!("environment variable {var} is not set"))
+        })?;
+        Self::from_seed_hex(&value)
+    }
+
+    /// Write the hex seed to a file with `0600` permissions on unix.
+    ///
+    /// The file is created with restrictive permissions from the start so the
+    /// secret is never briefly world-readable.
+    ///
+    /// # Errors
+    /// Returns [`AuditError::Io`] on write failure.
+    pub fn write_to_file(&self, path: impl AsRef<Path>) -> AuditResult<()> {
+        let path = path.as_ref();
+        let seed = Zeroizing::new(self.inner.to_bytes());
+        let hex_seed = Zeroizing::new(hex::encode(seed.as_ref()));
+
+        use std::io::Write as _;
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.mode(0o600);
+        }
+        let mut file = options
+            .open(path)
+            .map_err(|e| AuditError::Io(format!("creating signing key file: {e}")))?;
+        file.write_all(hex_seed.as_bytes())
+            .map_err(|e| AuditError::Io(format!("writing signing key file: {e}")))?;
+        file.write_all(b"\n")
+            .map_err(|e| AuditError::Io(format!("writing signing key file: {e}")))?;
+        Ok(())
+    }
+
+    /// The public key corresponding to this signing key.
+    #[must_use]
+    pub fn public_key(&self) -> AuditPublicKey {
+        AuditPublicKey {
+            inner: self.inner.verifying_key(),
+        }
+    }
+
+    /// Sign a 32-byte chain root, returning the raw 64-byte signature.
+    pub(crate) fn sign_root(&self, root: &[u8; 32]) -> [u8; 64] {
+        use ed25519_dalek::Signer as _;
+        self.inner.sign(root).to_bytes()
+    }
+}
+
+/// An Ed25519 public (verifying) key an auditor uses to check an artifact.
+#[derive(Clone)]
+pub struct AuditPublicKey {
+    inner: VerifyingKey,
+}
+
+impl std::fmt::Debug for AuditPublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuditPublicKey")
+            .field("hex", &self.to_hex())
+            .finish()
+    }
+}
+
+impl AuditPublicKey {
+    /// Lowercase-hex encoding of the 32-byte public key.
+    #[must_use]
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.inner.as_bytes())
+    }
+
+    /// Parse a public key from its 64-char lowercase-hex encoding.
+    ///
+    /// # Errors
+    /// Returns [`AuditError::InvalidPublicKey`] if not a valid 32-byte key.
+    pub fn from_hex(s: &str) -> AuditResult<Self> {
+        let bytes = hex::decode(s.trim())
+            .ok_or_else(|| AuditError::InvalidPublicKey("not valid hex".to_string()))?;
+        if bytes.len() != 32 {
+            return Err(AuditError::InvalidPublicKey(format!(
+                "public key must be 32 bytes, got {}",
+                bytes.len()
+            )));
+        }
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&bytes);
+        let inner = VerifyingKey::from_bytes(&arr)
+            .map_err(|e| AuditError::InvalidPublicKey(e.to_string()))?;
+        Ok(Self { inner })
+    }
+
+    /// Verify a 64-byte signature over a 32-byte chain root.
+    pub(crate) fn verify_root(&self, root: &[u8; 32], signature: &[u8; 64]) -> AuditResult<()> {
+        use ed25519_dalek::Verifier as _;
+        let sig = Signature::from_bytes(signature);
+        self.inner
+            .verify(root, &sig)
+            .map_err(|e| AuditError::SignatureInvalid(e.to_string()))
+    }
+}

--- a/src/audit/tests.rs
+++ b/src/audit/tests.rs
@@ -1,0 +1,185 @@
+//! Unit tests for audit-export internals (Issue #3358).
+
+use super::*;
+use crate::AletheiaDB;
+use crate::core::property::PropertyMapBuilder;
+
+fn key() -> AuditSigningKey {
+    AuditSigningKey::from_seed_bytes([11u8; 32])
+}
+
+#[test]
+fn signing_key_hex_roundtrip() {
+    let k = AuditSigningKey::from_seed_hex(&crate::core::hex::encode(&[4u8; 32])).unwrap();
+    assert_eq!(k.public_key().to_hex().len(), 64);
+}
+
+#[test]
+fn signing_key_rejects_short_hex() {
+    assert!(AuditSigningKey::from_seed_hex("abcd").is_err());
+    assert!(AuditSigningKey::from_seed_hex("nothex!!").is_err());
+}
+
+#[test]
+fn public_key_rejects_bad_hex() {
+    assert!(AuditPublicKey::from_hex("00").is_err());
+    assert!(AuditPublicKey::from_hex("zz").is_err());
+}
+
+#[test]
+fn signing_key_debug_hides_secret() {
+    let k = AuditSigningKey::from_seed_bytes([0xAB; 32]);
+    let dbg = format!("{k:?}");
+    assert!(!dbg.contains("abab"), "debug must not leak the seed");
+    assert!(dbg.contains("public_key"));
+}
+
+#[test]
+fn export_is_deterministic_for_same_content_ordering() {
+    // Two exports of the same entity produce identical chains (only the export
+    // timestamp/anchor differ, which live in metadata) — the per-version leaves
+    // must be identical.
+    let db = AletheiaDB::new().unwrap();
+    let id = db
+        .create_node("Person", PropertyMapBuilder::new().insert("n", "A").build())
+        .unwrap();
+    let k = key();
+    let e1 = db
+        .audit_export(AuditScope::node(id), &k, &ExportOptions::new("db"))
+        .unwrap();
+    let e2 = db
+        .audit_export(AuditScope::node(id), &k, &ExportOptions::new("db"))
+        .unwrap();
+    assert_eq!(e1.chain.leaves, e2.chain.leaves);
+}
+
+#[test]
+fn nonexistent_single_entity_errors_no_history() {
+    let db = AletheiaDB::new().unwrap();
+    let missing = crate::core::NodeId::new(999_999).unwrap();
+    let err = db
+        .audit_export(AuditScope::node(missing), &key(), &ExportOptions::new("db"))
+        .unwrap_err();
+    assert!(matches!(err, AuditError::NoHistory(_)));
+}
+
+#[test]
+fn entity_set_records_missing_as_not_included() {
+    let db = AletheiaDB::new().unwrap();
+    let present = db
+        .create_node("Person", PropertyMapBuilder::new().insert("n", "A").build())
+        .unwrap();
+    let missing = crate::core::NodeId::new(888_888).unwrap();
+    let export = db
+        .audit_export(
+            AuditScope::EntitySet(vec![EntityRef::Node(present), EntityRef::Node(missing)]),
+            &key(),
+            &ExportOptions::new("db"),
+        )
+        .unwrap();
+    assert_eq!(export.entity_count(), 1);
+    assert_eq!(export.metadata().scope.not_included.len(), 1);
+    assert_eq!(export.metadata().scope.not_included[0].reason, "no_history");
+    // Still verifies.
+    assert!(export.verify(Some(&key().public_key())).is_ok());
+}
+
+#[test]
+fn wrong_format_version_is_rejected() {
+    let db = AletheiaDB::new().unwrap();
+    let id = db
+        .create_node("Person", PropertyMapBuilder::new().insert("n", "A").build())
+        .unwrap();
+    let mut export = db
+        .audit_export(AuditScope::node(id), &key(), &ExportOptions::new("db"))
+        .unwrap();
+    export.format_version = 999;
+    let err = export.verify(Some(&key().public_key())).unwrap_err();
+    assert!(matches!(err, AuditError::UnsupportedFormat { .. }));
+}
+
+#[test]
+fn edge_history_is_exportable_with_endpoints() {
+    let db = AletheiaDB::new().unwrap();
+    let a = db
+        .create_node("Person", PropertyMapBuilder::new().insert("n", "A").build())
+        .unwrap();
+    let b = db
+        .create_node("Person", PropertyMapBuilder::new().insert("n", "B").build())
+        .unwrap();
+    let edge = db
+        .create_edge(
+            a,
+            b,
+            "KNOWS",
+            PropertyMapBuilder::new().insert("w", 1i64).build(),
+        )
+        .unwrap();
+    let export = db
+        .audit_export(AuditScope::edge(edge), &key(), &ExportOptions::new("db"))
+        .unwrap();
+    assert_eq!(export.entities[0].kind, "edge");
+    assert_eq!(export.entities[0].source, Some(a.as_u64()));
+    assert_eq!(export.entities[0].target, Some(b.as_u64()));
+    assert!(export.verify(Some(&key().public_key())).is_ok());
+}
+
+#[test]
+fn float_and_vector_values_survive_roundtrip_and_verify() {
+    let db = AletheiaDB::new().unwrap();
+    let id = db
+        .create_node(
+            "M",
+            PropertyMapBuilder::new()
+                .insert("score", 0.3333333333333333f64)
+                .insert(
+                    "embedding",
+                    crate::core::PropertyValue::vector(vec![0.1f32, 0.2, 0.3]),
+                )
+                .build(),
+        )
+        .unwrap();
+    let export = db
+        .audit_export(AuditScope::node(id), &key(), &ExportOptions::new("db"))
+        .unwrap();
+    let bytes = export.to_json_bytes().unwrap();
+    let report = verify_json_bytes(&bytes, Some(&key().public_key())).unwrap();
+    assert!(report.passed);
+}
+
+#[test]
+fn float_token_roundtrip_nan_and_inf() {
+    for v in [0.0f64, -0.0, 1.5, -2.25, f64::MAX, f64::MIN] {
+        let t = super::model::f64_to_token(v);
+        assert_eq!(
+            super::model::token_to_f64(&t).unwrap().to_bits(),
+            v.to_bits()
+        );
+    }
+    assert!(
+        super::model::token_to_f64(&super::model::f64_to_token(f64::NAN))
+            .unwrap()
+            .is_nan()
+    );
+    assert_eq!(super::model::token_to_f64("Infinity"), Some(f64::INFINITY));
+    assert_eq!(
+        super::model::token_to_f64("-Infinity"),
+        Some(f64::NEG_INFINITY)
+    );
+    assert_eq!(super::model::token_to_f64("garbage"), None);
+}
+
+#[test]
+fn render_chronology_contains_key_fields() {
+    let db = AletheiaDB::new().unwrap();
+    let id = db
+        .create_node("Person", PropertyMapBuilder::new().insert("n", "A").build())
+        .unwrap();
+    let export = db
+        .audit_export(AuditScope::node(id), &key(), &ExportOptions::new("db"))
+        .unwrap();
+    let text = export.render_chronology();
+    assert!(text.contains("Signed Audit Export"));
+    assert!(text.contains("Chain root:"));
+    assert!(text.contains("Version 1"));
+}

--- a/src/audit/verify.rs
+++ b/src/audit/verify.rs
@@ -410,12 +410,4 @@ fn render_value(v: &ExportedValue) -> String {
     }
 }
 
-/// Format microseconds-since-epoch as RFC 3339 (UTC), or raw micros if out of
-/// chrono's representable range.
-fn format_micros(micros: i64) -> String {
-    use chrono::{DateTime, Utc};
-    match DateTime::<Utc>::from_timestamp_micros(micros) {
-        Some(dt) => dt.to_rfc3339_opts(chrono::SecondsFormat::Micros, true),
-        None => format!("{micros}us"),
-    }
-}
+use crate::audit::model::rfc3339_micros as format_micros;

--- a/src/audit/verify.rs
+++ b/src/audit/verify.rs
@@ -1,0 +1,421 @@
+//! Offline verification + human rendering of a signed audit export (Issue #3358).
+//!
+//! Everything here runs with NO database and NO network — only the artifact
+//! bytes and (optionally) the signer's trusted public key. This is also the
+//! reference implementation a third party can port to independently verify the
+//! documented format.
+
+use crate::audit::canonical;
+use crate::audit::error::{AuditError, AuditResult};
+use crate::audit::model::{
+    AUDIT_FORMAT_VERSION, AuditExport, ExportMetadata, ExportedValue, HASH_ALGORITHM,
+    SIGNATURE_ALGORITHM, SIGNED_DESCRIPTION,
+};
+use crate::audit::signing::AuditPublicKey;
+
+/// The outcome of a successful verification: a human-facing summary (AC3).
+///
+/// Only ever produced when verification PASSED; a failed verification returns
+/// an [`AuditError`] instead.
+#[derive(Debug, Clone)]
+pub struct AuditVerification {
+    /// Always `true` (a value of this type means verification passed).
+    pub passed: bool,
+    /// Whether the signature was checked against a caller-supplied *trusted*
+    /// key (`true`) or only the artifact's self-asserted embedded key (`false`).
+    pub trusted_key: bool,
+    /// Database identity recorded in the artifact.
+    pub database_id: String,
+    /// Number of entities included.
+    pub entity_count: usize,
+    /// Total number of versions verified.
+    pub version_count: usize,
+    /// `(earliest, latest)` bi-temporal span across versions (RFC 3339), if any.
+    pub time_span: Option<(String, String)>,
+    /// The verified chain root (hex).
+    pub chain_root: String,
+    /// The chain-head anchor (WAL LSN) recorded at export time.
+    pub chain_anchor_lsn: u64,
+    /// Property keys that were redacted at export.
+    pub redacted_keys: Vec<String>,
+    /// One-line-per-entity summary (kind, id, label).
+    pub entity_summary: String,
+    /// The signer's public key (hex).
+    pub public_key: String,
+}
+
+impl AuditVerification {
+    /// A compact single-line human summary (entity, versions, span, anchor).
+    #[must_use]
+    pub fn summary(&self) -> String {
+        let span = self
+            .time_span
+            .as_ref()
+            .map(|(a, b)| format!("{a} .. {b}"))
+            .unwrap_or_else(|| "n/a".to_string());
+        let trust = if self.trusted_key {
+            "trusted-key"
+        } else {
+            "self-asserted-key"
+        };
+        format!(
+            "PASS [{trust}] db={} entities={} versions={} span={} anchor_lsn={} root={}…",
+            self.database_id,
+            self.entity_count,
+            self.version_count,
+            span,
+            self.chain_anchor_lsn,
+            &self.chain_root[..self.chain_root.len().min(12)],
+        )
+    }
+}
+
+impl AuditExport {
+    /// Serialize the artifact to pretty JSON bytes (the single-file artifact).
+    ///
+    /// # Errors
+    /// Returns [`AuditError::Serialization`] on an unexpected serializer error.
+    pub fn to_json_bytes(&self) -> AuditResult<Vec<u8>> {
+        serde_json::to_vec_pretty(self).map_err(|e| AuditError::Serialization(e.to_string()))
+    }
+
+    /// Parse an artifact from JSON bytes.
+    ///
+    /// # Errors
+    /// Returns [`AuditError::Serialization`] if the bytes are not a valid
+    /// artifact.
+    pub fn from_json_bytes(bytes: &[u8]) -> AuditResult<Self> {
+        serde_json::from_slice(bytes).map_err(|e| AuditError::Serialization(e.to_string()))
+    }
+
+    /// Total number of versions across all included entities.
+    #[must_use]
+    pub fn version_count(&self) -> usize {
+        self.entities.iter().map(|e| e.versions.len()).sum()
+    }
+
+    /// Number of entities included.
+    #[must_use]
+    pub fn entity_count(&self) -> usize {
+        self.entities.len()
+    }
+
+    /// The export metadata.
+    #[must_use]
+    pub fn metadata(&self) -> &ExportMetadata {
+        &self.metadata
+    }
+
+    /// The public key embedded in the artifact.
+    ///
+    /// # Errors
+    /// Returns [`AuditError::InvalidPublicKey`] if the embedded key is malformed.
+    pub fn embedded_public_key(&self) -> AuditResult<AuditPublicKey> {
+        AuditPublicKey::from_hex(&self.signature.public_key)
+    }
+
+    /// Verify this artifact offline (AC2/AC3/AC4).
+    ///
+    /// If `expected` is supplied, the signature is checked against that trusted
+    /// key AND the embedded key must equal it (defeating public-key
+    /// substitution). If `expected` is `None`, the embedded key is used and the
+    /// result is marked `trusted_key = false` (trust is self-asserted).
+    ///
+    /// # Errors
+    /// Returns a specific [`AuditError`] variant for each failure mode:
+    /// content tamper, chain-root mismatch, completeness mismatch, key
+    /// mismatch, or signature failure.
+    pub fn verify(&self, expected: Option<&AuditPublicKey>) -> AuditResult<AuditVerification> {
+        if self.format_version != AUDIT_FORMAT_VERSION {
+            return Err(AuditError::UnsupportedFormat {
+                found: self.format_version,
+                expected: AUDIT_FORMAT_VERSION,
+            });
+        }
+
+        // Descriptive/algorithm labels are not folded into the chain root, so
+        // pin them to the known constants here — otherwise a byte flipped in one
+        // of these fields would escape tamper detection. (An unknown algorithm
+        // is also a legitimate reason to refuse an artifact this build cannot
+        // interpret.)
+        if self.chain.algorithm != HASH_ALGORITHM {
+            return Err(AuditError::ContentTampered(format!(
+                "unexpected chain algorithm '{}'",
+                self.chain.algorithm
+            )));
+        }
+        if self.signature.algorithm != SIGNATURE_ALGORITHM {
+            return Err(AuditError::ContentTampered(format!(
+                "unexpected signature algorithm '{}'",
+                self.signature.algorithm
+            )));
+        }
+        if self.signature.signed != SIGNED_DESCRIPTION {
+            return Err(AuditError::ContentTampered(
+                "unexpected signature description".to_string(),
+            ));
+        }
+
+        // 1. Recompute the per-version leaves and the chain root from content.
+        let (leaves, root) = canonical::compute_chain(&self.metadata, &self.entities);
+
+        // 2. The stored per-version leaves must match exactly (precise per-version
+        //    tamper detection, and detects added/removed leaves).
+        if self.chain.leaves.len() != leaves.len() {
+            return Err(AuditError::CompletenessMismatch(format!(
+                "artifact declares {} leaves but content yields {}",
+                self.chain.leaves.len(),
+                leaves.len()
+            )));
+        }
+        for (i, (stored, computed)) in self.chain.leaves.iter().zip(leaves.iter()).enumerate() {
+            let stored = canonical::hex_to_32(stored).ok_or_else(|| {
+                AuditError::ContentTampered(format!("leaf {i} is not a valid hash"))
+            })?;
+            if &stored != computed {
+                return Err(AuditError::ContentTampered(format!(
+                    "version leaf {i} does not match its content"
+                )));
+            }
+        }
+
+        // 3. The recomputed root must match the stored root.
+        let stored_root = canonical::hex_to_32(&self.chain.root)
+            .ok_or_else(|| AuditError::ContentTampered("chain root is not a valid hash".into()))?;
+        if stored_root != root {
+            return Err(AuditError::ChainRootMismatch);
+        }
+
+        // 4. Completeness: declared counts must match actual content.
+        let actual_versions = self.version_count();
+        if self.metadata.version_count != actual_versions {
+            return Err(AuditError::CompletenessMismatch(format!(
+                "metadata declares {} versions but {} are present",
+                self.metadata.version_count, actual_versions
+            )));
+        }
+        if self.metadata.entity_count != self.entities.len() {
+            return Err(AuditError::CompletenessMismatch(format!(
+                "metadata declares {} entities but {} are present",
+                self.metadata.entity_count,
+                self.entities.len()
+            )));
+        }
+
+        // 5. Resolve the key to verify against and defeat key substitution.
+        let embedded = self.embedded_public_key()?;
+        let (verifying_key, trusted_key) = match expected {
+            Some(trusted) => {
+                if trusted.to_hex() != embedded.to_hex() {
+                    return Err(AuditError::KeyMismatch);
+                }
+                (trusted.clone(), true)
+            }
+            None => (embedded, false),
+        };
+
+        // 6. Verify the Ed25519 signature over the (recomputed) root.
+        let sig_bytes = crate::core::hex::decode(&self.signature.signature).ok_or_else(|| {
+            AuditError::SignatureInvalid("signature is not valid hex".to_string())
+        })?;
+        if sig_bytes.len() != 64 {
+            return Err(AuditError::SignatureInvalid(format!(
+                "signature must be 64 bytes, got {}",
+                sig_bytes.len()
+            )));
+        }
+        let mut sig = [0u8; 64];
+        sig.copy_from_slice(&sig_bytes);
+        verifying_key.verify_root(&root, &sig)?;
+
+        Ok(AuditVerification {
+            passed: true,
+            trusted_key,
+            database_id: self.metadata.database_id.clone(),
+            entity_count: self.entities.len(),
+            version_count: actual_versions,
+            time_span: self.time_span(),
+            chain_root: self.chain.root.clone(),
+            chain_anchor_lsn: self.metadata.chain_anchor.source_lsn,
+            redacted_keys: self.metadata.redacted_keys.clone(),
+            entity_summary: self.entity_summary(),
+            public_key: verifying_key.to_hex(),
+        })
+    }
+
+    /// Compute the `(earliest, latest)` bi-temporal span across all versions.
+    fn time_span(&self) -> Option<(String, String)> {
+        let mut earliest: Option<i64> = None;
+        let mut latest: Option<i64> = None;
+        for entity in &self.entities {
+            for v in &entity.versions {
+                let mut consider = |micros: i64| {
+                    earliest = Some(earliest.map_or(micros, |e| e.min(micros)));
+                    latest = Some(latest.map_or(micros, |l| l.max(micros)));
+                };
+                consider(v.valid_from_micros);
+                consider(v.transaction_from_micros);
+                if let Some(m) = v.valid_to_micros {
+                    consider(m);
+                }
+                if let Some(m) = v.transaction_to_micros {
+                    consider(m);
+                }
+            }
+        }
+        match (earliest, latest) {
+            (Some(a), Some(b)) => Some((format_micros(a), format_micros(b))),
+            _ => None,
+        }
+    }
+
+    fn entity_summary(&self) -> String {
+        self.entities
+            .iter()
+            .map(|e| {
+                let label = e.label.as_deref().unwrap_or("");
+                format!("{} {} ({label})", e.kind, e.id)
+            })
+            .collect::<Vec<_>>()
+            .join("; ")
+    }
+
+    /// Render the artifact as a human-readable chronology (AC7).
+    ///
+    /// This reads only the artifact's own bytes — call [`verify`](Self::verify)
+    /// first if you need assurance the bytes are authentic.
+    #[must_use]
+    pub fn render_chronology(&self) -> String {
+        let mut out = String::new();
+        out.push_str("=== AletheiaDB Signed Audit Export ===\n");
+        out.push_str(&format!("Database:    {}\n", self.metadata.database_id));
+        out.push_str(&format!("Exported at: {}\n", self.metadata.exported_at));
+        out.push_str(&format!(
+            "Scope:       {}\n",
+            self.metadata.scope_description
+        ));
+        out.push_str(&format!(
+            "Chain root:  {}\nChain anchor (WAL LSN): {}\n",
+            self.chain.root, self.metadata.chain_anchor.source_lsn
+        ));
+        if !self.metadata.redacted_keys.is_empty() {
+            out.push_str(&format!(
+                "Redacted keys: {}\n",
+                self.metadata.redacted_keys.join(", ")
+            ));
+        }
+        if !self.metadata.scope.not_included.is_empty() {
+            out.push_str("Not included:\n");
+            for ni in &self.metadata.scope.not_included {
+                out.push_str(&format!("  - {} {} ({})\n", ni.kind, ni.id, ni.reason));
+            }
+        }
+        out.push('\n');
+
+        for entity in &self.entities {
+            let label = entity.label.as_deref().unwrap_or("");
+            out.push_str(&format!(
+                "--- {} {} ({label}) — {} version(s) ---\n",
+                entity.kind,
+                entity.id,
+                entity.versions.len()
+            ));
+            if let (Some(s), Some(t)) = (entity.source, entity.target) {
+                out.push_str(&format!("  endpoints: {s} -> {t}\n"));
+            }
+            for v in &entity.versions {
+                let valid_to = v
+                    .valid_to_micros
+                    .map_or_else(|| "current".to_string(), format_micros);
+                let tx_to = v
+                    .transaction_to_micros
+                    .map_or_else(|| "current".to_string(), format_micros);
+                out.push_str(&format!(
+                    "  Version {} (id {}){}\n",
+                    v.version_number,
+                    v.version_id,
+                    if v.is_current { " [current]" } else { "" }
+                ));
+                out.push_str(&format!(
+                    "    valid: [{}, {})  recorded: [{}, {})\n",
+                    format_micros(v.valid_from_micros),
+                    valid_to,
+                    format_micros(v.transaction_from_micros),
+                    tx_to,
+                ));
+                if let Some(p) = &v.provenance {
+                    let mut parts = Vec::new();
+                    if let Some(s) = &p.source {
+                        parts.push(format!("source={s}"));
+                    }
+                    if let Some(c) = p.confidence {
+                        parts.push(format!("confidence={c}"));
+                    }
+                    if let Some(pr) = &p.principal {
+                        parts.push(format!("principal={pr}"));
+                    }
+                    if let Some(n) = &p.note {
+                        parts.push(format!("note={n}"));
+                    }
+                    if !parts.is_empty() {
+                        out.push_str(&format!("    Provenance: {}\n", parts.join(", ")));
+                    }
+                } else {
+                    out.push_str("    Provenance: (none recorded)\n");
+                }
+                for prop in &v.properties {
+                    if prop.redacted {
+                        out.push_str(&format!("    {} = [REDACTED]\n", prop.key));
+                    } else if let Some(val) = &prop.value {
+                        out.push_str(&format!("    {} = {}\n", prop.key, render_value(val)));
+                    }
+                }
+            }
+            out.push('\n');
+        }
+        out
+    }
+}
+
+/// Verify raw artifact bytes offline (AC3 entry point).
+///
+/// # Errors
+/// Returns an [`AuditError`] if the bytes cannot be parsed or verification
+/// fails.
+pub fn verify_json_bytes(
+    bytes: &[u8],
+    expected: Option<&AuditPublicKey>,
+) -> AuditResult<AuditVerification> {
+    let export = AuditExport::from_json_bytes(bytes)?;
+    export.verify(expected)
+}
+
+/// Compact rendering of a value for the human chronology.
+fn render_value(v: &ExportedValue) -> String {
+    match v {
+        ExportedValue::Null => "null".to_string(),
+        ExportedValue::Bool { value } => value.to_string(),
+        ExportedValue::Int { value } => value.to_string(),
+        ExportedValue::Float { value } => value.to_string(),
+        ExportedValue::String { value } => format!("\"{value}\""),
+        ExportedValue::Bytes { hex } => format!("0x{hex}"),
+        ExportedValue::Array { values } => {
+            let inner: Vec<String> = values.iter().map(render_value).collect();
+            format!("[{}]", inner.join(", "))
+        }
+        ExportedValue::Vector { values } => format!("<vector dim={}>", values.len()),
+        ExportedValue::SparseVector { dimension, .. } => {
+            format!("<sparse_vector dim={dimension}>")
+        }
+    }
+}
+
+/// Format microseconds-since-epoch as RFC 3339 (UTC), or raw micros if out of
+/// chrono's representable range.
+fn format_micros(micros: i64) -> String {
+    use chrono::{DateTime, Utc};
+    match DateTime::<Utc>::from_timestamp_micros(micros) {
+        Some(dt) => dt.to_rfc3339_opts(chrono::SecondsFormat::Micros, true),
+        None => format!("{micros}us"),
+    }
+}

--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -52,6 +52,14 @@ fn run() -> Result<(), String> {
         Some("daemon") => handle_daemon(args.collect()),
         Some("backup") => handle_backup(args.collect()),
         Some("restore") => handle_restore(args.collect()),
+        #[cfg(feature = "audit-export")]
+        Some("audit-keygen") => audit::handle_keygen(args.collect()),
+        #[cfg(feature = "audit-export")]
+        Some("audit-export") => audit::handle_export(args.collect()),
+        #[cfg(feature = "audit-export")]
+        Some("audit-verify") => audit::handle_verify(args.collect()),
+        #[cfg(feature = "audit-export")]
+        Some("audit-render") => audit::handle_render(args.collect()),
         Some("help") | Some("--help") | Some("-h") | None => {
             print_usage();
             Ok(())
@@ -75,11 +83,20 @@ Usage:\n\
   aletheia daemon status [--pid-file PATH]\n\
   aletheia backup <output_path>\n\
   aletheia restore <input_path>\n\
+  aletheia audit-keygen <key_file>\n\
+  aletheia audit-export <node|edge> <id> --key <key_file> --out <path> [--db-id ID] [--redact k1,k2]\n\
+  aletheia audit-verify <artifact_path> [--public-key HEX]\n\
+  aletheia audit-render <artifact_path>\n\
 \nCommands map to core MCP-style graph operations while using local storage.\n\
 \nBackup / Restore:\n\
   backup  — Write a portable .albk artifact capturing full bi-temporal state.\n\
             Opens the database via ALETHEIADB_CONFIG or ALETHEIADB_DATA_DIR.\n\
-  restore — Restore a .albk artifact into ALETHEIADB_DATA_DIR (must be empty).\n"
+  restore — Restore a .albk artifact into ALETHEIADB_DATA_DIR (must be empty).\n\
+\nSigned audit export (Issue #3358):\n\
+  audit-keygen — Generate an Ed25519 signing key (0600) and print its public key.\n\
+  audit-export — Sign an entity's full bi-temporal history into a portable artifact.\n\
+  audit-verify — Verify an artifact OFFLINE (no database) with the signer's public key.\n\
+  audit-render — Render an artifact as a human-readable chronology.\n"
     );
 }
 
@@ -675,6 +692,142 @@ fn print_json_pretty(value: &serde_json::Value) -> Result<(), String> {
         Ok(_) => Ok(()),
         Err(e) if e.kind() == ErrorKind::BrokenPipe => Ok(()),
         Err(e) => Err(format!("error writing JSON output: {e}")),
+    }
+}
+
+/// Signed audit export subcommands (Issue #3358).
+#[cfg(feature = "audit-export")]
+mod audit {
+    use super::{arg_value, open_db, parse_edge_id, parse_node_id};
+    use aletheiadb::audit::{
+        AuditPublicKey, AuditScope, AuditSigningKey, ExportOptions, verify_json_bytes,
+    };
+    use std::path::Path;
+
+    /// `aletheia audit-keygen <key_file>` — generate a signing key (0600) and
+    /// print its public key. The private seed is written to `<key_file>`.
+    pub(super) fn handle_keygen(args: Vec<String>) -> Result<(), String> {
+        let path = args
+            .first()
+            .ok_or_else(|| "usage: aletheia audit-keygen <key_file>".to_string())?;
+        if Path::new(path).exists() {
+            return Err(format!("refusing to overwrite existing key file '{path}'"));
+        }
+        let key = AuditSigningKey::generate();
+        key.write_to_file(path)
+            .map_err(|e| format!("failed to write key file: {e}"))?;
+        println!(
+            "{{\"ok\":true,\"key_file\":\"{}\",\"public_key\":\"{}\"}}",
+            path,
+            key.public_key().to_hex()
+        );
+        Ok(())
+    }
+
+    /// `aletheia audit-export <node|edge> <id> --key <file> --out <path>` —
+    /// sign an entity's full bi-temporal history into a portable artifact.
+    pub(super) fn handle_export(args: Vec<String>) -> Result<(), String> {
+        let kind = args.first().map(String::as_str).ok_or_else(usage_export)?;
+        let id_str = args.get(1).ok_or_else(usage_export)?;
+        let key_file = arg_value(&args, "--key").ok_or_else(usage_export)?;
+        let out = arg_value(&args, "--out").ok_or_else(usage_export)?;
+        let db_id = arg_value(&args, "--db-id").unwrap_or_else(|| "aletheiadb".to_string());
+
+        let scope = match kind {
+            "node" => AuditScope::node(parse_node_id(id_str)?),
+            "edge" => AuditScope::edge(parse_edge_id(id_str)?),
+            other => {
+                return Err(format!(
+                    "unknown entity kind '{other}' (expected node|edge)"
+                ));
+            }
+        };
+
+        let mut options = ExportOptions::new(db_id);
+        if let Some(redact) = arg_value(&args, "--redact") {
+            let keys: Vec<String> = redact
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(String::from)
+                .collect();
+            options = options.redact(keys);
+        }
+
+        let key = AuditSigningKey::from_file(&key_file)
+            .map_err(|e| format!("failed to load signing key: {e}"))?;
+        let db = open_db()?;
+        let export = db
+            .audit_export(scope, &key, &options)
+            .map_err(|e| format!("audit export failed: {e}"))?;
+        let bytes = export
+            .to_json_bytes()
+            .map_err(|e| format!("failed to serialize artifact: {e}"))?;
+        std::fs::write(&out, &bytes).map_err(|e| format!("failed to write artifact: {e}"))?;
+
+        println!(
+            "{{\"ok\":true,\"artifact\":\"{}\",\"entity_count\":{},\"version_count\":{},\
+             \"public_key\":\"{}\",\"chain_root\":\"{}\",\"anchor_lsn\":{}}}",
+            out,
+            export.entity_count(),
+            export.version_count(),
+            key.public_key().to_hex(),
+            export.chain.root,
+            export.metadata().chain_anchor.source_lsn,
+        );
+        Ok(())
+    }
+
+    /// `aletheia audit-verify <artifact> [--public-key HEX]` — verify OFFLINE.
+    /// Exits non-zero (via `Err`) when verification fails.
+    pub(super) fn handle_verify(args: Vec<String>) -> Result<(), String> {
+        let path = args.first().ok_or_else(|| {
+            "usage: aletheia audit-verify <artifact> [--public-key HEX]".to_string()
+        })?;
+        let bytes = std::fs::read(path).map_err(|e| format!("failed to read artifact: {e}"))?;
+
+        let expected = match arg_value(&args, "--public-key") {
+            Some(hex) => Some(
+                AuditPublicKey::from_hex(&hex).map_err(|e| format!("invalid --public-key: {e}"))?,
+            ),
+            None => None,
+        };
+
+        match verify_json_bytes(&bytes, expected.as_ref()) {
+            Ok(report) => {
+                println!("{}", report.summary());
+                println!("  entity summary: {}", report.entity_summary);
+                if !report.redacted_keys.is_empty() {
+                    println!("  redacted keys: {}", report.redacted_keys.join(", "));
+                }
+                if !report.trusted_key {
+                    println!(
+                        "  NOTE: no --public-key supplied; trust in the embedded key is \
+                         self-asserted. Supply the signer's known public key to establish trust."
+                    );
+                }
+                Ok(())
+            }
+            Err(e) => Err(format!("VERIFICATION FAILED: {e}")),
+        }
+    }
+
+    /// `aletheia audit-render <artifact>` — render a human-readable chronology.
+    pub(super) fn handle_render(args: Vec<String>) -> Result<(), String> {
+        let path = args
+            .first()
+            .ok_or_else(|| "usage: aletheia audit-render <artifact>".to_string())?;
+        let bytes = std::fs::read(path).map_err(|e| format!("failed to read artifact: {e}"))?;
+        let export = aletheiadb::audit::AuditExport::from_json_bytes(&bytes)
+            .map_err(|e| format!("failed to parse artifact: {e}"))?;
+        print!("{}", export.render_chronology());
+        Ok(())
+    }
+
+    fn usage_export() -> String {
+        "usage: aletheia audit-export <node|edge> <id> --key <key_file> --out <path> \
+         [--db-id ID] [--redact k1,k2]"
+            .to_string()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,10 @@ pub mod http;
 // server today and the MCP server in Phase 2, hence gated on either feature.
 #[cfg(any(feature = "http-server", feature = "mcp-server"))]
 pub mod auth;
+// Signed audit export of entity history for compliance (Issue #3358).
+// Offline-verifiable Ed25519-signed evidence artifacts built on history reads.
+#[cfg(feature = "audit-export")]
+pub mod audit;
 // Test utilities: available in unit tests and when the simulation feature is enabled
 // (integration tests under `--features simulation` need create_test_db).
 #[cfg(any(test, feature = "simulation"))]

--- a/src/mcp/auth.rs
+++ b/src/mcp/auth.rs
@@ -96,6 +96,8 @@ pub(crate) const TOOL_ACCESS_CLASSES: &[(&str, AccessClass)] = &[
     ("query", AccessClass::Read),
     ("get_schema", AccessClass::Read),
     ("temporal_extent", AccessClass::Read),
+    // Signed audit export reads history and signs it — no mutation (Issue #3358).
+    ("audit_export", AccessClass::Read),
     // ---- Metrics: operational health/stats.
     ("database_stats", AccessClass::Metrics),
     // ---- Write: graph mutations plus index/constraint state changes.

--- a/src/mcp/auth_tests.rs
+++ b/src/mcp/auth_tests.rs
@@ -829,8 +829,8 @@ fn write_and_metrics_sets_match_hardcoded_snapshot() {
     // Everything else must be Read (no fourth class sneaking in).
     assert_eq!(
         TOOL_ACCESS_CLASSES.len(),
-        actual_write.len() + actual_metrics.len() + 28,
-        "Read tool count changed (expected 28); if a tool was added or \
+        actual_write.len() + actual_metrics.len() + 29,
+        "Read tool count changed (expected 29); if a tool was added or \
          removed, re-verify its classification and update this count"
     );
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -3516,6 +3516,81 @@ impl AletheiaMcpServer {
         }
     }
 
+    /// Handle the `audit_export` tool (Issue #3358).
+    ///
+    /// Produces a signed, offline-verifiable evidence artifact of an entity's
+    /// complete bi-temporal history. The Ed25519 signing key is operator-
+    /// provided out of band via the `ALETHEIADB_AUDIT_SIGNING_KEY` environment
+    /// variable (a 32-byte hex seed); the secret is never returned or logged —
+    /// only the public key travels in the artifact.
+    fn handle_audit_export(&self, args: serde_json::Value) -> CallToolResult {
+        use crate::audit::{AuditScope, AuditSigningKey, ExportOptions, SIGNING_KEY_ENV};
+
+        let req: AuditExportRequest = match serde_json::from_value(args) {
+            Ok(r) => r,
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
+        };
+
+        let scope = match req.entity_type.as_str() {
+            "node" => match NodeId::new(req.entity_id) {
+                Ok(id) => AuditScope::node(id),
+                Err(e) => return self.invalid_argument(&e.to_string()),
+            },
+            "edge" => match crate::core::id::EdgeId::new(req.entity_id) {
+                Ok(id) => AuditScope::edge(id),
+                Err(e) => return self.invalid_argument(&e.to_string()),
+            },
+            other => {
+                return self.invalid_argument(&format!(
+                    "entity_type must be 'node' or 'edge', got '{other}'"
+                ));
+            }
+        };
+
+        // The signing key is a precondition supplied by the operator, not a
+        // caller argument — a missing key is a FAILED_PRECONDITION, never a
+        // silent unsigned export.
+        let signing_key = match AuditSigningKey::from_env(SIGNING_KEY_ENV) {
+            Ok(k) => k,
+            Err(_) => {
+                return self.failed_precondition(&format!(
+                    "audit export requires an operator-provided Ed25519 signing key in the \
+                     {SIGNING_KEY_ENV} environment variable (32-byte hex seed)"
+                ));
+            }
+        };
+
+        let mut options =
+            ExportOptions::new(req.database_id.unwrap_or_else(|| "aletheiadb".to_string()));
+        if !req.redact_keys.is_empty() {
+            options = options.redact(req.redact_keys);
+        }
+
+        match self.db.audit_export(scope, &signing_key, &options) {
+            Ok(export) => match serde_json::to_value(&export) {
+                Ok(artifact) => self.success_json(json!({
+                    "artifact": artifact,
+                    "public_key": signing_key.public_key().to_hex(),
+                    "entity_count": export.entity_count(),
+                    "version_count": export.version_count(),
+                    "chain_root": export.chain.root,
+                })),
+                Err(e) => self.error_result(McpError::new(
+                    McpErrorCode::Internal,
+                    format!("failed to serialize artifact: {e}"),
+                )),
+            },
+            Err(crate::audit::AuditError::NoHistory(msg)) => self.error_result(McpError::new(
+                McpErrorCode::NotFound,
+                format!("no exportable history: {msg}"),
+            )),
+            Err(e) => self.error_result(McpError::new(
+                McpErrorCode::Internal,
+                format!("audit export failed: {e}"),
+            )),
+        }
+    }
+
     /// Handle the `database_stats` tool (Issue #3222).
     ///
     /// Thin aggregator: delegates entirely to the public
@@ -4156,6 +4231,7 @@ impl AletheiaMcpServer {
             "query" => self.handle_query(args),
             "get_schema" => self.handle_get_schema(args),
             "temporal_extent" => self.handle_temporal_extent(args),
+            "audit_export" => self.handle_audit_export(args),
             "database_stats" => self.handle_database_stats(args),
             _ => self.error_result(
                 McpError::new(McpErrorCode::NotFound, format!("Unknown tool: {}", name))
@@ -4584,6 +4660,28 @@ fn tool_definitions() -> Vec<Tool> {
              (edge_types); per-label bounds are computed from hot-tier history only and may \
              be narrower than the overall bounds (or a label absent) after cold migration.",
             make_input_schema::<TemporalExtentRequest>(),
+        ),
+        Tool::new(
+            "audit_export",
+            "Produce a SIGNED, self-contained audit export of a single entity's (node or edge) \
+             complete bi-temporal history plus provenance — a portable evidence artifact a \
+             third party can verify OFFLINE with only the signer's public key (no database, no \
+             network). Use this to answer 'prove what the system knew about entity X, and \
+             when' for compliance, audits, GDPR/CCPA subject-access requests, or legal \
+             discovery. Arguments: entity_type ('node'|'edge'), entity_id, optional \
+             database_id (recorded in the artifact), optional redact_keys (property keys whose \
+             VALUES are omitted while the redaction stays recorded and verifiable). The \
+             artifact contains every version across both time dimensions (including superseded \
+             versions and delete tombstones), per-version provenance/principal where recorded, \
+             a per-version SHA-256 hash chain, and an Ed25519 signature over the chain root. \
+             The Ed25519 signing key is operator-provided out of band via the \
+             ALETHEIADB_AUDIT_SIGNING_KEY environment variable (32-byte hex seed); the secret \
+             is never returned — only the public key travels in the artifact. Returns the \
+             artifact JSON plus public_key, chain_root, and entity/version counts. Note: \
+             delete/retract operations do not yet stamp an authenticated principal (#3427); \
+             the export surfaces provenance faithfully, including its absence, and never \
+             fabricates attribution.",
+            make_input_schema::<AuditExportRequest>(),
         ),
         Tool::new(
             "database_stats",

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -12882,3 +12882,115 @@ mod per_request_now_tests {
         );
     }
 }
+
+#[cfg(feature = "audit-export")]
+mod audit_export_tool_tests {
+    use super::create_test_server;
+    use crate::audit::{AuditSigningKey, verify_json_bytes};
+    use crate::core::hex;
+    use serde_json::json;
+
+    const SEED: [u8; 32] = [23u8; 32];
+
+    fn dispatch_json(
+        server: &super::AletheiaMcpServer,
+        tool: &str,
+        args: serde_json::Value,
+    ) -> (serde_json::Value, bool) {
+        let result = server.dispatch_tool(tool, args);
+        let is_error = result.is_error.unwrap_or(false);
+        let text = result
+            .content
+            .first()
+            .and_then(|c| c.as_text().map(|t| t.text.clone()))
+            .expect("tool result should carry text content");
+        (serde_json::from_str(&text).expect("valid JSON"), is_error)
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn audit_export_tool_signs_and_verifies_offline() {
+        // SAFETY: env mutation serialized via #[serial]; restored below.
+        unsafe {
+            std::env::set_var("ALETHEIADB_AUDIT_SIGNING_KEY", hex::encode(&SEED));
+        }
+
+        let server = create_test_server();
+        let (created, is_err) = dispatch_json(
+            &server,
+            "create_node",
+            json!({"label": "Person", "properties": {"name": "Alice", "ssn": "secret"}}),
+        );
+        assert!(!is_err, "create_node failed: {created}");
+        let node_id = created["id"].as_u64().expect("node_id");
+
+        let (resp, is_err) = dispatch_json(
+            &server,
+            "audit_export",
+            json!({
+                "entity_type": "node",
+                "entity_id": node_id,
+                "database_id": "prod-db",
+                "redact_keys": ["ssn"],
+            }),
+        );
+        assert!(!is_err, "audit_export failed: {resp}");
+        assert_eq!(resp["version_count"].as_u64(), Some(1));
+
+        let pubkey_hex = resp["public_key"].as_str().unwrap();
+        let expected_pub = AuditSigningKey::from_seed_bytes(SEED).public_key();
+        assert_eq!(pubkey_hex, expected_pub.to_hex());
+
+        // The artifact verifies offline against the operator's public key.
+        let artifact_bytes = serde_json::to_vec(&resp["artifact"]).unwrap();
+        let report = verify_json_bytes(&artifact_bytes, Some(&expected_pub))
+            .expect("MCP-produced artifact must verify offline");
+        assert!(report.passed);
+        assert!(report.redacted_keys.iter().any(|k| k == "ssn"));
+        // Redacted value must not have leaked into the artifact.
+        assert!(
+            !String::from_utf8(artifact_bytes)
+                .unwrap()
+                .contains("secret")
+        );
+
+        unsafe {
+            std::env::remove_var("ALETHEIADB_AUDIT_SIGNING_KEY");
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn audit_export_tool_without_signing_key_is_failed_precondition() {
+        // SAFETY: env mutation serialized via #[serial].
+        unsafe {
+            std::env::remove_var("ALETHEIADB_AUDIT_SIGNING_KEY");
+        }
+        let server = create_test_server();
+        let (created, _) = dispatch_json(
+            &server,
+            "create_node",
+            json!({"label": "Person", "properties": {"name": "Bob"}}),
+        );
+        let node_id = created["id"].as_u64().unwrap();
+        let (resp, is_err) = dispatch_json(
+            &server,
+            "audit_export",
+            json!({"entity_type": "node", "entity_id": node_id}),
+        );
+        assert!(is_err, "expected an error without a signing key");
+        assert_eq!(resp["error"]["code"].as_str(), Some("FAILED_PRECONDITION"));
+    }
+
+    #[test]
+    fn audit_export_tool_rejects_bad_entity_type() {
+        let server = create_test_server();
+        let (resp, is_err) = dispatch_json(
+            &server,
+            "audit_export",
+            json!({"entity_type": "widget", "entity_id": 1}),
+        );
+        assert!(is_err);
+        assert_eq!(resp["error"]["code"].as_str(), Some("INVALID_ARGUMENT"));
+    }
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -805,6 +805,31 @@ pub struct GetNodeHistoryRequest {
     pub node_id: u64,
 }
 
+/// Request to produce a signed audit export of an entity's history (Issue #3358).
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct AuditExportRequest {
+    /// The entity kind to export: `node` or `edge`.
+    #[schemars(description = "Entity kind to export: 'node' or 'edge'")]
+    pub entity_type: String,
+
+    /// The unique identifier of the entity.
+    #[schemars(description = "The unique identifier of the node or edge to export")]
+    pub entity_id: u64,
+
+    /// Operator-supplied database identity recorded in the artifact.
+    #[serde(default)]
+    #[schemars(description = "Optional database identity recorded in the artifact metadata")]
+    pub database_id: Option<String>,
+
+    /// Property keys to redact at export (values omitted, redaction recorded).
+    #[serde(default)]
+    #[schemars(
+        description = "Optional list of property keys to redact at export; their values are \
+                       omitted but the redaction is recorded and remains verifiable"
+    )]
+    pub redact_keys: Vec<String>,
+}
+
 /// Request to compute the difference between two versions of a node.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct DiffNodeVersionsRequest {

--- a/tests/audit_export.rs
+++ b/tests/audit_export.rs
@@ -1,0 +1,512 @@
+#![cfg(feature = "audit-export")]
+//! Integration tests for the signed audit export of entity history (Issue #3358).
+//!
+//! These encode the acceptance criteria and the adversarial edge cases:
+//! full bi-temporal history is exported (incl. superseded versions and delete
+//! tombstones), provenance/principal is surfaced, the artifact verifies OFFLINE
+//! with only the signer's public key, and any single-byte tamper / truncation /
+//! reorder / wrong-key is DETECTED.
+
+use aletheiadb::api::transaction::WriteRequestOptions;
+use aletheiadb::audit::{
+    AuditPublicKey, AuditScope, AuditSigningKey, EntityRef, ExportOptions, verify_json_bytes,
+};
+use aletheiadb::core::temporal::time;
+use aletheiadb::{AletheiaDB, PropertyMapBuilder, Provenance};
+
+/// Build a database with a node that has a rich bi-temporal history:
+/// create (with provenance+principal) -> two updates -> delete tombstone.
+fn db_with_node_history() -> (AletheiaDB, aletheiadb::NodeId) {
+    let db = AletheiaDB::new().expect("db");
+    let prov = Provenance::builder()
+        .source("hr-system")
+        .confidence(0.9)
+        .note("initial import")
+        .build()
+        .expect("prov")
+        .with_principal("alice-key");
+    let id = db
+        .create_node_with_options(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .insert("city", "NYC")
+                .build(),
+            WriteRequestOptions::new().with_provenance(prov),
+        )
+        .expect("create");
+
+    db.update_node_with_valid_time(
+        id,
+        PropertyMapBuilder::new()
+            .insert("name", "Alice")
+            .insert("city", "London")
+            .build(),
+        None,
+    )
+    .expect("update1");
+
+    db.update_node_with_valid_time(
+        id,
+        PropertyMapBuilder::new()
+            .insert("name", "Alice")
+            .insert("city", "Paris")
+            .insert("verified", true)
+            .build(),
+        None,
+    )
+    .expect("update2");
+
+    // Delete tombstone closes the entity — attribution gap #3427 applies here.
+    db.delete_node_with_valid_time(id, None).expect("delete");
+
+    (db, id)
+}
+
+fn signing_key() -> AuditSigningKey {
+    // Deterministic seed so tests are reproducible.
+    AuditSigningKey::from_seed_bytes([7u8; 32])
+}
+
+// ── AC1: full bi-temporal history + provenance + coordinates + metadata ──────
+
+#[test]
+fn ac1_export_contains_every_version_with_provenance_and_metadata() {
+    let (db, id) = db_with_node_history();
+    let key = signing_key();
+    let export = db
+        .audit_export(
+            AuditScope::node(id),
+            &key,
+            &ExportOptions::new("audit-test-db"),
+        )
+        .expect("export");
+
+    // History read count must equal exported version count (zero silent omissions).
+    let history_count = db.get_node_history(id).unwrap().version_count();
+    assert_eq!(
+        export.version_count(),
+        history_count,
+        "export must include 100% of versions retrievable via history reads"
+    );
+    assert!(
+        export.version_count() >= 4,
+        "expected create + 2 updates + delete tombstone, got {}",
+        export.version_count()
+    );
+
+    // Metadata surfaces database identity, export time, and chain-head anchor.
+    let meta = export.metadata();
+    assert_eq!(meta.database_id, "audit-test-db");
+    assert!(!meta.exported_at.is_empty());
+    // Principal must be surfaced where present (#3224 / #3421).
+    let json = String::from_utf8(export.to_json_bytes().unwrap()).unwrap();
+    assert!(json.contains("alice-key"), "principal must be surfaced");
+    assert!(
+        json.contains("hr-system"),
+        "provenance source must be surfaced"
+    );
+}
+
+// ── AC2 + AC3: offline verification succeeds with only the public key ────────
+
+#[test]
+fn ac3_offline_verification_succeeds_with_public_key_only() {
+    let (db, id) = db_with_node_history();
+    let key = signing_key();
+    let export = db
+        .audit_export(AuditScope::node(id), &key, &ExportOptions::new("db"))
+        .unwrap();
+    let bytes = export.to_json_bytes().unwrap();
+
+    // Offline: only bytes + public key, no database.
+    let pubkey = key.public_key();
+    let report = verify_json_bytes(&bytes, Some(&pubkey)).expect("verification must pass");
+    assert!(report.passed);
+    assert!(report.trusted_key, "verified against caller-supplied key");
+    assert_eq!(report.version_count, export.version_count());
+    assert!(report.summary().contains("Person") || !report.entity_summary.is_empty());
+}
+
+#[test]
+fn ac3_verification_without_expected_key_uses_embedded_key_untrusted() {
+    let (db, id) = db_with_node_history();
+    let key = signing_key();
+    let bytes = db
+        .audit_export(AuditScope::node(id), &key, &ExportOptions::new("db"))
+        .unwrap()
+        .to_json_bytes()
+        .unwrap();
+
+    let report = verify_json_bytes(&bytes, None).expect("self-consistent verify passes");
+    assert!(report.passed);
+    assert!(
+        !report.trusted_key,
+        "trust is self-asserted when no external key supplied"
+    );
+}
+
+// ── AC4: tamper detection — THE CRUX ─────────────────────────────────────────
+
+#[test]
+fn ac4_single_byte_tamper_in_property_value_is_detected() {
+    let (db, id) = db_with_node_history();
+    let key = signing_key();
+    let pubkey = key.public_key();
+    let bytes = db
+        .audit_export(AuditScope::node(id), &key, &ExportOptions::new("db"))
+        .unwrap()
+        .to_json_bytes()
+        .unwrap();
+
+    // Sanity: the clean artifact verifies.
+    assert!(verify_json_bytes(&bytes, Some(&pubkey)).is_ok());
+
+    // Flip a property value "Paris" -> "Maris" via a structured edit that keeps
+    // the JSON valid but changes signed content.
+    let mut v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let s = serde_json::to_string(&v).unwrap();
+    assert!(s.contains("Paris"), "fixture should contain Paris");
+    let tampered_str = s.replacen("Paris", "Maris", 1);
+    v = serde_json::from_str(&tampered_str).unwrap();
+    let tampered = serde_json::to_vec(&v).unwrap();
+
+    assert!(
+        verify_json_bytes(&tampered, Some(&pubkey)).is_err(),
+        "tampering a property value MUST fail verification"
+    );
+}
+
+#[test]
+fn ac4_raw_single_byte_flip_anywhere_is_detected() {
+    let (db, id) = db_with_node_history();
+    let key = signing_key();
+    let pubkey = key.public_key();
+    let bytes = db
+        .audit_export(AuditScope::node(id), &key, &ExportOptions::new("db"))
+        .unwrap()
+        .to_json_bytes()
+        .unwrap();
+    assert!(verify_json_bytes(&bytes, Some(&pubkey)).is_ok());
+
+    // Flip one byte in the signature hex region and confirm detection.
+    let mut detected = 0usize;
+    let mut attempts = 0usize;
+    for i in (0..bytes.len()).step_by(7) {
+        let mut m = bytes.clone();
+        // Only flip printable ASCII to keep JSON parseable more often; either
+        // way, a parse failure or a verify failure both count as "detected".
+        m[i] ^= 0x01;
+        attempts += 1;
+        if verify_json_bytes(&m, Some(&pubkey)).is_err() {
+            detected += 1;
+        }
+    }
+    assert_eq!(
+        detected, attempts,
+        "every single-byte flip must be detected (parse-fail or verify-fail)"
+    );
+}
+
+#[test]
+fn ac4_tampered_timestamp_is_detected() {
+    let (db, id) = db_with_node_history();
+    let key = signing_key();
+    let pubkey = key.public_key();
+    let export = db
+        .audit_export(AuditScope::node(id), &key, &ExportOptions::new("db"))
+        .unwrap();
+    let mut v: serde_json::Value =
+        serde_json::from_slice(&export.to_json_bytes().unwrap()).unwrap();
+
+    // Reach into the first entity's first version valid_from micros and bump it.
+    let versions = v["entities"][0]["versions"].as_array_mut().unwrap();
+    let vf = versions[0]["valid_from_micros"].as_i64().unwrap();
+    versions[0]["valid_from_micros"] = serde_json::json!(vf + 1);
+    let tampered = serde_json::to_vec(&v).unwrap();
+    assert!(verify_json_bytes(&tampered, Some(&pubkey)).is_err());
+}
+
+#[test]
+fn ac4_truncation_removing_a_version_is_detected() {
+    let (db, id) = db_with_node_history();
+    let key = signing_key();
+    let pubkey = key.public_key();
+    let export = db
+        .audit_export(AuditScope::node(id), &key, &ExportOptions::new("db"))
+        .unwrap();
+    let mut v: serde_json::Value =
+        serde_json::from_slice(&export.to_json_bytes().unwrap()).unwrap();
+
+    // Drop the last version (truncate from the end).
+    let versions = v["entities"][0]["versions"].as_array_mut().unwrap();
+    versions.pop();
+    let tampered = serde_json::to_vec(&v).unwrap();
+    assert!(
+        verify_json_bytes(&tampered, Some(&pubkey)).is_err(),
+        "completeness is part of the proof — truncation must fail"
+    );
+}
+
+#[test]
+fn ac4_reordering_versions_is_detected() {
+    let (db, id) = db_with_node_history();
+    let key = signing_key();
+    let pubkey = key.public_key();
+    let export = db
+        .audit_export(AuditScope::node(id), &key, &ExportOptions::new("db"))
+        .unwrap();
+    let mut v: serde_json::Value =
+        serde_json::from_slice(&export.to_json_bytes().unwrap()).unwrap();
+    let versions = v["entities"][0]["versions"].as_array_mut().unwrap();
+    assert!(versions.len() >= 2);
+    versions.swap(0, 1);
+    let tampered = serde_json::to_vec(&v).unwrap();
+    assert!(
+        verify_json_bytes(&tampered, Some(&pubkey)).is_err(),
+        "order-dependent chain must detect reordering"
+    );
+}
+
+#[test]
+fn ac4_wrong_key_fails_verification() {
+    let (db, id) = db_with_node_history();
+    let key = signing_key();
+    let bytes = db
+        .audit_export(AuditScope::node(id), &key, &ExportOptions::new("db"))
+        .unwrap()
+        .to_json_bytes()
+        .unwrap();
+
+    let wrong = AuditSigningKey::from_seed_bytes([9u8; 32]).public_key();
+    assert!(
+        verify_json_bytes(&bytes, Some(&wrong)).is_err(),
+        "a different public key must not verify"
+    );
+}
+
+#[test]
+fn ac4_public_key_substitution_with_attacker_resign_fails_trusted_verify() {
+    // Attacker re-signs with their own key and swaps the embedded public key.
+    // Verifying against the TRUSTED operator key must still fail.
+    let (db, id) = db_with_node_history();
+    let operator = signing_key();
+    let operator_pub = operator.public_key();
+    let attacker = AuditSigningKey::from_seed_bytes([42u8; 32]);
+
+    let export = db
+        .audit_export(AuditScope::node(id), &attacker, &ExportOptions::new("db"))
+        .unwrap();
+    let bytes = export.to_json_bytes().unwrap();
+
+    // Self-consistent (attacker key embedded) — untrusted verify passes...
+    assert!(verify_json_bytes(&bytes, None).is_ok());
+    // ...but against the trusted operator key it MUST fail.
+    assert!(verify_json_bytes(&bytes, Some(&operator_pub)).is_err());
+}
+
+// ── AC5: scope options are explicit about inclusion ──────────────────────────
+
+#[test]
+fn ac5_entity_set_scope_records_what_was_included() {
+    let db = AletheiaDB::new().unwrap();
+    let a = db
+        .create_node("Person", PropertyMapBuilder::new().insert("n", "A").build())
+        .unwrap();
+    let b = db
+        .create_node("Person", PropertyMapBuilder::new().insert("n", "B").build())
+        .unwrap();
+    let key = signing_key();
+    let export = db
+        .audit_export(
+            AuditScope::EntitySet(vec![EntityRef::Node(a), EntityRef::Node(b)]),
+            &key,
+            &ExportOptions::new("db"),
+        )
+        .unwrap();
+    let report = verify_json_bytes(&export.to_json_bytes().unwrap(), Some(&key.public_key()))
+        .expect("verifies");
+    assert_eq!(report.entity_count, 2);
+    // Scope must be stated explicitly in the artifact.
+    assert!(export.metadata().scope_description.contains("entity_set"));
+}
+
+#[test]
+fn ac5_neighborhood_scope_states_coordinate_and_members() {
+    let db = AletheiaDB::new().unwrap();
+    let a = db
+        .create_node("Person", PropertyMapBuilder::new().insert("n", "A").build())
+        .unwrap();
+    let b = db
+        .create_node("Person", PropertyMapBuilder::new().insert("n", "B").build())
+        .unwrap();
+    db.create_edge(a, b, "KNOWS", PropertyMapBuilder::new().build())
+        .unwrap();
+    let key = signing_key();
+    let export = db
+        .audit_export(
+            AuditScope::Neighborhood {
+                start: a,
+                hops: 1,
+                valid_time: Some(time::now()),
+                transaction_time: Some(time::now()),
+            },
+            &key,
+            &ExportOptions::new("db"),
+        )
+        .unwrap();
+    assert!(export.metadata().scope_description.contains("neighborhood"));
+    // The start node plus its 1-hop neighbor and the connecting edge are included.
+    assert!(export.entity_count() >= 2);
+    assert!(verify_json_bytes(&export.to_json_bytes().unwrap(), Some(&key.public_key())).is_ok());
+}
+
+// ── AC6: explicit, verifiable redaction ──────────────────────────────────────
+
+#[test]
+fn ac6_redaction_is_explicit_and_still_verifies() {
+    let db = AletheiaDB::new().unwrap();
+    let id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .insert("ssn", "123-45-6789")
+                .build(),
+        )
+        .unwrap();
+    let key = signing_key();
+    let export = db
+        .audit_export(
+            AuditScope::node(id),
+            &key,
+            &ExportOptions::new("db").redact(["ssn"]),
+        )
+        .unwrap();
+    let bytes = export.to_json_bytes().unwrap();
+
+    // The redacted value must NOT appear; the fact of redaction MUST appear.
+    let json = String::from_utf8(bytes.clone()).unwrap();
+    assert!(!json.contains("123-45-6789"), "redacted value must be gone");
+    assert!(json.contains("ssn"), "redacted key must be recorded");
+    assert!(export.metadata().redacted_keys.iter().any(|k| k == "ssn"));
+
+    // Verification still passes over the redacted-but-signed content.
+    let report = verify_json_bytes(&bytes, Some(&key.public_key())).expect("verifies");
+    assert!(report.passed);
+    assert!(report.redacted_keys.iter().any(|k| k == "ssn"));
+}
+
+// ── AC7: human-readable chronology ───────────────────────────────────────────
+
+#[test]
+fn ac7_render_chronology_is_human_readable() {
+    let (db, id) = db_with_node_history();
+    let key = signing_key();
+    let export = db
+        .audit_export(AuditScope::node(id), &key, &ExportOptions::new("db"))
+        .unwrap();
+    let rendered = export.render_chronology();
+    assert!(rendered.contains("Version"));
+    assert!(rendered.contains("Person"));
+    // Sources appear in the chronology.
+    assert!(rendered.contains("hr-system") || rendered.contains("Provenance"));
+}
+
+// ── AC8 + #3427: key handling + documented attribution gap ───────────────────
+
+#[test]
+fn ac8_signing_key_roundtrips_via_file_without_leaking_secret() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("audit_signing.key");
+    let key = AuditSigningKey::from_seed_bytes([3u8; 32]);
+    key.write_to_file(&path).unwrap();
+
+    // 0600 permissions on unix.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "signing key file must be 0600");
+    }
+
+    let loaded = AuditSigningKey::from_file(&path).unwrap();
+    assert_eq!(
+        loaded.public_key().to_hex(),
+        key.public_key().to_hex(),
+        "roundtrip preserves the keypair"
+    );
+    // Debug output must not leak the secret seed.
+    let dbg = format!("{key:?}");
+    assert!(!dbg.contains("0303") && !dbg.to_lowercase().contains("seed"));
+}
+
+#[test]
+fn known_gap_3427_delete_tombstone_has_no_principal_attribution() {
+    // Honest documentation-as-test: deletes do NOT stamp a principal yet (#3427).
+    // The export surfaces provenance faithfully — including its ABSENCE on the
+    // delete tombstone — rather than fabricating attribution.
+    let (db, id) = db_with_node_history();
+    let key = signing_key();
+    let export = db
+        .audit_export(AuditScope::node(id), &key, &ExportOptions::new("db"))
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&export.to_json_bytes().unwrap()).unwrap();
+    let versions = v["entities"][0]["versions"].as_array().unwrap();
+    let last = versions.last().unwrap();
+    // The tombstone carries no principal (attribution gap, documented in guide).
+    let principal_present = last
+        .get("provenance")
+        .and_then(|p| p.get("principal"))
+        .is_some();
+    assert!(
+        !principal_present,
+        "delete attribution is a known gap (#3427); must not be fabricated"
+    );
+}
+
+#[test]
+fn public_key_hex_roundtrip() {
+    let key = AuditSigningKey::from_seed_bytes([5u8; 32]);
+    let pk = key.public_key();
+    let hex = pk.to_hex();
+    let parsed = AuditPublicKey::from_hex(&hex).unwrap();
+    assert_eq!(parsed.to_hex(), hex);
+}
+
+#[test]
+fn empty_history_edge_case_single_version_verifies() {
+    let db = AletheiaDB::new().unwrap();
+    let id = db
+        .create_node("Doc", PropertyMapBuilder::new().insert("t", "x").build())
+        .unwrap();
+    let key = signing_key();
+    let export = db
+        .audit_export(AuditScope::node(id), &key, &ExportOptions::new("db"))
+        .unwrap();
+    assert_eq!(export.version_count(), 1);
+    assert!(verify_json_bytes(&export.to_json_bytes().unwrap(), Some(&key.public_key())).is_ok());
+}
+
+#[test]
+fn unicode_property_values_roundtrip_and_tamper_still_detected() {
+    let db = AletheiaDB::new().unwrap();
+    let id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Ólafur 日本語 😀")
+                .build(),
+        )
+        .unwrap();
+    let key = signing_key();
+    let pubkey = key.public_key();
+    let export = db
+        .audit_export(AuditScope::node(id), &key, &ExportOptions::new("db"))
+        .unwrap();
+    let bytes = export.to_json_bytes().unwrap();
+    assert!(verify_json_bytes(&bytes, Some(&pubkey)).is_ok());
+
+    let s = String::from_utf8(bytes).unwrap().replacen("😀", "😎", 1);
+    assert!(verify_json_bytes(s.as_bytes(), Some(&pubkey)).is_err());
+}


### PR DESCRIPTION
Closes #3358.

## Before / After (plain language)

**Before.** The best answer to *"prove what your system knew about entity X, and when"* was a JSON dump of `get_node_history` — mutable, unattributed, and worthless as evidence the moment it left the database. Provenance stopped at the database boundary.

**After.** `aletheia audit-export node 42 --key k --out ev.json` produces a **single signed file** containing that entity's complete bi-temporal history plus provenance. Anyone can run `aletheia audit-verify ev.json --public-key <hex>` **offline — no database, no network** — and get a PASS/FAIL plus a human-readable summary. Altering any byte (a value, a timestamp, a provenance field, the version order) or dropping any version makes verification FAIL. This converts storage-layer trust into portable, courtroom-shaped evidence for AI-governance reviews, GDPR/CCPA subject-access requests, financial audits, and legal discovery.

## How (implementation)

- **Signing scheme: Ed25519 detached signature over a per-version SHA-256 hash chain root.** Chosen over an HMAC because verification must be possible with **only the signer's public key** (AC3) — a symmetric MAC would let the operator forge artifacts. The signature covers a deterministic **canonical binary encoding** of the typed content (not the JSON text), so re-pretty-printing is safe but any content change, reorder, or truncation is caught. The root fold is order- and count-dependent; per-version leaf hashes are stored for transparency and independent checking.
- **Surfaces:** Rust API (`AletheiaDB::audit_export` + `AuditExport::{to_json_bytes, from_json_bytes, verify, render_chronology}` + `audit::verify_json_bytes`), CLI (`audit-keygen` / `audit-export` / `audit-verify` / `audit-render`), and an MCP `audit_export` tool classified **read** in the access-control matrix (registry-sweep + RBAC conformance updated).
- **Scope options:** single entity, entity set, and N-hop neighborhood at a bi-temporal coordinate; each records what was and was not included so absence of data is never ambiguous.
- **Redaction** is explicit and folded into the signature — redacted keys are recorded, values omitted, verification still passes.
- **Key handling** mirrors the #3350/#3421 conventions: zeroizing seed, never logged, `0600` key files, public-key-fingerprint-only `Debug`, hex-seed file/env loading (`ALETHEIADB_AUDIT_SIGNING_KEY`).
- Behind the default-on `audit-export` feature (implied by `mcp-server`); cleanly excluded under `--no-default-features`.

## Acceptance criteria checklist

- [x] **AC1** — export command (CLI + Rust API + MCP) yields a single-file artifact with every version across both dimensions (incl. superseded versions + delete tombstones), per-version provenance, bi-temporal coordinates, and export metadata (database id, export time, chain-head LSN). *(`ac1_export_contains_every_version_with_provenance_and_metadata`; history-count cross-check)*
- [x] **AC2** — integrity proofs (per-version leaves) + Ed25519 signature over the chain root; verification proves no post-export alteration and consistency with the referenced chain-head anchor. *(`ac3_offline_verification_succeeds_with_public_key_only`)*
- [x] **AC3** — standalone `audit-verify` runs with no database/network and only the public key; returns pass/fail + summary; format + verifier documented for independent reimplementation. *(`docs/guides/audit-export.md`, `ac3_*`)*
- [x] **AC4** — tamper tests: property value, timestamp, provenance, reorder, truncation, wrong key, and public-key substitution all FAIL; an exhaustive single-byte-flip test detects **every** flip. *(`ac4_*`)*
- [x] **AC5** — single / entity-set / neighborhood scopes, each stating included vs not-included. *(`ac5_*`, `entity_set_records_missing_as_not_included`)*
- [x] **AC6** — explicit, verifiable redaction. *(`ac6_redaction_is_explicit_and_still_verifies`)*
- [x] **AC7** — human-readable chronology rendering. *(`ac7_render_chronology_is_human_readable`)*
- [x] **AC8** — operator-provided file/env signing keys; encryption-cluster interplay documented as configuration. *(`ac8_signing_key_roundtrips_via_file_without_leaking_secret`)*

## Offline verifier usage

```bash
aletheia audit-verify ev.json --public-key f80c…6215   # exits non-zero on failure
```
With `--public-key`, the embedded key must match the trusted key (defeats public-key substitution). Without it, the embedded key is used and the result is marked *self-asserted* with a prominent note. The Rust entry point is `aletheiadb::audit::verify_json_bytes`. The canonical encoding is fully documented in `docs/guides/audit-export.md` so third parties can implement their own verifier.

## Known limitation (#3427)

Delete/retract operations do not yet stamp an authenticated principal into provenance. The export surfaces provenance faithfully — **including its absence** on delete tombstones — and never fabricates attribution. This is documented in the guide and asserted by `known_gap_3427_delete_tombstone_has_no_principal_attribution`, rather than papered over.

## Quality gates

- `cargo clippy --all-targets --all-features -- -D warnings`: clean (0 warnings).
- `cargo fmt --all`: applied.
- Tests: 19 integration + 18 audit unit + 3 MCP tool tests pass; MCP RBAC/matrix conformance updated and passing; full default-feature lib suite (3563) green. Minimal and `mcp-server` builds compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156cK9izcExHB1oBEqLib6r

---
_Generated by [Claude Code](https://claude.ai/code/session_0156cK9izcExHB1oBEqLib6r)_