### PR TITLE
Implement runtime Cypher aggregation (count/sum/avg/min/max/collect), DISTINCT, ORDER BY (#558)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -731,10 +731,41 @@ let results = db.execute_cypher_with_params("MATCH (n:Person {name: $name}) RETU
 - Directions: `->` (outgoing), `<-` (incoming), `-` (both)
 - Filtering: `WHERE n.age > 18 AND n.name = 'Alice'`
 - Results: `RETURN`, `RETURN DISTINCT`, `AS` aliases
-- Ordering: `ORDER BY n.age DESC`
+- Aggregation (Issue #558): `count(*)`, `count(expr)`, `count(DISTINCT expr)`,
+  `sum`/`avg`/`min`/`max`/`collect` (each with optional `DISTINCT`), with
+  openCypher **implicit grouping** — non-aggregate `RETURN` items become the
+  group key (`RETURN n.dept, count(*)` groups by `n.dept`; a keyless
+  `RETURN count(*)` is one global row, `0` over empty input). `ORDER BY` over
+  aggregate output sorts by the output column / aggregate alias.
+- Ordering: `ORDER BY n.age DESC` — multi-key `ORDER BY a, b` sorts by `a`
+  (primary) then `b`; openCypher null placement (nulls **last** for `ASC`,
+  **first** for `DESC`)
 - Pagination: `SKIP 10 LIMIT 20`
 - Query chaining: `WITH b WHERE b.score > 0.5 RETURN b`
 - Parameters: `$paramName`
+
+**Aggregation v1 limitations (Issue #558):**
+- **Grouping by a whole node/edge is rejected** (`RETURN n, count(*)` returns a
+  structured `UnsupportedFeature` error): the single-entity row model cannot
+  express node-identity grouping — group by a property (`n.id`) instead.
+  `count(n)` (bare variable) is allowed and counts non-null bindings.
+  `count(DISTINCT *)` is a parse error (openCypher disallows it).
+- **`min`/`max`/`sum`/`avg` over mixed or non-numeric types are lenient**:
+  non-numeric values are skipped by `sum`/`avg`, and `min`/`max` treat
+  incomparable pairs as equal (retain input order) rather than erroring. An
+  all-integer `sum` that overflows `i64` promotes to `Float` (never silently
+  wraps).
+- **`RETURN DISTINCT <scalar projection>`** (e.g. `RETURN DISTINCT n.dept`)
+  deduplicates by entity id, **not** the projected value — a pre-existing
+  projection-model limitation (property projection is not yet lowered into the
+  row), independent of aggregation.
+- **MCP `query`-tool rendering (cross-lane)**: aggregate rows are carried on
+  `QueryRow.columns` with a null entity, but the MCP serializer
+  (`query_row_to_json`, `src/mcp/server.rs`) ignores `columns` and renders the
+  row as `{"entity": null, ...}`. Aggregation is correct at the
+  `execute_cypher`/Rust-API level; surfacing it through MCP is a one-branch
+  follow-up for the MCP lane owner (serialize `row.columns` via
+  `property_value_to_json` and make `query_columns()` dynamic).
 
 **Temporal Extensions:**
 - `AS OF TIMESTAMP '2024-01-15T10:00:00Z'`

--- a/src/cypher/ast.rs
+++ b/src/cypher/ast.rs
@@ -261,8 +261,17 @@ pub enum CypherExpr {
         /// The function name (case-insensitive at parse time).
         name: String,
         /// The arguments passed to the function.
+        ///
+        /// For the `count(*)` aggregate the single argument is
+        /// [`CypherExpr::Star`].
         args: Vec<CypherExpr>,
+        /// Whether the call used the `DISTINCT` quantifier, e.g.
+        /// `count(DISTINCT n.dept)`. Only meaningful for aggregate functions;
+        /// always `false` for ordinary/vector functions.
+        distinct: bool,
     },
+    /// The `*` wildcard argument, used only inside `count(*)`.
+    Star,
     /// A parenthesized sub-expression used for grouping.
     Grouped(Box<CypherExpr>),
 }

--- a/src/cypher/converter.rs
+++ b/src/cypher/converter.rs
@@ -42,8 +42,8 @@ use super::parser::CypherParser;
 use crate::core::temporal::{TimeRange, Timestamp};
 use crate::query::builder::Query;
 use crate::query::ir::{
-    AggregateFunc, AggregateGroupKey, AggregateSpec, Predicate, PredicateValue, QueryOp, SortKey,
-    TraversalDepth,
+    AggregateArg, AggregateFunc, AggregateGroupKey, AggregateSpec, Predicate, PredicateValue,
+    QueryOp, SortKey, TraversalDepth,
 };
 use crate::query::plan::{QueryHints, TemporalContext};
 
@@ -257,6 +257,16 @@ impl CypherConverter {
                 //    non-aggregate path.
                 if let Some(aggregate_op) = self.build_aggregate(&return_clause)? {
                     ops.push(aggregate_op);
+                    // ORDER BY over aggregate output: sort by the output column
+                    // name / aggregate alias (RETURN DISTINCT is subsumed by
+                    // grouping; vector rank does not apply to computed rows).
+                    for order_item in &return_clause.order_by {
+                        let key = self.aggregate_order_key(&return_clause, order_item)?;
+                        ops.push(QueryOp::Sort {
+                            key: SortKey::Property(key),
+                            descending: order_item.descending,
+                        });
+                    }
                 } else {
                     // 4a. RETURN DISTINCT
                     if return_clause.distinct {
@@ -747,14 +757,18 @@ impl CypherConverter {
                     ));
                 }
                 CypherReturnItem::Variable(name) => {
-                    group_keys.push(AggregateGroupKey {
-                        property_key: name.clone(),
-                        alias: name.clone(),
-                    });
+                    // Grouping by a whole node/edge cannot be expressed by the
+                    // single-entity row model (it would collapse into one
+                    // Null-keyed group). Reject rather than silently mis-group.
+                    return Err(CypherError::UnsupportedFeature(format!(
+                        "grouping by a whole node/edge is not supported \
+                         (RETURN {name}, <aggregate>); group by a property such \
+                         as {name}.<key> instead"
+                    )));
                 }
                 CypherReturnItem::Expression { expr, alias } => {
                     if let Some((func, args, distinct)) = Self::aggregate_call(expr) {
-                        let arg = Self::aggregate_arg_property(func, args)?;
+                        let arg = Self::aggregate_arg(func, args)?;
                         let default_alias = Self::aggregate_default_alias(func, args, distinct);
                         aggregates.push(AggregateSpec {
                             func,
@@ -808,23 +822,27 @@ impl CypherConverter {
         }
     }
 
-    /// Resolve the node property an aggregate reads from its argument list.
+    /// Resolve what an aggregate reads from each row into an [`AggregateArg`].
     ///
-    /// `count(*)` and a bare-variable `count(n)` yield `None` (count rows);
-    /// `func(v.prop)` yields `Some("prop")`. Non-property arguments to
-    /// value aggregates are rejected in v1.
-    fn aggregate_arg_property(
+    /// `count(*)` -> [`AggregateArg::Star`] (count every row); a bare-variable
+    /// `count(n)` -> [`AggregateArg::Entity`] (count rows with a non-null bound
+    /// entity, openCypher semantics); `func(v.prop)` ->
+    /// [`AggregateArg::Property`]. Non-property arguments to value aggregates
+    /// are rejected in v1.
+    fn aggregate_arg(
         func: AggregateFunc,
         args: &[CypherExpr],
-    ) -> Result<Option<String>, CypherError> {
+    ) -> Result<AggregateArg, CypherError> {
         match args {
-            [] | [CypherExpr::Star] => Ok(None),
-            [CypherExpr::Property { property, .. }] => Ok(Some(property.clone())),
+            // `*` (or the degenerate empty arg list) is only valid for count.
+            [CypherExpr::Star] | [] if func == AggregateFunc::Count => Ok(AggregateArg::Star),
+            [CypherExpr::Property { property, .. }] => Ok(AggregateArg::Property(property.clone())),
             // A bare variable argument (`count(n)`) references the bound entity,
-            // not a property: treat it as a row/entity count for `count`.
-            [CypherExpr::Variable(_)] if func == AggregateFunc::Count => Ok(None),
+            // not a property: count non-null bindings (distinct from count(*)).
+            [CypherExpr::Variable(_)] if func == AggregateFunc::Count => Ok(AggregateArg::Entity),
             _ => Err(CypherError::UnsupportedFeature(format!(
-                "aggregate argument must be `*` or a property access (e.g. n.age); got {args:?}"
+                "aggregate argument must be `*` (count only) or a property access \
+                 (e.g. n.age); got {args:?}"
             ))),
         }
     }
@@ -852,18 +870,67 @@ impl CypherConverter {
         format!("{func_name}({distinct_prefix}{arg_text})")
     }
 
-    /// Resolve a non-aggregate `RETURN`/`WITH` item into a grouping key:
+    /// Resolve a non-aggregate `RETURN` item into a grouping key:
     /// `(property_to_read, default_column_name)`.
+    ///
+    /// Only property access (`n.dept`) is supported. A bare variable
+    /// (whole node/edge) is rejected -- see the `Variable` arm in
+    /// [`Self::build_aggregate`].
     fn group_key_of(expr: &CypherExpr) -> Result<(String, String), CypherError> {
         match expr {
             CypherExpr::Property { variable, property } => {
                 Ok((property.clone(), format!("{variable}.{property}")))
             }
-            CypherExpr::Variable(name) => Ok((name.clone(), name.clone())),
+            CypherExpr::Variable(name) => Err(CypherError::UnsupportedFeature(format!(
+                "grouping by a whole node/edge is not supported \
+                 (RETURN {name}, <aggregate>); group by a property such as \
+                 {name}.<key> instead"
+            ))),
             _ => Err(CypherError::UnsupportedFeature(format!(
-                "grouping key must be a variable or property access; got {expr:?}"
+                "grouping key must be a property access (e.g. n.dept); got {expr:?}"
             ))),
         }
+    }
+
+    /// Resolve an `ORDER BY` item, in an aggregating query, to the output
+    /// column name it should sort by (the aggregate/group alias or generated
+    /// column name).
+    fn aggregate_order_key(
+        &self,
+        ret: &CypherReturn,
+        order_item: &CypherOrderItem,
+    ) -> Result<String, CypherError> {
+        let expr = &order_item.expr;
+
+        // A bare variable directly names an output column / AS alias.
+        if let CypherExpr::Variable(name) = expr {
+            return Ok(name.clone());
+        }
+
+        // Otherwise compute the column name the same way build_aggregate does.
+        let default_name = if let Some((func, args, distinct)) = Self::aggregate_call(expr) {
+            Self::aggregate_default_alias(func, args, distinct)
+        } else if let CypherExpr::Property { variable, property } = expr {
+            format!("{variable}.{property}")
+        } else {
+            return Err(CypherError::UnsupportedFeature(format!(
+                "unsupported ORDER BY expression over an aggregating query: {expr:?}"
+            )));
+        };
+
+        // If a RETURN item projects this exact expression under an alias, order
+        // by that alias (its actual output column name).
+        for item in &ret.items {
+            if let CypherReturnItem::Expression {
+                expr: item_expr,
+                alias: Some(alias),
+            } = item
+                && item_expr == expr
+            {
+                return Ok(alias.clone());
+            }
+        }
+        Ok(default_name)
     }
 
     // =======================================================================

--- a/src/cypher/converter.rs
+++ b/src/cypher/converter.rs
@@ -41,7 +41,10 @@ use super::error::CypherError;
 use super::parser::CypherParser;
 use crate::core::temporal::{TimeRange, Timestamp};
 use crate::query::builder::Query;
-use crate::query::ir::{Predicate, PredicateValue, QueryOp, SortKey, TraversalDepth};
+use crate::query::ir::{
+    AggregateFunc, AggregateGroupKey, AggregateSpec, Predicate, PredicateValue, QueryOp, SortKey,
+    TraversalDepth,
+};
 use crate::query::plan::{QueryHints, TemporalContext};
 
 // ---------------------------------------------------------------------------
@@ -235,37 +238,39 @@ impl CypherConverter {
                     with_idx += 1;
                 }
 
-                // 4. Convert RETURN clause modifiers
-                if return_clause.distinct {
-                    ops.push(QueryOp::Distinct);
-                }
+                // 4. Aggregation (openCypher implicit grouping). If any RETURN
+                //    item is an aggregate function call, the RETURN lowers to a
+                //    single Aggregate op grouping on the non-aggregate items.
+                //    Aggregation subsumes DISTINCT and changes what the pipeline
+                //    yields (computed column rows), so RETURN DISTINCT and the
+                //    ORDER BY / vector-rank projection are only applied on the
+                //    non-aggregate path.
+                if let Some(aggregate_op) = self.build_aggregate(&return_clause)? {
+                    ops.push(aggregate_op);
+                } else {
+                    // 4a. RETURN DISTINCT
+                    if return_clause.distinct {
+                        ops.push(QueryOp::Distinct);
+                    }
 
-                // 4b. Check for aggregation functions in RETURN items
-                for item in &return_clause.items {
-                    if let CypherReturnItem::Expression {
-                        expr: CypherExpr::FunctionCall { name, .. },
-                        ..
-                    } = item
-                        && name.eq_ignore_ascii_case("count")
-                    {
-                        ops.push(QueryOp::Count);
+                    // 4b. Check if ORDER BY contains a vector function call that
+                    // should be converted to RankBySimilarity instead of Sort.
+                    let vector_rank_emitted =
+                        self.try_emit_vector_rank(&return_clause, &mut ops)?;
+
+                    if !vector_rank_emitted {
+                        for order_item in &return_clause.order_by {
+                            let sort_key = self.convert_order_item_to_sort_key(order_item)?;
+                            ops.push(QueryOp::Sort {
+                                key: sort_key,
+                                descending: order_item.descending,
+                            });
+                        }
                     }
                 }
 
-                // Check if ORDER BY contains a vector function call that should
-                // be converted to RankBySimilarity instead of Sort.
-                let vector_rank_emitted = self.try_emit_vector_rank(&return_clause, &mut ops)?;
-
-                if !vector_rank_emitted {
-                    for order_item in &return_clause.order_by {
-                        let sort_key = self.convert_order_item_to_sort_key(order_item)?;
-                        ops.push(QueryOp::Sort {
-                            key: sort_key,
-                            descending: order_item.descending,
-                        });
-                    }
-                }
-
+                // SKIP / LIMIT page the final rows in both the aggregate and the
+                // ordinary case.
                 if let Some(skip) = return_clause.skip {
                     ops.push(QueryOp::Skip(skip));
                 }
@@ -663,6 +668,159 @@ impl CypherConverter {
     }
 
     // =======================================================================
+    // Aggregation (implicit grouping)
+    // =======================================================================
+
+    /// Build a [`QueryOp::Aggregate`] from the `RETURN` clause if it contains
+    /// any aggregate function call, applying openCypher implicit grouping:
+    /// every non-aggregate item becomes a grouping key and every aggregate
+    /// item becomes an [`AggregateSpec`]. Returns `Ok(None)` when the clause
+    /// has no aggregates (the ordinary projection path).
+    fn build_aggregate(&self, ret: &CypherReturn) -> Result<Option<QueryOp>, CypherError> {
+        let has_aggregate = ret.items.iter().any(|item| {
+            matches!(
+                item,
+                CypherReturnItem::Expression { expr, .. }
+                    if Self::aggregate_call(expr).is_some()
+            )
+        });
+        if !has_aggregate {
+            return Ok(None);
+        }
+
+        let mut group_keys = Vec::new();
+        let mut aggregates = Vec::new();
+
+        for item in &ret.items {
+            match item {
+                CypherReturnItem::Star => {
+                    return Err(CypherError::UnsupportedFeature(
+                        "RETURN * combined with aggregation; project explicit \
+                         grouping keys instead"
+                            .to_string(),
+                    ));
+                }
+                CypherReturnItem::Variable(name) => {
+                    group_keys.push(AggregateGroupKey {
+                        property_key: name.clone(),
+                        alias: name.clone(),
+                    });
+                }
+                CypherReturnItem::Expression { expr, alias } => {
+                    if let Some((func, args, distinct)) = Self::aggregate_call(expr) {
+                        let arg = Self::aggregate_arg_property(func, args)?;
+                        let default_alias = Self::aggregate_default_alias(func, args, distinct);
+                        aggregates.push(AggregateSpec {
+                            func,
+                            arg,
+                            distinct,
+                            alias: alias.clone().unwrap_or(default_alias),
+                        });
+                    } else {
+                        let (property_key, default_alias) = Self::group_key_of(expr)?;
+                        group_keys.push(AggregateGroupKey {
+                            property_key,
+                            alias: alias.clone().unwrap_or(default_alias),
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(Some(QueryOp::Aggregate {
+            group_keys,
+            aggregates,
+        }))
+    }
+
+    /// If `expr` is an aggregate function call, return its function, argument
+    /// list, and `DISTINCT` flag. Non-aggregate calls (e.g. `vector.cosine`)
+    /// and non-calls return `None`.
+    fn aggregate_call(expr: &CypherExpr) -> Option<(AggregateFunc, &[CypherExpr], bool)> {
+        if let CypherExpr::FunctionCall {
+            name,
+            args,
+            distinct,
+        } = expr
+            && let Some(func) = Self::aggregate_func_name(name)
+        {
+            return Some((func, args.as_slice(), *distinct));
+        }
+        None
+    }
+
+    /// Map a function name (case-insensitive) to an [`AggregateFunc`].
+    fn aggregate_func_name(name: &str) -> Option<AggregateFunc> {
+        match name.to_ascii_uppercase().as_str() {
+            "COUNT" => Some(AggregateFunc::Count),
+            "SUM" => Some(AggregateFunc::Sum),
+            "AVG" => Some(AggregateFunc::Avg),
+            "MIN" => Some(AggregateFunc::Min),
+            "MAX" => Some(AggregateFunc::Max),
+            "COLLECT" => Some(AggregateFunc::Collect),
+            _ => None,
+        }
+    }
+
+    /// Resolve the node property an aggregate reads from its argument list.
+    ///
+    /// `count(*)` and a bare-variable `count(n)` yield `None` (count rows);
+    /// `func(v.prop)` yields `Some("prop")`. Non-property arguments to
+    /// value aggregates are rejected in v1.
+    fn aggregate_arg_property(
+        func: AggregateFunc,
+        args: &[CypherExpr],
+    ) -> Result<Option<String>, CypherError> {
+        match args {
+            [] | [CypherExpr::Star] => Ok(None),
+            [CypherExpr::Property { property, .. }] => Ok(Some(property.clone())),
+            // A bare variable argument (`count(n)`) references the bound entity,
+            // not a property: treat it as a row/entity count for `count`.
+            [CypherExpr::Variable(_)] if func == AggregateFunc::Count => Ok(None),
+            _ => Err(CypherError::UnsupportedFeature(format!(
+                "aggregate argument must be `*` or a property access (e.g. n.age); got {args:?}"
+            ))),
+        }
+    }
+
+    /// Generate the default output column name for an aggregate (used when no
+    /// `AS` alias is supplied), e.g. `count(*)`, `sum(n.age)`,
+    /// `count(DISTINCT n.dept)`.
+    fn aggregate_default_alias(func: AggregateFunc, args: &[CypherExpr], distinct: bool) -> String {
+        let func_name = match func {
+            AggregateFunc::Count => "count",
+            AggregateFunc::Sum => "sum",
+            AggregateFunc::Avg => "avg",
+            AggregateFunc::Min => "min",
+            AggregateFunc::Max => "max",
+            AggregateFunc::Collect => "collect",
+        };
+        let arg_text = match args.first() {
+            None => String::new(),
+            Some(CypherExpr::Star) => "*".to_string(),
+            Some(CypherExpr::Property { variable, property }) => format!("{variable}.{property}"),
+            Some(CypherExpr::Variable(v)) => v.clone(),
+            Some(_) => "expr".to_string(),
+        };
+        let distinct_prefix = if distinct { "DISTINCT " } else { "" };
+        format!("{func_name}({distinct_prefix}{arg_text})")
+    }
+
+    /// Resolve a non-aggregate `RETURN`/`WITH` item into a grouping key:
+    /// `(property_to_read, default_column_name)`.
+    fn group_key_of(expr: &CypherExpr) -> Result<(String, String), CypherError> {
+        match expr {
+            CypherExpr::Property { variable, property } => {
+                Ok((property.clone(), format!("{variable}.{property}")))
+            }
+            CypherExpr::Variable(name) => Ok((name.clone(), name.clone())),
+            _ => Err(CypherError::UnsupportedFeature(format!(
+                "grouping key must be a variable or property access; got {expr:?}"
+            ))),
+        }
+    }
+
+    // =======================================================================
     // ORDER BY helpers
     // =======================================================================
 
@@ -754,7 +912,7 @@ impl CypherConverter {
         }
 
         let order_item = &return_clause.order_by[0];
-        if let CypherExpr::FunctionCall { name, args } = &order_item.expr
+        if let CypherExpr::FunctionCall { name, args, .. } = &order_item.expr
             && is_vector_function(name)
         {
             let (property_key, embedding) = self.extract_vector_args(args)?;
@@ -773,7 +931,7 @@ impl CypherConverter {
         if let CypherExpr::Variable(ref alias_name) = order_item.expr {
             for item in &return_clause.items {
                 if let CypherReturnItem::Expression {
-                    expr: CypherExpr::FunctionCall { name, args },
+                    expr: CypherExpr::FunctionCall { name, args, .. },
                     alias: Some(alias),
                 } = item
                     && alias == alias_name

--- a/src/cypher/parser.rs
+++ b/src/cypher/parser.rs
@@ -618,6 +618,7 @@ impl CypherParser {
                         Ok(CypherExpr::FunctionCall {
                             name: qualified_name,
                             args,
+                            distinct: false,
                         })
                     } else {
                         // Property access: var.prop
@@ -631,7 +632,11 @@ impl CypherParser {
                     self.advance();
                     let args = self.parse_function_args()?;
                     self.expect(TokenKind::RParen)?;
-                    Ok(CypherExpr::FunctionCall { name, args })
+                    Ok(CypherExpr::FunctionCall {
+                        name,
+                        args,
+                        distinct: false,
+                    })
                 } else {
                     // Bare variable
                     Ok(CypherExpr::Variable(name))
@@ -648,9 +653,22 @@ impl CypherParser {
                 let name_tok = self.advance().clone();
                 let name = name_tok.text.to_uppercase();
                 self.expect(TokenKind::LParen)?;
-                let args = self.parse_function_args()?;
+                // Optional DISTINCT quantifier: count(DISTINCT n.dept).
+                let distinct = self.eat(TokenKind::Distinct);
+                // `count(*)` -- the star wildcard is only valid as the sole
+                // argument (typically for count).
+                let args = if self.at(TokenKind::Star) {
+                    self.advance();
+                    vec![CypherExpr::Star]
+                } else {
+                    self.parse_function_args()?
+                };
                 self.expect(TokenKind::RParen)?;
-                Ok(CypherExpr::FunctionCall { name, args })
+                Ok(CypherExpr::FunctionCall {
+                    name,
+                    args,
+                    distinct,
+                })
             }
 
             // Literal values

--- a/src/cypher/parser.rs
+++ b/src/cypher/parser.rs
@@ -711,8 +711,14 @@ impl CypherParser {
                 // Optional DISTINCT quantifier: count(DISTINCT n.dept).
                 let distinct = self.eat(TokenKind::Distinct);
                 // `count(*)` -- the star wildcard is only valid as the sole
-                // argument (typically for count).
+                // argument (typically for count). `DISTINCT *` is rejected
+                // (openCypher does not allow `count(DISTINCT *)`).
                 let args = if self.at(TokenKind::Star) {
+                    if distinct {
+                        return Err(self.error(
+                            "DISTINCT * is not allowed (use count(*) or count(DISTINCT expr))",
+                        ));
+                    }
                     self.advance();
                     vec![CypherExpr::Star]
                 } else {

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -3190,8 +3190,213 @@ fn test_e2e_order_by() {
             .unwrap(),
     );
     let names: Vec<String> = rows.iter().filter_map(row_name).collect();
-    // DESC by age; Dave (null age) sorts last.
-    assert_eq!(names, vec!["Carol", "Bob", "Alice", "Eve", "Dave"]);
+    // DESC by age; openCypher orders nulls FIRST for DESC, so Dave (null age)
+    // leads, then 50, 40, 30, 20.
+    assert_eq!(names, vec!["Dave", "Carol", "Bob", "Alice", "Eve"]);
+}
+
+#[test]
+fn test_e2e_order_by_asc_nulls_last() {
+    let db = aggregation_test_db();
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) RETURN n.name ORDER BY n.age ASC")
+            .unwrap(),
+    );
+    let names: Vec<String> = rows.iter().filter_map(row_name).collect();
+    // ASC by age; openCypher orders nulls LAST for ASC.
+    assert_eq!(names, vec!["Eve", "Alice", "Bob", "Carol", "Dave"]);
+}
+
+#[test]
+fn test_e2e_order_by_multi_key_precedence() {
+    // Fix B: `ORDER BY n.dept ASC, n.age DESC` must sort by dept (primary) then
+    // age descending (secondary), NOT the inverted (age, dept).
+    let db = aggregation_test_db();
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) RETURN n.name ORDER BY n.dept ASC, n.age DESC")
+            .unwrap(),
+    );
+    let names: Vec<String> = rows.iter().filter_map(row_name).collect();
+    // Eng (Bob 40, Alice 30, Eve 20) then Sales (Dave null-first for DESC, Carol 50).
+    assert_eq!(names, vec!["Bob", "Alice", "Eve", "Dave", "Carol"]);
+}
+
+#[test]
+fn test_agg_order_by_aggregate_alias() {
+    // Fix A: ORDER BY over aggregation must not be dropped, and SortIterator
+    // must order computed rows by an aggregate alias.
+    let db = aggregation_test_db();
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) RETURN n.dept, count(*) AS c ORDER BY c DESC")
+            .unwrap(),
+    );
+    assert_eq!(rows.len(), 2);
+    // Eng (3) before Sales (2).
+    assert_eq!(
+        col(&rows[0], "n.dept").and_then(|v| v.as_str()),
+        Some("Eng")
+    );
+    assert_eq!(col(&rows[0], "c"), Some(&PropertyValue::Int(3)));
+    assert_eq!(
+        col(&rows[1], "n.dept").and_then(|v| v.as_str()),
+        Some("Sales")
+    );
+    assert_eq!(col(&rows[1], "c"), Some(&PropertyValue::Int(2)));
+}
+
+#[test]
+fn test_agg_reject_group_by_whole_node() {
+    // Fix C: grouping by a bare variable / whole node is rejected, not
+    // silently collapsed into one wrong group.
+    let db = aggregation_test_db();
+    let err = db
+        .execute_cypher("MATCH (n:Person) RETURN n, count(*)")
+        .map(|_| ())
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("whole node") || msg.contains("group by a property"),
+        "expected a structured node-grouping rejection, got: {msg}"
+    );
+}
+
+#[test]
+fn test_agg_count_variable_skips_null_bindings() {
+    // Fix D: count(x) counts NON-NULL bindings, unlike count(*).
+    let db = AletheiaDB::new().unwrap();
+    let alice = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .unwrap();
+    let bob = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+        )
+        .unwrap();
+    // Only Alice KNOWS someone; Bob has no outgoing KNOWS -> null x binding.
+    db.create_edge(alice, bob, "KNOWS", CorePropertyMap::new())
+        .unwrap();
+
+    // Two base rows (Alice, Bob); one has a matched x, one has null x.
+    let star = collect_rows(
+        db.execute_cypher("MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) RETURN count(*)")
+            .unwrap(),
+    );
+    assert_eq!(col(&star[0], "count(*)"), Some(&PropertyValue::Int(2)));
+
+    let non_null = collect_rows(
+        db.execute_cypher("MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) RETURN count(x)")
+            .unwrap(),
+    );
+    // count(x) skips the null binding -> 1, not 2.
+    assert_eq!(col(&non_null[0], "count(x)"), Some(&PropertyValue::Int(1)));
+}
+
+#[test]
+fn test_agg_count_distinct_star_is_error() {
+    // Fix H: count(DISTINCT *) is rejected (openCypher disallows it).
+    let db = aggregation_test_db();
+    let err = db
+        .execute_cypher("MATCH (n:Person) RETURN count(DISTINCT *)")
+        .map(|_| ())
+        .unwrap_err();
+    assert!(
+        err.to_string().to_lowercase().contains("distinct *"),
+        "expected a DISTINCT * rejection, got: {err}"
+    );
+}
+
+#[test]
+fn test_agg_group_key_int_vs_float_and_signed_zero() {
+    // Fix F: integral floats group with equal ints, and -0.0 groups with 0.0/0.
+    let db = AletheiaDB::new().unwrap();
+    db.create_node("M", PropertyMapBuilder::new().insert("k", 1i64).build())
+        .unwrap();
+    db.create_node("M", PropertyMapBuilder::new().insert("k", 1.0f64).build())
+        .unwrap();
+    db.create_node("M", PropertyMapBuilder::new().insert("k", 0.0f64).build())
+        .unwrap();
+    db.create_node("M", PropertyMapBuilder::new().insert("k", -0.0f64).build())
+        .unwrap();
+    db.create_node("M", PropertyMapBuilder::new().insert("k", 0i64).build())
+        .unwrap();
+
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:M) RETURN n.k, count(*)")
+            .unwrap(),
+    );
+    // Expect exactly two groups: {1 / 1.0} and {0 / 0.0 / -0.0}.
+    assert_eq!(
+        rows.len(),
+        2,
+        "1 and 1.0 must share a group; 0/0.0/-0.0 too"
+    );
+    let mut counts = std::collections::HashMap::new();
+    for row in &rows {
+        let k = col(row, "n.k")
+            .and_then(|v| v.as_int().or_else(|| v.as_float().map(|f| f as i64)))
+            .unwrap();
+        let c = col(row, "count(*)").and_then(|v| v.as_int()).unwrap();
+        counts.insert(k, c);
+    }
+    assert_eq!(counts.get(&1), Some(&2));
+    assert_eq!(counts.get(&0), Some(&3));
+}
+
+#[test]
+fn test_agg_collect_distinct_dedup_and_order() {
+    let db = AletheiaDB::new().unwrap();
+    for dept in ["Eng", "Sales", "Eng", "Ops", "Sales"] {
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("dept", dept).build(),
+        )
+        .unwrap();
+    }
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) RETURN collect(DISTINCT n.dept)")
+            .unwrap(),
+    );
+    match col(&rows[0], "collect(DISTINCT n.dept)") {
+        Some(PropertyValue::Array(items)) => {
+            // Deduped, first-occurrence order preserved: Eng, Sales, Ops.
+            let got: Vec<&str> = items.iter().filter_map(|v| v.as_str()).collect();
+            assert_eq!(got, vec!["Eng", "Sales", "Ops"]);
+        }
+        other => panic!("expected array, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_agg_two_independent_distinct_aggregates() {
+    let db = AletheiaDB::new().unwrap();
+    // dept in {Eng, Sales, Eng}; team in {A, A, B} -> distinct depts=2, teams=2.
+    for (dept, team) in [("Eng", "A"), ("Sales", "A"), ("Eng", "B")] {
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("dept", dept)
+                .insert("team", team)
+                .build(),
+        )
+        .unwrap();
+    }
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) RETURN count(DISTINCT n.dept), count(DISTINCT n.team)")
+            .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        col(&rows[0], "count(DISTINCT n.dept)"),
+        Some(&PropertyValue::Int(2))
+    );
+    assert_eq!(
+        col(&rows[0], "count(DISTINCT n.team)"),
+        Some(&PropertyValue::Int(2))
+    );
 }
 // Bi-temporal AS OF / BETWEEN runtime tests (Issues #550, #551, #552)
 //

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -2247,3 +2247,348 @@ fn test_e2e_optional_match_where_with_param() {
     assert_eq!(rows.len(), 1);
     assert!(rows[0].entity.is_null());
 }
+
+// ============================================================================
+// Runtime aggregation (Issue #558): count / sum / avg / min / max / collect,
+// implicit grouping, DISTINCT, count(*), plus ORDER BY and RETURN DISTINCT.
+// ============================================================================
+
+use crate::core::property::PropertyValue;
+
+/// Fixture: five Persons across two departments; Dave has no `age`.
+/// Alice{Eng,30}, Bob{Eng,40}, Carol{Sales,50}, Dave{Sales,null}, Eve{Eng,20}.
+fn aggregation_test_db() -> AletheiaDB {
+    let db = AletheiaDB::new().unwrap();
+    db.create_node(
+        "Person",
+        PropertyMapBuilder::new()
+            .insert("name", "Alice")
+            .insert("dept", "Eng")
+            .insert("age", 30i64)
+            .build(),
+    )
+    .unwrap();
+    db.create_node(
+        "Person",
+        PropertyMapBuilder::new()
+            .insert("name", "Bob")
+            .insert("dept", "Eng")
+            .insert("age", 40i64)
+            .build(),
+    )
+    .unwrap();
+    db.create_node(
+        "Person",
+        PropertyMapBuilder::new()
+            .insert("name", "Carol")
+            .insert("dept", "Sales")
+            .insert("age", 50i64)
+            .build(),
+    )
+    .unwrap();
+    // Dave: no age property (null age).
+    db.create_node(
+        "Person",
+        PropertyMapBuilder::new()
+            .insert("name", "Dave")
+            .insert("dept", "Sales")
+            .build(),
+    )
+    .unwrap();
+    db.create_node(
+        "Person",
+        PropertyMapBuilder::new()
+            .insert("name", "Eve")
+            .insert("dept", "Eng")
+            .insert("age", 20i64)
+            .build(),
+    )
+    .unwrap();
+    db
+}
+
+/// Look up a computed column value by name in an aggregate row.
+fn col<'a>(row: &'a crate::query::executor::QueryRow, name: &str) -> Option<&'a PropertyValue> {
+    row.columns
+        .as_ref()?
+        .iter()
+        .find(|(k, _)| k == name)
+        .map(|(_, v)| v)
+}
+
+#[test]
+fn test_agg_count_star() {
+    let db = aggregation_test_db();
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) RETURN count(*)")
+            .unwrap(),
+    );
+    assert_eq!(rows.len(), 1, "global aggregation yields exactly one row");
+    assert_eq!(col(&rows[0], "count(*)"), Some(&PropertyValue::Int(5)));
+}
+
+#[test]
+fn test_agg_count_property_skips_nulls() {
+    let db = aggregation_test_db();
+    // Dave has no age -> counted only where non-null: 4.
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) RETURN count(n.age)")
+            .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(col(&rows[0], "count(n.age)"), Some(&PropertyValue::Int(4)));
+}
+
+#[test]
+fn test_agg_sum() {
+    let db = aggregation_test_db();
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) RETURN sum(n.age)")
+            .unwrap(),
+    );
+    // 30 + 40 + 50 + 20 = 140 (Dave null skipped); integer input -> integer sum.
+    assert_eq!(col(&rows[0], "sum(n.age)"), Some(&PropertyValue::Int(140)));
+}
+
+#[test]
+fn test_agg_avg() {
+    let db = aggregation_test_db();
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) RETURN avg(n.age)")
+            .unwrap(),
+    );
+    // 140 / 4 = 35.0 (avg is always a float).
+    assert_eq!(
+        col(&rows[0], "avg(n.age)"),
+        Some(&PropertyValue::Float(35.0))
+    );
+}
+
+#[test]
+fn test_agg_min_max() {
+    let db = aggregation_test_db();
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) RETURN min(n.age), max(n.age)")
+            .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(col(&rows[0], "min(n.age)"), Some(&PropertyValue::Int(20)));
+    assert_eq!(col(&rows[0], "max(n.age)"), Some(&PropertyValue::Int(50)));
+}
+
+#[test]
+fn test_agg_collect() {
+    let db = aggregation_test_db();
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) RETURN collect(n.dept)")
+            .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    match col(&rows[0], "collect(n.dept)") {
+        Some(PropertyValue::Array(items)) => assert_eq!(items.len(), 5),
+        other => panic!("expected a 5-element array, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_agg_count_distinct() {
+    let db = aggregation_test_db();
+    // Two distinct departments: Eng, Sales.
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) RETURN count(DISTINCT n.dept)")
+            .unwrap(),
+    );
+    assert_eq!(
+        col(&rows[0], "count(DISTINCT n.dept)"),
+        Some(&PropertyValue::Int(2))
+    );
+}
+
+#[test]
+fn test_agg_grouped_count() {
+    let db = aggregation_test_db();
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) RETURN n.dept, count(*)")
+            .unwrap(),
+    );
+    assert_eq!(rows.len(), 2, "one row per department");
+    let mut counts = std::collections::HashMap::new();
+    for row in &rows {
+        let dept = col(row, "n.dept").and_then(|v| v.as_str()).unwrap();
+        let count = col(row, "count(*)").and_then(|v| v.as_int()).unwrap();
+        counts.insert(dept.to_string(), count);
+    }
+    assert_eq!(counts.get("Eng"), Some(&3));
+    assert_eq!(counts.get("Sales"), Some(&2));
+}
+
+#[test]
+fn test_agg_grouped_avg() {
+    let db = aggregation_test_db();
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) RETURN n.dept, avg(n.age)")
+            .unwrap(),
+    );
+    assert_eq!(rows.len(), 2);
+    let mut avgs = std::collections::HashMap::new();
+    for row in &rows {
+        let dept = col(row, "n.dept").and_then(|v| v.as_str()).unwrap();
+        let avg = col(row, "avg(n.age)").and_then(|v| v.as_float()).unwrap();
+        avgs.insert(dept.to_string(), avg);
+    }
+    // Eng: (30 + 40 + 20) / 3 = 30.0; Sales: 50 / 1 = 50.0 (Dave's null skipped).
+    assert_eq!(avgs.get("Eng"), Some(&30.0));
+    assert_eq!(avgs.get("Sales"), Some(&50.0));
+}
+
+#[test]
+fn test_agg_grouped_multi_aggregate() {
+    let db = aggregation_test_db();
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) RETURN n.dept, count(*), max(n.age)")
+            .unwrap(),
+    );
+    assert_eq!(rows.len(), 2);
+    for row in &rows {
+        let dept = col(row, "n.dept").and_then(|v| v.as_str()).unwrap();
+        let count = col(row, "count(*)").and_then(|v| v.as_int()).unwrap();
+        let max = col(row, "max(n.age)").and_then(|v| v.as_int()).unwrap();
+        match dept {
+            "Eng" => {
+                assert_eq!(count, 3);
+                assert_eq!(max, 40);
+            }
+            "Sales" => {
+                assert_eq!(count, 2);
+                assert_eq!(max, 50);
+            }
+            other => panic!("unexpected dept {other}"),
+        }
+    }
+}
+
+#[test]
+fn test_agg_empty_global_count_is_one_row_zero() {
+    let db = aggregation_test_db();
+    // No Ghost nodes: global count(*) still yields ONE row with 0.
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Ghost) RETURN count(*)")
+            .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(col(&rows[0], "count(*)"), Some(&PropertyValue::Int(0)));
+}
+
+#[test]
+fn test_agg_empty_grouped_is_zero_rows() {
+    let db = aggregation_test_db();
+    // No Ghost nodes: grouped aggregation yields ZERO rows.
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Ghost) RETURN n.dept, count(*)")
+            .unwrap(),
+    );
+    assert!(rows.is_empty());
+}
+
+#[test]
+fn test_agg_empty_global_sum_avg_min_max_collect() {
+    let db = aggregation_test_db();
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (n:Ghost) RETURN sum(n.age), avg(n.age), min(n.age), max(n.age), collect(n.age)",
+        )
+        .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    // sum over empty = 0; avg/min/max = null; collect = [].
+    assert_eq!(col(&rows[0], "sum(n.age)"), Some(&PropertyValue::Int(0)));
+    assert_eq!(col(&rows[0], "avg(n.age)"), Some(&PropertyValue::Null));
+    assert_eq!(col(&rows[0], "min(n.age)"), Some(&PropertyValue::Null));
+    assert_eq!(col(&rows[0], "max(n.age)"), Some(&PropertyValue::Null));
+    match col(&rows[0], "collect(n.age)") {
+        Some(PropertyValue::Array(items)) => assert!(items.is_empty()),
+        other => panic!("expected empty array, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_agg_alias() {
+    let db = aggregation_test_db();
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) RETURN count(*) AS c")
+            .unwrap(),
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(col(&rows[0], "c"), Some(&PropertyValue::Int(5)));
+}
+
+#[test]
+fn test_agg_collect_structured_exposes_columns() {
+    let db = aggregation_test_db();
+    let structured = db
+        .execute_cypher("MATCH (n:Person) RETURN count(*)")
+        .unwrap()
+        .collect_structured()
+        .unwrap();
+    let columns = structured
+        .columns
+        .expect("aggregate result must expose computed columns");
+    assert_eq!(columns.len(), 1);
+    assert_eq!(columns[0][0].0, "count(*)");
+    assert_eq!(columns[0][0].1, PropertyValue::Int(5));
+}
+
+#[test]
+fn test_e2e_return_distinct() {
+    let db = AletheiaDB::new().unwrap();
+    let alice = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .unwrap();
+    let bob = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+        )
+        .unwrap();
+    let carol = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Carol").build(),
+        )
+        .unwrap();
+    // Both Alice and Bob KNOW Carol: traversal reaches Carol twice.
+    db.create_edge(alice, carol, "KNOWS", CorePropertyMap::new())
+        .unwrap();
+    db.create_edge(bob, carol, "KNOWS", CorePropertyMap::new())
+        .unwrap();
+
+    // Without DISTINCT: Carol appears twice.
+    let all = collect_rows(
+        db.execute_cypher("MATCH (a:Person)-[:KNOWS]->(b) RETURN b")
+            .unwrap(),
+    );
+    assert_eq!(all.len(), 2);
+
+    // With DISTINCT: Carol appears once.
+    let distinct = collect_rows(
+        db.execute_cypher("MATCH (a:Person)-[:KNOWS]->(b) RETURN DISTINCT b")
+            .unwrap(),
+    );
+    assert_eq!(distinct.len(), 1);
+    assert_eq!(row_name(&distinct[0]).as_deref(), Some("Carol"));
+}
+
+#[test]
+fn test_e2e_order_by() {
+    let db = aggregation_test_db();
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) RETURN n.name ORDER BY n.age DESC")
+            .unwrap(),
+    );
+    let names: Vec<String> = rows.iter().filter_map(row_name).collect();
+    // DESC by age; Dave (null age) sorts last.
+    assert_eq!(names, vec!["Carol", "Bob", "Alice", "Eve", "Dave"]);
+}

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -18,7 +18,8 @@ use crate::core::property::PropertyValue;
 use crate::core::vector::cosine_similarity;
 use crate::core::{NodeId, Timestamp};
 use crate::query::ir::{
-    AggregateFunc, AggregateGroupKey, AggregateSpec, Direction, Predicate, PredicateValue, SortKey,
+    AggregateArg, AggregateFunc, AggregateGroupKey, AggregateSpec, Direction, Predicate,
+    PredicateValue, SortKey,
 };
 use crate::storage::current::CurrentStorage;
 use crate::storage::historical::HistoricalStorage;
