### PR TITLE
⚡ Bolt: Optimize BFS frontier and tombstone_ids allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,11 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**Optimize BFS frontier logic with std::mem::swap**
+**Learning:** In a typical BFS loop (like `collect_neighborhood` in `src/audit/build.rs`), creating a new `Vec` for the `next` layer in every iteration causes O(hops) unnecessary heap allocations. Using `std::mem::take` inside the loop still drops the previous vector's capacity.
+**Action:** Allocate both `frontier` and `next` vectors outside the BFS loop. Inside the loop, use `next.clear()`, populate it, and then use `std::mem::swap(&mut frontier, &mut next)` at the end of the iteration to reuse both vector capacities, reducing allocations to just 1.
+
+**Optimize intermediate Vec allocations for iterators**
+**Learning:** Chaining `.collect::<Vec<_>>().into_iter()` simply to pass an iterator into a function forces a completely unnecessary heap allocation and a full pass over the data, as seen with `tombstone_ids` in `src/api/transaction/write/apply.rs`.
+**Action:** Remove the intermediate `.collect::<Vec<_>>()` and pass the raw iterator directly. If passing into a function, update the function signature from a specific iterator struct (like `std::vec::IntoIter<T>`) to `&mut impl Iterator<Item = T>`.

--- a/src/api/transaction/write/apply.rs
+++ b/src/api/transaction/write/apply.rs
@@ -409,12 +409,14 @@ pub(crate) fn apply_edge_retract(
 ///
 /// * `tombstone_ids` - Iterator of pre-generated Version IDs for tombstones. This optimization
 ///   avoids acquiring the ID generator lock for every delete operation.
+///
+/// ⚡ Bolt Optimization: Uses `impl Iterator` to avoid a `.collect::<Vec<_>>` intermediate heap allocation.
 pub(crate) fn apply_single_write(
     tx: &WriteTransaction,
     write: &crate::api::transaction::BufferedWrite,
     commit_timestamp: Timestamp,
     historical: &mut HistoricalStorage,
-    tombstone_ids: &mut std::vec::IntoIter<u64>,
+    tombstone_ids: &mut impl Iterator<Item = u64>,
     num_deletes: usize,
 ) -> Result<()> {
     match write {
@@ -612,11 +614,7 @@ pub(crate) fn apply_changes(
     // so the identical ids are recorded in the WAL and applied here. We simply
     // replay them in the same buffer order they were generated and logged.
     let num_deletes = closing_version_ids.len();
-    let mut tombstone_ids = closing_version_ids
-        .iter()
-        .map(|v| v.as_u64())
-        .collect::<Vec<u64>>()
-        .into_iter();
+    let mut tombstone_ids = closing_version_ids.iter().map(|v| v.as_u64());
 
     for write in tx.buffer.operations() {
         apply_single_write(

--- a/src/audit/build.rs
+++ b/src/audit/build.rs
@@ -336,6 +336,8 @@ impl AletheiaDB {
 
     /// BFS the current graph from `start` up to `hops`, keeping only nodes/edges
     /// valid at the given bi-temporal coordinate. Returns `(nodes, edges)`.
+    ///
+    /// ⚡ Bolt Optimization: Pre-allocates and reuses `next` vector via `swap` and `clear` to eliminate O(hops) intermediate heap allocations during BFS traversal.
     fn collect_neighborhood(
         &self,
         start: NodeId,
@@ -346,6 +348,7 @@ impl AletheiaDB {
         let mut nodes: BTreeSet<u64> = BTreeSet::new();
         let mut edges: BTreeSet<u64> = BTreeSet::new();
         let mut frontier: Vec<NodeId> = Vec::new();
+        let mut next: Vec<NodeId> = Vec::new();
 
         if self.get_node_at_time(start, vt, tt).is_ok() {
             nodes.insert(start.as_u64());
@@ -353,12 +356,12 @@ impl AletheiaDB {
         }
 
         for _ in 0..hops {
-            let mut next = Vec::new();
-            for node in std::mem::take(&mut frontier) {
+            next.clear();
+            for node in &frontier {
                 for edge_id in self
-                    .get_outgoing_edges(node)
+                    .get_outgoing_edges(*node)
                     .into_iter()
-                    .chain(self.get_incoming_edges(node))
+                    .chain(self.get_incoming_edges(*node))
                 {
                     if self.get_edge_at_time(edge_id, vt, tt).is_err() {
                         continue;
@@ -379,7 +382,7 @@ impl AletheiaDB {
                     }
                 }
             }
-            frontier = next;
+            std::mem::swap(&mut frontier, &mut next);
         }
 
         let node_ids = nodes


### PR DESCRIPTION
💡 What: 
1. Optimized BFS logic in `collect_neighborhood` (`src/audit/build.rs`) to pre-allocate and reuse the `next` layer vector via `std::mem::swap` and `.clear()`.
2. Optimized tombstone ID collection in `apply_single_write` (`src/api/transaction/write/apply.rs`) by changing the function signature to accept `&mut impl Iterator<Item = u64>` and removing `.collect::<Vec<_>>()`.

🎯 Why: 
1. The BFS loop was previously calling `let mut next = Vec::new();` inside the core `hops` loop. Replacing this with a hoisted allocation and `swap` prevents the vector buffer capacity from being dropped and re-allocated for every level of the graph traversal.
2. The `closing_version_ids` processing was allocating a `Vec` array simply to pass an iterator. Passing the iterator directly completely eliminates this heap allocation.

📊 Impact: 
- Eliminates O(hops) heap allocations per `audit_export` request.
- Reduces memory allocations by 1 heap array per storage engine commit operation.

🔬 Measurement: 
Run the integration test suite: `cargo test --lib audit` and `cargo test --lib api::transaction::write`. Both pass and memory allocations are reduced.

---
*PR created automatically by Jules for task [10831838001268495201](https://jules.google.com/task/10831838001268495201) started by @madmax983*