### PR TITLE
Persist cold-tier temporal extent bounds across restarts (#3389)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -513,9 +513,10 @@ max of interval starts and *closed* ends, so the open-interval sentinel
 never leaks. Overall bounds are O(1) reads of a write-time-maintained
 aggregate and only ever widen while the server runs (cacheable per
 session). Optional `by_label: true` adds per-node-label / per-edge-type
-bounds folded from hot-tier history. Coverage caveat: bounds span the
-current process lifetime plus hot-tier history restored at startup —
-versions cold-migrated before the last restart are not reflected. See
+bounds folded from hot-tier history. Overall bounds also span history
+migrated to the cold tier across restarts (Issue #3389): the cold store
+persists its per-dimension extent bounds and they are merged into the
+aggregate at startup (the per-label breakdown remains hot-tier-only). See
 [docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md#discovering-the-queryable-temporal-extent-temporal_extent).
 
 **Authentication & RBAC (Issue #3350)**: both server surfaces (MCP and

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -787,7 +787,10 @@ The **per-label breakdown** is still folded from the hot-tier historical
 version store only: after cold migration a label's per-label bounds may be
 narrower than the overall bounds, or a label may be absent entirely (the
 persisted cold bounds are aggregate-only, not per-label). Bounds never
-shrink.
+shrink. One narrow gap: bounds are **not** backfilled for a cold file created
+by a pre-#3389 binary that already held versions — such pre-existing cold
+history is captured only from the first new write onward, so the extent can
+under-report (never over-report) until those versions are re-touched.
 
 **Calibration pattern:** if `temporal_extent` reports
 `valid_time.earliest = 2021-03-01`, an `AS OF '2019-01-01'` query is

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -776,17 +776,18 @@ maintain at write time; bounds only ever widen while the server runs, so a
 caller can cache the result for the duration of a session. The per-label
 breakdown is folded from the hot-tier historical version store.
 
-**Coverage caveat (cold storage + restarts).** Bounds cover all history
+**Coverage (cold storage + restarts).** Overall bounds cover all history
 recorded during the **current process lifetime**, plus the hot-tier history
-restored at startup. On databases with cold-storage migration enabled,
-versions migrated to the cold tier *before the last restart* are **not**
-reflected — the temporal indexes (and their extent aggregate) are rebuilt at
-startup from hot-tier versions only. Within a single process lifetime,
-cold-tier migration never shrinks the bounds. The per-label breakdown is
-additionally hot-tier-only even within a process lifetime: after cold
-migration a label's bounds may be narrower than the overall bounds, or a
-label may be absent entirely. A follow-up could persist cold-tier bounds
-metadata to close the restart gap.
+restored at startup, plus history migrated to the cold tier — including
+across restarts (Issue #3389). The cold store persists its min/max extent
+bounds per dimension in metadata (maintained incrementally as versions
+migrate), and those bounds are merged back into the extent aggregate at
+startup, so a fact migrated to cold before a restart still bounds the extent.
+The **per-label breakdown** is still folded from the hot-tier historical
+version store only: after cold migration a label's per-label bounds may be
+narrower than the overall bounds, or a label may be absent entirely (the
+persisted cold bounds are aggregate-only, not per-label). Bounds never
+shrink.
 
 **Calibration pattern:** if `temporal_extent` reports
 `valid_time.earliest = 2021-03-01`, an `AS OF '2019-01-01'` query is

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -631,6 +631,21 @@ impl AletheiaDB {
                 let tiered_config = TieredStorageConfig::default();
                 let tiered_storage = TieredStorage::new(tiered_config, cold_storage);
 
+                // Merge the cold tier's persisted extent bounds into the
+                // temporal index so `temporal_extent` spans history migrated to
+                // cold before this restart (Issue #3389). `wire_temporal_indexes`
+                // above rebuilt the extent aggregate from the hot tier only;
+                // absent/empty cold metadata leaves it untouched, and merging
+                // only ever widens (never narrows) the reported extent.
+                if let Some(bounds) = tiered_storage.cold_storage().get_temporal_extent_bounds()? {
+                    db.temporal_indexes.merge_extent_bounds(
+                        bounds.valid_earliest,
+                        bounds.valid_latest,
+                        bounds.tx_earliest,
+                        bounds.tx_latest,
+                    );
+                }
+
                 // Wire tiered storage to historical storage
                 // Note: migration_age_threshold and max_hot_versions from config.historical
                 // are used by HistoricalStorage's migration logic, not by TieredStorage

--- a/src/db/extent.rs
+++ b/src/db/extent.rs
@@ -766,4 +766,241 @@ mod tests {
             "open-interval sentinel must never leak into latest"
         );
     }
+
+    /// Store a single anchor `Person` node version into a fresh cold `.redb`
+    /// file at `cold_path` with the given valid/transaction ranges, then drop
+    /// the store — simulating history durable only in the cold tier before a
+    /// restart.
+    fn seed_cold_node(cold_path: &std::path::Path, valid: TimeRange, tx: TimeRange) {
+        use crate::core::id::{NodeId, VersionId};
+        use crate::core::interning::GLOBAL_INTERNER;
+        use crate::core::property::PropertyMap;
+        use crate::core::version::NodeVersion;
+        use crate::storage::redb_cold_storage::RedbColdStorage;
+
+        let cold = RedbColdStorage::with_default_config(cold_path).expect("cold open");
+        let version = NodeVersion::new_anchor(
+            VersionId::new(1).expect("vid"),
+            NodeId::new(1).expect("nid"),
+            BiTemporalInterval::new(valid, tx),
+            GLOBAL_INTERNER.intern("Person").expect("intern"),
+            PropertyMap::new(),
+        );
+        cold.store_node_version(&version)
+            .expect("store cold version");
+        // `cold` drops here, releasing the redb file.
+    }
+
+    /// Open a database with cold storage enabled against `cold_path` (index
+    /// persistence disabled; WAL under `temp_dir/wal`) — a simulated restart
+    /// that triggers the Issue #3389 startup merge of persisted cold bounds.
+    fn open_db_with_cold(temp_dir: &std::path::Path, cold_path: &std::path::Path) -> AletheiaDB {
+        use crate::config::{AletheiaDBConfig, HistoricalConfigBuilder, WalConfigBuilder};
+
+        let config = AletheiaDBConfig::builder()
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(temp_dir.join("wal"))
+                    .build(),
+            )
+            .persistence(crate::storage::index_persistence::PersistenceConfig {
+                enabled: false,
+                ..Default::default()
+            })
+            .historical(
+                HistoricalConfigBuilder::new()
+                    .enable_cold_storage(true)
+                    .cold_storage_path(cold_path)
+                    .build(),
+            )
+            .build();
+        AletheiaDB::with_unified_config(config).expect("db open with cold")
+    }
+
+    /// Core widen-only invariant at the DB level (Issue #3389): a cold-migrated
+    /// OLD fact and a newer hot fact must together bound the extent — earliest
+    /// WIDENS back to cold, latest is NOT narrowed away from the hot fact. This
+    /// is the merge's central contract, previously untested at DB level because
+    /// every other DB test has an empty/absent hot tier; it simultaneously
+    /// covers "migrated old version + newer hot version → extent spans both".
+    #[test]
+    fn cold_old_and_hot_recent_extent_spans_both_widen_only() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cold_path = temp.path().join("cold.redb");
+
+        // Cold tier: an OLD fact, earlier than anything the hot tier holds.
+        let cold_valid = ts(1_000_000_000_000_000); // ~2001
+        let cold_tx = ts(1_100_000_000_000_000); // ~2004
+        seed_cold_node(
+            &cold_path,
+            TimeRange::from(cold_valid),
+            TimeRange::from(cold_tx),
+        );
+
+        // Reopen against the same cold file, then write a RECENT fact through
+        // the public API so it lands in the hot tier. Its valid start is later
+        // than cold's (NARROWER earliest) and its coordinates are newer than
+        // cold's (WIDER latest) in BOTH dimensions.
+        let db = open_db_with_cold(temp.path(), &cold_path);
+        let hot_valid = ts(1_800_000_000_000_000); // ~2027, well after cold
+        let before_write = time::now();
+        db.create_node_with_valid_time("Person", props("name", "Bob"), Some(hot_valid))
+            .expect("create hot node");
+
+        let extent = db.temporal_extent().expect("extent");
+
+        // (i) earliest WIDENS back to the cold fact in both dimensions — the
+        //     startup merge restored cold's older bounds the hot tier lacked.
+        assert_eq!(
+            extent.valid_time.earliest,
+            Some(cold_valid),
+            "valid earliest must widen to the cold fact's older start"
+        );
+        assert_eq!(
+            extent.transaction_time.earliest,
+            Some(cold_tx),
+            "tx earliest must widen to the cold fact's older start"
+        );
+
+        // (ii) latest is NOT narrowed to cold's older coordinates — it retains
+        //      the newer hot fact. This is the widen-only proof: the merge
+        //      never pulls `latest` back to the smaller cold value.
+        assert_eq!(
+            extent.valid_time.latest,
+            Some(hot_valid),
+            "valid latest must retain the newer hot fact, not narrow to cold"
+        );
+        let tx_latest = extent.transaction_time.latest.expect("tx latest");
+        assert!(
+            tx_latest >= before_write,
+            "tx latest must retain the newer hot commit, not narrow to cold"
+        );
+        assert!(
+            tx_latest > cold_tx,
+            "tx latest must exceed the older cold coordinate"
+        );
+        assert!(
+            extent.valid_time.latest.expect("latest") < TIMESTAMP_MAX,
+            "open-interval sentinel must never leak into latest"
+        );
+    }
+
+    /// A cold-migrated version with a CLOSED transaction interval whose finite
+    /// end is strictly later than its start must survive a restart in
+    /// `transaction_time.latest` (Issue #3389). The existing restart test only
+    /// covers the open-interval `latest == start` case; this proves a real
+    /// closed end (`latest != start`) round-trips through the persisted bounds.
+    #[test]
+    fn cold_closed_tx_end_survives_restart_in_latest() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cold_path = temp.path().join("cold.redb");
+
+        let valid_start = ts(1_000_000_000_000_000);
+        let tx_start = ts(1_100_000_000_000_000);
+        let tx_end = ts(1_500_000_000_000_000); // finite close strictly after start
+        seed_cold_node(
+            &cold_path,
+            TimeRange::from(valid_start),
+            TimeRange::new(tx_start, tx_end).expect("closed tx range"),
+        );
+
+        let db = open_db_with_cold(temp.path(), &cold_path);
+        let extent = db.temporal_extent().expect("extent");
+
+        assert_eq!(
+            extent.transaction_time.earliest,
+            Some(tx_start),
+            "cold tx earliest must survive restart"
+        );
+        assert_eq!(
+            extent.transaction_time.latest,
+            Some(tx_end),
+            "a cold-migrated CLOSED tx end must survive restart in latest (not the start)"
+        );
+        assert_ne!(
+            extent.transaction_time.latest,
+            Some(tx_start),
+            "closed end must not collapse to the interval start"
+        );
+        assert!(extent.transaction_time.latest.expect("latest") < TIMESTAMP_MAX);
+    }
+
+    /// Locks in the documented hot-tier-only per-label contract: after a
+    /// cold-migrated restart the OVERALL bounds include a cold-only fact, but
+    /// the per-label breakdown (`temporal_extent_by_label`) does NOT attribute
+    /// it to any label (persisted cold bounds are aggregate-only, not
+    /// per-label).
+    #[test]
+    fn cold_only_fact_bounds_overall_but_not_per_label_after_restart() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cold_path = temp.path().join("cold.redb");
+
+        let cold_valid = ts(1_000_000_000_000_000);
+        let cold_tx = ts(1_100_000_000_000_000);
+        seed_cold_node(
+            &cold_path,
+            TimeRange::from(cold_valid),
+            TimeRange::from(cold_tx),
+        );
+
+        let db = open_db_with_cold(temp.path(), &cold_path);
+        let extent = db.temporal_extent_by_label().expect("extent");
+
+        // Overall bounds reflect the cold-only fact (merged at startup).
+        assert_eq!(
+            extent.valid_time.earliest,
+            Some(cold_valid),
+            "overall bounds must include the cold-only fact"
+        );
+        assert_eq!(extent.transaction_time.earliest, Some(cold_tx));
+
+        // Per-label breakdown is hot-tier-only: the cold fact's "Person" label
+        // is NOT attributed. With no hot versions the breakdown is empty.
+        assert!(
+            extent
+                .node_labels
+                .as_deref()
+                .expect("node labels")
+                .is_empty(),
+            "cold-only history must not appear in the per-label breakdown"
+        );
+        assert!(extent.edge_types.as_deref().expect("edge types").is_empty());
+    }
+
+    /// A cold-ENABLED but empty database must yield the same extent as a
+    /// hot-only database given identical writes: startup finds no persisted
+    /// cold bounds (`get_temporal_extent_bounds -> None`), so the merge branch
+    /// is a strict no-op. Distinct from the redb-unit `None`-when-empty test —
+    /// this exercises the merge's `None`-bounds branch at the DB layer.
+    #[test]
+    fn cold_enabled_but_empty_yields_same_extent_as_hot_only() {
+        let valid = ts(1_000_000_000_000_000);
+
+        // Hot-only database (no cold tier configured).
+        let hot_only = AletheiaDB::new().expect("db init");
+        hot_only
+            .create_node_with_valid_time("Person", props("name", "Alice"), Some(valid))
+            .expect("create node");
+        let hot_extent = hot_only.temporal_extent().expect("extent");
+
+        // Cold-ENABLED but empty database, same write.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cold_path = temp.path().join("cold.redb");
+        let cold_db = open_db_with_cold(temp.path(), &cold_path);
+        cold_db
+            .create_node_with_valid_time("Person", props("name", "Alice"), Some(valid))
+            .expect("create node");
+        let cold_extent = cold_db.temporal_extent().expect("extent");
+
+        // Valid-time extent is deterministic from the backdated write; the
+        // empty cold tier contributed nothing, so it must match hot-only
+        // exactly. (Transaction time differs by commit wallclock across the two
+        // databases, so only valid time is compared.)
+        assert_eq!(
+            cold_extent.valid_time, hot_extent.valid_time,
+            "cold-enabled-but-empty valid extent must equal hot-only"
+        );
+        assert_eq!(cold_extent.valid_time.earliest, Some(valid));
+        assert_eq!(hot_extent.valid_time.earliest, Some(valid));
+    }
 }