@@ -2222,11 +2223,35 @@ impl GroupKeyValue {
             None | Some(PropertyValue::Null) => GroupKeyValue::Null,
             Some(PropertyValue::Bool(b)) => GroupKeyValue::Bool(*b),
             Some(PropertyValue::Int(i)) => GroupKeyValue::Int(*i),
-            Some(PropertyValue::Float(f)) => GroupKeyValue::Float(f.to_bits()),
+            Some(PropertyValue::Float(f)) => Self::float_key(*f),
             Some(PropertyValue::String(s)) => GroupKeyValue::Str(s.to_string()),
             Some(other) => GroupKeyValue::Other(format!("{other:?}")),
         }
     }
+
+    /// Map a float to a grouping/DISTINCT key, canonicalizing `-0.0 -> 0.0`
+    /// (signed zeros group together) and unifying an integral float with the
+    /// equal integer (so `1` and `1.0` land in the same group / distinct set).
+    fn float_key(f: f64) -> Self {
+        let f = if f == 0.0 { 0.0 } else { f };
+        if f.is_finite() && f.fract() == 0.0 && f >= i64::MIN as f64 && f <= i64::MAX as f64 {
+            GroupKeyValue::Int(f as i64)
+        } else {
+            GroupKeyValue::Float(f.to_bits())
+        }
+    }
+}
+
+/// The resolved per-row input to one aggregate, computed once per row in
+/// [`AggregateIterator::drain`].
+enum AggInput<'a> {
+    /// `count(*)` -- count the row unconditionally.
+    Star,
+    /// `count(n)` -- count the row iff its bound entity is non-null.
+    Entity { present: bool },
+    /// `func(n.prop)` -- the row's value for the property (`None`/`Null` =
+    /// absent, skipped by every value aggregate).
+    Value(Option<&'a PropertyValue>),
 }
 
 /// Per-group, per-aggregate accumulator.
