### PR TITLE
test(#3406): harden tombstone version_id tests against mutations (follow-up to #3458)

### DIFF
--- a/fuzz/fuzz_targets/wal_replay.rs
+++ b/fuzz/fuzz_targets/wal_replay.rs
@@ -82,6 +82,7 @@ fuzz_target!(|case: WalReplayCase| {
                         node_id: NodeId::new(raw_node_id)
                             .expect("bounded fuzz node ID must be valid"),
                         valid_from: timestamp_from_step(step),
+                        version_id: None,
                     })
                 } else {
                     None

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -3210,6 +3210,96 @@ mod tests {
         }
     }
 
+    /// Issue #3406 back-compat: a GENUINE pre-v9 but *framed* (v7) `DeleteNode`
+    /// payload — `node_id` + `valid_from` and NO trailing tombstone
+    /// `version_id` — parses under the current (v9-max) reader without error and
+    /// yields `version_id == None`, so replay synthesizes the tombstone. This
+    /// closes the gap left by the v0-only `..._version_0_delete_node` test: v0
+    /// skips `valid_from` entirely, whereas v7 reads it and THEN hits the
+    /// `carries_delete_version_id` gate, exercising the realistic
+    /// old-reader-parsing-a-recent-but-pre-#3406-segment path.
+    ///
+    /// Limitation: this covers the PARSE half of the mixed-format recovery path
+    /// (the `carries_delete_version_id(version) == false` gate) at a genuine
+    /// older header version. The SYNTHESIS half is covered by the recovery
+    /// integration test `back_compat_synthesizes_when_version_id_absent`. A
+    /// single test driving a real old-header segment through
+    /// `CheckpointManager::recover` is impractical here: the WAL serializer is
+    /// test-only (`pub(crate)`) and always emits the highest (v9) payload shape,
+    /// so a genuine short old payload must be hand-assembled at the parse layer.
+    #[test]
+    fn test_parse_entry_at_pre_v9_framed_delete_node_has_no_version_id() {
+        let timestamp = time::now();
+        let valid_from = HybridTimestamp::new(time::now().wallclock() - 3_600_000_000, 0).unwrap();
+        let node_id = NodeId::new(77).unwrap();
+
+        // v7 DeleteNode op_data: node_id (8) + valid_from (12), NO version_id.
+        let mut op_data = Vec::new();
+        op_data.extend_from_slice(&node_id.as_u64().to_le_bytes());
+        valid_from.serialize_into(&mut op_data);
+        let buf = make_v0_buffer(6, &op_data, timestamp); // OP_DELETE_NODE = 6
+
+        let (entry, consumed) = parse_entry_at(&buf, 0, WAL_VERSION_TX_FRAMING).unwrap();
+        assert_eq!(
+            consumed,
+            buf.len(),
+            "parser must consume exactly the v7 payload — no phantom trailing version_id"
+        );
+        match entry.operation {
+            WalOperation::DeleteNode {
+                node_id: parsed_id,
+                valid_from: parsed_vf,
+                version_id,
+            } => {
+                assert_eq!(parsed_id, node_id);
+                assert_eq!(parsed_vf, valid_from, "v7 delete carries valid_from");
+                assert_eq!(
+                    version_id, None,
+                    "a genuine pre-v9 delete carries no tombstone version_id"
+                );
+            }
+            _ => panic!("Expected DeleteNode"),
+        }
+    }
+
+    /// Issue #3406 back-compat: same as above for a genuine pre-v9 (v7)
+    /// `RetractNode` payload — `node_id` + `valid_to` and NO trailing
+    /// `version_id` — must parse to `version_id == None`.
+    #[test]
+    fn test_parse_entry_at_pre_v9_framed_retract_node_has_no_version_id() {
+        let timestamp = time::now();
+        let valid_to = HybridTimestamp::new(1_700_000_000_000_000, 0).unwrap();
+        let node_id = NodeId::new(88).unwrap();
+
+        // v7 RetractNode op_data: node_id (8) + valid_to (12), NO version_id.
+        let mut op_data = Vec::new();
+        op_data.extend_from_slice(&node_id.as_u64().to_le_bytes());
+        valid_to.serialize_into(&mut op_data);
+        let buf = make_v0_buffer(10, &op_data, timestamp); // OP_RETRACT_NODE = 10
+
+        let (entry, consumed) = parse_entry_at(&buf, 0, WAL_VERSION_TX_FRAMING).unwrap();
+        assert_eq!(
+            consumed,
+            buf.len(),
+            "parser must consume exactly the v7 retract payload — no phantom version_id"
+        );
+        match entry.operation {
+            WalOperation::RetractNode {
+                node_id: parsed_id,
+                valid_to: parsed_vt,
+                version_id,
+            } => {
+                assert_eq!(parsed_id, node_id);
+                assert_eq!(parsed_vt, valid_to, "v7 retract carries valid_to");
+                assert_eq!(
+                    version_id, None,
+                    "a genuine pre-v9 retract carries no version_id"
+                );
+            }
+            _ => panic!("Expected RetractNode"),
+        }
+    }
+
     #[test]
     fn test_parse_entry_at_version_0_update_node() {
         let timestamp = time::now();

--- a/src/storage/wal/serialization.rs
+++ b/src/storage/wal/serialization.rs
@@ -221,6 +221,7 @@ fn provenance_serialized_size(provenance: Option<&Provenance>) -> usize {
 /// let delete_op = WalOperation::DeleteNode {
 ///     node_id: NodeId::try_from(1).unwrap(),
 ///     valid_from: Timestamp::from(12345),
+///     version_id: None, // no logged tombstone id (synthesized on replay)
 /// };
 ///
 /// // Fixed overhead (24 bytes) + DeleteNode payload (21 bytes)
@@ -339,6 +340,7 @@ pub(crate) fn estimate_entry_capacity(operation: &WalOperation) -> usize {
 /// let op = WalOperation::DeleteNode {
 ///     node_id: NodeId::try_from(42).unwrap(),
 ///     valid_from: Timestamp::from(100),
+///     version_id: None, // no logged tombstone id (synthesized on replay)
 /// };
 ///
 /// // 1. Pre-allocate the buffer using our estimate

--- a/src/storage/wal/serialization.rs
+++ b/src/storage/wal/serialization.rs
@@ -876,7 +876,7 @@ mod tests {
 mod prop_tests {
     use super::*;
     use crate::core::hlc::HybridTimestamp;
-    use crate::core::id::NodeId;
+    use crate::core::id::{EdgeId, NodeId};
     use crate::core::interning::GLOBAL_INTERNER;
     use crate::core::property::{PropertyMap, PropertyMapBuilder, PropertyValue};
     use proptest::prelude::*;
@@ -920,6 +920,18 @@ mod prop_tests {
         any::<i64>().prop_map(|t| HybridTimestamp::new_unchecked(t, 0))
     }
 
+    // Helper to generate an OPTIONAL tombstone/retraction version id (Issue
+    // #3406). Generates both `Some(id)` and `None` so the `u64::MAX` absent
+    // sentinel is fuzzed alongside real ids. The `Some` range stays well below
+    // both the sentinel and `MAX_VALID_ID`, so a fuzzed id is never mistaken for
+    // the sentinel and always survives `VersionId::new` validation on parse.
+    fn arb_opt_version_id() -> impl Strategy<Value = Option<VersionId>> {
+        prop_oneof![
+            Just(None),
+            (1u64..1_000_000u64).prop_map(|id| Some(VersionId::new_unchecked(id))),
+        ]
+    }
+
     // Helper to generate WalOperation
     fn arb_wal_operation() -> impl Strategy<Value = WalOperation> {
         prop_oneof![
@@ -939,16 +951,19 @@ mod prop_tests {
                         provenance: None,
                     }
                 }),
-            // DeleteNode
+            // DeleteNode (Issue #3406: fuzz BOTH a logged tombstone id AND the
+            // `None`/sentinel case, so the u64::MAX absent encoding is exercised
+            // through the estimate/serialize path too).
             (
                 (1u64..u64::MAX).prop_map(|id| NodeId::new(id).unwrap()),
-                arb_timestamp()
+                arb_timestamp(),
+                arb_opt_version_id(),
             )
-                .prop_map(|(node_id, valid_from)| {
+                .prop_map(|(node_id, valid_from, version_id)| {
                     WalOperation::DeleteNode {
                         node_id,
                         valid_from,
-                        version_id: Some(VersionId::new_unchecked(7)),
+                        version_id,
                     }
                 }),
             // Checkpoint
@@ -990,6 +1005,53 @@ mod prop_tests {
             // Small payloads might have high constant overhead relative to size, so be lenient
             if actual > 100 {
                 prop_assert!(estimated <= actual * 2, "Estimate {} > 2x Actual {}", estimated, actual);
+            }
+        }
+
+        /// Issue #3406: every delete/retract op's optional tombstone
+        /// `version_id` — INCLUDING the `None` case (encoded as the u64::MAX
+        /// sentinel) — round-trips serialize -> parse byte-for-byte. Fuzzing
+        /// `None` alongside `Some(id)` ensures the sentinel is decoded back to
+        /// `None` (not a spurious `Some(u64::MAX)`), and that the parser
+        /// consumes exactly the bytes serialized.
+        #[test]
+        fn delete_retract_version_id_round_trips(
+            id in 1u64..1_000_000u64,
+            ts in 1i64..1_000_000_000_000i64,
+            version_id in arb_opt_version_id(),
+        ) {
+            use crate::storage::wal::segment_reader::{parse_entry_at, WAL_VERSION_DELETE_VERSION_ID};
+            let ts = HybridTimestamp::new_unchecked(ts, 0);
+            let ops = [
+                WalOperation::DeleteNode {
+                    node_id: NodeId::new(id).unwrap(),
+                    valid_from: ts,
+                    version_id,
+                },
+                WalOperation::DeleteEdge {
+                    edge_id: EdgeId::new(id).unwrap(),
+                    valid_from: ts,
+                    version_id,
+                },
+                WalOperation::RetractNode {
+                    node_id: NodeId::new(id).unwrap(),
+                    valid_to: ts,
+                    version_id,
+                },
+                WalOperation::RetractEdge {
+                    edge_id: EdgeId::new(id).unwrap(),
+                    valid_to: ts,
+                    version_id,
+                },
+            ];
+            for op in ops {
+                let entry = WalEntry::new(LSN(1), op.clone());
+                let mut buffer = Vec::new();
+                serialize_entry_into(&entry, &mut buffer).unwrap();
+                let (parsed, consumed) =
+                    parse_entry_at(&buffer, 0, WAL_VERSION_DELETE_VERSION_ID).unwrap();
+                prop_assert_eq!(consumed, buffer.len());
+                prop_assert_eq!(parsed.operation, op);
             }
         }
     }

--- a/tests/recovery/tombstone_version_id_tests.rs
+++ b/tests/recovery/tombstone_version_id_tests.rs
@@ -25,6 +25,7 @@
 
 use aletheiadb::{
     AletheiaDB, GLOBAL_INTERNER,
+    api::transaction::WriteOps,
     config::{AletheiaDBConfig, WalConfigBuilder},
     core::error::Result,
     core::{
@@ -167,16 +168,23 @@ fn honor_logged_retract_node_version_id() -> Result<()> {
     let node_id = NodeId::new(1).unwrap();
     let live_retraction = VersionId::new(9999).unwrap();
 
+    // Distinct valid_from / valid_to so the assertion below catches a recovery
+    // arm that honored the id but MANGLED valid_to (e.g. substituting the
+    // head's valid_from or the replay/commit time) — both would leave the
+    // recovered interval closed at the wrong instant.
+    let created_at = time::from_secs(1_600_000_000); // 2020
+    let retract_valid_to = time::from_secs(1_700_000_000); // 2023 (> created_at)
+
     wal.append(WalOperation::CreateNode {
         node_id,
         label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: person("Alice"),
-        valid_from: time::now(),
+        valid_from: created_at,
         provenance: None,
     })?;
     wal.append(WalOperation::RetractNode {
         node_id,
-        valid_to: time::now(),
+        valid_to: retract_valid_to,
         version_id: Some(live_retraction),
     })?;
     wal.flush()?;
@@ -187,6 +195,26 @@ fn honor_logged_retract_node_version_id() -> Result<()> {
         historical.get_current_node_version(node_id),
         Some(live_retraction),
         "recovered retraction head must equal the logged live version_id"
+    );
+
+    // The retraction closed the valid-time interval at the LOGGED valid_to —
+    // not left open, not closed at valid_from or the commit time.
+    let head = historical
+        .get_node_version(live_retraction)
+        .expect("retraction version must exist under the logged id");
+    assert!(
+        head.temporal.valid_time().is_closed(),
+        "retraction must close the valid-time interval"
+    );
+    assert_eq!(
+        head.temporal.valid_time().end(),
+        retract_valid_to,
+        "recovered retraction must close valid time at the LOGGED valid_to"
+    );
+    assert_eq!(
+        head.temporal.valid_time().start(),
+        created_at,
+        "retraction must preserve the original valid_from"
     );
     Ok(())
 }
@@ -199,6 +227,11 @@ fn honor_logged_retract_edge_version_id() -> Result<()> {
     let tgt = NodeId::new(2).unwrap();
     let edge_id = EdgeId::new(1).unwrap();
     let live_retraction = VersionId::new(4242).unwrap();
+
+    // Distinct valid_from / valid_to (see honor_logged_retract_node_version_id)
+    // so a mangled valid_to on the edge retraction arm is caught.
+    let created_at = time::from_secs(1_600_000_000); // 2020
+    let retract_valid_to = time::from_secs(1_700_000_000); // 2023 (> created_at)
 
     for (id, name) in [(src, "Alice"), (tgt, "Bob")] {
         wal.append(WalOperation::CreateNode {
@@ -215,12 +248,12 @@ fn honor_logged_retract_edge_version_id() -> Result<()> {
         target: tgt,
         label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
         properties: PropertyMapBuilder::new().build(),
-        valid_from: time::now(),
+        valid_from: created_at,
         provenance: None,
     })?;
     wal.append(WalOperation::RetractEdge {
         edge_id,
-        valid_to: time::now(),
+        valid_to: retract_valid_to,
         version_id: Some(live_retraction),
     })?;
     wal.flush()?;
@@ -231,6 +264,25 @@ fn honor_logged_retract_edge_version_id() -> Result<()> {
         historical.get_current_edge_version(edge_id),
         Some(live_retraction),
         "recovered edge retraction head must equal the logged live version_id"
+    );
+
+    // The edge retraction closed the valid-time interval at the LOGGED valid_to.
+    let head = historical
+        .get_edge_version(live_retraction)
+        .expect("edge retraction version must exist under the logged id");
+    assert!(
+        head.temporal.valid_time().is_closed(),
+        "edge retraction must close the valid-time interval"
+    );
+    assert_eq!(
+        head.temporal.valid_time().end(),
+        retract_valid_to,
+        "recovered edge retraction must close valid time at the LOGGED valid_to"
+    );
+    assert_eq!(
+        head.temporal.valid_time().start(),
+        created_at,
+        "edge retraction must preserve the original valid_from"
     );
     Ok(())
 }
@@ -328,6 +380,134 @@ fn collision_does_not_clobber_history() -> Result<()> {
         "no version may be clobbered: expected 4 node versions"
     );
 
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// AC #2 (advancement guard): after HONORING a high logged tombstone id, replay
+// must bump `next_version_id` PAST it (`.max(id + 1)`), so a *subsequent*
+// synthesized tombstone lands ABOVE the honored id instead of colliding with —
+// or regressing below — it. Guards the four delete/retract arms'
+// `next_version_id = next_version_id.max(id + 1)`: reverting any to a plain
+// `next_version_id += 1` leaves the synthesized id small (it ignores the
+// honored high id), which these tests catch.
+// ---------------------------------------------------------------------------
+
+/// A delete whose honored id is HIGH, followed in the SAME recovery by a delete
+/// forcing synthesis: the synthesized id must skip past the honored high id.
+#[test]
+fn synthesized_delete_after_honored_high_id_skips_past_it() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let wal = new_wal(&temp_dir)?;
+
+    let a = NodeId::new(1).unwrap();
+    let c = NodeId::new(2).unwrap();
+    // Deliberately high: a synthesizing replay (max-seen + 1) would pick a small
+    // value, so honoring this id forces `next_version_id` far forward.
+    const HIGH: u64 = 7777;
+    let honored_high = VersionId::new(HIGH).unwrap();
+
+    for (id, name) in [(a, "Alice"), (c, "Carol")] {
+        wal.append(WalOperation::CreateNode {
+            node_id: id,
+            label: GLOBAL_INTERNER.intern("Person").unwrap(),
+            properties: person(name),
+            valid_from: time::now(),
+            provenance: None,
+        })?;
+    }
+    // Delete A with the HIGH honored id.
+    wal.append(WalOperation::DeleteNode {
+        node_id: a,
+        valid_from: time::now(),
+        version_id: Some(honored_high),
+    })?;
+    // Delete C with NO logged id -> replay must SYNTHESIZE its tombstone.
+    wal.append(WalOperation::DeleteNode {
+        node_id: c,
+        valid_from: time::now(),
+        version_id: None,
+    })?;
+    wal.flush()?;
+
+    let (_current, historical) = recover(&temp_dir, &wal)?;
+
+    // A's tombstone is the honored high id.
+    assert_eq!(
+        historical.get_current_node_version(a),
+        Some(honored_high),
+        "A's tombstone must be the honored high id"
+    );
+    // C's synthesized tombstone must skip PAST the honored high id — proof that
+    // honoring advanced `next_version_id` via `.max(id + 1)` (a plain `+= 1`
+    // would leave it small, at/below HIGH, and could even collide with A's id).
+    let c_tombstone = historical
+        .get_current_node_version(c)
+        .expect("C must have a synthesized tombstone head");
+    assert!(
+        c_tombstone.as_u64() > HIGH,
+        "synthesized tombstone {} must skip past the honored high id {}",
+        c_tombstone.as_u64(),
+        HIGH
+    );
+    assert_ne!(
+        c_tombstone, honored_high,
+        "synthesized tombstone must not collide with the honored high id"
+    );
+    Ok(())
+}
+
+/// Same shape, but the HIGH honored id comes from a RETRACT (exercising the
+/// retract arm's `.max(id + 1)` advancement rather than the delete arm's).
+#[test]
+fn synthesized_delete_after_honored_retract_high_id_skips_past_it() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let wal = new_wal(&temp_dir)?;
+
+    let a = NodeId::new(1).unwrap();
+    let c = NodeId::new(2).unwrap();
+    const HIGH: u64 = 7777;
+    let honored_high = VersionId::new(HIGH).unwrap();
+
+    for (id, name) in [(a, "Alice"), (c, "Carol")] {
+        wal.append(WalOperation::CreateNode {
+            node_id: id,
+            label: GLOBAL_INTERNER.intern("Person").unwrap(),
+            properties: person(name),
+            valid_from: time::now(),
+            provenance: None,
+        })?;
+    }
+    // Retract A with the HIGH honored id (retract arm advancement).
+    wal.append(WalOperation::RetractNode {
+        node_id: a,
+        valid_to: time::now(),
+        version_id: Some(honored_high),
+    })?;
+    // Delete C with NO logged id -> synthesis; must skip past the retract's id.
+    wal.append(WalOperation::DeleteNode {
+        node_id: c,
+        valid_from: time::now(),
+        version_id: None,
+    })?;
+    wal.flush()?;
+
+    let (_current, historical) = recover(&temp_dir, &wal)?;
+
+    assert_eq!(
+        historical.get_current_node_version(a),
+        Some(honored_high),
+        "A's retraction must be the honored high id"
+    );
+    let c_tombstone = historical
+        .get_current_node_version(c)
+        .expect("C must have a synthesized tombstone head");
+    assert!(
+        c_tombstone.as_u64() > HIGH,
+        "synthesized tombstone {} must skip past the honored retract id {}",
+        c_tombstone.as_u64(),
+        HIGH
+    );
     Ok(())
 }
 
@@ -441,8 +621,25 @@ fn live_delete_tombstone_id_survives_crash() -> Result<()> {
         let id = db
             .create_node("Person", person("Alice"))
             .expect("create_node");
-        db.delete_node_with_valid_time(id, None)
-            .expect("delete_node");
+
+        // Introduce a GAP so the live tombstone id is NON-CONTIGUOUS with what a
+        // pure-synthesis replay would assign at the delete's log position. In a
+        // single transaction, the delete/retract closing ids are pre-generated
+        // at commit (Issue #3406) — AFTER every buffered create has already
+        // drawn its version id — yet the DeleteNode entry is logged BEFORE the
+        // trailing create. So replaying in log order, a synthesizing reader
+        // would give the tombstone the id at THAT position (lower), whereas the
+        // live commit stamped it with the max (post-create) id. Honoring the
+        // logged id is the only way the recovered head equals the live one; a
+        // regression to pure synthesis would recover a smaller id and this
+        // test's `recovered == live` assertion would fail.
+        let mut tx = db.write_transaction().expect("begin tx");
+        tx.create_node("Filler", person("f1")).expect("create f1");
+        tx.delete_node(id).expect("delete_node"); // logged before f2/f3
+        tx.create_node("Filler", person("f2")).expect("create f2");
+        tx.create_node("Filler", person("f3")).expect("create f3");
+        tx.commit().expect("commit");
+
         // Hard crash: leak the handle so Drop never persists anything.
         std::mem::forget(db);
         id


### PR DESCRIPTION
## Summary

Follow-up **test-only** hardening for #3406 (WAL tombstone `version_id`), whose production code already merged to trunk via **#3458**. A test-hardening commit was pushed to the original feature branch around the same time as the merge and got orphaned by it, so this PR reapplies just those test changes on top of current trunk. **No production change** — the diff touches only `#[cfg(test)]` / `mod prop_tests` code and the integration test file; the tombstone logging/honoring production code remains exactly trunk's (already merged).

These tests close the mutation-coverage gaps a review found — specifically the `next_version_id.max(id + 1)` guard on the four delete/retract arms, and a no-gap coincidence in the live-crash test that let a full honor→synthesize revert slip through undetected.

## What changed (test-only)

- **`synthesized_delete_after_honored_high_id_skips_past_it`** + a retract variant: a synthesized tombstone after a HONORED high id must skip past it, guarding the `next_version_id.max(id + 1)` advancement — reverting to `+= 1` now fails.
- **`live_delete_tombstone_id_survives_crash`** reworked to introduce a real id gap (batched create/delete/create in one txn) so the live tombstone id is non-contiguous with log-position synthesis; a full honor→synthesize revert now fails.
- Genuine **pre-v9 (framed v7)** DeleteNode/RetractNode parse tests asserting `version_id == None` with exact byte consumption, covering the `carries_delete_version_id` gate at a realistic older header (previously only v0).
- `honor_logged_retract_{node,edge}` now assert the retraction closed valid time at the logged `valid_to` (and preserved `valid_from`), not just the version id.
- Serialization proptest strategy now fuzzes the optional tombstone `version_id` (`Some` + `None`/`u64::MAX` sentinel), plus a delete/retract round-trip proptest.

## Verification against current trunk

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all` — no changes
- `cargo test --test recovery` — 78 passed, 0 failed (incl. the new synthesized/retract/live-crash tests)
- `cargo test --lib -- storage::wal::serialization storage::wal::segment_reader` — 66 passed, 0 failed (incl. new pre-v9 parse tests and round-trip proptest)

The discriminating Fix A/B tests pass because trunk already carries the correct `.max()`/honor logic.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKAFWHHzF4ng6LybQJhYsH)_