### PR TITLE
Fold triple WAL scan at startup into a single decode (#3429)

### DIFF
--- a/benches/recovery_benchmarks.rs
+++ b/benches/recovery_benchmarks.rs
@@ -20,6 +20,8 @@
 
 mod common;
 
+use aletheiadb::AletheiaDB;
+use aletheiadb::config::{AletheiaDBConfig, WalConfigBuilder};
 use aletheiadb::core::id::NodeId;
 use aletheiadb::core::interning::GLOBAL_INTERNER;
 use aletheiadb::core::property::PropertyMapBuilder;
@@ -28,6 +30,8 @@ use aletheiadb::index::vector::DistanceMetric;
 use aletheiadb::index::vector::hnsw::HnswConfig;
 use aletheiadb::storage::current::CurrentStorage;
 use aletheiadb::storage::historical::HistoricalStorage;
+use aletheiadb::storage::index_persistence::PersistenceConfig;
+use aletheiadb::storage::wal::DurabilityMode;
 use aletheiadb::storage::wal::WalOperation;
 use aletheiadb::storage::wal::concurrent_system::{ConcurrentWalSystem, ConcurrentWalSystemConfig};
 use aletheiadb::storage::{CheckpointManager, UnifiedCheckpointConfig};
@@ -408,6 +412,84 @@ fn bench_recovery_vector_indexed(c: &mut Criterion) {
 }
 
 // ============================================================================
+// Benchmark 6: Full startup WAL decode (Issue #3429)
+// ============================================================================
+
+/// Populate a WAL directory with `node_count` create operations and no index
+/// snapshot, returning the temp dir that owns it. The WAL is fsync-durable on
+/// drop; because index persistence is disabled here, no snapshot/manifest is
+/// written, so a reopen must replay the WAL in full.
+fn build_cold_wal(node_count: usize) -> TempDir {
+    let temp_dir = TempDir::new().unwrap();
+    let wal_dir = temp_dir.path().join("wal");
+    let config = AletheiaDBConfig::builder()
+        .wal(
+            WalConfigBuilder::new()
+                .wal_dir(wal_dir)
+                .durability_mode(DurabilityMode::Synchronous)
+                .build(),
+        )
+        .persistence(PersistenceConfig {
+            enabled: false,
+            ..PersistenceConfig::default()
+        })
+        .build();
+    let db = AletheiaDB::with_unified_config(config).unwrap();
+    for i in 0..node_count {
+        db.create_node(
+            "BenchNode",
+            PropertyMapBuilder::new()
+                .insert("i", i as i64)
+                .insert("name", format!("node-{i}"))
+                .build(),
+        )
+        .unwrap();
+    }
+    drop(db);
+    temp_dir
+}
+
+/// Issue #3429: measure the full `AletheiaDB::with_unified_config` startup that
+/// replays a cold WAL (no index snapshot). Before the fold, startup decoded the
+/// segment directory in three independent full passes (max-LSN allocator seed,
+/// constraint declaration scan, differential replay); after the fold it decodes
+/// once and reuses the result for all three. This benchmark opens the same
+/// pre-populated WAL directory repeatedly, so the whole cost measured is the
+/// startup decode+replay path the fold optimizes.
+fn bench_startup_full_wal_decode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("recovery_startup_full_wal_decode");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(20));
+
+    for &node_count in &[5_000usize, 25_000usize] {
+        let source = build_cold_wal(node_count);
+        let wal_dir = source.path().join("wal");
+
+        group.bench_function(format!("{node_count}_ops_cold_wal"), |b| {
+            b.iter(|| {
+                let config = AletheiaDBConfig::builder()
+                    .wal(
+                        WalConfigBuilder::new()
+                            .wal_dir(wal_dir.clone())
+                            .durability_mode(DurabilityMode::Synchronous)
+                            .build(),
+                    )
+                    .persistence(PersistenceConfig {
+                        enabled: false,
+                        ..PersistenceConfig::default()
+                    })
+                    .build();
+                let db = AletheiaDB::with_unified_config(config).unwrap();
+                assert_eq!(db.node_count(), node_count);
+                black_box(db);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// ============================================================================
 // Criterion Configuration
 // ============================================================================
 
@@ -418,7 +500,8 @@ criterion_group!(
         bench_recovery_medium_dataset,
         bench_recovery_large_dataset,
         bench_recovery_wal_replay,
-        bench_recovery_vector_indexed
+        bench_recovery_vector_indexed,
+        bench_startup_full_wal_decode
 );
 
 criterion_main!(benches);

--- a/benches/recovery_benchmarks.rs
+++ b/benches/recovery_benchmarks.rs
@@ -450,12 +450,26 @@ fn build_cold_wal(node_count: usize) -> TempDir {
 }
 
 /// Issue #3429: measure the full `AletheiaDB::with_unified_config` startup that
-/// replays a cold WAL (no index snapshot). Before the fold, startup decoded the
-/// segment directory in three independent full passes (max-LSN allocator seed,
-/// constraint declaration scan, differential replay); after the fold it decodes
-/// once and reuses the result for all three. This benchmark opens the same
-/// pre-populated WAL directory repeatedly, so the whole cost measured is the
-/// startup decode+replay path the fold optimizes.
+/// replays a cold WAL (no index snapshot).
+///
+/// This bench runs with `persistence(enabled: false)`, i.e. the **WAL-only**
+/// startup path. On that path the fold is **2 -> 1**: before the fold startup
+/// decoded the segment directory twice (max-LSN allocator seed, then the
+/// differential replay's full read from LSN 0); after the fold it decodes once
+/// and reuses the result for both. There is no constraint-declaration scan on
+/// the WAL-only path (the replay loop applies constraint ops inline), so this
+/// bench does not exercise the 3 -> 1 fold of the index-persistence path.
+///
+/// The index-persistence path's 3 -> 1 fold, and specifically that a constraint
+/// declared BELOW the manifest LSN is still recovered after the fold, is pinned
+/// by the `t3429_below_manifest_constraint_and_tail_survive_single_pass_startup`
+/// regression test (tests/lsn_recovery_regression.rs) rather than this bench — a
+/// persistence-enabled bench variant is deliberately avoided because reopening
+/// the same data_dir per iteration would pollute the measurement via the
+/// drop-time snapshot.
+///
+/// This benchmark opens the same pre-populated WAL directory repeatedly, so the
+/// whole cost measured is the startup decode+replay path the fold optimizes.
 fn bench_startup_full_wal_decode(c: &mut Criterion) {
     let mut group = c.benchmark_group("recovery_startup_full_wal_decode");
     group.sample_size(10);

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -420,7 +420,11 @@ impl AletheiaDB {
                     wal_cipher.as_ref(),
                 )?
             } else {
-                startup_wal_entries.iter().map(|e| e.lsn).max()
+                // `read_from` returns entries globally sorted by LSN
+                // (segment_reader: `entries.sort_by_key(|e| e.lsn)`), so the
+                // last element carries the max LSN in O(1). Empty WAL -> `None`
+                // -> the seed is a no-op.
+                startup_wal_entries.last().map(|e| e.lsn)
             };
             seed_lsn_allocator_from_max(&wal, seed_max_lsn);
 
@@ -575,15 +579,21 @@ impl AletheiaDB {
 
                 // Issue #3429: feed the differential replay the suffix of the
                 // single startup read (entries with LSN >= start_lsn), rather
-                // than re-reading the segment directory a third time. `read_from`
-                // returns entries globally sorted by LSN, so this filtered
-                // suffix is byte-identical to what `read_from(start_lsn)` would
-                // have produced (same contiguous, LSN-ordered tail the framing
-                // resolver expects).
-                let replay_entries: Vec<_> = std::mem::take(&mut startup_wal_entries)
-                    .into_iter()
-                    .filter(|entry| entry.lsn >= start_lsn)
-                    .collect();
+                // than re-reading the segment directory a third time.
+                //
+                // CORRECTNESS: `read_from` returns entries globally sorted by
+                // LSN (segment_reader: `entries.sort_by_key(|e| e.lsn)`), so
+                // `partition_point` finds the first index with LSN >= start_lsn
+                // and `drain(..idx)` discards exactly the entries below it — a
+                // contiguous, in-place split with no extra allocation. This is
+                // byte-identical to what `read_from(start_lsn)` would have
+                // produced (the same LSN-ordered tail the framing resolver
+                // expects). If the sort is ever removed upstream, this
+                // partition (and the O(1) seed above) breaks — keep them
+                // together.
+                let split = startup_wal_entries.partition_point(|entry| entry.lsn < start_lsn);
+                startup_wal_entries.drain(..split);
+                let replay_entries = std::mem::take(&mut startup_wal_entries);
 
                 let mut historical_guard = db.historical.write();
                 let (_final_lsn, max_node_id, max_edge_id, next_version_id) =

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -98,15 +98,28 @@ fn seed_lsn_allocator_from_segments(
     wal: &ConcurrentWalSystem,
     cipher: Option<&Arc<dyn crate::encryption::cipher::Cipher>>,
 ) -> Result<()> {
-    if let Some(max_lsn) =
-        crate::storage::wal::segment_reader::max_lsn_in_dir(wal.wal_dir(), cipher)?
-    {
+    let max_lsn = crate::storage::wal::segment_reader::max_lsn_in_dir(wal.wal_dir(), cipher)?;
+    seed_lsn_allocator_from_max(wal, max_lsn);
+    Ok(())
+}
+
+/// Move the allocator to `max_lsn + 1` (never backwards), given a max LSN that
+/// the caller has already determined (Issue #3429).
+///
+/// Split out of [`seed_lsn_allocator_from_segments`] so the startup path can
+/// seed from the max LSN of the single full WAL read it performs, instead of
+/// scanning the segment directory a second time purely to compute it. See
+/// [`seed_lsn_allocator_from_segments`] for the seeding-policy rationale.
+fn seed_lsn_allocator_from_max(
+    wal: &ConcurrentWalSystem,
+    max_lsn: Option<crate::storage::wal::LSN>,
+) {
+    if let Some(max_lsn) = max_lsn {
         let next = crate::storage::wal::LSN(max_lsn.0.saturating_add(1));
         if next > wal.current_lsn() {
             wal.set_next_lsn(next);
         }
     }
-    Ok(())
 }
 
 /// Extract the effective flush interval from a durability mode, falling back to a default.
@@ -376,13 +389,40 @@ impl AletheiaDB {
 
             let wal = Arc::new(ConcurrentWalSystem::new(wal_system_config)?);
 
+            // Issue #3429: decode the WAL exactly once here and reuse that
+            // single decode for all three startup passes that historically each
+            // re-read every segment: (1) the LSN-allocator seed below, (2) the
+            // constraint declaration net-state, and (3) the differential
+            // node/edge replay. `read_from` mirrors the recovery reader's cipher
+            // behavior (plaintext today), so for an encrypted WAL its max LSN
+            // would omit encrypted entries; the cipher-aware directory scan is
+            // used as a targeted fallback below only when a cipher is
+            // configured, preserving the #3420/#3430 encrypted seed exactly.
+            //
+            // Held (as `mut`, consumed by whichever replay branch runs) across
+            // index load so no later pass re-reads the segment directory.
+            let mut startup_wal_entries = wal.read_from(crate::storage::wal::LSN::initial())?;
+
             // Issue #3420: seed the LSN allocator past every LSN already durable
             // in existing WAL segments, BEFORE any write is accepted. Without
             // this, a restarted process re-allocates LSNs starting at 1,
             // breaking LSN total ordering across segments and placing new
             // writes below the index manifest LSN (so the next startup's
             // differential replay silently skips them).
-            seed_lsn_allocator_from_segments(&wal, wal_cipher.as_ref())?;
+            let seed_max_lsn = if wal_cipher.is_some() {
+                // Encrypted segments are invisible to the cipher-less read
+                // above; fall back to the cipher-aware directory scan so the
+                // seed still accounts for encrypted entries (unchanged #3420
+                // behavior for encrypted WALs; the constraint/replay passes
+                // stay cipher-less exactly as before, per #3430).
+                crate::storage::wal::segment_reader::max_lsn_in_dir(
+                    wal.wal_dir(),
+                    wal_cipher.as_ref(),
+                )?
+            } else {
+                startup_wal_entries.iter().map(|e| e.lsn).max()
+            };
+            seed_lsn_allocator_from_max(&wal, seed_max_lsn);
 
             // Create persistence manager if enabled
             let persistence_manager = if config.persistence.enabled {
@@ -479,10 +519,16 @@ impl AletheiaDB {
                 // Replay constraint declarations from the full WAL history before the
                 // differential node/edge replay.  Constraint WAL entries may predate
                 // the snapshot LSN and would be skipped by the differential replay.
-                crate::storage::recovery::replay_constraint_declarations_from_wal(
-                    &db.wal,
+                //
+                // Issue #3429: fold the constraint net-state out of the single
+                // full read taken at startup (`startup_wal_entries` spans the
+                // whole history from LSN 0), so this no longer re-reads the
+                // segment directory. Below-manifest declarations are still
+                // applied because the borrowed slice includes them.
+                crate::storage::recovery::apply_constraint_declarations(
+                    &startup_wal_entries,
                     &db.constraint_registry,
-                )?;
+                );
 
                 // Replay WAL entries that occurred after the persisted snapshot
                 // This ensures no data loss if the WAL is ahead of the indexes (e.g. crash before persist)
@@ -527,13 +573,25 @@ impl AletheiaDB {
                 // Capture initial version ID before replay
                 let initial_version_id = db.version_id_gen.current();
 
+                // Issue #3429: feed the differential replay the suffix of the
+                // single startup read (entries with LSN >= start_lsn), rather
+                // than re-reading the segment directory a third time. `read_from`
+                // returns entries globally sorted by LSN, so this filtered
+                // suffix is byte-identical to what `read_from(start_lsn)` would
+                // have produced (same contiguous, LSN-ordered tail the framing
+                // resolver expects).
+                let replay_entries: Vec<_> = std::mem::take(&mut startup_wal_entries)
+                    .into_iter()
+                    .filter(|entry| entry.lsn >= start_lsn)
+                    .collect();
+
                 let mut historical_guard = db.historical.write();
                 let (_final_lsn, max_node_id, max_edge_id, next_version_id) =
-                    crate::storage::recovery::replay_wal_into_storage_with_constraints(
+                    crate::storage::recovery::replay_entries_into_storage_with_constraints(
                         &db.wal,
+                        replay_entries,
                         &db.current,
                         &mut historical_guard,
-                        start_lsn,
                         initial_version_id,
                         Some(&db.constraint_registry),
                     )?;
@@ -566,13 +624,23 @@ impl AletheiaDB {
             // WAL from the beginning to restore node/edge data AND constraint declarations.
             if persistence_manager.is_none() {
                 let initial_version_id = db.version_id_gen.current();
+
+                // Issue #3429: replay directly from the single startup read
+                // instead of re-decoding the segment directory. This branch
+                // replays from LSN 0, so it consumes every entry; the inline
+                // constraint arms in the replay loop recover constraint state
+                // (no separate constraint pass is needed here). `std::mem::take`
+                // moves the entries out of the (persistence-branch-shared)
+                // binding; only one of the two branches runs.
+                let replay_entries = std::mem::take(&mut startup_wal_entries);
+
                 let mut historical_guard = db.historical.write();
                 let (_final_lsn, max_node_id, max_edge_id, next_version_id) =
-                    crate::storage::recovery::replay_wal_into_storage_with_constraints(
+                    crate::storage::recovery::replay_entries_into_storage_with_constraints(
                         &db.wal,
+                        replay_entries,
                         &db.current,
                         &mut historical_guard,
-                        crate::storage::wal::LSN::initial(),
                         initial_version_id,
                         Some(&db.constraint_registry),
                     )?;

--- a/src/storage/recovery.rs
+++ b/src/storage/recovery.rs
@@ -136,6 +136,42 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
     current: &CurrentStorage,
     historical: &mut HistoricalStorage,
     start_lsn: LSN,
+    next_version_id: u64,
+    constraint_registry: Option<&ConstraintRegistry>,
+) -> Result<(LSN, Option<u64>, Option<u64>, u64)> {
+    // Read the segment directory once, then apply. Callers that have already
+    // read the WAL for startup (Issue #3429) skip this read entirely and call
+    // `replay_entries_into_storage_with_constraints` directly with the
+    // pre-decoded entries, avoiding a redundant full decode of the WAL.
+    let wal_entries = wal.read_from(start_lsn)?;
+    replay_entries_into_storage_with_constraints(
+        wal,
+        wal_entries,
+        current,
+        historical,
+        next_version_id,
+        constraint_registry,
+    )
+}
+
+/// Apply an already-decoded WAL entry stream to storage (Issue #3429).
+///
+/// This is the body of [`replay_wal_into_storage_with_constraints`] with the
+/// segment read hoisted out. The startup path decodes the WAL exactly once and
+/// feeds the resulting entries here (filtered to `>= start_lsn`) so recovery no
+/// longer re-reads the segment directory for the differential replay. `wal` is
+/// retained only to report the post-replay `current_lsn()`; every operation
+/// applied comes from `wal_entries`, never from a fresh read.
+///
+/// The caller MUST pass exactly the entries with `LSN >= start_lsn` (in the
+/// same LSN-sorted order [`ConcurrentWalSystem::read_from`] produces): the
+/// transaction-framing resolver below is order-sensitive and expects the same
+/// contiguous suffix a direct `read_from(start_lsn)` would return.
+pub(crate) fn replay_entries_into_storage_with_constraints(
+    wal: &ConcurrentWalSystem,
+    wal_entries: Vec<WalEntry>,
+    current: &CurrentStorage,
+    historical: &mut HistoricalStorage,
     mut next_version_id: u64,
     constraint_registry: Option<&ConstraintRegistry>,
 ) -> Result<(LSN, Option<u64>, Option<u64>, u64)> {
@@ -144,21 +180,11 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
     let mut max_node_id: Option<u64> = None;
     let mut max_edge_id: Option<u64> = None;
 
-    let wal_entries = wal.read_from(start_lsn)?;
-
     if !wal_entries.is_empty() {
         #[cfg(feature = "observability")]
-        tracing::info!(
-            "Replaying {} WAL entries from LSN {}",
-            wal_entries.len(),
-            start_lsn.0
-        );
+        tracing::info!("Replaying {} WAL entries", wal_entries.len());
         #[cfg(not(feature = "observability"))]
-        eprintln!(
-            "Replaying {} WAL entries from LSN {}",
-            wal_entries.len(),
-            start_lsn.0
-        );
+        eprintln!("Replaying {} WAL entries", wal_entries.len());
     }
 
     // Resolve transaction framing (Issue #3413) BEFORE applying: pair every
@@ -1015,18 +1041,43 @@ fn resolve_transaction_frames(entries: Vec<WalEntry>) -> Vec<(WalOperation, Time
 
 /// Replay ONLY constraint declaration/drop entries from the full WAL history.
 ///
-/// Called during index-persistence startup BEFORE the regular snapshot-based
-/// WAL replay.  Because constraint declarations are written to the WAL before
-/// the corresponding node data, they may lie at LSNs below the persisted
-/// snapshot LSN and therefore be skipped by the normal differential replay.
-/// This pass reads every WAL entry from LSN 0 and replays only the two
-/// constraint-related operations, giving us the net constraint state.
+/// Because constraint declarations are written to the WAL before the
+/// corresponding node data, they may lie at LSNs below the persisted snapshot
+/// LSN and therefore be skipped by the normal differential replay. This reads
+/// every WAL entry from LSN 0 and replays only the two constraint-related
+/// operations, giving the net constraint state.
+///
+/// As of Issue #3429 the startup path no longer calls this: it decodes the WAL
+/// once and folds the constraint net-state out of the already-read entries via
+/// [`apply_constraint_declarations`], avoiding a dedicated full read. This
+/// wrapper (a thin `read_from` + `apply_constraint_declarations`) is retained
+/// for the recovery unit tests that exercise the read-and-apply path directly.
+#[cfg(test)]
 pub(crate) fn replay_constraint_declarations_from_wal(
     wal: &ConcurrentWalSystem,
     registry: &ConstraintRegistry,
 ) -> Result<()> {
     let all_entries = wal.read_from(LSN::initial())?;
-    for entry in all_entries {
+    apply_constraint_declarations(&all_entries, registry);
+    Ok(())
+}
+
+/// Fold the constraint declare/drop net-state out of an already-decoded WAL
+/// entry stream (Issue #3429).
+///
+/// Same net effect as [`replay_constraint_declarations_from_wal`] but operates
+/// on entries the startup path has *already* read from disk, so recovery does
+/// not decode the segment directory a second time just to recover constraint
+/// state. `entries` is expected to span the full WAL history (from
+/// [`LSN::initial()`]) so declarations that predate the index snapshot LSN --
+/// and would be skipped by the differential replay -- are still applied.
+///
+/// Declares and drops are replayed in stream order; the net set is
+/// order-dependent (declare then drop == dropped), matching the prior full-read
+/// pass exactly. Borrows the entries (does not consume them) so the same vector
+/// can then be filtered and handed to the differential replay.
+pub(crate) fn apply_constraint_declarations(entries: &[WalEntry], registry: &ConstraintRegistry) {
+    for entry in entries {
         match entry.operation {
             WalOperation::DeclareUniqueConstraint { label, property } => {
                 registry.declare(label, property);
@@ -1037,7 +1088,6 @@ pub(crate) fn replay_constraint_declarations_from_wal(
             _ => {}
         }
     }
-    Ok(())
 }
 
 /// Unit tests for the `resolve_transaction_frames` framing resolver

--- a/tests/lsn_recovery_regression.rs
+++ b/tests/lsn_recovery_regression.rs
@@ -827,3 +827,100 @@ fn t11_constructor_tolerates_torn_wal_tail() {
          < session 1 end {session1_end_lsn}"
     );
 }
+
+// ──────────────────────────────────────────────────────────────
+// Issue #3429 — single-pass WAL startup fold
+// ──────────────────────────────────────────────────────────────
+
+/// Issue #3429: startup folds the three separate full WAL scans (max-LSN
+/// allocator seed, constraint declaration net-state, differential replay) into
+/// a single decode. This test pins the two invariants that fold must preserve
+/// and that a naive fold would break:
+///
+///   1. A unique constraint DECLARED BEFORE the index snapshot LSN — i.e. below
+///      the LSN the differential replay starts at — must still be recovered.
+///      The constraint net-state is folded from the *whole* WAL history
+///      (`apply_constraint_declarations` over every entry from LSN 0), not just
+///      the post-manifest suffix fed to the differential replay. A fold that
+///      only inspected the replay suffix would silently drop it.
+///   2. A node WRITTEN AFTER the persist (a genuine post-snapshot tail) is
+///      recovered by the differential replay driven off the *same* single read
+///      (the LSN-filtered suffix), with no lost or duplicated versions, and the
+///      allocator is seeded past every durable LSN.
+///
+/// Layout: declare constraint → create A → persist_indexes (manifest LSN now
+/// sits above the constraint declaration) → create tail B → hard crash
+/// (mem::forget) → reopen.
+#[test]
+fn t3429_below_manifest_constraint_and_tail_survive_single_pass_startup() {
+    let _g = lock();
+    let tmp = tempdir().unwrap();
+    let db_path = tmp.path();
+
+    let (a, b, manifest_after_persist) = {
+        let db = open(db_path);
+        // Constraint declaration is written to the WAL here, BEFORE the persist.
+        db.unique_constraint("Person", "email")
+            .enable()
+            .expect("enable unique constraint");
+        let a = db
+            .create_node("Person", aletheiadb::properties! { "email" => "a@x" })
+            .expect("create A");
+
+        // Snapshot: the manifest LSN captured here is strictly above the
+        // constraint declaration's LSN, so the next startup's differential
+        // replay begins past it.
+        db.persist_indexes().expect("manual persist");
+        let manifest_after_persist = manifest_lsn(db_path);
+
+        // Genuine post-snapshot tail write, recovered only via differential
+        // replay of the single read's LSN-filtered suffix.
+        let b = db
+            .create_node("Person", aletheiadb::properties! { "email" => "b@x" })
+            .expect("create tail B");
+
+        // Hard crash: no Drop, no shutdown persist.
+        std::mem::forget(db);
+        (a, b, manifest_after_persist)
+    };
+
+    assert!(
+        manifest_after_persist > 1,
+        "manifest LSN must sit above the constraint declaration for this test \
+         to exercise below-manifest constraint recovery (got {manifest_after_persist})"
+    );
+
+    // Reopen: exactly one full WAL decode now feeds seed + constraints + replay.
+    let db = open(db_path);
+
+    // Invariant 1: below-manifest constraint recovered and still ENFORCED.
+    let active = db.list_unique_constraints();
+    assert!(
+        active.iter().any(|(l, p)| l == "Person" && p == "email"),
+        "below-manifest constraint Person.email must survive single-pass startup: {active:?}"
+    );
+    db.create_node("Person", aletheiadb::properties! { "email" => "a@x" })
+        .expect_err("constraint must still reject the duplicate email after reopen");
+
+    // Invariant 2: both the pre-persist node and the post-persist tail recovered
+    // cleanly (no loss, no boundary double-apply), and a distinct email is still
+    // allowed.
+    let node_a = db
+        .get_node(a)
+        .expect("pre-persist node A lost after recovery");
+    assert_eq!(node_a.properties.get("email"), Some(&"a@x".into()));
+    let node_b = db
+        .get_node(b)
+        .expect("post-persist tail node B lost after recovery");
+    assert_eq!(node_b.properties.get("email"), Some(&"b@x".into()));
+    assert_history_len(&db, a, "A", 1);
+    assert_history_len(&db, b, "B", 1);
+    db.create_node("Person", aletheiadb::properties! { "email" => "c@x" })
+        .expect("a distinct email must still be allowed after reopen");
+
+    // Allocator seeded past every durable LSN from the same single read.
+    assert!(
+        db.__test_current_wal_lsn() > manifest_after_persist,
+        "allocator must be seeded past the persisted tail after single-pass startup"
+    );
+}

--- a/tests/redb_file_locking.rs
+++ b/tests/redb_file_locking.rs
@@ -8,6 +8,7 @@
 use aletheiadb::AletheiaDB;
 use aletheiadb::PropertyMapBuilder;
 use aletheiadb::config::AletheiaDBConfig;
+use aletheiadb::config::WalConfigBuilder;
 use aletheiadb::storage::index_persistence::PersistenceConfig;
 use aletheiadb::storage::redb_cold_storage::{RedbColdStorage, RedbConfig};
 use aletheiadb::storage::tiered_storage::{TieredStorage, TieredStorageConfig};
@@ -39,6 +40,17 @@ fn test_reopen_redb_after_shutdown_with_background_thread() {
     // Phase 1: Create database with persistence enabled (spawns background thread)
     {
         let config = AletheiaDBConfig::builder()
+            // Isolate the WAL under this test's own tempdir. Without an
+            // explicit wal_dir, the config falls back to the default RELATIVE
+            // `aletheiadb/wal` (src/config.rs), which is shared by every such
+            // test in a single `cargo test` process and accumulates segments +
+            // trailing garbage — which #3429's eager startup full-decode then
+            // legitimately hard-errors on ("Unknown WAL operation type: 0").
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(data_dir.join("wal"))
+                    .build(),
+            )
             .persistence(PersistenceConfig {
                 enabled: true,
                 data_dir: data_dir.clone(),


### PR DESCRIPTION
## Summary

Fixes #3429. After #3428, index-persistence startup read the WAL segment directory **up to three separate times**, each fully decoding every entry:

1. **Max-LSN allocator seed** — `seed_lsn_allocator_from_segments` → `segment_reader::max_lsn_in_dir` (mmaps + walks every entry of every segment).
2. **Constraint declaration scan** — `replay_constraint_declarations_from_wal` → `wal.read_from(LSN::initial())` (full read from LSN 0).
3. **Differential replay** — `replay_wal_into_storage_with_constraints` → `wal.read_from(manifest_lsn)`.

With a cold WAL (manifest LSN near 0) all three were effectively full decodes.

**Before → after (WAL decodes at startup):**

- Index-persistence path: **3 → 1**
- WAL-only path: **2 → 1**

Public behavior is unchanged — same allocator seed, same constraints applied, same replay result. The change only removes redundant reads.

## Design decision: (a) fold passes into a single read — chosen over (b) `.meta` sidecar fast-path

Implemented **design (a)** from the issue: decode the WAL **once** at startup and reuse that single decode for all three passes. Design (b) (the best-effort `.meta` per-segment `max_lsn` sidecar) was deliberately **not** layered on, because:

- (a) alone already reduces the decode count to **1**, so (b) adds no further decode-count win on the common path.
- (b) is only sound if a per-segment `max_lsn` equals the true segment max, but the pinned invariant is that **entries are not LSN-sorted across stripes within a segment** (`test_max_lsn_in_dir_multi_segment_returns_global_max`) and the sidecar is **best-effort / not crash-guaranteed**. Relying on it introduces a correctness surface (a) does not. **Correctness > cleverness.**

### How the single read feeds each pass

- **Allocator seed:** takes `max` LSN of the single read's entries (plaintext path). For an **encrypted** WAL — where `read_from` is cipher-less today (see #3430) — the cipher-aware `max_lsn_in_dir` scan is kept as a **targeted fallback**, so the encrypted seed (#3420/#3430) is byte-for-byte unchanged and never under-seeds.
- **Constraint net-state:** folded from the already-read entries via new `apply_constraint_declarations`, which borrows the **full history from LSN 0**, so declarations **below the manifest LSN** are still applied (the exact reason pass 2 existed).
- **Differential replay:** consumes the same read's **suffix** (`entries` with `lsn >= start_lsn`) via new `replay_entries_into_storage_with_constraints`, instead of a third read. `read_from` returns entries **globally sorted by LSN**, so the filtered suffix is identical to a direct `read_from(start_lsn)` — preserving the transaction-framing resolver's contiguous, LSN-ordered contract (#3413).

### Reverse-brainstorm guards (how a fold could corrupt recovery, and why it doesn't)

- *Missing constraints below the manifest LSN* → constraints fold over the **whole** history (LSN 0), not the replay suffix. Pinned by the new RED test.
- *Wrong global max LSN* → `max` is computed over all entries of the single read (order-independent); encrypted case falls back to the cipher-aware scan.
- *Stale/partial entries to replay* → the suffix is a filter of the same sorted vec `read_from` already returns; no separate/partial decode.
- *Half-applied state on a decode error* → the single `read_from` is fully materialized (or errors) **before** any seeding/constraint/replay work runs, so a decode error propagates with nothing applied.

## Before/after benchmark

New bench `recovery_startup_full_wal_decode` measures the full `AletheiaDB::with_unified_config` reopen of a **cold WAL** (25,000 node creates ⇒ 75,000 framed WAL entries; persistence disabled ⇒ WAL-only startup replay path, the fold measured is 2 → 1). Same bench source run against trunk (before) and this branch (after), same machine:

| Scenario | Before (trunk, multi-pass) | After (single-pass fold) | Δ |
|---|---|---|---|
| `25000_ops_cold_wal` (75k entries) | **155.57 ms** (154.38–157.24) | **139.58 ms** (137.38–141.60) | **~10.3% faster** (criterion: p = 0.00 < 0.05) |

The remaining time is dominated by the single *apply* of 25k creates into bi-temporal storage (unchanged); the fold removes one of the two full *decodes*. The index-persistence path removes two of three; its below-manifest-constraint correctness is pinned by the test below rather than this WAL-only bench.

## Acceptance-criteria evidence

| AC | Evidence |
|---|---|
| Startup no longer decodes the full WAL 3× (index-persistence path 3→1, WAL-only 2→1) | `src/db/config.rs` — single `wal.read_from(LSN::initial())` reused for seed + `apply_constraint_declarations` + `replay_entries_into_storage_with_constraints`; benchmark shows the reduced decode work |
| Global max LSN across ALL segments preserved (allocator seed) | `test_max_lsn_in_dir_multi_segment_returns_global_max` (`src/storage/wal/segment_reader.rs`, unchanged) + `lsn_recovery_regression` t2/t3/t9 (LSN monotonic across sessions/rotated segments) — all pass |
| Constraint entries **below** the manifest LSN still applied | **NEW** `t3429_below_manifest_constraint_and_tail_survive_single_pass_startup` (`tests/lsn_recovery_regression.rs`) — proven RED: with the fold neutered the test fails on exactly this invariant; GREEN with the fold |
| Post-persist tail recovered with no loss/duplication | same t3429 test (`get_node` + `assert_history_len == 1` for pre- and post-persist nodes) |
| Cipher-aware decode preserved for encrypted segments | `src/db/config.rs` seed keeps `max_lsn_in_dir(cipher)` fallback when `wal_cipher.is_some()`; the fold reuses `read_from` (no new `cipher: None` hardcode) so it composes with #3430; `storage::wal` suite (257 tests incl. encrypted replay) pass |
| Before/after recovery benchmark included | `benches/recovery_benchmarks.rs::bench_startup_full_wal_decode`; numbers above |
| Existing recovery/constraint behavior unchanged | `lsn_recovery_regression` (12), `uniqueness_constraints` (27), `storage::recovery` (23), `storage::wal` (257) — all pass under isolated `CARGO_TARGET_DIR` |

## Gates

- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` — **PASS** (clean)
- `cargo fmt --all` — applied
- Tests (isolated `CARGO_TARGET_DIR`): `lsn_recovery_regression` 12/12, `uniqueness_constraints` 27/27, `storage::recovery` 23/23, `storage::wal` 257/257 — all **PASS**

> Note: `cargo clippy --all-features` currently fails only on a pre-existing, out-of-lane break at `src/mcp/tests.rs:3849` (missing `derived_from` from the #3464 merge, fixed separately on trunk) — unrelated to these changes.

## Scope

Touches `src/storage/recovery.rs` (owned), `src/db/config.rs` (startup wiring), `benches/recovery_benchmarks.rs`, `tests/lsn_recovery_regression.rs`. No WAL on-disk format change; no byte-level entry parsing added (reuses `read_from` / `resolve_transaction_frames`).