@@ -2264,24 +2289,29 @@ impl AggAccumulator {
         }
     }
 
-    /// Fold one input row's value into the accumulator.
+    /// Fold one input row into the accumulator.
     ///
-    /// `is_star` marks `count(*)`, which counts the row unconditionally
-    /// (ignoring nulls and `DISTINCT`). Otherwise `value` is the row's value
-    /// for the aggregate argument; `None`/`Null` values are skipped by every
-    /// function (openCypher semantics).
-    fn update(&mut self, value: Option<&PropertyValue>, is_star: bool) {
-        if self.func == AggregateFunc::Count && is_star {
-            self.count += 1;
-            return;
-        }
-
-        let Some(v) = value else {
-            return;
+    /// `count(*)` ([`AggInput::Star`]) counts the row unconditionally and
+    /// `count(n)` ([`AggInput::Entity`]) counts non-null bindings, both
+    /// ignoring `DISTINCT`. Otherwise the value ([`AggInput::Value`]) feeds the
+    /// function; `None`/`Null` values are skipped (openCypher semantics).
+    fn update(&mut self, input: AggInput<'_>) {
+        let v = match input {
+            AggInput::Star => {
+                // Only Count uses Star (enforced by the converter).
+                self.count += 1;
+                return;
+            }
+            AggInput::Entity { present } => {
+                // Only Count uses Entity; count non-null bindings.
+                if present {
+                    self.count += 1;
+                }
+                return;
+            }
+            AggInput::Value(Some(v)) if !matches!(v, PropertyValue::Null) => v,
+            AggInput::Value(_) => return,
         };
-        if matches!(v, PropertyValue::Null) {
-            return;
-        }
 
         if self.distinct {
             let key = GroupKeyValue::from_property(Some(v));
@@ -2336,7 +2366,12 @@ impl AggAccumulator {
                 } else if self.saw_float {
                     PropertyValue::Float(self.sum_f)
                 } else {
-                    PropertyValue::Int(self.sum_i as i64)
+                    // Checked cast: an all-integer sum that overflows i64 falls
+                    // back to Float rather than silently wrapping.
+                    match i64::try_from(self.sum_i) {
+                        Ok(v) => PropertyValue::Int(v),
+                        Err(_) => PropertyValue::Float(self.sum_i as f64),
+                    }
                 }
             }
             AggregateFunc::Avg => {
@@ -2450,9 +2485,14 @@ impl AggregateIterator {
                 .get_mut(&key)
                 .expect("group inserted above must be present");
             for (spec, acc) in self.aggregates.iter().zip(group.accumulators.iter_mut()) {
-                let is_star = spec.arg.is_none();
-                let value = spec.arg.as_deref().and_then(|k| row_property(&row, k));
-                acc.update(value, is_star);
+                let input = match &spec.arg {
+                    AggregateArg::Star => AggInput::Star,
+                    AggregateArg::Entity => AggInput::Entity {
+                        present: !row.entity.is_null(),
+                    },
+                    AggregateArg::Property(k) => AggInput::Value(row_property(&row, k)),
+                };
+                acc.update(input);
             }
         }
 
@@ -2536,27 +2576,39 @@ impl ResultIterator for DistinctIterator {
     }
 }
 
-/// `ORDER BY` iterator: buffers the entire input, sorts it by the sort key, and
-/// then streams the sorted rows.
+/// Look up a value for ordering by column/property name: first a node property
+/// (entity rows), then a computed aggregate column (`row.columns`) so ORDER BY
+/// can sort grouped/aggregate rows by a group key or aggregate alias.
+fn row_value<'a>(row: &'a QueryRow, key: &str) -> Option<&'a PropertyValue> {
+    if let Some(v) = row_property(row, key) {
+        return Some(v);
+    }
+    row.columns
+        .as_ref()
+        .and_then(|cols| cols.iter().find(|(k, _)| k == key).map(|(_, v)| v))
+}
+
+/// `ORDER BY` iterator: buffers the entire input and stably sorts it by one or
+/// more keys in precedence order (first key primary), then streams the result.
 ///
-/// Sorting is stable. Rows missing the sort property sort **last** regardless of
-/// direction (a v1 simplification of openCypher's nulls-first-on-DESC rule),
-/// which keeps ordering deterministic without a tri-valued comparator.
+/// Each key carries its own ascending/descending flag. Null placement follows
+/// openCypher: a missing/null sort value orders **last** for an ascending key
+/// and **first** for a descending key. Property keys fall back to computed
+/// aggregate columns via [`row_value`], so grouped results can be ordered by a
+/// group key or aggregate alias.
 pub struct SortIterator {
     input: Option<Box<dyn ResultIterator>>,
-    key: SortKey,
-    descending: bool,
+    keys: Vec<(SortKey, bool)>,
     output: std::vec::IntoIter<QueryRow>,
     drained: bool,
 }
 
 impl SortIterator {
-    /// Create a new ORDER BY iterator.
-    pub fn new(input: Box<dyn ResultIterator>, key: SortKey, descending: bool) -> Self {
+    /// Create a new ORDER BY iterator sorting by `keys` (first = primary).
+    pub fn new(input: Box<dyn ResultIterator>, keys: Vec<(SortKey, bool)>) -> Self {
         SortIterator {
             input: Some(input),
-            key,
-            descending,
+            keys,
             output: Vec::new().into_iter(),
             drained: false,
         }
@@ -2578,28 +2630,56 @@ impl SortIterator {
 
     fn cmp_rows(&self, a: &QueryRow, b: &QueryRow) -> std::cmp::Ordering {
         use std::cmp::Ordering;
-        match &self.key {
-            SortKey::Property(prop) => {
-                match (row_property(a, prop), row_property(b, prop)) {
-                    (Some(x), Some(y)) => {
-                        let ord = compare_property(x, y);
-                        if self.descending { ord.reverse() } else { ord }
-                    }
-                    // Missing sort key always orders last, in both directions.
-                    (Some(_), None) => Ordering::Less,
-                    (None, Some(_)) => Ordering::Greater,
-                    (None, None) => Ordering::Equal,
-                }
+        for (key, descending) in &self.keys {
+            let ord = Self::cmp_by_key(a, b, key, *descending);
+            if ord != Ordering::Equal {
+                return ord;
             }
+        }
+        Ordering::Equal
+    }
+
+    /// Compare two rows by a single key, applying openCypher null placement
+    /// (nulls last for ASC, first for DESC).
+    fn cmp_by_key(
+        a: &QueryRow,
+        b: &QueryRow,
+        key: &SortKey,
+        descending: bool,
+    ) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        match key {
+            SortKey::Property(prop) => match (row_value(a, prop), row_value(b, prop)) {
+                (Some(x), Some(y)) => {
+                    let ord = compare_property(x, y);
+                    if descending { ord.reverse() } else { ord }
+                }
+                // openCypher: nulls last for ASC, first for DESC.
+                (Some(_), None) => {
+                    if descending {
+                        Ordering::Greater
+                    } else {
+                        Ordering::Less
+                    }
+                }
+                (None, Some(_)) => {
+                    if descending {
+                        Ordering::Less
+                    } else {
+                        Ordering::Greater
+                    }
+                }
+                (None, None) => Ordering::Equal,
+            },
             SortKey::Score => {
                 let ord = a.score.partial_cmp(&b.score).unwrap_or(Ordering::Equal);
-                if self.descending { ord.reverse() } else { ord }
+                if descending { ord.reverse() } else { ord }
             }
             SortKey::Timestamp => {
                 let av = a.timestamp.map(|t| t.wallclock());
                 let bv = b.timestamp.map(|t| t.wallclock());
                 let ord = av.cmp(&bv);
-                if self.descending { ord.reverse() } else { ord }
+                if descending { ord.reverse() } else { ord }
             }
         }
     }

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -17,7 +17,9 @@ use crate::core::interning::GLOBAL_INTERNER;
 use crate::core::property::PropertyValue;
 use crate::core::vector::cosine_similarity;
 use crate::core::{NodeId, Timestamp};
-use crate::query::ir::{Direction, Predicate, PredicateValue};
+use crate::query::ir::{
+    AggregateFunc, AggregateGroupKey, AggregateSpec, Direction, Predicate, PredicateValue, SortKey,
+};
 use crate::storage::current::CurrentStorage;
 use crate::storage::historical::HistoricalStorage;
 
@@ -1901,6 +1903,505 @@ impl ResultIterator for PropertyScanIterator {
             },
             None => None,
         }
+    }
+}
+
+// ============================================================================
+// Aggregation, DISTINCT, and ORDER BY iterators
+// ============================================================================
+
+/// Read a node property value from a row, for grouping / aggregation / sorting.
+///
+/// Returns `None` when the row has no backing node (e.g. a null binding or a
+/// computed aggregate row) or the property is absent.
+fn row_property<'a>(row: &'a QueryRow, key: &str) -> Option<&'a PropertyValue> {
+    row.entity.as_node().and_then(|n| n.properties.get(key))
+}
+
+/// Numeric view of a scalar property (`Int`/`Float`), used for sum/avg and
+/// numeric ordering. `None` for non-numeric values.
+fn property_as_f64(value: &PropertyValue) -> Option<f64> {
+    match value {
+        PropertyValue::Int(i) => Some(*i as f64),
+        PropertyValue::Float(f) => Some(*f),
+        _ => None,
+    }
+}
+
+/// Total order over comparable scalar property values (numbers compared
+/// numerically, strings lexicographically, bools by value). Non-comparable or
+/// mixed pairs compare `Equal` so they retain input order.
+fn compare_property(a: &PropertyValue, b: &PropertyValue) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    match (a, b) {
+        (PropertyValue::Int(x), PropertyValue::Int(y)) => x.cmp(y),
+        (
+            PropertyValue::Int(_) | PropertyValue::Float(_),
+            PropertyValue::Int(_) | PropertyValue::Float(_),
+        ) => match (property_as_f64(a), property_as_f64(b)) {
+            (Some(x), Some(y)) => x.partial_cmp(&y).unwrap_or(Ordering::Equal),
+            _ => Ordering::Equal,
+        },
+        (PropertyValue::String(x), PropertyValue::String(y)) => x.as_ref().cmp(y.as_ref()),
+        (PropertyValue::Bool(x), PropertyValue::Bool(y)) => x.cmp(y),
+        _ => Ordering::Equal,
+    }
+}
+
+/// A hashable, `Eq` projection of a scalar property value used both for
+/// grouping keys and for `DISTINCT` deduplication of aggregate arguments.
+/// Floats are keyed by their bit pattern (total order); non-scalar values fall
+/// back to their debug representation.
+#[derive(Clone, PartialEq, Eq, Hash)]
+enum GroupKeyValue {
+    Null,
+    Bool(bool),
+    Int(i64),
+    Float(u64),
+    Str(String),
+    Other(String),
+}
+
+impl GroupKeyValue {
+    fn from_property(value: Option<&PropertyValue>) -> Self {
+        match value {
+            None | Some(PropertyValue::Null) => GroupKeyValue::Null,
+            Some(PropertyValue::Bool(b)) => GroupKeyValue::Bool(*b),
+            Some(PropertyValue::Int(i)) => GroupKeyValue::Int(*i),
+            Some(PropertyValue::Float(f)) => GroupKeyValue::Float(f.to_bits()),
+            Some(PropertyValue::String(s)) => GroupKeyValue::Str(s.to_string()),
+            Some(other) => GroupKeyValue::Other(format!("{other:?}")),
+        }
+    }
+}
+
+/// Per-group, per-aggregate accumulator.
+struct AggAccumulator {
+    func: AggregateFunc,
+    distinct: bool,
+    /// Values already counted, for the `DISTINCT` quantifier.
+    seen: HashSet<GroupKeyValue>,
+    count: i64,
+    /// Integer running sum (i128 headroom against overflow) for all-integer sums.
+    sum_i: i128,
+    /// Floating running sum, always maintained (used for avg and float sums).
+    sum_f: f64,
+    saw_float: bool,
+    numeric_count: i64,
+    min: Option<PropertyValue>,
+    max: Option<PropertyValue>,
+    collected: Vec<PropertyValue>,
+}
+
+impl AggAccumulator {
+    fn new(spec: &AggregateSpec) -> Self {
+        AggAccumulator {
+            func: spec.func,
+            distinct: spec.distinct,
+            seen: HashSet::new(),
+            count: 0,
+            sum_i: 0,
+            sum_f: 0.0,
+            saw_float: false,
+            numeric_count: 0,
+            min: None,
+            max: None,
+            collected: Vec::new(),
+        }
+    }
+
+    /// Fold one input row's value into the accumulator.
+    ///
+    /// `is_star` marks `count(*)`, which counts the row unconditionally
+    /// (ignoring nulls and `DISTINCT`). Otherwise `value` is the row's value
+    /// for the aggregate argument; `None`/`Null` values are skipped by every
+    /// function (openCypher semantics).
+    fn update(&mut self, value: Option<&PropertyValue>, is_star: bool) {
+        if self.func == AggregateFunc::Count && is_star {
+            self.count += 1;
+            return;
+        }
+
+        let Some(v) = value else {
+            return;
+        };
+        if matches!(v, PropertyValue::Null) {
+            return;
+        }
+
+        if self.distinct {
+            let key = GroupKeyValue::from_property(Some(v));
+            if !self.seen.insert(key) {
+                return;
+            }
+        }
+
+        match self.func {
+            AggregateFunc::Count => self.count += 1,
+            AggregateFunc::Sum | AggregateFunc::Avg => {
+                if let Some(f) = property_as_f64(v) {
+                    self.sum_f += f;
+                    self.numeric_count += 1;
+                    match v {
+                        PropertyValue::Int(i) => self.sum_i += i128::from(*i),
+                        PropertyValue::Float(_) => self.saw_float = true,
+                        _ => {}
+                    }
+                }
+            }
+            AggregateFunc::Min => {
+                let replace = match &self.min {
+                    None => true,
+                    Some(m) => compare_property(v, m) == std::cmp::Ordering::Less,
+                };
+                if replace {
+                    self.min = Some(v.clone());
+                }
+            }
+            AggregateFunc::Max => {
+                let replace = match &self.max {
+                    None => true,
+                    Some(m) => compare_property(v, m) == std::cmp::Ordering::Greater,
+                };
+                if replace {
+                    self.max = Some(v.clone());
+                }
+            }
+            AggregateFunc::Collect => self.collected.push(v.clone()),
+        }
+    }
+
+    /// Produce the final aggregate value for this group.
+    fn finalize(self) -> PropertyValue {
+        match self.func {
+            AggregateFunc::Count => PropertyValue::Int(self.count),
+            AggregateFunc::Sum => {
+                if self.numeric_count == 0 {
+                    // openCypher: sum over no values is 0 (integer).
+                    PropertyValue::Int(0)
+                } else if self.saw_float {
+                    PropertyValue::Float(self.sum_f)
+                } else {
+                    PropertyValue::Int(self.sum_i as i64)
+                }
+            }
+            AggregateFunc::Avg => {
+                if self.numeric_count == 0 {
+                    PropertyValue::Null
+                } else {
+                    PropertyValue::Float(self.sum_f / self.numeric_count as f64)
+                }
+            }
+            AggregateFunc::Min => self.min.unwrap_or(PropertyValue::Null),
+            AggregateFunc::Max => self.max.unwrap_or(PropertyValue::Null),
+            AggregateFunc::Collect => PropertyValue::Array(Arc::new(self.collected)),
+        }
+    }
+}
+
+/// A single group's state during aggregation.
+struct AggGroup {
+    /// The group-key values (in `group_keys` order), captured from the first
+    /// row of the group for output.
+    key_values: Vec<PropertyValue>,
+    accumulators: Vec<AggAccumulator>,
+}
+
+/// Grouped aggregation iterator (openCypher implicit grouping).
+///
+/// Eagerly drains its input on the first `next()`, hash-groups rows by the
+/// group-key tuple, folds each aggregate per group, and then emits exactly one
+/// computed-column [`QueryRow`] per group (via [`QueryRow::from_columns`]) in
+/// group-discovery order. A global aggregation (no group keys) always emits one
+/// row even over empty input; a grouped aggregation over empty input emits no
+/// rows.
+pub struct AggregateIterator {
+    input: Option<Box<dyn ResultIterator>>,
+    group_keys: Vec<AggregateGroupKey>,
+    aggregates: Vec<AggregateSpec>,
+    output: std::vec::IntoIter<QueryRow>,
+    drained: bool,
+}
+
+impl AggregateIterator {
+    /// Create a new aggregation iterator.
+    pub fn new(
+        input: Box<dyn ResultIterator>,
+        group_keys: Vec<AggregateGroupKey>,
+        aggregates: Vec<AggregateSpec>,
+    ) -> Self {
+        AggregateIterator {
+            input: Some(input),
+            group_keys,
+            aggregates,
+            output: Vec::new().into_iter(),
+            drained: false,
+        }
+    }
+
+    fn drain(&mut self) -> Result<()> {
+        let mut input = match self.input.take() {
+            Some(i) => i,
+            None => return Ok(()),
+        };
+
+        let mut order: Vec<Vec<GroupKeyValue>> = Vec::new();
+        let mut groups: std::collections::HashMap<Vec<GroupKeyValue>, AggGroup> =
+            std::collections::HashMap::new();
+
+        // A global aggregation always yields exactly one row, even over empty
+        // input: seed the single (empty-key) group up front.
+        if self.group_keys.is_empty() {
+            let key: Vec<GroupKeyValue> = Vec::new();
+            order.push(key.clone());
+            groups.insert(
+                key,
+                AggGroup {
+                    key_values: Vec::new(),
+                    accumulators: self.aggregates.iter().map(AggAccumulator::new).collect(),
+                },
+            );
+        }
+
+        while let Some(row) = input.next() {
+            let row = row?;
+            let key: Vec<GroupKeyValue> = self
+                .group_keys
+                .iter()
+                .map(|gk| GroupKeyValue::from_property(row_property(&row, &gk.property_key)))
+                .collect();
+
+            if !groups.contains_key(&key) {
+                order.push(key.clone());
+                let key_values = self
+                    .group_keys
+                    .iter()
+                    .map(|gk| {
+                        row_property(&row, &gk.property_key)
+                            .cloned()
+                            .unwrap_or(PropertyValue::Null)
+                    })
+                    .collect();
+                let accumulators = self.aggregates.iter().map(AggAccumulator::new).collect();
+                groups.insert(
+                    key.clone(),
+                    AggGroup {
+                        key_values,
+                        accumulators,
+                    },
+                );
+            }
+
+            let group = groups
+                .get_mut(&key)
+                .expect("group inserted above must be present");
+            for (spec, acc) in self.aggregates.iter().zip(group.accumulators.iter_mut()) {
+                let is_star = spec.arg.is_none();
+                let value = spec.arg.as_deref().and_then(|k| row_property(&row, k));
+                acc.update(value, is_star);
+            }
+        }
+
+        let mut rows = Vec::with_capacity(order.len());
+        for key in order {
+            let group = groups.remove(&key).expect("group present in order");
+            let mut columns: Vec<(String, PropertyValue)> =
+                Vec::with_capacity(self.group_keys.len() + self.aggregates.len());
+            for (gk, val) in self.group_keys.iter().zip(group.key_values.into_iter()) {
+                columns.push((gk.alias.clone(), val));
+            }
+            for (spec, acc) in self.aggregates.iter().zip(group.accumulators.into_iter()) {
+                columns.push((spec.alias.clone(), acc.finalize()));
+            }
+            rows.push(QueryRow::from_columns(columns));
+        }
+        self.output = rows.into_iter();
+        Ok(())
+    }
+}
+
+impl ResultIterator for AggregateIterator {
+    fn next(&mut self) -> Option<Result<QueryRow>> {
+        if !self.drained {
+            self.drained = true;
+            if let Err(e) = self.drain() {
+                return Some(Err(e));
+            }
+        }
+        self.output.next().map(Ok)
+    }
+}
+
+/// A whole-row deduplication key for `DISTINCT`.
+#[derive(PartialEq, Eq, Hash)]
+enum DistinctRowKey {
+    /// Keyed by the row's entity identity (node/edge id, or `None` for a null
+    /// binding).
+    Entity(Option<EntityId>),
+    /// A computed aggregate row, keyed by its rendered columns.
+    Columns(String),
+}
+
+/// `RETURN DISTINCT` iterator: yields each distinct row once, preserving first
+/// occurrence order.
+pub struct DistinctIterator {
+    input: Box<dyn ResultIterator>,
+    seen: HashSet<DistinctRowKey>,
+}
+
+impl DistinctIterator {
+    /// Create a new DISTINCT iterator over `input`.
+    pub fn new(input: Box<dyn ResultIterator>) -> Self {
+        DistinctIterator {
+            input,
+            seen: HashSet::new(),
+        }
+    }
+
+    fn key(row: &QueryRow) -> DistinctRowKey {
+        if let Some(cols) = &row.columns {
+            DistinctRowKey::Columns(format!("{cols:?}"))
+        } else {
+            DistinctRowKey::Entity(row.entity.id())
+        }
+    }
+}
+
+impl ResultIterator for DistinctIterator {
+    fn next(&mut self) -> Option<Result<QueryRow>> {
+        loop {
+            match self.input.next()? {
+                Ok(row) => {
+                    if self.seen.insert(Self::key(&row)) {
+                        return Some(Ok(row));
+                    }
+                }
+                Err(e) => return Some(Err(e)),
+            }
+        }
+    }
+}
+
+/// `ORDER BY` iterator: buffers the entire input, sorts it by the sort key, and
+/// then streams the sorted rows.
+///
+/// Sorting is stable. Rows missing the sort property sort **last** regardless of
+/// direction (a v1 simplification of openCypher's nulls-first-on-DESC rule),
+/// which keeps ordering deterministic without a tri-valued comparator.
+pub struct SortIterator {
+    input: Option<Box<dyn ResultIterator>>,
+    key: SortKey,
+    descending: bool,
+    output: std::vec::IntoIter<QueryRow>,
+    drained: bool,
+}
+
+impl SortIterator {
+    /// Create a new ORDER BY iterator.
+    pub fn new(input: Box<dyn ResultIterator>, key: SortKey, descending: bool) -> Self {
+        SortIterator {
+            input: Some(input),
+            key,
+            descending,
+            output: Vec::new().into_iter(),
+            drained: false,
+        }
+    }
+
+    fn drain(&mut self) -> Result<()> {
+        let mut input = match self.input.take() {
+            Some(i) => i,
+            None => return Ok(()),
+        };
+        let mut rows: Vec<QueryRow> = Vec::new();
+        while let Some(row) = input.next() {
+            rows.push(row?);
+        }
+        rows.sort_by(|a, b| self.cmp_rows(a, b));
+        self.output = rows.into_iter();
+        Ok(())
+    }
+
+    fn cmp_rows(&self, a: &QueryRow, b: &QueryRow) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        match &self.key {
+            SortKey::Property(prop) => {
+                match (row_property(a, prop), row_property(b, prop)) {
+                    (Some(x), Some(y)) => {
+                        let ord = compare_property(x, y);
+                        if self.descending { ord.reverse() } else { ord }
+                    }
+                    // Missing sort key always orders last, in both directions.
+                    (Some(_), None) => Ordering::Less,
+                    (None, Some(_)) => Ordering::Greater,
+                    (None, None) => Ordering::Equal,
+                }
+            }
+            SortKey::Score => {
+                let ord = a.score.partial_cmp(&b.score).unwrap_or(Ordering::Equal);
+                if self.descending { ord.reverse() } else { ord }
+            }
+            SortKey::Timestamp => {
+                let av = a.timestamp.map(|t| t.wallclock());
+                let bv = b.timestamp.map(|t| t.wallclock());
+                let ord = av.cmp(&bv);
+                if self.descending { ord.reverse() } else { ord }
+            }
+        }
+    }
+}
+
+impl ResultIterator for SortIterator {
+    fn next(&mut self) -> Option<Result<QueryRow>> {
+        if !self.drained {
+            self.drained = true;
+            if let Err(e) = self.drain() {
+                return Some(Err(e));
+            }
+        }
+        self.output.next().map(Ok)
+    }
+}
+
+/// `Count` aggregate iterator: drains the input and yields a single computed
+/// row with the total row count under the column name `count`.
+pub struct CountIterator {
+    input: Option<Box<dyn ResultIterator>>,
+    done: bool,
+}
+
+impl CountIterator {
+    /// Create a new count iterator over `input`.
+    pub fn new(input: Box<dyn ResultIterator>) -> Self {
+        CountIterator {
+            input: Some(input),
+            done: false,
+        }
+    }
+}
+
+impl ResultIterator for CountIterator {
+    fn next(&mut self) -> Option<Result<QueryRow>> {
+        if self.done {
+            return None;
+        }
+        self.done = true;
+        let mut input = self.input.take()?;
+        let mut count: i64 = 0;
+        while let Some(row) = input.next() {
+            if let Err(e) = row {
+                return Some(Err(e));
+            }
+            count += 1;
+        }
+        Some(Ok(QueryRow::from_columns(vec![(
+            "count".to_string(),
+            PropertyValue::Int(count),
+        )])))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (usize::from(!self.done), Some(usize::from(!self.done)))
     }
 }
 

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -21,8 +21,9 @@ pub use iterators::NodeScanIterator;
 pub use iterators::ResultIterator;
 pub use iterators::TemporalNodeScanIterator;
 pub use iterators::{
-    BatchTemporalNodeIterator, FilterIterator, LimitIterator, ProjectIterator,
-    ProvenanceFilterIterator, TemporalNodeIterator, VectorRerankIterator, VectorResultIterator,
+    AggregateIterator, BatchTemporalNodeIterator, CountIterator, DistinctIterator, FilterIterator,
+    LimitIterator, ProjectIterator, ProvenanceFilterIterator, SortIterator, TemporalNodeIterator,
+    VectorRerankIterator, VectorResultIterator,
 };
 pub use results::{EntityId, EntityResult, QueryResults, QueryRow};
 
