### PR TITLE
Add OpenTelemetry tracing across query and write paths (#3376)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,9 @@ dependencies = [
  "memmap2",
  "metrics",
  "native-tls",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "parking_lot",
  "proptest",
  "quick_cache",
@@ -130,6 +133,8 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "tracy-client",
  "usearch",
  "zeroize",
@@ -4940,6 +4945,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.4",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5138,6 +5216,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5415,6 +5513,29 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6941,7 +7062,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -7277,6 +7398,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7351,6 +7483,27 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "tower"
@@ -7451,6 +7604,24 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec 1.15.1",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,18 @@ tracy-client = { version = "0.18", optional = true, default-features = false }
 tracing = { version = "0.1", optional = true }
 metrics = { version = "0.24", optional = true }
 
+# OpenTelemetry distributed tracing (Issue #3376), optional via the `otel`
+# feature. The OTLP exporter uses the HTTP/protobuf transport over the
+# already-present `reqwest` client, so no tonic/protoc build dependency is
+# introduced. `tracing-opentelemetry` bridges the crate's existing `tracing`
+# spans (ADR 0056) into OpenTelemetry; `tracing-subscriber` provides the
+# registry the OTel layer installs into.
+opentelemetry = { version = "0.30", optional = true }
+opentelemetry_sdk = { version = "0.30", optional = true, features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.30", optional = true, default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
+tracing-opentelemetry = { version = "0.31", optional = true }
+tracing-subscriber = { version = "0.3", optional = true, features = ["registry", "env-filter", "fmt", "std"] }
+
 # MCP server support (optional)
 # Note: rmcp re-exports schemars, so we don't need a separate dependency
 rmcp = { version = "1.7", features = ["server", "transport-io"], optional = true }
@@ -175,6 +187,21 @@ tracy = ["tracy-client/enable"]
 # Observability features
 observability = ["dep:tracing"]
 metrics-rs = ["observability", "dep:metrics"]
+
+# OpenTelemetry distributed tracing + OTLP export (Issue #3376).
+# Composes with `observability` (reuses its span vocabulary / ADR 0056
+# contract) and adds an OTLP exporter, sampler, W3C context propagation, and
+# a process-wide subscriber installer. Zero cost when absent: the whole
+# `observability::otel` module and every call site are `#[cfg]`-compiled out.
+otel = [
+    "observability",
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:tracing-opentelemetry",
+    "dep:tracing-subscriber",
+    "dep:tokio",
+]
 
 # Default features
 default = ["config-toml"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -343,6 +343,13 @@ harness = false
 path = "benches/performance_targets.rs"
 required-features = []
 
+# OpenTelemetry tracing overhead gate (Issue #3376): disabled vs enabled.
+[[bench]]
+name = "otel_overhead"
+harness = false
+path = "benches/otel_overhead.rs"
+required-features = ["otel"]
+
 # Storage layer - raw storage primitives and fast path
 [[bench]]
 name = "current_state"

--- a/benches/otel_overhead.rs
+++ b/benches/otel_overhead.rs
@@ -1,21 +1,32 @@
-//! OpenTelemetry tracing overhead bench (Issue #3376).
+//! OpenTelemetry tracing overhead micro-bench (Issue #3376).
 //!
-//! Guards the AC "overhead bounded and measured": the cost of the tracing hot
-//! path when the exporter is **compiled in but disabled** must be
-//! indistinguishable from noise, and the cost when **enabled** must be small
-//! and bounded. It compares three regimes for the per-request span work:
+//! Measures the magnitude of the per-request span hot path across the three
+//! regimes that matter for the "overhead bounded and measured" AC:
 //!
-//! - `disabled`: the span builder + attribute recording with no active
-//!   subscriber (a compiled-in-but-off deployment). This is the number that
-//!   must stay ~0 against the `performance_targets` suite.
-//! - `enabled_sampled_out`: the exporter is active but the head sampler drops
-//!   the trace, so no span is constructed on the hot path.
-//! - `enabled_recorded`: the exporter is active and the trace is sampled;
-//!   the span is built, an incoming W3C context is attached, and attributes
-//!   are recorded (the full cost, paid only for sampled requests).
+//! - `disabled`: the span builder + attribute recording with **no** subscriber
+//!   installed (a compiled-in-but-off deployment). Measured FIRST, before any
+//!   global subscriber exists, so the reading is genuinely the disabled cost.
+//! - `enabled_sampled_out`: the exporter is active but the trace is head-sampled
+//!   *out* (an incoming `...-00` parent under the parent-based sampler). The
+//!   span is constructed and the sampler runs, but the span is not recorded, so
+//!   the per-request attribute recording is inert.
+//! - `enabled_recorded`: the exporter is active and the trace is sampled (an
+//!   incoming `...-01` parent). The span is built, the incoming context is
+//!   attached, and attributes are recorded — the full cost, paid only for
+//!   sampled requests.
+//!
+//! **This criterion bench is a profiling aid, not the CI gate.** A single
+//! process can only ever hold one global `tracing` subscriber, so once it is
+//! installed the "disabled" cost can no longer be observed in-process; the
+//! `disabled` group is therefore registered first and measured before install.
+//! The authoritative, non-flaky, CI-run gate is the structural inertness test
+//! `tests/otel_overhead_gate.rs`. The in-memory global here uses
+//! `SimpleSpanProcessor` (export-on-end); production uses `BatchSpanProcessor`,
+//! so treat the `enabled_recorded` number as an upper bound on per-span export
+//! bookkeeping rather than a production-exact figure.
 //!
 //! Run with: `cargo bench --bench otel_overhead --features otel`
-//! Build-only gate: `cargo bench --no-run --features otel`.
+//! Build-only gate: `cargo bench --no-run --bench otel_overhead --features otel`.
 
 use std::hint::black_box;
 use std::sync::OnceLock;
@@ -26,34 +37,47 @@ use aletheiadb::observability::otel::{
 };
 use criterion::{Criterion, criterion_group, criterion_main};
 
-const SAMPLE_TRACEPARENT: &str = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+/// A `...-01` (sampled) incoming parent.
+const SAMPLED_TRACEPARENT: &str = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+/// A `...-00` (not-sampled) incoming parent.
+const UNSAMPLED_TRACEPARENT: &str = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00";
 
-/// Exercise the per-request span work: build the root span, attach an incoming
-/// W3C context, and record the safe-by-default attributes.
-fn request_span_work() {
+/// Exercise the per-request span hot path with the given incoming parent: build
+/// the root span, attach the incoming W3C context when active, and record the
+/// safe-by-default attributes. The exporter buffer (if any) is cleared each call
+/// so it cannot grow unbounded across millions of iterations.
+fn request_span_work(traceparent: &str, exporter: Option<&InMemorySpanExporter>) {
     let span = http_request_span("POST", "/query");
     if otel::is_active() {
-        attach_parent(&span, Some(SAMPLE_TRACEPARENT), None);
+        attach_parent(&span, Some(traceparent), None);
     }
     span.record("aletheiadb.operation", "create_node");
     span.record("aletheiadb.result.count", 1_i64);
     span.record("aletheiadb.temporal.scope", "current");
-    let _entered = span.enter();
-    black_box(&span);
+    {
+        let _entered = span.enter();
+        black_box(&span);
+    }
+    // Bound memory: keep the in-memory buffer from growing without limit.
+    if let Some(exp) = exporter {
+        exp.clear();
+    }
 }
 
-/// Install a global in-memory subscriber once, with the given sampler.
-fn install_global(sampler: SamplerConfig) -> InMemorySpanExporter {
+/// Install the global in-memory subscriber exactly once (parent-based sampler so
+/// the incoming flag decides sampled-out vs recorded per request).
+fn install_global() -> InMemorySpanExporter {
     static EXPORTER: OnceLock<InMemorySpanExporter> = OnceLock::new();
     EXPORTER
         .get_or_init(|| {
             let config = OtelConfig {
                 enabled: true,
-                sampler,
+                sampler: SamplerConfig::ParentBasedAlwaysOn,
                 ..OtelConfig::default()
             };
             let (guard, exp) =
                 otel::init_in_memory_global(&config).expect("install global otel subscriber");
+            // Leak the guard so tracing stays active for the whole bench binary.
             std::mem::forget(guard);
             exp
         })
@@ -61,20 +85,26 @@ fn install_global(sampler: SamplerConfig) -> InMemorySpanExporter {
 }
 
 fn bench_disabled(c: &mut Criterion) {
-    // No subscriber installed: spans are `tracing` no-ops. This is the
-    // compiled-in-but-off cost that must stay within noise.
+    // Registered first and measured before any global subscriber exists, so this
+    // is the true compiled-in-but-off cost.
+    assert!(
+        !otel::is_active(),
+        "the disabled bench must run before any subscriber is installed"
+    );
     c.bench_function("otel/disabled_request_span", |b| {
-        b.iter(request_span_work);
+        b.iter(|| request_span_work(SAMPLED_TRACEPARENT, None));
     });
 }
 
 fn bench_enabled(c: &mut Criterion) {
-    // Install the global subscriber once. The sampler is process-global, so we
-    // measure the "recorded" regime (AlwaysOn). The sampled-out regime is a
-    // separate benchmark binary in CI; here we bound the full-cost path.
-    let _exp = install_global(SamplerConfig::AlwaysOn);
+    let exp = install_global();
+
+    c.bench_function("otel/enabled_sampled_out_request_span", |b| {
+        b.iter(|| request_span_work(UNSAMPLED_TRACEPARENT, Some(&exp)));
+    });
+
     c.bench_function("otel/enabled_recorded_request_span", |b| {
-        b.iter(request_span_work);
+        b.iter(|| request_span_work(SAMPLED_TRACEPARENT, Some(&exp)));
     });
 }
 

--- a/benches/otel_overhead.rs
+++ b/benches/otel_overhead.rs
@@ -1,0 +1,82 @@
+//! OpenTelemetry tracing overhead bench (Issue #3376).
+//!
+//! Guards the AC "overhead bounded and measured": the cost of the tracing hot
+//! path when the exporter is **compiled in but disabled** must be
+//! indistinguishable from noise, and the cost when **enabled** must be small
+//! and bounded. It compares three regimes for the per-request span work:
+//!
+//! - `disabled`: the span builder + attribute recording with no active
+//!   subscriber (a compiled-in-but-off deployment). This is the number that
+//!   must stay ~0 against the `performance_targets` suite.
+//! - `enabled_sampled_out`: the exporter is active but the head sampler drops
+//!   the trace, so no span is constructed on the hot path.
+//! - `enabled_recorded`: the exporter is active and the trace is sampled;
+//!   the span is built, an incoming W3C context is attached, and attributes
+//!   are recorded (the full cost, paid only for sampled requests).
+//!
+//! Run with: `cargo bench --bench otel_overhead --features otel`
+//! Build-only gate: `cargo bench --no-run --features otel`.
+
+use std::hint::black_box;
+use std::sync::OnceLock;
+
+use aletheiadb::observability::http_request_span;
+use aletheiadb::observability::otel::{
+    self, InMemorySpanExporter, OtelConfig, SamplerConfig, attach_parent,
+};
+use criterion::{Criterion, criterion_group, criterion_main};
+
+const SAMPLE_TRACEPARENT: &str = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+/// Exercise the per-request span work: build the root span, attach an incoming
+/// W3C context, and record the safe-by-default attributes.
+fn request_span_work() {
+    let span = http_request_span("POST", "/query");
+    if otel::is_active() {
+        attach_parent(&span, Some(SAMPLE_TRACEPARENT), None);
+    }
+    span.record("aletheiadb.operation", "create_node");
+    span.record("aletheiadb.result.count", 1_i64);
+    span.record("aletheiadb.temporal.scope", "current");
+    let _entered = span.enter();
+    black_box(&span);
+}
+
+/// Install a global in-memory subscriber once, with the given sampler.
+fn install_global(sampler: SamplerConfig) -> InMemorySpanExporter {
+    static EXPORTER: OnceLock<InMemorySpanExporter> = OnceLock::new();
+    EXPORTER
+        .get_or_init(|| {
+            let config = OtelConfig {
+                enabled: true,
+                sampler,
+                ..OtelConfig::default()
+            };
+            let (guard, exp) =
+                otel::init_in_memory_global(&config).expect("install global otel subscriber");
+            std::mem::forget(guard);
+            exp
+        })
+        .clone()
+}
+
+fn bench_disabled(c: &mut Criterion) {
+    // No subscriber installed: spans are `tracing` no-ops. This is the
+    // compiled-in-but-off cost that must stay within noise.
+    c.bench_function("otel/disabled_request_span", |b| {
+        b.iter(request_span_work);
+    });
+}
+
+fn bench_enabled(c: &mut Criterion) {
+    // Install the global subscriber once. The sampler is process-global, so we
+    // measure the "recorded" regime (AlwaysOn). The sampled-out regime is a
+    // separate benchmark binary in CI; here we bound the full-cost path.
+    let _exp = install_global(SamplerConfig::AlwaysOn);
+    c.bench_function("otel/enabled_recorded_request_span", |b| {
+        b.iter(request_span_work);
+    });
+}
+
+criterion_group!(benches, bench_disabled, bench_enabled);
+criterion_main!(benches);

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -27,6 +27,27 @@ The crate emits named `tracing` spans such as:
 Applications install their own `tracing` subscriber, including any
 `tracing-opentelemetry` layer.
 
+### OTLP export (feature `otel`, Issue #3376)
+
+For a batteries-included OpenTelemetry story — an OTLP exporter, head sampling,
+W3C `traceparent`/`tracestate` propagation across the HTTP surface, and trace-id
+correlation in error responses — enable the `otel` feature (it composes with
+`observability`):
+
+```toml
+aletheiadb = { version = "0.3", features = ["http-server", "otel"] }
+```
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318" \
+  cargo run --bin aletheia-server --features http-server,otel
+```
+
+See **[guides/otel-tracing-guide.md](guides/otel-tracing-guide.md)** for
+enablement, exporter/env configuration, sampling guidance, the attribute/privacy
+model, and a worked "find the slow query" walkthrough with a collector + Jaeger
+compose example.
+
 ## Metrics
 
 Metrics flow through `observability::MetricsRecorder`. The default recorder is

--- a/docs/guides/otel-tracing-guide.md
+++ b/docs/guides/otel-tracing-guide.md
@@ -1,0 +1,205 @@
+# OpenTelemetry Distributed Tracing (Issue #3376)
+
+AletheiaDB emits [OpenTelemetry](https://opentelemetry.io/) spans for every
+HTTP request, query execution, and write transaction, and joins them to your
+application's traces via standard W3C context propagation. When a `hybrid_query`
+gets slow, a trace decomposes it into its traversal, k-NN, and
+temporal-reconstruction phases — an explainability artifact no incumbent graph
+database produces.
+
+This complements, and never duplicates, the metrics contract (ADR 0056) and
+Tracy micro-profiling. Metrics tell you *that* p99 spiked; traces tell you
+*which request, doing what, spent time where*.
+
+## Enablement
+
+Tracing lives behind the **`otel`** Cargo feature (which composes with
+`observability`). It is compiled out entirely when the feature is absent, so a
+build without `otel` pays exactly zero — the `observability::otel` module and
+all of its call sites do not exist.
+
+```toml
+# Cargo.toml
+aletheiadb = { version = "0.3", features = ["http-server", "otel"] }
+```
+
+Even compiled in, tracing stays **off** until initialized. The HTTP server
+(`aletheia-server`) turns it on when either `ALETHEIADB_OTEL` is truthy or an
+OTLP endpoint is configured:
+
+```bash
+# Point at your collector and start the server.
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
+export OTEL_SERVICE_NAME="aletheiadb"
+cargo run --bin aletheia-server --features http-server,otel
+```
+
+Programmatic (embedded) use installs the subscriber yourself and holds the
+returned guard for the process lifetime:
+
+```rust
+use aletheiadb::observability::otel::{self, OtelConfig};
+
+let _guard = otel::init(&OtelConfig::from_env())?; // Option<OtelGuard>
+// ... run workload ...
+// dropping `_guard` flushes and shuts the exporter down.
+```
+
+## Exporter and environment configuration
+
+The exporter speaks **OTLP over HTTP/protobuf** and reads the standard
+OpenTelemetry environment variables:
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector endpoint | `http://localhost:4318` |
+| `OTEL_SERVICE_NAME` | `service.name` resource attribute | `aletheiadb` |
+| `OTEL_TRACES_SAMPLER` | Head sampler (see below) | `parentbased_always_on` |
+| `OTEL_TRACES_SAMPLER_ARG` | Sampler ratio for the ratio samplers | `1.0` |
+| `ALETHEIADB_OTEL` | Master enable switch (`1`/`true`/`yes`/`on`) | off |
+| `ALETHEIADB_OTEL_CAPTURE_STATEMENTS` | Opt in to statement capture | off |
+
+## Sampling
+
+Head sampling is configured with `OTEL_TRACES_SAMPLER`:
+
+| Value | Behavior |
+|-------|----------|
+| `always_on` | Sample every trace |
+| `always_off` | Sample none |
+| `traceidratio` | Sample a fraction (`OTEL_TRACES_SAMPLER_ARG`, e.g. `0.01`) |
+| `parentbased_always_on` (default) | Honor the caller's decision; sample roots |
+| `parentbased_always_off` | Honor the caller's decision; drop roots |
+| `parentbased_traceidratio` | Honor the caller's decision; sample a fraction of roots |
+
+**Guidance.** In production use `parentbased_traceidratio` with a low ratio
+(1% is a good start): traces that arrive already-sampled from an upstream
+service are always continued (so you never get half a waterfall), while
+locally-rooted traces are sampled at your budget. A **sampled-out** request
+skips span construction on the hot path, so raising the ratio is the only knob
+that trades cost for coverage.
+
+## Attributes and the privacy model
+
+Spans are **safe by default**. They carry:
+
+- `db.system.name` (`aletheiadb`), `http.request.method`, `url.path` (route, not
+  query string);
+- `aletheiadb.operation` — the operation name (bounded set);
+- `aletheiadb.result.count` — number of entities/rows returned;
+- `aletheiadb.temporal.scope` — `as_of` vs `current`;
+- `aletheiadb.error.code` — the structured error code (Issue #3234) on failure;
+- the existing DB child-span attributes (query kind, durability mode,
+  transaction id, vector property, …).
+
+What is **never** emitted:
+
+- **Credentials.** API keys, the `Authorization` header, and bearer tokens are
+  never read into a span. The W3C carriers only touch `traceparent` and
+  `tracestate`. (A CI test captures spans and asserts the credential material
+  never appears.)
+- **Property values.** No node/edge property value is ever an attribute.
+- **Statement text**, unless you opt in with
+  `ALETHEIADB_OTEL_CAPTURE_STATEMENTS=1`. Even then only the query *template* is
+  attached as `db.query.text` (following OTel database semantic conventions);
+  parameters use `$`-bindings, so values are not interpolated.
+
+## Context propagation and correlation
+
+Incoming W3C `traceparent`/`tracestate` headers are honored, so AletheiaDB's
+spans appear as children inside your caller's trace. With no incoming context,
+AletheiaDB starts a fresh root trace — never a dangling child of framework
+middleware.
+
+Failures expose the active trace id for direct lookup in your backend: error
+responses carry a `trace_id` body field **and** an `x-trace-id` response header.
+
+```json
+{ "success": false, "error": "Node 999 not found", "trace_id": "0af7651916cd43dd8448eb211c80319c" }
+```
+
+## Overhead
+
+Overhead is bounded and enforced as a bench gate (`benches/otel_overhead.rs`):
+
+- **Compiled in but disabled**: within noise of the `performance_targets`
+  suite — spans are `tracing` no-ops.
+- **Enabled at low sampling**: small, bounded — sampled-out requests skip span
+  construction entirely.
+
+## Find-the-slow-query walkthrough (collector + Jaeger)
+
+A minimal local stack: an OpenTelemetry Collector receiving OTLP and forwarding
+to Jaeger.
+
+```yaml
+# docker-compose.yml
+services:
+  jaeger:
+    image: jaegertracing/all-in-one:1.60
+    ports:
+      - "16686:16686"   # Jaeger UI
+      - "4317"          # OTLP gRPC (internal)
+  otel-collector:
+    image: otel/opentelemetry-collector:0.106.1
+    command: ["--config=/etc/otel-collector.yaml"]
+    volumes:
+      - ./otel-collector.yaml:/etc/otel-collector.yaml
+    ports:
+      - "4318:4318"     # OTLP HTTP (AletheiaDB exports here)
+    depends_on: [jaeger]
+```
+
+```yaml
+# otel-collector.yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+exporters:
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp/jaeger]
+```
+
+Run it, then start AletheiaDB pointed at the collector:
+
+```bash
+docker compose up -d
+OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318" \
+OTEL_TRACES_SAMPLER="always_on" \
+ALETHEIADB_AUTH_MODE=anonymous \
+  cargo run --bin aletheia-server --features http-server,otel
+```
+
+Now diagnose a slow operation:
+
+1. Open the Jaeger UI at <http://localhost:16686> and pick service `aletheiadb`.
+2. Filter by the operation attribute — e.g. `aletheiadb.operation=execute_query`
+   — to slice to the query shape you suspect, or sort by duration to surface the
+   outliers.
+3. Open a slow trace. The `aletheiadb.http.request` root span decomposes into
+   child spans: `aletheiadb.query.execute`, `aletheiadb.vector.search`,
+   `aletheiadb.temporal.query`, `aletheiadb.transaction.commit`. The widest
+   child is the slow phase.
+4. If the request failed, read `aletheiadb.error.code` on the span (or the
+   `trace_id` returned in the error response) and jump straight to that trace.
+
+For an agent request that carried a `traceparent` in, the AletheiaDB spans are
+already nested inside the agent's trace — the database is no longer a black hole
+in the waterfall.
+
+## See also
+
+- [ADR 0056 — Observability Contract](../adr/0056-observability-contract.md)
+- [docs/OBSERVABILITY.md](../OBSERVABILITY.md)
+- [Access control matrix](access-control-matrix.md) (no new routes are added by
+  tracing; the `x-trace-id` header and `trace_id` field are additive to existing
+  responses)

--- a/docs/guides/otel-tracing-guide.md
+++ b/docs/guides/otel-tracing-guide.md
@@ -75,9 +75,20 @@ Head sampling is configured with `OTEL_TRACES_SAMPLER`:
 **Guidance.** In production use `parentbased_traceidratio` with a low ratio
 (1% is a good start): traces that arrive already-sampled from an upstream
 service are always continued (so you never get half a waterfall), while
-locally-rooted traces are sampled at your budget. A **sampled-out** request
-skips span construction on the hot path, so raising the ratio is the only knob
-that trades cost for coverage.
+locally-rooted traces are sampled at your budget.
+
+For a **sampled-out** request the root span is still *constructed* (the
+`tracing` layer runs the sampler at span creation, and the incoming W3C context
+is still attached first so parent-based sampling can honor the caller's
+decision), but it is **not recorded or exported**, and the per-request attribute
+recording (operation, result count, temporal scope, error code) is **skipped** —
+the hot path detects the not-recording span and does no attribute work. The
+residual cost of a sampled-out request is therefore the span construction plus
+the sampler decision, not the full attribute set; raising the ratio trades that
+remaining headroom for coverage. See [Overhead](#overhead).
+
+The ratio arg (`OTEL_TRACES_SAMPLER_ARG`) is clamped to `[0.0, 1.0]`; an
+out-of-range or non-numeric value falls back to full sampling (`1.0`).
 
 ## Attributes and the privacy model
 
@@ -104,6 +115,15 @@ What is **never** emitted:
   attached as `db.query.text` (following OTel database semantic conventions);
   parameters use `$`-bindings, so values are not interpolated.
 
+  > **Warning — enabling statement capture can leak literal values.** The
+  > captured `db.query.text` is the statement string *exactly as submitted*. If
+  > a caller inlines literal values into the statement (e.g.
+  > `MATCH (n {ssn: '123-45-6789'})` instead of `{ssn: $ssn}`), those literals
+  > land in the exported span and travel to your trace backend. Statement
+  > capture is off by default for this reason. When you enable it, keep values
+  > out of traces by using `$param` bindings for every value — the binding
+  > names are captured, the bound values are not.
+
 ## Context propagation and correlation
 
 Incoming W3C `traceparent`/`tracestate` headers are honored, so AletheiaDB's
@@ -120,12 +140,28 @@ responses carry a `trace_id` body field **and** an `x-trace-id` response header.
 
 ## Overhead
 
-Overhead is bounded and enforced as a bench gate (`benches/otel_overhead.rs`):
+Overhead is bounded and measured across three regimes:
 
-- **Compiled in but disabled**: within noise of the `performance_targets`
-  suite — spans are `tracing` no-ops.
-- **Enabled at low sampling**: small, bounded — sampled-out requests skip span
-  construction entirely.
+- **Compiled in but disabled** (no subscriber installed): spans are `tracing`
+  no-ops and the per-request attribute sites are skipped entirely — within noise
+  of the `performance_targets` suite.
+- **Enabled, sampled out**: the span is constructed and the sampler runs, but
+  the span is neither recorded nor exported and the per-request attribute
+  recording is skipped (the hot path checks the not-recording span first). This
+  is *not* zero — it is span construction plus the sampler decision — but it is
+  small and bounded.
+- **Enabled, recorded**: the full cost — span construction, W3C context attach,
+  and attribute recording — paid only for sampled requests.
+
+**How the gate is enforced.** The authoritative, non-flaky gate is a structural
+**inertness assertion** that runs in the normal `cargo test` suite (and thus in
+CI): with the `otel` feature compiled but tracing **not** initialized, it asserts
+`otel::is_active() == false` and that exercising the request-span hot path
+exports **zero** spans and does not panic — proving the disabled path is inert.
+The criterion micro-bench (`benches/otel_overhead.rs`) measures the three
+regimes above for local/manual profiling; wiring the criterion bench into the
+CI benchmark workflow is a follow-up (see the PR notes). Build the bench with
+`cargo bench --no-run --bench otel_overhead --features otel`.
 
 ## Find-the-slow-query walkthrough (collector + Jaeger)
 

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -59,7 +59,8 @@ impl AletheiaHttpError {
         }
     }
 
-    /// Stable machine-readable code, present only for auth errors (additive).
+    /// Stable machine-readable code, present only for auth errors in the
+    /// response body (additive; preserved for backward compatibility).
     fn code(&self) -> Option<&'static str> {
         match self {
             Self::Unauthorized => Some("UNAUTHENTICATED"),
@@ -67,12 +68,30 @@ impl AletheiaHttpError {
             _ => None,
         }
     }
-}
 
-impl IntoResponse for AletheiaHttpError {
-    fn into_response(self) -> Response {
+    /// Stable machine-readable code for *every* variant, using the Issue #3234
+    /// vocabulary. Used to stamp `aletheiadb.error.code` onto the trace span
+    /// (Issue #3376); the response body still only carries [`code`](Self::code)
+    /// for auth errors so the existing wire shape is unchanged.
+    #[must_use]
+    pub(crate) fn code_str(&self) -> &'static str {
+        match self {
+            Self::BadRequest(_) | Self::QueryParse(_) => "INVALID_ARGUMENT",
+            Self::NotFound(_) => "NOT_FOUND",
+            Self::Internal(_) | Self::StateMissing => "INTERNAL",
+            Self::Unauthorized => "UNAUTHENTICATED",
+            Self::PermissionDenied(_) => "PERMISSION_DENIED",
+        }
+    }
+
+    /// Convert to a response, additively including the active trace id
+    /// (Issue #3376) as a `trace_id` body field and `x-trace-id` header when
+    /// one is available, so a failing call can be looked up in the trace
+    /// backend directly.
+    #[must_use]
+    pub(crate) fn into_response_with_trace(self, trace_id: Option<String>) -> Response {
         let status = self.status();
-        let body = match self.code() {
+        let mut body = match self.code() {
             // Auth errors additively carry a stable `code` field.
             Some(code) => json!({
                 "success": false,
@@ -84,6 +103,9 @@ impl IntoResponse for AletheiaHttpError {
                 "error": self.to_string(),
             }),
         };
+        if let (Some(map), Some(tid)) = (body.as_object_mut(), trace_id.as_deref()) {
+            map.insert("trace_id".to_string(), json!(tid));
+        }
         let mut response = (status, Json(body)).into_response();
         if matches!(self, Self::Unauthorized) {
             response.headers_mut().insert(
@@ -91,6 +113,21 @@ impl IntoResponse for AletheiaHttpError {
                 axum::http::HeaderValue::from_static("Bearer"),
             );
         }
+        if let Some(tid) = trace_id.and_then(|t| axum::http::HeaderValue::from_str(&t).ok()) {
+            response
+                .headers_mut()
+                .insert(axum::http::HeaderName::from_static("x-trace-id"), tid);
+        }
         response
+    }
+}
+
+impl IntoResponse for AletheiaHttpError {
+    fn into_response(self) -> Response {
+        // Auto-conversion path (extractor rejections, `?` in handlers not
+        // wrapped in a root span): include a trace id if one happens to be
+        // active on this thread.
+        let trace_id = crate::http::trace::active_trace_id();
+        self.into_response_with_trace(trace_id)
     }
 }

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -74,6 +74,9 @@ impl AletheiaHttpError {
     /// (Issue #3376); the response body still only carries [`code`](Self::code)
     /// for auth errors so the existing wire shape is unchanged.
     #[must_use]
+    // Only consumed by the tracing span-stamping path, which is compiled out
+    // when `observability` is disabled; keep it available without warning.
+    #[cfg_attr(not(feature = "observability"), allow(dead_code))]
     pub(crate) fn code_str(&self) -> &'static str {
         match self {
             Self::BadRequest(_) | Self::QueryParse(_) => "INVALID_ARGUMENT",

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -697,10 +697,26 @@ pub async fn handle_query(
     state: AppState,
     Json(req): Json<QueryRequest>,
 ) -> Response {
-    trace.record_operation(operation_name(&req));
-    trace.record_temporal_scope(request_is_temporal(&req));
+    // Compute and stamp per-request attributes only when the span will actually
+    // be recorded (Issue #3376, MED2 / Perf). A feature-absent build compiles
+    // this block out entirely; a runtime-disabled or head-sampled-out span
+    // short-circuits `is_recording()` so the (otherwise-wasted) attribute
+    // computation — including `request_is_temporal`'s statement scan — never
+    // runs.
+    #[cfg(feature = "observability")]
+    let recording = trace.is_recording();
+    #[cfg(feature = "observability")]
+    if recording {
+        trace.record_operation(operation_name(&req));
+        trace.record_temporal_scope(request_is_temporal(&req));
+    }
     #[cfg(feature = "otel")]
     maybe_capture_statement(&trace, &req);
+    // In an observability-off build the extractor still runs (zero-sized no-op),
+    // but nothing consumes `trace`; keep it "used" without renaming the field
+    // (which is genuinely used under `observability`).
+    #[cfg(not(feature = "observability"))]
+    let _ = &trace;
 
     #[cfg(feature = "observability")]
     let span = trace.span();
@@ -759,11 +775,17 @@ pub async fn handle_query(
 
     match result {
         Ok(data) => {
-            trace.record_result_count(result_count(&data));
+            #[cfg(feature = "observability")]
+            if recording {
+                trace.record_result_count(result_count(&data));
+            }
             Json(ApiResponse::success(data)).into_response()
         }
         Err(e) => {
-            trace.record_error(e.code_str());
+            #[cfg(feature = "observability")]
+            if recording {
+                trace.record_error(e.code_str());
+            }
             #[cfg(feature = "observability")]
             let trace_id = span.in_scope(crate::http::trace::active_trace_id);
             #[cfg(not(feature = "observability"))]
@@ -775,6 +797,7 @@ pub async fn handle_query(
 
 /// The stable operation-name attribute for a `/query` request (bounded set,
 /// never user data).
+#[cfg(feature = "observability")]
 fn operation_name(req: &QueryRequest) -> &'static str {
     match req {
         QueryRequest::FindNode { .. } => "find_node",
@@ -792,6 +815,7 @@ fn operation_name(req: &QueryRequest) -> &'static str {
 
 /// Result-count attribute for a response payload: array length, `nodes` array
 /// length for the bulk-get shape, otherwise `1` for a single entity.
+#[cfg(feature = "observability")]
 fn result_count(data: &Value) -> usize {
     match data {
         Value::Array(items) => items.len(),
@@ -806,9 +830,19 @@ fn result_count(data: &Value) -> usize {
 /// Whether a request carries a temporal (`AS OF`) scope. Only statement-based
 /// operations can; detection is a cheap case-insensitive substring check that
 /// never inspects property values.
+#[cfg(feature = "observability")]
 fn request_is_temporal(req: &QueryRequest) -> bool {
+    /// Allocation-free, case-insensitive scan for the `as of` temporal marker.
+    /// The previous `to_ascii_lowercase().contains(..)` allocated a full
+    /// lowercased copy of the statement on every request; scanning byte windows
+    /// with `eq_ignore_ascii_case` matches identically for the ASCII needle
+    /// while allocating nothing (Issue #3376, MED2 / Perf).
     fn is_as_of(query: &str) -> bool {
-        query.to_ascii_lowercase().contains("as of")
+        const NEEDLE: &[u8] = b"as of";
+        query
+            .as_bytes()
+            .windows(NEEDLE.len())
+            .any(|w| w.eq_ignore_ascii_case(NEEDLE))
     }
     match req {
         QueryRequest::ExecuteQuery { query, .. } => is_as_of(query),

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -25,6 +25,7 @@ use crate::http::converters::{
 };
 use crate::http::error::AletheiaHttpError;
 use crate::http::state::AppState;
+use crate::http::trace::HttpTrace;
 use crate::query::QueryBuilder;
 use crate::query::converter::{parse_query, parse_query_with_params};
 use crate::query::ir::{Predicate, PredicateValue};
@@ -32,6 +33,7 @@ use crate::query::read_only::detect_mutating_clause;
 use autumn_web::Route;
 use autumn_web::prelude::{get, post, routes};
 use axum::Json;
+use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet};
@@ -55,7 +57,15 @@ pub struct HealthResponse {
 /// Classified [`AccessClass::Metrics`]: every role may probe liveness, but
 /// (in required-auth mode) only with a valid credential.
 #[get("/status")]
-pub async fn health_check(auth: AuthContext) -> Result<Json<HealthResponse>, AletheiaHttpError> {
+pub async fn health_check(
+    trace: HttpTrace,
+    auth: AuthContext,
+) -> Result<Json<HealthResponse>, AletheiaHttpError> {
+    trace.record_operation("health");
+    // Enter the root span so the probe is a first-class (non-orphaned) span.
+    // There is no `.await` inside this block, so holding the guard is sound.
+    #[cfg(feature = "observability")]
+    let _entered = trace.span().entered();
     auth.authorize(AccessClass::Metrics)?;
     Ok(Json(HealthResponse {
         status: "healthy".to_string(),
@@ -174,14 +184,25 @@ fn json_to_predicate_value(v: &Value) -> Option<PredicateValue> {
 }
 
 /// Run a CPU/IO-bound closure on the blocking pool and unwrap the join error.
+///
+/// The caller's current `tracing` span is propagated into the blocking thread
+/// and entered for the duration of `f`, so the database's own child spans
+/// (`aletheiadb.query.execute`, `aletheiadb.transaction.commit`, …) nest under
+/// the HTTP root span even though they run on a different thread (Issue #3376).
 async fn blocking<F, T>(f: F) -> Result<T, AletheiaHttpError>
 where
     F: FnOnce() -> Result<T, AletheiaHttpError> + Send + 'static,
     T: Send + 'static,
 {
-    tokio::task::spawn_blocking(f)
-        .await
-        .map_err(|e| AletheiaHttpError::Internal(e.to_string()))?
+    #[cfg(feature = "observability")]
+    let span = tracing::Span::current();
+    tokio::task::spawn_blocking(move || {
+        #[cfg(feature = "observability")]
+        let _entered = span.enter();
+        f()
+    })
+    .await
+    .map_err(|e| AletheiaHttpError::Internal(e.to_string()))?
 }
 
 // ============================================================================
@@ -664,53 +685,151 @@ fn query_access_class(req: &QueryRequest) -> AccessClass {
 /// Authorization happens *before* any database work: the request's operation
 /// is classified via [`query_access_class`] and checked against the caller's
 /// role.
+///
+/// The whole handler body runs inside the [`HttpTrace`] root span (Issue
+/// #3376), so the database's query/write child spans nest underneath it, the
+/// operation name / result count / error code are stamped onto the span, and a
+/// failure carries the active trace id back to the caller for correlation.
 #[post("/query")]
 pub async fn handle_query(
+    trace: HttpTrace,
     auth: AuthContext,
     state: AppState,
     Json(req): Json<QueryRequest>,
-) -> Result<Json<ApiResponse>, AletheiaHttpError> {
-    auth.authorize(query_access_class(&req))?;
-    let db = state.db_arc();
-    // Verified principal name (if any) for provenance stamping on write
-    // operations (Issue #3350). Anonymous mode yields None.
-    let principal = auth.principal().map(|p| p.name.clone());
+) -> Response {
+    trace.record_operation(operation_name(&req));
+    trace.record_temporal_scope(request_is_temporal(&req));
+    #[cfg(feature = "otel")]
+    maybe_capture_statement(&trace, &req);
 
-    let data = match req {
-        QueryRequest::CreateNode { label, properties } => {
-            handle_create_node(db, label, properties, principal).await?
-        }
-        QueryRequest::GetNode { node_id } => handle_get_node(db, node_id).await?,
-        QueryRequest::BulkCreateNodes { nodes } => {
-            handle_bulk_create_nodes(db, nodes, principal).await?
-        }
-        QueryRequest::BulkGetNodes { node_ids } => handle_bulk_get_nodes(db, node_ids).await?,
-        QueryRequest::BulkUpdateNodes { updates } => {
-            handle_bulk_update_nodes(db, updates, principal).await?
-        }
-        QueryRequest::BulkDeleteNodes { node_ids, cascade } => {
-            handle_bulk_delete_nodes(db, node_ids, cascade).await?
-        }
-        QueryRequest::FindNode {
-            label,
-            properties,
-            limit,
-            offset,
-        } => handle_find_node(db, label, properties, limit, offset).await?,
-        QueryRequest::FindNeighbors {
-            node_id,
-            limit,
-            offset,
-        } => handle_find_neighbors(db, node_id, limit, offset).await?,
-        QueryRequest::ExecuteQuery { query, parameters } => {
-            handle_execute_query(db, query, parameters).await?
-        }
-        QueryRequest::BulkExecuteQuery { queries } => {
-            handle_bulk_execute_query(db, queries).await?
-        }
+    #[cfg(feature = "observability")]
+    let span = trace.span();
+
+    // Authorization + dispatch, returning the JSON data payload or an error.
+    let work = async move {
+        auth.authorize(query_access_class(&req))?;
+        let db = state.db_arc();
+        // Verified principal name (if any) for provenance stamping on write
+        // operations (Issue #3350). Anonymous mode yields None.
+        let principal = auth.principal().map(|p| p.name.clone());
+
+        let data = match req {
+            QueryRequest::CreateNode { label, properties } => {
+                handle_create_node(db, label, properties, principal).await?
+            }
+            QueryRequest::GetNode { node_id } => handle_get_node(db, node_id).await?,
+            QueryRequest::BulkCreateNodes { nodes } => {
+                handle_bulk_create_nodes(db, nodes, principal).await?
+            }
+            QueryRequest::BulkGetNodes { node_ids } => handle_bulk_get_nodes(db, node_ids).await?,
+            QueryRequest::BulkUpdateNodes { updates } => {
+                handle_bulk_update_nodes(db, updates, principal).await?
+            }
+            QueryRequest::BulkDeleteNodes { node_ids, cascade } => {
+                handle_bulk_delete_nodes(db, node_ids, cascade).await?
+            }
+            QueryRequest::FindNode {
+                label,
+                properties,
+                limit,
+                offset,
+            } => handle_find_node(db, label, properties, limit, offset).await?,
+            QueryRequest::FindNeighbors {
+                node_id,
+                limit,
+                offset,
+            } => handle_find_neighbors(db, node_id, limit, offset).await?,
+            QueryRequest::ExecuteQuery { query, parameters } => {
+                handle_execute_query(db, query, parameters).await?
+            }
+            QueryRequest::BulkExecuteQuery { queries } => {
+                handle_bulk_execute_query(db, queries).await?
+            }
+        };
+        Ok::<Value, AletheiaHttpError>(data)
     };
 
-    Ok(Json(ApiResponse::success(data)))
+    #[cfg(feature = "observability")]
+    let result = {
+        use tracing::Instrument;
+        work.instrument(span.clone()).await
+    };
+    #[cfg(not(feature = "observability"))]
+    let result = work.await;
+
+    match result {
+        Ok(data) => {
+            trace.record_result_count(result_count(&data));
+            Json(ApiResponse::success(data)).into_response()
+        }
+        Err(e) => {
+            trace.record_error(e.code_str());
+            #[cfg(feature = "observability")]
+            let trace_id = span.in_scope(crate::http::trace::active_trace_id);
+            #[cfg(not(feature = "observability"))]
+            let trace_id = crate::http::trace::active_trace_id();
+            e.into_response_with_trace(trace_id)
+        }
+    }
+}
+
+/// The stable operation-name attribute for a `/query` request (bounded set,
+/// never user data).
+fn operation_name(req: &QueryRequest) -> &'static str {
+    match req {
+        QueryRequest::FindNode { .. } => "find_node",
+        QueryRequest::GetNode { .. } => "get_node",
+        QueryRequest::CreateNode { .. } => "create_node",
+        QueryRequest::BulkCreateNodes { .. } => "bulk_create_nodes",
+        QueryRequest::BulkGetNodes { .. } => "bulk_get_nodes",
+        QueryRequest::BulkUpdateNodes { .. } => "bulk_update_nodes",
+        QueryRequest::BulkDeleteNodes { .. } => "bulk_delete_nodes",
+        QueryRequest::FindNeighbors { .. } => "find_neighbors",
+        QueryRequest::ExecuteQuery { .. } => "execute_query",
+        QueryRequest::BulkExecuteQuery { .. } => "bulk_execute_query",
+    }
+}
+
+/// Result-count attribute for a response payload: array length, `nodes` array
+/// length for the bulk-get shape, otherwise `1` for a single entity.
+fn result_count(data: &Value) -> usize {
+    match data {
+        Value::Array(items) => items.len(),
+        Value::Object(map) => map
+            .get("nodes")
+            .and_then(Value::as_array)
+            .map_or(1, Vec::len),
+        _ => 1,
+    }
+}
+
+/// Whether a request carries a temporal (`AS OF`) scope. Only statement-based
+/// operations can; detection is a cheap case-insensitive substring check that
+/// never inspects property values.
+fn request_is_temporal(req: &QueryRequest) -> bool {
+    fn is_as_of(query: &str) -> bool {
+        query.to_ascii_lowercase().contains("as of")
+    }
+    match req {
+        QueryRequest::ExecuteQuery { query, .. } => is_as_of(query),
+        QueryRequest::BulkExecuteQuery { queries } => queries.iter().any(|q| is_as_of(&q.query)),
+        _ => false,
+    }
+}
+
+/// Attach sanitized statement text to the span when statement capture is
+/// explicitly enabled. Only single-statement `execute_query` is captured; the
+/// statement is the query template (parameters are `$`-bound, so no property
+/// values are interpolated). Off by default (Issue #3376 privacy model).
+#[cfg(feature = "otel")]
+fn maybe_capture_statement(trace: &HttpTrace, req: &QueryRequest) {
+    if !crate::observability::otel::is_active() || !crate::observability::otel::capture_statements()
+    {
+        return;
+    }
+    if let QueryRequest::ExecuteQuery { query, .. } = req {
+        trace.record_statement(query);
+    }
 }
 
 /// Collect the crate's HTTP routes as a `Vec<Route>`.

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -39,6 +39,7 @@ mod error;
 pub mod handlers;
 mod server;
 mod state;
+pub mod trace;
 
 pub use auth::{AuthContext, AuthState, validate_auth_startup};
 pub use config::{
@@ -48,3 +49,4 @@ pub use error::AletheiaHttpError;
 pub use handlers::{ApiResponse, QueryRequest, handle_query, health_check};
 pub use server::{build_test_router, build_test_router_with_auth, run_server};
 pub use state::AppState;
+pub use trace::HttpTrace;

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -78,6 +78,22 @@ use crate::http::state::AppState;
 /// (e.g. failing to bind the port) terminate the process via
 /// [`std::process::exit`]; they are not surfaced as `Err` here.
 pub async fn run_server(config: ServerConfig) -> std::io::Result<()> {
+    // Install OpenTelemetry tracing from the standard OTEL_* environment
+    // (Issue #3376). Disabled unless ALETHEIADB_OTEL is truthy or an OTLP
+    // endpoint is configured; the guard flushes + shuts the exporter down when
+    // `run_server` returns. A subscriber-already-installed error is non-fatal
+    // (the host process may own the subscriber).
+    #[cfg(feature = "otel")]
+    let _otel_guard =
+        match crate::observability::otel::init(&crate::observability::otel::OtelConfig::from_env())
+        {
+            Ok(guard) => guard,
+            Err(e) => {
+                eprintln!("WARNING: OpenTelemetry tracing not installed: {e}");
+                None
+            }
+        };
+
     // Validate config before wiring anything else.
     config
         .rate_limit()

--- a/src/http/trace.rs
+++ b/src/http/trace.rs
@@ -1,0 +1,161 @@
+//! HTTP root-span extractor and W3C context propagation (Issue #3376).
+//!
+//! autumn-web's sealed `IntoAppLayer` bound blocks arbitrary tower middleware
+//! on the production `run_server` path (see [`server`](super::server) and
+//! [`auth`](super::auth)), so — exactly like [`AuthContext`](super::AuthContext)
+//! — the HTTP root span is created by an **extractor** that runs before the
+//! handler body rather than a tower `Layer`. This keeps production and the
+//! test router in parity.
+//!
+//! The extractor:
+//!
+//! - builds the [`SPAN_HTTP_REQUEST`](crate::observability::SPAN_HTTP_REQUEST)
+//!   root span carrying the request method and route path;
+//! - honors an incoming W3C `traceparent`/`tracestate` so database spans nest
+//!   inside the caller's trace (absent → a new root trace); and
+//! - exposes recording methods the handler calls to stamp the operation name,
+//!   result count, and error code onto the span once known.
+//!
+//! Credentials (`Authorization`, `x-api-key`, bearer tokens) are never read
+//! here and never become span attributes.
+//!
+//! When the `observability` feature is disabled the extractor is a zero-sized
+//! no-op, so handler signatures are identical across feature sets.
+
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use std::convert::Infallible;
+
+/// Per-request tracing context: owns the HTTP root span.
+pub struct HttpTrace {
+    #[cfg(feature = "observability")]
+    span: tracing::Span,
+}
+
+impl HttpTrace {
+    /// A clone of the root span, for instrumenting the handler body so that
+    /// database child spans (query/commit) nest underneath it.
+    #[cfg(feature = "observability")]
+    #[must_use]
+    pub fn span(&self) -> tracing::Span {
+        self.span.clone()
+    }
+
+    /// Record the high-level operation name (e.g. the `/query` operation tag).
+    #[inline]
+    pub fn record_operation(&self, operation: &str) {
+        #[cfg(feature = "observability")]
+        self.span
+            .record(crate::observability::ATTR_OPERATION, operation);
+        #[cfg(not(feature = "observability"))]
+        let _ = operation;
+    }
+
+    /// Record the number of entities/rows the operation returned.
+    #[inline]
+    pub fn record_result_count(&self, count: usize) {
+        #[cfg(feature = "observability")]
+        self.span.record(
+            crate::observability::ATTR_RESULT_COUNT,
+            i64::try_from(count).unwrap_or(i64::MAX),
+        );
+        #[cfg(not(feature = "observability"))]
+        let _ = count;
+    }
+
+    /// Record whether the operation was temporally scoped (`as_of`) vs current.
+    #[inline]
+    pub fn record_temporal_scope(&self, as_of: bool) {
+        #[cfg(feature = "observability")]
+        self.span.record(
+            crate::observability::ATTR_TEMPORAL_SCOPE,
+            if as_of { "as_of" } else { "current" },
+        );
+        #[cfg(not(feature = "observability"))]
+        let _ = as_of;
+    }
+
+    /// Record a structured error code (Issue #3234) and mark the span errored.
+    #[inline]
+    pub fn record_error(&self, code: &str) {
+        #[cfg(feature = "observability")]
+        {
+            self.span
+                .record(crate::observability::ATTR_ERROR_CODE, code);
+            self.span.record("otel.status_code", "ERROR");
+        }
+        #[cfg(not(feature = "observability"))]
+        let _ = code;
+    }
+
+    /// Attach sanitized statement text — only when statement capture is
+    /// explicitly enabled. Property *values* are never included here; the
+    /// caller passes the statement string verbatim and is responsible for not
+    /// interpolating values into it (AQL/Cypher use `$param` bindings).
+    #[cfg(feature = "otel")]
+    #[inline]
+    pub fn record_statement(&self, statement: &str) {
+        #[cfg(feature = "observability")]
+        self.span
+            .record(crate::observability::ATTR_DB_QUERY_TEXT, statement);
+    }
+}
+
+#[cfg(feature = "observability")]
+fn header_value(parts: &Parts, name: &str) -> Option<String> {
+    parts
+        .headers
+        .get(name)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned)
+}
+
+impl FromRequestParts<autumn_web::prelude::AppState> for HttpTrace {
+    type Rejection = Infallible;
+
+    async fn from_request_parts(
+        _parts: &mut Parts,
+        _state: &autumn_web::prelude::AppState,
+    ) -> Result<Self, Self::Rejection> {
+        #[cfg(feature = "observability")]
+        let this = {
+            let method = _parts.method.as_str();
+            let path = _parts.uri.path();
+            let span = crate::observability::http_request_span(method, path);
+
+            // Honor an incoming W3C trace context so DB spans nest inside the
+            // caller's trace. Only meaningful (and only costed) when the OTel
+            // exporter is actually active.
+            #[cfg(feature = "otel")]
+            if crate::observability::otel::is_active() {
+                let traceparent = header_value(_parts, "traceparent");
+                let tracestate = header_value(_parts, "tracestate");
+                crate::observability::otel::attach_parent(
+                    &span,
+                    traceparent.as_deref(),
+                    tracestate.as_deref(),
+                );
+            }
+
+            Self { span }
+        };
+        #[cfg(not(feature = "observability"))]
+        let this = Self {};
+        Ok(this)
+    }
+}
+
+/// The active trace id for correlation, or `None` when tracing is inactive or
+/// the `otel` feature is disabled.
+#[cfg(feature = "otel")]
+#[must_use]
+pub fn active_trace_id() -> Option<String> {
+    crate::observability::otel::current_trace_id()
+}
+
+/// The active trace id — always `None` without the `otel` feature.
+#[cfg(not(feature = "otel"))]
+#[must_use]
+pub fn active_trace_id() -> Option<String> {
+    None
+}

--- a/src/http/trace.rs
+++ b/src/http/trace.rs
@@ -41,6 +41,34 @@ impl HttpTrace {
         self.span.clone()
     }
 
+    /// Whether recording per-request attributes onto the root span is
+    /// worthwhile. Callers gate the *computation* of attribute values on this so
+    /// that no work is done when nothing will consume it (Issue #3376, MED2 /
+    /// Perf):
+    ///
+    /// - `false` when no subscriber is interested in the span at all
+    ///   (`span.is_disabled()`), i.e. a compiled-in-but-runtime-disabled build;
+    /// - with the OTel exporter active, this reflects the head-sampling
+    ///   decision — a **sampled-out** span returns `false`, so per-request
+    ///   attribute recording is skipped for traces that will never be exported;
+    /// - otherwise `true` (some non-OTel subscriber may record the span).
+    ///
+    /// Compiled out entirely when `observability` is absent, so a feature-absent
+    /// build has no call site to evaluate.
+    #[cfg(feature = "observability")]
+    #[must_use]
+    #[inline]
+    pub fn is_recording(&self) -> bool {
+        if self.span.is_disabled() {
+            return false;
+        }
+        #[cfg(feature = "otel")]
+        if crate::observability::otel::is_active() {
+            return crate::observability::otel::span_is_sampled(&self.span);
+        }
+        true
+    }
+
     /// Record the high-level operation name (e.g. the `/query` operation tag).
     #[inline]
     pub fn record_operation(&self, operation: &str) {
@@ -101,13 +129,33 @@ impl HttpTrace {
     }
 }
 
-#[cfg(feature = "observability")]
+#[cfg(feature = "otel")]
 fn header_value(parts: &Parts, name: &str) -> Option<String> {
     parts
         .headers
         .get(name)
         .and_then(|v| v.to_str().ok())
         .map(str::to_owned)
+}
+
+/// Read the incoming W3C `traceparent`, treating a duplicated header as absent.
+///
+/// Per the [W3C Trace Context] spec, if more than one `traceparent` header is
+/// present the trace context is ambiguous and MUST be handled as if no parent
+/// were supplied — the request then starts a fresh root trace rather than
+/// nesting under an arbitrarily-chosen (and possibly forged) parent
+/// (Issue #3376, LOW5).
+///
+/// [W3C Trace Context]: https://www.w3.org/TR/trace-context/#traceparent-header
+#[cfg(feature = "otel")]
+fn traceparent_value(parts: &Parts) -> Option<String> {
+    let mut values = parts.headers.get_all("traceparent").iter();
+    let first = values.next()?;
+    if values.next().is_some() {
+        // Multiple `traceparent` values → no valid parent.
+        return None;
+    }
+    first.to_str().ok().map(str::to_owned)
 }
 
 impl FromRequestParts<autumn_web::prelude::AppState> for HttpTrace {
@@ -128,7 +176,7 @@ impl FromRequestParts<autumn_web::prelude::AppState> for HttpTrace {
             // exporter is actually active.
             #[cfg(feature = "otel")]
             if crate::observability::otel::is_active() {
-                let traceparent = header_value(_parts, "traceparent");
+                let traceparent = traceparent_value(_parts);
                 let tracestate = header_value(_parts, "tracestate");
                 crate::observability::otel::attach_parent(
                     &span,

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -49,6 +49,10 @@ pub const SPAN_STORAGE_HISTORICAL_QUERY: &str = "aletheiadb.storage.historical.q
 /// Span: commits a write transaction.
 pub const SPAN_TRANSACTION_COMMIT: &str = "aletheiadb.transaction.commit";
 
+/// Span: serves an inbound HTTP request (the root span of the HTTP surface,
+/// under which query/write child spans nest). Issue #3376.
+pub const SPAN_HTTP_REQUEST: &str = "aletheiadb.http.request";
+
 /// OTel semantic attribute: database system name.
 pub const ATTR_DB_SYSTEM_NAME: &str = "db.system.name";
 
@@ -72,6 +76,31 @@ pub const ATTR_ERROR_CATEGORY: &str = "aletheiadb.error.category";
 
 /// AletheiaDB attribute: bounded operation status.
 pub const ATTR_STATUS: &str = "aletheiadb.status";
+
+/// AletheiaDB attribute: high-level operation name (e.g. the `/query`
+/// operation tag). Bounded set; never contains user data.
+pub const ATTR_OPERATION: &str = "aletheiadb.operation";
+
+/// AletheiaDB attribute: number of entities/rows returned by an operation.
+pub const ATTR_RESULT_COUNT: &str = "aletheiadb.result.count";
+
+/// AletheiaDB attribute: whether the operation was temporally scoped
+/// (`as_of`) versus current-state.
+pub const ATTR_TEMPORAL_SCOPE: &str = "aletheiadb.temporal.scope";
+
+/// AletheiaDB attribute: structured error code (Issue #3234) on failure.
+pub const ATTR_ERROR_CODE: &str = "aletheiadb.error.code";
+
+/// OTel semantic attribute: HTTP request method.
+pub const ATTR_HTTP_REQUEST_METHOD: &str = "http.request.method";
+
+/// OTel semantic attribute: URL path (route), never the query string.
+pub const ATTR_URL_PATH: &str = "url.path";
+
+/// OTel semantic attribute: sanitized database statement text. Emitted only
+/// when statement capture is explicitly opted into; property *values* are
+/// never included.
+pub const ATTR_DB_QUERY_TEXT: &str = "db.query.text";
 
 static METRICS_RECORDER: LazyLock<ArcSwap<SharedMetricsRecorder>> =
     LazyLock::new(|| ArcSwap::from_pointee(SharedMetricsRecorder::new(Arc::new(NoOpMetrics))));
@@ -319,6 +348,35 @@ pub fn transaction_commit_span(tx_id: &str, durability_mode: &str) -> tracing::S
         "db.operation.name" = "transaction.commit",
         "aletheiadb.transaction.id" = tx_id,
         "aletheiadb.durability.mode" = durability_mode,
+    )
+}
+
+/// Create the root HTTP request span (Issue #3376).
+///
+/// The span carries the request method and route path up front. The
+/// operation name, result count, temporal scope, statement text, and error
+/// code are recorded later via [`tracing::Span::record`] once known — they are
+/// declared here as empty fields so the recording sites are cheap and the
+/// attribute set is stable. Credentials are deliberately never captured.
+#[must_use]
+pub fn http_request_span(method: &str, path: &str) -> tracing::Span {
+    // `parent: None` makes this a true root span, independent of any ambient
+    // tracing span (e.g. a tower `TraceLayer` request span). An incoming W3C
+    // context is attached afterward via `otel::attach_parent`, so the span is
+    // either a fresh root (absent traceparent) or nests under the caller's
+    // remote span — never accidentally under framework middleware.
+    tracing::info_span!(
+        parent: None,
+        SPAN_HTTP_REQUEST,
+        "db.system.name" = DB_SYSTEM_NAME,
+        "http.request.method" = method,
+        "url.path" = path,
+        "aletheiadb.operation" = tracing::field::Empty,
+        "aletheiadb.result.count" = tracing::field::Empty,
+        "aletheiadb.temporal.scope" = tracing::field::Empty,
+        "aletheiadb.error.code" = tracing::field::Empty,
+        "db.query.text" = tracing::field::Empty,
+        "otel.status_code" = tracing::field::Empty,
     )
 }
 

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -12,6 +12,9 @@ pub mod metrics;
 #[cfg(feature = "metrics-rs")]
 pub mod metrics_rs_adapter;
 
+#[cfg(feature = "otel")]
+pub mod otel;
+
 use arc_swap::ArcSwap;
 use std::sync::{Arc, LazyLock};
 

--- a/src/observability/otel.rs
+++ b/src/observability/otel.rs
@@ -1,0 +1,700 @@
+//! OpenTelemetry OTLP export, sampling, and W3C context propagation
+//! (Issue #3376).
+//!
+//! This module is the exporter/subscriber half of the observability story that
+//! [ADR 0056](../../../docs/adr/0056-observability-contract.md) deliberately
+//! left to the application. It composes with the `observability` feature — it
+//! reuses that module's stable `tracing` span vocabulary — and adds:
+//!
+//! - an **OTLP exporter** over HTTP/protobuf, configured from the standard
+//!   `OTEL_*` environment variables ([`OtelConfig::from_env`]);
+//! - **head sampling** (`always_on` / `always_off` / `traceidratio` and their
+//!   `parentbased_*` variants — [`SamplerConfig`]);
+//! - a process-wide **subscriber installer** ([`init`]) that bridges `tracing`
+//!   spans into OpenTelemetry and installs the W3C `TraceContextPropagator`;
+//! - reusable **W3C `traceparent`/`tracestate` extract/inject helpers**
+//!   ([`extract_context`], [`attach_parent`], [`inject_context`]) that the HTTP
+//!   surface uses and the MCP surface can reuse;
+//! - [`current_trace_id`] for stamping the active trace id into error responses
+//!   and logs;
+//! - an [`InMemorySpanExporter`] for tests / embedded assertions.
+//!
+//! # Zero cost when disabled
+//!
+//! The entire module is `#[cfg(feature = "otel")]`. When the feature is absent
+//! it does not exist and every call site is compiled out. When the feature is
+//! present but tracing is not initialized, [`is_active`] is a single relaxed
+//! atomic load that hot paths check before doing any context work.
+//!
+//! # Privacy
+//!
+//! No credential (API key, `Authorization` header, bearer token) is ever read
+//! or written by this module. The W3C carriers only ever touch the
+//! `traceparent` and `tracestate` header names. Query text is opt-in
+//! ([`OtelConfig::capture_statements`]); property *values* are never emitted.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use opentelemetry::propagation::{Extractor, Injector};
+use opentelemetry::trace::{TraceContextExt, TracerProvider as _};
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::error::OTelSdkResult;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::trace::{
+    Sampler, SdkTracerProvider, SimpleSpanProcessor, SpanData, SpanExporter,
+};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+/// Standard OTLP endpoint environment variable.
+pub const ENV_OTLP_ENDPOINT: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
+/// Standard OTel service-name environment variable.
+pub const ENV_SERVICE_NAME: &str = "OTEL_SERVICE_NAME";
+/// Standard OTel head-sampler selector environment variable.
+pub const ENV_TRACES_SAMPLER: &str = "OTEL_TRACES_SAMPLER";
+/// Standard OTel sampler argument (ratio) environment variable.
+pub const ENV_TRACES_SAMPLER_ARG: &str = "OTEL_TRACES_SAMPLER_ARG";
+/// AletheiaDB master enable switch for OTel tracing.
+pub const ENV_ENABLE: &str = "ALETHEIADB_OTEL";
+/// AletheiaDB opt-in switch for capturing sanitized statement text.
+pub const ENV_CAPTURE_STATEMENTS: &str = "ALETHEIADB_OTEL_CAPTURE_STATEMENTS";
+
+/// Tracer/instrumentation-scope name used for AletheiaDB spans.
+pub const TRACER_NAME: &str = super::DB_SYSTEM_NAME;
+
+/// Runtime flag: is OTel tracing currently active?
+///
+/// Hot paths load this (a single relaxed atomic) before doing any
+/// span-context work, so a compiled-in-but-uninitialized build pays only the
+/// load, never the OTel machinery.
+static OTEL_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// Whether OTel tracing has been initialized and is exporting.
+#[must_use]
+#[inline]
+pub fn is_active() -> bool {
+    OTEL_ACTIVE.load(Ordering::Relaxed)
+}
+
+fn set_active(active: bool) {
+    OTEL_ACTIVE.store(active, Ordering::Relaxed);
+}
+
+// ===========================================================================
+// Errors
+// ===========================================================================
+
+/// Errors raised while initializing OTel tracing.
+#[derive(Debug, thiserror::Error)]
+pub enum OtelError {
+    /// The OTLP exporter could not be constructed.
+    #[error("failed to build OTLP exporter: {0}")]
+    Exporter(String),
+
+    /// A global `tracing` subscriber was already installed.
+    #[error("a global tracing subscriber is already installed: {0}")]
+    SubscriberAlreadySet(String),
+}
+
+// ===========================================================================
+// Sampling
+// ===========================================================================
+
+/// Head-sampling policy, mirroring the OTel `OTEL_TRACES_SAMPLER` values.
+///
+/// The default is [`ParentBasedAlwaysOn`](SamplerConfig::ParentBasedAlwaysOn):
+/// it is the OTel default and the one that makes incoming `traceparent`
+/// continuation work out of the box.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum SamplerConfig {
+    /// Sample every trace.
+    AlwaysOn,
+    /// Sample no trace.
+    AlwaysOff,
+    /// Sample a fixed fraction of traces (`0.0..=1.0`).
+    TraceIdRatio(f64),
+    /// Respect the parent's decision; sample roots always.
+    #[default]
+    ParentBasedAlwaysOn,
+    /// Respect the parent's decision; drop roots.
+    ParentBasedAlwaysOff,
+    /// Respect the parent's decision; sample a fraction of roots.
+    ParentBasedTraceIdRatio(f64),
+}
+
+impl SamplerConfig {
+    /// Parse from the standard `OTEL_TRACES_SAMPLER` token and optional
+    /// `OTEL_TRACES_SAMPLER_ARG` ratio. Unknown tokens fall back to the
+    /// default (parent-based always-on).
+    #[must_use]
+    pub fn parse(token: &str, arg: Option<&str>) -> Self {
+        let ratio = || {
+            arg.and_then(|a| a.trim().parse::<f64>().ok())
+                .unwrap_or(1.0)
+        };
+        match token.trim().to_ascii_lowercase().as_str() {
+            "always_on" | "alwayson" => Self::AlwaysOn,
+            "always_off" | "alwaysoff" => Self::AlwaysOff,
+            "traceidratio" => Self::TraceIdRatio(ratio()),
+            "parentbased_always_off" => Self::ParentBasedAlwaysOff,
+            "parentbased_traceidratio" => Self::ParentBasedTraceIdRatio(ratio()),
+            _ => Self::ParentBasedAlwaysOn,
+        }
+    }
+
+    /// Read the sampler from the environment.
+    #[must_use]
+    pub fn from_env() -> Self {
+        match std::env::var(ENV_TRACES_SAMPLER) {
+            Ok(token) => {
+                let arg = std::env::var(ENV_TRACES_SAMPLER_ARG).ok();
+                Self::parse(&token, arg.as_deref())
+            }
+            Err(_) => Self::default(),
+        }
+    }
+
+    fn to_sdk_sampler(&self) -> Sampler {
+        match *self {
+            Self::AlwaysOn => Sampler::AlwaysOn,
+            Self::AlwaysOff => Sampler::AlwaysOff,
+            Self::TraceIdRatio(r) => Sampler::TraceIdRatioBased(r),
+            Self::ParentBasedAlwaysOn => Sampler::ParentBased(Box::new(Sampler::AlwaysOn)),
+            Self::ParentBasedAlwaysOff => Sampler::ParentBased(Box::new(Sampler::AlwaysOff)),
+            Self::ParentBasedTraceIdRatio(r) => {
+                Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(r)))
+            }
+        }
+    }
+}
+
+// ===========================================================================
+// Configuration
+// ===========================================================================
+
+/// Runtime configuration for OTel tracing.
+#[derive(Debug, Clone)]
+pub struct OtelConfig {
+    /// Master switch. When `false`, [`init`] is a no-op returning `None`.
+    pub enabled: bool,
+    /// OTLP endpoint. `None` lets the exporter use `OTEL_EXPORTER_OTLP_ENDPOINT`
+    /// or its built-in default (`http://localhost:4318`).
+    pub endpoint: Option<String>,
+    /// `service.name` resource attribute.
+    pub service_name: String,
+    /// Head-sampling policy.
+    pub sampler: SamplerConfig,
+    /// Opt-in: attach sanitized statement text as `db.query.text`. Off by
+    /// default so query text never leaves the process unless requested. Even
+    /// when on, property *values* are never emitted.
+    pub capture_statements: bool,
+}
+
+impl Default for OtelConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            endpoint: None,
+            service_name: super::DB_SYSTEM_NAME.to_string(),
+            sampler: SamplerConfig::default(),
+            capture_statements: false,
+        }
+    }
+}
+
+fn env_flag(name: &str) -> bool {
+    matches!(
+        std::env::var(name).map(|v| v.trim().to_ascii_lowercase()),
+        Ok(v) if v == "1" || v == "true" || v == "yes" || v == "on"
+    )
+}
+
+impl OtelConfig {
+    /// Build a configuration from the standard `OTEL_*` and AletheiaDB
+    /// environment variables.
+    ///
+    /// Tracing is enabled when `ALETHEIADB_OTEL` is truthy **or** an
+    /// `OTEL_EXPORTER_OTLP_ENDPOINT` is set (presence of an endpoint is a
+    /// strong signal the operator wired up a collector).
+    #[must_use]
+    pub fn from_env() -> Self {
+        let endpoint = std::env::var(ENV_OTLP_ENDPOINT)
+            .ok()
+            .filter(|s| !s.trim().is_empty());
+        let enabled = env_flag(ENV_ENABLE) || endpoint.is_some();
+        let service_name = std::env::var(ENV_SERVICE_NAME)
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| super::DB_SYSTEM_NAME.to_string());
+        Self {
+            enabled,
+            endpoint,
+            service_name,
+            sampler: SamplerConfig::from_env(),
+            capture_statements: env_flag(ENV_CAPTURE_STATEMENTS),
+        }
+    }
+
+    fn resource(&self) -> Resource {
+        Resource::builder()
+            .with_service_name(self.service_name.clone())
+            .build()
+    }
+}
+
+// ===========================================================================
+// W3C context propagation (reusable by HTTP + MCP)
+// ===========================================================================
+
+/// Extractor carrier holding only the two W3C trace-context headers.
+///
+/// Deliberately narrow: it can only ever surface `traceparent` and
+/// `tracestate`, so no credential header can leak into a propagated context.
+struct W3CExtractor {
+    traceparent: Option<String>,
+    tracestate: Option<String>,
+}
+
+impl Extractor for W3CExtractor {
+    fn get(&self, key: &str) -> Option<&str> {
+        match key.to_ascii_lowercase().as_str() {
+            "traceparent" => self.traceparent.as_deref(),
+            "tracestate" => self.tracestate.as_deref(),
+            _ => None,
+        }
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        let mut keys = Vec::new();
+        if self.traceparent.is_some() {
+            keys.push("traceparent");
+        }
+        if self.tracestate.is_some() {
+            keys.push("tracestate");
+        }
+        keys
+    }
+}
+
+/// Injector carrier that accumulates outbound header pairs.
+#[derive(Default)]
+struct W3CInjector {
+    pairs: Vec<(String, String)>,
+}
+
+impl Injector for W3CInjector {
+    fn set(&mut self, key: &str, value: String) {
+        self.pairs.push((key.to_string(), value));
+    }
+}
+
+/// Extract an OpenTelemetry [`Context`](opentelemetry::Context) from incoming
+/// W3C `traceparent`/`tracestate` header values.
+///
+/// Absent/invalid input yields an empty context (a subsequent span becomes a
+/// new root). Reusable by any transport that can surface the two header
+/// strings (HTTP headers, MCP metadata).
+#[must_use]
+pub fn extract_context(
+    traceparent: Option<&str>,
+    tracestate: Option<&str>,
+) -> opentelemetry::Context {
+    let carrier = W3CExtractor {
+        traceparent: traceparent.map(str::to_owned),
+        tracestate: tracestate.map(str::to_owned),
+    };
+    opentelemetry::global::get_text_map_propagator(|prop| prop.extract(&carrier))
+}
+
+/// Attach an incoming trace context to `span` as its remote parent, so DB
+/// spans nest inside the caller's trace.
+///
+/// When `traceparent` is absent, this is a no-op and `span` starts a new root
+/// trace — exactly the AC-required behavior.
+pub fn attach_parent(span: &tracing::Span, traceparent: Option<&str>, tracestate: Option<&str>) {
+    if traceparent.is_none() {
+        return;
+    }
+    let cx = extract_context(traceparent, tracestate);
+    span.set_parent(cx);
+}
+
+/// Inject the given context into W3C header pairs for outbound propagation.
+#[must_use]
+pub fn inject_context(cx: &opentelemetry::Context) -> Vec<(String, String)> {
+    let mut carrier = W3CInjector::default();
+    opentelemetry::global::get_text_map_propagator(|prop| prop.inject_context(cx, &mut carrier));
+    carrier.pairs
+}
+
+/// Inject the *currently active* span's context into W3C header pairs.
+#[must_use]
+pub fn current_context_headers() -> Vec<(String, String)> {
+    inject_context(&tracing::Span::current().context())
+}
+
+// ===========================================================================
+// Trace-id correlation
+// ===========================================================================
+
+/// The active trace id (32 lowercase hex chars) if a valid, sampled span is
+/// current; otherwise `None`.
+///
+/// Used to stamp the trace id into error responses and debug logs so a failing
+/// call can be looked up directly in the trace backend.
+#[must_use]
+pub fn current_trace_id() -> Option<String> {
+    if !is_active() {
+        return None;
+    }
+    let cx = tracing::Span::current().context();
+    let span = cx.span();
+    let sc = span.span_context();
+    if sc.is_valid() {
+        Some(sc.trace_id().to_string())
+    } else {
+        None
+    }
+}
+
+/// The active `(trace_id, span_id)` pair if a valid span is current.
+#[must_use]
+pub fn current_ids() -> Option<(String, String)> {
+    if !is_active() {
+        return None;
+    }
+    let cx = tracing::Span::current().context();
+    let span = cx.span();
+    let sc = span.span_context();
+    if sc.is_valid() {
+        Some((sc.trace_id().to_string(), sc.span_id().to_string()))
+    } else {
+        None
+    }
+}
+
+// ===========================================================================
+// In-memory exporter (tests / embedded assertions)
+// ===========================================================================
+
+/// A [`SpanExporter`] that retains finished spans in memory.
+///
+/// Cheap to clone (shares one buffer). Used by the integration tests as a
+/// stand-in OTLP receiver so parent-child structure and the credential-
+/// exclusion invariant can be asserted without a network collector.
+#[derive(Debug, Clone, Default)]
+pub struct InMemorySpanExporter {
+    spans: Arc<Mutex<Vec<SpanData>>>,
+}
+
+impl InMemorySpanExporter {
+    /// Create an empty exporter.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Snapshot of all spans exported so far.
+    #[must_use]
+    pub fn spans(&self) -> Vec<SpanData> {
+        self.spans.lock().expect("span buffer poisoned").clone()
+    }
+
+    /// Discard all retained spans.
+    pub fn clear(&self) {
+        self.spans.lock().expect("span buffer poisoned").clear();
+    }
+}
+
+impl SpanExporter for InMemorySpanExporter {
+    fn export(
+        &self,
+        batch: Vec<SpanData>,
+    ) -> impl std::future::Future<Output = OTelSdkResult> + Send {
+        if let Ok(mut guard) = self.spans.lock() {
+            guard.extend(batch);
+        }
+        std::future::ready(Ok(()))
+    }
+}
+
+// ===========================================================================
+// Provider / subscriber construction
+// ===========================================================================
+
+/// Build an [`SdkTracerProvider`] around an arbitrary exporter, applying the
+/// configured sampler and resource. `simple` selects synchronous export
+/// (tests) versus the batching processor (production).
+#[must_use]
+pub fn provider_with_exporter<E>(
+    config: &OtelConfig,
+    exporter: E,
+    simple: bool,
+) -> SdkTracerProvider
+where
+    E: SpanExporter + 'static,
+{
+    let builder = SdkTracerProvider::builder()
+        .with_sampler(config.sampler.to_sdk_sampler())
+        .with_resource(config.resource());
+    let builder = if simple {
+        builder.with_span_processor(SimpleSpanProcessor::new(exporter))
+    } else {
+        builder.with_batch_exporter(exporter)
+    };
+    builder.build()
+}
+
+/// Build the OTLP HTTP/protobuf exporter from `config`.
+fn build_otlp_exporter(config: &OtelConfig) -> Result<opentelemetry_otlp::SpanExporter, OtelError> {
+    use opentelemetry_otlp::WithExportConfig;
+    let mut builder = opentelemetry_otlp::SpanExporter::builder().with_http();
+    if let Some(endpoint) = &config.endpoint {
+        builder = builder.with_endpoint(endpoint.clone());
+    }
+    builder
+        .build()
+        .map_err(|e| OtelError::Exporter(e.to_string()))
+}
+
+/// Guard returned by [`init`]; flushes and shuts the exporter down on drop.
+#[must_use = "dropping the guard immediately shuts tracing down"]
+pub struct OtelGuard {
+    provider: SdkTracerProvider,
+}
+
+impl OtelGuard {
+    /// Flush any pending spans to the exporter.
+    pub fn force_flush(&self) {
+        let _ = self.provider.force_flush();
+    }
+}
+
+impl Drop for OtelGuard {
+    fn drop(&mut self) {
+        let _ = self.provider.force_flush();
+        let _ = self.provider.shutdown();
+        set_active(false);
+    }
+}
+
+/// Install a global OpenTelemetry `tracing` subscriber that exports over OTLP.
+///
+/// Returns `Ok(None)` when `config.enabled` is `false` (nothing installed).
+/// Returns `Ok(Some(guard))` on success; hold the guard for the process
+/// lifetime and drop it to flush + shut down.
+///
+/// # Errors
+///
+/// Returns [`OtelError`] if the OTLP exporter cannot be built or a global
+/// subscriber is already installed.
+pub fn init(config: &OtelConfig) -> Result<Option<OtelGuard>, OtelError> {
+    if !config.enabled {
+        return Ok(None);
+    }
+    let exporter = build_otlp_exporter(config)?;
+    let provider = provider_with_exporter(config, exporter, false);
+    install_global(provider.clone())?;
+    Ok(Some(OtelGuard { provider }))
+}
+
+/// Install a global subscriber that exports into the returned in-memory
+/// exporter. Test/embedding helper — makes the whole process's spans (across
+/// `spawn_blocking` threads) inspectable.
+///
+/// # Errors
+///
+/// Returns [`OtelError::SubscriberAlreadySet`] if a global subscriber already
+/// exists.
+pub fn init_in_memory_global(
+    config: &OtelConfig,
+) -> Result<(OtelGuard, InMemorySpanExporter), OtelError> {
+    let exporter = InMemorySpanExporter::new();
+    let provider = provider_with_exporter(config, exporter.clone(), true);
+    install_global(provider.clone())?;
+    Ok((OtelGuard { provider }, exporter))
+}
+
+fn install_global(provider: SdkTracerProvider) -> Result<(), OtelError> {
+    opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+    let tracer = provider.tracer(TRACER_NAME);
+    opentelemetry::global::set_tracer_provider(provider);
+    let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+    tracing_subscriber::registry()
+        .with(otel_layer)
+        .try_init()
+        .map_err(|e| OtelError::SubscriberAlreadySet(e.to_string()))?;
+    set_active(true);
+    Ok(())
+}
+
+/// Run `f` with a scoped (thread-local) OTel subscriber exporting into the
+/// returned in-memory exporter. Does not touch global state, so multiple unit
+/// tests can use it in the same process without conflict.
+///
+/// Note: because the subscriber is thread-local, spans created on other threads
+/// (e.g. inside `spawn_blocking`) are not captured — use
+/// [`init_in_memory_global`] for cross-thread scenarios.
+#[cfg(test)]
+fn with_scoped_in_memory<T>(config: &OtelConfig, f: impl FnOnce() -> T) -> (T, Vec<SpanData>) {
+    let exporter = InMemorySpanExporter::new();
+    let provider = provider_with_exporter(config, exporter.clone(), true);
+    set_active(true);
+    opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+    let tracer = provider.tracer(TRACER_NAME);
+    let subscriber =
+        tracing_subscriber::registry().with(tracing_opentelemetry::layer().with_tracer(tracer));
+    let out = tracing::subscriber::with_default(subscriber, f);
+    let _ = provider.force_flush();
+    (out, exporter.spans())
+}
+
+#[cfg(test)]
+fn set_active_test(v: bool) {
+    set_active(v);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    fn sampler_parse_covers_standard_tokens() {
+        assert_eq!(
+            SamplerConfig::parse("always_on", None),
+            SamplerConfig::AlwaysOn
+        );
+        assert_eq!(
+            SamplerConfig::parse("always_off", None),
+            SamplerConfig::AlwaysOff
+        );
+        assert_eq!(
+            SamplerConfig::parse("traceidratio", Some("0.25")),
+            SamplerConfig::TraceIdRatio(0.25)
+        );
+        assert_eq!(
+            SamplerConfig::parse("parentbased_always_off", None),
+            SamplerConfig::ParentBasedAlwaysOff
+        );
+        assert_eq!(
+            SamplerConfig::parse("parentbased_traceidratio", Some("0.5")),
+            SamplerConfig::ParentBasedTraceIdRatio(0.5)
+        );
+        // Unknown → default parent-based always-on.
+        assert_eq!(
+            SamplerConfig::parse("nonsense", None),
+            SamplerConfig::ParentBasedAlwaysOn
+        );
+    }
+
+    #[test]
+    fn sampler_all_variants_map_to_sdk() {
+        for cfg in [
+            SamplerConfig::AlwaysOn,
+            SamplerConfig::AlwaysOff,
+            SamplerConfig::TraceIdRatio(0.1),
+            SamplerConfig::ParentBasedAlwaysOn,
+            SamplerConfig::ParentBasedAlwaysOff,
+            SamplerConfig::ParentBasedTraceIdRatio(0.1),
+        ] {
+            // Must not panic constructing the SDK sampler.
+            let _ = cfg.to_sdk_sampler();
+        }
+    }
+
+    #[test]
+    fn default_config_is_disabled_and_private() {
+        let cfg = OtelConfig::default();
+        assert!(!cfg.enabled);
+        assert!(
+            !cfg.capture_statements,
+            "statement capture must default off"
+        );
+        assert_eq!(cfg.service_name, super::super::DB_SYSTEM_NAME);
+    }
+
+    #[test]
+    fn init_disabled_is_noop() {
+        let cfg = OtelConfig::default();
+        assert!(init(&cfg).expect("noop").is_none());
+    }
+
+    #[test]
+    fn current_trace_id_none_when_inactive() {
+        // With no active tracer, there is no trace id.
+        set_active_test(false);
+        assert!(current_trace_id().is_none());
+        assert!(current_ids().is_none());
+    }
+
+    /// Extraction is confined to the two W3C headers — a credential-shaped
+    /// key is never surfaced into the context carrier.
+    #[test]
+    fn extractor_only_exposes_w3c_headers() {
+        let ex = W3CExtractor {
+            traceparent: Some("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01".into()),
+            tracestate: Some("vendor=v".into()),
+        };
+        assert!(ex.get("traceparent").is_some());
+        assert!(ex.get("tracestate").is_some());
+        assert!(ex.get("authorization").is_none());
+        assert!(ex.get("x-api-key").is_none());
+        let keys = ex.keys();
+        assert!(keys.contains(&"traceparent"));
+        assert!(!keys.iter().any(|k| k.contains("auth")));
+    }
+
+    /// A child span created under an extracted parent shares the incoming
+    /// trace id (context continuity), and no credential leaks into attributes.
+    #[test]
+    #[serial]
+    fn scoped_child_span_inherits_incoming_trace() {
+        let incoming = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+        let cfg = OtelConfig {
+            enabled: true,
+            sampler: SamplerConfig::AlwaysOn,
+            ..OtelConfig::default()
+        };
+        let ((), spans) = with_scoped_in_memory(&cfg, || {
+            let span = tracing::info_span!(
+                "aletheiadb.http.request",
+                "http.request.method" = "POST",
+                "aletheiadb.credential" = "SHOULD-NOT-APPEAR",
+            );
+            attach_parent(&span, Some(incoming), None);
+            let _g = span.enter();
+            // A nested DB span.
+            let child = super::super::query_execute_span("query.execute", "aql");
+            let _cg = child.enter();
+        });
+        set_active_test(false);
+        assert!(!spans.is_empty(), "expected exported spans");
+        // All spans belong to the incoming trace id.
+        for s in &spans {
+            assert_eq!(
+                s.span_context.trace_id().to_string(),
+                "0af7651916cd43dd8448eb211c80319c",
+                "span {} did not inherit incoming trace id",
+                s.name
+            );
+        }
+        // Parent-child: the query.execute span's parent is the http root span.
+        let root = spans
+            .iter()
+            .find(|s| s.name == "aletheiadb.http.request")
+            .expect("root span present");
+        let child = spans
+            .iter()
+            .find(|s| s.name == super::super::SPAN_QUERY_EXECUTE)
+            .expect("child span present");
+        assert_eq!(
+            child.parent_span_id,
+            root.span_context.span_id(),
+            "child span not nested under http root"
+        );
+    }
+}

--- a/src/observability/otel.rs
+++ b/src/observability/otel.rs
@@ -146,9 +146,15 @@ impl SamplerConfig {
     /// default (parent-based always-on).
     #[must_use]
     pub fn parse(token: &str, arg: Option<&str>) -> Self {
+        // A probability sampler ratio must lie in `[0.0, 1.0]`. Clamp
+        // out-of-range values (e.g. `2.0 → 1.0`, `-1.0 → 0.0`) and treat a NaN
+        // or unparseable/missing arg as the default full-sampling ratio, so a
+        // hostile or fat-fingered `OTEL_TRACES_SAMPLER_ARG` can never construct
+        // a nonsensical sampler (Issue #3376, LOW3).
         let ratio = || {
             arg.and_then(|a| a.trim().parse::<f64>().ok())
-                .unwrap_or(1.0)
+                .filter(|r| !r.is_nan())
+                .map_or(1.0, |r| r.clamp(0.0, 1.0))
         };
         match token.trim().to_ascii_lowercase().as_str() {
             "always_on" | "alwayson" => Self::AlwaysOn,
@@ -355,11 +361,15 @@ pub fn current_context_headers() -> Vec<(String, String)> {
 // Trace-id correlation
 // ===========================================================================
 
-/// The active trace id (32 lowercase hex chars) if a valid, sampled span is
+/// The active trace id (32 lowercase hex chars) if a valid, **sampled** span is
 /// current; otherwise `None`.
 ///
 /// Used to stamp the trace id into error responses and debug logs so a failing
-/// call can be looked up directly in the trace backend.
+/// call can be looked up directly in the trace backend. The `is_sampled` gate
+/// is load-bearing: a head-sampler-dropped trace still carries a valid, non-zero
+/// id, but that trace is never exported — returning it would hand the caller a
+/// dead-end lookup. We therefore surface a trace id only when the current span
+/// is actually sampled and will reach the backend (Issue #3376, MED1).
 #[must_use]
 pub fn current_trace_id() -> Option<String> {
     if !is_active() {
@@ -368,11 +378,28 @@ pub fn current_trace_id() -> Option<String> {
     let cx = tracing::Span::current().context();
     let span = cx.span();
     let sc = span.span_context();
-    if sc.is_valid() {
+    if sc.is_valid() && sc.is_sampled() {
         Some(sc.trace_id().to_string())
     } else {
         None
     }
+}
+
+/// Whether `span`'s trace is sampled (i.e. it will be recorded and exported).
+///
+/// Hot paths gate per-request attribute recording on this: a head-sampled-out
+/// span is never exported, so recording attributes onto it is wasted work. The
+/// standard samplers this crate installs (`always_on`/`always_off`/
+/// `traceidratio` and their parent-based variants) only ever decide *drop* or
+/// *record-and-sample* — never OTel's record-only state — so `is_sampled` is an
+/// exact proxy for "will be recorded" here (Issue #3376, MED2 / Perf).
+#[must_use]
+pub fn span_is_sampled(span: &tracing::Span) -> bool {
+    if !is_active() {
+        return false;
+    }
+    let cx = span.context();
+    cx.span().span_context().is_sampled()
 }
 
 /// The active `(trace_id, span_id)` pair if a valid span is current.
@@ -537,14 +564,22 @@ pub fn init_in_memory_global(
 }
 
 fn install_global(provider: SdkTracerProvider) -> Result<(), OtelError> {
-    opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+    // Attempt the subscriber install FIRST. A second `init()` loses the race
+    // here and returns `SubscriberAlreadySet`; by trying it before mutating any
+    // other global we never swap out a healthy first provider/propagator on a
+    // failed re-init (Issue #3376, LOW4). The tracer clones an `Arc` to the
+    // provider, so the layer stays fully functional independent of the global
+    // tracer-provider slot.
     let tracer = provider.tracer(TRACER_NAME);
-    opentelemetry::global::set_tracer_provider(provider);
     let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
     tracing_subscriber::registry()
         .with(otel_layer)
         .try_init()
         .map_err(|e| OtelError::SubscriberAlreadySet(e.to_string()))?;
+    // Only now, having won the subscriber slot, publish the global propagator
+    // and tracer provider.
+    opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+    opentelemetry::global::set_tracer_provider(provider);
     set_active(true);
     Ok(())
 }
@@ -715,5 +750,126 @@ mod tests {
             root.span_context.span_id(),
             "child span not nested under http root"
         );
+    }
+
+    /// The sampler ratio arg is clamped into `[0.0, 1.0]`; NaN / unparseable /
+    /// missing falls back to the default full-sampling ratio (Issue #3376,
+    /// LOW3).
+    #[test]
+    fn sampler_arg_ratio_is_clamped() {
+        let ratio = |cfg: &SamplerConfig| match cfg {
+            SamplerConfig::TraceIdRatio(r) => *r,
+            other => panic!("expected TraceIdRatio, got {other:?}"),
+        };
+        assert!(
+            (ratio(&SamplerConfig::parse("traceidratio", Some("0.0"))) - 0.0).abs() < f64::EPSILON
+        );
+        assert!(
+            (ratio(&SamplerConfig::parse("traceidratio", Some("1.0"))) - 1.0).abs() < f64::EPSILON
+        );
+        // Above range → clamped down to 1.0.
+        assert!(
+            (ratio(&SamplerConfig::parse("traceidratio", Some("2.0"))) - 1.0).abs() < f64::EPSILON
+        );
+        // Below range → clamped up to 0.0.
+        assert!(
+            (ratio(&SamplerConfig::parse("traceidratio", Some("-1.0"))) - 0.0).abs() < f64::EPSILON
+        );
+        // NaN → default full sampling.
+        assert!(
+            (ratio(&SamplerConfig::parse("traceidratio", Some("NaN"))) - 1.0).abs() < f64::EPSILON
+        );
+        // Unparseable → default.
+        assert!(
+            (ratio(&SamplerConfig::parse("traceidratio", Some("abc"))) - 1.0).abs() < f64::EPSILON
+        );
+        // Missing arg → default.
+        assert!((ratio(&SamplerConfig::parse("traceidratio", None)) - 1.0).abs() < f64::EPSILON);
+        // Same clamping for the parent-based ratio variant.
+        match SamplerConfig::parse("parentbased_traceidratio", Some("5.0")) {
+            SamplerConfig::ParentBasedTraceIdRatio(r) => {
+                assert!((r - 1.0).abs() < f64::EPSILON);
+            }
+            other => panic!("expected ParentBasedTraceIdRatio, got {other:?}"),
+        }
+    }
+
+    /// A valid-but-**sampled-out** span must not surface a trace id (it will
+    /// never be exported — the id would be a dead-end lookup), while a sampled
+    /// span does. Regression guard for MED1 (Issue #3376).
+    #[test]
+    #[serial]
+    fn current_trace_id_gated_on_sampling() {
+        // `always_off`: root span is valid but dropped by the head sampler.
+        let off = OtelConfig {
+            enabled: true,
+            sampler: SamplerConfig::AlwaysOff,
+            ..OtelConfig::default()
+        };
+        let ((tid_off, sampled_off), _) = with_scoped_in_memory(&off, || {
+            let span = super::super::http_request_span("POST", "/query");
+            let _g = span.enter();
+            (current_trace_id(), span_is_sampled(&span))
+        });
+        set_active_test(false);
+        assert!(
+            tid_off.is_none(),
+            "sampled-out span must not surface a trace id, got {tid_off:?}"
+        );
+        assert!(!sampled_off, "sampled-out span must report not sampled");
+
+        // `always_on`: root span is sampled and will be exported.
+        let on = OtelConfig {
+            enabled: true,
+            sampler: SamplerConfig::AlwaysOn,
+            ..OtelConfig::default()
+        };
+        let ((tid_on, sampled_on), _) = with_scoped_in_memory(&on, || {
+            let span = super::super::http_request_span("POST", "/query");
+            let _g = span.enter();
+            (current_trace_id(), span_is_sampled(&span))
+        });
+        set_active_test(false);
+        assert_eq!(
+            tid_on.as_deref().map(str::len),
+            Some(32),
+            "sampled span must surface a 32-hex trace id, got {tid_on:?}"
+        );
+        assert!(sampled_on, "sampled span must report sampled");
+    }
+
+    /// The guard's `force_flush` delivers spans still buffered in the batch
+    /// processor. Uses the production (batch) processor so the flush is
+    /// load-bearing — unlike `SimpleSpanProcessor`, which exports on span end.
+    /// (Test gap: prior tests `mem::forget` the guard, leaving this unexercised.)
+    #[test]
+    #[serial]
+    fn guard_force_flush_delivers_pending_spans() {
+        let cfg = OtelConfig {
+            enabled: true,
+            sampler: SamplerConfig::AlwaysOn,
+            ..OtelConfig::default()
+        };
+        let exporter = InMemorySpanExporter::new();
+        let provider = provider_with_exporter(&cfg, exporter.clone(), false);
+        let tracer = provider.tracer(TRACER_NAME);
+        let subscriber =
+            tracing_subscriber::registry().with(tracing_opentelemetry::layer().with_tracer(tracer));
+        set_active(true);
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("aletheiadb.http.request");
+            let _g = span.enter();
+        });
+        // The span has closed but may still be buffered by the batch processor.
+        let guard = OtelGuard { provider };
+        guard.force_flush();
+        let spans = exporter.spans();
+        set_active(false);
+        assert!(
+            spans.iter().any(|s| s.name == "aletheiadb.http.request"),
+            "force_flush should have delivered the pending span, got {} spans",
+            spans.len()
+        );
+        drop(guard);
     }
 }

--- a/src/observability/otel.rs
+++ b/src/observability/otel.rs
@@ -42,12 +42,15 @@ use opentelemetry::trace::{TraceContextExt, TracerProvider as _};
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::propagation::TraceContextPropagator;
-use opentelemetry_sdk::trace::{
-    Sampler, SdkTracerProvider, SimpleSpanProcessor, SpanData, SpanExporter,
-};
+use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider, SimpleSpanProcessor, SpanExporter};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
+
+/// Re-export of the SDK's exported-span type so downstream tests / embedders
+/// can inspect captured spans (via [`InMemorySpanExporter::spans`]) without
+/// taking a direct dependency on `opentelemetry_sdk`.
+pub use opentelemetry_sdk::trace::SpanData;
 
 /// Standard OTLP endpoint environment variable.
 pub const ENV_OTLP_ENDPOINT: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
@@ -71,6 +74,7 @@ pub const TRACER_NAME: &str = super::DB_SYSTEM_NAME;
 /// span-context work, so a compiled-in-but-uninitialized build pays only the
 /// load, never the OTel machinery.
 static OTEL_ACTIVE: AtomicBool = AtomicBool::new(false);
+static CAPTURE_STATEMENTS: AtomicBool = AtomicBool::new(false);
 
 /// Whether OTel tracing has been initialized and is exporting.
 #[must_use]
@@ -79,8 +83,19 @@ pub fn is_active() -> bool {
     OTEL_ACTIVE.load(Ordering::Relaxed)
 }
 
+/// Whether sanitized statement capture is enabled (opt-in, off by default).
+#[must_use]
+#[inline]
+pub fn capture_statements() -> bool {
+    CAPTURE_STATEMENTS.load(Ordering::Relaxed)
+}
+
 fn set_active(active: bool) {
     OTEL_ACTIVE.store(active, Ordering::Relaxed);
+}
+
+fn set_capture_statements(capture: bool) {
+    CAPTURE_STATEMENTS.store(capture, Ordering::Relaxed);
 }
 
 // ===========================================================================
@@ -478,6 +493,7 @@ impl Drop for OtelGuard {
         let _ = self.provider.force_flush();
         let _ = self.provider.shutdown();
         set_active(false);
+        set_capture_statements(false);
     }
 }
 
@@ -498,6 +514,7 @@ pub fn init(config: &OtelConfig) -> Result<Option<OtelGuard>, OtelError> {
     let exporter = build_otlp_exporter(config)?;
     let provider = provider_with_exporter(config, exporter, false);
     install_global(provider.clone())?;
+    set_capture_statements(config.capture_statements);
     Ok(Some(OtelGuard { provider }))
 }
 
@@ -515,6 +532,7 @@ pub fn init_in_memory_global(
     let exporter = InMemorySpanExporter::new();
     let provider = provider_with_exporter(config, exporter.clone(), true);
     install_global(provider.clone())?;
+    set_capture_statements(config.capture_statements);
     Ok((OtelGuard { provider }, exporter))
 }
 
@@ -543,6 +561,7 @@ fn with_scoped_in_memory<T>(config: &OtelConfig, f: impl FnOnce() -> T) -> (T, V
     let exporter = InMemorySpanExporter::new();
     let provider = provider_with_exporter(config, exporter.clone(), true);
     set_active(true);
+    set_capture_statements(config.capture_statements);
     opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
     let tracer = provider.tracer(TRACER_NAME);
     let subscriber =

--- a/tests/http_otel_parent_sampling.rs
+++ b/tests/http_otel_parent_sampling.rs
@@ -1,0 +1,111 @@
+//! Parent-based sampling honors the incoming W3C `sampled` flag (Issue #3376
+//! test gap). Runs in its own test binary with a `parentbased_always_on` global
+//! subscriber (the default policy) so a request that arrives with an explicit
+//! parent decision follows it:
+//!
+//! - incoming `...-01` (sampled) → the trace is continued and exported;
+//! - incoming `...-00` (not sampled) → the trace is dropped, nothing exported.
+//!
+//! Run with: `cargo test --test http_otel_parent_sampling --features http-server,otel`
+
+#![cfg(all(feature = "http-server", feature = "otel"))]
+
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::auth::AuthMode;
+use aletheiadb::http::{AppState, ServerConfig, build_test_router};
+use aletheiadb::observability::otel::{InMemorySpanExporter, OtelConfig, SamplerConfig, SpanData};
+use autumn_web::test::{TestApp, TestClient};
+use serde_json::json;
+use serial_test::serial;
+
+const ROOT_SPAN: &str = "aletheiadb.http.request";
+const INCOMING_TRACE: &str = "0af7651916cd43dd8448eb211c80319c";
+
+fn exporter() -> InMemorySpanExporter {
+    static EXPORTER: OnceLock<InMemorySpanExporter> = OnceLock::new();
+    EXPORTER
+        .get_or_init(|| {
+            let config = OtelConfig {
+                enabled: true,
+                sampler: SamplerConfig::ParentBasedAlwaysOn,
+                ..OtelConfig::default()
+            };
+            let (guard, exp) = aletheiadb::observability::otel::init_in_memory_global(&config)
+                .expect("install global otel subscriber");
+            std::mem::forget(guard);
+            exp
+        })
+        .clone()
+}
+
+fn client() -> TestClient {
+    let db = Arc::new(AletheiaDB::new().unwrap());
+    let state = AppState::new(db);
+    let config = ServerConfig::builder()
+        .auth_mode(AuthMode::Anonymous)
+        .build();
+    let router = build_test_router(state, &config).expect("router builds");
+    TestApp::from_router(router)
+}
+
+fn root_in_trace(spans: &[SpanData]) -> Option<&SpanData> {
+    spans
+        .iter()
+        .find(|s| s.name == ROOT_SPAN && s.span_context.trace_id().to_string() == INCOMING_TRACE)
+}
+
+#[tokio::test]
+#[serial]
+async fn incoming_sampled_flag_continues_trace() {
+    let exp = exporter();
+    exp.clear();
+    let client = client();
+
+    // Parent decision: sampled (`-01`).
+    let resp = client
+        .post("/query")
+        .header(
+            "traceparent",
+            &format!("00-{INCOMING_TRACE}-b7ad6b7169203331-01"),
+        )
+        .json(&json!({"operation": "find_node", "label": "Nothing"}))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200);
+
+    let spans = exp.spans();
+    assert!(
+        root_in_trace(&spans).is_some(),
+        "a `-01` sampled parent must continue and export the trace"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn incoming_not_sampled_flag_drops_trace() {
+    let exp = exporter();
+    exp.clear();
+    let client = client();
+
+    // Parent decision: not sampled (`-00`).
+    let resp = client
+        .post("/query")
+        .header(
+            "traceparent",
+            &format!("00-{INCOMING_TRACE}-b7ad6b7169203331-00"),
+        )
+        .json(&json!({"operation": "find_node", "label": "Nothing"}))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200);
+
+    let spans = exp.spans();
+    assert!(
+        root_in_trace(&spans).is_none(),
+        "a `-00` not-sampled parent must drop the trace (nothing exported), got {} spans",
+        spans.len()
+    );
+}

--- a/tests/http_otel_sampled_out.rs
+++ b/tests/http_otel_sampled_out.rs
@@ -1,0 +1,113 @@
+//! HTTP-surface behavior when the head sampler drops the trace (Issue #3376,
+//! MED1 / MED2). Runs in its own test binary so it can install an `always_off`
+//! global subscriber independent of the `always_on` subscriber used by
+//! `http_otel_tracing.rs` (only one global `tracing` subscriber exists per
+//! process).
+//!
+//! Asserts that for a sampled-out request:
+//!
+//! - **no** span is exported (the trace is dropped, not just un-sent); and
+//! - an error response carries **no** `trace_id` body field and **no**
+//!   `x-trace-id` header — a dropped trace id would be a dead-end lookup.
+//!
+//! Run with: `cargo test --test http_otel_sampled_out --features http-server,otel`
+
+#![cfg(all(feature = "http-server", feature = "otel"))]
+
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::auth::AuthMode;
+use aletheiadb::http::{AppState, ServerConfig, build_test_router};
+use aletheiadb::observability::otel::{InMemorySpanExporter, OtelConfig, SamplerConfig};
+use autumn_web::test::{TestApp, TestClient};
+use serde_json::{Value, json};
+use serial_test::serial;
+
+const ROOT_SPAN: &str = "aletheiadb.http.request";
+
+/// Install an `always_off` global subscriber exactly once for this binary.
+fn exporter() -> InMemorySpanExporter {
+    static EXPORTER: OnceLock<InMemorySpanExporter> = OnceLock::new();
+    EXPORTER
+        .get_or_init(|| {
+            let config = OtelConfig {
+                enabled: true,
+                sampler: SamplerConfig::AlwaysOff,
+                ..OtelConfig::default()
+            };
+            let (guard, exp) = aletheiadb::observability::otel::init_in_memory_global(&config)
+                .expect("install global otel subscriber");
+            std::mem::forget(guard);
+            exp
+        })
+        .clone()
+}
+
+fn client() -> TestClient {
+    let db = Arc::new(AletheiaDB::new().unwrap());
+    let state = AppState::new(db);
+    let config = ServerConfig::builder()
+        .auth_mode(AuthMode::Anonymous)
+        .build();
+    let router = build_test_router(state, &config).expect("router builds");
+    TestApp::from_router(router)
+}
+
+#[tokio::test]
+#[serial]
+async fn sampled_out_error_response_omits_trace_id() {
+    let exp = exporter();
+    exp.clear();
+    let client = client();
+
+    // A get_node for a non-existent id → 404 error path.
+    let resp = client
+        .post("/query")
+        .json(&json!({"operation": "get_node", "node_id": 999_999_999}))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 404);
+
+    // The trace was dropped by the sampler: no trace_id anywhere.
+    let body: Value = serde_json::from_slice(&resp.body).expect("json error body");
+    assert!(
+        body.get("trace_id").is_none(),
+        "sampled-out error response must omit trace_id, got {body}"
+    );
+    assert!(
+        resp.header("x-trace-id").is_none(),
+        "sampled-out error response must omit the x-trace-id header"
+    );
+
+    // And no aletheiadb.http.request span was ever exported.
+    let spans = exp.spans();
+    assert!(
+        !spans.iter().any(|s| s.name == ROOT_SPAN),
+        "a sampled-out request must export no http root span, got {} spans",
+        spans.len()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn sampled_out_success_exports_no_span() {
+    let exp = exporter();
+    exp.clear();
+    let client = client();
+
+    let resp = client
+        .post("/query")
+        .json(&json!({"operation": "create_node", "label": "Person"}))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200);
+
+    let spans = exp.spans();
+    assert!(
+        !spans.iter().any(|s| s.name == ROOT_SPAN),
+        "a sampled-out request must export no http root span, got {} spans",
+        spans.len()
+    );
+}

--- a/tests/http_otel_tracing.rs
+++ b/tests/http_otel_tracing.rs
@@ -216,6 +216,121 @@ async fn absent_traceparent_starts_new_root_trace() {
     );
 }
 
+/// A malformed `traceparent` (`"garbage"`) must not error the request and must
+/// start a fresh, valid (non-all-zeros) root trace rather than nesting under a
+/// bogus parent (Issue #3376 test gap).
+#[tokio::test]
+#[serial]
+async fn malformed_traceparent_starts_fresh_root() {
+    let exp = exporter();
+    exp.clear();
+    let client = client();
+
+    // Each is rejected by the W3C parser: no structure; the forbidden `ff`
+    // version; and a truncated 4-field header missing the flags. (A merely
+    // *unknown* forward-compatible version like `99` is deliberately NOT here —
+    // the spec requires it still be parsed, so it would continue the trace.)
+    for bad in [
+        "garbage",
+        "ff-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+        "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331",
+    ] {
+        exp.clear();
+        let resp = client
+            .post("/query")
+            .header("traceparent", bad)
+            .json(&json!({"operation": "find_node", "label": "Nothing"}))
+            .send()
+            .await;
+        assert_eq!(
+            resp.status.as_u16(),
+            200,
+            "malformed traceparent {bad:?} must not error"
+        );
+
+        let spans = exp.spans();
+        let root = find_root(&spans);
+        assert_eq!(
+            root.parent_span_id.to_string(),
+            INVALID_SPAN_ID,
+            "malformed traceparent {bad:?} should yield a fresh root"
+        );
+        assert_ne!(
+            root.span_context.trace_id().to_string(),
+            "00000000000000000000000000000000",
+            "root should have a valid, freshly-generated trace id (not all zeros)"
+        );
+    }
+}
+
+/// Per W3C Trace Context, more than one `traceparent` header is ambiguous and
+/// must be treated as no parent — a fresh root trace (Issue #3376, LOW5).
+#[tokio::test]
+#[serial]
+async fn multiple_traceparent_headers_start_fresh_root() {
+    let exp = exporter();
+    exp.clear();
+    let client = client();
+
+    let incoming_trace = "0af7651916cd43dd8448eb211c80319c";
+
+    let resp = client
+        .post("/query")
+        .header(
+            "traceparent",
+            &format!("00-{incoming_trace}-b7ad6b7169203331-01"),
+        )
+        .header(
+            "traceparent",
+            "00-11111111111111111111111111111111-2222222222222222-01",
+        )
+        .json(&json!({"operation": "find_node", "label": "Nothing"}))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200);
+
+    let spans = exp.spans();
+    let root = find_root(&spans);
+    // Fresh root: neither incoming trace id is adopted, and there is no parent.
+    assert_eq!(root.parent_span_id.to_string(), INVALID_SPAN_ID);
+    assert_ne!(
+        root.span_context.trace_id().to_string(),
+        incoming_trace,
+        "duplicate traceparent must NOT continue the caller's trace"
+    );
+    assert_ne!(
+        root.span_context.trace_id().to_string(),
+        "00000000000000000000000000000000"
+    );
+}
+
+/// A `tracestate` with no accompanying `traceparent` carries no parent span —
+/// the request must start a fresh root trace (Issue #3376 test gap).
+#[tokio::test]
+#[serial]
+async fn tracestate_without_traceparent_starts_fresh_root() {
+    let exp = exporter();
+    exp.clear();
+    let client = client();
+
+    let resp = client
+        .post("/query")
+        .header("tracestate", "vendor=value")
+        .json(&json!({"operation": "find_node", "label": "Nothing"}))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200);
+
+    let spans = exp.spans();
+    let root = find_root(&spans);
+    assert_eq!(root.parent_span_id.to_string(), INVALID_SPAN_ID);
+    assert_ne!(
+        root.span_context.trace_id().to_string(),
+        "00000000000000000000000000000000",
+        "root should have a valid, freshly-generated trace id"
+    );
+}
+
 #[tokio::test]
 #[serial]
 async fn credentials_never_appear_in_span_attributes() {

--- a/tests/http_otel_tracing.rs
+++ b/tests/http_otel_tracing.rs
@@ -1,0 +1,328 @@
+//! End-to-end OpenTelemetry tracing tests for the HTTP surface (Issue #3376).
+//!
+//! Uses an in-memory span exporter as a stand-in OTLP receiver (installed once
+//! as the process-global subscriber so spans created on `spawn_blocking`
+//! threads are captured too) and drives the fully-wired test router. Verifies:
+//!
+//! - database child spans nest under the HTTP root span (0 orphaned spans);
+//! - an incoming W3C `traceparent` continues the caller's trace;
+//! - an absent `traceparent` starts a fresh root trace;
+//! - **credentials never appear in any span** (attributes/name/events);
+//! - error responses carry the active trace id for correlation;
+//! - a request is identifiable by its operation attribute.
+//!
+//! Run with: `cargo test --test http_otel_tracing --features http-server,otel`
+
+#![cfg(all(feature = "http-server", feature = "otel"))]
+
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::auth::AuthMode;
+use aletheiadb::http::{AppState, ServerConfig, build_test_router};
+use aletheiadb::observability::otel::{InMemorySpanExporter, OtelConfig, SamplerConfig, SpanData};
+use autumn_web::test::{TestApp, TestClient};
+use serde_json::{Value, json};
+use serial_test::serial;
+
+/// The HTTP root span name.
+const ROOT_SPAN: &str = "aletheiadb.http.request";
+/// The invalid/zero span id (16 hex zeros) that marks a root span's parent.
+const INVALID_SPAN_ID: &str = "0000000000000000";
+/// Canary credential material; no span may ever contain it.
+const CREDENTIAL_CANARY: &str = "credentialleakcanary0xdeadbeef";
+
+/// Install the global OTel subscriber exactly once (only one global `tracing`
+/// subscriber may exist per process) and return the shared in-memory exporter.
+/// The guard is intentionally leaked so tracing stays active for the whole
+/// test binary.
+fn exporter() -> InMemorySpanExporter {
+    static EXPORTER: OnceLock<InMemorySpanExporter> = OnceLock::new();
+    EXPORTER
+        .get_or_init(|| {
+            let config = OtelConfig {
+                enabled: true,
+                sampler: SamplerConfig::AlwaysOn,
+                ..OtelConfig::default()
+            };
+            let (guard, exp) = aletheiadb::observability::otel::init_in_memory_global(&config)
+                .expect("install global otel subscriber");
+            std::mem::forget(guard);
+            exp
+        })
+        .clone()
+}
+
+/// Fresh anonymous-mode router (auth is covered elsewhere; anonymous mode lets
+/// us send credential headers that are ignored, so we can prove they never
+/// leak into spans).
+fn client() -> TestClient {
+    let db = Arc::new(AletheiaDB::new().unwrap());
+    let state = AppState::new(db);
+    let config = ServerConfig::builder()
+        .auth_mode(AuthMode::Anonymous)
+        .build();
+    let router = build_test_router(state, &config).expect("router builds");
+    TestApp::from_router(router)
+}
+
+fn find_root(spans: &[SpanData]) -> &SpanData {
+    spans
+        .iter()
+        .find(|s| s.name == ROOT_SPAN)
+        .expect("an http root span was exported")
+}
+
+/// Spans belonging to the same trace as the HTTP root span. The test router's
+/// tower `TraceLayer` emits its own separate-trace request span; we scope
+/// nesting/continuity assertions to *our* trace.
+fn request_trace_spans(spans: &[SpanData]) -> Vec<&SpanData> {
+    let root = find_root(spans);
+    let trace = root.span_context.trace_id().to_string();
+    spans
+        .iter()
+        .filter(|s| s.span_context.trace_id().to_string() == trace)
+        .collect()
+}
+
+/// Full lowercase debug dump of a span, for credential-leak scanning across
+/// name, attributes, and events.
+fn span_dump(s: &SpanData) -> String {
+    format!("{s:?}").to_lowercase()
+}
+
+/// Read a string-valued attribute off a span.
+fn attr(s: &SpanData, key: &str) -> Option<String> {
+    s.attributes
+        .iter()
+        .find(|kv| kv.key.as_str() == key)
+        .map(|kv| kv.value.to_string())
+}
+
+#[tokio::test]
+#[serial]
+async fn db_child_spans_nest_under_http_root_with_no_orphans() {
+    let exp = exporter();
+    exp.clear();
+    let client = client();
+
+    // A write op produces an `aletheiadb.transaction.commit` child span.
+    let resp = client
+        .post("/query")
+        .json(&json!({"operation": "create_node", "label": "Person"}))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200, "create_node should succeed");
+
+    let all = exp.spans();
+    assert!(!all.is_empty(), "expected exported spans");
+    let spans = request_trace_spans(&all);
+    let root = find_root(&all);
+
+    // At least one child DB span nested under the http root.
+    let child_count = spans
+        .iter()
+        .filter(|s| s.parent_span_id == root.span_context.span_id())
+        .count();
+    assert!(
+        child_count >= 1,
+        "expected >=1 DB child span under the http root, got {child_count}"
+    );
+
+    // 0 orphans: every non-root span in the request trace has a parent present.
+    let ids: std::collections::HashSet<String> = spans
+        .iter()
+        .map(|s| s.span_context.span_id().to_string())
+        .collect();
+    for s in &spans {
+        let parent = s.parent_span_id.to_string();
+        if parent != INVALID_SPAN_ID {
+            assert!(
+                ids.contains(&parent),
+                "orphaned span {}: parent {parent} not present in request trace",
+                s.name
+            );
+        }
+    }
+    // The root itself is a root (no in-trace parent).
+    assert_eq!(root.parent_span_id.to_string(), INVALID_SPAN_ID);
+}
+
+#[tokio::test]
+#[serial]
+async fn incoming_traceparent_continues_caller_trace() {
+    let exp = exporter();
+    exp.clear();
+    let client = client();
+
+    // W3C traceparent: version-traceid-spanid-flags.
+    let incoming_trace = "0af7651916cd43dd8448eb211c80319c";
+    let incoming_span = "b7ad6b7169203331";
+    let traceparent = format!("00-{incoming_trace}-{incoming_span}-01");
+
+    let resp = client
+        .post("/query")
+        .header("traceparent", &traceparent)
+        .json(&json!({"operation": "create_node", "label": "Doc"}))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200);
+
+    let all = exp.spans();
+    assert!(!all.is_empty());
+    let root = find_root(&all);
+    // Continuity: the root joined the caller's trace, and every span in that
+    // trace (root + DB children) carries the incoming trace id.
+    assert_eq!(root.span_context.trace_id().to_string(), incoming_trace);
+    for s in request_trace_spans(&all) {
+        assert_eq!(
+            s.span_context.trace_id().to_string(),
+            incoming_trace,
+            "span {} did not join the caller's trace",
+            s.name
+        );
+    }
+    // The root span's parent is the caller's span id.
+    assert_eq!(
+        root.parent_span_id.to_string(),
+        incoming_span,
+        "http root did not nest under the incoming remote span"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn absent_traceparent_starts_new_root_trace() {
+    let exp = exporter();
+    exp.clear();
+    let client = client();
+
+    let resp = client
+        .post("/query")
+        .json(&json!({"operation": "find_node", "label": "Nothing"}))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200);
+
+    let spans = exp.spans();
+    let root = find_root(&spans);
+    // A fresh, valid trace with no remote parent.
+    assert_eq!(root.parent_span_id.to_string(), INVALID_SPAN_ID);
+    assert_ne!(
+        root.span_context.trace_id().to_string(),
+        "00000000000000000000000000000000",
+        "root should have a valid, freshly-generated trace id"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn credentials_never_appear_in_span_attributes() {
+    let exp = exporter();
+    exp.clear();
+    let client = client();
+
+    // Anonymous mode ignores these, but they must still never land in a span.
+    let resp = client
+        .post("/query")
+        .header("Authorization", &format!("Bearer {CREDENTIAL_CANARY}"))
+        .header("x-api-key", CREDENTIAL_CANARY)
+        .header(
+            "traceparent",
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+        )
+        .json(&json!({"operation": "create_node", "label": "Secret"}))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200);
+
+    let spans = exp.spans();
+    assert!(!spans.is_empty(), "expected spans to scan");
+    for s in &spans {
+        let dump = span_dump(s);
+        assert!(
+            !dump.contains(CREDENTIAL_CANARY),
+            "credential canary leaked into span {}: {dump}",
+            s.name
+        );
+        // The literal header names must not appear as attribute keys either.
+        for kv in &s.attributes {
+            let key = kv.key.as_str().to_ascii_lowercase();
+            assert_ne!(
+                key, "authorization",
+                "authorization became a span attribute"
+            );
+            assert_ne!(key, "x-api-key", "x-api-key became a span attribute");
+        }
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn error_response_carries_trace_id_for_correlation() {
+    let exp = exporter();
+    exp.clear();
+    let client = client();
+
+    // A get_node for a non-existent id → 404 error path.
+    let resp = client
+        .post("/query")
+        .json(&json!({"operation": "get_node", "node_id": 999_999_999}))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 404);
+
+    // Body carries a trace_id, and the x-trace-id header is present.
+    let body: Value = serde_json::from_slice(&resp.body).expect("json error body");
+    let trace_id = body
+        .get("trace_id")
+        .and_then(Value::as_str)
+        .expect("error body has trace_id");
+    assert_eq!(trace_id.len(), 32, "trace id should be 32 hex chars");
+    let header_tid = resp
+        .header("x-trace-id")
+        .expect("x-trace-id header present");
+    assert_eq!(header_tid, trace_id, "header and body trace id must match");
+
+    // And the id resolves to the root span actually exported for this request.
+    let spans = exp.spans();
+    let root = find_root(&spans);
+    assert_eq!(root.span_context.trace_id().to_string(), trace_id);
+    assert_eq!(
+        attr(root, "aletheiadb.error.code").as_deref(),
+        Some("NOT_FOUND")
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn request_is_identifiable_by_operation_attribute() {
+    let exp = exporter();
+    exp.clear();
+    let client = client();
+
+    // Mix a few operation shapes; then locate one by its span attribute.
+    for op in [
+        json!({"operation": "find_node", "label": "A"}),
+        json!({"operation": "create_node", "label": "B"}),
+    ] {
+        let resp = client.post("/query").json(&op).send().await;
+        assert_eq!(resp.status.as_u16(), 200);
+    }
+
+    let spans = exp.spans();
+    // The create_node root span is findable purely by attribute — the
+    // "find the offending operation" workflow.
+    let create_root = spans
+        .iter()
+        .find(|s| {
+            s.name == ROOT_SPAN && attr(s, "aletheiadb.operation").as_deref() == Some("create_node")
+        })
+        .expect("create_node request identifiable by operation attribute");
+    // Result count is stamped for slicing.
+    assert!(
+        attr(create_root, "aletheiadb.result.count").is_some(),
+        "result.count attribute should be recorded"
+    );
+}

--- a/tests/otel_double_init.rs
+++ b/tests/otel_double_init.rs
@@ -1,0 +1,60 @@
+//! A second global init must fail cleanly and never corrupt the first
+//! provider/propagator (Issue #3376, LOW4). Runs in its own test binary because
+//! it installs a real process-global subscriber.
+//!
+//! Run with: `cargo test --test otel_double_init --features otel`
+
+#![cfg(feature = "otel")]
+
+use aletheiadb::observability::otel::{
+    self, InMemorySpanExporter, OtelConfig, OtelError, SamplerConfig,
+};
+use serial_test::serial;
+
+fn config() -> OtelConfig {
+    OtelConfig {
+        enabled: true,
+        sampler: SamplerConfig::AlwaysOn,
+        ..OtelConfig::default()
+    }
+}
+
+#[test]
+#[serial]
+fn second_init_reports_already_set_and_preserves_first_provider() {
+    let (guard1, exp1): (_, InMemorySpanExporter) =
+        otel::init_in_memory_global(&config()).expect("first init installs the global subscriber");
+    assert!(otel::is_active(), "first init must activate tracing");
+
+    // A second init loses the subscriber race. With the LOW4 fix it attempts the
+    // subscriber install FIRST, so it returns `SubscriberAlreadySet` without
+    // swapping out the first provider/propagator — and it does not panic.
+    // (`OtelGuard` is not `Debug`, so reduce to a bool before asserting.)
+    let already_set = matches!(
+        otel::init_in_memory_global(&config()),
+        Err(OtelError::SubscriberAlreadySet(_))
+    );
+    assert!(
+        already_set,
+        "second init should report SubscriberAlreadySet without panicking"
+    );
+    assert!(
+        otel::is_active(),
+        "the first provider must remain active after a failed re-init"
+    );
+
+    // The first provider still records and exports.
+    {
+        let span = tracing::info_span!("aletheiadb.http.request");
+        let _g = span.enter();
+    }
+    guard1.force_flush();
+    assert!(
+        exp1.spans()
+            .iter()
+            .any(|s| s.name == "aletheiadb.http.request"),
+        "the first provider must still export after a failed re-init"
+    );
+
+    drop(guard1);
+}

--- a/tests/otel_overhead_gate.rs
+++ b/tests/otel_overhead_gate.rs
@@ -1,0 +1,73 @@
+//! Structural overhead gate for OTel tracing (Issue #3376, Perf HIGH).
+//!
+//! This is the **authoritative, non-flaky gate** for the "zero overhead when
+//! disabled" acceptance criterion — and, unlike a criterion micro-bench, it runs
+//! in the normal `cargo test` suite (and therefore in CI). It is a *structural*
+//! assertion, not a timing one, so it can never flake on a noisy runner:
+//!
+//! With the `otel` feature compiled in but tracing **never initialized**
+//! (runtime-disabled), the per-request span hot path must be inert — it must not
+//! activate tracing, must surface no trace id, must export nothing (no in-memory
+//! exporter is installed), and must not panic no matter how many times it runs.
+//!
+//! The companion criterion micro-bench (`benches/otel_overhead.rs`) measures the
+//! *magnitude* of the three regimes for local profiling; this test proves the
+//! disabled path is truly inert.
+//!
+//! Run with: `cargo test --test otel_overhead_gate --features otel`
+
+#![cfg(feature = "otel")]
+
+use aletheiadb::observability::http_request_span;
+use aletheiadb::observability::otel;
+
+const SAMPLE_TRACEPARENT: &str = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+/// The per-request span hot path, mirroring what the HTTP surface does: build
+/// the root span, attach an incoming W3C context *only when active*, and record
+/// the safe-by-default attributes.
+fn request_span_work() {
+    let span = http_request_span("POST", "/query");
+    if otel::is_active() {
+        otel::attach_parent(&span, Some(SAMPLE_TRACEPARENT), None);
+    }
+    span.record("aletheiadb.operation", "create_node");
+    span.record("aletheiadb.result.count", 1_i64);
+    span.record("aletheiadb.temporal.scope", "current");
+    let _entered = span.enter();
+    std::hint::black_box(&span);
+}
+
+#[test]
+fn disabled_request_span_hot_path_is_inert() {
+    // Nothing installs a subscriber in this binary → tracing is compiled in but
+    // runtime-disabled. This is deterministic (a fresh process), so the gate is
+    // never order-dependent.
+    assert!(
+        !otel::is_active(),
+        "tracing must be inactive when never initialized"
+    );
+    assert!(
+        otel::current_trace_id().is_none(),
+        "no trace id may be surfaced when tracing is inactive"
+    );
+    assert!(
+        !otel::span_is_sampled(&http_request_span("POST", "/x")),
+        "no span may report sampled when tracing is inactive"
+    );
+
+    // Exercising the hot path heavily must never panic, never activate tracing,
+    // and never produce a trace id — the disabled path is inert.
+    for _ in 0..100_000 {
+        request_span_work();
+    }
+
+    assert!(
+        !otel::is_active(),
+        "the hot path must not activate tracing as a side effect"
+    );
+    assert!(
+        otel::current_trace_id().is_none(),
+        "the hot path must not produce a trace id while disabled"
+    );
+}


### PR DESCRIPTION
Closes #3376.

## Summary

Adds feature-gated OpenTelemetry distributed tracing across the HTTP + query/write paths, joined to callers' traces via W3C context propagation. Builds on the existing `observability` span vocabulary (ADR 0056) rather than reinventing it. Zero cost when the feature is absent; a single relaxed atomic load when compiled-in but off.

## Acceptance criteria → evidence

| AC (#3376) | Implementation |
|---|---|
| Feature-gated OTLP exporter, standard env config, runtime enable/disable | New `otel` feature (composes with `observability`). `observability::otel` — OTLP HTTP/protobuf exporter reading `OTEL_EXPORTER_OTLP_ENDPOINT`/`OTEL_SERVICE_NAME`/`OTEL_TRACES_SAMPLER*`; `OtelConfig::from_env`; `init()` returns a flush-on-drop guard. |
| Spans for HTTP request (root) + query + write + coarse child spans | HTTP root span via the `HttpTrace` extractor; the existing `query_execute`/`transaction_commit`/vector/temporal child spans nest under it (the shared `blocking()` helper re-enters the current span inside `spawn_blocking`). |
| W3C `traceparent`/`tracestate` propagation; absent → root; 0 orphans | `otel::extract_context`/`attach_parent`; root span built `parent: None` so ambient middleware spans are ignored. Integration-tested: continuity, fresh-root, 0 orphans. |
| Safe-by-default attributes; statement OFF by default; values never emitted | `aletheiadb.operation`, `result.count`, `temporal.scope`, `error.code` (#3234). `db.query.text` only when `ALETHEIADB_OTEL_CAPTURE_STATEMENTS=1`; property values never attributes. |
| **Credentials never in spans** + test | W3C carriers only touch `traceparent`/`tracestate`; `Authorization`/`x-api-key` never read. Test `credentials_never_appear_in_span_attributes`. |
| Trace id in error responses (+ debug logs) | `error.rs` adds `trace_id` body field + `x-trace-id` header when active. |
| Sampling: always/never/ratio + parent-based; skip cost when sampled out | `SamplerConfig` (6 variants) from `OTEL_TRACES_SAMPLER`. |
| Overhead bounded & measured (bench gate) | `benches/otel_overhead.rs` (`required-features=["otel"]`): disabled vs enabled+recorded. |
| E2E against OTLP receiver; parent-child; slow request by attribute | `tests/http_otel_tracing.rs` with an in-memory OTLP receiver (6 tests). |
| Docs | `docs/guides/otel-tracing-guide.md` (enable/config/sampling/privacy/find-the-slow-query + Jaeger compose); linked from `docs/OBSERVABILITY.md`. |

## Design note (approach chosen)

Three wiring options were considered: **(a)** global tracing-subscriber + OTel layer at startup with an **extractor-based root span**; **(b)** a per-request span guard; **(c)** a tower `Layer` (test path only). autumn-web's sealed `IntoAppLayer` bound blocks arbitrary tower middleware on the production `run_server` path (why auth is an extractor), so **(a)** is the only option with production/test parity — the HTTP root span goes through the `HttpTrace` extractor exactly like `AuthContext`, and the handler body is `.instrument()`-ed so DB child spans (which run in `spawn_blocking`) nest correctly. Chosen: **(a)**.

## Scope

In lane: `src/observability/*`, `src/http/*`, `Cargo.toml`, `benches/`, `tests/`, `docs/`. No changes to `src/cypher` or `src/mcp` (MCP per-tool spans are a separate lane; the reusable `otel::extract_context`/`attach_parent` helpers are ready for them). No new HTTP routes (access-control matrix unaffected; `x-trace-id`/`trace_id` are additive).

## Testing

- New: `observability::otel` unit tests (7), `tests/http_otel_tracing.rs` (6).
- No regression: `http_server` (18), `http_auth` (24), `http_api` (5), `warden_http_*` (8) all pass.
- `cargo clippy` clean (`http-server`, `http-server,otel`); `cargo fmt` applied.
- Compiles feature-absent (`--no-default-features`) and otel-standalone (`--no-default-features --features otel`).
- Bench builds (`cargo bench --no-run --features otel`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwRkYyiuAD3fzCnpJdfQKh

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwRkYyiuAD3fzCnpJdfQKh)_