--- a/src/db/extent.rs
+++ b/src/db/extent.rs
@@ -16,11 +16,12 @@
 //!   startup — not just the current state. A fact written for 2019 and
 //!   later corrected still counts toward `earliest`. This is a calendar
 //!   *range*, not a current-state count.
-//! - **Cold-storage caveat**: on databases with cold-storage migration
-//!   enabled, versions migrated to the cold tier **before the last restart**
-//!   are not reflected — the temporal indexes (and their extent aggregate)
-//!   are rebuilt at startup from hot-tier versions only. A follow-up could
-//!   persist cold-tier bounds metadata to close this gap.
+//! - **Cold storage (Issue #3389)**: on databases with cold-storage migration
+//!   enabled, versions migrated to the cold tier are also reflected across
+//!   restarts. The cold store persists min/max extent bounds per dimension in
+//!   its metadata (maintained incrementally as versions migrate), and those
+//!   bounds are merged back into the extent aggregate at startup — so a fact
+//!   migrated to cold before a restart still counts toward `earliest`.
 //! - **`earliest`**: the minimum interval start observed in that dimension.
 //! - **`latest`**: the maximum *finite* coordinate observed in that
 //!   dimension — the max over every interval start and every **closed**
@@ -166,13 +167,14 @@ impl AletheiaDB {
     /// ever widen while the process runs, so callers may cache the result
     /// for the duration of a session.
     ///
-    /// # Coverage across restarts (cold-storage caveat)
+    /// # Coverage across restarts
     ///
-    /// Bounds cover all history recorded during the current process
-    /// lifetime plus the hot-tier history restored at startup. On databases
-    /// with cold-storage migration enabled, versions migrated to the cold
-    /// tier **before the last restart** are not reflected (the temporal
-    /// indexes rebuild from hot-tier versions only). See the
+    /// Bounds cover all history recorded during the current process lifetime
+    /// plus the hot-tier history restored at startup. On databases with
+    /// cold-storage migration enabled, history migrated to the cold tier is
+    /// covered across restarts too (Issue #3389): the cold store persists its
+    /// extent bounds and they are merged into the aggregate at startup, so a
+    /// fact migrated to cold before a restart still bounds the extent. See the
     /// [module docs](self) for details.
     ///
     /// # Example
@@ -204,15 +206,16 @@ impl AletheiaDB {
     /// so a caller can scope `AS OF` calibration to exactly the labels it
     /// queries.
     ///
-    /// The overall bounds are identical to [`temporal_extent`](Self::temporal_extent).
-    /// The per-label breakdown is computed from the historical version
-    /// store, which retains all recorded versions **still resident in the
-    /// hot tier**; on databases with cold-storage migration enabled,
-    /// versions whose payload has been migrated to the cold tier are not
-    /// attributed to a label, and after a restart neither the per-label
-    /// bounds nor the overall bounds reflect versions cold-migrated before
-    /// that restart (see [module docs](self)). On a hot-only database every
-    /// per-label bound lies within the overall bounds.
+    /// The overall bounds are identical to [`temporal_extent`](Self::temporal_extent)
+    /// and, as of Issue #3389, reflect cold-migrated history across restarts.
+    /// The **per-label breakdown**, however, is computed from the historical
+    /// version store, which retains only versions **still resident in the hot
+    /// tier**: on databases with cold-storage migration enabled, versions
+    /// whose payload has been migrated to the cold tier are not attributed to
+    /// a label (the persisted cold bounds are aggregate-only, not per-label).
+    /// So after a restart a label's per-label bound can be narrower than the
+    /// overall bound if that label's older history lives only in cold. On a
+    /// hot-only database every per-label bound lies within the overall bounds.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn temporal_extent_by_label(&self) -> Result<TemporalExtent> {
         // Take the historical read lock FIRST, then read the overall bounds
@@ -684,5 +687,83 @@ mod tests {
         let schema_inside = db.schema_as_of(earliest, tx_at).expect("schema inside");
         assert_eq!(schema_inside.node_labels.len(), 1);
         assert_eq!(schema_inside.node_labels[0].label, "Person");
+    }
+
+    /// Regression for Issue #3389: on a cold-storage-enabled database, history
+    /// migrated to the cold tier before a restart must still be reflected in
+    /// `temporal_extent` after the restart. Previously the temporal-index
+    /// extent aggregate rebuilt from the hot tier only, so a backdated fact
+    /// migrated to cold silently vanished from the reported extent — making an
+    /// in-range `AS OF` misread as "never existed".
+    #[test]
+    fn cold_migrated_extent_survives_restart() {
+        use crate::config::{AletheiaDBConfig, HistoricalConfigBuilder, WalConfigBuilder};
+        use crate::core::id::{NodeId, VersionId};
+        use crate::core::interning::GLOBAL_INTERNER;
+        use crate::core::property::PropertyMap;
+        use crate::core::version::NodeVersion;
+        use crate::storage::redb_cold_storage::RedbColdStorage;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cold_path = temp.path().join("cold.redb");
+
+        // A fact valid since ~2001, recorded ~2004, that lives ONLY in the
+        // cold tier (as if migrated out of the hot maps before a restart).
+        let old_valid = ts(1_000_000_000_000_000);
+        let tx_at = ts(1_100_000_000_000_000);
+
+        {
+            let cold = RedbColdStorage::with_default_config(&cold_path).expect("cold open");
+            let version = NodeVersion::new_anchor(
+                VersionId::new(1).expect("vid"),
+                NodeId::new(1).expect("nid"),
+                BiTemporalInterval::new(TimeRange::from(old_valid), TimeRange::from(tx_at)),
+                GLOBAL_INTERNER.intern("Person").expect("intern"),
+                PropertyMap::new(),
+            );
+            cold.store_node_version(&version)
+                .expect("store cold version");
+            // `cold` is dropped here, releasing the redb file — simulating a
+            // process exit with this history durable only in the cold tier.
+        }
+
+        // Reopen the database against the same cold file (simulated restart).
+        let config = AletheiaDBConfig::builder()
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(temp.path().join("wal"))
+                    .build(),
+            )
+            .persistence(crate::storage::index_persistence::PersistenceConfig {
+                enabled: false,
+                ..Default::default()
+            })
+            .historical(
+                HistoricalConfigBuilder::new()
+                    .enable_cold_storage(true)
+                    .cold_storage_path(&cold_path)
+                    .build(),
+            )
+            .build();
+        let db = AletheiaDB::with_unified_config(config).expect("db reopen");
+
+        let extent = db.temporal_extent().expect("extent");
+        assert_eq!(
+            extent.valid_time.earliest,
+            Some(old_valid),
+            "cold-migrated backdated valid start must survive restart"
+        );
+        assert_eq!(
+            extent.transaction_time.earliest,
+            Some(tx_at),
+            "cold-migrated transaction start must survive restart"
+        );
+        // The single migrated fact has an open valid_to; `latest` must be its
+        // start, never the open-interval sentinel.
+        assert_eq!(extent.valid_time.latest, Some(old_valid));
+        assert!(
+            extent.valid_time.latest.expect("latest") < TIMESTAMP_MAX,
+            "open-interval sentinel must never leak into latest"
+        );
     }
 }