@@ -346,6 +347,42 @@ impl QueryExecutor {
                     Arc::clone(&self.current),
                     Arc::clone(&self.historical),
                 )))
+            }
+
+            PhysicalOp::Aggregate {
+                input,
+                group_keys,
+                aggregates,
+            } => {
+                let input_iter = self.execute_op(input)?;
+                Ok(Box::new(iterators::AggregateIterator::new(
+                    input_iter,
+                    group_keys.clone(),
+                    aggregates.clone(),
+                )))
+            }
+
+            PhysicalOp::Distinct { input } => {
+                let input_iter = self.execute_op(input)?;
+                Ok(Box::new(iterators::DistinctIterator::new(input_iter)))
+            }
+
+            PhysicalOp::Sort {
+                input,
+                key,
+                descending,
+            } => {
+                let input_iter = self.execute_op(input)?;
+                Ok(Box::new(iterators::SortIterator::new(
+                    input_iter,
+                    key.clone(),
+                    *descending,
+                )))
+            }
+
+            PhysicalOp::Count { input } => {
+                let input_iter = self.execute_op(input)?;
+                Ok(Box::new(iterators::CountIterator::new(input_iter)))
             }
 
             PhysicalOp::Empty => Ok(Box::new(iterators::EmptyIterator)),

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -457,16 +457,11 @@ impl QueryExecutor {
                 Ok(Box::new(iterators::DistinctIterator::new(input_iter)))
             }
 
