### PR TITLE
Fix clippy useless_conversion in #3462 aggregation iterator (unblocks Linting)

### DIFF
--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -2501,10 +2501,10 @@ impl AggregateIterator {
             let group = groups.remove(&key).expect("group present in order");
             let mut columns: Vec<(String, PropertyValue)> =
                 Vec::with_capacity(self.group_keys.len() + self.aggregates.len());
-            for (gk, val) in self.group_keys.iter().zip(group.key_values.into_iter()) {
+            for (gk, val) in self.group_keys.iter().zip(group.key_values) {
                 columns.push((gk.alias.clone(), val));
             }
-            for (spec, acc) in self.aggregates.iter().zip(group.accumulators.into_iter()) {
+            for (spec, acc) in self.aggregates.iter().zip(group.accumulators) {
                 columns.push((spec.alias.clone(), acc.finalize()));
             }
             rows.push(QueryRow::from_columns(columns));

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -2818,6 +2818,89 @@ mod tests {
         }
     }
 
+    fn test_node_with_dept_age(id: u64, dept: &str, age: i64) -> Node {
+        let props = PropertyMapBuilder::new()
+            .insert("dept", dept)
+            .insert("age", age)
+            .build();
+        let label = GLOBAL_INTERNER.intern("Person").unwrap();
+        Node::new(
+            NodeId::new(id).unwrap(),
+            label,
+            props,
+            VersionId::new(1).unwrap(),
+        )
+    }
+
+    // ==================== AggregateIterator Tests ====================
+
+    /// Drives `AggregateIterator`'s group-finalize path directly (no cypher
+    /// parser), so it runs under any feature set including the coverage job's
+    /// `--features "config-toml,mcp-server,sharding-rpc"` (no `cypher`). Groups
+    /// by `dept` and computes both `count(*)` and `sum(age)`, so the
+    /// finalize loop executes with BOTH a group key and aggregate accumulators.
+    #[test]
+    fn test_aggregate_iterator_group_key_and_aggregates() {
+        // Two "eng" rows and one "sales" row; first-seen group order is
+        // eng, then sales.
+        let nodes = vec![
+            test_node_with_dept_age(1, "eng", 30),
+            test_node_with_dept_age(2, "eng", 20),
+            test_node_with_dept_age(3, "sales", 40),
+        ];
+        let input = Box::new(MockIterator::from_nodes(nodes));
+
+        let group_keys = vec![AggregateGroupKey {
+            property_key: "dept".to_string(),
+            alias: "dept".to_string(),
+        }];
+        let aggregates = vec![
+            AggregateSpec {
+                func: AggregateFunc::Count,
+                arg: AggregateArg::Star,
+                distinct: false,
+                alias: "cnt".to_string(),
+            },
+            AggregateSpec {
+                func: AggregateFunc::Sum,
+                arg: AggregateArg::Property("age".to_string()),
+                distinct: false,
+                alias: "sum_age".to_string(),
+            },
+        ];
+
+        let mut iter = AggregateIterator::new(input, group_keys, aggregates);
+
+        // Drain all output rows.
+        let mut rows = Vec::new();
+        while let Some(row) = iter.next() {
+            rows.push(row.expect("aggregate row"));
+        }
+
+        assert_eq!(rows.len(), 2, "expected one row per group");
+
+        // Each row's `columns` carries (alias, value): the group key first,
+        // then each aggregate in spec order.
+        let cols: Vec<Vec<(String, PropertyValue)>> = rows
+            .into_iter()
+            .map(|r| r.columns.expect("aggregate row has columns"))
+            .collect();
+
+        // Group 1: eng -> count 2, sum(age) 50.
+        assert_eq!(cols[0][0].0, "dept");
+        assert_eq!(cols[0][0].1, PropertyValue::from("eng"));
+        assert_eq!(cols[0][1].0, "cnt");
+        assert_eq!(cols[0][1].1, PropertyValue::Int(2));
+        assert_eq!(cols[0][2].0, "sum_age");
+        assert_eq!(cols[0][2].1, PropertyValue::Int(50));
+
+        // Group 2: sales -> count 1, sum(age) 40.
+        assert_eq!(cols[1][0].0, "dept");
+        assert_eq!(cols[1][0].1, PropertyValue::from("sales"));
+        assert_eq!(cols[1][1].1, PropertyValue::Int(1));
+        assert_eq!(cols[1][2].1, PropertyValue::Int(40));
+    }
+
     // ==================== EmptyIterator Tests ====================
 
     #[test]


### PR DESCRIPTION
## Problem

CI's **Linting** check (`cargo clippy --all-targets --all-features -- -D warnings`, clippy 1.97) fails on trunk with two `clippy::useless_conversion` errors introduced by the #3462 runtime-aggregation merge, in `src/query/executor/iterators.rs`:

```
error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
  --> src/query/executor/iterators.rs:2504:57
     for (gk, val) in self.group_keys.iter().zip(group.key_values.into_iter()) {
  --> src/query/executor/iterators.rs:2507:59
     for (spec, acc) in self.aggregates.iter().zip(group.accumulators.into_iter()) {
```

The author's local clippy (older version, run as `--lib --features cypher`) did not flag these; CI's 1.97 with `--all-targets --all-features` does. This blocked Linting on trunk and on every open PR.

## Fix

`Iterator::zip` accepts `IntoIterator`, so the explicit `.into_iter()` calls are redundant. Removed them:

**Before**
```rust
for (gk, val) in self.group_keys.iter().zip(group.key_values.into_iter()) {
for (spec, acc) in self.aggregates.iter().zip(group.accumulators.into_iter()) {
```

**After**
```rust
for (gk, val) in self.group_keys.iter().zip(group.key_values) {
for (spec, acc) in self.aggregates.iter().zip(group.accumulators) {
```

Behavior is identical (`Vec::into_iter` is exactly what `zip` would call internally).

This **unblocks the Linting check for trunk and all open PRs**.

## Additional clippy fixes

None. I ran the full CI-equivalent command `cargo clippy --all-targets --all-features -- -D warnings` over the whole tree; these two `useless_conversion` errors were the only findings. No other new-in-1.97 lints surfaced in the aggregation/sort/distinct code (`src/cypher/**`, `src/query/**`) or elsewhere.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` → clean, exit 0, zero warnings.
- `cargo test --lib --features cypher` → 3805 passed, 0 failed (2 ignored). Aggregation tests (`cypher::tests::test_agg_*`) pass.
- `cargo fmt --all` → no changes beyond the two edited lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWUZoNegCxQ4oN2ZUvYPru

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWUZoNegCxQ4oN2ZUvYPru)_