--- a/src/index/temporal/mod.rs
+++ b/src/index/temporal/mod.rs
@@ -1558,6 +1558,38 @@ impl TemporalIndexes {
         }
     }
 
+    /// Merge externally-sourced extent bounds into the write-time aggregate
+    /// (Issue #3389).
+    ///
+    /// Each dimension is folded in with the aggregate's normal
+    /// `earliest = min`, `latest = max` union, so this can only **widen** the
+    /// reported extent, never narrow it — matching every in-process mutation.
+    /// A `None` bound leaves that field untouched.
+    ///
+    /// The intended caller is startup restore: versions migrated to the cold
+    /// tier before the current process began are absent from the hot-tier
+    /// rebuild, so their persisted bounds (see
+    /// [`RedbColdStorage::get_temporal_extent_bounds`](crate::storage::redb_cold_storage::RedbColdStorage::get_temporal_extent_bounds))
+    /// are merged here to keep [`extent`](Self::extent) — and thus
+    /// `temporal_extent` — spanning cold history. Because only real observed
+    /// coordinates are merged (the open-interval sentinel is never persisted),
+    /// this preserves the `latest` convention and cannot leak `TIMESTAMP_MAX`.
+    pub fn merge_extent_bounds(
+        &self,
+        valid_earliest: Option<Timestamp>,
+        valid_latest: Option<Timestamp>,
+        tx_earliest: Option<Timestamp>,
+        tx_latest: Option<Timestamp>,
+    ) {
+        let delta = ExtentAggregate {
+            valid_earliest,
+            valid_latest,
+            tx_earliest,
+            tx_latest,
+        };
+        self.extent_aggregate.lock().merge(delta);
+    }
+
     /// Get the total number of indexed version entries.
     ///
     /// Returns the count of unique versions across all entities.

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -39,9 +39,9 @@ pub use migration::{
     MigrationStats,
 };
 pub use redb_cold_storage::{
-    AtomicColdStorageStats, ColdStorageConfig, ColdStorageStats, CompressionAlgorithm,
-    RedbColdStorage, RedbConfig, decode_edge_version, decode_node_version, encode_edge_version,
-    encode_node_version,
+    AtomicColdStorageStats, ColdStorageConfig, ColdStorageStats, ColdTemporalExtentBounds,
+    CompressionAlgorithm, RedbColdStorage, RedbConfig, decode_edge_version, decode_node_version,
+    encode_edge_version, encode_node_version,
 };
 pub use snapshot::{CurrentStorageSnapshot, HistoricalStorageSnapshot};
 pub use tiered_storage::{

--- a/src/storage/redb_cold_storage/mod.rs
+++ b/src/storage/redb_cold_storage/mod.rs
@@ -1206,6 +1206,14 @@ impl RedbColdStorage {
         }
         let mut current = match table.get(TEMPORAL_EXTENT_KEY) {
             Ok(Some(value)) => {
+                // An existing record with an UNRECOGNIZED version tag decodes to
+                // `None` and is clobbered here: `unwrap_or_default()` starts from
+                // empty bounds and rebuilds them widen-only from post-write
+                // deltas. That makes a downgrade across a future
+                // `EXTENT_RECORD_VERSION` bump lossy (bounds a newer binary
+                // persisted are dropped, then re-accumulated only from writes the
+                // older binary performs) — acceptable because the extent is
+                // advisory (under-reporting is safe) and only ever widens.
                 ColdTemporalExtentBounds::from_bytes(value.value()).unwrap_or_default()
             }
             Ok(None) => ColdTemporalExtentBounds::default(),

--- a/src/storage/redb_cold_storage/mod.rs
+++ b/src/storage/redb_cold_storage/mod.rs
@@ -53,7 +53,8 @@
 
 use crate::core::error::{Result, StorageError};
 use crate::core::id::VersionId;
-use crate::core::version::{EdgeVersion, EntityVersion, NodeVersion};
+use crate::core::temporal::{BiTemporalInterval, TIMESTAMP_MAX, Timestamp};
+use crate::core::version::{EdgeVersion, EntityVersion, NodeVersion, TemporalVersion};
 use crate::storage::wal::LSN;
 use rayon::prelude::*;
 use redb::{ReadableDatabase, ReadableTable, ReadableTableMetadata, TableHandle};
@@ -77,6 +78,183 @@ const METADATA_TABLE: redb::TableDefinition<'static, &'static str, &'static [u8]
 
 /// Metadata keys stored in the metadata table.
 const FLUSHED_LSN_KEY: &str = "flushed_lsn";
+
+/// Metadata key for the persisted cold-tier bi-temporal extent (Issue #3389).
+const TEMPORAL_EXTENT_KEY: &str = "temporal_extent";
+
+/// Layout version tag for the persisted extent record. Records with an
+/// unrecognized version are treated as absent, so an older binary that cannot
+/// understand a newer layout simply falls back to hot-tier-only bounds rather
+/// than misreading bytes.
+const EXTENT_RECORD_VERSION: u8 = 1;
+
+/// Byte length of a serialized [`ColdTemporalExtentBounds`]:
+/// 1 version tag + 4 dimensions × (1 presence flag + 8 wallclock + 4 logical).
+const EXTENT_RECORD_LEN: usize = 1 + 4 * 13;
+
+/// Persisted bi-temporal extent bounds for the cold tier (Issue #3389).
+///
+/// Cold-migrated versions are removed from the hot-tier temporal indexes, so
+/// after a restart the write-time extent aggregate — which is rebuilt from the
+/// hot tier only — would silently omit them, wrongly narrowing the reported
+/// [`temporal_extent`](crate::AletheiaDB::temporal_extent). To close that gap
+/// the cold store maintains these bounds incrementally as versions are written
+/// to it, persisted durably in the `metadata` table;
+/// [`RedbColdStorage::get_temporal_extent_bounds`] returns them at startup so
+/// they can be merged back into the aggregate.
+///
+/// Bounds follow the exact convention of the in-memory extent aggregate:
+/// `earliest` is the minimum interval start; `latest` is the maximum of
+/// interval starts and *closed* interval ends — an open (`TIMESTAMP_MAX`) end
+/// contributes only its start, so the open-interval sentinel never leaks. All
+/// four fields are `None` on an empty cold tier and become `Some` together
+/// once any version is stored. Merging is monotonic (bounds only ever widen).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ColdTemporalExtentBounds {
+    /// Minimum valid-time interval start observed across cold versions.
+    pub valid_earliest: Option<Timestamp>,
+    /// Maximum finite valid-time coordinate observed across cold versions.
+    pub valid_latest: Option<Timestamp>,
+    /// Minimum transaction-time interval start observed across cold versions.
+    pub tx_earliest: Option<Timestamp>,
+    /// Maximum finite transaction-time coordinate observed across cold versions.
+    pub tx_latest: Option<Timestamp>,
+}
+
+impl ColdTemporalExtentBounds {
+    /// `true` when no bounds have been observed (all fields `None`).
+    fn is_empty(&self) -> bool {
+        self.valid_earliest.is_none()
+            && self.valid_latest.is_none()
+            && self.tx_earliest.is_none()
+            && self.tx_latest.is_none()
+    }
+
+    /// Fold one `[start, end)` range into a single dimension's bounds, applying
+    /// the extent convention: `earliest` = min start; `latest` = max of starts
+    /// and *closed* ends (an open `TIMESTAMP_MAX` end contributes only its
+    /// start, so the sentinel never leaks).
+    fn observe_range(
+        earliest: &mut Option<Timestamp>,
+        latest: &mut Option<Timestamp>,
+        start: Timestamp,
+        end: Timestamp,
+    ) {
+        *earliest = Some(earliest.map_or(start, |e| e.min(start)));
+        // TimeRange guarantees end >= start, so a closed end is itself the
+        // latest candidate; open ends fall back to the start.
+        let candidate = if end == TIMESTAMP_MAX { start } else { end };
+        *latest = Some(latest.map_or(candidate, |l| l.max(candidate)));
+    }
+
+    /// Fold one bi-temporal interval (both dimensions) into these bounds.
+    fn observe_interval(&mut self, temporal: &BiTemporalInterval) {
+        let valid = temporal.valid_time();
+        Self::observe_range(
+            &mut self.valid_earliest,
+            &mut self.valid_latest,
+            valid.start(),
+            valid.end(),
+        );
+        let tx = temporal.transaction_time();
+        Self::observe_range(
+            &mut self.tx_earliest,
+            &mut self.tx_latest,
+            tx.start(),
+            tx.end(),
+        );
+    }
+
+    /// Accumulate the bounds contributed by a batch of versions.
+    fn from_versions<V: TemporalVersion>(versions: &[V]) -> Self {
+        let mut bounds = Self::default();
+        for version in versions {
+            bounds.observe_interval(version.temporal());
+        }
+        bounds
+    }
+
+    /// Merge another set of bounds into these (monotonic widen-only union).
+    fn merge(&mut self, other: &Self) {
+        Self::merge_dim(
+            &mut self.valid_earliest,
+            &mut self.valid_latest,
+            other.valid_earliest,
+            other.valid_latest,
+        );
+        Self::merge_dim(
+            &mut self.tx_earliest,
+            &mut self.tx_latest,
+            other.tx_earliest,
+            other.tx_latest,
+        );
+    }
+
+    fn merge_dim(
+        earliest: &mut Option<Timestamp>,
+        latest: &mut Option<Timestamp>,
+        other_earliest: Option<Timestamp>,
+        other_latest: Option<Timestamp>,
+    ) {
+        if let Some(e) = other_earliest {
+            *earliest = Some(earliest.map_or(e, |cur| cur.min(e)));
+        }
+        if let Some(l) = other_latest {
+            *latest = Some(latest.map_or(l, |cur| cur.max(l)));
+        }
+    }
+
+    /// Serialize to the fixed-length metadata record layout.
+    fn to_bytes(self) -> [u8; EXTENT_RECORD_LEN] {
+        let mut buf = [0u8; EXTENT_RECORD_LEN];
+        buf[0] = EXTENT_RECORD_VERSION;
+        let mut offset = 1;
+        for field in [
+            self.valid_earliest,
+            self.valid_latest,
+            self.tx_earliest,
+            self.tx_latest,
+        ] {
+            if let Some(ts) = field {
+                buf[offset] = 1;
+                buf[offset + 1..offset + 9].copy_from_slice(&ts.wallclock().to_le_bytes());
+                buf[offset + 9..offset + 13].copy_from_slice(&ts.logical().to_le_bytes());
+            }
+            offset += 13;
+        }
+        buf
+    }
+
+    /// Deserialize from the metadata record layout. Returns `Ok(None)` for an
+    /// unrecognized version tag or wrong length (treated as absent), never an
+    /// error, so a forward-incompatible record can never panic startup.
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != EXTENT_RECORD_LEN || bytes[0] != EXTENT_RECORD_VERSION {
+            return None;
+        }
+        let read_field = |offset: usize| -> Option<Timestamp> {
+            if bytes[offset] == 0 {
+                return None;
+            }
+            let mut wall = [0u8; 8];
+            wall.copy_from_slice(&bytes[offset + 1..offset + 9]);
+            let mut logical = [0u8; 4];
+            logical.copy_from_slice(&bytes[offset + 9..offset + 13]);
+            // Values were validated when the source versions were created, so
+            // reconstructing them from trusted internal storage is sound.
+            Some(Timestamp::new_unchecked(
+                i64::from_le_bytes(wall),
+                u32::from_le_bytes(logical),
+            ))
+        };
+        Some(Self {
+            valid_earliest: read_field(1),
+            valid_latest: read_field(14),
+            tx_earliest: read_field(27),
+            tx_latest: read_field(40),
+        })
+    }
+}
 
 /// Batch size threshold where parallel pre-compression becomes worthwhile.
 const PARALLEL_COMPRESSION_THRESHOLD: usize = 1_024;
