### PR TITLE
fix(mcp): render Cypher aggregate/computed rows in the query tool (#558)

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -5861,6 +5861,7 @@ mod server_unit_tests {
     use std::sync::Arc;
 
     use super::AletheiaMcpServer;
+    use crate::core::PropertyValue;
     use crate::core::error::{Error, QueryError};
     use crate::core::id::{EdgeId, NodeId};
     use crate::db::AletheiaDB;
@@ -5954,6 +5955,58 @@ mod server_unit_tests {
         let json = server.query_row_to_json(row);
         assert_eq!(json["entity"]["type"].as_str(), Some("edge"));
         assert_eq!(json["entity"]["id"].as_u64(), Some(99));
+    }
+
+    // --- #558 MCP surface: computed/aggregate rows render their named columns.
+    // These are deliberately feature-independent (no `#[cfg(feature = "cypher")]`)
+    // so the coverage job -- which compiles without `cypher` -- still exercises
+    // the aggregate branches of `query_row_to_json`, `handle_query`'s column
+    // selection, and `computed_query_columns`. `QueryRow::from_columns` builds
+    // exactly the `entity: Null, columns: Some(..)` shape those branches key on.
+
+    #[test]
+    fn query_row_to_json_renders_computed_columns() {
+        let server = make_server();
+        let row = QueryRow::from_columns(vec![("count(*)".to_string(), PropertyValue::Int(5))]);
+        let json = server.query_row_to_json(row);
+        // The aggregate value is surfaced under its column name, not lost.
+        assert_eq!(json["count(*)"].as_i64(), Some(5), "got: {json}");
+        // Computed rows use the bare column-map shape: no entity/score/path/timestamp keys.
+        let obj = json
+            .as_object()
+            .expect("computed row must be a JSON object");
+        assert!(!obj.contains_key("entity"), "no entity key: {json}");
+        assert!(!obj.contains_key("score"), "no score key: {json}");
+        assert!(!obj.contains_key("path"), "no path key: {json}");
+        assert!(!obj.contains_key("timestamp"), "no timestamp key: {json}");
+    }
+
+    #[test]
+    fn query_row_to_json_renders_multi_column_computed_row() {
+        let server = make_server();
+        let row = QueryRow::from_columns(vec![
+            ("n.dept".to_string(), PropertyValue::String("Eng".into())),
+            ("c".to_string(), PropertyValue::Int(3)),
+        ]);
+        let json = server.query_row_to_json(row);
+        assert_eq!(json["n.dept"].as_str(), Some("Eng"), "got: {json}");
+        assert_eq!(json["c"].as_i64(), Some(3), "got: {json}");
+    }
+
+    #[test]
+    fn computed_query_columns_names_the_columns() {
+        let names = vec!["count(*)".to_string(), "c".to_string()];
+        let cols = super::computed_query_columns(&names);
+        let arr = cols.as_array().expect("columns must be a JSON array");
+        assert_eq!(arr.len(), 2, "one entry per column, in order: {cols}");
+        assert_eq!(arr[0]["name"].as_str(), Some("count(*)"), "got: {cols}");
+        assert_eq!(arr[1]["name"].as_str(), Some("c"), "got: {cols}");
+        // Each entry carries the response schema shape (name/type/description).
+        assert!(arr[0].get("type").is_some(), "type present: {cols}");
+        assert!(
+            arr[0].get("description").is_some(),
+            "description present: {cols}"
+        );
     }
 
     #[test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -4710,6 +4710,20 @@ impl AletheiaMcpServer {
     /// per-entity version-metadata lookup just to discard the result
     /// (Issue #3391).
     fn query_row_to_json(&self, row: crate::query::executor::QueryRow) -> serde_json::Value {
+        // Computed/aggregate row (e.g. `RETURN count(*)`, `RETURN n.dept,
+        // count(*)`): the meaningful payload lives in `row.columns`, not
+        // `row.entity` (which is `EntityResult::Null`). Render each named column
+        // via `property_value_to_json` so an LLM sees the aggregate/group value
+        // instead of a lossy `entity: null`. Closes the #558 MCP-surface
+        // follow-up. `include_vectors: true` -- computed aggregate values are
+        // not stored embeddings, so nothing should be elided.
+        if let Some(columns) = row.columns {
+            let mut obj = serde_json::Map::with_capacity(columns.len());
+            for (name, value) in columns {
+                obj.insert(name, self.property_value_to_json(&value, true));
+            }
+            return serde_json::Value::Object(obj);
+        }
         let entity = match row.entity {
             EntityResult::Node(node) => json!({
                 "type": "node",
@@ -4944,16 +4958,34 @@ impl AletheiaMcpServer {
             Err(e) => return self.map_query_error(e, &language),
         };
         let truncated = collected.len() > limit;
+        // Detect computed/aggregate rows (#558): a row carrying named `columns`
+        // (e.g. `RETURN count(*)`, `RETURN n.dept, count(*)`) reports its own
+        // column schema in projection order. Ordinary entity rows leave this
+        // `None`, so the static entity/score/path/timestamp schema is retained
+        // byte-for-byte.
+        let mut computed_columns: Option<Vec<String>> = None;
         let rows: Vec<serde_json::Value> = collected
             .into_iter()
             .take(limit)
-            .map(|row| self.query_row_to_json(row))
+            .map(|row| {
+                if computed_columns.is_none()
+                    && let Some(cols) = &row.columns
+                {
+                    computed_columns = Some(cols.iter().map(|(name, _)| name.clone()).collect());
+                }
+                self.query_row_to_json(row)
+            })
             .collect();
         let row_count = rows.len();
 
+        let columns = match &computed_columns {
+            Some(names) => computed_query_columns(names),
+            None => query_columns(),
+        };
+
         self.success_json(json!({
             "language": language,
-            "columns": query_columns(),
+            "columns": columns,
             "rows": rows,
             "row_count": row_count,
             "truncated": truncated,
@@ -5251,6 +5283,27 @@ fn query_columns() -> serde_json::Value {
             ])
         })
         .clone()
+}
+
+/// Build the column schema for a computed/aggregate `query` result (#558).
+///
+/// When a result carries named `QueryRow::columns` (e.g. `RETURN count(*)` or
+/// `RETURN n.dept, count(*)`), the response advertises those column names in
+/// projection order instead of the static entity/score/path/timestamp schema,
+/// so a caller can map each row's values to their columns.
+fn computed_query_columns(names: &[String]) -> serde_json::Value {
+    serde_json::Value::Array(
+        names
+            .iter()
+            .map(|name| {
+                json!({
+                    "name": name,
+                    "type": "value",
+                    "description": "Computed column from a RETURN projection or aggregation."
+                })
+            })
+            .collect(),
+    )
 }
 
 /// Build the list of tool definitions advertised by this MCP server.

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -3673,6 +3673,170 @@ mod query_tool_tests {
         );
     }
 
+    // --- #558 MCP surface: Cypher aggregate/computed rows must render their
+    // named column values (not `entity: null`). See the aggregation limitation
+    // note in CLAUDE.md that this closes at the MCP layer.
+
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn test_query_cypher_aggregate_count_renders_value_not_null() {
+        let server = create_test_server();
+        for name in ["a", "b", "c", "d", "e"] {
+            seed_named(&server, "Person", name);
+        }
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "cypher".to_string(),
+                query: "MATCH (n:Person) RETURN count(*)".to_string(),
+                params: None,
+                limit: None,
+            },
+        );
+        assert_eq!(value["row_count"].as_u64(), Some(1), "{value}");
+        // The aggregate value must be surfaced under its column name, not lost
+        // to an `entity: null` rendering.
+        assert_eq!(
+            value["rows"][0]["count(*)"].as_i64(),
+            Some(5),
+            "aggregate count must render its value under its column name: {value}"
+        );
+        assert!(
+            value["rows"][0]["entity"].is_null(),
+            "aggregate row must not carry a non-null entity payload: {value}"
+        );
+        // Column metadata names the aggregate column (not the static schema).
+        let cols = value["columns"].as_array().expect("columns array");
+        assert!(
+            cols.iter().any(|c| c["name"].as_str() == Some("count(*)")),
+            "columns must name the aggregate column: {value}"
+        );
+    }
+
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn test_query_cypher_grouped_aggregate_renders_group_and_count() {
+        let server = create_test_server();
+        for (name, dept) in [
+            ("a", "Eng"),
+            ("b", "Eng"),
+            ("c", "Eng"),
+            ("d", "Sales"),
+            ("e", "Sales"),
+        ] {
+            let mut props = HashMap::new();
+            props.insert("name".to_string(), serde_json::json!(name));
+            props.insert("dept".to_string(), serde_json::json!(dept));
+            let resp = server.create_node(CreateNodeRequest {
+                valid_time: None,
+                label: "Person".to_string(),
+                properties: Some(props),
+                provenance: None,
+            });
+            let _: NodeResponse = parse_response(&resp).expect("seed node should succeed");
+        }
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "cypher".to_string(),
+                query: "MATCH (n:Person) RETURN n.dept, count(*)".to_string(),
+                params: None,
+                limit: None,
+            },
+        );
+        assert_eq!(value["row_count"].as_u64(), Some(2), "{value}");
+        let rows = value["rows"].as_array().expect("rows array");
+        let mut counts = HashMap::new();
+        for r in rows {
+            let dept = r["n.dept"]
+                .as_str()
+                .unwrap_or_else(|| panic!("group column `n.dept` must be present: {value}"))
+                .to_string();
+            let cnt = r["count(*)"]
+                .as_i64()
+                .unwrap_or_else(|| panic!("aggregate column `count(*)` must be present: {value}"));
+            counts.insert(dept, cnt);
+        }
+        assert_eq!(counts.get("Eng"), Some(&3), "{value}");
+        assert_eq!(counts.get("Sales"), Some(&2), "{value}");
+        let cols = value["columns"].as_array().expect("columns array");
+        let names: Vec<&str> = cols.iter().filter_map(|c| c["name"].as_str()).collect();
+        assert!(
+            names.contains(&"n.dept") && names.contains(&"count(*)"),
+            "columns must list both the group key and the aggregate: {value}"
+        );
+    }
+
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn test_query_cypher_aggregate_alias_names_column() {
+        let server = create_test_server();
+        for name in ["a", "b", "c"] {
+            seed_named(&server, "Person", name);
+        }
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "cypher".to_string(),
+                query: "MATCH (n:Person) RETURN count(*) AS c".to_string(),
+                params: None,
+                limit: None,
+            },
+        );
+        assert_eq!(
+            value["rows"][0]["c"].as_i64(),
+            Some(3),
+            "aliased aggregate value must render under its alias: {value}"
+        );
+        let cols = value["columns"].as_array().expect("columns array");
+        assert!(
+            cols.iter().any(|c| c["name"].as_str() == Some("c")),
+            "columns must name the aggregate alias `c`: {value}"
+        );
+    }
+
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn test_query_cypher_plain_entity_row_rendering_unchanged() {
+        // Non-regression: a plain entity query keeps the exact
+        // entity/score/path/timestamp row shape and static column schema.
+        let server = create_test_server();
+        seed_named(&server, "Person", "Alice");
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "cypher".to_string(),
+                query: "MATCH (n:Person {name: 'Alice'}) RETURN n".to_string(),
+                params: None,
+                limit: None,
+            },
+        );
+        let row = &value["rows"][0];
+        assert_eq!(row["entity"]["label"].as_str(), Some("Person"), "{value}");
+        assert_eq!(
+            row["entity"]["properties"]["name"].as_str(),
+            Some("Alice"),
+            "{value}"
+        );
+        assert!(row.get("score").is_some(), "score key present: {value}");
+        assert!(row.get("path").is_some(), "path key present: {value}");
+        assert!(
+            row.get("timestamp").is_some(),
+            "timestamp key present: {value}"
+        );
+        let names: Vec<&str> = value["columns"]
+            .as_array()
+            .expect("columns array")
+            .iter()
+            .filter_map(|c| c["name"].as_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["entity", "score", "path", "timestamp"],
+            "plain entity query keeps the static column schema: {value}"
+        );
+    }
+
     #[cfg(feature = "cypher")]
     #[test]
     fn test_query_cypher_optional_match_null_row_serializes_as_json_null() {


### PR DESCRIPTION
## Summary

Completes the runtime Cypher aggregation feature (#558) **at the MCP surface**. Runtime aggregation landed on trunk (`db.execute_cypher("RETURN count(*)")` returns correct values), but the MCP `query` tool dropped the computed columns — the documented one-branch follow-up for the MCP lane.

## Before / After

A `query` result carries aggregate/group rows on `QueryRow.columns` (`entity = EntityResult::Null`). The MCP serializer ignored `columns`.

**Before** — `RETURN count(*)` over 5 nodes:
```json
{
  "columns": [{"name":"entity",...},{"name":"score",...},{"name":"path",...},{"name":"timestamp",...}],
  "rows": [{"entity": null, "score": null, "path": null, "timestamp": null}],
  "row_count": 1
}
```
The aggregate value (5) was lost; an LLM running `RETURN count(*)` got `null`.

**After**:
```json
{
  "columns": [{"name":"count(*)","type":"value","description":"Computed column from a RETURN projection or aggregation."}],
  "rows": [{"count(*)": 5}],
  "row_count": 1
}
```
Grouped `RETURN n.dept, count(*)` yields one row per group with the group value + count (`{"n.dept":"Eng","count(*)":3}`), and `columns` lists both. `RETURN count(*) AS c` renders the value under alias `c`.

## How

Both changes are confined to `src/mcp/server.rs` (MCP serialization only — no changes to the row model or `src/query`):

- `query_row_to_json`: when `row.columns` is `Some`, serialize each `(name, PropertyValue)` via the existing `property_value_to_json` into a `{column → value}` object. When `None`, the exact prior entity/score/path/timestamp rendering is retained.
- `handle_query`: when a returned row carries named `columns`, advertise the computed column schema (aggregate/group aliases in projection order) via the new `computed_query_columns`; otherwise the static `query_columns()` schema is retained byte-for-byte.

The `#3234` structured-error envelope, `#3353` token budgets, and cursor behavior are untouched.

## Non-regression

Plain entity queries (`MATCH (n) RETURN n`) are byte-identical to today: entity object present, static `entity/score/path/timestamp` column schema. Covered by a dedicated non-regression test plus the pre-existing `test_query_cypher_returns_rows` / `test_query_aql_returns_structured_rows`.

## Tests (TDD, red → green)

New tests in `src/mcp/tests.rs` (gated on `cypher`):
- `test_query_cypher_aggregate_count_renders_value_not_null`
- `test_query_cypher_grouped_aggregate_renders_group_and_count`
- `test_query_cypher_aggregate_alias_names_column`
- `test_query_cypher_plain_entity_row_rendering_unchanged`

`cargo test --lib --features "mcp-server,cypher"`: 4290 passed, 0 failed. Clippy clean (`--lib --tests --features "mcp-server,cypher" -- -D warnings`); `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWUZoNegCxQ4oN2ZUvYPru

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWUZoNegCxQ4oN2ZUvYPru)_