### PR TITLE
fix: add missing derived_from field to CreateNodeRequest to unbreak --all-features build

### DIFF
--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -3851,6 +3851,7 @@ mod query_tool_tests {
                 label: "Person".to_string(),
                 properties: Some(props),
                 provenance: None,
+                derived_from: None,
             });
             let _: NodeResponse = parse_response(&resp).expect("seed node should succeed");
         }


### PR DESCRIPTION
## Summary

The `--all-features` build of `trunk` fails to compile. #3371 (derivation lineage) added a **required** `derived_from` field to `mcp::tools::CreateNodeRequest`, but one `cypher`-gated construction site in the test suite was not updated. Because that site only compiles when the `cypher` feature is enabled, the default build stayed green while the `--all-features` CI gate broke.

### Before

```
error[E0063]: missing field `derived_from` in initializer of `mcp::tools::CreateNodeRequest`
  --> src/mcp/tests.rs:3849
```

### After

`cargo clippy --all-targets --all-features -- -D warnings` compiles clean (exit 0).

## How

Adds the missing `derived_from: None` default at the single omitted construction site (`src/mcp/tests.rs`, in the `cypher`-gated `query_tool_tests` module), matching every adjacent construction site. `derived_from` is `Option<Vec<LineageRefRequest>>`, so `None` is the neutral default that reproduces prior behavior. Minimal, mechanical, one-line change.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings` — passes (previously failed to compile).
- `cargo fmt --all` — applied, no changes.
- Selected-feature clippy and the full test suite were already passing on trunk and are left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ed7WBy4sBFC2zrSbW2bnE

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ed7WBy4sBFC2zrSbW2bnE)_