@@ -971,6 +1149,83 @@ impl RedbColdStorage {
         Ok(())
     }
 
+    /// Read the persisted cold-tier bi-temporal extent bounds (Issue #3389).
+    ///
+    /// Returns `Ok(None)` when the cold tier has never stored a version (no
+    /// extent record yet) or when the persisted record uses an unrecognized
+    /// layout version — both mean "no cold bounds to contribute", so callers
+    /// leave the hot-tier extent untouched. Otherwise returns the bounds
+    /// accumulated across every version ever written to this cold store,
+    /// following the same `earliest`/`latest` convention as the in-memory
+    /// extent aggregate (the open-interval sentinel never appears).
+    ///
+    /// This is an O(1) single metadata read; it is the startup counterpart to
+    /// the incremental bounds maintained on every cold write, letting
+    /// [`temporal_extent`](crate::AletheiaDB::temporal_extent) span history
+    /// migrated to cold before the current process started.
+    pub fn get_temporal_extent_bounds(&self) -> Result<Option<ColdTemporalExtentBounds>> {
+        let read_txn = self
+            .db
+            .begin_read()
+            .map_err(map_transaction_error("Failed to begin read transaction"))?;
+        let table = match read_txn.open_table(METADATA_TABLE) {
+            Ok(table) => table,
+            // A cold store that never persisted metadata has no such table.
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(None),
+            Err(e) => {
+                return Err(StorageError::io_error(format!(
+                    "Failed to open metadata table: {}",
+                    e
+                ))
+                .into());
+            }
+        };
+
+        match table.get(TEMPORAL_EXTENT_KEY) {
+            Ok(Some(value)) => Ok(ColdTemporalExtentBounds::from_bytes(value.value())),
+            Ok(None) => Ok(None),
+            Err(e) => {
+                Err(StorageError::io_error(format!("Failed to read temporal_extent: {}", e)).into())
+            }
+        }
+    }
+
+    /// Merge a batch of freshly-written versions' bounds into the persisted
+    /// cold-tier extent, within the caller's write transaction (Issue #3389).
+    ///
+    /// A no-op when the delta is empty (nothing observed). The read-modify-write
+    /// happens on the same `metadata` table the caller already opens, so the
+    /// extent update is atomic with the version writes: either the versions and
+    /// their widened bounds both commit, or neither does.
+    fn merge_extent_into_metadata(
+        table: &mut redb::Table<'_, &'static str, &'static [u8]>,
+        delta: &ColdTemporalExtentBounds,
+    ) -> Result<()> {
+        if delta.is_empty() {
+            return Ok(());
+        }
+        let mut current = match table.get(TEMPORAL_EXTENT_KEY) {
+            Ok(Some(value)) => {
+                ColdTemporalExtentBounds::from_bytes(value.value()).unwrap_or_default()
+            }
+            Ok(None) => ColdTemporalExtentBounds::default(),
+            Err(e) => {
+                return Err(StorageError::io_error(format!(
+                    "Failed to read temporal_extent: {}",
+                    e
+                ))
+                .into());
+            }
+        };
+        current.merge(delta);
+        table
+            .insert(TEMPORAL_EXTENT_KEY, current.to_bytes().as_slice())
+            .map_err(|e| -> crate::core::error::Error {
+                StorageError::io_error(format!("Failed to write temporal_extent: {}", e)).into()
+            })?;
+        Ok(())
+    }
+
     // ========================================================================
     // Logic moved from ColdStorage trait impl
     // ========================================================================
