### PR TITLE
ci: scope GITHUB_TOKEN permissions on feature-matrix job (CodeQL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,8 @@ jobs:
   feature-matrix:
     name: Feature Matrix
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

CodeQL flagged the `feature-matrix` job in `.github/workflows/ci.yml` for not limiting `GITHUB_TOKEN` permissions.

This adds a minimal per-job scoped `permissions` block to only the `feature-matrix` job:

```yaml
  feature-matrix:
    name: Feature Matrix
    runs-on: ubuntu-latest
    permissions:
      contents: read
    steps:
```

`contents: read` suffices — the job only runs `cargo check` / `just check-features` (no writes to the repo, releases, or PRs). No other jobs are altered (the workflow has no top-level `permissions` block and no other per-job blocks, so a minimal per-job scope on just this job matches the existing convention).

## Validation

`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses cleanly; jobs: `test, coverage, lint, security, feature-matrix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkubkQo6gZJc9iQtzaRtED

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkubkQo6gZJc9iQtzaRtED)_