### PR TITLE
Close checkpoint/backup finalize window: hold historical write guard across commit_timestamp finalization (#3425)

### DIFF
--- a/src/api/transaction/write/apply.rs
+++ b/src/api/transaction/write/apply.rs
@@ -591,12 +591,25 @@ pub(crate) fn apply_single_write(
 /// for the duration of all operations. This avoids lock thrashing (acquiring/releasing
 /// for every single write) and ensures atomicity of the historical updates.
 ///
+/// The acquired `historical.write()` guard is **returned to the caller** rather than
+/// dropped internally (Issue #3425). The caller must keep it alive across
+/// [`finalize_current_commit_timestamps`] so that the current-side writes and their
+/// `commit_timestamp` finalization are atomic with respect to any snapshot
+/// (checkpoint / backup) that holds `historical.read()`. Otherwise a snapshot landing
+/// between the guard drop and finalize could capture a committed node/edge whose
+/// `commit_timestamp` is still `None`. Respecting the documented lock order
+/// (`historical` precedes `snapshot_lock`, adjacency, and the temporal-vector index
+/// lock), holding this guard across finalize introduces no lock-order inversion.
+///
 /// # Performance
 ///
-/// - **Locking**: Single lock acquisition for historical storage.
+/// - **Locking**: Single lock acquisition for historical storage, held across finalize.
 /// - **ID Generation**: Tombstone IDs are pre-generated in a batch to minimize lock contention.
 /// - **Adjacency**: Adjacency indexes are compacted *once* after all edge operations are complete.
-pub(crate) fn apply_changes(tx: &WriteTransaction, commit_timestamp: Timestamp) -> Result<()> {
+pub(crate) fn apply_changes<'a>(
+    tx: &'a WriteTransaction,
+    commit_timestamp: Timestamp,
+) -> Result<parking_lot::RwLockWriteGuard<'a, HistoricalStorage>> {
     // Create temporal interval for all operations in this transaction.
     let _temporal = BiTemporalInterval::current(commit_timestamp);
 
@@ -647,12 +660,13 @@ pub(crate) fn apply_changes(tx: &WriteTransaction, commit_timestamp: Timestamp) 
         num_deletes
     );
 
-    drop(historical);
-
     // With incremental adjacency indexes, edge updates are immediately visible
     // via merged reads. Background compaction handles delta->frozen promotion.
 
-    Ok(())
+    // Return the guard (Issue #3425): the caller holds it across
+    // `finalize_current_commit_timestamps` so a concurrent `historical.read()`
+    // snapshot cannot observe a committed node/edge with `commit_timestamp: None`.
+    Ok(historical)
 }
 
 /// Finalize commit timestamps in current storage after a successful `apply_changes`.

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -585,18 +585,39 @@ impl WriteTransaction {
 
         // Apply all changes atomically.
         // Nodes/edges are written with commit_timestamp: None during this phase.
-        apply::apply_changes(self, commit_timestamp)?;
+        //
+        // Issue #3425: `apply_changes` returns the `historical.write()` guard
+        // instead of dropping it internally. We hold it across finalization below
+        // so the current-side writes and their `commit_timestamp` finalization are
+        // atomic w.r.t. any snapshot (checkpoint / backup) holding `historical.read()`
+        // — closing the window in which a committed node/edge could be captured with
+        // `commit_timestamp: None`. This respects the documented lock order
+        // (`historical` precedes `snapshot_lock`, adjacency, and the temporal-vector
+        // index lock), so no lock-order inversion is introduced.
+        let historical_guard = apply::apply_changes(self, commit_timestamp)?;
 
         // Notify temporal vector index of transaction completion (for snapshot creation)
-        // Only call this if the transaction modified vector properties to avoid unnecessary overhead
+        // Only call this if the transaction modified vector properties to avoid unnecessary overhead.
+        // Safe to run under `historical_guard`: it only touches the temporal-vector
+        // index's own locks (never `historical`), so the lock order still holds.
         if self.buffer.has_vector_operations() {
             self.current.on_temporal_vector_transaction()?;
         }
+
+        // Test-only interleaving hook (Issue #3425): fires at the exact point
+        // between the historical writes and the commit-timestamp finalization,
+        // while `historical_guard` is held. Production builds compile this away.
+        #[cfg(test)]
+        commit_test_hooks::run_pre_finalize_hook();
 
         // Finalize commit timestamps in current storage.
         // Only reached on the success path — sets commit_timestamp: Some(T) on all
         // written nodes/edges, making them visible to future snapshot readers.
         apply::finalize_current_commit_timestamps(self, commit_timestamp);
+
+        // Finalization complete: release the historical write guard. Snapshots
+        // blocked on `historical.read()` now proceed and observe resolved timestamps.
+        drop(historical_guard);
 
         // Commit the constraint guard before registering with the visibility manager.
         // Committing first ensures that freed old-value slots are released before
@@ -1704,6 +1725,50 @@ impl Drop for WriteTransaction {
             // Register abort with visibility manager
             self.visibility_manager.register_abort(self.tx_id);
             self.state = TxState::Aborted;
+        }
+    }
+}
+
+/// Test-only interleaving hooks for the commit path (Issue #3425).
+///
+/// These let a test park a committing writer at a precise point — between the
+/// historical writes and the commit-timestamp finalization — so a concurrent
+/// snapshot (checkpoint / backup) can be driven into the exact window the
+/// hardening closes. The entire module is `#[cfg(test)]`, so it is compiled
+/// out of production builds and adds zero cost to the commit hot path.
+#[cfg(test)]
+pub(crate) mod commit_test_hooks {
+    use std::sync::{Arc, Mutex};
+
+    type Hook = Arc<dyn Fn() + Send + Sync>;
+
+    static PRE_FINALIZE_HOOK: Mutex<Option<Hook>> = Mutex::new(None);
+
+    /// Install a hook fired just before `finalize_current_commit_timestamps`.
+    pub(crate) fn set_pre_finalize_hook(hook: Hook) {
+        *PRE_FINALIZE_HOOK
+            .lock()
+            .expect("pre-finalize hook mutex poisoned") = Some(hook);
+    }
+
+    /// Remove any installed pre-finalize hook.
+    pub(crate) fn clear_pre_finalize_hook() {
+        *PRE_FINALIZE_HOOK
+            .lock()
+            .expect("pre-finalize hook mutex poisoned") = None;
+    }
+
+    /// Invoke the installed pre-finalize hook, if any.
+    ///
+    /// The `Arc` is cloned out from under the mutex so the hook body never runs
+    /// while holding the registry lock (the hook may block for a long time).
+    pub(crate) fn run_pre_finalize_hook() {
+        let hook = PRE_FINALIZE_HOOK
+            .lock()
+            .expect("pre-finalize hook mutex poisoned")
+            .clone();
+        if let Some(hook) = hook {
+            hook();
         }
     }
 }

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -590,19 +590,14 @@ impl WriteTransaction {
         // instead of dropping it internally. We hold it across finalization below
         // so the current-side writes and their `commit_timestamp` finalization are
         // atomic w.r.t. any snapshot (checkpoint / backup) holding `historical.read()`
-        // — closing the window in which a committed node/edge could be captured with
-        // `commit_timestamp: None`. This respects the documented lock order
-        // (`historical` precedes `snapshot_lock`, adjacency, and the temporal-vector
-        // index lock), so no lock-order inversion is introduced.
+        // — closing the *in-memory* window in which a committed node/edge could be
+        // captured with `commit_timestamp: None`. (The persisted index format does
+        // not serialize `commit_timestamp` and reconstructs it as committed on
+        // restore, so this fix hardens the in-memory snapshot invariant rather than
+        // fixing any on-disk corruption.) This respects the documented lock order
+        // (`historical` precedes `snapshot_lock` and adjacency), so no lock-order
+        // inversion is introduced.
         let historical_guard = apply::apply_changes(self, commit_timestamp)?;
-
-        // Notify temporal vector index of transaction completion (for snapshot creation)
-        // Only call this if the transaction modified vector properties to avoid unnecessary overhead.
-        // Safe to run under `historical_guard`: it only touches the temporal-vector
-        // index's own locks (never `historical`), so the lock order still holds.
-        if self.buffer.has_vector_operations() {
-            self.current.on_temporal_vector_transaction()?;
-        }
 
         // Test-only interleaving hook (Issue #3425): fires at the exact point
         // between the historical writes and the commit-timestamp finalization,
@@ -617,7 +612,23 @@ impl WriteTransaction {
 
         // Finalization complete: release the historical write guard. Snapshots
         // blocked on `historical.read()` now proceed and observe resolved timestamps.
+        //
+        // Issue #3425: only `finalize_current_commit_timestamps` must run under the
+        // guard to close the snapshot finalize window. The temporal-vector notify
+        // below is deliberately kept OUTSIDE the guard: it touches only the vector
+        // index's own locks and is independent of current-side commit_timestamp
+        // finalization, so serializing its (potentially O(N log N)) HNSW snapshot
+        // build under the global historical write lock would only add latency
+        // without any correctness benefit.
         drop(historical_guard);
+
+        // Notify temporal vector index of transaction completion (for snapshot creation).
+        // Only call this if the transaction modified vector properties to avoid unnecessary overhead.
+        // No ordering dependency on finalize: the vectors were already added to the
+        // index during `apply_changes`; this only triggers snapshot creation.
+        if self.buffer.has_vector_operations() {
+            self.current.on_temporal_vector_transaction()?;
+        }
 
         // Commit the constraint guard before registering with the visibility manager.
         // Committing first ensures that freed old-value slots are released before

--- a/src/db/backup.rs
+++ b/src/db/backup.rs
@@ -35,15 +35,36 @@ impl AletheiaDB {
         let source_lsn = self.wal.current_lsn().0;
 
         // Take consistent point-in-time snapshots.
-        let current_snapshot = self
-            .current
-            .create_snapshot(crate::storage::wal::LSN(source_lsn));
-        let (historical_snapshot, tiered_arc) = {
+        //
+        // Issue #3425: the current-storage snapshot is taken INSIDE the
+        // `historical.read()` guard (and under `snapshot_lock`, mirroring
+        // `create_checkpoint`'s locking contract) rather than before/outside it.
+        // A committing writer holds `historical.write()` across its
+        // `commit_timestamp` finalization, so acquiring `historical.read()` here
+        // excludes that window: without this, the backup could clone a committed
+        // node/edge whose `commit_timestamp` is still `None` (an in-memory
+        // finalize-window artifact). Lock order is preserved
+        // (`historical` -> `snapshot_lock` -> DashMap shards); `create_snapshot`
+        // takes no `historical`/`wal`/`current_timestamp` lock, so no inversion.
+        let (current_snapshot, historical_snapshot, tiered_arc) = {
             let hist = self.historical.read();
-            let snap = hist.create_snapshot(crate::storage::wal::LSN(source_lsn));
+            let current_snapshot = {
+                let _snap_lock = self.current.snapshot_lock.write();
+                self.current
+                    .create_snapshot(crate::storage::wal::LSN(source_lsn))
+            };
+            let historical_snapshot = hist.create_snapshot(crate::storage::wal::LSN(source_lsn));
             let tiered = hist.tiered_storage_arc();
-            (snap, tiered)
+            (current_snapshot, historical_snapshot, tiered)
         };
+
+        // Test-only seam (Issue #3425): lets the backup-path regression test inspect
+        // the exact current-storage snapshot this backup captured, so it can prove
+        // the snapshot never contains a committed node with `commit_timestamp: None`
+        // even when a concurrent writer is parked in the finalize window. Production
+        // builds compile this away.
+        #[cfg(test)]
+        backup_test_hooks::run_post_current_snapshot_hook(&current_snapshot);
 
         // Scan cold-tier versions outside the historical lock (disk I/O).
         let (cold_node_versions, cold_edge_versions) = if let Some(tiered) = tiered_arc {
@@ -168,4 +189,50 @@ fn build_restore_config(persistence_dir: &Path, wal_dir: std::path::PathBuf) -> 
             ..Default::default()
         })
         .build()
+}
+
+/// Test-only interleaving seam for the Issue #3425 backup-path regression test.
+///
+/// Lets a test observe the exact current-storage snapshot that a real `backup()`
+/// call captured. The hook fires immediately after the snapshot is taken (inside
+/// the `historical.read()` guard block), so a test can drive the real backup path
+/// concurrently with a writer parked in the finalize window and assert the
+/// captured snapshot never contains a committed node with `commit_timestamp: None`.
+/// Compiled away in non-test builds.
+#[cfg(test)]
+pub(crate) mod backup_test_hooks {
+    use crate::storage::snapshot::CurrentStorageSnapshot;
+    use std::sync::{Arc, Mutex};
+
+    type Hook = Arc<dyn Fn(&CurrentStorageSnapshot) + Send + Sync>;
+
+    static POST_CURRENT_SNAPSHOT_HOOK: Mutex<Option<Hook>> = Mutex::new(None);
+
+    /// Install a hook fired just after `backup()` captures its current snapshot.
+    pub(crate) fn set_post_current_snapshot_hook(hook: Hook) {
+        *POST_CURRENT_SNAPSHOT_HOOK
+            .lock()
+            .expect("backup post-snapshot hook mutex poisoned") = Some(hook);
+    }
+
+    /// Remove any installed post-snapshot hook.
+    pub(crate) fn clear_post_current_snapshot_hook() {
+        *POST_CURRENT_SNAPSHOT_HOOK
+            .lock()
+            .expect("backup post-snapshot hook mutex poisoned") = None;
+    }
+
+    /// Invoke the installed post-snapshot hook, if any.
+    ///
+    /// The `Arc` is cloned out from under the mutex so the hook body never runs
+    /// while holding the registry lock.
+    pub(crate) fn run_post_current_snapshot_hook(snapshot: &CurrentStorageSnapshot) {
+        let hook = POST_CURRENT_SNAPSHOT_HOOK
+            .lock()
+            .expect("backup post-snapshot hook mutex poisoned")
+            .clone();
+        if let Some(hook) = hook {
+            hook(snapshot);
+        }
+    }
 }

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -2825,3 +2825,104 @@ fn test_stats_cold_storage_reports_migrated_versions() {
         "migrated versions must leave the hot historical counters"
     );
 }
+
+/// Regression test for Issue #3425: a checkpoint/backup snapshot must never
+/// capture a *committed* node whose `commit_timestamp` is still `None`.
+///
+/// The latent bug: the commit path finalized `commit_timestamp`
+/// (`None -> Some(T)`) *after* dropping the `historical.write()` guard and took
+/// no snapshot lock, leaving a narrow window in which a snapshot holding
+/// `historical.read()` could clone a committed node while its timestamp was
+/// still `None` (which downstream visibility logic treats as uncommitted).
+///
+/// The hardening (Option A in the issue) holds the `historical.write()` guard
+/// across finalization, making the current-write + finalize atomic w.r.t. any
+/// `historical.read()`-holding snapshot.
+///
+/// This test uses the `#[cfg(test)]` pre-finalize hook to deterministically park
+/// a committing writer in that exact window while a checker thread mimics
+/// `create_checkpoint`'s snapshot block -- holding `historical.read()` (outer)
+/// then `snapshot_lock.write()` (inner), exactly as the issue describes -- and
+/// inspects every captured node. Before the fix the checker observes
+/// `commit_timestamp: None` (RED). After the fix the checker's `historical.read()`
+/// blocks until finalize completes under the writer's held guard, so it only ever
+/// sees resolved timestamps (GREEN).
+#[test]
+fn test_checkpoint_never_captures_uncommitted_finalize_window_3425() {
+    use crate::api::transaction::write::commit_test_hooks;
+    use crate::storage::wal::LSN;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Barrier};
+    use std::time::{Duration, Instant};
+
+    let db = Arc::new(AletheiaDB::new().unwrap());
+
+    // Writer sets this when it enters the finalize window (pre-finalize hook).
+    let in_window = Arc::new(AtomicBool::new(false));
+    // Both threads rendezvous before the writer begins its commit.
+    let barrier = Arc::new(Barrier::new(2));
+
+    // Install a pre-finalize hook that (1) announces the window and (2) parks the
+    // writer long enough for the checker to attempt its snapshot. In the buggy
+    // code the `historical.write()` guard is already dropped here; in the fixed
+    // code it is still held across this sleep.
+    {
+        let in_window = Arc::clone(&in_window);
+        commit_test_hooks::set_pre_finalize_hook(Arc::new(move || {
+            in_window.store(true, Ordering::SeqCst);
+            std::thread::sleep(Duration::from_millis(200));
+        }));
+    }
+
+    // Writer thread: commit a single node. Its commit fires the hook.
+    let writer = {
+        let db = Arc::clone(&db);
+        let barrier = Arc::clone(&barrier);
+        std::thread::spawn(move || {
+            barrier.wait();
+            let props = PropertyMapBuilder::new().insert("name", "Alice").build();
+            db.create_node("Person", props).expect("create_node failed");
+        })
+    };
+
+    // Checker thread: once the writer is in the window, replicate the checkpoint
+    // snapshot block and assert no captured node is finalize-pending.
+    let checker = {
+        let db = Arc::clone(&db);
+        let in_window = Arc::clone(&in_window);
+        let barrier = Arc::clone(&barrier);
+        std::thread::spawn(move || {
+            barrier.wait();
+            // Spin until the writer signals it has entered the finalize window.
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while !in_window.load(Ordering::SeqCst) {
+                assert!(Instant::now() < deadline, "writer never entered window");
+                std::thread::yield_now();
+            }
+
+            // Mimic `create_checkpoint`'s consistent-snapshot block: hold the
+            // historical read guard (outer) then the snapshot lock (inner).
+            let hist_guard = db.historical.read();
+            let snap_lock = db.current.snapshot_lock.write();
+            let snapshot = db.current.create_snapshot(LSN(0));
+            let captured_none = snapshot
+                .nodes()
+                .iter()
+                .any(|n| n.metadata.commit_timestamp.is_none());
+            drop(snap_lock);
+            drop(hist_guard);
+            captured_none
+        })
+    };
+
+    writer.join().expect("writer thread panicked");
+    let captured_none = checker.join().expect("checker thread panicked");
+
+    commit_test_hooks::clear_pre_finalize_hook();
+
+    assert!(
+        !captured_none,
+        "Issue #3425: checkpoint snapshot captured a committed node with \
+         commit_timestamp: None inside the finalize window"
+    );
+}

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -2847,6 +2847,11 @@ fn test_stats_cold_storage_reports_migrated_versions() {
 /// `commit_timestamp: None` (RED). After the fix the checker's `historical.read()`
 /// blocks until finalize completes under the writer's held guard, so it only ever
 /// sees resolved timestamps (GREEN).
+/// Serializes the finalize-window tests (#3425). Both install the *global*
+/// `commit_test_hooks` pre-finalize hook, so they must never run concurrently or
+/// they would clobber each other's hook and interleave unpredictably.
+static FINALIZE_WINDOW_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[test]
 fn test_checkpoint_never_captures_uncommitted_finalize_window_3425() {
     use crate::api::transaction::write::commit_test_hooks;
@@ -2854,6 +2859,10 @@ fn test_checkpoint_never_captures_uncommitted_finalize_window_3425() {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Barrier};
     use std::time::{Duration, Instant};
+
+    let _serial = FINALIZE_WINDOW_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
 
     let db = Arc::new(AletheiaDB::new().unwrap());
 
@@ -2923,6 +2932,116 @@ fn test_checkpoint_never_captures_uncommitted_finalize_window_3425() {
     assert!(
         !captured_none,
         "Issue #3425: checkpoint snapshot captured a committed node with \
+         commit_timestamp: None inside the finalize window"
+    );
+}
+
+/// Regression test for Issue #3425 on the **`backup()`** path specifically.
+///
+/// The checkpoint test above only replicates the checkpoint lock ordering. This
+/// test drives the *real* `AletheiaDB::backup()` code concurrently with a writer
+/// parked in the finalize window, and — via a `#[cfg(test)]` seam inside
+/// `backup()` — inspects the exact current-storage snapshot `backup()` captured.
+///
+/// Before the Finding-1 fix, `backup()` cloned the current snapshot BEFORE (and
+/// outside) the `historical.read()` guard, so it could observe a committed node
+/// whose `commit_timestamp` is still `None` (RED). After the fix the snapshot is
+/// taken INSIDE `historical.read()`, which blocks on the writer's held
+/// `historical.write()` guard until finalize completes, so it only ever sees a
+/// resolved timestamp (GREEN).
+#[test]
+fn test_backup_never_captures_uncommitted_finalize_window_3425() {
+    use crate::api::transaction::write::commit_test_hooks;
+    use crate::db::backup::backup_test_hooks;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Barrier};
+    use std::time::{Duration, Instant};
+
+    let _serial = FINALIZE_WINDOW_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+
+    let db = Arc::new(AletheiaDB::new().unwrap());
+
+    // Writer sets this when it enters the finalize window (pre-finalize hook).
+    let in_window = Arc::new(AtomicBool::new(false));
+    // Records whether the snapshot that real `backup()` captured held a committed
+    // node with `commit_timestamp: None` (the bug).
+    let captured_none = Arc::new(AtomicBool::new(false));
+    // Set once the backup hook has fired (so we know backup reached its snapshot).
+    let backup_snapshotted = Arc::new(AtomicBool::new(false));
+    // Both threads rendezvous before the writer begins its commit.
+    let barrier = Arc::new(Barrier::new(2));
+
+    // Pre-finalize hook: announce the window and park the writer so the backup
+    // thread can run. In the buggy code the `historical.write()` guard is already
+    // dropped here; in the fixed code it is still held across this sleep.
+    {
+        let in_window = Arc::clone(&in_window);
+        commit_test_hooks::set_pre_finalize_hook(Arc::new(move || {
+            in_window.store(true, Ordering::SeqCst);
+            std::thread::sleep(Duration::from_millis(200));
+        }));
+    }
+
+    // Backup post-snapshot hook: inspect the real snapshot `backup()` took.
+    {
+        let captured_none = Arc::clone(&captured_none);
+        let backup_snapshotted = Arc::clone(&backup_snapshotted);
+        backup_test_hooks::set_post_current_snapshot_hook(Arc::new(move |snapshot| {
+            let has_none = snapshot
+                .nodes()
+                .iter()
+                .any(|n| n.metadata.commit_timestamp.is_none());
+            captured_none.store(has_none, Ordering::SeqCst);
+            backup_snapshotted.store(true, Ordering::SeqCst);
+        }));
+    }
+
+    // Writer thread: commit a single node. Its commit fires the pre-finalize hook.
+    let writer = {
+        let db = Arc::clone(&db);
+        let barrier = Arc::clone(&barrier);
+        std::thread::spawn(move || {
+            barrier.wait();
+            let props = PropertyMapBuilder::new().insert("name", "Alice").build();
+            db.create_node("Person", props).expect("create_node failed");
+        })
+    };
+
+    // Backup thread: once the writer is in the window, run the real backup path.
+    let backup_thread = {
+        let db = Arc::clone(&db);
+        let in_window = Arc::clone(&in_window);
+        let barrier = Arc::clone(&barrier);
+        std::thread::spawn(move || {
+            barrier.wait();
+            // Spin until the writer signals it has entered the finalize window.
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while !in_window.load(Ordering::SeqCst) {
+                assert!(Instant::now() < deadline, "writer never entered window");
+                std::thread::yield_now();
+            }
+
+            let tmp = tempfile::TempDir::new().expect("tempdir");
+            let path = tmp.path().join("finalize_window.albk");
+            db.backup(&path).expect("backup failed");
+        })
+    };
+
+    writer.join().expect("writer thread panicked");
+    backup_thread.join().expect("backup thread panicked");
+
+    commit_test_hooks::clear_pre_finalize_hook();
+    backup_test_hooks::clear_post_current_snapshot_hook();
+
+    assert!(
+        backup_snapshotted.load(Ordering::SeqCst),
+        "backup never captured its current snapshot (hook did not fire)"
+    );
+    assert!(
+        !captured_none.load(Ordering::SeqCst),
+        "Issue #3425: backup() captured a committed node with \
          commit_timestamp: None inside the finalize window"
     );
 }

--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -411,11 +411,25 @@ impl CheckpointManager {
     /// - Temporal index (all version chains)
     /// - Manifest (LSN and metadata)
     ///
+    /// # Locking contract (Issue #3425)
+    ///
+    /// `historical` is taken as a bare `&HistoricalStorage`, but a consistent
+    /// (and data-race-free) snapshot requires the **caller to hold the
+    /// `historical` `RwLock` read guard** for the whole duration of this call —
+    /// exactly as [`crate::db::AletheiaDB::backup`] does. Holding that read guard
+    /// is what makes the snapshot mutually exclusive with the commit path's
+    /// `historical.write()` guard, which (as of #3425) is now held across
+    /// `commit_timestamp` finalization. Without it, a snapshot can race the
+    /// finalize step and capture a committed node/edge whose `commit_timestamp`
+    /// is still `None`. Callers that already hold the guard by construction (e.g.
+    /// via `historical.read()`) satisfy this contract; do not call this method
+    /// with an unlocked `historical`.
+    ///
     /// # Arguments
     ///
     /// * `lsn` - Current LSN for consistency tracking
     /// * `current` - Current storage to persist
-    /// * `historical` - Historical storage to persist
+    /// * `historical` - Historical storage to persist (caller must hold its read guard)
     ///
     /// # Errors
     ///


### PR DESCRIPTION
Fixes #3425.

## Before / After (plain language)

**Before.** When a transaction committed, it wrote nodes/edges into current storage with `commit_timestamp: None` (pending), and finalized them to `Some(T)` **after** dropping the `historical.write()` guard, taking no snapshot lock. A concurrent snapshot — a checkpoint or `backup()` holding `historical.read()` — that landed in that few-instruction window could clone a *committed* node/edge while its `commit_timestamp` was still `None`. Downstream in-memory visibility logic (`is_visible_with_embedded_ts`) treats `None` as uncommitted, so a snapshot reader could momentarily misclassify a committed fact as uncommitted.

**After.** The `historical.write()` guard is now held continuously from the current-side writes through the `commit_timestamp` finalization, then released. Any snapshot must acquire `historical.read()`, which is mutually exclusive with the held write guard, so it can never observe a committed entity mid-finalize. It waits until finalization completes and sees a resolved timestamp.

### Scope of the invariant (calibration — Finding 4)

This is a **defense-in-depth fix for the in-memory snapshot invariant**, not an on-disk data-corruption fix. The persisted index-persistence graph format (`PersistedNode`) does **not** serialize `commit_timestamp`, and restore reconstructs it as `Some(current_time)` — so a `None` can never actually reach a persisted artifact or a restored database today. The fix closes the in-memory finalize window at the snapshot layer for **both** `create_checkpoint` **and** `backup()`; the persisted format independently already reconstructs `commit_timestamp` as committed on restore.

## How

This implements **Option A** from the issue (the filer's preferred, minimal design — no new lock primitive):

- `apply_changes` now **returns** the `historical.write()` guard instead of dropping it internally.
- The commit path holds that guard across `finalize_current_commit_timestamps` only, then drops it.
- **Finding 1 (backup gap — REQUIRED):** `backup()` previously cloned the current-storage snapshot **before/outside** the `historical.read()` guard, so the finalize-window exclusion did not cover it — `backup()` is the only production consumer of `current.create_snapshot` (`create_checkpoint` has no production caller). The current snapshot is now taken **inside** the `historical.read()` guard, under `snapshot_lock`, mirroring `create_checkpoint`'s documented locking contract.
- **Finding 2 (perf — vector notify):** `on_temporal_vector_transaction` (which can trigger an O(N log N) HNSW snapshot build) previously ran **while `historical.write()` was held**. It touches only the temporal-vector index's own locks and has **no ordering dependency** on finalize (the vectors were already added to the index during `apply_changes`; the notify only triggers snapshot creation). It is now run **after** the guard drops, so only `finalize_current_commit_timestamps` — the single step that needs the guard for #3425 correctness — is serialized under the global historical write lock.

**Lock-order / deadlock-freedom.** The documented order is `current_timestamp → wal → historical → temporal_indexes → id gens → outgoing → incoming`, with `snapshot_lock` and adjacency after `historical`. The writer acquires `historical` (write) then, per-write, `snapshot_lock` (read) — order preserved. Both snapshot paths (checkpoint and, after Finding 1, backup) acquire `historical` (read) → `snapshot_lock` (write) → DashMap index shards — same order. `create_snapshot` takes no `historical`/`wal`/`current_timestamp` lock, so no earlier primitive is ever taken while holding a later one. No inversion is introduced by the backup reorder.

`create_checkpoint` also documents its implicit "caller holds `historical` read guard" contract (the issue's "Also:" item).

## Red → Green tests

Two `#[cfg(test)]`-only regression tests (compiled out of production; zero hot-path cost) park a committing writer in the exact finalize window via a pre-finalize interleaving hook:

- `test_checkpoint_never_captures_uncommitted_finalize_window_3425` — a checker thread replicates `create_checkpoint`'s snapshot block (`historical.read()` outer, `snapshot_lock.write()` inner) and asserts no captured node has `commit_timestamp: None`.
- `test_backup_never_captures_uncommitted_finalize_window_3425` (**Finding 3, new**) — drives the **real `AletheiaDB::backup()`** path concurrently with the parked writer and, via a `#[cfg(test)]` seam inside `backup()`, inspects the exact current-storage snapshot `backup()` captured.
  - **RED** (before the Finding-1 reorder): `backup()` clones the current snapshot outside the guard → captures a committed node with `commit_timestamp: None` → assertion fails.
  - **GREEN** (after): `backup()`'s `historical.read()` blocks on the writer's held `historical.write()` guard until finalize completes → only resolved timestamps observed.

Both tests share a serialization lock because they install the same process-global pre-finalize hook.

## Acceptance criteria

- [x] Snapshot (checkpoint **and** backup) can no longer capture a committed node/edge with `commit_timestamp: None` — closed by holding the `historical.write()` guard across finalize (checkpoint) and taking the backup current snapshot under `historical.read()` (backup). Verified by two RED→GREEN regression tests.
- [x] Fix respects the documented lock-acquisition order (no new primitive; `historical` still precedes `snapshot_lock`/adjacency/temporal-vector locks). See deadlock-freedom argument above.
- [x] `create_checkpoint`'s implicit "caller holds `historical` read guard" contract is documented.
- [x] No `unsafe` introduced; no `.unwrap()`/`.expect()` on production paths (only in the `#[cfg(test)]` hooks/tests).

## Gates

- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all` — applied.
- `cargo test --lib` — 3580 passed, 0 failed, 2 ignored (the uid-0 havoc tests; pre-existing). Includes both #3425 tests.
- Miri: not applicable — no `unsafe` code added or modified (only parking_lot guard lifetimes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkubkQo6gZJc9iQtzaRtED

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkubkQo6gZJc9iQtzaRtED)_