@@ -1015,6 +1270,17 @@ impl RedbColdStorage {
             table
                 .insert(version.version_id().as_u64(), to_store.as_slice())
                 .map_err(map_storage_error("Failed to store version"))?;
+        }
+
+        // Widen the persisted cold-tier extent atomically with the version
+        // write, so it survives restarts (Issue #3389).
+        {
+            let mut delta = ColdTemporalExtentBounds::default();
+            delta.observe_interval(version.temporal());
+            let mut meta = write_txn
+                .open_table(METADATA_TABLE)
+                .map_err(map_table_error("Failed to open metadata table"))?;
+            Self::merge_extent_into_metadata(&mut meta, &delta)?;
         }
 
         write_txn
@@ -1522,6 +1788,7 @@ impl RedbColdStorage {
 
         let prepared = prepare_fn(versions)?;
         let version_count = prepared.entries.len() as u64;
+        let extent_delta = ColdTemporalExtentBounds::from_versions(versions);
 
         let write_txn = self
             .db
@@ -1529,6 +1796,15 @@ impl RedbColdStorage {
             .map_err(map_transaction_error("Failed to begin write transaction"))?;
 
         Self::write_prepared_batch_to_table(&write_txn, table_def, &prepared)?;
+
+        // Widen the persisted cold-tier extent atomically with the batch so it
+        // survives restarts (Issue #3389).
+        {
+            let mut meta = write_txn
+                .open_table(METADATA_TABLE)
+                .map_err(map_table_error("Failed to open metadata table"))?;
+            Self::merge_extent_into_metadata(&mut meta, &extent_delta)?;
+        }
 
         write_txn
             .commit()
@@ -1722,12 +1998,17 @@ impl RedbColdStorage {
         // Store edge versions
         Self::write_prepared_batch_to_table(&write_txn, EDGE_VERSIONS_TABLE, &prepared_edges)?;
 
-        // Update flushed_lsn atomically with the batch
+        // Update flushed_lsn and widen the persisted cold-tier extent
+        // atomically with the batch (Issue #3389).
         {
             let mut table = write_txn
                 .open_table(METADATA_TABLE)
                 .map_err(map_table_error("Failed to open metadata table"))?;
             Self::set_flushed_lsn_internal(&mut table, lsn)?;
+
+            let mut extent_delta = ColdTemporalExtentBounds::from_versions(nodes);
+            extent_delta.merge(&ColdTemporalExtentBounds::from_versions(edges));
+            Self::merge_extent_into_metadata(&mut table, &extent_delta)?;
         }
 
         // Commit atomically

--- a/src/storage/redb_cold_storage/tests.rs
+++ b/src/storage/redb_cold_storage/tests.rs
@@ -2432,3 +2432,154 @@ fn test_stats_version_counters_seeded_on_reopen() {
         .unwrap();
     assert_eq!(reopened.stats().node_versions_stored, 4);
 }
+
+// ========================================================================
+// Persisted cold-tier temporal extent bounds (Issue #3389)
+// ========================================================================
+
+/// Build a node version whose valid interval starts at `valid_start` (open
+/// ended) and whose transaction interval starts at `tx_start`.
+fn node_version_with_times(id: u64, valid_start: i64, tx_start: i64) -> NodeVersion {
+    use crate::core::temporal::TimeRange;
+    NodeVersion::new_anchor(
+        VersionId::new(id).unwrap(),
+        NodeId::new(id).unwrap(),
+        BiTemporalInterval::new(
+            TimeRange::from(Timestamp::from(valid_start)),
+            TimeRange::from(Timestamp::from(tx_start)),
+        ),
+        GLOBAL_INTERNER.intern("Person").unwrap(),
+        PropertyMapBuilder::new().insert("name", "Alice").build(),
+    )
+}
+
+#[test]
+fn extent_bounds_none_when_cold_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = RedbColdStorage::with_default_config(dir.path().join("cold.redb")).unwrap();
+    assert_eq!(
+        store.get_temporal_extent_bounds().unwrap(),
+        None,
+        "an empty cold tier contributes no extent bounds"
+    );
+}
+
+#[test]
+fn extent_bounds_persist_across_reopen() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("cold.redb");
+
+    {
+        let store = RedbColdStorage::with_default_config(&path).unwrap();
+        store
+            .store_node_version(&node_version_with_times(1, 1_000, 5_000))
+            .unwrap();
+        // Bounds are visible immediately after the write.
+        let bounds = store.get_temporal_extent_bounds().unwrap().unwrap();
+        assert_eq!(bounds.valid_earliest, Some(Timestamp::from(1_000)));
+        assert_eq!(bounds.tx_earliest, Some(Timestamp::from(5_000)));
+    }
+
+    // Reopen the file (simulated restart): the bounds must survive.
+    let reopened = RedbColdStorage::with_default_config(&path).unwrap();
+    let bounds = reopened.get_temporal_extent_bounds().unwrap().unwrap();
+    assert_eq!(
+        bounds.valid_earliest,
+        Some(Timestamp::from(1_000)),
+        "cold-tier valid earliest must survive reopen"
+    );
+    assert_eq!(bounds.tx_earliest, Some(Timestamp::from(5_000)));
+}
+
+#[test]
+fn extent_bounds_open_valid_to_never_leaks_sentinel() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = RedbColdStorage::with_default_config(dir.path().join("cold.redb")).unwrap();
+    // Open valid_to (TimeRange::from is [start, MAX)).
+    store
+        .store_node_version(&node_version_with_times(1, 2_000, 2_000))
+        .unwrap();
+
+    let bounds = store.get_temporal_extent_bounds().unwrap().unwrap();
+    // A single open-ended fact: latest equals its start, never TIMESTAMP_MAX.
+    assert_eq!(bounds.valid_latest, Some(Timestamp::from(2_000)));
+    assert!(bounds.valid_latest.unwrap() < TIMESTAMP_MAX);
+    assert_eq!(bounds.tx_latest, Some(Timestamp::from(2_000)));
+    assert!(bounds.tx_latest.unwrap() < TIMESTAMP_MAX);
+}
+
+#[test]
+fn extent_bounds_widen_monotonically_across_stores() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = RedbColdStorage::with_default_config(dir.path().join("cold.redb")).unwrap();
+
+    store
+        .store_node_version(&node_version_with_times(1, 3_000, 9_000))
+        .unwrap();
+    // A backdated fact widens earliest; a later one widens latest.
+    store
+        .store_node_version(&node_version_with_times(2, 1_000, 5_000))
+        .unwrap();
+    store
+        .store_node_version(&node_version_with_times(3, 7_000, 12_000))
+        .unwrap();
+
+    let bounds = store.get_temporal_extent_bounds().unwrap().unwrap();
+    assert_eq!(bounds.valid_earliest, Some(Timestamp::from(1_000)));
+    assert_eq!(bounds.valid_latest, Some(Timestamp::from(7_000)));
+    assert_eq!(bounds.tx_earliest, Some(Timestamp::from(5_000)));
+    assert_eq!(bounds.tx_latest, Some(Timestamp::from(12_000)));
+}
+
+#[test]
+fn extent_bounds_updated_by_batch_paths() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = RedbColdStorage::with_default_config(dir.path().join("cold.redb")).unwrap();
+
+    // store_node_versions_batch path.
+    store
+        .store_node_versions_batch(&[
+            node_version_with_times(1, 4_000, 8_000),
+            node_version_with_times(2, 2_000, 6_000),
+        ])
+        .unwrap();
+    let bounds = store.get_temporal_extent_bounds().unwrap().unwrap();
+    assert_eq!(bounds.valid_earliest, Some(Timestamp::from(2_000)));
+
+    // store_batch_with_lsn path widens further.
+    store
+        .store_batch_with_lsn(&[node_version_with_times(3, 1_000, 5_000)], &[], LSN(42))
+        .unwrap();
+    let bounds = store.get_temporal_extent_bounds().unwrap().unwrap();
+    assert_eq!(bounds.valid_earliest, Some(Timestamp::from(1_000)));
+    assert_eq!(bounds.tx_earliest, Some(Timestamp::from(5_000)));
+    // The flushed LSN update in the same path still works alongside the extent.
+    assert_eq!(store.get_flushed_lsn().unwrap(), Some(LSN(42)));
+}
+
+#[test]
+fn extent_bounds_round_trip_serialization() {
+    // Every-field-present round trip, including an absent (None) latest arm.
+    let bounds = ColdTemporalExtentBounds {
+        valid_earliest: Some(Timestamp::from(1_000)),
+        valid_latest: Some(Timestamp::from(9_000)),
+        tx_earliest: Some(Timestamp::from(2_000)),
+        tx_latest: Some(Timestamp::from(8_000)),
+    };
+    let decoded = ColdTemporalExtentBounds::from_bytes(&bounds.to_bytes()).unwrap();
+    assert_eq!(decoded, bounds);
+
+    // A default (all-None) record round-trips to all-None.
+    let empty = ColdTemporalExtentBounds::default();
+    assert_eq!(
+        ColdTemporalExtentBounds::from_bytes(&empty.to_bytes()).unwrap(),
+        empty
+    );
+
+    // A record with an unrecognized version tag is treated as absent.
+    let mut bad = bounds.to_bytes();
+    bad[0] = 0xFF;
+    assert_eq!(ColdTemporalExtentBounds::from_bytes(&bad), None);
+    // Wrong length is also treated as absent, never a panic.
+    assert_eq!(ColdTemporalExtentBounds::from_bytes(&[1, 2, 3]), None);
+}