-            PhysicalOp::Sort {
-                input,
-                key,
-                descending,
-            } => {
+            PhysicalOp::Sort { input, keys } => {
                 let input_iter = self.execute_op(input)?;
                 Ok(Box::new(iterators::SortIterator::new(
                     input_iter,
-                    key.clone(),
-                    *descending,
+                    keys.clone(),
                 )))
             }
 

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -38,7 +38,7 @@
 use crate::core::error::Result;
 use crate::core::graph::{Edge, Node};
 use crate::core::id::VersionId;
-use crate::core::property::PropertyMap;
+use crate::core::property::{PropertyMap, PropertyValue};
 use crate::core::temporal::Timestamp;
 use crate::core::{EdgeId, NodeId};
 
@@ -165,6 +165,16 @@ pub struct QueryRow {
     pub path: Option<Vec<EntityId>>,
     /// The specific point in bi-temporal history this result represents.
     pub timestamp: Option<Timestamp>,
+    /// Computed output columns for a row that does not correspond to a single
+    /// stored entity -- e.g. the grouped result of a Cypher aggregation
+    /// (`RETURN n.dept, count(*)`). Each entry is an `(column_name, value)`
+    /// pair, in projection order.
+    ///
+    /// `None` for ordinary entity rows (the overwhelming common case), so those
+    /// rows are byte-identical to their pre-aggregation form. When `Some`, the
+    /// row's [`entity`](Self::entity) is typically [`EntityResult::Null`]: the
+    /// meaningful payload lives here.
+    pub columns: Option<Vec<(String, PropertyValue)>>,
 }
 
 impl QueryRow {
@@ -176,6 +186,36 @@ impl QueryRow {
             score: None,
             path: None,
             timestamp: None,
+            columns: None,
+        }
+    }
+
+    /// Create a computed-output row carrying named columns rather than a stored
+    /// entity.
+    ///
+    /// Used by aggregation (`RETURN count(*)`, `RETURN n.dept, count(*)`) where
+    /// the output row is derived from a group of input rows and has no single
+    /// backing node/edge. The row's entity is [`EntityResult::Null`]; consumers
+    /// read the payload from [`QueryRow::columns`].
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::executor::QueryRow;
+    /// use aletheiadb::core::property::PropertyValue;
+    ///
+    /// let row = QueryRow::from_columns(vec![("count(*)".to_string(), PropertyValue::Int(5))]);
+    /// assert!(row.entity.is_null());
+    /// assert_eq!(row.columns.as_ref().unwrap()[0].1, PropertyValue::Int(5));
+    /// ```
+    #[must_use]
+    pub fn from_columns(columns: Vec<(String, PropertyValue)>) -> Self {
+        QueryRow {
+            entity: EntityResult::Null,
+            score: None,
+            path: None,
+            timestamp: None,
+            columns: Some(columns),
         }
     }
 
@@ -198,6 +238,7 @@ impl QueryRow {
             score: Some(score),
             path: None,
             timestamp: None,
+            columns: None,
         }
     }
 
