### PR TITLE
Log and honor tombstone/retraction version_id in WAL delete/retract payloads (#3406)

### DIFF
--- a/examples/recovery/basic_recovery.rs
+++ b/examples/recovery/basic_recovery.rs
@@ -151,6 +151,7 @@ fn main() -> Result<()> {
     wal.append(WalOperation::DeleteNode {
         node_id: node_id_25,
         valid_from: time::now(),
+        version_id: None,
     })?;
     println!("✓ Deleted node 25");
 

--- a/src/api/transaction/write/apply.rs
+++ b/src/api/transaction/write/apply.rs
@@ -596,38 +596,27 @@ pub(crate) fn apply_single_write(
 /// - **Locking**: Single lock acquisition for historical storage.
 /// - **ID Generation**: Tombstone IDs are pre-generated in a batch to minimize lock contention.
 /// - **Adjacency**: Adjacency indexes are compacted *once* after all edge operations are complete.
-pub(crate) fn apply_changes(tx: &WriteTransaction, commit_timestamp: Timestamp) -> Result<()> {
+pub(crate) fn apply_changes(
+    tx: &WriteTransaction,
+    commit_timestamp: Timestamp,
+    closing_version_ids: &[VersionId],
+) -> Result<()> {
     // Create temporal interval for all operations in this transaction.
     let _temporal = BiTemporalInterval::current(commit_timestamp);
 
     // Acquire lock on historical storage once before processing all operations.
     let mut historical = tx.historical.write();
 
-    // Pre-generate all closing-version IDs (delete tombstones + retraction
-    // versions) at once to reduce lock contention
-    let num_deletes = tx
-        .buffer
-        .operations()
+    // Issue #3406: the closing-version IDs (delete tombstones + retraction
+    // versions) are pre-generated once per commit — BEFORE the WAL log phase —
+    // so the identical ids are recorded in the WAL and applied here. We simply
+    // replay them in the same buffer order they were generated and logged.
+    let num_deletes = closing_version_ids.len();
+    let mut tombstone_ids = closing_version_ids
         .iter()
-        .filter(|op| {
-            matches!(
-                op,
-                crate::api::transaction::BufferedWrite::DeleteNode { .. }
-                    | crate::api::transaction::BufferedWrite::DeleteEdge { .. }
-                    | crate::api::transaction::BufferedWrite::RetractNode { .. }
-                    | crate::api::transaction::BufferedWrite::RetractEdge { .. }
-            )
-        })
-        .count();
-
-    let mut tombstone_ids = if num_deletes > 0 {
-        let ids: Result<Vec<u64>> = (0..num_deletes)
-            .map(|_| tx.version_id_gen.next().map_err(Into::into))
-            .collect();
-        ids?.into_iter()
-    } else {
-        Vec::new().into_iter()
-    };
+        .map(|v| v.as_u64())
+        .collect::<Vec<u64>>()
+        .into_iter();
 
     for write in tx.buffer.operations() {
         apply_single_write(

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -401,6 +401,16 @@ impl WriteTransaction {
             None
         };
 
+        // Issue #3406: pre-generate the closing (delete tombstone / retraction)
+        // version ids BEFORE WAL logging, so the SAME ids are both (a) recorded
+        // in the WAL delete/retract payloads and (b) applied to historical
+        // storage. This makes crash recovery reproduce the live version chain
+        // bit-for-bit instead of synthesizing ids that can diverge from — or
+        // collide with — later-logged version ids. Generated here (id
+        // generators are lock-free atomics, order class 5) before the
+        // `current_timestamp` lock is taken, preserving the lock-order contract.
+        let closing_version_ids = self.pregenerate_closing_version_ids()?;
+
         // Acquire commit timestamp and perform mode-aware WAL flush.
         //
         // CRITICAL: We must hold the timestamp lock until WAL logging is complete
@@ -531,7 +541,7 @@ impl WriteTransaction {
 
             // Log operations to WAL (lock-free striped append!)
             // This must happen BEFORE applying changes for durability.
-            wal::log_operations_to_wal(self, commit)?;
+            wal::log_operations_to_wal(self, commit, &closing_version_ids)?;
 
             #[cfg(feature = "observability")]
             let wal_logged = std::time::Instant::now();
@@ -585,7 +595,9 @@ impl WriteTransaction {
 
         // Apply all changes atomically.
         // Nodes/edges are written with commit_timestamp: None during this phase.
-        apply::apply_changes(self, commit_timestamp)?;
+        // The pre-generated closing version ids (Issue #3406) are consumed here
+        // in the same buffer order they were logged to the WAL.
+        apply::apply_changes(self, commit_timestamp, &closing_version_ids)?;
 
         // Notify temporal vector index of transaction completion (for snapshot creation)
         // Only call this if the transaction modified vector properties to avoid unnecessary overhead
@@ -630,6 +642,42 @@ impl WriteTransaction {
         }
 
         Ok(commit_timestamp)
+    }
+
+    /// Pre-generate the closing version ids for every buffered delete/retract
+    /// operation, in buffer order (Issue #3406).
+    ///
+    /// Delete tombstones and valid-time retractions each append exactly one
+    /// closing version; both draw from the shared `version_id_gen`. Generating
+    /// them here — before the WAL log phase — lets the exact same id be written
+    /// into the WAL payload AND applied to historical storage, so crash
+    /// recovery reproduces the live version chain instead of synthesizing a
+    /// (potentially colliding) id.
+    ///
+    /// The returned vector has one id per delete/retract op in the buffer,
+    /// ordered to match the iteration order used by both
+    /// [`wal::log_operations_to_wal`] and [`apply::apply_changes`].
+    fn pregenerate_closing_version_ids(&self) -> Result<Vec<VersionId>> {
+        let num_closing = self
+            .buffer
+            .operations()
+            .iter()
+            .filter(|op| {
+                matches!(
+                    op,
+                    super::BufferedWrite::DeleteNode { .. }
+                        | super::BufferedWrite::DeleteEdge { .. }
+                        | super::BufferedWrite::RetractNode { .. }
+                        | super::BufferedWrite::RetractEdge { .. }
+                )
+            })
+            .count();
+
+        let mut ids = Vec::with_capacity(num_closing);
+        for _ in 0..num_closing {
+            ids.push(VersionId::new_unchecked(self.version_id_gen.next()?));
+        }
+        Ok(ids)
     }
 
     /// Rollback the transaction.

--- a/src/api/transaction/write/wal.rs
+++ b/src/api/transaction/write/wal.rs
@@ -24,6 +24,7 @@
 
 use super::WriteTransaction;
 use crate::core::error::Result;
+use crate::core::id::VersionId;
 use crate::core::temporal::Timestamp;
 use crate::storage::wal::WalOperation;
 
@@ -72,6 +73,7 @@ use crate::storage::wal::WalOperation;
 pub(crate) fn log_operations_to_wal(
     tx: &WriteTransaction,
     commit_timestamp: Timestamp,
+    closing_version_ids: &[VersionId],
 ) -> Result<()> {
     // Collect all buffered writes into a single batch and append them under one atomic
     // LSN allocation via the WAL `append_batch` path (Issue #219). This is strictly more
@@ -95,7 +97,26 @@ pub(crate) fn log_operations_to_wal(
     // markers and stay on the immediate-apply recovery path.
     let mut operations: Vec<WalOperation> = Vec::with_capacity(buffered.len() + 2);
     operations.push(WalOperation::BeginTx { tx_id });
-    operations.extend(buffered.iter().map(WalOperation::from));
+
+    // Issue #3406: stamp the pre-generated closing (tombstone / retraction)
+    // version id onto each delete/retract op, in buffer order, so the WAL
+    // records the exact id historical storage will use. `closing_version_ids`
+    // was generated with one id per delete/retract op in this same order.
+    let mut closing_ids = closing_version_ids.iter().copied();
+    for bw in buffered.iter() {
+        let mut op = WalOperation::from(bw);
+        match &mut op {
+            WalOperation::DeleteNode { version_id, .. }
+            | WalOperation::DeleteEdge { version_id, .. }
+            | WalOperation::RetractNode { version_id, .. }
+            | WalOperation::RetractEdge { version_id, .. } => {
+                *version_id = closing_ids.next();
+            }
+            _ => {}
+        }
+        operations.push(op);
+    }
+
     operations.push(WalOperation::CommitTx {
         tx_id,
         entry_count: buffered.len() as u32,

--- a/src/api/transaction/write_buffer.rs
+++ b/src/api/transaction/write_buffer.rs
@@ -497,12 +497,17 @@ impl From<&BufferedWrite> for crate::storage::wal::WalOperation {
                 valid_from: *valid_from,
                 provenance: provenance.as_deref().cloned(),
             },
+            // The tombstone/retraction `version_id` (Issue #3406) is not known
+            // at the buffer level — it is pre-generated at commit time and
+            // stamped onto the WAL op by `log_operations_to_wal`. This blanket
+            // conversion therefore emits `None`; see that function.
             BufferedWrite::DeleteNode {
                 node_id,
                 valid_from,
             } => crate::storage::wal::WalOperation::DeleteNode {
                 node_id: *node_id,
                 valid_from: *valid_from,
+                version_id: None,
             },
             BufferedWrite::DeleteEdge {
                 edge_id,
@@ -510,17 +515,20 @@ impl From<&BufferedWrite> for crate::storage::wal::WalOperation {
             } => crate::storage::wal::WalOperation::DeleteEdge {
                 edge_id: *edge_id,
                 valid_from: *valid_from,
+                version_id: None,
             },
             BufferedWrite::RetractNode { node_id, valid_to } => {
                 crate::storage::wal::WalOperation::RetractNode {
                     node_id: *node_id,
                     valid_to: *valid_to,
+                    version_id: None,
                 }
             }
             BufferedWrite::RetractEdge { edge_id, valid_to } => {
                 crate::storage::wal::WalOperation::RetractEdge {
                     edge_id: *edge_id,
                     valid_to: *valid_to,
+                    version_id: None,
                 }
             }
         }

--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -1999,6 +1999,7 @@ mod tests {
         wal.append(WalOperation::DeleteNode {
             node_id,
             valid_from: time::now(),
+            version_id: None,
         })?;
         wal.flush()?;
 
@@ -2057,6 +2058,7 @@ mod tests {
         wal.append(WalOperation::DeleteEdge {
             edge_id,
             valid_from: time::now(),
+            version_id: None,
         })?;
         wal.flush()?;
 

--- a/src/storage/recovery.rs
+++ b/src/storage/recovery.rs
@@ -453,6 +453,7 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
             WalOperation::DeleteNode {
                 node_id,
                 valid_from,
+                version_id: logged_tombstone_id,
             } => {
                 // Idempotent re-application guard, per store (review round 2,
                 // #3428). Background persistence may snapshot current and
@@ -502,8 +503,17 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                         )?;
                     }
 
-                    let tombstone_version_id = VersionId::new(next_version_id)?;
-                    next_version_id += 1;
+                    // Honor the LOGGED tombstone version_id (Issue #3406) so the
+                    // recovered version chain is bit-identical to the live one
+                    // and replay is idempotent; segments predating
+                    // WAL_VERSION_DELETE_VERSION_ID carry no id, so synthesize as
+                    // before. Either way, advance next_version_id past it to keep
+                    // future synthesized ids collision-free.
+                    let tombstone_version_id = match logged_tombstone_id {
+                        Some(vid) => vid,
+                        None => VersionId::new(next_version_id)?,
+                    };
+                    next_version_id = next_version_id.max(tombstone_version_id.as_u64() + 1);
 
                     // Honor the LOGGED valid_from (possibly backdated, Issues
                     // #3221/#3400) — mirroring the live path's
@@ -528,6 +538,7 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
             WalOperation::DeleteEdge {
                 edge_id,
                 valid_from,
+                version_id: logged_tombstone_id,
             } => {
                 // Per-store re-application guard — see the DeleteNode arm
                 // above (review round 2, #3428).
@@ -575,8 +586,14 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                         )?;
                     }
 
-                    let tombstone_version_id = VersionId::new(next_version_id)?;
-                    next_version_id += 1;
+                    // Honor the LOGGED tombstone version_id (Issue #3406); see
+                    // the DeleteNode arm above for rationale and the synthesis
+                    // fallback for pre-v9 segments.
+                    let tombstone_version_id = match logged_tombstone_id {
+                        Some(vid) => vid,
+                        None => VersionId::new(next_version_id)?,
+                    };
+                    next_version_id = next_version_id.max(tombstone_version_id.as_u64() + 1);
 
                     // Honor the LOGGED valid_from (possibly backdated, Issues
                     // #3221/#3400) — mirroring the live path's
@@ -600,7 +617,11 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                     current.delete_edge_direct(edge_id)?;
                 }
             }
-            WalOperation::RetractNode { node_id, valid_to } => {
+            WalOperation::RetractNode {
+                node_id,
+                valid_to,
+                version_id: logged_retraction_id,
+            } => {
                 // Valid-time retraction (Issue #3230). Reconstruct exactly what
                 // the original commit did:
                 //   (a) close the head version's TRANSACTION time (its valid
@@ -656,8 +677,14 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                         )?;
                     }
 
-                    let retraction_version_id = VersionId::new(next_version_id)?;
-                    next_version_id += 1;
+                    // Honor the LOGGED retraction version_id (Issue #3406); see
+                    // the DeleteNode arm for rationale and the pre-v9 synthesis
+                    // fallback.
+                    let retraction_version_id = match logged_retraction_id {
+                        Some(vid) => vid,
+                        None => VersionId::new(next_version_id)?,
+                    };
+                    next_version_id = next_version_id.max(retraction_version_id.as_u64() + 1);
 
                     historical.add_retracted_node_version(
                         node_id,
@@ -674,7 +701,11 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                     current.delete_node_direct(node_id, commit_timestamp)?;
                 }
             }
-            WalOperation::RetractEdge { edge_id, valid_to } => {
+            WalOperation::RetractEdge {
+                edge_id,
+                valid_to,
+                version_id: logged_retraction_id,
+            } => {
                 // Valid-time retraction of an edge (Issue #3230); mirrors the
                 // RetractNode arm above, honoring the logged `valid_to`, with
                 // the same per-store re-application guards (#3428).
@@ -727,8 +758,14 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                         )?;
                     }
 
-                    let retraction_version_id = VersionId::new(next_version_id)?;
-                    next_version_id += 1;
+                    // Honor the LOGGED retraction version_id (Issue #3406); see
+                    // the DeleteNode arm for rationale and the pre-v9 synthesis
+                    // fallback.
+                    let retraction_version_id = match logged_retraction_id {
+                        Some(vid) => vid,
+                        None => VersionId::new(next_version_id)?,
+                    };
+                    next_version_id = next_version_id.max(retraction_version_id.as_u64() + 1);
 
                     historical.add_retracted_edge_version(
                         edge_id,
@@ -1372,8 +1409,12 @@ mod tests {
             provenance: None,
         })
         .unwrap();
-        wal.append(WalOperation::RetractNode { node_id, valid_to })
-            .unwrap();
+        wal.append(WalOperation::RetractNode {
+            node_id,
+            valid_to,
+            version_id: None,
+        })
+        .unwrap();
         wal.flush().unwrap();
 
         let current = CurrentStorage::new();
@@ -1502,8 +1543,12 @@ mod tests {
             provenance: None,
         })
         .unwrap();
-        wal.append(WalOperation::RetractEdge { edge_id, valid_to })
-            .unwrap();
+        wal.append(WalOperation::RetractEdge {
+            edge_id,
+            valid_to,
+            version_id: None,
+        })
+        .unwrap();
         wal.flush().unwrap();
 
         let current = CurrentStorage::new();
@@ -1706,6 +1751,7 @@ mod tests {
         wal.append(WalOperation::DeleteNode {
             node_id,
             valid_from: time::now(),
+            version_id: None,
         })
         .unwrap();
         wal.append(WalOperation::CreateNode {
@@ -1813,6 +1859,7 @@ mod tests {
         wal.append(WalOperation::DeleteEdge {
             edge_id,
             valid_from: time::now(),
+            version_id: None,
         })
         .unwrap();
         wal.append(WalOperation::CreateEdge {
@@ -1952,11 +1999,13 @@ mod tests {
         wal.append(WalOperation::DeleteEdge {
             edge_id,
             valid_from: time::now(),
+            version_id: None,
         })
         .unwrap();
         wal.append(WalOperation::DeleteNode {
             node_id,
             valid_from: time::now(),
+            version_id: None,
         })
         .unwrap();
         wal.flush().unwrap();
@@ -2037,11 +2086,13 @@ mod tests {
         wal.append(WalOperation::DeleteEdge {
             edge_id,
             valid_from: time::now(),
+            version_id: None,
         })
         .unwrap();
         wal.append(WalOperation::DeleteNode {
             node_id,
             valid_from: time::now(),
+            version_id: None,
         })
         .unwrap();
         wal.flush().unwrap();

--- a/src/storage/wal/entry.rs
+++ b/src/storage/wal/entry.rs
@@ -104,6 +104,12 @@ pub enum WalOperation {
         node_id: NodeId,
         /// When the deletion became valid (typically commit time)
         valid_from: Timestamp,
+        /// The tombstone version ID assigned by the live write path (Issue
+        /// #3406). Logged so replay reproduces the exact same version chain
+        /// instead of synthesizing a (potentially colliding) id. `None` for
+        /// segments written before `WAL_VERSION_DELETE_VERSION_ID` (v9/v10),
+        /// which fall back to synthesis during replay.
+        version_id: Option<VersionId>,
     },
     /// Delete an edge
     DeleteEdge {
@@ -111,6 +117,9 @@ pub enum WalOperation {
         edge_id: EdgeId,
         /// When the deletion became valid (typically commit time)
         valid_from: Timestamp,
+        /// The tombstone version ID assigned by the live write path (Issue
+        /// #3406). See [`WalOperation::DeleteNode`]'s `version_id`.
+        version_id: Option<VersionId>,
     },
     /// Retract a node: close its valid-time interval at `valid_to` without
     /// deleting its history (Issue #3230).
@@ -119,6 +128,9 @@ pub enum WalOperation {
         node_id: NodeId,
         /// When the fact stopped being true in the real world (user-controlled)
         valid_to: Timestamp,
+        /// The retraction (closing) version ID assigned by the live write path
+        /// (Issue #3406). See [`WalOperation::DeleteNode`]'s `version_id`.
+        version_id: Option<VersionId>,
     },
     /// Retract an edge: close its valid-time interval at `valid_to` without
     /// deleting its history (Issue #3230).
@@ -127,6 +139,9 @@ pub enum WalOperation {
         edge_id: EdgeId,
         /// When the relationship stopped being true in the real world (user-controlled)
         valid_to: Timestamp,
+        /// The retraction (closing) version ID assigned by the live write path
+        /// (Issue #3406). See [`WalOperation::DeleteNode`]'s `version_id`.
+        version_id: Option<VersionId>,
     },
     /// Checkpoint marker - indicates a snapshot was taken
     Checkpoint {

--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -45,7 +45,8 @@ use super::ring_buffer::PendingEntry;
 use crate::core::error::{Error, Result, StorageError};
 
 use super::segment_reader::{
-    WAL_HEADER_SIZE, WAL_MAGIC, WAL_VERSION_ENCRYPTED_TX_FRAMING, WAL_VERSION_TX_FRAMING,
+    WAL_HEADER_SIZE, WAL_MAGIC, WAL_VERSION_DELETE_VERSION_ID,
+    WAL_VERSION_ENCRYPTED_DELETE_VERSION_ID,
 };
 
 /// Metadata about a WAL segment's LSN range.
@@ -386,17 +387,20 @@ impl FlushCoordinator {
             return Ok(());
         }
 
-        // New segments use the transaction-framing format (Issue #3413),
-        // which is a superset of the principal-carrying provenance format
-        // (Issues #3224 + #3350): version 8 for encrypted segments, version 7
-        // for plaintext. Non-transactional producers (raw appends, control
-        // ops) simply omit the BeginTx/CommitTx markers; the version bump only
-        // signals that such markers MAY be present so old readers reject the
-        // segment cleanly rather than misparsing an unknown op tag.
+        // New segments use the delete-version-id format (Issue #3406), a strict
+        // superset of the transaction-framing format (Issue #3413) which is in
+        // turn a superset of the principal-carrying provenance format (Issues
+        // #3224 + #3350): version 10 for encrypted segments, version 9 for
+        // plaintext. It keeps the BeginTx/CommitTx framing markers AND appends
+        // the tombstone/retraction version_id to delete/retract payloads.
+        // Non-transactional producers simply omit the framing markers; the
+        // version bump signals both the markers AND the extended payload MAY be
+        // present so old readers reject the segment cleanly rather than
+        // misparsing.
         let write_version = if self.config.wal_cipher.is_some() {
-            WAL_VERSION_ENCRYPTED_TX_FRAMING
+            WAL_VERSION_ENCRYPTED_DELETE_VERSION_ID
         } else {
-            WAL_VERSION_TX_FRAMING
+            WAL_VERSION_DELETE_VERSION_ID
         };
 
         // Allocate the next segment id, rolling past any existing non-empty
@@ -1148,11 +1152,11 @@ mod tests {
         );
 
         // ...the write must have rolled forward to a fresh segment with the
-        // current writer (v7 transaction-framing) header...
+        // current writer (v9 delete-version-id) header...
         assert_eq!(coordinator.current_segment_id(), 2);
         let new_segment = std::fs::read(dir.path().join("000002.log")).unwrap();
         assert_eq!(&new_segment[0..4], &WAL_MAGIC);
-        assert_eq!(new_segment[4], WAL_VERSION_TX_FRAMING);
+        assert_eq!(new_segment[4], WAL_VERSION_DELETE_VERSION_ID);
 
         // ...and a full-directory replay succeeds, with the new entry's
         // principal intact.
@@ -1382,7 +1386,7 @@ mod tests {
 
         assert!(data.len() >= WAL_HEADER_SIZE);
         assert_eq!(&data[0..4], &WAL_MAGIC);
-        assert_eq!(data[4], WAL_VERSION_TX_FRAMING);
+        assert_eq!(data[4], WAL_VERSION_DELETE_VERSION_ID);
     }
 
     #[test]

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -57,7 +57,7 @@ use crate::core::provenance::Provenance;
 use super::serialization::{
     OP_BEGIN_TX, OP_CHECKPOINT, OP_COMMIT_TX, OP_CREATE_EDGE, OP_CREATE_NODE,
     OP_DECLARE_UNIQUE_CONSTRAINT, OP_DELETE_EDGE, OP_DELETE_NODE, OP_DROP_UNIQUE_CONSTRAINT,
-    OP_RETRACT_EDGE, OP_RETRACT_NODE, OP_UPDATE_EDGE, OP_UPDATE_NODE,
+    OP_RETRACT_EDGE, OP_RETRACT_NODE, OP_UPDATE_EDGE, OP_UPDATE_NODE, TOMBSTONE_VERSION_ID_ABSENT,
 };
 use super::{LSN, WalEntry, WalOperation};
 
@@ -125,8 +125,28 @@ pub(crate) const WAL_VERSION_TX_FRAMING: u8 = 7;
 /// transaction-framing entry format (i.e. [`WAL_VERSION_TX_FRAMING`]).
 pub(crate) const WAL_VERSION_ENCRYPTED_TX_FRAMING: u8 = 8;
 
+/// WAL format version for plaintext segments whose delete/retract payloads
+/// carry the tombstone/retraction `version_id` (Issue #3406).
+///
+/// A strict superset of [`WAL_VERSION_TX_FRAMING`]: it keeps the tx-framing
+/// markers and additionally appends an 8-byte `version_id` to the
+/// `DeleteNode`/`DeleteEdge`/`RetractNode`/`RetractEdge` payloads, so crash
+/// recovery reproduces the live tombstone version chain bit-for-bit instead of
+/// synthesizing a (possibly colliding) id. The `framed` predicate
+/// ([`is_framed_version`]) and this delete-version-id gate
+/// ([`carries_delete_version_id`]) are independent booleans on the same version
+/// byte and compose without conflict (per the #3413 reservation note above).
+/// Bumping the header version makes an older reader reject the file cleanly
+/// rather than mis-length the extended payload, following the #3224/#3413
+/// precedent.
+pub(crate) const WAL_VERSION_DELETE_VERSION_ID: u8 = 9;
+
+/// WAL format version for encrypted segments whose decrypted payload uses the
+/// delete-version-id entry format (i.e. [`WAL_VERSION_DELETE_VERSION_ID`]).
+pub(crate) const WAL_VERSION_ENCRYPTED_DELETE_VERSION_ID: u8 = 10;
+
 /// Maximum supported WAL version (inclusive).
-const WAL_VERSION_MAX: u8 = WAL_VERSION_ENCRYPTED_TX_FRAMING;
+const WAL_VERSION_MAX: u8 = WAL_VERSION_ENCRYPTED_DELETE_VERSION_ID;
 
 /// Returns `true` if `version` denotes an encrypted segment (the original
 /// encrypted format or one of its provenance/framing-carrying successors).
@@ -136,6 +156,7 @@ fn is_encrypted_version(version: u8) -> bool {
         || version == WAL_VERSION_ENCRYPTED_PROVENANCE
         || version == WAL_VERSION_ENCRYPTED_PROVENANCE_PRINCIPAL
         || version == WAL_VERSION_ENCRYPTED_TX_FRAMING
+        || version == WAL_VERSION_ENCRYPTED_DELETE_VERSION_ID
 }
 
 /// Returns `true` if `version` (a plaintext/payload version) supports the
@@ -144,6 +165,17 @@ fn is_encrypted_version(version: u8) -> bool {
 #[inline]
 fn is_framed_version(version: u8) -> bool {
     version >= WAL_VERSION_TX_FRAMING
+}
+
+/// Returns `true` if `version` (a plaintext/payload version) carries the
+/// tombstone/retraction `version_id` in delete/retract payloads (Issue #3406).
+///
+/// Independent of [`is_framed_version`]: both are monotonic `>=` predicates on
+/// the same version byte, so v9/v10 segments are simultaneously framed AND
+/// delete-version-id-carrying.
+#[inline]
+fn carries_delete_version_id(version: u8) -> bool {
+    version >= WAL_VERSION_DELETE_VERSION_ID
 }
 
 /// Map a segment/container format version to the logical *payload* version
@@ -159,6 +191,7 @@ fn payload_version(version: u8) -> u8 {
         WAL_VERSION_ENCRYPTED_PROVENANCE => WAL_VERSION_PROVENANCE,
         WAL_VERSION_ENCRYPTED_PROVENANCE_PRINCIPAL => WAL_VERSION_PROVENANCE_PRINCIPAL,
         WAL_VERSION_ENCRYPTED_TX_FRAMING => WAL_VERSION_TX_FRAMING,
+        WAL_VERSION_ENCRYPTED_DELETE_VERSION_ID => WAL_VERSION_DELETE_VERSION_ID,
         v => v,
     }
 }
@@ -1249,6 +1282,37 @@ fn parse_update_edge_op(
     })
 }
 
+/// Parse an optional tombstone/retraction `version_id` trailing a delete/retract
+/// payload (Issue #3406).
+///
+/// For segments below [`WAL_VERSION_DELETE_VERSION_ID`] the field is absent, so
+/// this returns `None` and replay falls back to synthesizing the id. For v9+
+/// segments it reads a fixed 8-byte LE u64; the
+/// [`TOMBSTONE_VERSION_ID_ABSENT`] sentinel maps back to `None`.
+fn parse_opt_tombstone_version_id(
+    buffer: &[u8],
+    offset: &mut usize,
+    version: u8,
+    context: &str,
+) -> Result<Option<VersionId>> {
+    if !carries_delete_version_id(version) {
+        return Ok(None);
+    }
+    require_bytes(buffer, *offset, 8, context)?;
+    let raw = u64::from_le_bytes(buffer[*offset..*offset + 8].try_into().unwrap());
+    advance(offset, 8)?;
+    if raw == TOMBSTONE_VERSION_ID_ABSENT {
+        return Ok(None);
+    }
+    let vid = VersionId::new(raw).map_err(|e| {
+        Error::Storage(StorageError::CorruptedData(format!(
+            "Invalid tombstone version ID in WAL {}: {}",
+            context, e
+        )))
+    })?;
+    Ok(Some(vid))
+}
+
 fn parse_delete_node_op(
     buffer: &[u8],
     offset: &mut usize,
@@ -1264,9 +1328,11 @@ fn parse_delete_node_op(
     } else {
         tx_timestamp
     };
+    let version_id = parse_opt_tombstone_version_id(buffer, offset, version, "DeleteNode")?;
     Ok(WalOperation::DeleteNode {
         node_id,
         valid_from,
+        version_id,
     })
 }
 
@@ -1285,33 +1351,49 @@ fn parse_delete_edge_op(
     } else {
         tx_timestamp
     };
+    let version_id = parse_opt_tombstone_version_id(buffer, offset, version, "DeleteEdge")?;
     Ok(WalOperation::DeleteEdge {
         edge_id,
         valid_from,
+        version_id,
     })
 }
 
-/// Parse a `RetractNode` payload: `[node_id: 8][valid_to: 12]`.
+/// Parse a `RetractNode` payload: `[node_id: 8][valid_to: 12]` plus, for v9+
+/// segments, an 8-byte tombstone `version_id` (Issue #3406).
 ///
-/// No version gating is needed: the `OP_RETRACT_NODE` tag (Issue #3230) only
-/// ever appears in segments written by versions that serialize `valid_to`.
-fn parse_retract_node_op(buffer: &[u8], offset: &mut usize) -> Result<WalOperation> {
+/// The `valid_to` needs no version gating: the `OP_RETRACT_NODE` tag (Issue
+/// #3230) only ever appears in segments written by versions that serialize
+/// `valid_to`. The trailing `version_id` is gated on
+/// [`WAL_VERSION_DELETE_VERSION_ID`].
+fn parse_retract_node_op(buffer: &[u8], offset: &mut usize, version: u8) -> Result<WalOperation> {
     let node_id = deserialize_node_id(buffer, *offset, "RetractNode")?;
     advance(offset, 8)?;
     let (valid_to, ts_len) = HybridTimestamp::deserialize(&buffer[*offset..])?;
     advance(offset, ts_len)?;
-    Ok(WalOperation::RetractNode { node_id, valid_to })
+    let version_id = parse_opt_tombstone_version_id(buffer, offset, version, "RetractNode")?;
+    Ok(WalOperation::RetractNode {
+        node_id,
+        valid_to,
+        version_id,
+    })
 }
 
-/// Parse a `RetractEdge` payload: `[edge_id: 8][valid_to: 12]`.
+/// Parse a `RetractEdge` payload: `[edge_id: 8][valid_to: 12]` plus, for v9+
+/// segments, an 8-byte tombstone `version_id` (Issue #3406).
 ///
-/// See [`parse_retract_node_op`] for why no version gating is needed.
-fn parse_retract_edge_op(buffer: &[u8], offset: &mut usize) -> Result<WalOperation> {
+/// See [`parse_retract_node_op`] for version-gating details.
+fn parse_retract_edge_op(buffer: &[u8], offset: &mut usize, version: u8) -> Result<WalOperation> {
     let edge_id = deserialize_edge_id(buffer, *offset, "RetractEdge")?;
     advance(offset, 8)?;
     let (valid_to, ts_len) = HybridTimestamp::deserialize(&buffer[*offset..])?;
     advance(offset, ts_len)?;
-    Ok(WalOperation::RetractEdge { edge_id, valid_to })
+    let version_id = parse_opt_tombstone_version_id(buffer, offset, version, "RetractEdge")?;
+    Ok(WalOperation::RetractEdge {
+        edge_id,
+        valid_to,
+        version_id,
+    })
 }
 
 fn parse_checkpoint_op(buffer: &[u8], offset: &mut usize) -> Result<WalOperation> {
@@ -1424,8 +1506,8 @@ pub(crate) fn parse_entry_at(
         OP_UPDATE_EDGE => parse_update_edge_op(buffer, &mut cur, version, timestamp)?,
         OP_DELETE_NODE => parse_delete_node_op(buffer, &mut cur, version, timestamp)?,
         OP_DELETE_EDGE => parse_delete_edge_op(buffer, &mut cur, version, timestamp)?,
-        OP_RETRACT_NODE => parse_retract_node_op(buffer, &mut cur)?,
-        OP_RETRACT_EDGE => parse_retract_edge_op(buffer, &mut cur)?,
+        OP_RETRACT_NODE => parse_retract_node_op(buffer, &mut cur, version)?,
+        OP_RETRACT_EDGE => parse_retract_edge_op(buffer, &mut cur, version)?,
         OP_CHECKPOINT => parse_checkpoint_op(buffer, &mut cur)?,
         OP_DECLARE_UNIQUE_CONSTRAINT => {
             let label = read_label(buffer, &mut cur, "DeclareUniqueConstraint.label")?;
@@ -1980,14 +2062,22 @@ mod tests {
         // Issue #3230: RetractNode must round-trip its valid_to exactly.
         let node_id = NodeId::new(7).unwrap();
         let valid_to = crate::core::hlc::HybridTimestamp::new(1_234_567, 42).unwrap();
-        let operation = WalOperation::RetractNode { node_id, valid_to };
+        // Issue #3406: the retraction version_id round-trips too. Serialization
+        // always writes the highest (v9+) payload shape, so parse at that
+        // version to consume the same bytes.
+        let version_id = Some(VersionId::new(321).unwrap());
+        let operation = WalOperation::RetractNode {
+            node_id,
+            valid_to,
+            version_id,
+        };
         let entry = WalEntry::new(LSN(10), operation);
 
         let mut buffer = Vec::new();
         serialize_entry_into(&entry, &mut buffer).unwrap();
 
         let (parsed_entry, bytes_consumed) =
-            parse_entry_at(&buffer, 0, WAL_VERSION_PROVENANCE).unwrap();
+            parse_entry_at(&buffer, 0, WAL_VERSION_DELETE_VERSION_ID).unwrap();
 
         assert_eq!(parsed_entry.lsn, LSN(10));
         assert_eq!(bytes_consumed, buffer.len());
@@ -1995,9 +2085,11 @@ mod tests {
             WalOperation::RetractNode {
                 node_id: parsed_id,
                 valid_to: parsed_valid_to,
+                version_id: parsed_version_id,
             } => {
                 assert_eq!(parsed_id, node_id);
                 assert_eq!(parsed_valid_to, valid_to, "valid_to must survive verbatim");
+                assert_eq!(parsed_version_id, version_id, "version_id must round-trip");
             }
             other => panic!("Expected RetractNode operation, got {other:?}"),
         }
@@ -2008,14 +2100,20 @@ mod tests {
         // Issue #3230: RetractEdge must round-trip its valid_to exactly.
         let edge_id = EdgeId::new(11).unwrap();
         let valid_to = crate::core::hlc::HybridTimestamp::new(9_876_543, 3).unwrap();
-        let operation = WalOperation::RetractEdge { edge_id, valid_to };
+        // Issue #3406: the retraction version_id round-trips too.
+        let version_id = Some(VersionId::new(654).unwrap());
+        let operation = WalOperation::RetractEdge {
+            edge_id,
+            valid_to,
+            version_id,
+        };
         let entry = WalEntry::new(LSN(11), operation);
 
         let mut buffer = Vec::new();
         serialize_entry_into(&entry, &mut buffer).unwrap();
 
         let (parsed_entry, bytes_consumed) =
-            parse_entry_at(&buffer, 0, WAL_VERSION_PROVENANCE).unwrap();
+            parse_entry_at(&buffer, 0, WAL_VERSION_DELETE_VERSION_ID).unwrap();
 
         assert_eq!(parsed_entry.lsn, LSN(11));
         assert_eq!(bytes_consumed, buffer.len());
@@ -2023,9 +2121,11 @@ mod tests {
             WalOperation::RetractEdge {
                 edge_id: parsed_id,
                 valid_to: parsed_valid_to,
+                version_id: parsed_version_id,
             } => {
                 assert_eq!(parsed_id, edge_id);
                 assert_eq!(parsed_valid_to, valid_to, "valid_to must survive verbatim");
+                assert_eq!(parsed_version_id, version_id, "version_id must round-trip");
             }
             other => panic!("Expected RetractEdge operation, got {other:?}"),
         }
@@ -2124,9 +2224,14 @@ mod tests {
         // through serialization exactly, it is honored by WAL replay).
         let node_id = NodeId::new(42).unwrap();
         let valid_from = HybridTimestamp::new(time::now().wallclock() - 3_600_000_000, 0).unwrap(); // 1h ago
+        // Issue #3406: the tombstone version_id round-trips too. Serialization
+        // always writes the highest (v9+) payload shape, so parse at that
+        // version to consume the same bytes.
+        let version_id = Some(VersionId::new(555).unwrap());
         let operation = WalOperation::DeleteNode {
             node_id,
             valid_from,
+            version_id,
         };
         let entry = WalEntry::new(LSN(5), operation);
 
@@ -2135,7 +2240,8 @@ mod tests {
         serialize_entry_into(&entry, &mut buffer).unwrap();
 
         // Parse it back
-        let (parsed_entry, bytes_consumed) = parse_entry_at(&buffer, 0, WAL_VERSION).unwrap();
+        let (parsed_entry, bytes_consumed) =
+            parse_entry_at(&buffer, 0, WAL_VERSION_DELETE_VERSION_ID).unwrap();
 
         // Verify
         assert_eq!(parsed_entry.lsn, LSN(5));
@@ -2144,12 +2250,14 @@ mod tests {
             WalOperation::DeleteNode {
                 node_id: parsed_id,
                 valid_from: parsed_valid_from,
+                version_id: parsed_version_id,
             } => {
                 assert_eq!(parsed_id, node_id);
                 assert_eq!(
                     parsed_valid_from, valid_from,
                     "backdated delete valid_from must roundtrip exactly"
                 );
+                assert_eq!(parsed_version_id, version_id, "version_id must round-trip");
             }
             _ => panic!("Expected DeleteNode operation"),
         }
@@ -2162,9 +2270,12 @@ mod tests {
         // through serialization exactly, it is honored by WAL replay).
         let edge_id = EdgeId::new(100).unwrap();
         let valid_from = HybridTimestamp::new(time::now().wallclock() - 3_600_000_000, 0).unwrap(); // 1h ago
+        // Issue #3406: the tombstone version_id round-trips too.
+        let version_id = Some(VersionId::new(556).unwrap());
         let operation = WalOperation::DeleteEdge {
             edge_id,
             valid_from,
+            version_id,
         };
         let entry = WalEntry::new(LSN(6), operation);
 
@@ -2173,7 +2284,8 @@ mod tests {
         serialize_entry_into(&entry, &mut buffer).unwrap();
 
         // Parse it back
-        let (parsed_entry, bytes_consumed) = parse_entry_at(&buffer, 0, WAL_VERSION).unwrap();
+        let (parsed_entry, bytes_consumed) =
+            parse_entry_at(&buffer, 0, WAL_VERSION_DELETE_VERSION_ID).unwrap();
 
         // Verify
         assert_eq!(parsed_entry.lsn, LSN(6));
@@ -2182,12 +2294,14 @@ mod tests {
             WalOperation::DeleteEdge {
                 edge_id: parsed_id,
                 valid_from: parsed_valid_from,
+                version_id: parsed_version_id,
             } => {
                 assert_eq!(parsed_id, edge_id);
                 assert_eq!(
                     parsed_valid_from, valid_from,
                     "backdated delete valid_from must roundtrip exactly"
                 );
+                assert_eq!(parsed_version_id, version_id, "version_id must round-trip");
             }
             _ => panic!("Expected DeleteEdge operation"),
         }
@@ -3062,9 +3176,13 @@ mod tests {
             WalOperation::DeleteNode {
                 node_id: parsed_id,
                 valid_from,
+                version_id,
             } => {
                 assert_eq!(parsed_id, node_id);
                 assert_eq!(valid_from, timestamp);
+                // v0 segments carry no tombstone version_id (Issue #3406);
+                // replay synthesizes it.
+                assert_eq!(version_id, None);
             }
             _ => panic!("Expected DeleteNode"),
         }
@@ -3081,9 +3199,12 @@ mod tests {
             WalOperation::DeleteEdge {
                 edge_id: parsed_id,
                 valid_from,
+                version_id,
             } => {
                 assert_eq!(parsed_id, edge_id);
                 assert_eq!(valid_from, timestamp);
+                // v0 segments carry no tombstone version_id (Issue #3406).
+                assert_eq!(version_id, None);
             }
             _ => panic!("Expected DeleteEdge"),
         }

--- a/src/storage/wal/serialization.rs
+++ b/src/storage/wal/serialization.rs
@@ -35,6 +35,7 @@
 use super::entry::WalEntry;
 use super::entry::{LSN, WalOperation};
 use crate::core::error::Result;
+use crate::core::id::VersionId;
 use crate::core::interning::InternedString;
 use crate::core::provenance::Provenance;
 use crate::core::temporal::Timestamp;
@@ -52,6 +53,14 @@ pub(crate) const OP_DECLARE_UNIQUE_CONSTRAINT: u8 = 8;
 pub(crate) const OP_DROP_UNIQUE_CONSTRAINT: u8 = 9;
 pub(crate) const OP_RETRACT_NODE: u8 = 10;
 pub(crate) const OP_RETRACT_EDGE: u8 = 11;
+
+/// Sentinel u64 stored in a v9+ delete/retract payload when the operation
+/// carries no tombstone `version_id` (Issue #3406). `u64::MAX` is always
+/// `> MAX_VALID_ID` (`u64::MAX - 1000`), so it can never collide with a real
+/// version id and round-trips cleanly back to `None` on parse. In practice the
+/// live write path always logs `Some(id)`; the sentinel only exists to make the
+/// `Option<VersionId>` serialization total.
+pub(crate) const TOMBSTONE_VERSION_ID_ABSENT: u64 = u64::MAX;
 /// Terminal transaction-commit marker (Issue #3413). Only appears in segments
 /// at or above `WAL_VERSION_TX_FRAMING`.
 pub(crate) const OP_COMMIT_TX: u8 = 12;
@@ -63,6 +72,16 @@ pub(crate) const OP_BEGIN_TX: u8 = 13;
 #[inline(always)]
 fn serialize_interned_string(s: InternedString, buffer: &mut Vec<u8>) {
     buffer.extend_from_slice(&s.as_u32().to_le_bytes());
+}
+
+/// Serialize an optional tombstone/retraction `version_id` as a fixed 8-byte LE
+/// u64 (Issue #3406). `None` is encoded as [`TOMBSTONE_VERSION_ID_ABSENT`], a
+/// value that can never be a valid version id, so parsing round-trips it back
+/// to `None` and drives the replay synthesis fallback.
+#[inline]
+fn serialize_tombstone_version_id(version_id: Option<VersionId>, buffer: &mut Vec<u8>) {
+    let raw = version_id.map_or(TOMBSTONE_VERSION_ID_ABSENT, |v| v.as_u64());
+    buffer.extend_from_slice(&raw.to_le_bytes());
 }
 
 /// Serialize an optional `&str`: `[1-byte presence][4-byte LE len][UTF-8 bytes]`.
@@ -253,20 +272,20 @@ pub(crate) fn estimate_entry_capacity(operation: &WalOperation) -> usize {
             base + properties.serialized_size() + provenance_serialized_size(provenance.as_ref())
         }
         WalOperation::DeleteNode { .. } => {
-            // op type (1) + node_id (8) + valid_from (12)
-            1 + 8 + TIMESTAMP_SIZE
+            // op type (1) + node_id (8) + valid_from (12) + version_id (8, #3406)
+            1 + 8 + TIMESTAMP_SIZE + 8
         }
         WalOperation::DeleteEdge { .. } => {
-            // op type (1) + edge_id (8) + valid_from (12)
-            1 + 8 + TIMESTAMP_SIZE
+            // op type (1) + edge_id (8) + valid_from (12) + version_id (8, #3406)
+            1 + 8 + TIMESTAMP_SIZE + 8
         }
         WalOperation::RetractNode { .. } => {
-            // op type (1) + node_id (8) + valid_to (12)
-            1 + 8 + TIMESTAMP_SIZE
+            // op type (1) + node_id (8) + valid_to (12) + version_id (8, #3406)
+            1 + 8 + TIMESTAMP_SIZE + 8
         }
         WalOperation::RetractEdge { .. } => {
-            // op type (1) + edge_id (8) + valid_to (12)
-            1 + 8 + TIMESTAMP_SIZE
+            // op type (1) + edge_id (8) + valid_to (12) + version_id (8, #3406)
+            1 + 8 + TIMESTAMP_SIZE + 8
         }
         WalOperation::Checkpoint { .. } => {
             // op type (1) + lsn (8) + timestamp (12)
@@ -422,28 +441,46 @@ pub(crate) fn serialize_operation_into(
         WalOperation::DeleteNode {
             node_id,
             valid_from,
+            version_id,
         } => {
             buffer.push(OP_DELETE_NODE);
             buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
             valid_from.serialize_into(buffer);
+            // Issue #3406: log the tombstone version id (v9+ format). New
+            // segments always use the highest version, so this field is always
+            // present on disk; the sentinel handles a `None` (never produced by
+            // the live path) so the encoding is total.
+            serialize_tombstone_version_id(*version_id, buffer);
         }
         WalOperation::DeleteEdge {
             edge_id,
             valid_from,
+            version_id,
         } => {
             buffer.push(OP_DELETE_EDGE);
             buffer.extend_from_slice(&edge_id.as_u64().to_le_bytes());
             valid_from.serialize_into(buffer);
+            serialize_tombstone_version_id(*version_id, buffer);
         }
-        WalOperation::RetractNode { node_id, valid_to } => {
+        WalOperation::RetractNode {
+            node_id,
+            valid_to,
+            version_id,
+        } => {
             buffer.push(OP_RETRACT_NODE);
             buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
             valid_to.serialize_into(buffer);
+            serialize_tombstone_version_id(*version_id, buffer);
         }
-        WalOperation::RetractEdge { edge_id, valid_to } => {
+        WalOperation::RetractEdge {
+            edge_id,
+            valid_to,
+            version_id,
+        } => {
             buffer.push(OP_RETRACT_EDGE);
             buffer.extend_from_slice(&edge_id.as_u64().to_le_bytes());
             valid_to.serialize_into(buffer);
+            serialize_tombstone_version_id(*version_id, buffer);
         }
         WalOperation::Checkpoint { lsn, timestamp } => {
             buffer.push(OP_CHECKPOINT);
@@ -541,16 +578,17 @@ mod tests {
 
     #[test]
     fn test_estimate_capacity_delete_node() {
-        // DeleteNode: op type (1) + node_id (8) + valid_from (12) = 21 bytes
+        // DeleteNode: op type (1) + node_id (8) + valid_from (12) + version_id (8) = 29 bytes
         // Fixed overhead: 24 bytes
-        // Total: 45 bytes
+        // Total: 53 bytes (Issue #3406 added the 8-byte tombstone version_id)
         let op = WalOperation::DeleteNode {
             node_id: NodeId::new(1).unwrap(),
             valid_from: test_timestamp(),
+            version_id: Some(VersionId::new(7).unwrap()),
         };
 
         let estimated = estimate_entry_capacity(&op);
-        assert_eq!(estimated, 45, "DeleteNode should be exactly 45 bytes");
+        assert_eq!(estimated, 53, "DeleteNode should be exactly 53 bytes");
 
         // Verify by actually serializing
         let entry = WalEntry::new(LSN(1), op);
@@ -566,15 +604,16 @@ mod tests {
 
     #[test]
     fn test_estimate_capacity_retract_node() {
-        // RetractNode: op type (1) + node_id (8) + valid_to (12) = 21 bytes
-        // Fixed overhead: 24 bytes => 45 total (same shape as DeleteNode).
+        // RetractNode: op type (1) + node_id (8) + valid_to (12) + version_id (8) = 29 bytes
+        // Fixed overhead: 24 bytes => 53 total (same shape as DeleteNode, #3406).
         let op = WalOperation::RetractNode {
             node_id: NodeId::new(1).unwrap(),
             valid_to: test_timestamp(),
+            version_id: Some(VersionId::new(7).unwrap()),
         };
 
         let estimated = estimate_entry_capacity(&op);
-        assert_eq!(estimated, 45, "RetractNode should be exactly 45 bytes");
+        assert_eq!(estimated, 53, "RetractNode should be exactly 53 bytes");
 
         let entry = WalEntry::new(LSN(1), op);
         let mut buffer = Vec::new();
@@ -589,15 +628,16 @@ mod tests {
 
     #[test]
     fn test_estimate_capacity_retract_edge() {
-        // RetractEdge: op type (1) + edge_id (8) + valid_to (12) = 21 bytes
-        // Fixed overhead: 24 bytes => 45 total (same shape as DeleteEdge).
+        // RetractEdge: op type (1) + edge_id (8) + valid_to (12) + version_id (8) = 29 bytes
+        // Fixed overhead: 24 bytes => 53 total (same shape as DeleteEdge, #3406).
         let op = WalOperation::RetractEdge {
             edge_id: EdgeId::new(1).unwrap(),
             valid_to: test_timestamp(),
+            version_id: Some(VersionId::new(7).unwrap()),
         };
 
         let estimated = estimate_entry_capacity(&op);
-        assert_eq!(estimated, 45, "RetractEdge should be exactly 45 bytes");
+        assert_eq!(estimated, 53, "RetractEdge should be exactly 53 bytes");
 
         let entry = WalEntry::new(LSN(1), op);
         let mut buffer = Vec::new();
@@ -612,16 +652,17 @@ mod tests {
 
     #[test]
     fn test_estimate_capacity_delete_edge() {
-        // DeleteEdge: op type (1) + edge_id (8) + valid_from (12) = 21 bytes
+        // DeleteEdge: op type (1) + edge_id (8) + valid_from (12) + version_id (8) = 29 bytes
         // Fixed overhead: 24 bytes
-        // Total: 45 bytes
+        // Total: 53 bytes (Issue #3406 added the 8-byte tombstone version_id)
         let op = WalOperation::DeleteEdge {
             edge_id: EdgeId::new(1).unwrap(),
             valid_from: test_timestamp(),
+            version_id: Some(VersionId::new(7).unwrap()),
         };
 
         let estimated = estimate_entry_capacity(&op);
-        assert_eq!(estimated, 45, "DeleteEdge should be exactly 45 bytes");
+        assert_eq!(estimated, 53, "DeleteEdge should be exactly 53 bytes");
 
         // Verify by actually serializing
         let entry = WalEntry::new(LSN(1), op);
@@ -907,6 +948,7 @@ mod prop_tests {
                     WalOperation::DeleteNode {
                         node_id,
                         valid_from,
+                        version_id: Some(VersionId::new_unchecked(7)),
                     }
                 }),
             // Checkpoint

--- a/tests/recovery.rs
+++ b/tests/recovery.rs
@@ -111,3 +111,6 @@ mod checkpoint_recovery_tests;
 
 #[path = "recovery/property_based_tests.rs"]
 mod property_based_tests;
+
+#[path = "recovery/tombstone_version_id_tests.rs"]
+mod tombstone_version_id_tests;

--- a/tests/recovery/checkpoint_recovery_tests.rs
+++ b/tests/recovery/checkpoint_recovery_tests.rs
@@ -389,6 +389,7 @@ fn test_checkpoint_recovery_with_deletes() -> Result<()> {
     wal.append(WalOperation::DeleteNode {
         node_id: NodeId::new(2)?,
         valid_from: time::now(),
+        version_id: None,
     })?;
 
     wal.flush()?;
@@ -514,7 +515,11 @@ fn test_retraction_then_checkpoint_survives_recovery() -> Result<()> {
         valid_from,
         provenance: None,
     })?;
-    wal.append(WalOperation::RetractNode { node_id, valid_to })?;
+    wal.append(WalOperation::RetractNode {
+        node_id,
+        valid_to,
+        version_id: None,
+    })?;
     wal.flush()?;
 
     // First recovery replays the create + retraction, then we checkpoint
@@ -614,7 +619,11 @@ fn test_retraction_replayed_after_checkpoint() -> Result<()> {
     }
 
     // The retraction lands in the WAL after the checkpoint.
-    wal.append(WalOperation::RetractNode { node_id, valid_to })?;
+    wal.append(WalOperation::RetractNode {
+        node_id,
+        valid_to,
+        version_id: None,
+    })?;
     wal.flush()?;
 
     // Recovery loads the checkpoint, then replays ONLY the retraction.
@@ -732,7 +741,11 @@ fn test_checkpoint_restore_only_preserves_node_bitemporal_fidelity() -> Result<(
         valid_from,
         provenance: None,
     })?;
-    wal.append(WalOperation::RetractNode { node_id, valid_to })?;
+    wal.append(WalOperation::RetractNode {
+        node_id,
+        valid_to,
+        version_id: None,
+    })?;
     wal.flush()?;
 
     // First recovery replays the full WAL (the known-good path), giving the
@@ -916,7 +929,11 @@ fn test_checkpoint_restore_only_preserves_edge_bitemporal_fidelity() -> Result<(
         valid_from,
         provenance: None,
     })?;
-    wal.append(WalOperation::RetractEdge { edge_id, valid_to })?;
+    wal.append(WalOperation::RetractEdge {
+        edge_id,
+        valid_to,
+        version_id: None,
+    })?;
     wal.flush()?;
 
     let checkpoint_lsn = LSN(wal.current_lsn().0.saturating_sub(1));

--- a/tests/recovery/large_dataset_recovery.rs
+++ b/tests/recovery/large_dataset_recovery.rs
@@ -515,6 +515,7 @@ fn test_large_dataset_with_deletions() -> Result<()> {
         wal.append(WalOperation::DeleteNode {
             node_id: NodeId::new(node_id).unwrap(),
             valid_from: time::now(),
+            version_id: None,
         })?;
     }
 

--- a/tests/recovery/property_based_tests.rs
+++ b/tests/recovery/property_based_tests.rs
@@ -255,6 +255,7 @@ impl RecoveryTestHarness {
                         wal.append(WalOperation::DeleteNode {
                             node_id: NodeId::new(*id)?,
                             valid_from: timestamp_counter,
+                            version_id: None,
                         })?;
                         created_nodes.remove(id);
                     }
@@ -302,6 +303,7 @@ impl RecoveryTestHarness {
                         wal.append(WalOperation::DeleteEdge {
                             edge_id: EdgeId::new(*id)?,
                             valid_from: timestamp_counter,
+                            version_id: None,
                         })?;
                         created_edges.remove(id);
                     }

--- a/tests/recovery/replay_delete_tests.rs
+++ b/tests/recovery/replay_delete_tests.rs
@@ -68,6 +68,7 @@ fn test_replay_delete_node_basic() -> Result<()> {
     wal.append(WalOperation::DeleteNode {
         node_id,
         valid_from: timestamp2,
+        version_id: None,
     })?;
     wal.flush()?;
 
@@ -124,6 +125,7 @@ fn test_replay_delete_node_after_update() -> Result<()> {
     wal.append(WalOperation::DeleteNode {
         node_id,
         valid_from: time::now(),
+        version_id: None,
     })?;
     wal.flush()?;
 
@@ -187,6 +189,7 @@ fn test_replay_delete_edge_basic() -> Result<()> {
     wal.append(WalOperation::DeleteEdge {
         edge_id,
         valid_from: time::now(),
+        version_id: None,
     })?;
     wal.flush()?;
 
@@ -243,6 +246,7 @@ fn test_replay_delete_node_preserves_temporal_intervals() -> Result<()> {
     wal.append(WalOperation::DeleteNode {
         node_id,
         valid_from: delete_vf,
+        version_id: None,
     })?;
     wal.flush()?;
 
@@ -363,6 +367,7 @@ fn test_replay_delete_edge_preserves_temporal_intervals() -> Result<()> {
     wal.append(WalOperation::DeleteEdge {
         edge_id,
         valid_from: delete_vf,
+        version_id: None,
     })?;
     wal.flush()?;
 
@@ -477,6 +482,7 @@ fn test_replay_delete_node_honors_logged_valid_from() -> Result<()> {
     wal.append(WalOperation::DeleteNode {
         node_id,
         valid_from: delete_vf,
+        version_id: None,
     })?;
     wal.flush()?;
 
@@ -563,6 +569,7 @@ fn test_replay_delete_edge_honors_logged_valid_from() -> Result<()> {
     wal.append(WalOperation::DeleteEdge {
         edge_id,
         valid_from: delete_vf,
+        version_id: None,
     })?;
     wal.flush()?;
 
@@ -637,6 +644,7 @@ fn test_replay_multiple_deletes() -> Result<()> {
         wal.append(WalOperation::DeleteNode {
             node_id: NodeId::new(id).unwrap(),
             valid_from: time::now(),
+            version_id: None,
         })?;
     }
 
@@ -689,6 +697,7 @@ fn test_replay_delete_with_vector() -> Result<()> {
     wal.append(WalOperation::DeleteNode {
         node_id,
         valid_from: time::now(),
+        version_id: None,
     })?;
     wal.flush()?;
 
@@ -748,6 +757,7 @@ fn test_replay_mixed_creates_updates_deletes() -> Result<()> {
     wal.append(WalOperation::DeleteNode {
         node_id: NodeId::new(2).unwrap(),
         valid_from: time::now(),
+        version_id: None,
     })?;
 
     // Create node 3

--- a/tests/recovery/replay_id_tracking_tests.rs
+++ b/tests/recovery/replay_id_tracking_tests.rs
@@ -235,6 +235,7 @@ fn test_recover_with_deletes_tracks_max_ids() -> Result<()> {
     wal.append(WalOperation::DeleteNode {
         node_id: NodeId::new(2).unwrap(),
         valid_from: time::now(),
+        version_id: None,
     })?;
     wal.flush()?;
 

--- a/tests/recovery/replay_loop_tests.rs
+++ b/tests/recovery/replay_loop_tests.rs
@@ -252,6 +252,7 @@ fn test_recover_handles_non_sequential_version_ids() -> Result<()> {
     wal.append(WalOperation::DeleteNode {
         node_id,
         valid_from: time::now(),
+        version_id: None,
     })?;
 
     wal.flush()?;
@@ -318,6 +319,7 @@ fn test_recover_with_multiple_operation_types() -> Result<()> {
     wal.append(WalOperation::DeleteNode {
         node_id,
         valid_from: time::now(),
+        version_id: None,
     })?;
 
     wal.flush()?;

--- a/tests/recovery/tombstone_version_id_tests.rs
+++ b/tests/recovery/tombstone_version_id_tests.rs
@@ -1,0 +1,478 @@
+//! Tests for logging + honoring the tombstone/retraction `version_id` in the
+//! WAL delete/retract payloads (Issue #3406).
+//!
+//! Background
+//! ----------
+//! The live write path pre-generates a tombstone/retraction `VersionId` for
+//! every `DeleteNode`/`DeleteEdge`/`RetractNode`/`RetractEdge` from the shared
+//! `version_id_gen`. Before this issue the WAL delete/retract payloads did NOT
+//! carry that id, so crash recovery SYNTHESIZED a tombstone id from
+//! `next_version_id` (max-seen + 1). Two consequences:
+//!
+//!   1. Recovered tombstone ids could DIFFER from the live ones -> version
+//!      chains not bit-identical across a crash.
+//!   2. A synthesized tombstone id could COLLIDE with a `version_id` carried by
+//!      a later-logged `Update` entry -> both land under the same global
+//!      `VersionId` map key and the later insert silently CLOBBERS the earlier
+//!      -> history loss on recovery.
+//!
+//! The fix logs the tombstone/retraction `version_id` (WAL v9/v10) and makes
+//! replay HONOR it (bumping `next_version_id` past it), with a synthesis
+//! fallback for pre-v9 segments that never carried the field.
+//!
+//! These tests drive REAL on-disk WAL replay via `CheckpointManager::recover`
+//! and inspect `HistoricalStorage` directly to assert exact version ids.
+
+use aletheiadb::{
+    AletheiaDB, GLOBAL_INTERNER,
+    config::{AletheiaDBConfig, WalConfigBuilder},
+    core::error::Result,
+    core::{
+        id::{EdgeId, NodeId, VersionId},
+        property::PropertyMapBuilder,
+        temporal::time,
+    },
+    storage::{
+        checkpoint::{CheckpointConfig, CheckpointManager},
+        index_persistence::PersistenceConfig,
+        wal::{
+            DurabilityMode, LSN, WalOperation,
+            concurrent_system::{ConcurrentWalSystem, ConcurrentWalSystemConfig},
+        },
+    },
+};
+use tempfile::TempDir;
+
+/// Build a fresh raw WAL in a tempdir.
+fn new_wal(temp_dir: &TempDir) -> Result<ConcurrentWalSystem> {
+    let wal_dir = temp_dir.path().join("wal");
+    ConcurrentWalSystem::new(ConcurrentWalSystemConfig::new(wal_dir))
+}
+
+/// Recover a WAL from scratch (full replay — no checkpoint/index snapshot to
+/// short-circuit it) and return the reconstructed storages.
+fn recover(
+    temp_dir: &TempDir,
+    wal: &ConcurrentWalSystem,
+) -> Result<(
+    aletheiadb::storage::current::CurrentStorage,
+    aletheiadb::storage::historical::HistoricalStorage,
+)> {
+    let config = CheckpointConfig::with_data_dir(temp_dir.path().join("checkpoints"));
+    let mut manager = CheckpointManager::new(config)?;
+    let (current, historical, _lsn) = manager.recover(wal)?;
+    Ok((current, historical))
+}
+
+fn person(name: &str) -> aletheiadb::core::property::PropertyMap {
+    PropertyMapBuilder::new().insert("name", name).build()
+}
+
+// ---------------------------------------------------------------------------
+// AC #1 + #2: replay HONORS the logged tombstone/retraction version_id, so the
+// recovered head version id equals the id the live path logged (bit-identical).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn honor_logged_delete_node_version_id() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let wal = new_wal(&temp_dir)?;
+    let node_id = NodeId::new(1).unwrap();
+
+    // A distinct, high tombstone id — one a synthesizing replay would NEVER
+    // pick (synthesis would use max-seen + 1, i.e. a small value).
+    let live_tombstone = VersionId::new(7777).unwrap();
+
+    wal.append(WalOperation::CreateNode {
+        node_id,
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
+        properties: person("Alice"),
+        valid_from: time::now(),
+        provenance: None,
+    })?;
+    wal.append(WalOperation::DeleteNode {
+        node_id,
+        valid_from: time::now(),
+        version_id: Some(live_tombstone),
+    })?;
+    wal.flush()?;
+
+    let (current, historical) = recover(&temp_dir, &wal)?;
+
+    // Node is gone from current state, but its head historical version is the
+    // EXACT logged tombstone id — not a synthesized one.
+    assert!(current.get_node(node_id).is_err());
+    assert_eq!(
+        historical.get_current_node_version(node_id),
+        Some(live_tombstone),
+        "recovered tombstone head must equal the logged live version_id"
+    );
+    let v = historical
+        .get_node_version(live_tombstone)
+        .expect("tombstone version must exist under the logged id");
+    assert_eq!(v.node_id, node_id);
+
+    Ok(())
+}
+
+#[test]
+fn honor_logged_delete_edge_version_id() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let wal = new_wal(&temp_dir)?;
+    let src = NodeId::new(1).unwrap();
+    let tgt = NodeId::new(2).unwrap();
+    let edge_id = EdgeId::new(1).unwrap();
+    let live_tombstone = VersionId::new(8888).unwrap();
+
+    for (id, name) in [(src, "Alice"), (tgt, "Bob")] {
+        wal.append(WalOperation::CreateNode {
+            node_id: id,
+            label: GLOBAL_INTERNER.intern("Person").unwrap(),
+            properties: person(name),
+            valid_from: time::now(),
+            provenance: None,
+        })?;
+    }
+    wal.append(WalOperation::CreateEdge {
+        edge_id,
+        source: src,
+        target: tgt,
+        label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
+        properties: PropertyMapBuilder::new().build(),
+        valid_from: time::now(),
+        provenance: None,
+    })?;
+    wal.append(WalOperation::DeleteEdge {
+        edge_id,
+        valid_from: time::now(),
+        version_id: Some(live_tombstone),
+    })?;
+    wal.flush()?;
+
+    let (current, historical) = recover(&temp_dir, &wal)?;
+
+    assert!(current.get_edge(edge_id).is_err());
+    assert_eq!(
+        historical.get_current_edge_version(edge_id),
+        Some(live_tombstone),
+        "recovered edge tombstone head must equal the logged live version_id"
+    );
+    Ok(())
+}
+
+#[test]
+fn honor_logged_retract_node_version_id() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let wal = new_wal(&temp_dir)?;
+    let node_id = NodeId::new(1).unwrap();
+    let live_retraction = VersionId::new(9999).unwrap();
+
+    wal.append(WalOperation::CreateNode {
+        node_id,
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
+        properties: person("Alice"),
+        valid_from: time::now(),
+        provenance: None,
+    })?;
+    wal.append(WalOperation::RetractNode {
+        node_id,
+        valid_to: time::now(),
+        version_id: Some(live_retraction),
+    })?;
+    wal.flush()?;
+
+    let (_current, historical) = recover(&temp_dir, &wal)?;
+
+    assert_eq!(
+        historical.get_current_node_version(node_id),
+        Some(live_retraction),
+        "recovered retraction head must equal the logged live version_id"
+    );
+    Ok(())
+}
+
+#[test]
+fn honor_logged_retract_edge_version_id() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let wal = new_wal(&temp_dir)?;
+    let src = NodeId::new(1).unwrap();
+    let tgt = NodeId::new(2).unwrap();
+    let edge_id = EdgeId::new(1).unwrap();
+    let live_retraction = VersionId::new(4242).unwrap();
+
+    for (id, name) in [(src, "Alice"), (tgt, "Bob")] {
+        wal.append(WalOperation::CreateNode {
+            node_id: id,
+            label: GLOBAL_INTERNER.intern("Person").unwrap(),
+            properties: person(name),
+            valid_from: time::now(),
+            provenance: None,
+        })?;
+    }
+    wal.append(WalOperation::CreateEdge {
+        edge_id,
+        source: src,
+        target: tgt,
+        label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
+        properties: PropertyMapBuilder::new().build(),
+        valid_from: time::now(),
+        provenance: None,
+    })?;
+    wal.append(WalOperation::RetractEdge {
+        edge_id,
+        valid_to: time::now(),
+        version_id: Some(live_retraction),
+    })?;
+    wal.flush()?;
+
+    let (_current, historical) = recover(&temp_dir, &wal)?;
+
+    assert_eq!(
+        historical.get_current_edge_version(edge_id),
+        Some(live_retraction),
+        "recovered edge retraction head must equal the logged live version_id"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// AC #3 (load-bearing): a synthesized tombstone id colliding with a
+// later-logged Update's version_id must NOT clobber either version.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn collision_does_not_clobber_history() -> Result<()> {
+    // Fresh recovery seeds next_version_id = 0, so:
+    //   CreateNode(A) -> version 0   (next = 1)
+    //   CreateNode(B) -> version 1   (next = 2)
+    //   DeleteNode(A) -> pre-fix synth tombstone = 2 (next = 3)
+    //   UpdateNode(B, version_id = 2) -> collides with A's synth tombstone!
+    //
+    // With the fix, DeleteNode(A) carries a distinct logged tombstone id
+    // (500), so A's tombstone (500) and B's update (2) never share a key and
+    // neither is lost.
+    let temp_dir = TempDir::new().unwrap();
+    let wal = new_wal(&temp_dir)?;
+
+    let a = NodeId::new(1).unwrap();
+    let b = NodeId::new(2).unwrap();
+
+    // The real, unique live tombstone id for A's delete — deliberately high so
+    // it differs from what synthesis (2) would pick.
+    let a_tombstone = VersionId::new(500).unwrap();
+    // B's update id — equal to the value a SYNTHESIZING replay would assign to
+    // A's tombstone. This is the collision.
+    let b_update = VersionId::new(2).unwrap();
+
+    wal.append(WalOperation::CreateNode {
+        node_id: a,
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
+        properties: person("Alice"),
+        valid_from: time::now(),
+        provenance: None,
+    })?;
+    wal.append(WalOperation::CreateNode {
+        node_id: b,
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
+        properties: person("Bob"),
+        valid_from: time::now(),
+        provenance: None,
+    })?;
+    wal.append(WalOperation::DeleteNode {
+        node_id: a,
+        valid_from: time::now(),
+        version_id: Some(a_tombstone),
+    })?;
+    wal.append(WalOperation::UpdateNode {
+        node_id: b,
+        version_id: b_update,
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
+        properties: PropertyMapBuilder::new()
+            .insert("name", "Bob")
+            .insert("age", 31_i64)
+            .build(),
+        valid_from: time::now(),
+        provenance: None,
+    })?;
+    wal.flush()?;
+
+    let (_current, historical) = recover(&temp_dir, &wal)?;
+
+    // A's tombstone must live under its OWN logged id and belong to A.
+    let a_v = historical
+        .get_node_version(a_tombstone)
+        .expect("A's tombstone must exist under its logged id (not clobbered)");
+    assert_eq!(a_v.node_id, a, "A's tombstone id must map to node A");
+    assert_eq!(
+        historical.get_current_node_version(a),
+        Some(a_tombstone),
+        "A's head must be its logged tombstone"
+    );
+
+    // B's update must live under version id 2 and belong to B — proving the
+    // key that synthesis would have collided on is B's, uncorrupted.
+    let b_v = historical
+        .get_node_version(b_update)
+        .expect("B's update must exist");
+    assert_eq!(b_v.node_id, b, "version id 2 must map to node B's update");
+    assert_eq!(
+        historical.get_current_node_version(b),
+        Some(b_update),
+        "B's head must be its update version"
+    );
+
+    // Nothing lost: A (create + tombstone) + B (create + update) = 4 versions.
+    let stats = historical.stats();
+    assert_eq!(
+        stats.total_node_versions, 4,
+        "no version may be clobbered: expected 4 node versions"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency: repeated replay yields the same (logged) tombstone id + chain.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repeated_replay_is_stable() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let wal = new_wal(&temp_dir)?;
+    let node_id = NodeId::new(1).unwrap();
+    let live_tombstone = VersionId::new(1234).unwrap();
+
+    wal.append(WalOperation::CreateNode {
+        node_id,
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
+        properties: person("Alice"),
+        valid_from: time::now(),
+        provenance: None,
+    })?;
+    wal.append(WalOperation::DeleteNode {
+        node_id,
+        valid_from: time::now(),
+        version_id: Some(live_tombstone),
+    })?;
+    wal.flush()?;
+
+    let (_c1, h1) = recover(&temp_dir, &wal)?;
+    let (_c2, h2) = recover(&temp_dir, &wal)?;
+
+    assert_eq!(h1.get_current_node_version(node_id), Some(live_tombstone));
+    assert_eq!(
+        h1.get_current_node_version(node_id),
+        h2.get_current_node_version(node_id),
+        "tombstone id must be stable across repeated replays"
+    );
+    assert_eq!(
+        h1.stats().total_node_versions,
+        h2.stats().total_node_versions,
+        "version chain length must be stable across repeated replays"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// AC #4: back-compat — a segment WITHOUT a logged tombstone version_id (old
+// format, simulated with `version_id: None`) still replays via synthesis
+// without error.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn back_compat_synthesizes_when_version_id_absent() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let wal = new_wal(&temp_dir)?;
+    let node_id = NodeId::new(1).unwrap();
+
+    wal.append(WalOperation::CreateNode {
+        node_id,
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
+        properties: person("Alice"),
+        valid_from: time::now(),
+        provenance: None,
+    })?;
+    // `None` mirrors a pre-v9 segment that never carried the field.
+    wal.append(WalOperation::DeleteNode {
+        node_id,
+        valid_from: time::now(),
+        version_id: None,
+    })?;
+    wal.flush()?;
+
+    let (current, historical) = recover(&temp_dir, &wal)?;
+
+    // No error, node deleted, tombstone synthesized (head present), 2 versions.
+    assert!(current.get_node(node_id).is_err());
+    assert!(
+        historical.get_current_node_version(node_id).is_some(),
+        "a synthesized tombstone head must exist for a pre-v9 delete"
+    );
+    assert_eq!(historical.stats().total_node_versions, 2);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: a REAL live commit logs the tombstone id it applied, and a
+// crash + full WAL replay recovers that exact id (bit-identical chain).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn live_delete_tombstone_id_survives_crash() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let wal_dir = temp_dir.path().join("wal");
+
+    // Durable, WAL-only (no index snapshot), fsync-per-commit.
+    let config = AletheiaDBConfig::builder()
+        .wal(
+            WalConfigBuilder::new()
+                .wal_dir(wal_dir.clone())
+                .durability_mode(DurabilityMode::Synchronous)
+                .build(),
+        )
+        .persistence(PersistenceConfig {
+            enabled: false,
+            ..PersistenceConfig::default()
+        })
+        .build();
+
+    let node_id = {
+        let db = AletheiaDB::with_unified_config(config).expect("open db");
+        let id = db
+            .create_node("Person", person("Alice"))
+            .expect("create_node");
+        db.delete_node_with_valid_time(id, None)
+            .expect("delete_node");
+        // Hard crash: leak the handle so Drop never persists anything.
+        std::mem::forget(db);
+        id
+    };
+
+    // Reopen the WAL from disk and extract the LIVE tombstone id the commit
+    // logged into the DeleteNode payload (Issue #3406).
+    let wal = ConcurrentWalSystem::new(ConcurrentWalSystemConfig::new(wal_dir))?;
+    let entries = wal.read_from(LSN::initial())?;
+    let live_tombstone = entries
+        .iter()
+        .find_map(|e| match &e.operation {
+            WalOperation::DeleteNode {
+                node_id: n,
+                version_id,
+                ..
+            } if *n == node_id => Some(*version_id),
+            _ => None,
+        })
+        .expect("a DeleteNode entry for our node must be in the WAL")
+        .expect("the live DeleteNode entry must carry a logged tombstone version_id");
+
+    // Full replay recovers that exact id.
+    let (current, historical) = recover(&temp_dir, &wal)?;
+    assert!(current.get_node(node_id).is_err());
+    assert_eq!(
+        historical.get_current_node_version(node_id),
+        Some(live_tombstone),
+        "recovered tombstone head must equal the id the LIVE commit logged"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #3406.

> Builds on the now-merged **#3450 (#3413, WAL tx framing)** and **#3453 (#3414)**. Originally developed as a stacked PR; since #3413 landed in `trunk`, this is rebased onto `trunk` and its diff shows ONLY the #3406 delta (no framing changes).

## Before / After (plain language)

**Before.** When you delete or retract a node/edge, the live database picks a fresh "tombstone" version id (from the shared version-id generator) and records that closing version in history. But the WAL entry for the delete/retract wrote only the id + valid time — it **never wrote the tombstone's version id**. So after a crash, replay had to *guess* the tombstone id (max-seen + 1). Two things could go wrong:

1. The guessed id could **differ** from the live one → the recovered version chain was not bit-identical to what was running before the crash.
2. The guessed id could **collide** with a version id that a *later* Update entry legitimately logged. Both then landed under the same global `VersionId` map key and the later write **silently clobbered** the tombstone → **history was lost on recovery**.

**After.** The delete/retract WAL payloads carry the tombstone/retraction `version_id`, and replay **honors** it (advancing `next_version_id` past it). Recovered chains are bit-identical to live and idempotent across repeated replay; the collision/clobber data-loss path is eliminated. Old segments (any version < 9) that predate the new format still replay via the existing synthesis fallback.

## How

- **Enum + wire format.** Added `version_id: Option<VersionId>` to `DeleteNode`/`DeleteEdge`/`RetractNode`/`RetractEdge`. Serialized as a fixed 8-byte LE trailer; `None` uses a `u64::MAX` sentinel (always `> MAX_VALID_ID`, so it can never be a real id and round-trips back to `None`). Parsing is gated on `carries_delete_version_id(version)`.
- **New WAL versions** (consuming the 9/10 slot #3413 reserved in-code): `WAL_VERSION_DELETE_VERSION_ID = 9` (plaintext) / `WAL_VERSION_ENCRYPTED_DELETE_VERSION_ID = 10` (encrypted); `WAL_VERSION_MAX = 10`; `payload_version(10) => 9`; `is_encrypted_version(10) => true`. `carries_delete_version_id` (`>= 9`) and `is_framed_version` (`>= 7`) are independent monotonic predicates on the same version byte and compose without conflict. New segments are written at the highest version; v1–v8 delete payloads carry no id and replay synthesizes as before.
- **Live path.** Closing (tombstone/retraction) version ids are now pre-generated **before** the WAL log phase (`pregenerate_closing_version_ids`; id generators are lock-free atomics taken before the `current_timestamp` lock — CLAUDE.md lock order preserved) and the **same** ids are threaded into both the WAL payload (`log_operations_to_wal`) and the apply phase (`apply_changes`), in buffer order.
- **Replay.** The four recovery arms honor the logged id and bump `next_version_id` past it, with `None → synthesize` fallback. #3413's framed commit-timestamp re-stamping and #3403's logged-`valid_from` honoring are preserved in the same arms (composed, not regressed).

## New WAL version constants

| Constant | Value | Notes |
|---|---|---|
| `WAL_VERSION_DELETE_VERSION_ID` | 9 | plaintext, carries delete/retract `version_id` |
| `WAL_VERSION_ENCRYPTED_DELETE_VERSION_ID` | 10 | encrypted counterpart (`payload_version(10) → 9`) |
| `WAL_VERSION_MAX` | 10 | raised from 8 |
| `TOMBSTONE_VERSION_ID_ABSENT` | `u64::MAX` | on-wire sentinel for `None` |

## Acceptance criteria → tests

All in `tests/recovery/tombstone_version_id_tests.rs` (real on-disk WAL, full replay via `CheckpointManager::recover`, direct `HistoricalStorage` inspection). Field round-trip is also covered by the updated `test_parse_entry_at_{delete,retract}_{node,edge}` unit tests in `segment_reader.rs`.

- [x] **AC1 (log the id) + AC2 (replay honors it, bit-identical):** `honor_logged_delete_node_version_id`, `honor_logged_delete_edge_version_id`, `honor_logged_retract_node_version_id`, `honor_logged_retract_edge_version_id` — each logs a distinct high id a synthesizer would never pick and asserts the recovered head equals it.
- [x] **AC3 (eliminate collision/clobber):** `collision_does_not_clobber_history` — the load-bearing test. Constructs the interleaving where a *synthesized* tombstone id would equal a later Update's logged id; asserts both versions survive under the correct owning node and 4 total node versions. **Fails on synthesis (pre-fix), passes with honoring.**
- [x] **Idempotency:** `repeated_replay_is_stable` — tombstone id and chain length stable across repeated replays.
- [x] **AC4 (back-compat):** `back_compat_synthesizes_when_version_id_absent` — a delete with no logged id (`None`, i.e. a pre-v9 segment) still replays via synthesis without error.
- [x] **End-to-end:** `live_delete_tombstone_id_survives_crash` — a real live commit logs the id it applied; after a simulated crash (`mem::forget`) + full WAL replay the recovered head equals the id the live commit logged.

## RED → GREEN evidence

With recovery temporarily reverted to synthesize (ignore the logged id), the 6 discriminating new tests fail — including the collision clobber (`left: Some(VersionId(2))` — B's update overwrote A's tombstone) and divergence (`left: Some(VersionId(1)) right: Some(VersionId(1234))`). With honoring restored, all 8 pass.

## Gates

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all` — applied
- `cargo test --lib` — 3566 passed, 0 failed
- `cargo test --test recovery` — 76 passed (incl. 8 new); `--test wal_tx_framing` (11), `--test lsn_recovery_regression` (11), `--test wal_recovery_integration`, `--test regression_wal_replay`, `--test backup_restore` (8) — all green
- (2 uid-0 havoc failures are pre-existing/environmental; coverage ENOSPCs locally — skipped per issue notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKAFWHHzF4ng6LybQJhYsH

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKAFWHHzF4ng6LybQJhYsH)_