### PR TITLE
fix(wal): fail loud on WAL directory scan I/O errors (#3423)

### DIFF
--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -274,6 +274,24 @@ impl FlushCoordinator {
     }
 
     /// Initialize from existing WAL segments.
+    ///
+    /// # Failure semantics (Issue #3423)
+    ///
+    /// The maximum existing segment id determines where `ensure_segment_open`
+    /// starts allocating. Under-reporting it (e.g. defaulting to 0 after a
+    /// failed directory scan) can land the writer on a stale/existing segment
+    /// and — combined with a payload-version bump — produce an unparseable
+    /// mixed-version segment. We therefore distinguish two cases:
+    ///
+    /// - **Directory does not exist yet** (`NotFound`): a normal first run on
+    ///   a fresh data dir. The scan yields no segments and we start at id 0.
+    ///   This is not an error.
+    /// - **Any other I/O error** (permission denied, not-a-directory, a
+    ///   transient failure): we cannot trust that segment id 0 is unused, so
+    ///   we **fail loud** and propagate the error rather than silently
+    ///   defaulting to 0. The header-version check in `ensure_segment_open`
+    ///   remains a second line of defense, but a swallowed scan error must not
+    ///   be the reason we rely on it.
     fn initialize_from_existing(&self) -> Result<()> {
         let mut max_segment_id = 0u64;
 
@@ -291,19 +309,18 @@ impl FlushCoordinator {
                     }
                 }
             }
+            // First run: the WAL directory has not been created yet. Treat an
+            // absent directory as "no existing segments" and start at id 0.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            // A genuine I/O error: refuse to proceed rather than under-report
+            // the max segment id and risk appending to an existing segment.
             Err(e) => {
-                // Under-reporting the max segment id here would make
-                // `ensure_segment_open` collide with existing segment files.
-                // That collision is now caught defensively by the
-                // header-version check (Issue #3423), but warn loudly so
-                // operators can see the scan failed.
-                eprintln!(
-                    "WARNING: failed to scan WAL directory {} for existing segments ({}); \
-                     segment id allocation starts at 0 and relies on the header-version \
-                     check to avoid appending to mismatched segments",
+                return Err(Error::Storage(StorageError::IoError(format!(
+                    "Failed to scan WAL directory {} for existing segments: {}; \
+                     refusing to start segment allocation at 0 (Issue #3423)",
                     self.config.wal_dir.display(),
                     e
-                );
+                ))));
             }
         }
 
@@ -1206,6 +1223,62 @@ mod tests {
         assert!(
             !dir.path().join("000002.log").exists(),
             "no roll-forward for a version-matching segment"
+        );
+    }
+
+    /// Regression test for Issue #3423 (secondary hardening): a genuine I/O
+    /// failure while scanning the WAL directory for existing segments must
+    /// **propagate** rather than being swallowed and silently defaulting the
+    /// segment-id counter to 0. Defaulting to 0 after a failed scan is one of
+    /// the ways the writer can land on a stale/existing segment; failing loud
+    /// lets the operator see the problem instead of risking a poisoned
+    /// mixed-version segment.
+    #[test]
+    fn test_initialize_from_existing_propagates_real_io_error() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+        let config = FlushCoordinatorConfig::new(&wal_dir);
+
+        // `new()` creates the directory and scans it successfully.
+        let coordinator = FlushCoordinator::new(config).unwrap();
+
+        // Now replace the WAL directory with a regular FILE at the same path.
+        // `read_dir` on a non-directory fails with a real I/O error (NOT
+        // `NotFound`), which the scan must surface rather than swallow.
+        std::fs::remove_dir_all(&wal_dir).unwrap();
+        std::fs::write(&wal_dir, b"not a directory").unwrap();
+
+        let result = coordinator.initialize_from_existing();
+        assert!(
+            result.is_err(),
+            "a real read_dir I/O error must propagate, not silently default to segment id 0"
+        );
+    }
+
+    /// The first-run case -- the WAL directory does not exist yet -- must NOT
+    /// be treated as an error: a missing directory is normal on a fresh data
+    /// dir and must still succeed with segment id 0.
+    #[test]
+    fn test_initialize_from_existing_missing_dir_is_ok() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+        let config = FlushCoordinatorConfig::new(&wal_dir);
+
+        // `new()` creates the directory; remove it entirely so the scan hits
+        // a genuinely absent directory (`NotFound`).
+        let coordinator = FlushCoordinator::new(config).unwrap();
+        std::fs::remove_dir_all(&wal_dir).unwrap();
+        assert!(!wal_dir.exists());
+
+        let result = coordinator.initialize_from_existing();
+        assert!(
+            result.is_ok(),
+            "a missing WAL directory (first run) must succeed, not error"
+        );
+        assert_eq!(
+            coordinator.current_segment_id.load(Ordering::Relaxed),
+            0,
+            "an absent WAL directory yields segment id 0"
         );
     }
 

