### PR TITLE
⚖️ Elenchus: test: add error propagation tests for aggregation iterators

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -346,3 +346,10 @@
 **Finding:** The `LimitPushdown` tests originally missed several behavioral edge cases and logic checks, particularly regarding the propagation limits in BinaryOp combinations (`||`), updating limit values correctly against child bounds, and setting vector rank limits.
 **Evidence:** `cargo mutants` caught mutants in `LimitPushdown::push_down` specifically targeting the changed boolean condition logic and bounds assignment.
 **Recommendation:** Added `sentry_tests` to `LimitPushdown` that explicitly trigger tests enforcing the boolean change propagation, verifying that updated properties reflect correct nested limits, and vector bounds assignment. Tests now prevent `||` to `&&` mutations and correct top-k modifications.
+
+## [Cypher Aggregation Iterators Error Propagation]
+**Module:** `src/query/executor/iterators.rs`
+**Verdict:** 🟡 Suspect
+**Finding:** Mutation testing revealed that the `drain` method on `AggregateIterator` can be replaced with `Ok(())` (or its error propagation can be bypassed) without failing tests focused on the "happy path" of aggregation logic. The underlying issue is that there are no tests specifically asserting that if the *input* iterator to an `AggregateIterator` (or potentially `SortIterator`, `DistinctIterator`) yields an error during the buffering/draining phase, that error must be correctly propagated up to the caller rather than swallowed or panicked.
+**Evidence:** `cargo mutants` run against `src/query/executor/iterators.rs` showed a mutation replacing `AggregateIterator::drain -> Result<()>` with `Ok(())`. While Cypher E2E tests (`test_agg_*` in `src/cypher/tests.rs`) thoroughly test the data correctness and grouping logic (so replacing drain completely would break E2E), there's a gap in explicit unit-level error propagation testing for these batching iterators.
+**Recommendation:** Added `aggregate_sentry_tests` and `distinct_sentry_tests` inside `src/query/executor/iterators.rs` using a `MockIterator` returning an error to ensure that `AggregateIterator`, `SortIterator`, and `DistinctIterator` correctly propagate errors returned by their input's `next()` method.

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -5255,3 +5255,76 @@ mod tests {
         assert!(dropped.next().is_none());
     }
 }
+
+#[cfg(test)]
+mod aggregate_sentry_tests {
+    use super::*;
+    use crate::Error;
+    use crate::core::error::QueryError;
+
+    // Helper mock iterator that returns an error
+    struct ErrorIterator;
+    impl ResultIterator for ErrorIterator {
+        fn next(&mut self) -> Option<Result<QueryRow>> {
+            Some(Err(Error::Query(QueryError::SyntaxError {
+                message: "mock error".into(),
+            })))
+        }
+    }
+
+    #[test]
+    fn test_aggregate_iterator_propagates_errors() {
+        let input = Box::new(ErrorIterator);
+        let mut it = AggregateIterator::new(input, vec![], vec![]);
+
+        let res = it.next();
+        assert!(res.is_some());
+        let err = res.unwrap().unwrap_err();
+        assert!(
+            matches!(err, Error::Query(QueryError::SyntaxError { message }) if message == "mock error")
+        );
+    }
+
+    #[test]
+    fn test_sort_iterator_propagates_errors() {
+        let input = Box::new(ErrorIterator);
+        let mut it = SortIterator::new(input, vec![]);
+
+        let res = it.next();
+        assert!(res.is_some());
+        let err = res.unwrap().unwrap_err();
+        assert!(
+            matches!(err, Error::Query(QueryError::SyntaxError { message }) if message == "mock error")
+        );
+    }
+}
+
+#[cfg(test)]
+mod distinct_sentry_tests {
+    use super::*;
+    use crate::Error;
+    use crate::core::error::QueryError;
+
+    // Helper mock iterator that returns an error
+    struct ErrorIterator;
+    impl ResultIterator for ErrorIterator {
+        fn next(&mut self) -> Option<Result<QueryRow>> {
+            Some(Err(Error::Query(QueryError::SyntaxError {
+                message: "mock error".into(),
+            })))
+        }
+    }
+
+    #[test]
+    fn test_distinct_iterator_propagates_errors() {
+        let input = Box::new(ErrorIterator);
+        let mut it = DistinctIterator::new(input);
+
+        let res = it.next();
+        assert!(res.is_some());
+        let err = res.unwrap().unwrap_err();
+        assert!(
+            matches!(err, Error::Query(QueryError::SyntaxError { message }) if message == "mock error")
+        );
+    }
+}


### PR DESCRIPTION
**Summary**
This PR adds explicit tests to ensure that `AggregateIterator`, `SortIterator`, and `DistinctIterator` correctly propagate errors encountered from their input iterators during their `drain()` or `next()` phases.

**Changes**
- Added `aggregate_sentry_tests` and `distinct_sentry_tests` in `src/query/executor/iterators.rs`.
- These tests use a mock `ErrorIterator` to verify that `SyntaxError`s are not swallowed or panicked upon, addressing a mutation testing gap identified by `cargo mutants` (e.g. replacing `AggregateIterator::drain` with `Ok(())`).
- Added an entry to the `.jules/elenchus.md` journal documenting this finding and fix.

---
*PR created automatically by Jules for task [2540743738075022806](https://jules.google.com/task/2540743738075022806) started by @madmax983*