### PR TITLE
WAL transaction framing for atomic crash recovery (#3413)

### DIFF
--- a/src/api/transaction/write/wal.rs
+++ b/src/api/transaction/write/wal.rs
@@ -44,17 +44,34 @@ use crate::storage::wal::WalOperation;
 /// full string labels and keys, it copies their 4-byte `InternedString` IDs.
 /// This minimizes memory allocation and bus traffic during the critical commit path.
 ///
+/// # Transaction framing (Issue #3413)
+///
+/// The buffered data ops are bracketed by a leading [`WalOperation::BeginTx`]
+/// and a terminal [`WalOperation::CommitTx`] carrying the real
+/// `commit_timestamp` and the data-op count, and the whole
+/// `[BeginTx, ..data.., CommitTx]` sequence is appended in the SAME atomic
+/// `append_batch_async` allocation (one LSN band, one flush epoch). This lets
+/// crash recovery (a) discard a batch whose commit marker never became durable
+/// — instead of replaying a torn prefix as a half-committed transaction — and
+/// (b) re-stamp every recovered version of the transaction with the single
+/// `commit_timestamp` instead of each entry's own wallclock (which previously
+/// let `AS OF SYSTEM_TIME` bisect an atomic batch).
+///
+/// The markers ride entirely inside the existing `wal` critical section, so the
+/// CLAUDE.md lock order (current_timestamp → wal → …) is unchanged.
+///
 /// # Arguments
 ///
 /// * `tx` - The active write transaction containing the write buffer.
-/// * `_commit_timestamp` - The timestamp assigned to this commit (currently unused in WAL op, but required by API).
+/// * `commit_timestamp` - The authoritative bi-temporal commit timestamp, carried
+///   in the terminal `CommitTx` marker and re-stamped onto every replayed version.
 ///
 /// # Errors
 ///
 /// Returns an error if the WAL append fails (e.g., disk full, IO error).
 pub(crate) fn log_operations_to_wal(
     tx: &WriteTransaction,
-    _commit_timestamp: Timestamp,
+    commit_timestamp: Timestamp,
 ) -> Result<()> {
     // Collect all buffered writes into a single batch and append them under one atomic
     // LSN allocation via the WAL `append_batch` path (Issue #219). This is strictly more
@@ -62,16 +79,28 @@ pub(crate) fn log_operations_to_wal(
     // transactions — e.g. each chunk committed by the bulk importer (Issue #3211) — and is
     // behavior-preserving: `append_batch_async` only buffers, leaving the subsequent
     // `wal.commit()` to perform the `DurabilityMode`-appropriate flush.
-    let operations: Vec<WalOperation> = tx
-        .buffer
-        .operations()
-        .iter()
-        .map(WalOperation::from)
-        .collect();
+    let buffered = tx.buffer.operations();
 
-    if operations.is_empty() {
+    if buffered.is_empty() {
+        // Empty transaction: no data ops, therefore no frame and no marker.
+        // Reproduces the prior early-return exactly.
         return Ok(());
     }
+
+    let tx_id = tx.tx_id.as_u64();
+
+    // [BeginTx, ..data ops.., CommitTx]. Begin+Commit bracket the data ops so
+    // replay buffers exactly this transaction's ops until the commit marker is
+    // seen; raw (non-transactional) appends and legacy segments carry no such
+    // markers and stay on the immediate-apply recovery path.
+    let mut operations: Vec<WalOperation> = Vec::with_capacity(buffered.len() + 2);
+    operations.push(WalOperation::BeginTx { tx_id });
+    operations.extend(buffered.iter().map(WalOperation::from));
+    operations.push(WalOperation::CommitTx {
+        tx_id,
+        entry_count: buffered.len() as u32,
+        commit_timestamp,
+    });
 
     tx.wal.append_batch_async(operations)?;
 

--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -599,7 +599,20 @@ impl CheckpointManager {
             current.ensure_version_id_generator_at_least(next_version_id);
         }
 
-        // Replay WAL entries after checkpoint LSN
+        // Replay WAL entries after checkpoint LSN.
+        //
+        // ⚠️ Transaction-framing invariant (Issue #3413): this EXCLUSIVE
+        // `.next()` convention starts replay one LSN PAST `checkpoint_lsn`. If
+        // `checkpoint_lsn` ever pointed at the last op of a committed
+        // `[BeginTx .. CommitTx]` band, `.next()` would begin replay mid-band
+        // (at the `CommitTx`, with its `BeginTx` skipped) — which
+        // `resolve_transaction_frames` only tolerates as a benign no-op because
+        // its buffered ops are also below the boundary. This whole `recover*`
+        // path is currently test-only and unwired (production replays from an
+        // INCLUSIVE `manifest.lsn`, always a band start; see `db::config` and
+        // the resolver's load-bearing-invariant doc). Before wiring any of these
+        // to production, ensure the start LSN lands on a transaction-frame
+        // boundary, not mid-band.
         let start_lsn = checkpoint_lsn.next();
         let (current, historical, final_lsn) =
             self.replay_wal(wal, current, historical, start_lsn)?;

--- a/src/storage/recovery.rs
+++ b/src/storage/recovery.rs
@@ -803,6 +803,22 @@ fn lsns_contiguous(pending: &[(LSN, WalOperation)]) -> bool {
 /// entry stream into the ordered list of `(operation, transaction_timestamp)`
 /// pairs that replay must apply — with uncommitted transaction tails removed.
 ///
+/// # Load-bearing invariant: replay begins at a transaction-frame boundary
+///
+/// This resolver assumes the entry stream it is handed **never begins in the
+/// middle of a `[BeginTx .. CommitTx]` band** — i.e. `start_lsn` is always a
+/// band start (or a legacy/unframed boundary), never a data op or `CommitTx`
+/// whose `BeginTx` was already skipped. Production guarantees this: startup
+/// replays from an inclusive `start_lsn = manifest.lsn` (see `db::config`), and
+/// the manifest LSN is the observable next-to-allocate LSN, which
+/// `allocate_batch` only ever advances by a WHOLE `[BeginTx .. CommitTx]` band
+/// in one atomic step — so it can never fall mid-band. If that invariant were
+/// ever violated (see the note on `checkpoint.rs`'s exclusive `.next()`
+/// convention, currently test-only and unwired), a `CommitTx` could arrive with
+/// no open frame; this resolver treats that as a **benign skip** (its `BeginTx`
+/// lies below `start_lsn`, so there are no buffered ops to apply) rather than a
+/// "failed validation" corruption warning.
+///
 /// # Framed-replay invariant
 ///
 /// A committing `WriteTransaction` writes `[BeginTx, ..data ops.., CommitTx]`
@@ -829,8 +845,11 @@ fn resolve_transaction_frames(entries: Vec<WalEntry>) -> Vec<(WalOperation, Time
     let mut resolved: Vec<(WalOperation, Timestamp)> = Vec::with_capacity(entries.len());
     // Buffered data ops of the currently-open frame, with their LSNs.
     let mut pending: Vec<(LSN, WalOperation)> = Vec::new();
-    // `tx_id` of the currently-open frame, if any.
-    let mut open_tx: Option<u64> = None;
+    // `(tx_id, begin_lsn)` of the currently-open frame, if any. The `BeginTx`
+    // LSN is retained so the terminal `CommitTx` can bracket-check the band
+    // (Issue #3413 integrity check R5): the whole `[BeginTx .. CommitTx]` band
+    // must be gap-free at BOTH ends, not just internally contiguous.
+    let mut open_tx: Option<(u64, LSN)> = None;
 
     for entry in entries {
         // Legacy / non-transactional entries apply immediately with their own
@@ -853,28 +872,54 @@ fn resolve_transaction_frames(entries: Vec<WalEntry>) -> Vec<(WalOperation, Time
                     );
                     pending.clear();
                 }
-                open_tx = Some(tx_id);
+                open_tx = Some((tx_id, entry_lsn));
             }
             WalOperation::CommitTx {
                 tx_id,
                 entry_count,
                 commit_timestamp,
             } => {
-                let valid = open_tx == Some(tx_id)
-                    && pending.len() == entry_count as usize
-                    && lsns_contiguous(&pending);
-                if valid {
-                    // Commit the frame atomically: every op takes the marker's
-                    // authoritative commit timestamp.
-                    for (_lsn, op) in pending.drain(..) {
-                        resolved.push((op, commit_timestamp));
+                match open_tx {
+                    // Benign skip (see the load-bearing invariant on this fn): a
+                    // `CommitTx` with no open frame is a band whose `BeginTx`
+                    // lies below `start_lsn`. Under the production invariant this
+                    // never happens; if it ever did, `pending` is empty and there
+                    // is nothing to apply — quietly skip rather than emit a
+                    // spurious corruption warning.
+                    None => {
+                        debug_assert!(
+                            pending.is_empty(),
+                            "a CommitTx with no open frame must have no buffered ops"
+                        );
                     }
-                } else {
-                    warn_discarded_frame(
-                        "CommitTx failed validation (tx_id / entry_count / LSN contiguity)",
-                        pending.len(),
-                    );
-                    pending.clear();
+                    Some((open_id, begin_lsn)) => {
+                        // Bracket check (R5): the band must be gap-free at both
+                        // ends — the first data op immediately follows BeginTx
+                        // and CommitTx immediately follows the last data op — in
+                        // addition to being internally contiguous (R4) and
+                        // matching the marker's tx_id / entry_count.
+                        let brackets_ok = pending.first().map(|(l, _)| l.0)
+                            == Some(begin_lsn.0.wrapping_add(1))
+                            && pending.last().map(|(l, _)| l.0.wrapping_add(1))
+                                == Some(entry_lsn.0);
+                        let valid = open_id == tx_id
+                            && pending.len() == entry_count as usize
+                            && lsns_contiguous(&pending)
+                            && brackets_ok;
+                        if valid {
+                            // Commit the frame atomically: every op takes the
+                            // marker's authoritative commit timestamp.
+                            for (_lsn, op) in pending.drain(..) {
+                                resolved.push((op, commit_timestamp));
+                            }
+                        } else {
+                            warn_discarded_frame(
+                                "CommitTx failed validation (tx_id / entry_count / LSN contiguity / band brackets)",
+                                pending.len(),
+                            );
+                            pending.clear();
+                        }
+                    }
                 }
                 open_tx = None;
             }
@@ -899,9 +944,21 @@ fn resolve_transaction_frames(entries: Vec<WalEntry>) -> Vec<(WalOperation, Time
                 if open_tx.is_some() {
                     pending.push((entry_lsn, op));
                 } else {
-                    // Framed segment but no open frame: a raw append landed in
-                    // a v7+ segment (only test/tooling paths do this). Apply
-                    // immediately with the entry's own timestamp.
+                    // ⚠️ LANDMINE (Issue #3413): a framed data op with NO open
+                    // frame falls through to immediate-apply with its OWN
+                    // per-entry timestamp — exactly the per-op timestamp
+                    // bisection transaction framing exists to prevent. This is
+                    // deliberately reachable ONLY for raw `append`/`append_async`
+                    // into a v7+ segment (test/tooling paths), which carry the
+                    // `framed` flag from the segment version yet legitimately
+                    // have no `BeginTx`; for them immediate-apply is correct.
+                    // The real committing producer (`log_operations_to_wal`)
+                    // ALWAYS brackets its data ops in a `[BeginTx .. CommitTx]`
+                    // band, so a *transactional* op never lands here. If any
+                    // future producer raw-appends framed data ops that were
+                    // meant to share a commit timestamp, this branch would
+                    // silently re-bisect them — audit this path before adding
+                    // one.
                     resolved.push((op, entry_ts));
                 }
             }
@@ -1170,6 +1227,81 @@ mod framing_tests {
             resolved[0].0,
             WalOperation::DeclareUniqueConstraint { .. }
         ));
+    }
+
+    /// Fix #3413 (defensive benign skip): a `CommitTx` that arrives with no
+    /// open frame (its `BeginTx` lay below `start_lsn`) applies nothing and is
+    /// NOT a validation failure. Unreachable in production (replay always
+    /// starts at a band boundary) but must degrade gracefully if it ever isn't.
+    #[test]
+    fn stray_commit_tx_with_no_open_frame_is_benign_skip() {
+        let entries = vec![framed(
+            5,
+            WalOperation::CommitTx {
+                tx_id: 9,
+                entry_count: 0,
+                commit_timestamp: ts(100),
+            },
+            ts(13),
+        )];
+        let resolved = resolve_transaction_frames(entries);
+        assert!(
+            resolved.is_empty(),
+            "a stray CommitTx with no open frame must apply nothing"
+        );
+    }
+
+    /// Fix #3413 (band bracket check, R5): a frame that is internally contiguous
+    /// AND matches tx_id/entry_count but has a GAP between `BeginTx` and the
+    /// first data op (head gap) must be discarded — the band is not fully
+    /// bracketed, so an op may be missing at the head.
+    #[test]
+    fn discards_frame_on_head_gap_between_begin_and_first_op() {
+        let entries = vec![
+            framed(1, WalOperation::BeginTx { tx_id: 1 }, ts(10)),
+            // Head gap: first data op at LSN 3, not 2 (BeginTx.lsn + 1).
+            framed(3, create_node_op(1), ts(11)),
+            framed(4, create_node_op(2), ts(12)),
+            framed(
+                5,
+                WalOperation::CommitTx {
+                    tx_id: 1,
+                    entry_count: 2,
+                    commit_timestamp: ts(100),
+                },
+                ts(13),
+            ),
+        ];
+        assert!(
+            resolve_transaction_frames(entries).is_empty(),
+            "a head-gapped band (BeginTx not immediately followed by first data op) must discard"
+        );
+    }
+
+    /// Fix #3413 (band bracket check, R5): a GAP between the last data op and
+    /// the terminal `CommitTx` (tail gap) must also discard the frame, even
+    /// though the data ops are internally contiguous.
+    #[test]
+    fn discards_frame_on_tail_gap_between_last_op_and_commit() {
+        let entries = vec![
+            framed(1, WalOperation::BeginTx { tx_id: 1 }, ts(10)),
+            framed(2, create_node_op(1), ts(11)),
+            framed(3, create_node_op(2), ts(12)),
+            // Tail gap: CommitTx at LSN 5, not 4 (last data op.lsn + 1).
+            framed(
+                5,
+                WalOperation::CommitTx {
+                    tx_id: 1,
+                    entry_count: 2,
+                    commit_timestamp: ts(100),
+                },
+                ts(13),
+            ),
+        ];
+        assert!(
+            resolve_transaction_frames(entries).is_empty(),
+            "a tail-gapped band (last data op not immediately followed by CommitTx) must discard"
+        );
     }
 }
 

--- a/src/storage/recovery.rs
+++ b/src/storage/recovery.rs
@@ -28,11 +28,12 @@ use crate::core::constraint::ConstraintRegistry;
 use crate::core::error::Result;
 use crate::core::graph::{Edge, Node};
 use crate::core::id::{TxId, VersionId};
+use crate::core::temporal::Timestamp;
 use crate::core::version::VersionMetadata;
 use crate::storage::current::CurrentStorage;
 use crate::storage::historical::HistoricalStorage;
 use crate::storage::wal::concurrent_system::ConcurrentWalSystem;
-use crate::storage::wal::{LSN, WalOperation};
+use crate::storage::wal::{LSN, WalEntry, WalOperation};
 
 /// Replay WAL entries starting from a given LSN into existing storage instances.
 ///
@@ -160,8 +161,16 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
         );
     }
 
-    for entry in wal_entries {
-        match entry.operation {
+    // Resolve transaction framing (Issue #3413) BEFORE applying: pair every
+    // operation with the timestamp it must be recorded at, and drop any
+    // uncommitted transaction tail. Framed data ops committed by a durable
+    // `CommitTx` are paired with that marker's authoritative commit timestamp
+    // (so an atomic batch's versions all share ONE transaction time); legacy
+    // (pre-v7) and non-transactional entries keep their own logged timestamp.
+    let resolved = resolve_transaction_frames(wal_entries);
+
+    for (operation, commit_timestamp) in resolved {
+        match operation {
             WalOperation::CreateNode {
                 node_id,
                 label,
@@ -204,8 +213,11 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
 
                 let interned_label = label;
 
-                // Transaction time comes from when the WAL entry was logged
-                let commit_timestamp = entry.timestamp;
+                // Transaction time is `commit_timestamp` (Issue #3413): for a
+                // framed transaction this is the CommitTx marker's single
+                // authoritative commit time (shared by every op in the batch);
+                // for legacy/non-transactional entries it is the entry's own
+                // logged timestamp. Either way it is supplied by the caller.
                 let metadata = VersionMetadata::new(TxId::new(RECOVERY_TX_ID), commit_timestamp);
                 // Reuse whichever store already applied this create so that
                 // `current.current_version == historical head id` stays
@@ -288,7 +300,6 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
 
                 let interned_label = label;
 
-                let commit_timestamp = entry.timestamp;
                 let metadata = VersionMetadata::new(TxId::new(RECOVERY_TX_ID), commit_timestamp);
                 let version_id = match (live_head, &current_edge) {
                     (Some(vid), _) => vid,
@@ -344,7 +355,6 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
 
                 let interned_label = label;
 
-                let commit_timestamp = entry.timestamp;
                 let metadata = VersionMetadata::new(TxId::new(RECOVERY_TX_ID), commit_timestamp);
 
                 let node = Node::with_metadata(
@@ -401,7 +411,6 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
 
                 let interned_label = label;
 
-                let commit_timestamp = entry.timestamp;
                 let metadata = VersionMetadata::new(TxId::new(RECOVERY_TX_ID), commit_timestamp);
 
                 let edge = Edge::with_metadata(
@@ -459,7 +468,6 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                 //       behavior) left the head open forever.
                 // The historical side applies iff the head is still live; the
                 // current side applies iff the node is present.
-                let commit_timestamp = entry.timestamp;
                 let current_node = current.get_node(node_id).ok();
                 let historical_head = historical.get_current_node_version(node_id);
                 let live_head = historical_head.filter(|vid| {
@@ -523,7 +531,6 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
             } => {
                 // Per-store re-application guard — see the DeleteNode arm
                 // above (review round 2, #3428).
-                let commit_timestamp = entry.timestamp;
                 let current_edge = current.get_edge(edge_id).ok();
                 let historical_head = historical.get_current_edge_version(edge_id);
                 let live_head = historical_head.filter(|vid| {
@@ -608,7 +615,6 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                 // head already retracted/tombstoned means this retraction's
                 // historical effect was applied); the current-side removal
                 // applies iff the node is present.
-                let commit_timestamp = entry.timestamp;
                 let current_node = current.get_node(node_id).ok();
                 let head_version_id = historical.get_current_node_version(node_id);
                 let live_head = head_version_id.filter(|vid| {
@@ -672,7 +678,6 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                 // Valid-time retraction of an edge (Issue #3230); mirrors the
                 // RetractNode arm above, honoring the logged `valid_to`, with
                 // the same per-store re-application guards (#3428).
-                let commit_timestamp = entry.timestamp;
                 let current_edge = current.get_edge(edge_id).ok();
                 let head_version_id = historical.get_current_edge_version(edge_id);
                 let live_head = head_version_id.filter(|vid| {
@@ -755,12 +760,163 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                     reg.undeclare(label, property);
                 }
             }
+            // Transaction framing markers (Issue #3413) are consumed by
+            // `resolve_transaction_frames` above and never reach this apply
+            // loop; the arm exists only for match exhaustiveness.
+            WalOperation::BeginTx { .. } | WalOperation::CommitTx { .. } => {}
         }
     }
 
     let final_lsn = wal.current_lsn();
 
     Ok((final_lsn, max_node_id, max_edge_id, next_version_id))
+}
+
+/// Warn about a discarded (torn / uncommitted) transaction frame during replay.
+fn warn_discarded_frame(reason: &str, dropped: usize) {
+    #[cfg(feature = "observability")]
+    tracing::warn!(
+        "Discarding {} buffered WAL op(s) during recovery: {}",
+        dropped,
+        reason
+    );
+    #[cfg(not(feature = "observability"))]
+    eprintln!(
+        "WARNING: discarding {} buffered WAL op(s) during recovery: {}",
+        dropped, reason
+    );
+}
+
+/// Are the buffered ops' LSNs strictly consecutive (`l, l+1, l+2, …`)?
+///
+/// A committing transaction owns one contiguous LSN band (single atomic
+/// `allocate_batch`), so a gap means the buffer does not correspond to an
+/// intact batch and the frame must be rejected (Issue #3413, integrity check
+/// R4).
+fn lsns_contiguous(pending: &[(LSN, WalOperation)]) -> bool {
+    pending
+        .windows(2)
+        .all(|w| w[1].0.0 == w[0].0.0.wrapping_add(1))
+}
+
+/// Resolve transaction framing (Issue #3413), turning the raw, LSN-ordered WAL
+/// entry stream into the ordered list of `(operation, transaction_timestamp)`
+/// pairs that replay must apply — with uncommitted transaction tails removed.
+///
+/// # Framed-replay invariant
+///
+/// A committing `WriteTransaction` writes `[BeginTx, ..data ops.., CommitTx]`
+/// as one atomic, contiguous LSN band inside a single flush epoch (see
+/// `api::transaction::write::wal::log_operations_to_wal`). Because the durable
+/// suffix of the WAL is always an LSN-ordered *prefix* of what was appended,
+/// the terminal `CommitTx` marker is present on disk **iff** every op of its
+/// batch is — so:
+///
+/// * A `BeginTx … data … CommitTx` frame whose marker validated (matching
+///   `tx_id`, `entry_count` equal to the buffered op count, contiguous LSNs)
+///   is applied **atomically**, and every one of its ops is stamped with the
+///   marker's single `commit_timestamp`. This is what makes an atomic batch's
+///   versions share one transaction time so `AS OF SYSTEM_TIME` can never
+///   observe a half-batch.
+/// * A frame whose marker never reached disk (a crash tail), or that fails the
+///   integrity checks, is **discarded whole** — never applied as a torn prefix.
+/// * Entries from pre-v7 segments (`!framed`), and any op appended outside a
+///   frame (raw `append`/`append_async`, control ops such as checkpoints and
+///   constraint declarations), keep the legacy **immediate-apply** path using
+///   their own logged timestamp. This preserves the behavior of every existing
+///   non-transactional WAL producer unchanged.
+fn resolve_transaction_frames(entries: Vec<WalEntry>) -> Vec<(WalOperation, Timestamp)> {
+    let mut resolved: Vec<(WalOperation, Timestamp)> = Vec::with_capacity(entries.len());
+    // Buffered data ops of the currently-open frame, with their LSNs.
+    let mut pending: Vec<(LSN, WalOperation)> = Vec::new();
+    // `tx_id` of the currently-open frame, if any.
+    let mut open_tx: Option<u64> = None;
+
+    for entry in entries {
+        // Legacy / non-transactional entries apply immediately with their own
+        // logged timestamp (pre-v7 segments never carry framing markers).
+        if !entry.framed {
+            resolved.push((entry.operation, entry.timestamp));
+            continue;
+        }
+
+        // Copy the header fields we need before moving `operation` out.
+        let entry_lsn = entry.lsn;
+        let entry_ts = entry.timestamp;
+
+        match entry.operation {
+            WalOperation::BeginTx { tx_id } => {
+                if !pending.is_empty() {
+                    warn_discarded_frame(
+                        "new BeginTx encountered before the previous frame committed",
+                        pending.len(),
+                    );
+                    pending.clear();
+                }
+                open_tx = Some(tx_id);
+            }
+            WalOperation::CommitTx {
+                tx_id,
+                entry_count,
+                commit_timestamp,
+            } => {
+                let valid = open_tx == Some(tx_id)
+                    && pending.len() == entry_count as usize
+                    && lsns_contiguous(&pending);
+                if valid {
+                    // Commit the frame atomically: every op takes the marker's
+                    // authoritative commit timestamp.
+                    for (_lsn, op) in pending.drain(..) {
+                        resolved.push((op, commit_timestamp));
+                    }
+                } else {
+                    warn_discarded_frame(
+                        "CommitTx failed validation (tx_id / entry_count / LSN contiguity)",
+                        pending.len(),
+                    );
+                    pending.clear();
+                }
+                open_tx = None;
+            }
+            // Self-committing control ops are never written inside a
+            // transaction batch; if a frame is somehow open it is torn, so
+            // discard it, then apply the control op immediately.
+            op @ (WalOperation::Checkpoint { .. }
+            | WalOperation::DeclareUniqueConstraint { .. }
+            | WalOperation::DropUniqueConstraint { .. }) => {
+                if !pending.is_empty() {
+                    warn_discarded_frame(
+                        "control op encountered inside an open transaction frame",
+                        pending.len(),
+                    );
+                    pending.clear();
+                }
+                open_tx = None;
+                resolved.push((op, entry_ts));
+            }
+            // A framed data op.
+            op => {
+                if open_tx.is_some() {
+                    pending.push((entry_lsn, op));
+                } else {
+                    // Framed segment but no open frame: a raw append landed in
+                    // a v7+ segment (only test/tooling paths do this). Apply
+                    // immediately with the entry's own timestamp.
+                    resolved.push((op, entry_ts));
+                }
+            }
+        }
+    }
+
+    // Any buffer still open at end-of-stream is an uncommitted crash tail.
+    if !pending.is_empty() {
+        warn_discarded_frame(
+            "WAL ended with an uncommitted transaction frame (crash tail)",
+            pending.len(),
+        );
+    }
+
+    resolved
 }
 
 /// Replay ONLY constraint declaration/drop entries from the full WAL history.
@@ -788,6 +944,233 @@ pub(crate) fn replay_constraint_declarations_from_wal(
         }
     }
     Ok(())
+}
+
+/// Unit tests for the `resolve_transaction_frames` framing resolver
+/// (Issue #3413). These exercise the buffer-until-marker logic directly on
+/// synthetic `WalEntry` streams, independent of disk/replay.
+#[cfg(test)]
+mod framing_tests {
+    use super::*;
+    use crate::core::hlc::HybridTimestamp;
+    use crate::core::interning::GLOBAL_INTERNER;
+    use crate::core::property::PropertyMap;
+
+    fn ts(v: i64) -> Timestamp {
+        HybridTimestamp::new_unchecked(v, 0)
+    }
+
+    fn create_node_op(id: u64) -> WalOperation {
+        WalOperation::CreateNode {
+            node_id: crate::core::NodeId::new(id).unwrap(),
+            label: GLOBAL_INTERNER.intern("FramingTest").unwrap(),
+            properties: PropertyMap::new(),
+            valid_from: ts(1),
+            provenance: None,
+        }
+    }
+
+    /// Build an entry as read from a framed (v7+) segment.
+    fn framed(lsn: u64, op: WalOperation, timestamp: Timestamp) -> WalEntry {
+        WalEntry {
+            lsn: LSN(lsn),
+            timestamp,
+            operation: op,
+            checksum: 0,
+            framed: true,
+        }
+    }
+
+    /// Build an entry as read from a legacy (pre-v7) segment.
+    fn legacy(lsn: u64, op: WalOperation, timestamp: Timestamp) -> WalEntry {
+        WalEntry {
+            lsn: LSN(lsn),
+            timestamp,
+            operation: op,
+            checksum: 0,
+            framed: false,
+        }
+    }
+
+    fn node_id_of(op: &WalOperation) -> u64 {
+        match op {
+            WalOperation::CreateNode { node_id, .. } => node_id.as_u64(),
+            other => panic!("expected CreateNode, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn commits_framed_batch_atomically_with_marker_timestamp() {
+        let marker_ts = ts(9999);
+        let entries = vec![
+            framed(1, WalOperation::BeginTx { tx_id: 7 }, ts(10)),
+            framed(2, create_node_op(1), ts(11)),
+            framed(3, create_node_op(2), ts(12)),
+            framed(
+                4,
+                WalOperation::CommitTx {
+                    tx_id: 7,
+                    entry_count: 2,
+                    commit_timestamp: marker_ts,
+                },
+                ts(13),
+            ),
+        ];
+        let resolved = resolve_transaction_frames(entries);
+        assert_eq!(resolved.len(), 2);
+        // Both ops re-stamped with the SINGLE marker timestamp (AC#3).
+        for (_op, t) in &resolved {
+            assert_eq!(*t, marker_ts);
+        }
+        assert_eq!(node_id_of(&resolved[0].0), 1);
+        assert_eq!(node_id_of(&resolved[1].0), 2);
+    }
+
+    #[test]
+    fn discards_uncommitted_tail_at_eof() {
+        // BeginTx + data ops, marker never arrived (crash tail).
+        let entries = vec![
+            framed(1, WalOperation::BeginTx { tx_id: 1 }, ts(10)),
+            framed(2, create_node_op(1), ts(11)),
+            framed(3, create_node_op(2), ts(12)),
+        ];
+        let resolved = resolve_transaction_frames(entries);
+        assert!(resolved.is_empty(), "uncommitted frame must be discarded");
+    }
+
+    #[test]
+    fn keeps_committed_frame_then_discards_following_uncommitted_frame() {
+        let entries = vec![
+            framed(1, WalOperation::BeginTx { tx_id: 1 }, ts(10)),
+            framed(2, create_node_op(1), ts(11)),
+            framed(
+                3,
+                WalOperation::CommitTx {
+                    tx_id: 1,
+                    entry_count: 1,
+                    commit_timestamp: ts(100),
+                },
+                ts(12),
+            ),
+            framed(4, WalOperation::BeginTx { tx_id: 2 }, ts(13)),
+            framed(5, create_node_op(2), ts(14)),
+            // tx 2's CommitTx lost.
+        ];
+        let resolved = resolve_transaction_frames(entries);
+        assert_eq!(resolved.len(), 1, "only the committed frame survives");
+        assert_eq!(node_id_of(&resolved[0].0), 1);
+        assert_eq!(resolved[0].1, ts(100));
+    }
+
+    #[test]
+    fn discards_frame_on_entry_count_mismatch() {
+        let entries = vec![
+            framed(1, WalOperation::BeginTx { tx_id: 1 }, ts(10)),
+            framed(2, create_node_op(1), ts(11)),
+            framed(
+                3,
+                WalOperation::CommitTx {
+                    tx_id: 1,
+                    entry_count: 5, // wrong: only 1 data op buffered
+                    commit_timestamp: ts(100),
+                },
+                ts(12),
+            ),
+        ];
+        assert!(resolve_transaction_frames(entries).is_empty());
+    }
+
+    #[test]
+    fn discards_frame_on_non_contiguous_lsns() {
+        let entries = vec![
+            framed(1, WalOperation::BeginTx { tx_id: 1 }, ts(10)),
+            framed(2, create_node_op(1), ts(11)),
+            framed(9, create_node_op(2), ts(12)), // LSN gap
+            framed(
+                10,
+                WalOperation::CommitTx {
+                    tx_id: 1,
+                    entry_count: 2,
+                    commit_timestamp: ts(100),
+                },
+                ts(13),
+            ),
+        ];
+        assert!(resolve_transaction_frames(entries).is_empty());
+    }
+
+    #[test]
+    fn discards_frame_on_tx_id_mismatch() {
+        let entries = vec![
+            framed(1, WalOperation::BeginTx { tx_id: 1 }, ts(10)),
+            framed(2, create_node_op(1), ts(11)),
+            framed(
+                3,
+                WalOperation::CommitTx {
+                    tx_id: 2, // does not match the open BeginTx
+                    entry_count: 1,
+                    commit_timestamp: ts(100),
+                },
+                ts(12),
+            ),
+        ];
+        assert!(resolve_transaction_frames(entries).is_empty());
+    }
+
+    #[test]
+    fn legacy_unframed_entries_apply_immediately_with_own_timestamp() {
+        // Pre-v7 segment: no markers, each op keeps its own logged timestamp.
+        let entries = vec![
+            legacy(1, create_node_op(1), ts(50)),
+            legacy(2, create_node_op(2), ts(60)),
+        ];
+        let resolved = resolve_transaction_frames(entries);
+        assert_eq!(resolved.len(), 2);
+        assert_eq!(resolved[0].1, ts(50));
+        assert_eq!(resolved[1].1, ts(60));
+    }
+
+    #[test]
+    fn control_op_is_self_committing_and_not_buffered() {
+        // A framed Checkpoint applies immediately even though it lives in a
+        // v7 segment; it must not be swallowed into a pending buffer.
+        let entries = vec![framed(
+            1,
+            WalOperation::Checkpoint {
+                lsn: LSN(1),
+                timestamp: ts(5),
+            },
+            ts(70),
+        )];
+        let resolved = resolve_transaction_frames(entries);
+        assert_eq!(resolved.len(), 1);
+        assert!(matches!(resolved[0].0, WalOperation::Checkpoint { .. }));
+        assert_eq!(resolved[0].1, ts(70));
+    }
+
+    #[test]
+    fn control_op_discards_an_open_frame_then_applies() {
+        // Defensive: a control op appearing while a frame is open discards the
+        // (torn) buffer and still applies the control op.
+        let entries = vec![
+            framed(1, WalOperation::BeginTx { tx_id: 1 }, ts(10)),
+            framed(2, create_node_op(1), ts(11)),
+            framed(
+                3,
+                WalOperation::DeclareUniqueConstraint {
+                    label: GLOBAL_INTERNER.intern("L").unwrap(),
+                    property: GLOBAL_INTERNER.intern("p").unwrap(),
+                },
+                ts(80),
+            ),
+        ];
+        let resolved = resolve_transaction_frames(entries);
+        assert_eq!(resolved.len(), 1);
+        assert!(matches!(
+            resolved[0].0,
+            WalOperation::DeclareUniqueConstraint { .. }
+        ));
+    }
 }
 
 #[cfg(test)]

--- a/src/storage/wal/entry.rs
+++ b/src/storage/wal/entry.rs
@@ -149,6 +149,40 @@ pub enum WalOperation {
         /// The property key the constraint was on.
         property: InternedString,
     },
+    /// Open a transaction frame (Issue #3413).
+    ///
+    /// Written as the FIRST entry of a committing `WriteTransaction`'s WAL
+    /// batch (before its data ops), inside the SAME atomic `append_batch`
+    /// allocation as the ops and the terminal [`WalOperation::CommitTx`]. Its
+    /// presence tells replay "the following data ops belong to a transaction
+    /// and must be buffered until the matching commit record"; its ABSENCE
+    /// (a raw `append`/`append_async`, a control op, or a legacy pre-v7
+    /// segment) keeps the immediate-apply path, so no existing non-framed
+    /// producer is disturbed.
+    BeginTx {
+        /// The originating `WriteTransaction` id (provenance + pair matching).
+        tx_id: u64,
+    },
+    /// Close (commit) a transaction frame (Issue #3413).
+    ///
+    /// Written as the LAST entry of a committing `WriteTransaction`'s WAL
+    /// batch, in the same atomic `append_batch` allocation as its
+    /// [`WalOperation::BeginTx`] and data ops. Carries the authoritative
+    /// bi-temporal commit timestamp that replay re-stamps onto EVERY buffered
+    /// version of the transaction (fixing per-op timestamp bisection), plus
+    /// the data-op `entry_count` as a batch-integrity check. Only when this
+    /// marker is durable does replay apply the buffered ops; a batch whose
+    /// marker never reached disk (an uncommitted crash tail) is discarded
+    /// whole.
+    CommitTx {
+        /// The originating `WriteTransaction` id (must match the frame's
+        /// [`WalOperation::BeginTx`]).
+        tx_id: u64,
+        /// Number of DATA ops in this transaction (excludes Begin/Commit).
+        entry_count: u32,
+        /// The authoritative transaction commit timestamp.
+        commit_timestamp: Timestamp,
+    },
 }
 
 /// A single WAL entry.
@@ -182,6 +216,16 @@ pub struct WalEntry {
     ///
     /// The checksum is computed over the entire serialized entry, excluding the checksum field itself.
     pub checksum: u32,
+    /// Whether this entry was read from a transaction-framing-capable segment
+    /// (WAL format version >= `WAL_VERSION_TX_FRAMING`, Issue #3413).
+    ///
+    /// Additive, in-memory-only metadata set by the segment parsers from the
+    /// segment header version; it is NOT part of the serialized entry. Replay
+    /// uses it to keep legacy (pre-v7) segments on the immediate-apply path:
+    /// only framed entries can participate in `BeginTx`/`CommitTx` buffering.
+    /// Entries constructed in-process (e.g. via [`WalEntry::new`]) default to
+    /// `false` — the flag is meaningful only for entries recovered from disk.
+    pub framed: bool,
 }
 
 impl WalEntry {
@@ -194,6 +238,7 @@ impl WalEntry {
             timestamp,
             operation,
             checksum: 0, // Will be set during serialization
+            framed: false,
         }
     }
 
@@ -342,6 +387,7 @@ mod sentry_tests {
             timestamp: fixed_timestamp,
             operation: op,
             checksum: 0,
+            framed: false,
         };
 
         // Serialize

--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -45,8 +45,7 @@ use super::ring_buffer::PendingEntry;
 use crate::core::error::{Error, Result, StorageError};
 
 use super::segment_reader::{
-    WAL_HEADER_SIZE, WAL_MAGIC, WAL_VERSION_ENCRYPTED_PROVENANCE_PRINCIPAL,
-    WAL_VERSION_PROVENANCE_PRINCIPAL,
+    WAL_HEADER_SIZE, WAL_MAGIC, WAL_VERSION_ENCRYPTED_TX_FRAMING, WAL_VERSION_TX_FRAMING,
 };
 
 /// Metadata about a WAL segment's LSN range.
@@ -387,13 +386,17 @@ impl FlushCoordinator {
             return Ok(());
         }
 
-        // New segments always use the principal-carrying provenance
-        // format (Issues #3224 + #3350): version 6 for encrypted
-        // segments, version 5 for plaintext.
+        // New segments use the transaction-framing format (Issue #3413),
+        // which is a superset of the principal-carrying provenance format
+        // (Issues #3224 + #3350): version 8 for encrypted segments, version 7
+        // for plaintext. Non-transactional producers (raw appends, control
+        // ops) simply omit the BeginTx/CommitTx markers; the version bump only
+        // signals that such markers MAY be present so old readers reject the
+        // segment cleanly rather than misparsing an unknown op tag.
         let write_version = if self.config.wal_cipher.is_some() {
-            WAL_VERSION_ENCRYPTED_PROVENANCE_PRINCIPAL
+            WAL_VERSION_ENCRYPTED_TX_FRAMING
         } else {
-            WAL_VERSION_PROVENANCE_PRINCIPAL
+            WAL_VERSION_TX_FRAMING
         };
 
         // Allocate the next segment id, rolling past any existing non-empty
@@ -1144,12 +1147,12 @@ mod tests {
             "existing v3 segment must not be appended to"
         );
 
-        // ...the write must have rolled forward to a fresh segment with a
-        // matching (v5) header...
+        // ...the write must have rolled forward to a fresh segment with the
+        // current writer (v7 transaction-framing) header...
         assert_eq!(coordinator.current_segment_id(), 2);
         let new_segment = std::fs::read(dir.path().join("000002.log")).unwrap();
         assert_eq!(&new_segment[0..4], &WAL_MAGIC);
-        assert_eq!(new_segment[4], WAL_VERSION_PROVENANCE_PRINCIPAL);
+        assert_eq!(new_segment[4], WAL_VERSION_TX_FRAMING);
 
         // ...and a full-directory replay succeeds, with the new entry's
         // principal intact.
@@ -1379,7 +1382,7 @@ mod tests {
 
         assert!(data.len() >= WAL_HEADER_SIZE);
         assert_eq!(&data[0..4], &WAL_MAGIC);
-        assert_eq!(data[4], WAL_VERSION_PROVENANCE_PRINCIPAL);
+        assert_eq!(data[4], WAL_VERSION_TX_FRAMING);
     }
 
     #[test]

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -236,9 +236,17 @@ pub fn read_entries_from_dir_with_cipher(
 ) -> Result<Vec<WalEntry>> {
     let mut entries = Vec::new();
 
-    // Read entries from each segment
-    for (_, path) in sorted_segment_paths(wal_dir) {
-        let segment_entries = read_segment_with_cipher(&path, start_lsn, cipher)?;
+    // Read entries from each segment. Only the FINAL segment is allowed to
+    // tolerate a torn trailing entry (a crash during the commit-marker flush,
+    // Issue #3413): a truncated entry at the true end of the last segment is a
+    // benign torn append, whereas the same shape in a NON-final segment (a
+    // later segment exists past it) is real corruption and must still hard-error.
+    let segment_paths = sorted_segment_paths(wal_dir);
+    let last_idx = segment_paths.len().saturating_sub(1);
+    for (i, (_, path)) in segment_paths.iter().enumerate() {
+        let tolerate_torn_tail = i == last_idx;
+        let segment_entries =
+            read_segment_with_cipher_tolerant(path, start_lsn, cipher, tolerate_torn_tail)?;
         entries.extend(segment_entries);
     }
 
@@ -603,6 +611,29 @@ pub fn read_segment_with_cipher(
     start_lsn: LSN,
     cipher: Option<&Arc<dyn crate::encryption::cipher::Cipher>>,
 ) -> Result<Vec<WalEntry>> {
+    // Standalone single-segment reads keep the strict contract: a torn trailing
+    // entry hard-errors, exactly as before. Only the recovery dir-reader
+    // (`read_entries_from_dir_with_cipher`) opts the FINAL segment into
+    // torn-tail tolerance (Issue #3413).
+    read_segment_with_cipher_tolerant(path, start_lsn, cipher, false)
+}
+
+/// Read WAL entries from a single segment, optionally tolerating a torn
+/// trailing entry (a crash during the final flush, Issue #3413).
+///
+/// When `tolerate_torn_tail` is `true` and the segment's LAST entry fails to
+/// parse **because its declared payload runs past end-of-buffer** (a truncated
+/// trailing entry — e.g. a half-written `CommitTx` marker), the decodable
+/// prefix is kept and the read stops without error. Any other parse failure
+/// (checksum mismatch, unknown op type, invalid UTF-8 — all of which mean the
+/// entry's bytes were fully present but wrong) still hard-errors, and so does
+/// every parse failure when `tolerate_torn_tail` is `false`.
+fn read_segment_with_cipher_tolerant(
+    path: &Path,
+    start_lsn: LSN,
+    cipher: Option<&Arc<dyn crate::encryption::cipher::Cipher>>,
+    tolerate_torn_tail: bool,
+) -> Result<Vec<WalEntry>> {
     // Open file, only treating NotFound as "empty" - all other errors are propagated
     let file = match File::open(path) {
         Ok(f) => f,
@@ -677,7 +708,7 @@ pub fn read_segment_with_cipher(
         return Ok(Vec::new()); // Empty segment
     };
 
-    // Encrypted segments (version 2 or 4) require a cipher for decryption.
+    // Encrypted segments (versions 2/4/6/8) require a cipher for decryption.
     if is_encrypted_version(version) && cipher.is_none() {
         return Err(StorageError::Encryption(format!(
             "Cannot read encrypted WAL segment (version {}) without a cipher",
@@ -688,7 +719,7 @@ pub fn read_segment_with_cipher(
 
     // Dispatch to the appropriate parsing loop based on version.
     if is_encrypted_version(version) {
-        // Version 2/4: length-prefixed encrypted entries.
+        // Encrypted (2/4/6/8): length-prefixed encrypted entries.
         let cipher = cipher.expect("cipher presence checked above");
         parse_encrypted_entries(
             buffer,
@@ -698,16 +729,53 @@ pub fn read_segment_with_cipher(
             path,
             &mut entries,
             version,
+            tolerate_torn_tail,
         )?;
     } else {
-        // Version 1/3: plaintext entries.
-        parse_plaintext_entries(buffer, &mut offset, version, start_lsn, path, &mut entries)?;
+        // Plaintext (1/3/5/7): plaintext entries.
+        parse_plaintext_entries(
+            buffer,
+            &mut offset,
+            version,
+            start_lsn,
+            path,
+            &mut entries,
+            tolerate_torn_tail,
+        )?;
     }
 
     Ok(entries)
 }
 
-/// Parse plaintext (version 1) entries from a WAL segment buffer.
+/// Does `err` denote a WAL parse failure caused by the entry's declared
+/// payload running **past the end of the buffer** (a truncated / torn entry),
+/// as opposed to corruption whose bytes were fully present but wrong?
+///
+/// This is the signal that separates a benign torn append (Issue #3413: a
+/// crash during the commit-marker flush leaves a full 24-byte header but a
+/// truncated payload) from real damage (a checksum mismatch, an unknown op
+/// type, invalid UTF-8 — all of which mean the entry was fully written but is
+/// bad). Every truncation-origin error carries one of these stable,
+/// test-locked substrings emitted whenever a reader needs more bytes than the
+/// buffer holds (`require_bytes`, `HybridTimestamp::deserialize`,
+/// `PropertyMap::deserialize`). Because such an error only fires once the
+/// parser has consumed to the very end of the buffer, a truncation error at a
+/// tail entry provably has no valid entries after it — which is exactly why it
+/// is safe to stop and keep the decodable prefix.
+///
+/// NOTE: sibling Issue #3433 generalizes torn-tail tolerance to all entry
+/// types across replay via a structured signal; here we implement only the
+/// narrow marker-specific slice #3413's own crash-during-marker-flush case
+/// needs.
+fn is_truncation_error(err: &Error) -> bool {
+    let msg = err.to_string();
+    msg.contains("Insufficient buffer size") || msg.contains("too short")
+}
+
+/// Parse plaintext (versions 1/3/5/7) entries from a WAL segment buffer.
+///
+/// See [`read_segment_with_cipher_tolerant`] for the meaning of
+/// `tolerate_torn_tail`.
 fn parse_plaintext_entries(
     buffer: &[u8],
     offset: &mut usize,
@@ -715,6 +783,7 @@ fn parse_plaintext_entries(
     start_lsn: LSN,
     path: &Path,
     entries: &mut Vec<WalEntry>,
+    tolerate_torn_tail: bool,
 ) -> Result<()> {
     while *offset < buffer.len() {
         match parse_entry_at(buffer, *offset, version) {
@@ -748,6 +817,27 @@ fn parse_plaintext_entries(
                         break;
                     }
 
+                    // Torn trailing entry (Issue #3413): a full 24-byte header
+                    // but a payload truncated past end-of-buffer, at the true
+                    // end of the FINAL segment (a crash during the commit-marker
+                    // flush). This is a benign torn append — keep the decodable
+                    // prefix and stop. Restricted to a genuine truncation error
+                    // (payload ran past EOF); any other corruption still
+                    // hard-errors, and a non-final segment never sets
+                    // `tolerate_torn_tail`.
+                    if tolerate_torn_tail && is_truncation_error(&e) {
+                        #[cfg(feature = "observability")]
+                        tracing::debug!(
+                            "Torn trailing entry at end of final WAL segment {:?} (offset {}/{}): {}; \
+                             keeping decodable prefix",
+                            path,
+                            offset,
+                            buffer.len(),
+                            e
+                        );
+                        break;
+                    }
+
                     #[cfg(feature = "observability")]
                     tracing::error!(
                         "Failed to parse WAL entry in segment {:?} at offset {}: {}",
@@ -771,12 +861,16 @@ fn parse_plaintext_entries(
     Ok(())
 }
 
-/// Parse encrypted (version 2 or 4) entries from a WAL segment buffer.
+/// Parse encrypted (versions 2/4/6/8) entries from a WAL segment buffer.
 ///
 /// Each entry is stored as `[4-byte LE length][encrypted entry bytes]`.
 /// The encrypted entry bytes are decrypted using the provided cipher,
 /// then parsed as a normal WAL entry using the payload version implied by
 /// `container_version` (see [`payload_version`]).
+///
+/// See [`read_segment_with_cipher_tolerant`] for the meaning of
+/// `tolerate_torn_tail`.
+#[allow(clippy::too_many_arguments)]
 fn parse_encrypted_entries(
     buffer: &[u8],
     offset: &mut usize,
@@ -785,6 +879,7 @@ fn parse_encrypted_entries(
     path: &Path,
     entries: &mut Vec<WalEntry>,
     container_version: u8,
+    tolerate_torn_tail: bool,
 ) -> Result<()> {
     let entry_version = payload_version(container_version);
     while *offset < buffer.len() {
@@ -850,6 +945,24 @@ fn parse_encrypted_entries(
                 }
             }
             Err(e) => {
+                // Torn trailing entry (Issue #3413): a length-complete final
+                // frame that decrypts but whose decrypted payload is truncated
+                // past its own end (a crash during the commit-marker flush at
+                // the true end of the final segment). Mirrors the plaintext
+                // path — keep the decodable prefix on a genuine truncation
+                // error; any other corruption still hard-errors. (The more
+                // common encrypted torn tail — an incomplete length prefix or
+                // frame — is already caught by the benign breaks above.)
+                if tolerate_torn_tail && is_truncation_error(&e) {
+                    #[cfg(feature = "observability")]
+                    tracing::debug!(
+                        "Torn trailing decrypted entry at end of final WAL segment {:?}: {}; \
+                         keeping decodable prefix",
+                        path,
+                        e
+                    );
+                    break;
+                }
                 #[cfg(feature = "observability")]
                 tracing::error!(
                     "Failed to parse decrypted WAL entry in segment {:?}: {}",

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -55,9 +55,9 @@ use crate::core::property::PropertyMap;
 use crate::core::provenance::Provenance;
 
 use super::serialization::{
-    OP_CHECKPOINT, OP_CREATE_EDGE, OP_CREATE_NODE, OP_DECLARE_UNIQUE_CONSTRAINT, OP_DELETE_EDGE,
-    OP_DELETE_NODE, OP_DROP_UNIQUE_CONSTRAINT, OP_RETRACT_EDGE, OP_RETRACT_NODE, OP_UPDATE_EDGE,
-    OP_UPDATE_NODE,
+    OP_BEGIN_TX, OP_CHECKPOINT, OP_COMMIT_TX, OP_CREATE_EDGE, OP_CREATE_NODE,
+    OP_DECLARE_UNIQUE_CONSTRAINT, OP_DELETE_EDGE, OP_DELETE_NODE, OP_DROP_UNIQUE_CONSTRAINT,
+    OP_RETRACT_EDGE, OP_RETRACT_NODE, OP_UPDATE_EDGE, OP_UPDATE_NODE,
 };
 use super::{LSN, WalEntry, WalOperation};
 
@@ -103,16 +103,47 @@ pub(crate) const WAL_VERSION_PROVENANCE_PRINCIPAL: u8 = 5;
 /// [`WAL_VERSION_PROVENANCE_PRINCIPAL`]).
 pub(crate) const WAL_VERSION_ENCRYPTED_PROVENANCE_PRINCIPAL: u8 = 6;
 
+/// WAL format version for plaintext segments that may contain transaction
+/// framing markers (`BeginTx`/`CommitTx`, Issue #3413).
+///
+/// Identical entry payload layout to [`WAL_VERSION_PROVENANCE_PRINCIPAL`] for
+/// every pre-existing op; it additionally permits the two framing op tags
+/// (`OP_BEGIN_TX` / `OP_COMMIT_TX`). Bumping the header version (rather than
+/// silently emitting the new tags into a v5 segment) makes an older reader
+/// reject the file cleanly with "Unsupported WAL version" instead of
+/// misparsing an unknown op tag, following the #3224 / #3421 precedent.
+///
+/// NOTE: sibling Issue #3406 will also extend the delete/retract payloads and
+/// must coordinate the WAL version-byte bump with this one — if both land in
+/// the same release train they should share a single combined version; if they
+/// land separately the second takes 9/10. The `framed` predicate here and any
+/// #3406 payload gate are independent booleans on the same version byte and
+/// compose without conflict.
+pub(crate) const WAL_VERSION_TX_FRAMING: u8 = 7;
+
+/// WAL format version for encrypted segments whose decrypted payload uses the
+/// transaction-framing entry format (i.e. [`WAL_VERSION_TX_FRAMING`]).
+pub(crate) const WAL_VERSION_ENCRYPTED_TX_FRAMING: u8 = 8;
+
 /// Maximum supported WAL version (inclusive).
-const WAL_VERSION_MAX: u8 = WAL_VERSION_ENCRYPTED_PROVENANCE_PRINCIPAL;
+const WAL_VERSION_MAX: u8 = WAL_VERSION_ENCRYPTED_TX_FRAMING;
 
 /// Returns `true` if `version` denotes an encrypted segment (the original
-/// encrypted format or one of its provenance-carrying successors).
+/// encrypted format or one of its provenance/framing-carrying successors).
 #[inline]
 fn is_encrypted_version(version: u8) -> bool {
     version == WAL_VERSION_ENCRYPTED
         || version == WAL_VERSION_ENCRYPTED_PROVENANCE
         || version == WAL_VERSION_ENCRYPTED_PROVENANCE_PRINCIPAL
+        || version == WAL_VERSION_ENCRYPTED_TX_FRAMING
+}
+
+/// Returns `true` if `version` (a plaintext/payload version) supports the
+/// [`WalOperation::BeginTx`]/[`WalOperation::CommitTx`] transaction-framing
+/// markers (Issue #3413). Drives the additive `WalEntry::framed` flag.
+#[inline]
+fn is_framed_version(version: u8) -> bool {
+    version >= WAL_VERSION_TX_FRAMING
 }
 
 /// Map a segment/container format version to the logical *payload* version
@@ -127,6 +158,7 @@ fn payload_version(version: u8) -> u8 {
         WAL_VERSION_ENCRYPTED => WAL_VERSION,
         WAL_VERSION_ENCRYPTED_PROVENANCE => WAL_VERSION_PROVENANCE,
         WAL_VERSION_ENCRYPTED_PROVENANCE_PRINCIPAL => WAL_VERSION_PROVENANCE_PRINCIPAL,
+        WAL_VERSION_ENCRYPTED_TX_FRAMING => WAL_VERSION_TX_FRAMING,
         v => v,
     }
 }
@@ -1184,6 +1216,34 @@ fn parse_checkpoint_op(buffer: &[u8], offset: &mut usize) -> Result<WalOperation
     })
 }
 
+/// Parse a `BeginTx` payload: `[tx_id: 8]` (Issue #3413).
+///
+/// No version gating is needed: the `OP_BEGIN_TX` tag only ever appears in
+/// segments at or above [`WAL_VERSION_TX_FRAMING`].
+fn parse_begin_tx_op(buffer: &[u8], offset: &mut usize) -> Result<WalOperation> {
+    require_bytes(buffer, *offset, 8, "BeginTx")?;
+    let tx_id = u64::from_le_bytes(buffer[*offset..*offset + 8].try_into().unwrap());
+    advance(offset, 8)?;
+    Ok(WalOperation::BeginTx { tx_id })
+}
+
+/// Parse a `CommitTx` payload: `[tx_id: 8][entry_count: 4][commit_timestamp: 12]`
+/// (Issue #3413). See [`parse_begin_tx_op`] for why no version gating is needed.
+fn parse_commit_tx_op(buffer: &[u8], offset: &mut usize) -> Result<WalOperation> {
+    require_bytes(buffer, *offset, 12, "CommitTx header")?;
+    let tx_id = u64::from_le_bytes(buffer[*offset..*offset + 8].try_into().unwrap());
+    advance(offset, 8)?;
+    let entry_count = u32::from_le_bytes(buffer[*offset..*offset + 4].try_into().unwrap());
+    advance(offset, 4)?;
+    let (commit_timestamp, ts_len) = HybridTimestamp::deserialize(&buffer[*offset..])?;
+    advance(offset, ts_len)?;
+    Ok(WalOperation::CommitTx {
+        tx_id,
+        entry_count,
+        commit_timestamp,
+    })
+}
+
 /// Parse a single WAL entry from a buffer at the specified offset.
 ///
 /// This function extracts the parsing logic that was previously duplicated
@@ -1264,6 +1324,8 @@ pub(crate) fn parse_entry_at(
             let property = read_label(buffer, &mut cur, "DropUniqueConstraint.property")?;
             WalOperation::DropUniqueConstraint { label, property }
         }
+        OP_BEGIN_TX => parse_begin_tx_op(buffer, &mut cur)?,
+        OP_COMMIT_TX => parse_commit_tx_op(buffer, &mut cur)?,
         _ => {
             return Err(StorageError::CorruptedData(format!(
                 "Unknown WAL operation type: {}",
@@ -1294,6 +1356,11 @@ pub(crate) fn parse_entry_at(
         timestamp,
         operation,
         checksum,
+        // Segments at or above WAL_VERSION_TX_FRAMING carry transaction
+        // framing markers; `version` here is the plaintext/payload version
+        // (encrypted container versions are mapped via `payload_version`
+        // before reaching this function), so the comparison is uniform.
+        framed: is_framed_version(version),
     };
     let bytes_consumed = cur - start_offset;
     Ok((entry, bytes_consumed))
@@ -1366,6 +1433,64 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let entries = read_entries_from_dir(dir.path(), LSN(1)).unwrap();
         assert!(entries.is_empty());
+    }
+
+    /// Issue #3413: `CommitTx` serializes and parses back byte-for-byte under
+    /// the transaction-framing version, and the parsed entry is flagged
+    /// `framed`.
+    #[test]
+    fn test_commit_tx_round_trip() {
+        let commit_timestamp = crate::core::hlc::HybridTimestamp::new(1_234_567, 9).unwrap();
+        let op = WalOperation::CommitTx {
+            tx_id: 42,
+            entry_count: 3,
+            commit_timestamp,
+        };
+        let mut entry = WalEntry::new(LSN(100), op.clone());
+        entry.timestamp = crate::core::hlc::HybridTimestamp::new(2_000_000, 0).unwrap();
+
+        let mut buffer = Vec::new();
+        serialize_entry_into(&entry, &mut buffer).unwrap();
+
+        let (parsed, consumed) = parse_entry_at(&buffer, 0, WAL_VERSION_TX_FRAMING).unwrap();
+        assert_eq!(consumed, buffer.len());
+        assert_eq!(parsed.operation, op);
+        assert_eq!(parsed.lsn, LSN(100));
+        assert!(parsed.framed, "v7 entries must be flagged framed");
+    }
+
+    /// Issue #3413: `BeginTx` round-trips too.
+    #[test]
+    fn test_begin_tx_round_trip() {
+        let op = WalOperation::BeginTx { tx_id: 77 };
+        let entry = WalEntry::new(LSN(5), op.clone());
+        let mut buffer = Vec::new();
+        serialize_entry_into(&entry, &mut buffer).unwrap();
+        let (parsed, consumed) = parse_entry_at(&buffer, 0, WAL_VERSION_TX_FRAMING).unwrap();
+        assert_eq!(consumed, buffer.len());
+        assert_eq!(parsed.operation, op);
+        assert!(parsed.framed);
+    }
+
+    /// Issue #3413: a pre-framing (v6) segment parses entries with
+    /// `framed == false`, keeping them on the legacy immediate-apply path.
+    #[test]
+    fn test_pre_framing_version_not_flagged_framed() {
+        let op = WalOperation::CreateNode {
+            node_id: NodeId::new(1).unwrap(),
+            label: GLOBAL_INTERNER.intern("Legacy").unwrap(),
+            properties: PropertyMap::new(),
+            valid_from: time::now(),
+            provenance: None,
+        };
+        let entry = WalEntry::new(LSN(1), op);
+        let mut buffer = Vec::new();
+        serialize_entry_into(&entry, &mut buffer).unwrap();
+        let (parsed, _) = parse_entry_at(&buffer, 0, WAL_VERSION_PROVENANCE_PRINCIPAL).unwrap();
+        assert!(
+            !parsed.framed,
+            "pre-v7 segments must not be treated as framed"
+        );
     }
 
     #[test]

--- a/src/storage/wal/serialization.rs
+++ b/src/storage/wal/serialization.rs
@@ -52,6 +52,12 @@ pub(crate) const OP_DECLARE_UNIQUE_CONSTRAINT: u8 = 8;
 pub(crate) const OP_DROP_UNIQUE_CONSTRAINT: u8 = 9;
 pub(crate) const OP_RETRACT_NODE: u8 = 10;
 pub(crate) const OP_RETRACT_EDGE: u8 = 11;
+/// Terminal transaction-commit marker (Issue #3413). Only appears in segments
+/// at or above `WAL_VERSION_TX_FRAMING`.
+pub(crate) const OP_COMMIT_TX: u8 = 12;
+/// Leading transaction-begin marker (Issue #3413). Only appears in segments at
+/// or above `WAL_VERSION_TX_FRAMING`.
+pub(crate) const OP_BEGIN_TX: u8 = 13;
 
 /// Helper to serialize an InternedString into the buffer (4-byte ID)
 #[inline(always)]
@@ -271,6 +277,14 @@ pub(crate) fn estimate_entry_capacity(operation: &WalOperation) -> usize {
             // op type (1) + label (4) + property (4)
             1 + 4 + 4
         }
+        WalOperation::BeginTx { .. } => {
+            // op type (1) + tx_id (8)
+            1 + 8
+        }
+        WalOperation::CommitTx { .. } => {
+            // op type (1) + tx_id (8) + entry_count (4) + commit_timestamp (12)
+            1 + 8 + 4 + TIMESTAMP_SIZE
+        }
     };
 
     FIXED_OVERHEAD + variable_size
@@ -446,6 +460,20 @@ pub(crate) fn serialize_operation_into(
             buffer.push(OP_DROP_UNIQUE_CONSTRAINT);
             serialize_interned_string(*label, buffer);
             serialize_interned_string(*property, buffer);
+        }
+        WalOperation::BeginTx { tx_id } => {
+            buffer.push(OP_BEGIN_TX);
+            buffer.extend_from_slice(&tx_id.to_le_bytes());
+        }
+        WalOperation::CommitTx {
+            tx_id,
+            entry_count,
+            commit_timestamp,
+        } => {
+            buffer.push(OP_COMMIT_TX);
+            buffer.extend_from_slice(&tx_id.to_le_bytes());
+            buffer.extend_from_slice(&entry_count.to_le_bytes());
+            commit_timestamp.serialize_into(buffer);
         }
     }
 

--- a/tests/wal_tx_framing.rs
+++ b/tests/wal_tx_framing.rs
@@ -146,6 +146,162 @@ fn atomic_batch_shares_single_transaction_time() {
     }
 }
 
+/// AC#3 (authoritative commit timestamp): the `CommitTx` marker must carry the
+/// **real MVCC commit timestamp** — the exact value the live version was stamped
+/// with — not a fresh `time::now()` sampled at commit or replay. Capture a
+/// committed node's LIVE `transaction_from` BEFORE the simulated crash, then
+/// after forced replay assert the recovered version's transaction time is
+/// **exactly equal**. A marker stamped with `time::now()` would differ from the
+/// HLC commit timestamp (different logical/wallclock), so this pins that the
+/// marker is authoritative rather than merely "internally consistent across the
+/// batch" (which `atomic_batch_shares_single_transaction_time` alone allows).
+#[test]
+fn test_commit_timestamp_matches_live_commit() {
+    let dir = tempdir().unwrap();
+    let data_dir = dir.path().join("db");
+
+    let (id, live_tx_time) = {
+        let db = AletheiaDB::open(&data_dir).unwrap();
+        let id = commit_batch(&db, &["Live"])[0];
+        let live = db
+            .get_node_history(id)
+            .expect("live history")
+            .versions
+            .last()
+            .expect("at least one live version")
+            .temporal
+            .transaction_time()
+            .start();
+        (id, live)
+    };
+
+    force_full_replay(&data_dir);
+
+    let db2 = AletheiaDB::open(&data_dir).unwrap();
+    let recovered_tx_time = db2
+        .get_node_history(id)
+        .expect("history after replay")
+        .versions
+        .last()
+        .expect("at least one recovered version")
+        .temporal
+        .transaction_time()
+        .start();
+
+    assert_eq!(
+        recovered_tx_time, live_tx_time,
+        "recovered transaction time {:?} must EXACTLY equal the authoritative live commit \
+         timestamp {:?}; a marker stamped with time::now() instead of the MVCC commit \
+         timestamp would differ",
+        recovered_tx_time, live_tx_time
+    );
+}
+
+/// AC#3 companion (cross-batch distinctness): two SEPARATE transactions must
+/// recover with DIFFERENT unified transaction times. Within each batch every
+/// version shares one time (pinned elsewhere); across batches they must differ.
+/// This guards against an "everything collapses to one global timestamp"
+/// regression that a single-batch equality test cannot catch.
+#[test]
+fn distinct_batches_have_distinct_transaction_times() {
+    let dir = tempdir().unwrap();
+    let data_dir = dir.path().join("db");
+
+    let (a, b) = {
+        let db = AletheiaDB::open(&data_dir).unwrap();
+        let a = commit_batch(&db, &["A1", "A2"]);
+        let b = commit_batch(&db, &["B1", "B2"]);
+        (a, b)
+    };
+
+    force_full_replay(&data_dir);
+    let db2 = AletheiaDB::open(&data_dir).unwrap();
+
+    let ts_of = |id: &NodeId| {
+        db2.get_node_history(*id)
+            .expect("history after replay")
+            .versions
+            .last()
+            .expect("version present")
+            .temporal
+            .transaction_time()
+            .start()
+    };
+
+    // Within each batch: one shared transaction time.
+    let a_ts = ts_of(&a[0]);
+    assert_eq!(
+        a_ts,
+        ts_of(&a[1]),
+        "batch A must share one transaction time"
+    );
+    let b_ts = ts_of(&b[0]);
+    assert_eq!(
+        b_ts,
+        ts_of(&b[1]),
+        "batch B must share one transaction time"
+    );
+
+    // Across batches: distinct times (no global-timestamp collapse).
+    assert_ne!(
+        a_ts, b_ts,
+        "two separate transactions must have DISTINCT unified transaction times \
+         (got {:?} for both)",
+        a_ts
+    );
+}
+
+/// Fix #3413 (torn/partial CommitTx marker): a crash can leave the FINAL
+/// `CommitTx` with a full 24-byte entry header but a **truncated payload**
+/// (24–48 of its 49 bytes). Recovery must treat that as a benign torn tail —
+/// discard the un-terminated transaction and KEEP every prior committed
+/// transaction — not hard-error the whole segment read (which would discard
+/// PRIOR committed data too).
+#[test]
+fn torn_partial_commit_marker_keeps_prior_tx() {
+    // Truncating this many bytes off the tail leaves 30 bytes of the 49-byte
+    // marker: the full 24-byte header + op tag + 5 payload bytes, so the entry
+    // dispatches to the CommitTx parser which then fails needing more bytes —
+    // exactly the "full header, truncated payload" shape.
+    const TORN_MARKER_TRUNC: u64 = 19;
+
+    let dir = tempdir().unwrap();
+    let data_dir = dir.path().join("db");
+
+    let (tx1, tx2) = {
+        let db = AletheiaDB::open(&data_dir).unwrap();
+        let tx1 = commit_batch(&db, &["K1", "K2"]);
+        let tx2 = commit_batch(&db, &["D1", "D2"]);
+        (tx1, tx2)
+    };
+
+    // Leave tx2's CommitTx as a full-header/truncated-payload torn entry.
+    truncate_last_segment_tail(&data_dir, TORN_MARKER_TRUNC);
+    force_full_replay(&data_dir);
+
+    // Reopen MUST succeed despite the torn trailing marker.
+    let db2 = AletheiaDB::open(&data_dir).expect(
+        "reopen must succeed: a torn trailing CommitTx is a benign tail, not a segment-read error",
+    );
+
+    // tx1 (marker intact) fully present.
+    for id in &tx1 {
+        assert!(
+            db2.get_node(*id).is_ok(),
+            "prior committed tx node {:?} must survive a torn following marker",
+            id
+        );
+    }
+    // tx2 (torn marker) fully discarded.
+    for id in &tx2 {
+        assert!(
+            db2.get_node(*id).is_err(),
+            "node {:?} from the tx whose CommitTx was torn must be discarded",
+            id
+        );
+    }
+}
+
 /// AC#2 (prefix discard): a batch whose commit marker never reached disk must
 /// replay as **all-or-nothing** — zero of its writes may survive. On trunk the
 /// unframed prefix leaks (some nodes survive).
@@ -268,6 +424,86 @@ fn single_op_tx_is_framed() {
     assert!(
         db3.get_node(id2).is_err(),
         "single-op tx whose marker was lost must be discarded"
+    );
+}
+
+/// An EMPTY transaction (no buffered writes) must write **zero** WAL entries —
+/// no `BeginTx`/`CommitTx` frame, no data ops (Issue #3413: framing is elided
+/// for empty commits, reproducing the pre-framing early return exactly).
+#[test]
+fn test_empty_tx_writes_no_marker() {
+    use aletheiadb::storage::LSN;
+    use aletheiadb::storage::wal::segment_reader::read_entries_from_dir;
+
+    let dir = tempdir().unwrap();
+    let data_dir = dir.path().join("db");
+
+    {
+        let db = AletheiaDB::open(&data_dir).unwrap();
+        // Commit a transaction that buffers no writes.
+        db.write(|_tx| Ok::<_, aletheiadb::Error>(()))
+            .expect("empty commit");
+    }
+
+    let entries = read_entries_from_dir(&data_dir.join("wal"), LSN::initial()).unwrap();
+    assert!(
+        entries.is_empty(),
+        "an empty transaction must write zero WAL entries, found {}: {:?}",
+        entries.len(),
+        entries.iter().map(|e| &e.operation).collect::<Vec<_>>()
+    );
+}
+
+/// Raw-segment shape check: a committed transaction of N data ops leaves exactly
+/// one trailing `CommitTx {{ entry_count: N }}` on disk, positioned one LSN past
+/// the last data op (i.e. at `BeginTx.lsn + N + 1`).
+#[test]
+fn committed_tx_has_trailing_commit_marker_with_entry_count() {
+    use aletheiadb::storage::LSN;
+    use aletheiadb::storage::WalOperation;
+    use aletheiadb::storage::wal::segment_reader::read_entries_from_dir;
+
+    let dir = tempdir().unwrap();
+    let data_dir = dir.path().join("db");
+
+    const N: u32 = 3;
+    {
+        let db = AletheiaDB::open(&data_dir).unwrap();
+        commit_batch(&db, &["N1", "N2", "N3"]);
+    }
+
+    let entries = read_entries_from_dir(&data_dir.join("wal"), LSN::initial()).unwrap();
+
+    let begin_lsn = entries
+        .iter()
+        .find_map(|e| match e.operation {
+            WalOperation::BeginTx { .. } => Some(e.lsn),
+            _ => None,
+        })
+        .expect("a committed tx must have a BeginTx marker");
+
+    let commit_markers: Vec<_> = entries
+        .iter()
+        .filter_map(|e| match &e.operation {
+            WalOperation::CommitTx { entry_count, .. } => Some((e.lsn, *entry_count)),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(
+        commit_markers.len(),
+        1,
+        "exactly one CommitTx marker for one committed batch"
+    );
+    let (commit_lsn, entry_count) = commit_markers[0];
+    assert_eq!(
+        entry_count, N,
+        "CommitTx entry_count must equal the number of data ops"
+    );
+    assert_eq!(
+        commit_lsn.0,
+        begin_lsn.0 + u64::from(N) + 1,
+        "the trailing CommitTx must sit at BeginTx.lsn + N + 1"
     );
 }
 

--- a/tests/wal_tx_framing.rs
+++ b/tests/wal_tx_framing.rs
@@ -1,0 +1,329 @@
+#![cfg(test)]
+
+//! Crash-matrix integration tests for WAL transaction framing (Issue #3413).
+//!
+//! A committing `WriteTransaction` translates its N buffered writes into N
+//! independent WAL operations under one LSN batch. Before this change there was
+//! **no** begin/commit framing record, which produced two correctness bugs that
+//! these tests pin:
+//!
+//! 1. **Prefix-replay / atomicity break** — a crash during the commit flush can
+//!    persist and later replay a *prefix* of a batch whose commit was never
+//!    acknowledged, so half a transaction becomes durable.
+//! 2. **Timestamp bisection** — replay re-stamps each recovered version with
+//!    that entry's *own* wallclock, so one atomic transaction's versions receive
+//!    N distinct transaction times and `AS OF SYSTEM_TIME` between two of them
+//!    can observe a half-batch.
+//!
+//! Every test here drives **real** WAL replay: it writes through a durable
+//! on-disk `AletheiaDB::open`, drops the handle (synchronously flushing), then
+//! **deletes the index-persistence snapshot** before reopening so the reopen is
+//! forced to replay the WAL from LSN 1 rather than being short-circuited by the
+//! snapshot. Data reappearing after that deletion is proof the WAL replay ran.
+
+use aletheiadb::api::WriteOps;
+use aletheiadb::core::NodeId;
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::tempdir;
+
+/// Serialized size (bytes) of a terminal `CommitTx` marker entry:
+/// 24 fixed overhead (LSN 8 + timestamp 12 + checksum 4) + 1 op tag +
+/// 8 tx_id + 4 entry_count + 12 commit_timestamp = 49.
+///
+/// Truncating exactly this many bytes off the tail of the last segment removes
+/// the marker of the last transaction while leaving its data ops on disk —
+/// deterministically simulating "crash after the data ops, before/at the commit
+/// record reached durability".
+const COMMIT_MARKER_LEN: u64 = 49;
+
+/// Delete the index-persistence snapshot so the next `open` must replay the WAL
+/// from the beginning instead of loading current state from the snapshot.
+fn force_full_replay(data_dir: &Path) {
+    let indexes = data_dir.join("indexes");
+    if indexes.exists() {
+        fs::remove_dir_all(&indexes).expect("remove index snapshot");
+    }
+}
+
+/// Return the `*.log` WAL segment files under `{data_dir}/wal`, sorted by their
+/// numeric segment id (ascending) — the last is the most-recently written.
+fn wal_segments(data_dir: &Path) -> Vec<PathBuf> {
+    let wal_dir = data_dir.join("wal");
+    let mut segs: Vec<(u64, PathBuf)> = fs::read_dir(&wal_dir)
+        .expect("read wal dir")
+        .flatten()
+        .filter_map(|e| {
+            let p = e.path();
+            let stem = p.file_stem()?.to_str()?.to_string();
+            if p.extension().and_then(|s| s.to_str()) == Some("log") {
+                stem.parse::<u64>().ok().map(|id| (id, p))
+            } else {
+                None
+            }
+        })
+        .collect();
+    segs.sort_by_key(|(id, _)| *id);
+    segs.into_iter().map(|(_, p)| p).collect()
+}
+
+/// Truncate `bytes` off the tail of the last (highest-id) non-empty WAL segment,
+/// simulating a torn write / lost tail. Returns the new length.
+fn truncate_last_segment_tail(data_dir: &Path, bytes: u64) -> u64 {
+    let seg = wal_segments(data_dir)
+        .into_iter()
+        .rev()
+        .find(|p| fs::metadata(p).map(|m| m.len() > 0).unwrap_or(false))
+        .expect("a non-empty WAL segment must exist");
+    let len = fs::metadata(&seg).unwrap().len();
+    assert!(
+        len > bytes,
+        "segment {:?} ({} bytes) too small to truncate {} bytes",
+        seg,
+        len,
+        bytes
+    );
+    let new_len = len - bytes;
+    let f = fs::OpenOptions::new().write(true).open(&seg).unwrap();
+    f.set_len(new_len).unwrap();
+    f.sync_all().unwrap();
+    new_len
+}
+
+/// Commit `labels.len()` nodes as ONE atomic transaction and return their ids.
+fn commit_batch(db: &AletheiaDB, labels: &[&str]) -> Vec<NodeId> {
+    db.write(|tx| {
+        let mut ids = Vec::new();
+        for (i, label) in labels.iter().enumerate() {
+            let id = tx.create_node(
+                label,
+                PropertyMapBuilder::new().insert("i", i as i64).build(),
+            )?;
+            ids.push(id);
+        }
+        Ok::<_, aletheiadb::Error>(ids)
+    })
+    .expect("batch commit")
+}
+
+/// AC#3 (timestamp coherence): after replay, every version produced by ONE
+/// atomic batch must carry an *identical* transaction time. On trunk each op is
+/// re-stamped with its own per-entry wallclock, so the five differ.
+#[test]
+fn atomic_batch_shares_single_transaction_time() {
+    let dir = tempdir().unwrap();
+    let data_dir = dir.path().join("db");
+
+    let ids = {
+        let db = AletheiaDB::open(&data_dir).unwrap();
+        commit_batch(&db, &["A", "B", "C", "D", "E"])
+    };
+
+    force_full_replay(&data_dir);
+
+    let db2 = AletheiaDB::open(&data_dir).unwrap();
+    let tx_times: Vec<_> = ids
+        .iter()
+        .map(|id| {
+            let hist = db2.get_node_history(*id).expect("history after replay");
+            hist.versions
+                .last()
+                .expect("at least one version")
+                .temporal
+                .transaction_time()
+                .start()
+        })
+        .collect();
+
+    let first = tx_times[0];
+    for (i, t) in tx_times.iter().enumerate() {
+        assert_eq!(
+            *t, first,
+            "version {} transaction time {:?} must equal the batch's single commit time {:?}",
+            i, t, first
+        );
+    }
+}
+
+/// AC#2 (prefix discard): a batch whose commit marker never reached disk must
+/// replay as **all-or-nothing** — zero of its writes may survive. On trunk the
+/// unframed prefix leaks (some nodes survive).
+#[test]
+fn replay_discards_uncommitted_batch_prefix() {
+    let dir = tempdir().unwrap();
+    let data_dir = dir.path().join("db");
+
+    let ids = {
+        let db = AletheiaDB::open(&data_dir).unwrap();
+        commit_batch(&db, &["P", "Q", "R", "S"])
+    };
+
+    // Drop the marker (and, on the unframed trunk, tear the last data op).
+    truncate_last_segment_tail(&data_dir, COMMIT_MARKER_LEN);
+    force_full_replay(&data_dir);
+
+    let db2 = AletheiaDB::open(&data_dir).unwrap();
+    for id in &ids {
+        assert!(
+            db2.get_node(*id).is_err(),
+            "node {:?} from an uncommitted (marker-less) batch must NOT survive replay",
+            id
+        );
+    }
+}
+
+/// Companion to the prefix-discard test: a fully-committed batch (marker intact)
+/// must replay in full. Guards against over-discarding.
+#[test]
+fn replay_keeps_fully_committed_batch() {
+    let dir = tempdir().unwrap();
+    let data_dir = dir.path().join("db");
+
+    let ids = {
+        let db = AletheiaDB::open(&data_dir).unwrap();
+        commit_batch(&db, &["P", "Q", "R", "S"])
+    };
+
+    force_full_replay(&data_dir);
+
+    let db2 = AletheiaDB::open(&data_dir).unwrap();
+    for id in &ids {
+        assert!(
+            db2.get_node(*id).is_ok(),
+            "node {:?} from a fully committed batch must survive replay",
+            id
+        );
+    }
+}
+
+/// AC#1/AC#2: a committed transaction (marker intact) and a following
+/// transaction whose marker was lost must recover with an **exact** boundary —
+/// the first fully present, the second fully absent. On trunk the second tx's
+/// prefix leaks in.
+#[test]
+fn committed_tx_kept_following_uncommitted_tx_discarded() {
+    let dir = tempdir().unwrap();
+    let data_dir = dir.path().join("db");
+
+    let (committed, uncommitted) = {
+        let db = AletheiaDB::open(&data_dir).unwrap();
+        let committed = commit_batch(&db, &["C1", "C2"]);
+        let uncommitted = commit_batch(&db, &["U1", "U2"]);
+        (committed, uncommitted)
+    };
+
+    // Remove only the last transaction's commit marker.
+    truncate_last_segment_tail(&data_dir, COMMIT_MARKER_LEN);
+    force_full_replay(&data_dir);
+
+    let db2 = AletheiaDB::open(&data_dir).unwrap();
+    for id in &committed {
+        assert!(
+            db2.get_node(*id).is_ok(),
+            "committed tx node {:?} must survive",
+            id
+        );
+    }
+    for id in &uncommitted {
+        assert!(
+            db2.get_node(*id).is_err(),
+            "uncommitted (marker-less) tx node {:?} must be discarded",
+            id
+        );
+    }
+}
+
+/// A single-op transaction is framed too: it survives a clean replay, and losing
+/// its marker discards it (all-or-nothing even for N=1).
+#[test]
+fn single_op_tx_is_framed() {
+    let dir = tempdir().unwrap();
+    let data_dir = dir.path().join("db");
+
+    // Clean replay keeps it.
+    {
+        let id = {
+            let db = AletheiaDB::open(&data_dir).unwrap();
+            commit_batch(&db, &["Solo"])[0]
+        };
+        force_full_replay(&data_dir);
+        let db2 = AletheiaDB::open(&data_dir).unwrap();
+        assert!(
+            db2.get_node(id).is_ok(),
+            "committed single-op tx must survive"
+        );
+    }
+
+    // Fresh dir: losing the marker discards the single op.
+    let dir2 = tempdir().unwrap();
+    let data_dir2 = dir2.path().join("db");
+    let id2 = {
+        let db = AletheiaDB::open(&data_dir2).unwrap();
+        commit_batch(&db, &["SoloUncommitted"])[0]
+    };
+    truncate_last_segment_tail(&data_dir2, COMMIT_MARKER_LEN);
+    force_full_replay(&data_dir2);
+    let db3 = AletheiaDB::open(&data_dir2).unwrap();
+    assert!(
+        db3.get_node(id2).is_err(),
+        "single-op tx whose marker was lost must be discarded"
+    );
+}
+
+/// Concurrency: several transactions committed from different threads each carry
+/// their own single commit time, and after replay every committed batch is fully
+/// present with all its versions sharing one transaction time (no marker crosses
+/// between concurrent transactions).
+#[test]
+fn interleaved_concurrent_txs_each_atomic() {
+    use std::sync::Arc;
+    use std::thread;
+
+    let dir = tempdir().unwrap();
+    let data_dir = dir.path().join("db");
+
+    let all_ids: Vec<Vec<NodeId>> = {
+        let db = Arc::new(AletheiaDB::open(&data_dir).unwrap());
+        let mut handles = Vec::new();
+        for t in 0..4u32 {
+            let db = Arc::clone(&db);
+            handles.push(thread::spawn(move || {
+                let l1 = format!("T{}a", t);
+                let l2 = format!("T{}b", t);
+                let l3 = format!("T{}c", t);
+                commit_batch(&db, &[&l1, &l2, &l3])
+            }));
+        }
+        let ids: Vec<Vec<NodeId>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        // Arc dropped at end of scope, flushing.
+        Arc::try_unwrap(db)
+            .map(drop)
+            .unwrap_or_else(|_| panic!("db still shared"));
+        ids
+    };
+
+    force_full_replay(&data_dir);
+
+    let db2 = AletheiaDB::open(&data_dir).unwrap();
+    for batch in &all_ids {
+        let mut batch_ts = None;
+        for id in batch {
+            let hist = db2.get_node_history(*id).expect("history after replay");
+            let ts = hist
+                .versions
+                .last()
+                .expect("version present")
+                .temporal
+                .transaction_time()
+                .start();
+            match batch_ts {
+                None => batch_ts = Some(ts),
+                Some(prev) => assert_eq!(
+                    ts, prev,
+                    "all versions of one atomic batch must share one transaction time"
+                ),
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #3413.

## Before

A committing `WriteTransaction` translated its N buffered writes into N independent WAL operations under one LSN batch with **no** begin/commit framing record. Two bugs followed from that missing frame:

1. **Prefix-replay / atomicity break.** A crash during the commit flush could persist and later replay a *prefix* of a batch whose commit was never acknowledged — so half a transaction became durable.
2. **Timestamp bisection.** Replay re-stamped each recovered version with *that entry's own* wallclock, so one atomic transaction's versions received N distinct transaction times. `AS OF SYSTEM_TIME` between two of them could observe a half-batch.

## After

Every committing transaction now brackets its data ops with a **`BeginTx` … data … `CommitTx`** frame, appended in the *same* atomic `append_batch` allocation (one LSN band, one flush epoch). On recovery:

- A frame is applied **all-or-nothing**: only when its terminal `CommitTx` marker is durable and validates (matching `tx_id`, `entry_count`, contiguous LSNs) are the buffered ops applied. A frame whose marker never reached disk (an uncommitted crash tail) is **discarded whole** — never replayed as a torn prefix.
- Every op of a committed frame is re-stamped with the marker's **single** authoritative commit timestamp, so an atomic batch's versions all share one transaction time and `AS OF SYSTEM_TIME` can never bisect it.
- Legacy (pre-v7) segments, raw `append`/`append_async` producers, and self-committing control ops (checkpoints, constraint declare/drop) keep the existing **immediate-apply** path unchanged — only ops inside a `BeginTx`/`CommitTx` frame are buffered.

## How

- **New WAL ops.** `WalOperation::CommitTx { tx_id, entry_count, commit_timestamp }` (op tag **12**) and `WalOperation::BeginTx { tx_id }` (op tag **13**). The terminal `CommitTx` carries the real commit timestamp threaded through `log_operations_to_wal` (previously discarded as `_commit_timestamp`) plus a batch-integrity `entry_count`.
- **WAL format version bump** (following the #3224/#3421 precedent): `WAL_VERSION_TX_FRAMING = 7` (plaintext), `WAL_VERSION_ENCRYPTED_TX_FRAMING = 8` (encrypted); `WAL_VERSION_MAX = 8`; `payload_version(8) => 7`; `is_encrypted_version(8) => true`. New segments are written at v7/v8; v1–v6 segments still parse and replay exactly as before (roll-forward already isolates version-mismatched segments).
- **Additive `WalEntry.framed`** flag, set by the segment parsers from the segment version — in-memory only, not serialized.
- **Framed replay.** `resolve_transaction_frames` pre-resolves the LSN-ordered entry stream into `(operation, transaction_timestamp)` pairs: framed frames committed atomically with the marker timestamp, legacy/control/raw entries with their own timestamp, uncommitted tails dropped. The existing apply-`match` is unchanged apart from taking its timestamp from that pre-resolution.
- Markers ride entirely inside the existing `wal` critical section — **no lock-order change** (CLAUDE.md order preserved).
- **Torn-tail resilient:** a truncated final `CommitTx` is handled by the existing torn-tail parse (sibling #3433) — the frame is simply un-terminated and discarded.

### Design note: why a leading `BeginTx` (refinement over pure terminal-only)

The design doc specified a terminal-only `CommitTx`. In this codebase, `wal.read_from()` reads *versioned disk segments*, and ~180 existing recovery tests (plus checkpoints/constraints in production) raw-append data ops **without** a transaction. Under pure segment-version framing those unmarked data ops would be indistinguishable from a crashed prefix and get discarded. A leading `BeginTx` marker cleanly separates "this op belongs to a transaction (buffer until commit)" from "raw/legacy/control op (apply immediately)", satisfying AC#2 for even a single crashed transaction while leaving every existing non-transactional producer untouched. It composes with the same version bump and adds no lock changes.

### Coordination

Sibling **#3406** will also bump the WAL version to extend delete/retract payloads — the `framed` predicate and any #3406 payload gate are independent booleans on the same version byte; if they land separately the second takes 9/10 (noted in code).

## Acceptance criteria → tests

- [x] **AC#1 — append a per-transaction commit record (tx id + entry count + commit timestamp) as the final WAL entry.**
  - `single_op_tx_is_framed`, `replay_keeps_fully_committed_batch` (tests/wal_tx_framing.rs)
  - `test_commit_tx_round_trip`, `test_begin_tx_round_trip` (segment_reader unit tests)
- [x] **AC#2 — replay buffers per transaction and skips any uncommitted tail.**
  - `replay_discards_uncommitted_batch_prefix`, `committed_tx_kept_following_uncommitted_tx_discarded`, `single_op_tx_is_framed` (tests/wal_tx_framing.rs)
  - `discards_uncommitted_tail_at_eof`, `keeps_committed_frame_then_discards_following_uncommitted_frame`, `discards_frame_on_entry_count_mismatch`, `discards_frame_on_non_contiguous_lsns`, `discards_frame_on_tx_id_mismatch` (resolve_transaction_frames unit tests)
- [x] **AC#3 — carry the commit timestamp in the record and re-stamp ALL replayed versions with it.**
  - `atomic_batch_shares_single_transaction_time`, `interleaved_concurrent_txs_each_atomic` (tests/wal_tx_framing.rs)
  - `commits_framed_batch_atomically_with_marker_timestamp`, `legacy_unframed_entries_apply_immediately_with_own_timestamp` (unit tests)

Back-compat / control-op safety: `test_pre_framing_version_not_flagged_framed`, `control_op_is_self_committing_and_not_buffered`, `control_op_discards_an_open_frame_then_applies`.

Every durability test uses a real on-disk `AletheiaDB::open`, drops the handle to flush, **deletes the index snapshot before reopen** so replay actually runs (not short-circuited by the snapshot), and truncates the segment tail to simulate a lost commit marker.

## Test status

- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --all`: applied
- `cargo test --lib`: 3563 passed, 0 failed
- WAL/recovery integration crates (recovery, regression_wal_replay, durability_modes, index_persistence[_recovery], lsn_recovery_regression, backup_restore, open_durable, repro_empty_segment, reproduce_log_corruption, regression_deserialize, **wal_tx_framing 6/6**): all green
- Pre-existing sandbox caveat: `test_metadata_corruption_on_error` (and `test_flush_deadlock_on_io_error`) fail only under uid 0 — unrelated to this change. Coverage was not run locally (instrumented builds ENOSPC); defer to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKAFWHHzF4ng6LybQJhYsH

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKAFWHHzF4ng6LybQJhYsH)_