@@ -209,6 +250,7 @@ impl QueryRow {
             score: None,
             path: Some(path),
             timestamp: None,
+            columns: None,
         }
     }
 
@@ -415,6 +457,14 @@ pub struct QueryResult {
     pub paths: Option<Vec<Path>>,
     /// Version IDs for temporal results
     pub versions: Option<Vec<VersionId>>,
+    /// Computed column rows for aggregation results (`RETURN count(*)`,
+    /// `RETURN n.dept, count(*)`).
+    ///
+    /// `Some` when at least one collected row carried [`QueryRow::columns`];
+    /// each inner vector is one output row's `(column_name, value)` pairs in
+    /// projection order. `None` for ordinary entity result sets, so existing
+    /// consumers are unaffected.
+    pub columns: Option<Vec<Vec<(String, PropertyValue)>>>,
 }
 
 impl QueryResult {
@@ -427,6 +477,7 @@ impl QueryResult {
             scores: None,
             paths: None,
             versions: None,
+            columns: None,
         }
     }
 
@@ -439,6 +490,7 @@ impl QueryResult {
             scores: None,
             paths: None,
             versions: None,
+            columns: None,
         }
     }
 
@@ -663,11 +715,13 @@ impl QueryResults {
         // Determine which fields we have (single pass)
         let (mut has_any_scores, mut has_any_paths, mut has_any_versions, mut has_any_nodes) =
             (false, false, false, false);
+        let mut has_any_columns = false;
         let mut node_count = 0usize;
         for row in &rows {
             has_any_scores = has_any_scores || row.score.is_some();
             has_any_paths = has_any_paths || row.path.is_some();
             has_any_versions = has_any_versions || row.timestamp.is_some();
+            has_any_columns = has_any_columns || row.columns.is_some();
             if row.entity.as_node().is_some() {
                 has_any_nodes = true;
                 node_count += 1;
@@ -697,6 +751,11 @@ impl QueryResults {
         } else {
             None
         };
+        let mut columns = if has_any_columns {
+            Some(Vec::with_capacity(capacity))
+        } else {
+            None
+        };
 
         for row in rows {
             let QueryRow {
@@ -704,7 +763,14 @@ impl QueryResults {
                 score,
                 path,
                 timestamp,
+                columns: row_columns,
             } = row;
+
+            // Extract computed aggregation columns (padding rows without any
+            // with an empty column list to preserve positional alignment).
+            if let Some(ref mut cols) = columns {
+                cols.push(row_columns.unwrap_or_default());
+            }
 
             // ⚡ Bolt Optimization: Consumes the entity directly by value instead of cloning
             // properties map via `as_node().map(|n| n.properties.clone())`. This eliminates
@@ -775,6 +841,7 @@ impl QueryResults {
             scores,
             paths,
             versions,
+            columns,
         })
     }
 }

--- a/src/query/ir.rs
+++ b/src/query/ir.rs
@@ -173,11 +173,72 @@ pub enum QueryOp {
     /// Count results
     Count,
 
+    /// Grouped aggregation over the input rows (openCypher implicit grouping).
+    ///
+    /// Partitions input rows by the values of `group_keys` (empty = a single
+    /// global group) and, for each group, evaluates every entry in
+    /// `aggregates`. Emits one output row per group carrying the group-key
+    /// values followed by the aggregate values as named columns. A global
+    /// aggregation over empty input still emits exactly one row (e.g.
+    /// `count(*) = 0`); a grouped aggregation over empty input emits no rows.
+    Aggregate {
+        /// Grouping keys (non-aggregate `RETURN`/`WITH` items). Empty means a
+        /// single global group.
+        group_keys: Vec<AggregateGroupKey>,
+        /// The aggregate expressions to compute per group.
+        aggregates: Vec<AggregateSpec>,
+    },
+
     /// Collect unique values
     Distinct,
 
     /// Project specific properties
     Project(Vec<String>),
+}
+
+/// A grouping key in a [`QueryOp::Aggregate`] (a non-aggregate projection
+/// item such as `n.dept`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AggregateGroupKey {
+    /// The node property to read for the grouping value (e.g. `"dept"` for
+    /// `n.dept`).
+    pub property_key: String,
+    /// The output column name for this key (alias if given, else the source
+    /// text such as `"n.dept"`).
+    pub alias: String,
+}
+
+/// A single aggregate expression in a [`QueryOp::Aggregate`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AggregateSpec {
+    /// Which aggregate function to apply.
+    pub func: AggregateFunc,
+    /// The node property the aggregate reads (e.g. `"age"` for `sum(n.age)`).
+    /// `None` for `count(*)`, which counts rows regardless of any value.
+    pub arg: Option<String>,
+    /// Whether the `DISTINCT` quantifier was supplied (deduplicates values
+    /// before aggregating).
+    pub distinct: bool,
+    /// The output column name (alias if given, else generated source text such
+    /// as `"count(*)"`).
+    pub alias: String,
+}
+
+/// The aggregate functions supported by [`QueryOp::Aggregate`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AggregateFunc {
+    /// `count(...)` / `count(*)` -- number of (non-null) rows/values.
+    Count,
+    /// `sum(...)` -- numeric sum, skipping nulls (0 over no values).
+    Sum,
+    /// `avg(...)` -- numeric mean, skipping nulls (null over no values).
+    Avg,
+    /// `min(...)` -- minimum value in natural order, skipping nulls.
+    Min,
+    /// `max(...)` -- maximum value in natural order, skipping nulls.
+    Max,
+    /// `collect(...)` -- gather non-null values into a list, preserving order.
+    Collect,
 }
 
 /// Specifies how deep to traverse in graph operations.

