### PR TITLE
Serialize WAL batch entries up front to prevent partial-append residue (#3414)

### DIFF
--- a/src/storage/wal/concurrent.rs
+++ b/src/storage/wal/concurrent.rs
@@ -414,16 +414,33 @@ impl ConcurrentWal {
         // Allocate all LSNs in a single atomic operation
         let (first_lsn, _last_lsn) = self.lsn_allocator.allocate_batch(count);
 
-        // Pre-allocate result vector
-        let mut lsns = Vec::with_capacity(operations.len());
-
-        // Serialize and append each operation individually since each entry has its own LSN.
-        // The main optimization is the single batch LSN allocation above (vs N atomic operations).
+        // Phase 1 (fallible): serialize EVERY entry up front. Only once all
+        // entries have serialized successfully do we begin appending. If any
+        // entry fails to serialize (e.g. an oversized entry rejected by the
+        // MAX_WAL_ENTRY_SIZE guard), we return the error WITHOUT having
+        // appended anything, so the failed batch leaves ZERO WAL residue -- no
+        // prefix is written, flushed, or replayed on recovery (Issue #3414).
+        //
+        // The reserved LSN range is consumed but unwritten on failure, which
+        // is benign: recovery seeds the allocator from the max *written* LSN,
+        // and the single-op `append_async` path already produces the identical
+        // hole on a serialize failure. Rolling back the shared atomic
+        // allocator would be unsound under concurrent batches, so we reserve
+        // up front and simply bail without appending.
+        let mut serialized: Vec<(LSN, Vec<u8>)> = Vec::with_capacity(count as usize);
         for (idx, operation) in operations.into_iter().enumerate() {
             let lsn = LSN(first_lsn.0 + idx as u64);
-            lsns.push(lsn);
-
             let data = self.serialize_entry(lsn, &operation)?;
+            serialized.push((lsn, data));
+        }
+
+        // Phase 2 (append): every entry serialized successfully, so append
+        // them all. An append failure here (buffer closed) is covered by the
+        // WAL transaction-framing work (Issue #3413) and is out of scope for
+        // this contained serialize-first fix.
+        let mut lsns = Vec::with_capacity(serialized.len());
+        for (lsn, data) in serialized {
+            lsns.push(lsn);
             let stripe = self.get_stripe();
 
             match stripe.append_blocking(lsn, data) {
@@ -471,17 +488,26 @@ impl ConcurrentWal {
         // Allocate all LSNs in a single atomic operation
         let (first_lsn, _last_lsn) = self.lsn_allocator.allocate_batch(count);
 
-        // Pre-allocate result vectors
-        let mut lsns = Vec::with_capacity(operations.len());
-        let mut handles = Vec::with_capacity(operations.len());
-
-        // Serialize and append each operation individually since each entry has its own LSN.
-        // The main optimization is the single batch LSN allocation above (vs N atomic operations).
+        // Phase 1 (fallible): serialize EVERY entry up front, exactly as in
+        // `append_batch`. A serialization failure (e.g. an oversized entry)
+        // returns the error WITHOUT appending anything, so the failed batch
+        // leaves ZERO WAL residue -- nothing is written, flushed, or replayed
+        // (Issue #3414). The reserved-but-unwritten LSN range is benign (see
+        // `append_batch` for the rationale).
+        let mut serialized: Vec<(LSN, Vec<u8>)> = Vec::with_capacity(count as usize);
         for (idx, operation) in operations.into_iter().enumerate() {
             let lsn = LSN(first_lsn.0 + idx as u64);
-            lsns.push(lsn);
-
             let data = self.serialize_entry(lsn, &operation)?;
+            serialized.push((lsn, data));
+        }
+
+        // Phase 2 (append): every entry serialized successfully, so append
+        // them all. An append failure here (buffer closed) is covered by the
+        // WAL transaction-framing work (Issue #3413) and is out of scope here.
+        let mut lsns = Vec::with_capacity(serialized.len());
+        let mut handles = Vec::with_capacity(serialized.len());
+        for (lsn, data) in serialized {
+            lsns.push(lsn);
             let stripe = self.get_stripe();
 
             match stripe.append_sync_blocking(lsn, data) {

--- a/src/storage/wal/concurrent.rs
+++ b/src/storage/wal/concurrent.rs
@@ -385,6 +385,15 @@ impl ConcurrentWal {
     /// Vector of allocated LSNs in the same order as the operations.
     /// Returns an empty vector if `operations` is empty.
     ///
+    /// # Failure atomicity
+    ///
+    /// Serializing all entries before appending any guarantees zero WAL residue
+    /// on a **serialization** failure (e.g. an oversized entry rejected by the
+    /// `MAX_WAL_ENTRY_SIZE` guard): no prefix is written, flushed, or replayed.
+    /// A phase-2 append failure (reachable only if the stripe is closed
+    /// mid-batch during teardown) is out of scope and covered by transaction
+    /// framing (#3413).
+    ///
     /// # Example
     ///
     /// ```ignore
@@ -418,8 +427,10 @@ impl ConcurrentWal {
         // entries have serialized successfully do we begin appending. If any
         // entry fails to serialize (e.g. an oversized entry rejected by the
         // MAX_WAL_ENTRY_SIZE guard), we return the error WITHOUT having
-        // appended anything, so the failed batch leaves ZERO WAL residue -- no
-        // prefix is written, flushed, or replayed on recovery (Issue #3414).
+        // appended anything, so a SERIALIZATION failure leaves ZERO WAL residue
+        // -- no prefix is written, flushed, or replayed on recovery
+        // (Issue #3414). (A phase-2 append failure is a distinct, narrower case
+        // scoped out below.)
         //
         // The reserved LSN range is consumed but unwritten on failure, which
         // is benign: recovery seeds the allocator from the max *written* LSN,
@@ -435,9 +446,11 @@ impl ConcurrentWal {
         }
 
         // Phase 2 (append): every entry serialized successfully, so append
-        // them all. An append failure here (buffer closed) is covered by the
-        // WAL transaction-framing work (Issue #3413) and is out of scope for
-        // this contained serialize-first fix.
+        // them all. An append failure here is reachable ONLY if the stripe is
+        // closed mid-batch during teardown (abnormal shutdown), and could leave
+        // a partial prefix; that residue is out of scope for this contained
+        // serialize-first fix and is covered by the WAL transaction-framing
+        // work (Issue #3413).
         let mut lsns = Vec::with_capacity(serialized.len());
         for (lsn, data) in serialized {
             lsns.push(lsn);
@@ -468,6 +481,13 @@ impl ConcurrentWal {
     /// A tuple containing:
     /// - Vector of allocated LSNs
     /// - Vector of completion handles corresponding to each operation
+    ///
+    /// # Failure atomicity
+    ///
+    /// Serializing all entries before appending any guarantees zero WAL residue
+    /// on a **serialization** failure. A phase-2 append failure (reachable only
+    /// if the stripe is closed mid-batch during teardown) is out of scope and
+    /// covered by transaction framing (#3413).
     pub fn append_batch_with_handles(
         &self,
         operations: Vec<WalOperation>,
@@ -489,11 +509,11 @@ impl ConcurrentWal {
         let (first_lsn, _last_lsn) = self.lsn_allocator.allocate_batch(count);
 
         // Phase 1 (fallible): serialize EVERY entry up front, exactly as in
-        // `append_batch`. A serialization failure (e.g. an oversized entry)
-        // returns the error WITHOUT appending anything, so the failed batch
-        // leaves ZERO WAL residue -- nothing is written, flushed, or replayed
-        // (Issue #3414). The reserved-but-unwritten LSN range is benign (see
-        // `append_batch` for the rationale).
+        // `append_batch`. A SERIALIZATION failure (e.g. an oversized entry)
+        // returns the error WITHOUT appending anything, so it leaves ZERO WAL
+        // residue -- nothing is written, flushed, or replayed (Issue #3414).
+        // The reserved-but-unwritten LSN range is benign (see `append_batch`
+        // for the rationale).
         let mut serialized: Vec<(LSN, Vec<u8>)> = Vec::with_capacity(count as usize);
         for (idx, operation) in operations.into_iter().enumerate() {
             let lsn = LSN(first_lsn.0 + idx as u64);
@@ -502,8 +522,10 @@ impl ConcurrentWal {
         }
 
         // Phase 2 (append): every entry serialized successfully, so append
-        // them all. An append failure here (buffer closed) is covered by the
-        // WAL transaction-framing work (Issue #3413) and is out of scope here.
+        // them all. An append failure here is reachable ONLY if the stripe is
+        // closed mid-batch during teardown (abnormal shutdown), and could leave
+        // a partial prefix; that residue is out of scope here and is covered by
+        // the WAL transaction-framing work (Issue #3413).
         let mut lsns = Vec::with_capacity(serialized.len());
         let mut handles = Vec::with_capacity(serialized.len());
         for (lsn, data) in serialized {

--- a/tests/havoc/havoc_wal_gaps.rs
+++ b/tests/havoc/havoc_wal_gaps.rs
@@ -72,6 +72,11 @@ fn huge_operation(id: u64) -> WalOperation {
 // successfully. A serialization failure therefore leaves ZERO WAL residue.
 // This test is flipped ON PURPOSE to pin that new zero-residue contract: no
 // entry of the failed batch may appear in the ring buffer.
+//
+// NOTE: the tests in this file pin the SERIALIZE-failure case specifically
+// (an oversized entry rejected in phase 1). A phase-2 append failure --
+// reachable only if a stripe is closed mid-batch during teardown -- is a
+// distinct, narrower case deferred to WAL transaction framing (#3413).
 // ---------------------------------------------------------------------------
 #[test]
 fn test_havoc_wal_batch_gaps() {
@@ -137,6 +142,76 @@ fn test_havoc_wal_batch_gaps() {
     );
 
     println!("✅ ZERO-RESIDUE: failed batch left no entries in the ring buffer.");
+}
+
+// ---------------------------------------------------------------------------
+// Max-residue variant (Issue #3414): the OVERSIZED entry is LAST.
+//
+// `test_havoc_wal_batch_gaps` fails the MIDDLE entry, so buggy pre-#3414 code
+// would have leaked a single-entry prefix (LSN 1). This test fails the LAST
+// entry of a three-entry batch -- the worst case for the old serialize-in-loop
+// bug, which would have appended the entire N-1 prefix (LSNs 1 AND 2) before
+// hitting the oversized entry. Pinning the last-entry position proves the
+// serialize-first fix abandons the WHOLE batch, not just a trailing suffix:
+// zero residue regardless of how far into the batch serialization fails.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_havoc_wal_batch_last_entry_failure_no_residue() {
+    let dir = tempdir().unwrap();
+    let config = ConcurrentWalConfig::new(dir.path());
+    let wal = ConcurrentWal::new(config).unwrap();
+
+    // Batch: [Valid(1), Valid(2), Huge(3) - invalid LAST entry].
+    // On buggy serialize-in-loop code this would append LSN 1 and LSN 2 (the
+    // full N-1 prefix) before the oversized entry aborts the loop.
+    let ops = vec![test_operation(1), test_operation(2), huge_operation(3)];
+
+    let result = wal.append_batch(ops);
+    assert!(
+        result.is_err(),
+        "batch with an oversized LAST entry must fail"
+    );
+
+    let err = result.unwrap_err();
+    println!("Append batch error (expected): {}", err);
+    assert!(
+        err.to_string().contains("CapacityExceeded") || err.to_string().contains("WAL entry size")
+    );
+
+    // A later valid op must still succeed and be the ONLY visible entry.
+    let lsn_after = wal.append_async(test_operation(4)).unwrap();
+    println!("Appended valid op after failure, LSN: {:?}", lsn_after);
+
+    let entries = wal.drain_all();
+    let lsns: Vec<u64> = entries.iter().map(|e| e.lsn.0).collect();
+    println!("Drained LSNs: {:?}", lsns);
+
+    // The max-residue assertion: NEITHER LSN 1 NOR LSN 2 (the full N-1 prefix
+    // the buggy code would have leaked) may be present.
+    assert!(
+        !lsns.contains(&1),
+        "LSN 1 must be ABSENT: no prefix of the failed batch may be appended (buggy code leaked LSNs 1,2)"
+    );
+    assert!(
+        !lsns.contains(&2),
+        "LSN 2 must be ABSENT: the full N-1 prefix must be abandoned, not just the failed suffix"
+    );
+    assert!(
+        !lsns.contains(&3),
+        "LSN 3 must be absent (failed serialization)"
+    );
+    assert!(
+        lsns.contains(&lsn_after.0),
+        "the post-failure valid append must be present"
+    );
+    assert_eq!(
+        lsns.len(),
+        1,
+        "exactly one entry (the post-failure op) should be present; the failed batch left zero residue, got {:?}",
+        lsns
+    );
+
+    println!("✅ ZERO-RESIDUE (last-entry failure): full N-1 prefix abandoned.");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/havoc/havoc_wal_gaps.rs
+++ b/tests/havoc/havoc_wal_gaps.rs
@@ -2,8 +2,10 @@ use aletheiadb::core::id::NodeId;
 use aletheiadb::core::interning::GLOBAL_INTERNER;
 use aletheiadb::core::property::PropertyMap;
 use aletheiadb::core::temporal::time;
+use aletheiadb::storage::wal::DurabilityMode;
 use aletheiadb::storage::wal::concurrent::{ConcurrentWal, ConcurrentWalConfig};
-use aletheiadb::storage::wal::entry::{MAX_WAL_ENTRY_SIZE, WalOperation};
+use aletheiadb::storage::wal::concurrent_system::{ConcurrentWalSystem, ConcurrentWalSystemConfig};
+use aletheiadb::storage::wal::entry::{LSN, MAX_WAL_ENTRY_SIZE, WalOperation};
 use tempfile::tempdir;
 
 fn test_operation(id: u64) -> WalOperation {
@@ -55,6 +57,22 @@ fn huge_operation(id: u64) -> WalOperation {
     }
 }
 
+// ---------------------------------------------------------------------------
+// DELIBERATE BEHAVIOR CHANGE (Issue #3414): serialize-first batch append.
+//
+// This test USED TO PIN the buggy partial-append behavior: a batch whose
+// middle entry failed to serialize left the entries appended *before* the
+// failure sitting in the ring buffer, where a later flush swept them to disk
+// and recovery replayed them -- a batch the caller was told FAILED
+// resurrected as a prefix. The old assertions literally required LSN 1 to be
+// present and panicked ("Boring") if the sequence was contiguous.
+//
+// #3414 makes `append_batch` serialize EVERY entry up front (the fallible
+// phase) and only begins appending once all entries have serialized
+// successfully. A serialization failure therefore leaves ZERO WAL residue.
+// This test is flipped ON PURPOSE to pin that new zero-residue contract: no
+// entry of the failed batch may appear in the ring buffer.
+// ---------------------------------------------------------------------------
 #[test]
 fn test_havoc_wal_batch_gaps() {
     let dir = tempdir().unwrap();
@@ -64,7 +82,7 @@ fn test_havoc_wal_batch_gaps() {
     // 1. Create a batch: [Valid, Huge (Invalid), Valid]
     let ops = vec![test_operation(1), huge_operation(2), test_operation(3)];
 
-    // 2. Append batch - should fail
+    // 2. Append batch - should fail (oversized middle entry)
     let result = wal.append_batch(ops);
     assert!(
         result.is_err(),
@@ -87,48 +105,107 @@ fn test_havoc_wal_batch_gaps() {
 
     println!("Drained LSNs: {:?}", lsns);
 
-    // 5. Verify the wreckage: Gaps in LSN sequence
-    // Expected: LSN 1 (from first op in batch) MIGHT be there?
-    // No, `append_batch` loop:
-    // 1. Allocates 3 LSNs (current, current+1, current+2).
-    // 2. Loop idx=0: Serialize (ok), Append (ok). LSN 1 written.
-    // 3. Loop idx=1: Serialize (fail), Return Err.
-    // 4. Loop idx=2: Never executed.
-
-    // So LSN 1 should be written.
-    // LSN 2 was allocated but serialization failed.
-    // LSN 3 was allocated but loop aborted.
-    // Next LSN allocated by `append_async` should be 4.
-
-    // So we expect LSNs: [1, 4]
-    // Gap: 2, 3 are missing.
-
+    // 5. Verify the NEW contract: the failed batch left ZERO residue.
+    //
+    // `append_batch` reserves the LSN range (1, 2, 3) atomically, then
+    // serializes all three entries BEFORE appending any. Serializing the
+    // oversized middle entry fails, so the whole batch is abandoned without a
+    // single append. The reserved-but-unwritten LSN range is benign -- the
+    // single-op `append_async` path already produces the identical hole on a
+    // serialize failure, and recovery seeds the allocator from the max
+    // *written* LSN. `append_async(op4)` therefore lands at LSN 4.
     assert!(
-        lsns.contains(&1),
-        "LSN 1 should be present (written before failure)"
+        !lsns.contains(&1),
+        "LSN 1 must be ABSENT: no prefix of the failed batch may be appended (was present pre-#3414)"
     );
     assert!(
         !lsns.contains(&2),
-        "LSN 2 should be missing (failed serialization)"
+        "LSN 2 must be absent (failed serialization)"
     );
-    assert!(!lsns.contains(&3), "LSN 3 should be missing (aborted loop)");
+    assert!(!lsns.contains(&3), "LSN 3 must be absent (batch abandoned)");
     assert!(
         lsns.contains(&lsn_after.0),
-        "LSN after batch should be present"
+        "the post-failure valid append must be present"
     );
 
-    // Prove non-contiguity
-    let mut contiguous = true;
-    for i in 0..lsns.len() - 1 {
-        if lsns[i + 1] != lsns[i] + 1 {
-            contiguous = false;
-            break;
-        }
+    // The only drained entry is the post-failure op -- the batch is invisible.
+    assert_eq!(
+        lsns.len(),
+        1,
+        "exactly one entry (the post-failure op) should be present; the failed batch left zero residue, got {:?}",
+        lsns
+    );
+
+    println!("✅ ZERO-RESIDUE: failed batch left no entries in the ring buffer.");
+}
+
+// ---------------------------------------------------------------------------
+// Real on-disk replay regression test (Issue #3414).
+//
+// This is the crash-recovery-faithful version of the bug: it flushes to real
+// on-disk WAL segments and then reads them back through the same segment
+// reader that crash recovery uses (`read_from`). On the buggy (pre-#3414)
+// code the prefix entry (node 1) that the failed batch orphaned in the ring
+// buffer gets swept to disk by the *next* unrelated flush and reappears on
+// replay. After #3414 the failed batch never appends anything, so replay sees
+// only writes that actually succeeded.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_havoc_wal_batch_no_residue_on_replay() {
+    let dir = tempdir().unwrap();
+    let wal_path = dir.path().join("wal");
+    std::fs::create_dir_all(&wal_path).unwrap();
+
+    // Synchronous durability: a successful write is flushed to on-disk
+    // segments immediately, so `read_from` observes exactly what crash
+    // recovery would replay.
+    let config =
+        ConcurrentWalSystemConfig::new(&wal_path).with_durability_mode(DurabilityMode::Synchronous);
+    let system = ConcurrentWalSystem::new(config).unwrap();
+
+    // Batch: [Valid(1), Huge(2) - invalid, Valid(3)]
+    let ops = vec![test_operation(1), huge_operation(2), test_operation(3)];
+    let result = system.append_batch(ops);
+    assert!(
+        result.is_err(),
+        "batch containing an oversized entry must fail"
+    );
+
+    // A later, genuinely valid write that MUST persist and replay. On the
+    // buggy code this flush is what sweeps the orphaned prefix (node 1) to
+    // disk.
+    let lsn_after = system.append_sync(test_operation(4)).unwrap();
+    println!("post-failure durable write at LSN {:?}", lsn_after);
+
+    // Force REAL replay: read entries back from the on-disk WAL segments,
+    // exactly as crash recovery does (no index snapshot exists at this layer
+    // to short-circuit it).
+    let replayed = system.read_from(LSN(1)).unwrap();
+    let replayed_ids: Vec<u64> = replayed
+        .iter()
+        .filter_map(|e| match &e.operation {
+            WalOperation::CreateNode { node_id, .. } => Some(node_id.as_u64()),
+            _ => None,
+        })
+        .collect();
+    println!("replayed node ids: {:?}", replayed_ids);
+
+    // No entry of the FAILED batch may survive replay.
+    for failed_id in [1u64, 2, 3] {
+        assert!(
+            !replayed_ids.contains(&failed_id),
+            "node {} from the FAILED batch must NOT be replayed (found {:?})",
+            failed_id,
+            replayed_ids
+        );
     }
 
-    if !contiguous {
-        println!("👺 HAVOC SUCCESS: Found gaps in LSN sequence! System is fragile.");
-    } else {
-        panic!("Boring. LSNs are contiguous. Failed to break it.");
-    }
+    // The post-failure write is durable and replayed.
+    assert!(
+        replayed_ids.contains(&4),
+        "the post-failure durable write (node 4) must be replayed, found {:?}",
+        replayed_ids
+    );
+
+    println!("✅ ZERO-RESIDUE ON REPLAY: failed batch left no on-disk entries.");
 }


### PR DESCRIPTION
Fixes #3414.

## Before / After (plain language)

**Before.** `ConcurrentWal::append_batch` and `append_batch_with_handles` serialized *and* appended each entry inside one loop. When an entry failed to serialize partway through a batch — e.g. an oversized entry rejected by the `MAX_WAL_ENTRY_SIZE` guard — every entry appended **before** the failure was already sitting in the ring buffer. The batch returned an error, but that orphaned prefix got swept to disk by the next flush and **replayed on recovery**. A batch the caller was explicitly told FAILED silently resurrected as a partial prefix — a durability/correctness violation.

**After.** Both methods are split into two phases:
1. **Serialize every entry up front (fallible phase).** If any entry fails to serialize, the method returns the error having appended **nothing**.
2. **Append phase.** Only reached once *all* entries serialized successfully, so appends can no longer be interrupted mid-batch by a serialization error.

A batch that fails **during serialization** now leaves **zero WAL residue**: nothing appended, nothing flushed, nothing replayed. (An append-*phase* failure is a separate, narrower case — see scope note below.)

## How

- The single atomic `allocate_batch` LSN reservation is kept up front. On a serialize failure the reserved-but-unwritten LSN range is consumed but **benign**: recovery seeds the allocator from the max *written* LSN, and the existing single-op `append_async` path already produces the identical hole on a serialize failure. Rolling back the shared atomic allocator would be unsound under concurrent batches, so we reserve up front and simply bail without appending.
- **Scope note.** This fix guarantees zero residue on a *serialization*-phase failure. Phase 2 still appends entries one-by-one, so a phase-2 `append_blocking`/`append_sync_blocking` failure — reachable **only** if a stripe is `close()`d concurrently with an in-flight batch (narrow, abnormal-teardown only) — could still leave a partial prefix. That append-phase residue is out of scope here and deferred to the WAL transaction-framing work (#3413). The doc/inline comments and the `havoc_wal_gaps` header state this precisely.
- Change is contained to `src/storage/wal/concurrent.rs` — **no WAL format change**.

## Deliberate `havoc_wal_gaps` behavior change ⚠️

`tests/havoc/havoc_wal_gaps.rs::test_havoc_wal_batch_gaps` previously **pinned the buggy behavior**: it asserted the leaked prefix `LSN 1` *was* present after a failed batch and `panic!(&#34;Boring&#34;)` if the LSN sequence was contiguous. That contract encoded the bug. This PR **intentionally flips it** to pin the new zero-residue contract — `LSN 1` must be **absent**, and the only surviving entry is the post-failure write. The rationale is documented inline at the top of the flipped test.

## Acceptance criteria → tests

- [x] **AC1 — a serialization failure leaves ZERO WAL residue (nothing appended/flushed/replayed).**
  - `test_havoc_wal_batch_no_residue_on_replay` — flushes to a real on-disk WAL (Synchronous durability) and reads segments back through the recovery reader (`read_from`); asserts no node of the failed batch is replayed and the post-failure write is. Was RED on trunk (`replayed node ids: [1, 4]`), now GREEN (`[4]`).
  - `test_havoc_wal_batch_gaps` (flipped, in-memory) — fails the **middle** entry; asserts the failed batch leaves exactly one drained entry (the post-failure op) and `LSN 1` is absent.
  - `test_havoc_wal_batch_last_entry_failure_no_residue` — fails the **last** entry of a three-entry batch (the max-residue case: buggy code would leak the full N−1 prefix, LSNs 1 *and* 2). Asserts both are absent and the drain shows only the post-failure op. Mutation-verified: reverting to serialize-in-loop drains `[1, 2, 4]` and the test fails; with the fix it drains `[4]` and passes.
- [x] **AC2 — append failures after serialization remain covered by #3413 (out of scope).** No change to the append-phase error path; the scope is now documented precisely in code and PR (see scope note).
- [x] **AC3 — `havoc_wal_gaps` flipped deliberately to the new contract, documented.** See section above and the inline comment in the test.

## Gates

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all` — applied
- `cargo test --lib storage::` — 1044 passed
- `cargo test --test havoc` — 34 passed (only the pre-existing uid-0 `test_flush_deadlock_on_io_error` fails, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKAFWHHzF4ng6LybQJhYsH

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKAFWHHzF4ng6LybQJhYsH)_