--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -293,27 +293,21 @@ impl FlushCoordinator {
     ///   remains a second line of defense, but a swallowed scan error must not
     ///   be the reason we rely on it.
     fn initialize_from_existing(&self) -> Result<()> {
-        let mut max_segment_id = 0u64;
-
-        match std::fs::read_dir(&self.config.wal_dir) {
-            Ok(entries) => {
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    if let Some(id) = path
-                        .extension()
-                        .filter(|ext| *ext == "log")
-                        .and_then(|_| path.file_stem())
-                        .and_then(|s| s.to_string_lossy().parse::<u64>().ok())
-                    {
-                        max_segment_id = max_segment_id.max(id);
-                    }
-                }
-            }
+        let max_segment_id = match std::fs::read_dir(&self.config.wal_dir) {
+            // Map each yielded entry to its path (a cheap, non-fallible op)
+            // while preserving per-entry iteration errors as `Err`, then fold
+            // to the max segment id. `scan_max_segment_id` propagates those
+            // per-entry errors instead of swallowing them with `.flatten()`.
+            Ok(entries) => Self::scan_max_segment_id(
+                &self.config.wal_dir,
+                entries.map(|entry| entry.map(|e| e.path())),
+            )?,
             // First run: the WAL directory has not been created yet. Treat an
             // absent directory as "no existing segments" and start at id 0.
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            // A genuine I/O error: refuse to proceed rather than under-report
-            // the max segment id and risk appending to an existing segment.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => 0,
+            // A genuine I/O error opening the directory: refuse to proceed
+            // rather than under-report the max segment id and risk appending
+            // to an existing segment.
             Err(e) => {
                 return Err(Error::Storage(StorageError::IoError(format!(
                     "Failed to scan WAL directory {} for existing segments: {}; \
@@ -322,11 +316,45 @@ impl FlushCoordinator {
                     e
                 ))));
             }
-        }
+        };
 
         self.current_segment_id
             .store(max_segment_id, Ordering::Relaxed);
         Ok(())
+    }
+
+    /// Fold a WAL-directory listing into the maximum `NNNNNN.log` segment id.
+    ///
+    /// A per-entry iteration error (an `Err` yielded partway through the
+    /// directory scan) is **propagated**, never swallowed: skipping an entry
+    /// could let the returned max id under-report and default the writer
+    /// toward segment id 0, exactly the fail-loud gap this hardening closes
+    /// (Issue #3423). Extracted from `initialize_from_existing` so the
+    /// per-entry error path is unit-testable without a filesystem mock.
+    fn scan_max_segment_id(
+        wal_dir: &Path,
+        entries: impl Iterator<Item = std::io::Result<PathBuf>>,
+    ) -> Result<u64> {
+        let mut max_segment_id = 0u64;
+        for entry in entries {
+            let path = entry.map_err(|e| {
+                Error::Storage(StorageError::IoError(format!(
+                    "Failed to read a WAL directory entry in {}: {}; \
+                     refusing to start segment allocation at 0 (Issue #3423)",
+                    wal_dir.display(),
+                    e
+                )))
+            })?;
+            if let Some(id) = path
+                .extension()
+                .filter(|ext| *ext == "log")
+                .and_then(|_| path.file_stem())
+                .and_then(|s| s.to_string_lossy().parse::<u64>().ok())
+            {
+                max_segment_id = max_segment_id.max(id);
+            }
+        }
+        Ok(max_segment_id)
     }
 
     /// Get the path for a segment file.
@@ -1280,6 +1308,40 @@ mod tests {
             0,
             "an absent WAL directory yields segment id 0"
         );