--- a/src/query/ir.rs
+++ b/src/query/ir.rs
@@ -213,15 +213,26 @@ pub struct AggregateGroupKey {
 pub struct AggregateSpec {
     /// Which aggregate function to apply.
     pub func: AggregateFunc,
-    /// The node property the aggregate reads (e.g. `"age"` for `sum(n.age)`).
-    /// `None` for `count(*)`, which counts rows regardless of any value.
-    pub arg: Option<String>,
+    /// What the aggregate reads from each row.
+    pub arg: AggregateArg,
     /// Whether the `DISTINCT` quantifier was supplied (deduplicates values
     /// before aggregating).
     pub distinct: bool,
     /// The output column name (alias if given, else generated source text such
     /// as `"count(*)"`).
     pub alias: String,
+}
+
+/// The argument an aggregate reads from each input row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AggregateArg {
+    /// `count(*)` -- count every row unconditionally (ignores nulls/DISTINCT).
+    Star,
+    /// `count(n)` -- count rows whose bound entity is non-null (openCypher
+    /// `count(<variable>)`). Distinct from [`AggregateArg::Star`].
+    Entity,
+    /// `func(n.prop)` -- read the named node property from each row.
+    Property(String),
 }
 
 /// The aggregate functions supported by [`QueryOp::Aggregate`].