--- a/src/storage/redb_cold_storage/tests.rs
+++ b/src/storage/redb_cold_storage/tests.rs
@@ -2559,7 +2559,7 @@ fn extent_bounds_updated_by_batch_paths() {
 
 #[test]
 fn extent_bounds_round_trip_serialization() {
-    // Every-field-present round trip, including an absent (None) latest arm.
+    // Every-field-present round trip (all four dimensions Some).
     let bounds = ColdTemporalExtentBounds {
         valid_earliest: Some(Timestamp::from(1_000)),
         valid_latest: Some(Timestamp::from(9_000)),
@@ -2568,6 +2568,33 @@ fn extent_bounds_round_trip_serialization() {
     };
     let decoded = ColdTemporalExtentBounds::from_bytes(&bounds.to_bytes()).unwrap();
     assert_eq!(decoded, bounds);
+
+    // Mixed presence: some dimensions Some, others None. Exercises the
+    // per-field presence flag independently in both `to_bytes`/`from_bytes`
+    // arms (a Some field must decode back Some, a None field back None) rather
+    // than the all-present fixture above, which cannot distinguish the arms.
+    let mixed = ColdTemporalExtentBounds {
+        valid_earliest: Some(Timestamp::from(1_000)),
+        valid_latest: None,
+        tx_earliest: None,
+        tx_latest: Some(Timestamp::from(8_000)),
+    };
+    assert_eq!(
+        ColdTemporalExtentBounds::from_bytes(&mixed.to_bytes()).unwrap(),
+        mixed
+    );
+
+    // Extreme wallclock values round-trip losslessly through the i64 encoding.
+    let extremes = ColdTemporalExtentBounds {
+        valid_earliest: Some(Timestamp::new_unchecked(i64::MIN, 0)),
+        valid_latest: Some(Timestamp::new_unchecked(i64::MAX, u32::MAX)),
+        tx_earliest: Some(Timestamp::new_unchecked(i64::MIN, u32::MAX)),
+        tx_latest: Some(Timestamp::new_unchecked(i64::MAX, 0)),
+    };
+    assert_eq!(
+        ColdTemporalExtentBounds::from_bytes(&extremes.to_bytes()).unwrap(),
+        extremes
+    );
 
     // A default (all-None) record round-trips to all-None.
     let empty = ColdTemporalExtentBounds::default();
@@ -2582,4 +2609,7 @@ fn extent_bounds_round_trip_serialization() {
     assert_eq!(ColdTemporalExtentBounds::from_bytes(&bad), None);
     // Wrong length is also treated as absent, never a panic.
     assert_eq!(ColdTemporalExtentBounds::from_bytes(&[1, 2, 3]), None);
+    // An empty buffer likewise decodes to None (guards the length check
+    // against an index-out-of-bounds panic on `bytes[0]`).
+    assert_eq!(ColdTemporalExtentBounds::from_bytes(&[]), None);
 }


### PR DESCRIPTION
Closes #3389.

## Before / After

**Before.** On cold-storage-enabled databases, `temporal_extent` rebuilt its extent aggregate from the **hot tier only** at startup. Any history migrated to the cold tier before a restart silently vanished from the reported extent, wrongly narrowing it — a 2019 fact migrated to cold then restarted made `valid_time.earliest` report a later date, so an LLM could misread an in-range `AS OF` as "never existed."

**After.** The cold store persists min/max bi-temporal extent bounds per dimension in its `metadata` table, maintained incrementally as versions migrate. At startup those bounds are merged back into the temporal-index aggregate, so the reported extent spans cold history across restarts. No-cold and empty databases are byte-for-byte unchanged.

## How

- **`ColdTemporalExtentBounds`** (new, in `redb_cold_storage`): persisted, fixed-length, versioned record. Forward-compatible — an unknown layout tag or wrong length is treated as *absent* (falls back to hot-tier bounds), never a panic. Follows the exact extent convention: `earliest = min(start)`, `latest = max(start, closed-end)`; the open `TIMESTAMP_MAX` sentinel never contributes.
- Bounds are folded in **atomically with the version write** on every cold write path — `store_entry_internal` (single), `store_entries_batch_internal` (batch), and `store_batch_with_lsn` (alongside the flushed-LSN update). O(1) per write; no full-cold rescan.
- **`RedbColdStorage::get_temporal_extent_bounds`** reads them O(1) at startup (returns `None` for an empty/absent/forward-incompatible record).
- **`TemporalIndexes::merge_extent_bounds`** injects them into the write-time aggregate as a **monotonic widen-only** union.
- `with_unified_config` merges cold bounds right after the hot-tier `rebuild_temporal_index_from_versions`. Acquires only the extent aggregate's leaf mutex (lock order preserved).
- The per-label breakdown remains hot-tier-only (persisted bounds are aggregate-only, not per-label); docs updated to say so.
- Removes the documented restart limitation from the `db::extent` module docs, the MCP query-tool guide, and CLAUDE.md.

## Approach chosen

Incrementally-maintained bounds persisted in cold-store metadata (approach c + a). Rejected a full cold-tier rescan on startup (approach b) — it would defeat the point of migration by scanning all cold history on every boot. The chosen path mirrors the already-O(1) hot write-time aggregate, folds only real migrated intervals, and can never wrongly widen or leak the sentinel.

## Acceptance criteria

- [x] **Extent survives restart with cold-migrated history** — `db::extent::tests::cold_migrated_extent_survives_restart`: writes an old-valid-time version to a cold `.redb`, drops the handle, reopens the DB via `with_unified_config` against the same file, asserts `valid_time.earliest`/`transaction_time.earliest` still reflect the old bounds. (Confirmed red before the fix — `valid_time.earliest` was `None`; green after.)
- [x] **Empty / no-cold cases unchanged** — `extent_bounds_none_when_cold_empty` (empty cold → `None`); existing `empty_database_returns_all_none_bounds` and all 11 `db::extent` + 71 `index::temporal` tests still pass; merge is a no-op when cold bounds are absent.
- [x] **Docs updated to remove the limitation note** — removed from `src/db/extent.rs` module & method docs, `docs/guides/mcp-query-tool.md`, and `CLAUDE.md`.
- [x] **Open-interval sentinel never leaks** — `extent_bounds_open_valid_to_never_leaks_sentinel` + the regression test assert `latest < TIMESTAMP_MAX` for an open `valid_to`.

Extra coverage: `extent_bounds_persist_across_reopen`, `extent_bounds_widen_monotonically_across_stores`, `extent_bounds_updated_by_batch_paths` (batch + LSN paths), `extent_bounds_round_trip_serialization` (incl. bad-version tag & short-buffer → `None`).

## Gates

- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --all`: applied.
- `cargo test --lib`: 3558 passed, 0 failed, 2 ignored.

Benchmarks: none added — `temporal_extent` stays an O(1) aggregate read; the cold-write bounds fold is O(batch) within the existing migration transaction and adds no new scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkubkQo6gZJc9iQtzaRtED

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkubkQo6gZJc9iQtzaRtED)_