+    }
+
+    /// Regression test for Issue #3423 (secondary hardening): a per-entry
+    /// iteration error yielded partway through the WAL-directory scan must
+    /// **propagate**, not be swallowed by `.flatten()`. Swallowing it could
+    /// skip an existing segment, under-report the max id, and default the
+    /// writer toward segment id 0. Exercised directly on the extracted
+    /// `scan_max_segment_id` helper with a synthetic mid-iteration I/O error,
+    /// since a genuine `ReadDir::next()` error is not portably injectable.
+    #[test]
+    fn test_scan_max_segment_id_propagates_per_entry_error() {
+        let wal_dir = Path::new("/some/wal");
+
+        // A well-formed listing with an I/O error yielded between valid
+        // entries must surface the error, not skip past it.
+        let entries: Vec<std::io::Result<PathBuf>> = vec![
+            Ok(wal_dir.join("000001.log")),
+            Err(std::io::Error::other("simulated readdir failure")),
+            Ok(wal_dir.join("000009.log")),
+        ];
+        let result = FlushCoordinator::scan_max_segment_id(wal_dir, entries.into_iter());
+        assert!(
+            result.is_err(),
+            "a per-entry iteration error must propagate, not be swallowed"
+        );
+
+        // Sanity: an all-Ok listing folds to the max id.
+        let ok_entries: Vec<std::io::Result<PathBuf>> = vec![
+            Ok(wal_dir.join("000003.log")),
+            Ok(wal_dir.join("notes.txt")), // ignored (wrong extension)
+            Ok(wal_dir.join("000007.log")),
+        ];
+        let max = FlushCoordinator::scan_max_segment_id(wal_dir, ok_entries.into_iter()).unwrap();
+        assert_eq!(max, 7, "max id folds over well-formed .log entries");
     }
 
     // ============================================================


### PR DESCRIPTION
## Summary

Closes the remaining open item of **Issue #3423** ("WAL appends to existing segments without checking header version").

### Before / after (plain language)

`FlushCoordinator::initialize_from_existing` scans the WAL directory at startup to learn the highest existing segment id, which tells `ensure_segment_open` where to begin allocating new segment ids.

- **Before:** *any* `read_dir` error was swallowed — the code logged an `eprintln!` warning and then defaulted the counter to `0` and returned `Ok(())`. A transient I/O failure during the startup scan therefore silently under-reports the max segment id, and the first flush can land the writer on a pre-existing segment (`000001.log`). Combined with a payload-version bump, appending new-shape entries under an old-version header produces an **unparseable mixed-version segment** — exactly the corruption class the issue describes (CRC mismatch → replay hard-fails, or a desynced offset near EOF → committed writes silently dropped as a torn tail).
- **After:** the two failure modes are distinguished. A **missing** WAL directory (`ErrorKind::NotFound`) — the normal first-run case on a fresh data dir — still succeeds with segment id `0`. Any **other** I/O error (permission denied, not-a-directory, transient failure) now **propagates** instead of silently defaulting to `0`.

The change is confined to `src/storage/wal/flush_coordinator.rs`.

## Design decision & rationale

**Question:** should `initialize_from_existing` propagate `read_dir` errors, or is defaulting-to-0-with-warning acceptable now that the header-version check backstops it?

Applied brainstorming + reverse-brainstorming + six-hats:

