### PR TITLE
Fix variable-length path depth-range semantics (#548)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -663,7 +663,16 @@ let results = db.execute_cypher_with_params("MATCH (n:Person {name: $name}) RETU
   earlier variable is rejected, and comma-separated patterns per optional
   clause are rejected (no variable-binding analysis yet -- all three would
   silently produce wrong rows)
-- Variable-depth: `-[:KNOWS*1..3]->`
+- Variable-depth: `-[:KNOWS*1..3]->` -- binds the far node to every node
+  reachable within the range (Issue #548); `*min..max`, `*..max`, `*min..`,
+  `*n`, and bare `*` are all honored. **Known v1 limitations**: (1) matching is
+  **node-distinct / shortest-path reachability**, a deliberate simplification of
+  openCypher trail (path-enumeration) semantics -- each distinct target is bound
+  once at its *shortest* hop-distance, so a node whose shortest path is below
+  `min` (or an anchor reached only via an in-range cycle) is not re-emitted at a
+  longer in-range depth (full trail semantics is a tracked follow-up); (2) the
+  open-ended upper bounds (`*` and `*min..`) are capped at depth **10**
+  (`DEFAULT_MAX_TRAVERSAL_DEPTH`; a configurable cap is a follow-up).
 - Directions: `->` (outgoing), `<-` (incoming), `-` (both)
 - Filtering: `WHERE n.age > 18 AND n.name = 'Alice'`
 - Results: `RETURN`, `RETURN DISTINCT`, `AS` aliases

--- a/benches/query_optimization.rs
+++ b/benches/query_optimization.rs
@@ -149,6 +149,7 @@ fn bench_cost_estimation(c: &mut Criterion) {
             }),
             direction: aletheiadb::query::ir::Direction::Outgoing,
             label: Some("KNOWS".to_string()),
+            min_depth: 2,
             depth: 2,
             temporal_context: None,
         }),

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -1399,19 +1399,132 @@ fn test_e2e_multi_hop_traversal() {
     let rows: Vec<_> = results.collect();
     assert_eq!(rows.len(), 1); // Bob
 
-    // 2-hop: Alice -> Bob -> Charlie (yields nodes at depth 2)
+    // 2-hop: Alice -> Bob -> Charlie.
+    // openCypher range `*1..2` binds `b` to EVERY node reachable at depth 1
+    // (Bob) or depth 2 (Charlie), not only the terminal-depth node.
     let results = db
         .execute_cypher("MATCH (a:Person {name: 'Alice'})-[:KNOWS*1..2]->(b) RETURN b")
         .unwrap();
-    let rows: Vec<_> = results.collect();
-    // Range *1..2 should yield nodes at depth 1 (Bob) and depth 2 (Charlie),
-    // but the executor may only return terminal-depth nodes depending on the
-    // TraversalDepth::Range semantics.  Assert at least 1 result.
-    assert!(
-        !rows.is_empty(),
-        "expected at least 1 result from *1..2 traversal, got {}",
-        rows.len()
+    let rows: Vec<_> = collect_rows(results);
+    let mut names: Vec<String> = rows.iter().filter_map(row_name).collect();
+    names.sort();
+    assert_eq!(names, vec!["Bob".to_string(), "Charlie".to_string()]);
+}
+
+// ============================================================================
+// Variable-length path depth-range matrix (Issue #548)
+//
+// openCypher `-[:R*min..max]->` binds the far node to EVERY distinct node
+// reachable at any depth d with min <= d <= max, not only the terminal depth.
+// ============================================================================
+
+/// Build a linear chain N0-[:R]->N1->N2->N3->N4 (5 nodes, 4 edges) and run
+/// `MATCH (a:N {name:'N0'})-[:R<spec>]->(b) RETURN b`, returning the SORTED
+/// list of resulting `b.name` values so tests can assert an exact set.
+fn varlen_chain_names(spec: &str) -> Vec<String> {
+    let db = AletheiaDB::new().unwrap();
+    let mut ids = Vec::new();
+    for i in 0..5 {
+        let id = db
+            .create_node(
+                "N",
+                PropertyMapBuilder::new()
+                    .insert("name", format!("N{i}"))
+                    .build(),
+            )
+            .unwrap();
+        ids.push(id);
+    }
+    for i in 0..4 {
+        db.create_edge(ids[i], ids[i + 1], "R", CorePropertyMap::new())
+            .unwrap();
+    }
+    let q = format!("MATCH (a:N {{name: 'N0'}})-[:R{spec}]->(b) RETURN b");
+    let rows = collect_rows(db.execute_cypher(&q).unwrap());
+    let mut names: Vec<String> = rows.iter().filter_map(row_name).collect();
+    names.sort();
+    names
+}
+
+#[test]
+fn test_varlen_depth_exact_1() {
+    assert_eq!(varlen_chain_names("*1..1"), vec!["N1"]);
+    assert_eq!(varlen_chain_names("*1"), vec!["N1"]);
+}
+
+#[test]
+fn test_varlen_depth_1_to_2() {
+    assert_eq!(varlen_chain_names("*1..2"), vec!["N1", "N2"]);
+}
+
+#[test]
+fn test_varlen_depth_1_to_3() {
+    assert_eq!(varlen_chain_names("*1..3"), vec!["N1", "N2", "N3"]);
+}
+
+#[test]
+fn test_varlen_depth_2_to_3() {
+    assert_eq!(varlen_chain_names("*2..3"), vec!["N2", "N3"]);
+}
+
+#[test]
+fn test_varlen_depth_exact_2() {
+    assert_eq!(varlen_chain_names("*2..2"), vec!["N2"]);
+    assert_eq!(varlen_chain_names("*2"), vec!["N2"]);
+}
+
+#[test]
+fn test_varlen_depth_max_only_2() {
+    assert_eq!(varlen_chain_names("*..2"), vec!["N1", "N2"]);
+}
+
+#[test]
+fn test_varlen_depth_min_only_3() {
+    // `*3..` is unbounded above; capped at DEFAULT_MAX_TRAVERSAL_DEPTH (10),
+    // well beyond the chain length, so it reaches N4.
+    assert_eq!(varlen_chain_names("*3.."), vec!["N3", "N4"]);
+}
+
+#[test]
+fn test_varlen_depth_unbounded() {
+    // `*` is Variable depth; capped at DEFAULT_MAX_TRAVERSAL_DEPTH (10).
+    assert_eq!(varlen_chain_names("*"), vec!["N1", "N2", "N3", "N4"]);
+}
+
+#[test]
+fn test_varlen_cycle_distinct_nodes_no_infinite_loop() {
+    // Triangle N0->N1->N2->N0. Per-input-node isomorphism dedup means each
+    // distinct reachable node is emitted at most once and the cycle back to
+    // the start node terminates instead of looping forever.
+    let db = AletheiaDB::new().unwrap();
+    let mut ids = Vec::new();
+    for i in 0..3 {
+        let id = db
+            .create_node(
+                "N",
+                PropertyMapBuilder::new()
+                    .insert("name", format!("N{i}"))
+                    .build(),
+            )
+            .unwrap();
+        ids.push(id);
+    }
+    db.create_edge(ids[0], ids[1], "R", CorePropertyMap::new())
+        .unwrap();
+    db.create_edge(ids[1], ids[2], "R", CorePropertyMap::new())
+        .unwrap();
+    db.create_edge(ids[2], ids[0], "R", CorePropertyMap::new())
+        .unwrap();
+
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (a:N {name: 'N0'})-[:R*1..5]->(b) RETURN b")
+            .unwrap(),
     );
+    let mut names: Vec<String> = rows.iter().filter_map(row_name).collect();
+    names.sort();
+    // N1 (depth 1) and N2 (depth 2) each once; N0 reached again at depth 3 is
+    // suppressed by the visited set (and the depth-0 start is never emitted).
+    assert_eq!(names, vec!["N1", "N2"]);
 }
 
 #[test]

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -1414,8 +1414,16 @@ fn test_e2e_multi_hop_traversal() {
 // ============================================================================
 // Variable-length path depth-range matrix (Issue #548)
 //
-// openCypher `-[:R*min..max]->` binds the far node to EVERY distinct node
-// reachable at any depth d with min <= d <= max, not only the terminal depth.
+// `-[:R*min..max]->` binds the far node to every DISTINCT node reachable at a
+// SHORTEST hop-distance d with min <= d <= max, not only the terminal depth.
+// This is node-distinct / shortest-path reachability: a deliberate v1
+// simplification of openCypher trail semantics (a node whose shortest path is
+// below `min`, or the anchor reached only via an in-range cycle, is not
+// re-emitted at a longer in-range depth). See
+// `test_varlen_min_ge_2_shortest_path_underreport` and
+// `test_varlen_cycle_distinct_nodes_no_infinite_loop` for the pinned
+// simplifications. On a linear chain (no shortcuts) shortest-depth == the only
+// depth, so the matrix below matches full openCypher semantics exactly.
 // ============================================================================
 
 /// Build a linear chain N0-[:R]->N1->N2->N3->N4 (5 nodes, 4 edges) and run
@@ -1493,7 +1501,7 @@ fn test_varlen_depth_unbounded() {
 
 #[test]
 fn test_varlen_cycle_distinct_nodes_no_infinite_loop() {
-    // Triangle N0->N1->N2->N0. Per-input-node isomorphism dedup means each
+    // Triangle N0->N1->N2->N0. Node-distinct / shortest-path dedup means each
     // distinct reachable node is emitted at most once and the cycle back to
     // the start node terminates instead of looping forever.
     let db = AletheiaDB::new().unwrap();
@@ -1522,9 +1530,209 @@ fn test_varlen_cycle_distinct_nodes_no_infinite_loop() {
     );
     let mut names: Vec<String> = rows.iter().filter_map(row_name).collect();
     names.sort();
-    // N1 (depth 1) and N2 (depth 2) each once; N0 reached again at depth 3 is
-    // suppressed by the visited set (and the depth-0 start is never emitted).
+    // Documented v1 (shortest-path) result: N1 (depth 1) and N2 (depth 2) each
+    // once; N0 reached again at depth 3 via the cycle is suppressed by the
+    // visited set (and the depth-0 start is never emitted).
+    //
+    // KNOWN LIMITATION: full openCypher trail semantics would ADDITIONALLY bind
+    // the anchor N0 here (via the length-3 trail N0->N1->N2->N0, which lands in
+    // the [1,5] range). This engine does not — node-distinct/shortest-path
+    // reachability is a deliberate simplification (tracked follow-up). This test
+    // records that documented behavior, not a claim of trail conformance.
     assert_eq!(names, vec!["N1", "N2"]);
+}
+
+#[test]
+fn test_varlen_min_ge_2_shortest_path_underreport() {
+    // Branching graph with a shortcut: N0->N1, N0->N2, N1->N2. Query `*2..2`.
+    //
+    // Full openCypher trail semantics would bind N2 via the length-2 trail
+    // N0->N1->N2. This engine binds each node at its SHORTEST depth only: N2's
+    // shortest path is N0->N2 (depth 1), which is below min=2, so N2 is marked
+    // visited at depth 1 and never re-emitted at depth 2 -> the result is EMPTY.
+    //
+    // This pins the documented v1 shortest-path/node-distinct simplification so
+    // the under-report is stated-and-tested, not a silent surprise. Full trail
+    // semantics is a tracked follow-up.
+    let db = AletheiaDB::new().unwrap();
+    let mut ids = Vec::new();
+    for i in 0..3 {
+        let id = db
+            .create_node(
+                "N",
+                PropertyMapBuilder::new()
+                    .insert("name", format!("N{i}"))
+                    .build(),
+            )
+            .unwrap();
+        ids.push(id);
+    }
+    db.create_edge(ids[0], ids[1], "R", CorePropertyMap::new())
+        .unwrap();
+    db.create_edge(ids[0], ids[2], "R", CorePropertyMap::new())
+        .unwrap();
+    db.create_edge(ids[1], ids[2], "R", CorePropertyMap::new())
+        .unwrap();
+
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (a:N {name: 'N0'})-[:R*2..2]->(b) RETURN b")
+            .unwrap(),
+    );
+    let names: Vec<String> = rows.iter().filter_map(row_name).collect();
+    // Documented shortest-path result (openCypher trail semantics would return
+    // ["N2"]).
+    assert_eq!(names, Vec::<String>::new());
+}
+
+/// Build a linear chain of `n` nodes N0->..->N{n-1} joined by `:R` edges, run
+/// `MATCH (a:N {name:'N0'})-[:R<spec>]->(b) RETURN b` with the given arrow
+/// syntax around the relationship, and return the SORTED result `b.name` set.
+/// `left`/`right` let a test pick edge direction (`-`/`->`, `<-`/`-`, `-`/`-`).
+fn varlen_chain_names_dir(n: usize, left: &str, spec: &str, right: &str) -> Vec<String> {
+    let db = AletheiaDB::new().unwrap();
+    let mut ids = Vec::new();
+    for i in 0..n {
+        let id = db
+            .create_node(
+                "N",
+                PropertyMapBuilder::new()
+                    .insert("name", format!("N{i}"))
+                    .build(),
+            )
+            .unwrap();
+        ids.push(id);
+    }
+    for i in 0..n.saturating_sub(1) {
+        db.create_edge(ids[i], ids[i + 1], "R", CorePropertyMap::new())
+            .unwrap();
+    }
+    let q = format!("MATCH (a:N {{name: 'N0'}}){left}[:R{spec}]{right}(b) RETURN b");
+    let rows = collect_rows(db.execute_cypher(&q).unwrap());
+    let mut names: Vec<String> = rows.iter().filter_map(row_name).collect();
+    names.sort();
+    names
+}
+
+#[test]
+fn test_varlen_incoming_direction_range() {
+    // Chain N0->N1->N2->N3 (outgoing edges). From N0, an INCOMING var-length
+    // pattern `<-[:R*1..3]-` follows edges backwards and reaches nothing (N0 has
+    // no in-edges). From N3 it would reach N2,N1,N0. Assert the reverse anchor:
+    // build the chain and query incoming from N3 via a direct db build.
+    let db = AletheiaDB::new().unwrap();
+    let mut ids = Vec::new();
+    for i in 0..4 {
+        let id = db
+            .create_node(
+                "N",
+                PropertyMapBuilder::new()
+                    .insert("name", format!("N{i}"))
+                    .build(),
+            )
+            .unwrap();
+        ids.push(id);
+    }
+    for i in 0..3 {
+        db.create_edge(ids[i], ids[i + 1], "R", CorePropertyMap::new())
+            .unwrap();
+    }
+    // Incoming traversal from N3 reaches N2 (d1), N1 (d2), N0 (d3).
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (a:N {name: 'N3'})<-[:R*1..3]-(b) RETURN b")
+            .unwrap(),
+    );
+    let mut names: Vec<String> = rows.iter().filter_map(row_name).collect();
+    names.sort();
+    assert_eq!(names, vec!["N0", "N1", "N2"]);
+}
+
+#[test]
+fn test_varlen_both_direction_range() {
+    // Undirected traversal `-[:R*1..3]-` over the chain N0->N1->N2->N3 from N0
+    // follows edges regardless of stored direction, reaching N1 (d1), N2 (d2),
+    // N3 (d3).
+    assert_eq!(
+        varlen_chain_names_dir(4, "-", "*1..3", "-"),
+        vec!["N1", "N2", "N3"]
+    );
+}
+
+#[test]
+fn test_varlen_cap_at_default_max_depth() {
+    // Chain longer than DEFAULT_MAX_TRAVERSAL_DEPTH (10): 14 nodes N0..N13.
+    // Unbounded `*` (and `*3..`) are capped at depth 10, so nodes beyond depth
+    // 10 (N11, N12, N13) are excluded; N1..N10 are reached.
+    // Sort expected the same (lexical) way the helper sorts its output.
+    let mut expected_all: Vec<String> = (1..=10).map(|i| format!("N{i}")).collect();
+    expected_all.sort();
+    assert_eq!(varlen_chain_names_dir(14, "-", "*", "->"), expected_all);
+
+    // `*3..` caps the same way: depths 3..=10 -> N3..N10.
+    let mut expected_min3: Vec<String> = (3..=10).map(|i| format!("N{i}")).collect();
+    expected_min3.sort();
+    assert_eq!(varlen_chain_names_dir(14, "-", "*3..", "->"), expected_min3);
+}
+
+#[test]
+fn test_varlen_optional_match_range_emits_intermediates() {
+    // The second bug site: OPTIONAL MATCH var-length range. Over the chain
+    // N0->N1->N2->N3, `OPTIONAL MATCH (a)-[:R*1..3]->(b)` must emit the
+    // intermediate-depth nodes (N1, N2, N3), not only the terminal depth.
+    let db = AletheiaDB::new().unwrap();
+    let mut ids = Vec::new();
+    for i in 0..4 {
+        let id = db
+            .create_node(
+                "N",
+                PropertyMapBuilder::new()
+                    .insert("name", format!("N{i}"))
+                    .build(),
+            )
+            .unwrap();
+        ids.push(id);
+    }
+    for i in 0..3 {
+        db.create_edge(ids[i], ids[i + 1], "R", CorePropertyMap::new())
+            .unwrap();
+    }
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (a:N {name: 'N0'}) OPTIONAL MATCH (a)-[:R*1..3]->(b) RETURN b")
+            .unwrap(),
+    );
+    let mut names: Vec<String> = rows.iter().filter_map(row_name).collect();
+    names.sort();
+    assert_eq!(names, vec!["N1", "N2", "N3"]);
+}
+
+#[test]
+fn test_varlen_optional_match_range_unmatched_preserves_row_with_null() {
+    // A leaf node (N3, no out-edges) with an OPTIONAL MATCH var-length pattern
+    // that matches nothing must still preserve the base row and bind `b` to
+    // null (left-outer semantics), rather than dropping the row.
+    let db = AletheiaDB::new().unwrap();
+    let mut ids = Vec::new();
+    for i in 0..4 {
+        let id = db
+            .create_node(
+                "N",
+                PropertyMapBuilder::new()
+                    .insert("name", format!("N{i}"))
+                    .build(),
+            )
+            .unwrap();
+        ids.push(id);
+    }
+    for i in 0..3 {
+        db.create_edge(ids[i], ids[i + 1], "R", CorePropertyMap::new())
+            .unwrap();
+    }
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (a:N {name: 'N3'}) OPTIONAL MATCH (a)-[:R*1..3]->(b) RETURN a, b")
+            .unwrap(),
+    );
+    // Exactly one row (the base row for N3) is preserved even though the
+    // optional var-length pattern matched nothing.
+    assert_eq!(rows.len(), 1);
 }
 
 #[test]

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -773,6 +773,23 @@ impl ResultIterator for TemporalNodeScanIterator {
 
 /// Iterator for graph traversal using BFS.
 ///
+/// # Variable-length depth-range semantics (`*min..max`)
+///
+/// For a variable-length pattern this iterator binds each **distinct** reachable
+/// target node **once**, at its **shortest** hop-distance from the anchor, and
+/// emits it iff `min <= shortestDepth <= max`. Because the per-input `visited`
+/// set is populated when a node is first enqueued (its shortest BFS depth), a
+/// node whose shortest path is shorter than `min` is marked visited early and is
+/// **not** re-emitted at a longer, in-range depth; likewise an anchor reachable
+/// again only via an in-range cycle is not re-bound.
+///
+/// This is **node-distinct / shortest-path reachability**, a deliberate v1
+/// simplification of openCypher's trail (path-enumeration) semantics. Under full
+/// trail semantics `MATCH (a)-[*2..2]->(b)` over `a->x, a->y, x->y` would also
+/// bind `y` via `a->x->y`; here `y`'s shortest depth is 1, so it is excluded.
+/// Full trail semantics is a tracked follow-up (it requires per-path state and
+/// carries cross-lane perf/regression risk in this shared engine).
+///
 /// # Deduplication Semantics
 ///
 /// The `visited` set is cleared for each new input node. This means:
@@ -794,7 +811,9 @@ pub struct TraversalIterator {
     input: Box<dyn ResultIterator>,
     direction: Direction,
     label: Option<String>,
-    /// Minimum depth (inclusive) at which a reached node is emitted.
+    /// Minimum depth (inclusive) at which a reached node is emitted. A node is
+    /// bound iff `min_depth <= shortestDepth <= depth` (node-distinct /
+    /// shortest-path reachability; see the struct-level docs).
     min_depth: usize,
     /// Maximum depth (inclusive); BFS expansion stops beyond this depth.
     depth: usize,
@@ -1010,9 +1029,13 @@ impl ResultIterator for TraversalIterator {
                 if current_depth < self.depth {
                     let neighbors = self.get_neighbors(node_id);
                     for (target, edge_id) in neighbors {
-                        // Per-input-node isomorphism: a node reachable at
-                        // multiple depths is enqueued (and thus emitted) once,
-                        // which also makes cyclic graphs terminate.
+                        // Node-distinct / shortest-path reachability: a node is
+                        // enqueued (and thus later emitted) once, at its shortest
+                        // BFS depth. This also makes cyclic graphs terminate. It
+                        // is a v1 simplification of openCypher trail semantics --
+                        // a target whose shortest path is below `min_depth` is
+                        // marked visited here and never re-emitted deeper (see the
+                        // struct-level docs).
                         if self.visited.insert(target) {
                             // ⚡ Bolt Optimization: Pre-allocate capacity for new path to avoid reallocations.
                             // We are adding exactly 2 elements (edge and node) to the current path length.

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -794,6 +794,9 @@ pub struct TraversalIterator {
     input: Box<dyn ResultIterator>,
     direction: Direction,
     label: Option<String>,
+    /// Minimum depth (inclusive) at which a reached node is emitted.
+    min_depth: usize,
+    /// Maximum depth (inclusive); BFS expansion stops beyond this depth.
     depth: usize,
     current: Arc<CurrentStorage>,
     historical: Arc<RwLock<HistoricalStorage>>,
@@ -813,10 +816,12 @@ impl TraversalIterator {
     /// This is the core engine for `MATCH (a)-[*]->(b)` operations. It manages
     /// a frontier of visited nodes to prevent infinite loops in cyclic graphs,
     /// and conditionally queries the historical storage if a temporal context is present.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         input: Box<dyn ResultIterator>,
         direction: Direction,
         label: Option<String>,
+        min_depth: usize,
         depth: usize,
         current: Arc<CurrentStorage>,
         historical: Arc<RwLock<HistoricalStorage>>,
@@ -826,6 +831,7 @@ impl TraversalIterator {
             input,
             direction,
             label,
+            min_depth,
             depth,
             current,
             historical,
@@ -997,28 +1003,40 @@ impl ResultIterator for TraversalIterator {
         loop {
             // Process current frontier
             if let Some((node_id, path, current_depth)) = self.frontier.pop_front() {
-                if current_depth >= self.depth {
-                    // Reached target depth, yield result
+                // Expansion and yielding are INDEPENDENT so a range like `*1..3`
+                // both emits intermediate-depth nodes AND keeps exploring to the
+                // maximum depth. First expand (if we have not reached the max
+                // depth), enqueuing unvisited neighbors one hop deeper.
+                if current_depth < self.depth {
+                    let neighbors = self.get_neighbors(node_id);
+                    for (target, edge_id) in neighbors {
+                        // Per-input-node isomorphism: a node reachable at
+                        // multiple depths is enqueued (and thus emitted) once,
+                        // which also makes cyclic graphs terminate.
+                        if self.visited.insert(target) {
+                            // ⚡ Bolt Optimization: Pre-allocate capacity for new path to avoid reallocations.
+                            // We are adding exactly 2 elements (edge and node) to the current path length.
+                            let mut new_path = Vec::with_capacity(path.len() + 2);
+                            new_path.extend_from_slice(&path);
+                            new_path.push(EntityId::Edge(edge_id));
+                            new_path.push(EntityId::Node(target));
+                            self.frontier
+                                .push_back((target, new_path, current_depth + 1));
+                        }
+                    }
+                }
+
+                // Then, if this node's depth falls within [min_depth, depth],
+                // yield it. The depth-0 start node is never emitted.
+                if current_depth >= 1
+                    && current_depth >= self.min_depth
+                    && current_depth <= self.depth
+                {
                     match self.current.get_node(node_id) {
                         Ok(node) => {
                             return Some(Ok(QueryRow::with_path(EntityResult::Node(node), path)));
                         }
                         Err(e) => return Some(Err(e)),
-                    }
-                }
-
-                // Expand neighbors
-                let neighbors = self.get_neighbors(node_id);
-                for (target, edge_id) in neighbors {
-                    if self.visited.insert(target) {
-                        // ⚡ Bolt Optimization: Pre-allocate capacity for new path to avoid reallocations.
-                        // We are adding exactly 2 elements (edge and node) to the current path length.
-                        let mut new_path = Vec::with_capacity(path.len() + 2);
-                        new_path.extend_from_slice(&path);
-                        new_path.push(EntityId::Edge(edge_id));
-                        new_path.push(EntityId::Node(target));
-                        self.frontier
-                            .push_back((target, new_path, current_depth + 1));
                     }
                 }
                 continue;
@@ -1410,12 +1428,14 @@ impl OptionalApplyIterator {
                 OptionalPhysicalStep::Traverse {
                     direction,
                     label,
+                    min_depth,
                     depth,
                     temporal_context,
                 } => Box::new(TraversalIterator::new(
                     iter,
                     *direction,
                     label.clone(),
+                    *min_depth,
                     *depth,
                     Arc::clone(&self.current),
                     Arc::clone(&self.historical),
@@ -4276,6 +4296,7 @@ mod tests {
             vec![OptionalPhysicalStep::Traverse {
                 direction: Direction::Outgoing,
                 label: Some("KNOWS".to_string()),
+                min_depth: 1,
                 depth: 1,
                 temporal_context: None,
             }],
@@ -4347,6 +4368,7 @@ mod tests {
             vec![OptionalPhysicalStep::Traverse {
                 direction: Direction::Outgoing,
                 label: Some("KNOWS".to_string()),
+                min_depth: 1,
                 depth: 1,
                 temporal_context: None,
             }],

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -271,6 +271,7 @@ impl QueryExecutor {
                 input,
                 direction,
                 label,
+                min_depth,
                 depth,
                 temporal_context,
             } => {
@@ -279,6 +280,7 @@ impl QueryExecutor {
                     input_iter,
                     *direction,
                     label.clone(),
+                    *min_depth,
                     *depth,
                     Arc::clone(&self.current),
                     Arc::clone(&self.historical),
@@ -710,6 +712,7 @@ mod tests {
                 }),
                 direction: crate::query::ir::Direction::Outgoing,
                 label: Some("KNOWS".to_string()),
+                min_depth: 1,
                 depth: 1,
                 temporal_context: None,
             },
@@ -894,6 +897,7 @@ mod tests {
                         }),
                         direction: crate::query::ir::Direction::Outgoing,
                         label: Some("KNOWS".to_string()),
+                        min_depth: 1,
                         depth: 1,
                         temporal_context: None,
                     }),
@@ -1511,6 +1515,7 @@ mod tests {
                 steps: vec![OptionalPhysicalStep::Traverse {
                     direction: crate::query::ir::Direction::Outgoing,
                     label: Some("KNOWS".to_string()),
+                    min_depth: 1,
                     depth: 1,
                     temporal_context: None,
                 }],
@@ -1545,6 +1550,7 @@ mod tests {
                 steps: vec![OptionalPhysicalStep::Traverse {
                     direction: crate::query::ir::Direction::Outgoing,
                     label: Some("FOLLOWS".to_string()),
+                    min_depth: 1,
                     depth: 1,
                     temporal_context: None,
                 }],
@@ -1580,6 +1586,7 @@ mod tests {
                     OptionalPhysicalStep::Traverse {
                         direction: crate::query::ir::Direction::Outgoing,
                         label: Some("KNOWS".to_string()),
+                        min_depth: 1,
                         depth: 1,
                         temporal_context: None,
                     },

--- a/src/query/ir.rs
+++ b/src/query/ir.rs
@@ -241,6 +241,24 @@ impl TraversalDepth {
             TraversalDepth::Variable => None,
         }
     }
+
+    /// Get the minimum depth for this specification.
+    ///
+    /// openCypher variable-length paths bind the far node to every distinct
+    /// node reachable at any depth `d` with `min <= d <= max`. This returns the
+    /// lower bound `min`:
+    /// - `Exact(n)` => `n` (a single fixed depth),
+    /// - `Max(_)` => `1` (`*..n` starts at one hop),
+    /// - `Range { min, .. }` => `min`,
+    /// - `Variable` => `1` (`*` starts at one hop).
+    #[must_use]
+    pub fn min_depth(&self) -> usize {
+        match self {
+            TraversalDepth::Exact(n) => *n,
+            TraversalDepth::Max(_) | TraversalDepth::Variable => 1,
+            TraversalDepth::Range { min, .. } => *min,
+        }
+    }
 }
 
 /// Edge traversal direction.

--- a/src/query/ir.rs
+++ b/src/query/ir.rs
@@ -244,13 +244,21 @@ impl TraversalDepth {
 
     /// Get the minimum depth for this specification.
     ///
-    /// openCypher variable-length paths bind the far node to every distinct
-    /// node reachable at any depth `d` with `min <= d <= max`. This returns the
-    /// lower bound `min`:
+    /// Variable-length traversal in this engine binds the far node to each
+    /// **distinct** reachable target once, at its **shortest** hop-distance,
+    /// returning it iff `min <= shortestDepth <= max`. This returns the lower
+    /// bound `min`:
     /// - `Exact(n)` => `n` (a single fixed depth),
     /// - `Max(_)` => `1` (`*..n` starts at one hop),
     /// - `Range { min, .. }` => `min`,
     /// - `Variable` => `1` (`*` starts at one hop).
+    ///
+    /// Note this is **node-distinct / shortest-path reachability**, a deliberate
+    /// v1 simplification of openCypher's trail (path-enumeration) semantics: a
+    /// node whose *shortest* path is shorter than `min` is not re-emitted at a
+    /// longer, in-range depth, and an anchor reachable only via an in-range
+    /// cycle is not re-bound. See the `TraversalIterator` docs for details;
+    /// full trail semantics is a tracked follow-up.
     #[must_use]
     pub fn min_depth(&self) -> usize {
         match self {

--- a/src/query/planner/cost.rs
+++ b/src/query/planner/cost.rs
@@ -822,6 +822,7 @@ mod tests {
             }),
             direction: crate::query::ir::Direction::Outgoing,
             label: None,
+            min_depth: 2,
             depth: 2,
             temporal_context: None,
         };

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -85,6 +85,21 @@ const DEFAULT_PROPERTY_SCAN_ROWS: usize = 100;
 /// Fallback maximum traversal depth when the query specifies unbounded (`Variable`) depth.
 const DEFAULT_MAX_TRAVERSAL_DEPTH: usize = 10;
 
+/// Resolve the effective maximum traversal depth for a [`TraversalDepth`],
+/// clamping the unbounded upper cases to [`DEFAULT_MAX_TRAVERSAL_DEPTH`].
+///
+/// Both `Variable` (`*`) and the `*N..` / `Min` form (which the converter
+/// models as `Range { min, max: usize::MAX }`) are unbounded above and must be
+/// capped so BFS terminates; finite bounds (`Exact`, `Max`, closed `Range`)
+/// pass through unchanged. Configurable caps are a noted follow-up.
+fn cap_traversal_depth(depth: &super::ir::TraversalDepth) -> usize {
+    match depth.max_depth() {
+        Some(max) if max == usize::MAX => DEFAULT_MAX_TRAVERSAL_DEPTH,
+        Some(max) => max,
+        None => DEFAULT_MAX_TRAVERSAL_DEPTH,
+    }
+}
+
 /// Default `top_k` for vector re-rank when the caller does not provide one.
 const DEFAULT_VECTOR_TOP_K: usize = 10;
 
@@ -764,7 +779,8 @@ impl QueryPlanner {
                     input: Box::new(input),
                     direction: *direction,
                     label: label.clone(),
-                    depth: depth.max_depth().unwrap_or(DEFAULT_MAX_TRAVERSAL_DEPTH),
+                    min_depth: depth.min_depth(),
+                    depth: cap_traversal_depth(depth),
                     temporal_context: temporal_ctx,
                 })
             }
@@ -825,7 +841,8 @@ impl QueryPlanner {
                         } => physical::OptionalPhysicalStep::Traverse {
                             direction: *direction,
                             label: label.clone(),
-                            depth: depth.max_depth().unwrap_or(DEFAULT_MAX_TRAVERSAL_DEPTH),
+                            min_depth: depth.min_depth(),
+                            depth: cap_traversal_depth(depth),
                             temporal_context: temporal_ctx,
                         },
                         OptionalStep::Filter(predicate) => {
@@ -2003,11 +2020,13 @@ mod tests {
                     physical::OptionalPhysicalStep::Traverse {
                         direction,
                         label,
+                        min_depth,
                         depth,
                         temporal_context,
                     } => {
                         assert_eq!(*direction, Direction::Outgoing);
                         assert_eq!(label.as_deref(), Some("KNOWS"));
+                        assert_eq!(*min_depth, 1);
                         assert_eq!(*depth, 1);
                         assert!(temporal_context.is_none());
                     }

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -455,8 +455,11 @@ pub enum PhysicalOp {
         direction: Direction,
         /// Optional edge label filter
         label: Option<String>,
-        /// Minimum depth (inclusive). A node bound at depth `d` is emitted only
-        /// when `min_depth <= d <= depth` (openCypher `*min..max` semantics).
+        /// Minimum depth (inclusive). A target is bound iff
+        /// `min_depth <= shortestDepth <= depth` -- node-distinct /
+        /// shortest-path reachability, a deliberate v1 simplification of
+        /// openCypher's `*min..max` trail semantics (see `TraversalIterator`
+        /// docs; full trail semantics is a tracked follow-up).
         min_depth: usize,
         /// Maximum depth (inclusive).
         depth: usize,
@@ -1504,7 +1507,7 @@ mod tests {
         assert!(explain.contains("IndexedTraversal"));
         assert!(explain.contains("Outgoing"));
         assert!(explain.contains("KNOWS"));
-        assert!(explain.contains("depth: 2"));
+        assert!(explain.contains("depth: 2..2"));
     }
 
     #[test]

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -455,7 +455,10 @@ pub enum PhysicalOp {
         direction: Direction,
         /// Optional edge label filter
         label: Option<String>,
-        /// Maximum depth
+        /// Minimum depth (inclusive). A node bound at depth `d` is emitted only
+        /// when `min_depth <= d <= depth` (openCypher `*min..max` semantics).
+        min_depth: usize,
+        /// Maximum depth (inclusive).
         depth: usize,
         /// Optional temporal context (valid_time, transaction_time) for edge filtering.
         /// When present, only edges that existed at the specified point in time are traversed.
@@ -610,7 +613,9 @@ pub enum OptionalPhysicalStep {
         direction: Direction,
         /// Optional edge label filter.
         label: Option<String>,
-        /// Maximum depth.
+        /// Minimum depth (inclusive), mirroring [`PhysicalOp::IndexedTraversal`].
+        min_depth: usize,
+        /// Maximum depth (inclusive).
         depth: usize,
         /// Optional temporal context (valid_time, transaction_time) for edge
         /// filtering, mirroring [`PhysicalOp::IndexedTraversal`].
@@ -788,6 +793,7 @@ impl PhysicalOp {
                 input,
                 direction,
                 label,
+                min_depth,
                 depth,
                 temporal_context,
             } => {
@@ -797,9 +803,10 @@ impl PhysicalOp {
                     String::new()
                 };
                 format!(
-                    "{prefix}{name} (dir: {:?}, label: {:?}, depth: {}{})\n{}",
+                    "{prefix}{name} (dir: {:?}, label: {:?}, depth: {}..{}{})\n{}",
                     direction,
                     label,
+                    min_depth,
                     depth,
                     temporal_str,
                     input.explain_indent(indent + 1)
@@ -1014,6 +1021,7 @@ mod tests {
                 input: Box::new(PhysicalOp::Empty),
                 direction: Direction::Outgoing,
                 label: None,
+                min_depth: 1,
                 depth: 1,
                 temporal_context: None,
             }
@@ -1202,6 +1210,7 @@ mod tests {
                 input: Box::new(PhysicalOp::Empty),
                 direction: Direction::Outgoing,
                 label: None,
+                min_depth: 1,
                 depth: 1,
                 temporal_context: None,
             }
@@ -1486,6 +1495,7 @@ mod tests {
             input: Box::new(PhysicalOp::Empty),
             direction: Direction::Outgoing,
             label: Some("KNOWS".to_string()),
+            min_depth: 2,
             depth: 2,
             temporal_context: None,
         };
@@ -1826,6 +1836,7 @@ mod tests {
                     }),
                     direction: Direction::Outgoing,
                     label: Some("KNOWS".to_string()),
+                    min_depth: 2,
                     depth: 2,
                     temporal_context: None,
                 }),
@@ -2100,6 +2111,7 @@ mod tests {
             steps: vec![OptionalPhysicalStep::Traverse {
                 direction: Direction::Outgoing,
                 label: Some("KNOWS".to_string()),
+                min_depth: 1,
                 depth: 1,
                 temporal_context: None,
             }],

--- a/tests/sentry_traversal.rs
+++ b/tests/sentry_traversal.rs
@@ -69,6 +69,7 @@ mod tests {
                 input: Box::new(PhysicalOp::NodeLookup { node_ids: vec![a] }),
                 direction: aletheiadb::query::ir::Direction::Outgoing,
                 label: None,
+                min_depth: 2,
                 depth: 2,
                 temporal_context: None,
             },
@@ -107,6 +108,7 @@ mod tests {
                 }), // Double A
                 direction: aletheiadb::query::ir::Direction::Outgoing,
                 label: None,
+                min_depth: 1,
                 depth: 1,
                 temporal_context: None,
             },


### PR DESCRIPTION
Closes #548.

## What & why

Variable-length paths `-[:REL*min..max]->` returned only **terminal-depth** nodes (e.g. `*1..3` on a 2-hop chain returned **0 rows**). Two defects combined:

1. **Planner** collapsed the range to a single max via `depth.max_depth()`, discarding `min`, and did not cap the unbounded `*N..` (`Range { min, max: usize::MAX }`) upper case — only bare `*` was capped.
2. **Executor** `TraversalIterator` yielded a node only at exactly the maximum depth (yield short-circuited before expansion).

### Behavior on a linear chain `N0->N1->N2->N3->N4`

| Query | Before | After |
|-------|--------|-------|
| `*1..1` / `*1` | `[N1]` | `[N1]` |
| `*1..2` | `[N2]` only | `[N1, N2]` |
| `*1..3` | `[N3]` only | `[N1, N2, N3]` |
| `*2..3` | `[N3]` only | `[N2, N3]` |
| `*2..2` / `*2` | `[N2]` | `[N2]` |
| `*..2` | `[N2]` only | `[N1, N2]` |
| `*3..` | `[]` (uncapped/none) | `[N3, N4]` |
| `*` | terminal only | `[N1..N4]` (within cap 10) |

## Semantics — documented contract (node-distinct / shortest-path)

This PR does **not** rewrite the shared traversal engine to full openCypher trail semantics (that is path-enumeration — cross-lane perf/regression risk, architecturally significant; tracked as a follow-up). The engine's actual, now-documented contract is **node-distinct / shortest-path reachability**: each distinct target is bound **once**, at its **shortest** hop-distance `d`, and emitted iff `min <= d <= max`.

Consequence (a deliberate v1 simplification, stated in code docs, CLAUDE.md, and pinned by tests): a node whose *shortest* path is shorter than `min` — or the anchor reached again only via an in-range cycle — is **not** re-emitted at a longer in-range depth. Example: on `N0->N1, N0->N2, N1->N2`, `*2..2` returns **empty** here (N2's shortest depth is 1); full trail semantics would bind N2 via `N0->N1->N2`. On a linear chain (no shortcuts) shortest-depth is the only depth, so the matrix above matches full openCypher semantics exactly.

The over-claiming doc-comments from the first commit were reworded to state this real contract (`TraversalDepth::min_depth`, `TraversalIterator` + its field + the enqueue comment — dropped the inaccurate "isomorphism" wording — and `IndexedTraversal::min_depth`), and a **Known v1 limitations** note was added to the CLAUDE.md Cypher variable-depth bullet (shortest-path semantics + the depth-10 cap).

## How (code)

- `TraversalDepth::min_depth()` accessor (`ir.rs`).
- `min_depth: usize` field on `PhysicalOp::IndexedTraversal` and `OptionalPhysicalStep::Traverse` (`physical.rs`); `depth` stays the inclusive **max**.
- Planner (`planner/mod.rs`, main + OPTIONAL arms): set `min_depth = depth.min_depth()`, resolve the max through a shared `cap_traversal_depth` helper clamping the unbounded cases (`usize::MAX` / `Variable`) to `DEFAULT_MAX_TRAVERSAL_DEPTH` (10). Configurable cap is a noted follow-up.
- Executor (`executor/iterators.rs`): BFS expansion and yielding made **independent** — a dequeued node expands (if `current_depth < depth`) then is emitted iff `1 <= min_depth <= current_depth <= depth`; depth-0 start never emitted; per-input `visited` dedup preserved (shortest-depth binding, cycle-safe).
- `min_depth` threaded through both `TraversalIterator::new` call sites and the executor dispatch.

## Tests (`cypher` feature, all TDD)

Depth matrix (linear chain): `test_varlen_depth_exact_1`, `_1_to_2`, `_1_to_3`, `_2_to_3`, `_exact_2`, `_max_only_2`, `_min_only_3`, `_unbounded`.

Semantics / limitation pinning:
- `test_varlen_cycle_distinct_nodes_no_infinite_loop` — triangle, `*1..5`; asserts the documented shortest-path result with a comment that trail semantics would also bind the anchor via the cycle.
- `test_varlen_min_ge_2_shortest_path_underreport` — `N0->N1, N0->N2, N1->N2` with `*2..2` → empty; documents that trail semantics would return `[N2]`.

Coverage added (this review round):
- `test_varlen_optional_match_range_emits_intermediates` + `test_varlen_optional_match_range_unmatched_preserves_row_with_null` — the OPTIONAL MATCH var-length site (2nd bug site), previously only struct-literal tested; e2e emission of intermediates and left-outer null-row preservation.
- `test_varlen_incoming_direction_range` (`<-[:R*1..3]-`) and `test_varlen_both_direction_range` (`-[:R*1..3]-`).
- `test_varlen_cap_at_default_max_depth` — 14-node chain asserts `*` and `*3..` stop at depth 10 (N11–N13 excluded), pinning `cap_traversal_depth`.
- Tightened the `physical.rs` explain assertion from substring `depth: 2` to `depth: 2..2`; tightened `test_e2e_multi_hop_traversal` to the exact set `[Bob, Charlie]`.

### Gates
- `cargo test --features cypher --lib`: **3732 passed, 0 failed** (2 ignored).
- Integration: `sentry_traversal` (2), `hybrid_query_planner` (49), `hybrid_query` (29), `temporal_adjacency_query_api_tests` (6) — all pass (cycle node-isomorphism sentry still holds).
- Query lib tests under default features (AQL/`traverse` share the engine): pass.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean. `cargo fmt --all`: applied.
- Latest `trunk` merged in (merge commit, no force-push); no conflicts in touched files.

## Follow-ups (tracked, not in this PR)
- Full openCypher trail (path-enumeration) semantics for variable-length paths.
- Configurable traversal depth cap (currently fixed at 10).

## Merge coordination
Extends the same traversal structs/constructors as sibling Cypher work (`IndexedTraversal`, `OptionalPhysicalStep::Traverse`, `TraversalIterator::new`). `temporal_context` is already in trunk (merged), so this PR adds `min_depth` alongside it — a second-to-merge sibling needs only a trivial field-merge keeping both fields/params.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWUZoNegCxQ4oN2ZUvYPru