### PR TITLE
⚡ Bolt: Remove unnecessary heap allocation during transaction apply

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**[Optimize intermediate Vec collections with Map]**
+**Learning:** Found an unnecessary intermediate heap allocation during transaction apply in `src/api/transaction/write/apply.rs` where an iterator was mapped, collected into a `Vec<u64>`, and immediately converted back `into_iter()`. This is a hot path and causes memory overhead.
+**Action:** Replaced `.collect::<Vec<u64>>().into_iter()` with `.map(|v| v.as_u64())` and updated the parameter type in `apply_single_write` from `&mut std::vec::IntoIter<u64>` to `&mut impl Iterator<Item = u64>`. This eliminates one heap allocation per transaction commit.

--- a/src/api/transaction/write/apply.rs
+++ b/src/api/transaction/write/apply.rs
@@ -409,12 +409,14 @@ pub(crate) fn apply_edge_retract(
 ///
 /// * `tombstone_ids` - Iterator of pre-generated Version IDs for tombstones. This optimization
 ///   avoids acquiring the ID generator lock for every delete operation.
+/// ⚡ Bolt Optimization: Uses `impl Iterator` to avoid allocating an intermediate `Vec<u64>`
+/// during transaction commit, saving memory and processing overhead on a hot path.
 pub(crate) fn apply_single_write(
     tx: &WriteTransaction,
     write: &crate::api::transaction::BufferedWrite,
     commit_timestamp: Timestamp,
     historical: &mut HistoricalStorage,
-    tombstone_ids: &mut std::vec::IntoIter<u64>,
+    tombstone_ids: &mut impl Iterator<Item = u64>,
     num_deletes: usize,
 ) -> Result<()> {
     match write {
@@ -622,11 +624,7 @@ pub(crate) fn apply_changes<'a>(
     // so the identical ids are recorded in the WAL and applied here. We simply
     // replay them in the same buffer order they were generated and logged.
     let num_deletes = closing_version_ids.len();
-    let mut tombstone_ids = closing_version_ids
-        .iter()
-        .map(|v| v.as_u64())
-        .collect::<Vec<u64>>()
-        .into_iter();
+    let mut tombstone_ids = closing_version_ids.iter().map(|v| v.as_u64());
 
     for write in tx.buffer.operations() {
         apply_single_write(


### PR DESCRIPTION
💡 What: Changed `tombstone_ids` extraction from `closing_version_ids` to use a lazy iterator `.map(|v| v.as_u64())` instead of `.collect::<Vec<u64>>().into_iter()`, and updated `apply_single_write` to accept `&mut impl Iterator<Item = u64>`.
🎯 Why: The intermediate `Vec` collection created an unnecessary heap allocation during transaction commit, which is a hot path.
📊 Impact: Removes one heap allocation per transaction commit.
🔬 Measurement: Run `cargo bench` or `cargo test` to verify functionality.

---
*PR created automatically by Jules for task [1027127198634567473](https://jules.google.com/task/1027127198634567473) started by @madmax983*