- **Brainstorm (options):** (a) keep swallow+warn; (b) propagate all errors; (c) propagate only *genuine* I/O errors, treat "directory absent" as normal first-run.
- **Reverse-brainstorm (how could fail-loud make things worse?):** naively propagating *all* `read_dir` errors would turn a **missing WAL directory into a startup failure**, breaking first-run `open()` on a fresh data dir — unacceptable. (In practice `FlushCoordinator::new` calls `create_dir_all` before the scan, so the dir usually exists by then; but the function must remain correct independent of call-site ordering.)
- **Six-hats:**
  - *White (facts):* the scan result decides id allocation; a wrong low value can poison a segment; the header-version check (landed in PR #3421) is a second line of defense but a swallowed scan error should not be the reason we depend on it.
  - *Black (risk):* over-eager fail-loud breaks first-run.
  - *Yellow (benefit):* fail-loud surfaces real corruption-risk conditions to the operator instead of hiding them behind an `eprintln!`.
  - *Green (creative):* match on `ErrorKind` to separate the benign "not created yet" case from real failures.
  - *Red (gut):* silently proceeding after a failed scan of durability metadata is the wrong default for a database.
  - *Blue (process):* minimal, well-tested, in-lane change.

**Decision → option (c):** `NotFound` ⇒ `Ok` (start at 0); every other error ⇒ propagate. Defense-in-depth alongside the already-landed header-version rollover; first-run is explicitly preserved and covered by a test.

## Verification of the already-landed core fix (header-version rollover)

The primary defensive fix landed on trunk via **PR #3421** (`ensure_segment_open`, `flush_coordinator.rs`). I re-audited the id-allocation loop: the only branch that appends to a non-empty segment is the one where the existing header version **equals** the writer's `write_version`; an empty/absent slot writes a fresh header; a non-empty segment with a differing **or unreadable/no-magic** header rolls the id forward. There is no path that appends across versions, the loop advances monotonically (no infinite loop), and it runs under the writer lock. **No remaining gap found.** Evidence (unchanged, still green):

- `test_ensure_segment_open_rolls_past_mismatched_version_segment` — asserts an existing v3 segment is byte-for-byte untouched, the writer rolls forward to a fresh v9 segment, and full-directory replay succeeds with the new entry's principal intact.
- `test_ensure_segment_open_appends_to_version_matching_segment` — asserts a version-matching segment IS appended to in place (no spurious roll-forward).

## Acceptance criteria checklist

| Issue #3423 requirement | Status | Evidence |
|---|---|---|
| `ensure_segment_open` must not append new-shape entries into an existing older-version segment (read header version, roll to fresh id on mismatch) | ✅ Already resolved on trunk (PR #3421) | `flush_coordinator.rs` `ensure_segment_open` version-rollover loop; `test_ensure_segment_open_rolls_past_mismatched_version_segment`, `test_ensure_segment_open_appends_to_version_matching_segment` |
| A version-matching existing segment IS still appended to (no regression) | ✅ Already resolved on trunk (PR #3421) | `test_ensure_segment_open_appends_to_version_matching_segment` |
| Harden `initialize_from_existing` to not swallow `read_dir` errors — fail loud instead of defaulting to segment id 0 | ✅ This PR | `initialize_from_existing` now returns `Error::Storage(IoError(..))` on non-`NotFound` errors; `test_initialize_from_existing_propagates_real_io_error` |
| A missing WAL directory (first run) must NOT become a startup error | ✅ This PR (explicitly preserved) | `NotFound` arm returns `Ok`; `test_initialize_from_existing_missing_dir_is_ok` |

## Tests

TDD red → green → refactor. New tests in `src/storage/wal/flush_coordinator.rs`:

- `test_initialize_from_existing_propagates_real_io_error` — replaces the WAL dir with a regular file so `read_dir` fails with a real I/O error (not `NotFound`); asserts the scan returns `Err`. Confirmed **RED** against pre-change code (error was swallowed → `Ok`), **GREEN** after.
- `test_initialize_from_existing_missing_dir_is_ok` — removes the WAL dir entirely so the scan hits `NotFound`; asserts `Ok` with segment id `0`.

## Gate results

- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` (exact CI lint set) — **clean** (`Finished` with no warnings).
- `cargo test --lib storage::wal` — **259 passed**; `cargo test --lib storage::recovery` — **23 passed**; `flush_coordinator` module — **30 passed** (incl. the 2 new + 2 existing #3423 regression tests).
- `cargo fmt --all --check` — clean.
- `cargo clippy --all-targets --all-features -- -D warnings` — fails **only** on a **pre-existing, out-of-lane** error in `src/mcp/tests.rs:3849` (`missing field 'derived_from' in CreateNodeRequest`, from the #3371 derivation-lineage merge). Verified pre-existing: it reproduces on trunk HEAD with this branch's change stashed. Not touched here (outside this wave's `src/storage/wal/**` + `src/storage/recovery.rs` lane); flagged as a follow-up for the MCP lane owner.

## Scope note

Change is limited to `src/storage/wal/flush_coordinator.rs` (implementation + tests). No WAL format change, no locking change.