--- a/src/query/plan.rs
+++ b/src/query/plan.rs
@@ -287,6 +287,16 @@ pub enum UnaryOp {
     /// Count results (aggregate)
     Count,
 
+    /// Grouped aggregation (openCypher implicit grouping): partition by
+    /// `group_keys` and compute `aggregates` per group. Mirrors
+    /// [`super::ir::QueryOp::Aggregate`].
+    Aggregate {
+        /// Grouping keys (empty = single global group).
+        group_keys: Vec<super::ir::AggregateGroupKey>,
+        /// Aggregate expressions computed per group.
+        aggregates: Vec<super::ir::AggregateSpec>,
+    },
+
     /// Left-outer application of an optional sub-pattern (`OPTIONAL MATCH`).
     ///
     /// For each input row, the `steps` sub-pipeline runs seeded from that row;

--- a/src/query/planner/cost.rs
+++ b/src/query/planner/cost.rs
@@ -460,6 +460,7 @@ impl CostModel {
             PhysicalOp::Project { input, .. }
             | PhysicalOp::Distinct { input }
             | PhysicalOp::Count { input }
+            | PhysicalOp::Aggregate { input, .. }
             | PhysicalOp::Materialize { input }
             | PhysicalOp::TemporalTrack { input, .. } => self.estimate(input, stats),
 
@@ -535,6 +536,19 @@ impl CostModel {
                 (self.estimate_cardinality(input, stats) as f64 * DEFAULT_DISTINCT_RATIO) as usize
             }
             PhysicalOp::Count { .. } => 1,
+            PhysicalOp::Aggregate {
+                group_keys, input, ..
+            } => {
+                if group_keys.is_empty() {
+                    1
+                } else {
+                    // One row per distinct group; approximate with the default
+                    // distinct ratio over the input cardinality (at least one).
+                    ((self.estimate_cardinality(input, stats) as f64 * DEFAULT_DISTINCT_RATIO)
+                        as usize)
+                        .max(1)
+                }
+            }
             PhysicalOp::HashJoin { left, right, .. } => {
                 // Assume default join selectivity of cross product
                 let left_card = self.estimate_cardinality(left, stats);

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -589,6 +589,14 @@ impl QueryPlanner {
             LogicalOp::Scan(scan) => self.scan_to_physical(scan, temporal),
 
             LogicalOp::Unary { op, input } => {
+                // Fold a chain of consecutive Sort ops (from a multi-key
+                // `ORDER BY a, b, c`) into ONE multi-key PhysicalOp::Sort so the
+                // FIRST-emitted key is primary. Emitting one stable Sort per key
+                // would otherwise invert precedence (the last-applied stable
+                // sort dominates). Fixes both Cypher and AQL (Issue #558).
+                if matches!(op, UnaryOp::Sort { .. }) {
+                    return self.fold_sort_chain(logical, temporal);
+                }
                 let physical_input = self.to_physical_op(input, temporal)?;
                 self.unary_to_physical(op, physical_input, temporal)
             }
@@ -601,6 +609,46 @@ impl QueryPlanner {
 
             LogicalOp::Empty => Ok(PhysicalOp::Empty),
         }
+    }
+
+    /// Fold a chain of consecutive [`UnaryOp::Sort`] operators into a single
+    /// multi-key [`PhysicalOp::Sort`].
+    ///
+    /// The logical chain nests outermost = last-emitted `ORDER BY` key,
+    /// innermost = first-emitted key. openCypher wants the first key to be
+    /// primary, so we collect from the outside in, then reverse: the resulting
+    /// `keys` vector is in precedence order (first = primary). The base (first
+    /// non-Sort operator) is converted once.
+    fn fold_sort_chain(
+        &self,
+        logical: &LogicalOp,
+        temporal: &Option<TemporalContext>,
+    ) -> Result<PhysicalOp> {
+        use super::plan::SortKey;
+
+        let mut keys: Vec<(SortKey, bool)> = Vec::new();
+        let mut cursor = logical;
+        let base = loop {
+            match cursor {
+                LogicalOp::Unary {
+                    op: UnaryOp::Sort { key, descending },
+                    input,
+                } => {
+                    keys.push((key.clone(), *descending));
+                    cursor = input;
+                }
+                other => break other,
+            }
+        };
+
+        let physical_input = self.to_physical_op(base, temporal)?;
+        // Reverse so the first-emitted (innermost) key becomes primary.
+        keys.reverse();
+
+        Ok(PhysicalOp::Sort {
+            input: Box::new(physical_input),
+            keys,
+        })
     }
 
     /// Helper to validate vector index existence
@@ -861,10 +909,11 @@ impl QueryPlanner {
                 })
             }
 
+            // A lone Sort (not part of a chain intercepted by the fold in
+            // `to_physical_op`) lowers to a single-key multi-key Sort.
             UnaryOp::Sort { key, descending } => Ok(PhysicalOp::Sort {
                 input: Box::new(input),
-                key: key.clone(),
-                descending: *descending,
+                keys: vec![(key.clone(), *descending)],
             }),
 
             UnaryOp::Project(props) => Ok(PhysicalOp::Project {

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -453,6 +453,17 @@ impl QueryPlanner {
             // Aggregation operations
             QueryOp::Count => Ok(LogicalOp::unary(UnaryOp::Count, input)),
 
+            QueryOp::Aggregate {
+                group_keys,
+                aggregates,
+            } => Ok(LogicalOp::unary(
+                UnaryOp::Aggregate {
+                    group_keys: group_keys.clone(),
+                    aggregates: aggregates.clone(),
+                },
+                input,
+            )),
+
             QueryOp::Distinct => Ok(LogicalOp::unary(UnaryOp::Distinct, input)),
 
             QueryOp::Project(props) => Ok(LogicalOp::unary(UnaryOp::Project(props.clone()), input)),
@@ -494,6 +505,7 @@ impl QueryPlanner {
             QueryOp::Limit(_) => "Limit",
             QueryOp::Skip(_) => "Skip",
             QueryOp::Count => "Count",
+            QueryOp::Aggregate { .. } => "Aggregate",
             QueryOp::Distinct => "Distinct",
             QueryOp::Project(_) => "Project",
             QueryOp::Sort { .. } => "Sort",
@@ -801,6 +813,15 @@ impl QueryPlanner {
 
             UnaryOp::Count => Ok(PhysicalOp::Count {
                 input: Box::new(input),
+            }),
+
+            UnaryOp::Aggregate {
+                group_keys,
+                aggregates,
+            } => Ok(PhysicalOp::Aggregate {
+                input: Box::new(input),
+                group_keys: group_keys.clone(),
+                aggregates: aggregates.clone(),
             }),
 
             UnaryOp::TemporalTrack { time_range } => Ok(PhysicalOp::TemporalTrack {

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -293,6 +293,7 @@ impl PhysicalPlan {
             | PhysicalOp::Project { input, .. }
             | PhysicalOp::Distinct { input, .. }
             | PhysicalOp::Count { input, .. }
+            | PhysicalOp::Aggregate { input, .. }
             | PhysicalOp::Materialize { input, .. }
             | PhysicalOp::TemporalTrack { input, .. }
             | PhysicalOp::IndexedTraversal { input, .. }
@@ -561,6 +562,20 @@ pub enum PhysicalOp {
         input: Box<PhysicalOp>,
     },
 
+    /// Grouped aggregation (openCypher implicit grouping).
+    ///
+    /// Partitions input rows by `group_keys` (empty = one global group) and
+    /// computes each entry of `aggregates` per group, emitting one computed
+    /// column row per group. Maps 1:1 to the executor's `AggregateIterator`.
+    Aggregate {
+        /// Input operator providing the rows to aggregate.
+        input: Box<PhysicalOp>,
+        /// Grouping keys (empty = single global group).
+        group_keys: Vec<crate::query::ir::AggregateGroupKey>,
+        /// Aggregate expressions computed per group.
+        aggregates: Vec<crate::query::ir::AggregateSpec>,
+    },
+
     /// Track temporal changes
     TemporalTrack {
         /// Input operator
@@ -646,6 +661,7 @@ impl PhysicalOp {
             PhysicalOp::Project { .. } => "Project",
             PhysicalOp::Distinct { .. } => "Distinct",
             PhysicalOp::Count { .. } => "Count",
+            PhysicalOp::Aggregate { .. } => "Aggregate",
             PhysicalOp::TemporalTrack { .. } => "TemporalTrack",
             PhysicalOp::Materialize { .. } => "Materialize",
             PhysicalOp::OptionalApply { .. } => "OptionalApply",
@@ -692,6 +708,7 @@ impl PhysicalOp {
             | PhysicalOp::Project { input, .. }
             | PhysicalOp::Distinct { input, .. }
             | PhysicalOp::Count { input, .. }
+            | PhysicalOp::Aggregate { input, .. }
             | PhysicalOp::TemporalTrack { input, .. }
             | PhysicalOp::Materialize { input, .. }
             | PhysicalOp::OptionalApply { input, .. } => 1 + input.depth(),
@@ -876,6 +893,7 @@ impl PhysicalOp {
             | PhysicalOp::Project { input, .. }
             | PhysicalOp::Distinct { input, .. }
             | PhysicalOp::Count { input, .. }
+            | PhysicalOp::Aggregate { input, .. }
             | PhysicalOp::TemporalTrack { input, .. }
             | PhysicalOp::Materialize { input, .. }
             | PhysicalOp::OptionalApply { input, .. } => Some(input),

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -286,10 +286,8 @@ impl PhysicalPlan {
             PhysicalOp::VectorRerank { k, .. } => {
                 line.push_str(&format!(" (k={})", k));
             }
-            PhysicalOp::Sort {
-                key, descending, ..
-            } => {
-                line.push_str(&format!(" (key={:?}, desc={})", key, descending));
+            PhysicalOp::Sort { keys, .. } => {
+                line.push_str(&format!(" (keys={:?})", keys));
             }
             PhysicalOp::HashJoin {
                 left_key,
@@ -596,14 +594,19 @@ pub enum PhysicalOp {
         property_key: Option<String>,
     },
 
-    /// Sort by key
+    /// Sort by one or more keys (stable, multi-key).
+    ///
+    /// `keys` lists `(key, descending)` pairs in **precedence order**: the
+    /// first entry is the primary sort key, the second breaks ties, and so on.
+    /// A folded chain of `ORDER BY a, b, c` produces a single `Sort` with
+    /// `keys = [(a, ..), (b, ..), (c, ..)]` (Issue #558 fold), so the primary
+    /// key is never inverted by stable-sort composition.
     Sort {
         /// Input operator
         input: Box<PhysicalOp>,
-        /// Sort key
-        key: SortKey,
-        /// Descending order
-        descending: bool,
+        /// Sort keys in precedence order (first = primary), each with its own
+        /// descending flag.
+        keys: Vec<(SortKey, bool)>,
     },
 
     /// Limit with optional offset
@@ -1203,8 +1206,7 @@ mod tests {
         assert_eq!(
             PhysicalOp::Sort {
                 input: Box::new(PhysicalOp::Empty),
-                key: SortKey::Property("name".to_string()),
-                descending: false
+                keys: vec![(SortKey::Property("name".to_string()), false)],
             }
             .name(),
             "Sort"
@@ -1495,8 +1497,7 @@ mod tests {
         assert_eq!(
             PhysicalOp::Sort {
                 input: Box::new(base.clone()),
-                key: SortKey::Property("name".to_string()),
-                descending: false
+                keys: vec![(SortKey::Property("name".to_string()), false)],
             }
             .depth(),
             2
@@ -1669,8 +1670,7 @@ mod tests {
         // Sort
         let sort = PhysicalOp::Sort {
             input: Box::new(PhysicalOp::Empty),
-            key: SortKey::Property("name".to_string()),
-            descending: false,
+            keys: vec![(SortKey::Property("name".to_string()), false)],
         };
         let explain = sort.explain();
         assert!(explain.contains("Sort"));


### PR DESCRIPTION
Closes #558.

## What

Runtime Cypher aggregation executed end-to-end via `db.execute_cypher(...)` + `collect_rows`/`collect_structured`: `count`/`sum`/`avg`/`min`/`max`/`collect` (each with `DISTINCT`), `count(*)`, openCypher **implicit grouping**, plus the `RETURN DISTINCT` and `ORDER BY` executor arms that shared the same catch-all bug.

```cypher
MATCH (n:Person) RETURN n.dept, count(*), max(n.age)            -- grouped, multi-aggregate
MATCH (n:Person) RETURN n.dept, count(*) AS c ORDER BY c DESC    -- ORDER BY over aggregation
MATCH (n:Person) RETURN count(DISTINCT n.dept)                   -- DISTINCT
MATCH (n:Ghost)  RETURN count(*)                                 -- one row: 0 (global, empty)
MATCH (n:Person) RETURN n.name ORDER BY n.dept ASC, n.age DESC   -- multi-key, correct precedence
```

## How

- **Row model** (`results.rs`): `QueryRow::columns: Option<Vec<(String, PropertyValue)>>` computed-output carrier + `QueryRow::from_columns`. Entity rows keep `columns: None` (byte-identical). `QueryResult` gains a `columns` field surfaced by `collect_structured`. No `EntityResult` variants added (would force an out-of-lane exhaustive-match edit in `src/mcp`).
- **Parser/AST**: `FunctionCall { distinct }` + `CypherExpr::Star`; parse `count(*)`, `count(DISTINCT n.x)`; reject `count(DISTINCT *)`.
- **IR/plan/planner/physical/cost**: `Aggregate { group_keys, aggregates }` op with `AggregateSpec`/`AggregateFunc`/`AggregateArg{Star,Entity,Property}`.
- **Converter**: openCypher implicit grouping (partition RETURN items → group keys vs aggregates); alias preservation; ORDER BY over aggregate output mapped to the output column/alias.
- **Executor**: `AggregateIterator` (hash-group by key tuple, float keys via bit wrapper, eager drain, one row/group, exactly one for global incl. empty), `DistinctIterator`, `SortIterator` (multi-key, stable, column fallback), `CountIterator`.

## Review fixes (second commit)

| | Fix |
|---|---|
| **A** | **ORDER BY + aggregation** was dropped and `SortIterator` couldn't sort computed rows. Converter now emits Sort in the aggregate branch (target → output column/alias); `SortIterator` falls back to `row.columns` by name. |
| **B** | **Multi-key ORDER BY precedence** was inverted (last key dominated). `PhysicalOp::Sort` now carries `Vec<(SortKey, bool)>`; the planner folds a Sort-chain into one stable multi-key sort with the **first-emitted key primary** — fixes **both Cypher and AQL**. |
| **C** | **Grouping by a whole node/variable** (`RETURN n, count(*)`) is now **rejected** with a structured `UnsupportedFeature` error instead of collapsing into one wrong group. |
| **D** | **`count(<variable>)`** counts **non-null** bindings (`AggregateArg::Entity`), distinct from `count(*)` (`AggregateArg::Star`). |
| **E** | **`sum`** uses a checked `i128 -> i64` cast, promoting to `Float` on overflow (no silent wrap). |
| **F** | **Group/DISTINCT keys** canonicalize `-0.0 -> 0.0` and unify integral floats with equal ints (`1` and `1.0` group together). |
| **G** | **ORDER BY null placement** now openCypher: nulls **last** for ASC, **first** for DESC. |
| **H** | **`count(DISTINCT *)`** is a parse error. |

## Semantics

count(*) counts rows; count(expr)/DISTINCT skip nulls/dedup; sum/avg/min/max skip nulls; collect skips nulls → list; DISTINCT dedupes. Empty global → one row (count=0, sum=0, avg/min/max=null, collect=[]); grouped+empty → zero rows. avg→float; sum stays int for ints.

## v1 limitations (documented in CLAUDE.md)

- **min/max/sum/avg over mixed/non-numeric types are lenient** — non-numeric values are skipped; incomparable min/max pairs compare equal (retain input order), no error.
- **`RETURN DISTINCT <scalar projection>`** (e.g. `RETURN DISTINCT n.dept`) dedups by entity id, not the projected value — a pre-existing projection-model limitation, independent of aggregation.
- **MCP `query`-tool rendering (cross-lane)**: aggregate rows are carried on `QueryRow.columns` (null entity), but the MCP serializer `query_row_to_json` (`src/mcp/server.rs:4712`) ignores `columns` and renders `{"entity": null, ...}` — so `RETURN count(*)` over MCP yields a null-valued row today. Aggregation is correct at the `execute_cypher`/Rust-API level (verified by tests). **One-branch follow-up for the MCP lane owner:** in `query_row_to_json`, when `row.columns` is `Some`, serialize those `(name, PropertyValue)` pairs (helper `property_value_to_json` exists at `src/mcp/server.rs:1015`) and make `query_columns()` (`:5225`) reflect dynamic columns.

## Merge / sibling PRs

Merged current `trunk` twice (merge commits, no force): #3444 (parser depth cap), #3451 (temporal NodeScan/RangeScan), #3457 (var-length min_depth), and the OTel work — all conflicts resolved keeping every match arm.

## Testing

`cargo test --lib --features cypher` — cypher suite **209 passed / 0 failed**, `query::` non-regression **679 passed / 0 failed**. `cargo clippy --lib --features cypher -- -D warnings` clean; `cargo fmt --all` applied. (Sandbox ENOSPC prevented `--all-targets --all-features`; all touched `src/query/**` code is not cypher-gated, so it compiles identically by default — validated via the `--features cypher` superset.)

New tests: `test_agg_count_star`, `test_agg_count_property_skips_nulls`, `test_agg_sum`, `test_agg_avg`, `test_agg_min_max`, `test_agg_collect`, `test_agg_count_distinct`, `test_agg_grouped_count`, `test_agg_grouped_avg`, `test_agg_grouped_multi_aggregate`, `test_agg_empty_global_count_is_one_row_zero`, `test_agg_empty_grouped_is_zero_rows`, `test_agg_empty_global_sum_avg_min_max_collect`, `test_agg_alias`, `test_agg_collect_structured_exposes_columns`, `test_e2e_return_distinct`, `test_e2e_order_by`, `test_e2e_order_by_asc_nulls_last`, `test_e2e_order_by_multi_key_precedence`, `test_agg_order_by_aggregate_alias`, `test_agg_reject_group_by_whole_node`, `test_agg_count_variable_skips_null_bindings`, `test_agg_count_distinct_star_is_error`, `test_agg_group_key_int_vs_float_and_signed_zero`, `test_agg_collect_distinct_dedup_and_order`, `test_agg_two_independent_distinct_aggregates`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWUZoNegCxQ4oN2ZUvYPru