### PR TITLE
🛡️ Sentry: HybridTimestamp error path coverage improvement

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -37,3 +37,6 @@
 **[Fix `execute_traversal` target shards bug]**
 **Learning:** `plan.steps` from `route_traversal` returns empty list, and we need `involved_shards`
 **Action:** Replace `steps` with `involved_shards` and update the test.
+**HybridTimestamp Validation Coverage**
+**Learning:** Error paths for `HybridTimestamp::deserialize` (`StorageError::CorruptedData` on buffer underflow or invalid wallclock logic) and `HybridTimestamp::new` (`TemporalError::InvalidTimestamp` on wallclock bounds) lacked explicit branch coverage. While `cargo test` passes, if validation logic were accidentally modified, no targeted test would fail.
+**Action:** Always add targeted tests checking explicit error returns and parsing logic for foundational primitives (like `HybridTimestamp`).

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1115,6 +1115,49 @@ mod tests {
     }
 
     #[test]
+    fn test_hybrid_timestamp_deserialize_errors() {
+        use crate::core::hlc::HybridTimestamp;
+        // 1. Buffer too short
+        let short_buffer = [0u8; 11];
+        let result = HybridTimestamp::deserialize(&short_buffer);
+        assert!(
+            matches!(result, Err(crate::core::error::StorageError::CorruptedData(ref msg)) if msg.contains("Buffer too short")),
+            "Expected CorruptedData for short buffer"
+        );
+
+        // 2. Wallclock > MAX_VALID_TIMESTAMP
+        let mut buffer = [0u8; 12];
+        let invalid_wallclock: i64 = MAX_VALID_TIMESTAMP + 1;
+        buffer[0..8].copy_from_slice(&invalid_wallclock.to_le_bytes());
+        let result = HybridTimestamp::deserialize(&buffer);
+        assert!(
+            matches!(result, Err(crate::core::error::StorageError::CorruptedData(ref msg)) if msg.contains("exceeds MAX_VALID_TIMESTAMP")),
+            "Expected CorruptedData for exceeding MAX_VALID_TIMESTAMP"
+        );
+
+        // 3. Wallclock == i64::MAX but logical != 0
+        let mut buffer2 = [0u8; 12];
+        buffer2[0..8].copy_from_slice(&i64::MAX.to_le_bytes());
+        buffer2[8..12].copy_from_slice(&1u32.to_le_bytes()); // logical = 1
+        let result2 = HybridTimestamp::deserialize(&buffer2);
+        assert!(
+            matches!(result2, Err(crate::core::error::StorageError::CorruptedData(ref msg)) if msg.contains("non-zero logical counter")),
+            "Expected CorruptedData for i64::MAX with non-zero logical"
+        );
+    }
+
+    #[test]
+    fn test_hybrid_timestamp_new_validation() {
+        use crate::core::hlc::HybridTimestamp;
+        let invalid_wallclock: i64 = MAX_VALID_TIMESTAMP + 1;
+        let result = HybridTimestamp::new(invalid_wallclock, 0);
+        assert!(
+            matches!(result, Err(TemporalError::InvalidTimestamp { .. })),
+            "Expected InvalidTimestamp when wallclock exceeds MAX_VALID_TIMESTAMP"
+        );
+    }
+
+    #[test]
     fn test_hybrid_timestamp_serialization_size() {
         use crate::core::hlc::HybridTimestamp;
 


### PR DESCRIPTION
🎯 Target: `HybridTimestamp::deserialize` and `HybridTimestamp::new` in `src/core/temporal.rs`.
💣 Risk: Previous tests didn't explicitly cover `StorageError::CorruptedData` or `TemporalError::InvalidTimestamp` branches within core timestamp generation and deserialization functions. Regression in these paths could silently corrupt temporal data parsing or generation without tripping CI.
🧪 Strategy: Added explicit boundary tests for `HybridTimestamp` ensuring `deserialize` accurately traps under-length buffers, out-of-bound `wallclock`, and malformed logical counter constraints. Also added a `HybridTimestamp::new` bounds validation test.
🔬 Verification: `cargo test --lib test_hybrid_timestamp_`

---
*PR created automatically by Jules for task [1027311594873657193](https://jules.google.com/task/1027311594873657193) started by @madmax983*