### PR TITLE
Fix trunk Linting: clear BOTH clippy errors (WAL dead-code + query executor useless_conversion)

### DIFF
--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -2501,10 +2501,10 @@ impl AggregateIterator {
             let group = groups.remove(&key).expect("group present in order");
             let mut columns: Vec<(String, PropertyValue)> =
                 Vec::with_capacity(self.group_keys.len() + self.aggregates.len());
-            for (gk, val) in self.group_keys.iter().zip(group.key_values.into_iter()) {
+            for (gk, val) in self.group_keys.iter().zip(group.key_values) {
                 columns.push((gk.alias.clone(), val));
             }
-            for (spec, acc) in self.aggregates.iter().zip(group.accumulators.into_iter()) {
+            for (spec, acc) in self.aggregates.iter().zip(group.accumulators) {
                 columns.push((spec.alias.clone(), acc.finalize()));
             }
             rows.push(QueryRow::from_columns(columns));

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -214,7 +214,7 @@ fn payload_version(version: u8) -> u8 {
 /// History of the newest plaintext version: #3224→3, #3421→5, #3413→7,
 /// #3406→9. Bump on every WAL plaintext format increase.
 #[inline]
-#[cfg_attr(not(any(fuzzing, feature = "fuzzing")), allow(dead_code))]
+#[cfg(any(fuzzing, feature = "fuzzing"))]
 pub(crate) fn newest_plaintext_wal_version() -> u8 {
     payload_version(WAL_VERSION_MAX)
 }

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -214,6 +214,7 @@ fn payload_version(version: u8) -> u8 {
 /// History of the newest plaintext version: #3224→3, #3421→5, #3413→7,
 /// #3406→9. Bump on every WAL plaintext format increase.
 #[inline]
+#[cfg_attr(not(any(fuzzing, feature = "fuzzing")), allow(dead_code))]
 pub(crate) fn newest_plaintext_wal_version() -> u8 {
     payload_version(WAL_VERSION_MAX)
 }


### PR DESCRIPTION
## Problem

Trunk's **Linting** CI job is RED, blocking every lane. It has **two** independent clippy errors, and this PR clears **both** in a single PR.

The CI Linting job runs:

```
cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings
```

### Error 1 — WAL `newest_plaintext_wal_version` dead-code

That feature set does **not** include `fuzzing`. PR #3472 added `pub(crate) fn newest_plaintext_wal_version()` in `src/storage/wal/segment_reader.rs`, whose only caller is `src/fuzzing.rs` (gated `#[cfg(any(fuzzing, feature = "fuzzing"))]`). So under the CI feature set the helper is unused → dead-code warning → `-D warnings` fails.

Local `--all-features` passes because it includes `fuzzing`, which is why this slipped through — a feature-set mismatch.

```
error: function `newest_plaintext_wal_version` is never used
   --> src/storage/wal/segment_reader.rs:217:15
    |
217 | pub(crate) fn newest_plaintext_wal_version() -> u8 {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D dead-code` implied by `-D warnings`
error: could not compile `aletheiadb` (lib) due to 1 previous error
```

### Error 2 — `clippy::useless_conversion` in query executor

`src/query/executor/iterators.rs` calls `.into_iter()` on values already passed to `.zip()` (which takes `IntoIterator`), tripping `clippy::useless_conversion` under `-D warnings`.

## Fix

**(a) WAL dead-code** — a single cfg-gated attribute above the function definition:

```rust
#[cfg_attr(not(any(fuzzing, feature = "fuzzing")), allow(dead_code))]
```

Silences the dead-code lint **only** when the fuzzing cfg is absent; under `--features fuzzing` the function is still used and the attribute is inert. Body unchanged.

**(b) query executor `useless_conversion`** — drop the redundant `.into_iter()` at the two `AggregateIterator` group-finalization sites (behavior-identical, `.zip()` takes `IntoIterator`):

```diff
-            for (gk, val) in self.group_keys.iter().zip(group.key_values.into_iter()) {
+            for (gk, val) in self.group_keys.iter().zip(group.key_values) {
...
-            for (spec, acc) in self.aggregates.iter().zip(group.accumulators.into_iter()) {
+            for (spec, acc) in self.aggregates.iter().zip(group.accumulators) {
```

This 2-line query-executor fix is **identical to #3468 (Lane B)**; consolidated here per coordinator to clear trunk Linting in a single PR. **#3468 will be closed as superseded.**

## Verification (GREEN)

- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` → `Finished` (exit 0) — the exact CI command
- `cargo clippy --all-targets --all-features -- -D warnings` → clean (exit 0)
- `cargo test --lib --features cypher query::executor` → `test result: ok. 198 passed; 0 failed`
- `cargo test -p aletheiadb --lib --features fuzzing fuzzing` → `test result: ok. 5 passed; 0 failed`

## Notes

Restores trunk green by clearing both Linting errors at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKAFWHHzF4ng6LybQJhYsH