### PR TITLE
Make WriteTransaction write-path reads buffer-aware (#3417)

### DIFF
--- a/src/api/transaction/write/conflict.rs
+++ b/src/api/transaction/write/conflict.rs
@@ -16,7 +16,10 @@
 //! greater than our `snapshot_timestamp`, a conflict has occurred.
 
 use super::WriteTransaction;
+use crate::api::transaction::BufferedWrite;
 use crate::core::error::{Result, TransactionError};
+use crate::core::id::{EdgeId, NodeId};
+use std::collections::HashSet;
 
 /// Detect write-write conflicts for Snapshot Isolation.
 ///
@@ -36,10 +39,41 @@ use crate::core::error::{Result, TransactionError};
 ///
 /// Returns `TransactionError::SerializationFailure` if a write-write conflict is detected.
 pub(crate) fn detect_conflicts(tx: &WriteTransaction) -> Result<()> {
+    // Entities CREATED in this same transaction cannot conflict with another
+    // transaction (Issue #3417): their ids were freshly allocated by this
+    // tx's id generators, so no other committed transaction can hold a version
+    // for them. A later update/delete/retract of a same-tx-created entity
+    // reads its buffered create (read-your-own-writes), which means the
+    // absence of a *committed* row is expected — not a concurrent deletion.
+    // Without this skip, the "missing committed row => deleted by another tx"
+    // branches below would raise a spurious SerializationFailure for a
+    // create-then-update/delete/retract in one transaction.
+    let created_nodes: HashSet<NodeId> = tx
+        .buffer
+        .operations()
+        .iter()
+        .filter_map(|w| match w {
+            BufferedWrite::CreateNode { node_id, .. } => Some(*node_id),
+            _ => None,
+        })
+        .collect();
+    let created_edges: HashSet<EdgeId> = tx
+        .buffer
+        .operations()
+        .iter()
+        .filter_map(|w| match w {
+            BufferedWrite::CreateEdge { edge_id, .. } => Some(*edge_id),
+            _ => None,
+        })
+        .collect();
+
     for write in tx.buffer.operations() {
         match write {
             // UpdateNode: check if node was modified or deleted after our snapshot
             crate::api::transaction::BufferedWrite::UpdateNode { node_id, .. } => {
+                if created_nodes.contains(node_id) {
+                    continue;
+                }
                 match tx.current.get_node(*node_id) {
                     Ok(current_node) => {
                         // Node exists - check if it was modified after our snapshot
@@ -71,6 +105,9 @@ pub(crate) fn detect_conflicts(tx: &WriteTransaction) -> Result<()> {
 
             // UpdateEdge: check if edge was modified or deleted after our snapshot
             crate::api::transaction::BufferedWrite::UpdateEdge { edge_id, .. } => {
+                if created_edges.contains(edge_id) {
+                    continue;
+                }
                 match tx.current.get_edge(*edge_id) {
                     Ok(current_edge) => {
                         // Edge exists - check if it was modified after our snapshot
@@ -100,6 +137,9 @@ pub(crate) fn detect_conflicts(tx: &WriteTransaction) -> Result<()> {
 
             // DeleteNode: check if node was modified after our snapshot
             crate::api::transaction::BufferedWrite::DeleteNode { node_id, .. } => {
+                if created_nodes.contains(node_id) {
+                    continue;
+                }
                 // Get current version from storage
                 if let Ok(current_node) = tx.current.get_node(*node_id)
                     && let Some(commit_ts) = current_node.metadata.commit_timestamp
@@ -118,6 +158,9 @@ pub(crate) fn detect_conflicts(tx: &WriteTransaction) -> Result<()> {
 
             // DeleteEdge: check if edge was modified after our snapshot
             crate::api::transaction::BufferedWrite::DeleteEdge { edge_id, .. } => {
+                if created_edges.contains(edge_id) {
+                    continue;
+                }
                 // Get current version from storage
                 if let Ok(current_edge) = tx.current.get_edge(*edge_id)
                     && let Some(commit_ts) = current_edge.metadata.commit_timestamp
@@ -139,6 +182,9 @@ pub(crate) fn detect_conflicts(tx: &WriteTransaction) -> Result<()> {
             // (entity gone) or a concurrent update (newer commit) both
             // invalidate the valid_from this retraction was validated against.
             crate::api::transaction::BufferedWrite::RetractNode { node_id, .. } => {
+                if created_nodes.contains(node_id) {
+                    continue;
+                }
                 match tx.current.get_node(*node_id) {
                     Ok(current_node) => {
                         if let Some(commit_ts) = current_node.metadata.commit_timestamp
@@ -166,6 +212,9 @@ pub(crate) fn detect_conflicts(tx: &WriteTransaction) -> Result<()> {
 
             // RetractEdge: same contract as RetractNode.
             crate::api::transaction::BufferedWrite::RetractEdge { edge_id, .. } => {
+                if created_edges.contains(edge_id) {
+                    continue;
+                }
                 match tx.current.get_edge(*edge_id) {
                     Ok(current_edge) => {
                         if let Some(commit_ts) = current_edge.metadata.commit_timestamp

--- a/src/api/transaction/write/conflict.rs
+++ b/src/api/transaction/write/conflict.rs
@@ -48,24 +48,19 @@ pub(crate) fn detect_conflicts(tx: &WriteTransaction) -> Result<()> {
     // Without this skip, the "missing committed row => deleted by another tx"
     // branches below would raise a spurious SerializationFailure for a
     // create-then-update/delete/retract in one transaction.
-    let created_nodes: HashSet<NodeId> = tx
-        .buffer
-        .operations()
-        .iter()
-        .filter_map(|w| match w {
-            BufferedWrite::CreateNode { node_id, .. } => Some(*node_id),
-            _ => None,
-        })
-        .collect();
-    let created_edges: HashSet<EdgeId> = tx
-        .buffer
-        .operations()
-        .iter()
-        .filter_map(|w| match w {
-            BufferedWrite::CreateEdge { edge_id, .. } => Some(*edge_id),
-            _ => None,
-        })
-        .collect();
+    let mut created_nodes: HashSet<NodeId> = HashSet::new();
+    let mut created_edges: HashSet<EdgeId> = HashSet::new();
+    for write in tx.buffer.operations() {
+        match write {
+            BufferedWrite::CreateNode { node_id, .. } => {
+                created_nodes.insert(*node_id);
+            }
+            BufferedWrite::CreateEdge { edge_id, .. } => {
+                created_edges.insert(*edge_id);
+            }
+            _ => {}
+        }
+    }
 
     for write in tx.buffer.operations() {
         match write {

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -1457,11 +1457,17 @@ impl WriteOps for WriteTransaction {
         // Collect all edges connected to this node (both outgoing and incoming)
         // We do this before any deletions to avoid borrowing issues
         //
-        // LIMITATION: This uses ReadOps methods which currently don't support
-        // read-your-writes semantics for edge traversal. This means edges created
-        // in the same transaction (but not yet committed) won't be found and deleted.
-        // This is consistent with the existing ReadOps behavior but may leave orphaned
-        // edges in same-transaction scenarios. See issue for future improvement.
+        // LIMITATION (buffer-aware cascade adjacency — tracked for #3416):
+        // the #3417 read-your-own-writes fix makes the node existence check
+        // (above) and per-edge delete_edge reads buffer-aware, but the
+        // adjacency ENUMERATION below still routes through
+        // get_outgoing_edges/get_incoming_edges, which read committed
+        // adjacency only. So a same-tx create_node → create_edge → cascade
+        // does NOT see (and cannot delete) the same-tx-created edge, which can
+        // leave it orphaned. Buffer-aware adjacency is deferred to #3416. Note
+        // this does not affect the MCP #3209 refuse/detach idempotency
+        // contract, which is enforced at the MCP layer over committed
+        // adjacency and is unaffected by this gap.
         let outgoing_edges = self.get_outgoing_edges(node_id)?;
         let incoming_edges = self.get_incoming_edges(node_id)?;
 

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -798,13 +798,34 @@ impl WriteTransaction {
     }
 }
 
-impl ReadOps for WriteTransaction {
-    fn get_node(&self, id: NodeId) -> Result<Node> {
-        let buffered_result = self
-            .buffer
+impl WriteTransaction {
+    /// Resolve a node purely from THIS transaction's write buffer, if it has a
+    /// buffered write for it (read-your-own-writes, Issue #3417).
+    ///
+    /// Returns:
+    /// - `Some(Ok(node))` for a buffered `CreateNode`/`UpdateNode` (the node's
+    ///   in-flight state),
+    /// - `Some(Err(NodeNotFound))` for a buffered `DeleteNode`/`RetractNode`
+    ///   (removed in this tx),
+    /// - `None` when the buffer holds no write for this id, so the caller
+    ///   falls back to committed storage.
+    ///
+    /// This is the single source of buffer-resolution shared by the
+    /// snapshot-isolated [`ReadOps::get_node`] and the write-path
+    /// [`read_own_node`](Self::read_own_node); the two differ only in how they
+    /// treat the committed fallback.
+    fn buffered_node(&self, id: NodeId) -> Option<Result<Node>> {
+        self.buffer
             .get_node_write(id)
             .and_then(|buffered| match buffered {
                 super::BufferedWrite::CreateNode {
+                    node_id,
+                    label,
+                    properties,
+                    version_id,
+                    ..
+                }
+                | super::BufferedWrite::UpdateNode {
                     node_id,
                     label,
                     properties,
@@ -820,15 +841,42 @@ impl ReadOps for WriteTransaction {
                         commit_timestamp: None, // Not yet committed
                     },
                 ))),
-                super::BufferedWrite::UpdateNode {
-                    node_id,
+                super::BufferedWrite::DeleteNode { .. }
+                | super::BufferedWrite::RetractNode { .. } => {
+                    Some(Err(StorageError::NodeNotFound(id).into()))
+                }
+                _ => None, // Not a node operation
+            })
+    }
+
+    /// Resolve an edge purely from THIS transaction's write buffer; see
+    /// [`buffered_node`](Self::buffered_node).
+    fn buffered_edge(&self, id: EdgeId) -> Option<Result<Edge>> {
+        self.buffer
+            .get_edge_write(id)
+            .and_then(|buffered| match buffered {
+                super::BufferedWrite::CreateEdge {
+                    edge_id,
+                    source,
+                    target,
                     label,
                     properties,
                     version_id,
                     ..
-                } => Some(Ok(Node::with_metadata(
-                    *node_id,
+                }
+                | super::BufferedWrite::UpdateEdge {
+                    edge_id,
+                    source,
+                    target,
+                    label,
+                    properties,
+                    version_id,
+                    ..
+                } => Some(Ok(Edge::with_metadata(
+                    *edge_id,
                     *label,
+                    *source,
+                    *target,
                     properties.clone(),
                     *version_id,
                     VersionMetadata {
@@ -836,12 +884,45 @@ impl ReadOps for WriteTransaction {
                         commit_timestamp: None,
                     },
                 ))),
-                super::BufferedWrite::DeleteNode { .. }
-                | super::BufferedWrite::RetractNode { .. } => {
-                    Some(Err(StorageError::NodeNotFound(id).into()))
+                super::BufferedWrite::DeleteEdge { .. }
+                | super::BufferedWrite::RetractEdge { .. } => {
+                    Some(Err(StorageError::EdgeNotFound(id).into()))
                 }
-                _ => None, // Not a node operation
-            });
+                _ => None, // Not an edge operation
+            })
+    }
+
+    /// Read-your-own-writes resolution for the mutating WRITE path (Issue
+    /// #3417): consult this tx's buffer first, then fall back to the latest
+    /// committed version via a **direct** current-storage read.
+    ///
+    /// Unlike [`ReadOps::get_node`], the committed fallback here does NOT apply
+    /// snapshot-visibility filtering. The write path must operate on the latest
+    /// committed version and relies on [`conflict::detect_conflicts`] for
+    /// snapshot-isolation correctness: a version committed at or after this
+    /// tx's snapshot must still be found so the update/delete/retract proceeds
+    /// and the write-write conflict is caught at commit — filtering it out
+    /// would spuriously 404 a live node. The buffer branch makes an entity
+    /// created/updated earlier in THIS transaction visible to a later write.
+    fn read_own_node(&self, id: NodeId) -> Result<Node> {
+        if let Some(buffered) = self.buffered_node(id) {
+            return buffered;
+        }
+        self.current.get_node(id)
+    }
+
+    /// Edge counterpart of [`read_own_node`](Self::read_own_node).
+    fn read_own_edge(&self, id: EdgeId) -> Result<Edge> {
+        if let Some(buffered) = self.buffered_edge(id) {
+            return buffered;
+        }
+        self.current.get_edge(id)
+    }
+}
+
+impl ReadOps for WriteTransaction {
+    fn get_node(&self, id: NodeId) -> Result<Node> {
+        let buffered_result = self.buffered_node(id);
 
         let result = if let Some(result) = buffered_result {
             result
@@ -868,56 +949,7 @@ impl ReadOps for WriteTransaction {
     }
 
     fn get_edge(&self, id: EdgeId) -> Result<Edge> {
-        let buffered_result = self
-            .buffer
-            .get_edge_write(id)
-            .and_then(|buffered| match buffered {
-                super::BufferedWrite::CreateEdge {
-                    edge_id,
-                    source,
-                    target,
-                    label,
-                    properties,
-                    version_id,
-                    ..
-                } => Some(Ok(Edge::with_metadata(
-                    *edge_id,
-                    *label,
-                    *source,
-                    *target,
-                    properties.clone(),
-                    *version_id,
-                    VersionMetadata {
-                        created_by_tx: self.tx_id,
-                        commit_timestamp: None,
-                    },
-                ))),
-                super::BufferedWrite::UpdateEdge {
-                    edge_id,
-                    source,
-                    target,
-                    label,
-                    properties,
-                    version_id,
-                    ..
-                } => Some(Ok(Edge::with_metadata(
-                    *edge_id,
-                    *label,
-                    *source,
-                    *target,
-                    properties.clone(),
-                    *version_id,
-                    VersionMetadata {
-                        created_by_tx: self.tx_id,
-                        commit_timestamp: None,
-                    },
-                ))),
-                super::BufferedWrite::DeleteEdge { .. }
-                | super::BufferedWrite::RetractEdge { .. } => {
-                    Some(Err(StorageError::EdgeNotFound(id).into()))
-                }
-                _ => None, // Not an edge operation
-            });
+        let buffered_result = self.buffered_edge(id);
 
         let result = if let Some(result) = buffered_result {
             result
@@ -1200,8 +1232,12 @@ impl WriteOps for WriteTransaction {
                 .into());
             }
 
-            // Get current node to preserve label and existing properties
-            let node = self.current.get_node(node_id)?;
+            // Get current node to preserve label and existing properties.
+            // Buffer-aware read (Issue #3417): read-your-own-writes so an
+            // update of a node created/updated earlier in THIS transaction
+            // merges onto the buffered state, not committed-only storage
+            // (which would 404 a same-tx-created node).
+            let node = self.read_own_node(node_id)?;
             let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
 
             // PATCH semantics: Merge new properties with existing ones
@@ -1223,7 +1259,11 @@ impl WriteOps for WriteTransaction {
             // Validate valid_from is not too far in future
             validation::validate_valid_from_future(valid_from)?;
 
-            // Validate valid_from is not before entity creation
+            // Validate valid_from is not before entity creation.
+            // A node created earlier in THIS transaction is not yet in
+            // historical storage (that happens at commit), so
+            // `node_creation_time` returns None and this check is skipped —
+            // acceptable for v1 read-your-own-writes (Issue #3417).
             let creation_time = {
                 let historical = self.historical.read();
                 historical.node_creation_time(node_id)
@@ -1276,8 +1316,11 @@ impl WriteOps for WriteTransaction {
                 .into());
             }
 
-            // Get current edge to preserve source, target, label and existing properties
-            let edge = self.current.get_edge(edge_id)?;
+            // Get current edge to preserve source, target, label and existing
+            // properties. Buffer-aware read (Issue #3417): read-your-own-writes
+            // so an update of a same-tx-created/updated edge merges onto the
+            // buffered state instead of 404-ing against committed storage.
+            let edge = self.read_own_edge(edge_id)?;
             let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
 
             // PATCH semantics: Merge new properties with existing ones
@@ -1353,8 +1396,10 @@ impl WriteOps for WriteTransaction {
                 .into());
             }
 
-            // Verify node exists and check for vector properties
-            let node = self.current.get_node(node_id)?;
+            // Verify node exists and check for vector properties.
+            // Buffer-aware read (Issue #3417): a node created earlier in THIS
+            // transaction is deletable (read-your-own-writes).
+            let node = self.read_own_node(node_id)?;
 
             // If the node being deleted contains vector properties, mark the buffer
             // to ensure the temporal vector index is notified on commit
@@ -1404,8 +1449,10 @@ impl WriteOps for WriteTransaction {
             .into());
         }
 
-        // Verify node exists before attempting deletion
-        let _node = self.current.get_node(node_id)?;
+        // Verify node exists before attempting deletion.
+        // Buffer-aware read (Issue #3417): a node created earlier in THIS
+        // transaction can be cascade-deleted (read-your-own-writes).
+        let _node = self.read_own_node(node_id)?;
 
         // Collect all edges connected to this node (both outgoing and incoming)
         // We do this before any deletions to avoid borrowing issues
@@ -1447,8 +1494,10 @@ impl WriteOps for WriteTransaction {
                 .into());
             }
 
-            // Verify edge exists and check for vector properties
-            let edge = self.current.get_edge(edge_id)?;
+            // Verify edge exists and check for vector properties.
+            // Buffer-aware read (Issue #3417): an edge created earlier in THIS
+            // transaction is deletable (read-your-own-writes).
+            let edge = self.read_own_edge(edge_id)?;
 
             // If the edge being deleted contains vector properties, mark the buffer
             // to ensure the temporal vector index is notified on commit
@@ -1581,7 +1630,11 @@ impl WriteTransaction {
                 _ => {}
             }
 
-            match self.current.get_node(node_id) {
+            // Buffer-aware read (Issue #3417): a node created earlier in THIS
+            // transaction is retractable (read-your-own-writes). The buffered
+            // Retract/Delete cases are already handled by the guard above; a
+            // buffered Create/Update falls through to here.
+            match self.read_own_node(node_id) {
                 Ok(node) => {
                     // If the node being retracted contains vector properties, mark
                     // the buffer so the temporal vector index is notified on commit.
@@ -1683,7 +1736,9 @@ impl WriteTransaction {
                 _ => {}
             }
 
-            match self.current.get_edge(edge_id) {
+            // Buffer-aware read (Issue #3417): an edge created earlier in THIS
+            // transaction is retractable (read-your-own-writes).
+            match self.read_own_edge(edge_id) {
                 Ok(edge) => {
                     if !self.buffer.has_vector_operations() && edge.properties.contains_vector() {
                         self.buffer.mark_has_vector_operations();

--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -4429,3 +4429,393 @@ mod lock_poisoning_tests {
         }
     }
 }
+
+/// Issue #3417: write-path reads must be buffer-aware (read-your-own-writes).
+///
+/// An entity created earlier in the SAME transaction must be visible to a
+/// later update/delete/retract in that transaction, and a same-tx
+/// create-then-update/delete must NOT raise a spurious write-write conflict at
+/// commit. Cross-transaction isolation must be preserved: an entity created by
+/// another, still-uncommitted transaction stays invisible.
+#[cfg(test)]
+mod buffer_aware_read_tests {
+    use super::*;
+    use crate::core::id::TxIdGenerator;
+    use crate::core::property::PropertyMapBuilder;
+    use crate::storage::wal::concurrent_system::ConcurrentWalSystemConfig;
+    use tempfile::TempDir;
+
+    /// Shared infrastructure so multiple transactions observe the same
+    /// storage / visibility manager (needed for the cross-tx isolation test).
+    struct TestHarness {
+        current: Arc<CurrentStorage>,
+        historical: Arc<RwLock<HistoricalStorage>>,
+        temporal_indexes: Arc<TemporalIndexes>,
+        wal: Arc<ConcurrentWalSystem>,
+        current_timestamp: Arc<Mutex<Timestamp>>,
+        visibility_manager: Arc<TxVisibilityManager>,
+        node_id_gen: Arc<IdGenerator>,
+        edge_id_gen: Arc<IdGenerator>,
+        version_id_gen: Arc<IdGenerator>,
+        tx_id_gen: TxIdGenerator,
+        _temp_dir: TempDir,
+    }
+
+    impl TestHarness {
+        fn new() -> Self {
+            let current = Arc::new(CurrentStorage::new());
+            let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
+            let temporal_indexes = Arc::new(TemporalIndexes::new());
+
+            let temp_dir = TempDir::new().unwrap();
+            let wal_config = ConcurrentWalSystemConfig::new(temp_dir.path());
+            let wal = Arc::new(ConcurrentWalSystem::new(wal_config).unwrap());
+
+            let current_timestamp = Arc::new(Mutex::new(time::now()));
+            let node_id_gen = Arc::new(IdGenerator::new());
+            let edge_id_gen = Arc::new(IdGenerator::new());
+            let version_id_gen = Arc::new(IdGenerator::new());
+            let tx_id_gen = TxIdGenerator::new();
+            let visibility_manager = Arc::new(TxVisibilityManager::new());
+
+            TestHarness {
+                current,
+                historical,
+                temporal_indexes,
+                wal,
+                current_timestamp,
+                visibility_manager,
+                node_id_gen,
+                edge_id_gen,
+                version_id_gen,
+                tx_id_gen,
+                _temp_dir: temp_dir,
+            }
+        }
+
+        fn create_tx(&self) -> WriteTransaction {
+            let snapshot = TransactionSnapshot {
+                snapshot_timestamp: *self.current_timestamp.lock().unwrap(),
+                active_transactions: Arc::new(std::collections::HashSet::new()),
+            };
+
+            WriteTransaction::new(
+                self.tx_id_gen.next(),
+                snapshot,
+                self.current.clone(),
+                self.historical.clone(),
+                self.temporal_indexes.clone(),
+                self.wal.clone(),
+                self.current_timestamp.clone(),
+                self.visibility_manager.clone(),
+                self.node_id_gen.clone(),
+                self.edge_id_gen.clone(),
+                self.version_id_gen.clone(),
+            )
+        }
+    }
+
+    /// create_node then update_node in one tx: the update sees the buffered
+    /// create (no NodeNotFound) and PATCH-merges onto the buffered properties.
+    #[test]
+    fn test_3417_create_then_update_node_same_tx() {
+        let harness = TestHarness::new();
+        let mut tx = harness.create_tx();
+
+        let node_id = tx
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("name", "Alice")
+                    .insert("age", 30i64)
+                    .build(),
+            )
+            .unwrap();
+
+        // Update the just-created node in the SAME transaction.
+        tx.update_node(
+            node_id,
+            PropertyMapBuilder::new()
+                .insert("age", 31i64)
+                .insert("city", "NYC")
+                .build(),
+        )
+        .expect("update of same-tx-created node must succeed (read-your-own-writes)");
+
+        tx.commit().unwrap();
+
+        let node = harness.current.get_node(node_id).unwrap();
+        // Merge composed onto the buffered CREATE, not committed-only state.
+        assert_eq!(
+            node.get_property("name").and_then(|v| v.as_str()),
+            Some("Alice"),
+            "original property from the buffered create must survive the merge"
+        );
+        assert_eq!(
+            node.get_property("age").and_then(|v| v.as_int()),
+            Some(31),
+            "updated property must overwrite the created value"
+        );
+        assert_eq!(
+            node.get_property("city").and_then(|v| v.as_str()),
+            Some("NYC"),
+            "new property from the update must be present"
+        );
+    }
+
+    /// create_node then delete_node in one tx: delete sees the buffered create
+    /// (no NodeNotFound) and the node is absent after commit.
+    #[test]
+    fn test_3417_create_then_delete_node_same_tx() {
+        let harness = TestHarness::new();
+        let mut tx = harness.create_tx();
+
+        let node_id = tx
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Bob").build(),
+            )
+            .unwrap();
+
+        tx.delete_node(node_id)
+            .expect("delete of same-tx-created node must succeed (read-your-own-writes)");
+
+        tx.commit().unwrap();
+
+        assert!(
+            harness.current.get_node(node_id).is_err(),
+            "node created then deleted in one tx must be absent after commit"
+        );
+    }
+
+    /// create_edge then update_edge in one tx: the update sees the buffered
+    /// create and PATCH-merges onto the buffered edge properties.
+    #[test]
+    fn test_3417_create_then_update_edge_same_tx() {
+        let harness = TestHarness::new();
+        let mut tx = harness.create_tx();
+
+        let n1 = tx
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n2 = tx
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let edge_id = tx
+            .create_edge(
+                n1,
+                n2,
+                "KNOWS",
+                PropertyMapBuilder::new().insert("weight", 5i64).build(),
+            )
+            .unwrap();
+
+        tx.update_edge(
+            edge_id,
+            PropertyMapBuilder::new()
+                .insert("weight", 10i64)
+                .insert("since", 2020i64)
+                .build(),
+        )
+        .expect("update of same-tx-created edge must succeed (read-your-own-writes)");
+
+        tx.commit().unwrap();
+
+        let edge = harness.current.get_edge(edge_id).unwrap();
+        assert_eq!(
+            edge.get_property("weight").and_then(|v| v.as_int()),
+            Some(10),
+            "updated edge property must overwrite the created value"
+        );
+        assert_eq!(
+            edge.get_property("since").and_then(|v| v.as_int()),
+            Some(2020),
+            "new edge property from the update must be present"
+        );
+    }
+
+    /// create_edge then delete_edge in one tx: delete sees the buffered create
+    /// and the edge is absent after commit (endpoints remain).
+    #[test]
+    fn test_3417_create_then_delete_edge_same_tx() {
+        let harness = TestHarness::new();
+        let mut tx = harness.create_tx();
+
+        let n1 = tx
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n2 = tx
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let edge_id = tx
+            .create_edge(n1, n2, "KNOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        tx.delete_edge(edge_id)
+            .expect("delete of same-tx-created edge must succeed (read-your-own-writes)");
+
+        tx.commit().unwrap();
+
+        assert!(
+            harness.current.get_edge(edge_id).is_err(),
+            "edge created then deleted in one tx must be absent after commit"
+        );
+        assert!(
+            harness.current.get_node(n1).is_ok() && harness.current.get_node(n2).is_ok(),
+            "endpoints must remain after the same-tx edge delete"
+        );
+    }
+
+    /// create_node then retract_node in one tx: retract sees the buffered
+    /// create (no NodeNotFound) and closes the valid interval.
+    #[test]
+    fn test_3417_create_then_retract_node_same_tx() {
+        let harness = TestHarness::new();
+        let mut tx = harness.create_tx();
+
+        let node_id = tx
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Carol").build(),
+            )
+            .unwrap();
+
+        let valid_to = time::now();
+        let result = tx
+            .retract_node(node_id, valid_to)
+            .expect("retract of same-tx-created node must succeed (read-your-own-writes)");
+        assert!(
+            !result.already_retracted,
+            "a freshly-created node is not already retracted"
+        );
+
+        tx.commit().unwrap();
+
+        assert!(
+            harness.current.get_node(node_id).is_err(),
+            "retracted node must be absent from current state after commit"
+        );
+    }
+
+    /// create_edge then retract_edge in one tx.
+    #[test]
+    fn test_3417_create_then_retract_edge_same_tx() {
+        let harness = TestHarness::new();
+        let mut tx = harness.create_tx();
+
+        let n1 = tx
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n2 = tx
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let edge_id = tx
+            .create_edge(n1, n2, "KNOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        let valid_to = time::now();
+        let result = tx
+            .retract_edge(edge_id, valid_to)
+            .expect("retract of same-tx-created edge must succeed (read-your-own-writes)");
+        assert!(!result.already_retracted);
+
+        tx.commit().unwrap();
+
+        assert!(
+            harness.current.get_edge(edge_id).is_err(),
+            "retracted edge must be absent from current state after commit"
+        );
+    }
+
+    /// A same-tx create-then-update must NOT raise a spurious
+    /// SerializationFailure at commit: `detect_conflicts` treats a missing
+    /// committed row as "deleted by another tx", but a same-tx-created entity
+    /// has no committed row by design. This exercises the conflict.rs skip.
+    #[test]
+    fn test_3417_create_then_update_no_spurious_conflict() {
+        let harness = TestHarness::new();
+        let mut tx = harness.create_tx();
+
+        let node_id = tx
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("v", 1i64).build(),
+            )
+            .unwrap();
+        tx.update_node(node_id, PropertyMapBuilder::new().insert("v", 2i64).build())
+            .unwrap();
+
+        let result = tx.commit();
+        assert!(
+            result.is_ok(),
+            "create-then-update in one tx must commit without a spurious \
+             write-write conflict, got: {:?}",
+            result.err()
+        );
+    }
+
+    /// Collapse: create then delete the same node in one tx commits cleanly
+    /// (no phantom left behind, node absent).
+    #[test]
+    fn test_3417_create_then_delete_collapse_commits_clean() {
+        let harness = TestHarness::new();
+        let node_before = harness.current.node_count();
+
+        let mut tx = harness.create_tx();
+        let node_id = tx
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("x", 1i64).build(),
+            )
+            .unwrap();
+        tx.delete_node(node_id).unwrap();
+
+        tx.commit()
+            .expect("create-then-delete collapse must commit cleanly");
+
+        assert!(
+            harness.current.get_node(node_id).is_err(),
+            "collapsed node must be absent"
+        );
+        assert_eq!(
+            harness.current.node_count(),
+            node_before,
+            "no phantom node should remain after a create-then-delete collapse"
+        );
+    }
+
+    /// Cross-transaction isolation preserved: an entity created by another,
+    /// still-uncommitted transaction stays invisible (buffer-awareness is
+    /// strictly per-transaction, it does not leak reads across txns).
+    #[test]
+    fn test_3417_cross_tx_created_entity_invisible() {
+        let harness = TestHarness::new();
+
+        let mut tx_a = harness.create_tx();
+        let node_id = tx_a
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Dana").build(),
+            )
+            .unwrap();
+
+        // A concurrent, independent transaction must not see tx_a's buffered
+        // (uncommitted) create.
+        let mut tx_b = harness.create_tx();
+        assert!(
+            ReadOps::get_node(&tx_b, node_id).is_err(),
+            "an uncommitted create in another tx must be invisible"
+        );
+        assert!(
+            tx_b.update_node(
+                node_id,
+                PropertyMapBuilder::new().insert("name", "X").build()
+            )
+            .is_err(),
+            "updating an entity created by another uncommitted tx must fail NotFound"
+        );
+
+        drop(tx_a);
+        drop(tx_b);
+    }
+}

--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -4754,10 +4754,214 @@ mod buffer_aware_read_tests {
         );
     }
 
-    /// Collapse: create then delete the same node in one tx commits cleanly
-    /// (no phantom left behind, node absent).
+    /// Headline #3417 scenario for nodes: create → update → update in ONE tx.
+    /// The SECOND update must read-your-own-writes onto the FIRST update's
+    /// buffered state (not a stale committed/created read), so all three
+    /// writes compose in the committed result.
     #[test]
-    fn test_3417_create_then_delete_collapse_commits_clean() {
+    fn test_3417_create_update_update_node_chain_merges() {
+        let harness = TestHarness::new();
+        let mut tx = harness.create_tx();
+
+        let node_id = tx
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("name", "Alice")
+                    .insert("age", 30i64)
+                    .build(),
+            )
+            .unwrap();
+        // First update: sets age onto the buffered CREATE.
+        tx.update_node(
+            node_id,
+            PropertyMapBuilder::new().insert("age", 31i64).build(),
+        )
+        .unwrap();
+        // Second update: MUST merge onto the buffered FIRST update, adding a
+        // new key while preserving the first update's age and the created name.
+        tx.update_node(
+            node_id,
+            PropertyMapBuilder::new().insert("city", "NYC").build(),
+        )
+        .unwrap();
+
+        tx.commit().unwrap();
+
+        let node = harness.current.get_node(node_id).unwrap();
+        assert_eq!(
+            node.get_property("name").and_then(|v| v.as_str()),
+            Some("Alice"),
+            "created property must survive both updates"
+        );
+        assert_eq!(
+            node.get_property("age").and_then(|v| v.as_int()),
+            Some(31),
+            "first update must survive the second (chained merge, not stale read)"
+        );
+        assert_eq!(
+            node.get_property("city").and_then(|v| v.as_str()),
+            Some("NYC"),
+            "second update's new key must be present"
+        );
+    }
+
+    /// Headline #3417 scenario for a COMMITTED node: two updates in one tx must
+    /// compose — the second reads the buffered first update, not committed
+    /// state (which is exactly the bug: a second write dropping the first's
+    /// merge). This is the multi-write-per-committed-entity case #3417 names.
+    #[test]
+    fn test_3417_double_update_committed_node_composes() {
+        let harness = TestHarness::new();
+
+        let node_id = {
+            let mut tx = harness.create_tx();
+            let id = tx
+                .create_node(
+                    "Person",
+                    PropertyMapBuilder::new()
+                        .insert("name", "Bob")
+                        .insert("age", 40i64)
+                        .build(),
+                )
+                .unwrap();
+            tx.commit().unwrap();
+            id
+        };
+
+        let mut tx = harness.create_tx();
+        // First update onto committed state.
+        tx.update_node(
+            node_id,
+            PropertyMapBuilder::new().insert("age", 41i64).build(),
+        )
+        .unwrap();
+        // Second update MUST see the buffered first update (age=41) and add a
+        // key, rather than re-reading committed state (age=40) and dropping it.
+        tx.update_node(
+            node_id,
+            PropertyMapBuilder::new().insert("city", "LA").build(),
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        let node = harness.current.get_node(node_id).unwrap();
+        assert_eq!(
+            node.get_property("name").and_then(|v| v.as_str()),
+            Some("Bob"),
+            "committed property untouched by the updates must survive"
+        );
+        assert_eq!(
+            node.get_property("age").and_then(|v| v.as_int()),
+            Some(41),
+            "first update must not be dropped by the second (composed merge)"
+        );
+        assert_eq!(
+            node.get_property("city").and_then(|v| v.as_str()),
+            Some("LA"),
+            "second update's key must be present"
+        );
+    }
+
+    /// Edge equivalent of the headline scenario: create → update → update edge
+    /// in ONE tx composes all three writes.
+    #[test]
+    fn test_3417_create_update_update_edge_chain_merges() {
+        let harness = TestHarness::new();
+        let mut tx = harness.create_tx();
+
+        let n1 = tx
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n2 = tx
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let edge_id = tx
+            .create_edge(
+                n1,
+                n2,
+                "KNOWS",
+                PropertyMapBuilder::new().insert("weight", 1i64).build(),
+            )
+            .unwrap();
+        tx.update_edge(
+            edge_id,
+            PropertyMapBuilder::new().insert("weight", 2i64).build(),
+        )
+        .unwrap();
+        tx.update_edge(
+            edge_id,
+            PropertyMapBuilder::new().insert("since", 2020i64).build(),
+        )
+        .unwrap();
+
+        tx.commit().unwrap();
+
+        let edge = harness.current.get_edge(edge_id).unwrap();
+        assert_eq!(
+            edge.get_property("weight").and_then(|v| v.as_int()),
+            Some(2),
+            "first edge update must survive the second (chained merge)"
+        );
+        assert_eq!(
+            edge.get_property("since").and_then(|v| v.as_int()),
+            Some(2020),
+            "second edge update's new key must be present"
+        );
+    }
+
+    /// A same-tx create_edge → update_edge must NOT raise a spurious
+    /// SerializationFailure at commit (dedicated edge conflict-skip coverage,
+    /// mirroring the node case).
+    #[test]
+    fn test_3417_create_then_update_edge_no_spurious_conflict() {
+        let harness = TestHarness::new();
+        let mut tx = harness.create_tx();
+
+        let n1 = tx
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n2 = tx
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let edge_id = tx
+            .create_edge(
+                n1,
+                n2,
+                "KNOWS",
+                PropertyMapBuilder::new().insert("weight", 1i64).build(),
+            )
+            .unwrap();
+        tx.update_edge(
+            edge_id,
+            PropertyMapBuilder::new().insert("weight", 2i64).build(),
+        )
+        .unwrap();
+
+        let result = tx.commit();
+        assert!(
+            result.is_ok(),
+            "create-then-update of an edge in one tx must commit without a \
+             spurious write-write conflict, got: {:?}",
+            result.err()
+        );
+    }
+
+    /// Collapse: create then delete the same node in one tx commits cleanly
+    /// and leaves **current state** clean (no phantom, node absent).
+    ///
+    /// Scope: this asserts CURRENT-STATE cleanliness only. The historical
+    /// record is intentionally NOT collapsed: apply replays the buffer in
+    /// order, so it writes a create version AND a delete tombstone, both
+    /// stamped with the same commit_timestamp. The create version therefore
+    /// ends up with a zero-width transaction-time interval (opened and closed
+    /// at the same commit instant) and the tombstone closes the valid-time
+    /// interval — i.e. the node is never visible at any (valid, tx) coordinate
+    /// after this commit. Verifying that bi-temporal shape is out of scope for
+    /// this test (and for #3417); it belongs with the apply/temporal-index
+    /// coverage.
+    #[test]
+    fn test_3417_create_then_delete_collapse_current_state_clean() {
         let harness = TestHarness::new();
         let node_before = harness.current.node_count();
 
@@ -4775,12 +4979,13 @@ mod buffer_aware_read_tests {
 
         assert!(
             harness.current.get_node(node_id).is_err(),
-            "collapsed node must be absent"
+            "collapsed node must be absent from current state"
         );
         assert_eq!(
             harness.current.node_count(),
             node_before,
-            "no phantom node should remain after a create-then-delete collapse"
+            "no phantom node should remain in current state after a \
+             create-then-delete collapse"
         );
     }
 
@@ -4817,5 +5022,72 @@ mod buffer_aware_read_tests {
 
         drop(tx_a);
         drop(tx_b);
+    }
+
+    /// Cross-transaction MVCC safety: the write-path read is deliberately
+    /// UN-filtered (it sees the latest committed version, not just versions
+    /// visible to this tx's snapshot), so a concurrent commit landing AFTER
+    /// tx_b's snapshot is read by tx_b's update — but `detect_conflicts` MUST
+    /// still abort tx_b with `SerializationFailure` at commit (first-committer
+    /// wins). This is the abort the unfiltered read relies on for correctness.
+    #[test]
+    fn test_3417_cross_tx_committed_after_snapshot_still_conflicts() {
+        let harness = TestHarness::new();
+
+        // Committed baseline node.
+        let node_id = {
+            let mut tx = harness.create_tx();
+            let id = tx
+                .create_node(
+                    "Person",
+                    PropertyMapBuilder::new().insert("age", 1i64).build(),
+                )
+                .unwrap();
+            tx.commit().unwrap();
+            id
+        };
+
+        // tx_b captures its snapshot BEFORE tx_a commits.
+        let mut tx_b = harness.create_tx();
+
+        // tx_a commits a new version of the node AFTER tx_b's snapshot.
+        let mut tx_a = harness.create_tx();
+        tx_a.update_node(
+            node_id,
+            PropertyMapBuilder::new().insert("age", 2i64).build(),
+        )
+        .unwrap();
+        tx_a.commit().unwrap();
+
+        // tx_b's write-path read is unfiltered, so this update succeeds (it
+        // reads the just-committed version)...
+        tx_b.update_node(
+            node_id,
+            PropertyMapBuilder::new().insert("age", 3i64).build(),
+        )
+        .unwrap();
+
+        // ...but the commit MUST abort: tx_a committed after tx_b's snapshot.
+        let result = tx_b.commit();
+        assert!(
+            result.is_err(),
+            "tx_b must abort: a concurrent commit landed after its snapshot"
+        );
+        assert!(
+            format!("{:?}", result.unwrap_err()).contains("SerializationFailure"),
+            "expected SerializationFailure (first-committer-wins)"
+        );
+
+        // First committer (tx_a) wins.
+        assert_eq!(
+            harness
+                .current
+                .get_node(node_id)
+                .unwrap()
+                .get_property("age")
+                .and_then(|v| v.as_int()),
+            Some(2),
+            "first committer's value must stand"
+        );
     }
 }


### PR DESCRIPTION
Fixes the core gap in #3417: `WriteTransaction`'s mutating write-path reads were not buffer-aware.

## Before / After (plain language)

**Before:** `update_node`/`update_edge`/`delete_node`/`delete_edge`/`retract_node`/`retract_edge` (and `delete_node_cascade`) read **committed current storage directly** (`self.current.get_node/get_edge`). An entity created earlier in the SAME transaction is not in committed storage yet, so a later update/delete/retract of that same-tx-created node/edge failed with `NodeNotFound`/`EdgeNotFound` at op time. Worse, even against a committed entity, a same-tx `create → update` would raise a **spurious `SerializationFailure`** at commit, because `detect_conflicts` treats "no committed row" as "deleted by another transaction"; and a **second write to the same entity in one tx** re-read stale committed state, silently dropping the first write's merge.

**After:** those reads go through new buffer-aware helpers (read-your-own-writes). A same-tx-created entity is visible to a later write; a PATCH update merges onto the **buffered** created/updated properties; chained writes compose (second update sees the first); and `detect_conflicts` skips same-tx-created entities so `create → update/delete/retract` in one transaction commits cleanly. Cross-transaction isolation and MVCC first-committer-wins are unchanged.

## How

- **`buffered_node` / `buffered_edge`** (`src/api/transaction/write/mod.rs`): single shared source of buffer resolution — `Some(Ok(entity))` for a buffered `Create*`/`Update*`, `Some(Err(NotFound))` for a buffered `Delete*`/`Retract*`, `None` to fall back to storage. `ReadOps::get_node`/`get_edge` refactored to use them (no behavior change for snapshot-isolated reads).
- **`read_own_node` / `read_own_edge`** (`src/api/transaction/write/mod.rs`): the write-path readers — buffer first, then a **direct** committed read **without** snapshot-visibility filtering. This is the load-bearing distinction from `ReadOps::get_node`: the write path must operate on the *latest committed* version and relies on `detect_conflicts` for snapshot-isolation correctness. A visibility-filtered read would 404 a live node committed at/after the tx snapshot (it did — it broke 23 existing conflict/validation tests before this distinction was introduced).
- **`conflict.rs`**: a single pass over the buffer collects the ids with a buffered `CreateNode`/`CreateEdge`, then the Update/Delete/Retract branches `continue` past them. A freshly-allocated id cannot collide with another transaction's committed version, so skipping is safe and prevents the spurious `SerializationFailure`.
- **`node_creation_time == None`**: a same-tx create is not yet in historical storage, so the backdate-validation `if let Some(creation_time)` naturally skips — documented inline; acceptable for v1.

## AC evidence (from #3417)

All tests live under `api::transaction::write::tests::buffer_aware_read_tests::…`.

| Acceptance criterion | Test | Result |
|---|---|---|
| update reads buffer first (same-tx-created node) + PATCH merge onto buffered props | `test_3417_create_then_update_node_same_tx` | ✅ |
| update reads buffer first (same-tx-created edge) + merge | `test_3417_create_then_update_edge_same_tx` | ✅ |
| delete reads buffer first (same-tx-created node) | `test_3417_create_then_delete_node_same_tx` | ✅ |
| delete reads buffer first (same-tx-created edge; endpoints remain) | `test_3417_create_then_delete_edge_same_tx` | ✅ |
| retract reads buffer first (same-tx-created node) | `test_3417_create_then_retract_node_same_tx` | ✅ |
| retract reads buffer first (same-tx-created edge) | `test_3417_create_then_retract_edge_same_tx` | ✅ |
| **headline: create → update → update (node) composes all three writes onto buffered state** | `test_3417_create_update_update_node_chain_merges` | ✅ |
| **headline: double update of a COMMITTED node composes (2nd sees buffered 1st, not stale committed)** | `test_3417_double_update_committed_node_composes` | ✅ |
| **headline: create → update → update (edge) composes** | `test_3417_create_update_update_edge_chain_merges` | ✅ |
| no spurious `SerializationFailure` for same-tx-created node | `test_3417_create_then_update_no_spurious_conflict` | ✅ |
| no spurious `SerializationFailure` for same-tx-created **edge** (dedicated) | `test_3417_create_then_update_edge_no_spurious_conflict` | ✅ |
| create-then-delete collapse leaves **current state** clean (scope documented in test) | `test_3417_create_then_delete_collapse_current_state_clean` | ✅ |
| cross-tx isolation: other uncommitted tx's create is invisible | `test_3417_cross_tx_created_entity_invisible` | ✅ |
| **cross-tx MVCC: unfiltered write-path read of a commit landing after snapshot still aborts (first-committer-wins)** | `test_3417_cross_tx_committed_after_snapshot_still_conflicts` | ✅ |

RED confirmed first: the 8 same-tx tests failed with `Storage(NodeNotFound)`/`EdgeNotFound` before the fix; the cross-tx invisibility test passed both before and after (isolation not weakened).

## Gates
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.
- `cargo test --lib api::transaction` — **183 passed, 0 failed** (was 155/23 before the fix; +5 new tests over the initial fix).
- `cargo test --lib db::` — **227 passed, 0 failed**.

## Follow-ups
- **buffer-aware cascade adjacency tracked for #3416**: `delete_node_cascade` reads the node existence and per-edge deletes buffer-aware, but its adjacency **enumeration** (`get_outgoing_edges`/`get_incoming_edges`) still reads committed adjacency only — so a same-tx `create_node → create_edge → cascade` can orphan the same-tx-created edge. Buffer-aware adjacency is deferred to #3416 (in-code comment added). This gap does **not** affect the MCP #3209 refuse/detach idempotency contract, which is enforced at the MCP layer over committed adjacency and is unaffected.

## Deferred (MCP lane)
Not in this PR — these live under `src/mcp/` (out of this lane's scope) and build on the storage-layer behavior landed here:
- Expose delete/retract **tombstone version ids** (e.g. a `commit_with_report()` variant) so `apply_batch` delete results carry `version_id`.
- `--max-batch-operations` CLI flag for the `aletheia-mcp` binary (builder-only today).
- Lift the two `apply_batch` v1 rejection tests (no update/delete of `$alias` batch-created refs; one write per committed entity per batch) now that the underlying buffer-aware reads make it correct.

Closes #3417 (storage/transaction-layer portion; MCP-lane sub-items tracked as follow-ons above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F9nforiPb4nfb5z4BhPqK