### PR TITLE
Cypher UNWIND clause (#559)

### DIFF
--- a/src/cypher/ast.rs
+++ b/src/cypher/ast.rs
@@ -50,6 +50,29 @@ pub enum CypherStatement {
         /// [`CypherOptionalMatch::preceding_withs`].
         optional_matches: Vec<CypherOptionalMatch>,
     },
+
+    /// A standalone `UNWIND <list> AS <var> RETURN ...` statement (Issue #559).
+    ///
+    /// `UNWIND` expands a list value into one row per element, binding each
+    /// element to `variable`. This variant models the *standalone* form only
+    /// (an `UNWIND` that is not preceded by `MATCH`/`WITH` and does not feed a
+    /// subsequent graph pattern); it is executed directly by the dedicated
+    /// Cypher UNWIND runtime rather than lowered into the graph query pipeline.
+    ///
+    /// openCypher list semantics apply: an empty list and the `null` value both
+    /// expand to zero rows.
+    Unwind {
+        /// The list-valued source expression. Supported forms are a list
+        /// literal (`[...]`), a parameter reference (`$list`), or the `null`
+        /// literal; other (row-context-dependent) expressions are rejected at
+        /// execution time.
+        source: CypherExpr,
+        /// The variable each list element is bound to (the `AS <var>` target).
+        variable: String,
+        /// The trailing `RETURN` projection (with optional `DISTINCT`,
+        /// `ORDER BY`, `SKIP`, `LIMIT`).
+        return_clause: CypherReturn,
+    },
 }
 
 /// A subsequent `OPTIONAL MATCH` clause within a `MATCH` statement.
@@ -274,6 +297,12 @@ pub enum CypherExpr {
     Star,
     /// A parenthesized sub-expression used for grouping.
     Grouped(Box<CypherExpr>),
+    /// A list literal, e.g. `[1, 2, 3]` or `[[1, 2], [3, 4]]`.
+    ///
+    /// Currently produced (and consumed) by the `UNWIND` source position; a
+    /// list literal appearing where a scalar predicate operand is expected is
+    /// rejected during conversion rather than silently mishandled.
+    List(Vec<CypherExpr>),
 }
 
 /// A comparison operator in a Cypher expression.

--- a/src/cypher/converter.rs
+++ b/src/cypher/converter.rs
@@ -79,6 +79,11 @@ pub enum CypherParameterValue {
     String(String),
     /// A dense vector embedding for similarity search.
     Embedding(Arc<[f32]>),
+    /// A homogeneous or heterogeneous list of parameter values.
+    ///
+    /// Bound to the `$list` position of a standalone `UNWIND $list AS x`
+    /// (Issue #559). Lists are not valid as scalar predicate values.
+    List(Vec<CypherParameterValue>),
 }
 
 impl CypherParameterValue {
@@ -98,6 +103,9 @@ impl CypherParameterValue {
             CypherParameterValue::String(s) => Ok(PredicateValue::String(s.clone())),
             CypherParameterValue::Embedding(_) => Err(CypherError::ParameterError(
                 "embedding parameters cannot be used as predicate values".to_string(),
+            )),
+            CypherParameterValue::List(_) => Err(CypherError::ParameterError(
+                "list parameters cannot be used as predicate values".to_string(),
             )),
         }
     }
@@ -307,6 +315,17 @@ impl CypherConverter {
                     hints: QueryHints::default(),
                 })
             }
+            // A standalone `UNWIND` produces scalar rows, not stored entities,
+            // so it has no representation in the entity-oriented `Query` IR. It
+            // is executed by the dedicated Cypher UNWIND runtime instead (see
+            // [`crate::cypher::plan_cypher`] / `AletheiaDB::execute_cypher`).
+            // Reject conversion explicitly rather than answer silently wrong.
+            CypherStatement::Unwind { .. } => Err(CypherError::UnsupportedFeature(
+                "UNWIND does not lower into the graph query pipeline; execute it \
+                 via AletheiaDB::execute_cypher (or cypher::plan_cypher), which \
+                 evaluates the list-expansion runtime directly"
+                    .to_string(),
+            )),
         }
     }
 

--- a/src/cypher/exec.rs
+++ b/src/cypher/exec.rs
@@ -1,0 +1,572 @@
+//! Standalone Cypher `UNWIND` planning and execution (Issue #559).
+//!
+//! `UNWIND <list> AS <var>` expands a list value into one row per element. The
+//! resulting rows are *scalar* rows (a named value per element), which have no
+//! representation in AletheiaDB's entity-oriented [`Query`] IR. Rather than
+//! forcing list expansion through the graph executor, a **standalone** UNWIND
+//! (one not preceded by `MATCH`/`WITH` and not feeding a subsequent graph
+//! pattern) is evaluated directly here and materialized into [`QueryRow`]s via
+//! [`QueryRow::from_columns`] -- the same computed-column row shape the runtime
+//! aggregation path (Issue #558) uses.
+//!
+//! # Entry point
+//!
+//! [`plan_cypher`] / [`plan_cypher_with_params`] parse a Cypher string and
+//! return a [`CypherExecution`]: either a [`Query`] to run through the standard
+//! executor (every non-UNWIND statement) or a pre-computed [`QueryResults`]
+//! stream (a standalone UNWIND). `AletheiaDB::execute_cypher` dispatches on it.
+//!
+//! # Supported semantics (executed correctly)
+//!
+//! - Source: a list literal (`[1, 2, 3]`, including nested lists), a parameter
+//!   (`$list` bound to [`CypherParameterValue::List`]), or the `null` literal.
+//! - `UNWIND []` and `UNWIND null` both expand to **zero** rows (openCypher).
+//! - `RETURN` of the unwound variable (`RETURN x`, `RETURN x AS y`, `RETURN *`),
+//!   optionally with `DISTINCT`, `ORDER BY <var>`, `SKIP`, and `LIMIT`.
+//!
+//! # Rejected (structured error, never answered silently wrong)
+//!
+//! Everything requiring per-row graph context or the entity executor is
+//! rejected with a [`CypherError`]:
+//!
+//! - UNWIND combined with `MATCH`/`WITH`/traversal (rejected at parse time --
+//!   the standalone grammar does not accept it).
+//! - A source that is a scalar (`UNWIND 5`) or a row-dependent expression
+//!   (`UNWIND n.tags`).
+//! - `RETURN` items other than the unwound variable/`*` (properties, functions,
+//!   **aggregates**, arithmetic).
+//! - `ORDER BY` over a non-variable expression or over a heterogeneous /
+//!   non-scalar list.
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::core::error::Result as CoreResult;
+use crate::core::property::PropertyValue;
+use crate::query::Query;
+use crate::query::executor::{QueryResults, QueryRow, ResultIterator};
+
+use super::ast::{CypherExpr, CypherReturn, CypherReturnItem, CypherStatement, CypherValue};
+use super::converter::{CypherConverter, CypherParameterValue};
+use super::error::CypherError;
+use super::parser::CypherParser;
+
+/// Defensive recursion bound for evaluating a nested list source/element.
+///
+/// The parser already caps list-literal nesting at 128, so for any parsed AST
+/// this never fires. It guards against a hand-built [`CypherParameterValue::List`]
+/// (or `CypherExpr`) nested arbitrarily deep, which would otherwise overflow the
+/// stack during evaluation. Kept above the parser's cap so it only ever rejects
+/// pathological hand-built input.
+const MAX_UNWIND_DEPTH: usize = 256;
+
+/// One projected UNWIND output row: the unwound element value (retained for a
+/// possible `ORDER BY`) paired with its `(column_name, value)` output columns.
+type UnwindRow = (PropertyValue, Vec<(String, PropertyValue)>);
+
+/// The outcome of planning a Cypher statement for execution.
+///
+/// A non-UNWIND statement lowers to a [`Query`] for the standard executor; a
+/// standalone `UNWIND` is evaluated eagerly into a [`QueryResults`] stream.
+pub enum CypherExecution {
+    /// A graph query to run through the standard planner + executor.
+    Query(Query),
+    /// Pre-computed result rows (a standalone `UNWIND` expansion).
+    Rows(QueryResults),
+}
+
+/// Parse and plan a Cypher string with no bound parameters.
+///
+/// # Errors
+///
+/// Returns [`CypherError`] on lex, parse, conversion, or UNWIND-evaluation
+/// errors.
+pub fn plan_cypher(input: &str) -> Result<CypherExecution, CypherError> {
+    plan_cypher_with_params(input, HashMap::new())
+}
+
+/// Parse and plan a Cypher string with parameter bindings.
+///
+/// A standalone `UNWIND` statement is evaluated here and returned as
+/// [`CypherExecution::Rows`]; every other statement is converted to a
+/// [`Query`] and returned as [`CypherExecution::Query`].
+///
+/// # Errors
+///
+/// Returns [`CypherError`] on lex, parse, conversion, missing-parameter, or
+/// UNWIND-evaluation errors.
+pub fn plan_cypher_with_params(
+    input: &str,
+    params: HashMap<String, CypherParameterValue>,
+) -> Result<CypherExecution, CypherError> {
+    let stmt = CypherParser::parse(input)?;
+    match stmt {
+        CypherStatement::Unwind {
+            source,
+            variable,
+            return_clause,
+        } => {
+            let results = execute_unwind(&source, &variable, &return_clause, &params)?;
+            Ok(CypherExecution::Rows(results))
+        }
+        other => {
+            let query = CypherConverter::with_params(params).convert(other)?;
+            Ok(CypherExecution::Query(query))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// UNWIND runtime
+// ---------------------------------------------------------------------------
+
+/// A vector-backed [`ResultIterator`] wrapping pre-computed rows.
+struct VecResultIterator {
+    rows: std::vec::IntoIter<QueryRow>,
+}
+
+impl VecResultIterator {
+    fn new(rows: Vec<QueryRow>) -> Self {
+        Self {
+            rows: rows.into_iter(),
+        }
+    }
+}
+
+impl ResultIterator for VecResultIterator {
+    fn next(&mut self) -> Option<CoreResult<QueryRow>> {
+        self.rows.next().map(Ok)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let n = self.rows.len();
+        (n, Some(n))
+    }
+}
+
+/// Execute a standalone `UNWIND <source> AS <variable> <return_clause>`.
+fn execute_unwind(
+    source: &CypherExpr,
+    variable: &str,
+    ret: &CypherReturn,
+    params: &HashMap<String, CypherParameterValue>,
+) -> Result<QueryResults, CypherError> {
+    // Validate the projection and ordering statically (independent of the list
+    // contents) so an unsupported RETURN/ORDER BY is rejected, not mis-answered.
+    validate_return_items(ret, variable)?;
+    let needs_order = validate_order_by(ret, variable)?;
+
+    // Evaluate the source into its list of element values (empty for `[]` /
+    // `null`).
+    let elements = unwind_source_values(source, variable, params)?;
+
+    // Project each element into its output columns, keeping the element value
+    // alongside for a possible ORDER BY.
+    let mut projected: Vec<UnwindRow> = Vec::with_capacity(elements.len());
+    for value in elements {
+        let columns = project_element(ret, variable, &value);
+        projected.push((value, columns));
+    }
+
+    // RETURN DISTINCT: deduplicate by the output column tuple, first occurrence
+    // wins.
+    if ret.distinct {
+        projected = distinct_rows(projected);
+    }
+
+    // ORDER BY <var>: sort by the unwound value.
+    if needs_order {
+        let descending = ret.order_by[0].descending;
+        order_rows(&mut projected, descending)?;
+    }
+
+    // SKIP / LIMIT paginate the final rows.
+    let skip = ret.skip.unwrap_or(0);
+    let rows: Vec<QueryRow> = match ret.limit {
+        Some(limit) => projected
+            .into_iter()
+            .skip(skip)
+            .take(limit)
+            .map(|(_, columns)| QueryRow::from_columns(columns))
+            .collect(),
+        None => projected
+            .into_iter()
+            .skip(skip)
+            .map(|(_, columns)| QueryRow::from_columns(columns))
+            .collect(),
+    };
+
+    Ok(QueryResults::new(Box::new(VecResultIterator::new(rows))))
+}
+
+/// Resolve the `UNWIND` source expression into its list of element values.
+///
+/// `[]` and `null` (literal or parameter) yield an empty list. A scalar or
+/// row-dependent source is rejected.
+fn unwind_source_values(
+    source: &CypherExpr,
+    variable: &str,
+    params: &HashMap<String, CypherParameterValue>,
+) -> Result<Vec<PropertyValue>, CypherError> {
+    match source {
+        // `UNWIND null AS x` -> zero rows (openCypher).
+        CypherExpr::Value(CypherValue::Null) => Ok(Vec::new()),
+        // `UNWIND [ ... ] AS x`
+        CypherExpr::List(elements) => {
+            let mut out = Vec::with_capacity(elements.len());
+            for element in elements {
+                out.push(eval_element(element, params, 0)?);
+            }
+            Ok(out)
+        }
+        // `UNWIND $list AS x`
+        CypherExpr::Value(CypherValue::Parameter(name)) => {
+            let param = params.get(name).ok_or_else(|| {
+                CypherError::ParameterError(format!("unbound parameter: ${name}"))
+            })?;
+            match param {
+                CypherParameterValue::Null => Ok(Vec::new()),
+                CypherParameterValue::List(items) => {
+                    let mut out = Vec::with_capacity(items.len());
+                    for item in items {
+                        out.push(param_to_property(item, 0)?);
+                    }
+                    Ok(out)
+                }
+                other => Err(CypherError::SemanticError(format!(
+                    "UNWIND requires a list or null, but parameter ${name} is a \
+                     scalar ({other:?}); bind a list value or wrap it, e.g. \
+                     UNWIND [$val] AS {variable}"
+                ))),
+            }
+        }
+        CypherExpr::Grouped(inner) => unwind_source_values(inner, variable, params),
+        // A scalar literal (`UNWIND 5`) or a row-dependent expression
+        // (`UNWIND n.tags`) cannot be expanded by a standalone UNWIND.
+        other => Err(CypherError::SemanticError(format!(
+            "UNWIND requires a list literal, a list parameter, or null; got a \
+             scalar or row-dependent expression ({other:?}). Wrap scalars in a \
+             list (e.g. UNWIND [5] AS {variable}); list-valued node/edge \
+             properties require an UNWIND fed by a preceding MATCH, which is not \
+             yet supported"
+        ))),
+    }
+}
+
+/// Evaluate a single list-element expression into a [`PropertyValue`].
+fn eval_element(
+    expr: &CypherExpr,
+    params: &HashMap<String, CypherParameterValue>,
+    depth: usize,
+) -> Result<PropertyValue, CypherError> {
+    if depth > MAX_UNWIND_DEPTH {
+        return Err(CypherError::ParseError {
+            position: 0,
+            message: "UNWIND list nesting too deep for evaluation (max 256)".to_string(),
+        });
+    }
+    match expr {
+        CypherExpr::Value(value) => value_to_property(value, params),
+        CypherExpr::List(elements) => {
+            let mut out = Vec::with_capacity(elements.len());
+            for element in elements {
+                out.push(eval_element(element, params, depth + 1)?);
+            }
+            Ok(PropertyValue::Array(Arc::new(out)))
+        }
+        CypherExpr::Grouped(inner) => eval_element(inner, params, depth + 1),
+        other => Err(CypherError::UnsupportedFeature(format!(
+            "UNWIND list element must be a literal, parameter, or nested list; \
+             got a row-dependent expression ({other:?}) that a standalone UNWIND \
+             cannot evaluate"
+        ))),
+    }
+}
+
+/// Convert a Cypher literal value (resolving parameters) into a [`PropertyValue`].
+fn value_to_property(
+    value: &CypherValue,
+    params: &HashMap<String, CypherParameterValue>,
+) -> Result<PropertyValue, CypherError> {
+    match value {
+        CypherValue::Null => Ok(PropertyValue::Null),
+        CypherValue::Bool(b) => Ok(PropertyValue::Bool(*b)),
+        CypherValue::Int(n) => Ok(PropertyValue::Int(*n)),
+        CypherValue::Float(f) => Ok(PropertyValue::Float(*f)),
+        CypherValue::String(s) => Ok(PropertyValue::String(Arc::from(s.as_str()))),
+        CypherValue::Vector(v) => Ok(PropertyValue::Vector(Arc::clone(v))),
+        CypherValue::Parameter(name) => {
+            let param = params.get(name).ok_or_else(|| {
+                CypherError::ParameterError(format!("unbound parameter: ${name}"))
+            })?;
+            param_to_property(param, 0)
+        }
+    }
+}
+
+/// Convert a runtime parameter value into a [`PropertyValue`].
+fn param_to_property(
+    param: &CypherParameterValue,
+    depth: usize,
+) -> Result<PropertyValue, CypherError> {
+    if depth > MAX_UNWIND_DEPTH {
+        return Err(CypherError::ParseError {
+            position: 0,
+            message: "UNWIND list parameter nesting too deep for evaluation (max 256)".to_string(),
+        });
+    }
+    Ok(match param {
+        CypherParameterValue::Null => PropertyValue::Null,
+        CypherParameterValue::Bool(b) => PropertyValue::Bool(*b),
+        CypherParameterValue::Int(n) => PropertyValue::Int(*n),
+        CypherParameterValue::Float(f) => PropertyValue::Float(*f),
+        CypherParameterValue::String(s) => PropertyValue::String(Arc::from(s.as_str())),
+        CypherParameterValue::Embedding(e) => PropertyValue::Vector(Arc::clone(e)),
+        CypherParameterValue::List(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items {
+                out.push(param_to_property(item, depth + 1)?);
+            }
+            PropertyValue::Array(Arc::new(out))
+        }
+    })
+}
+
+// ---------------------------------------------------------------------------
+// RETURN projection + validation
+// ---------------------------------------------------------------------------
+
+/// Validate that every `RETURN` item is supported by the standalone UNWIND
+/// runtime: the unwound variable (bare or aliased) or `*`. Anything else --
+/// aggregates, functions, properties, other variables -- is rejected.
+fn validate_return_items(ret: &CypherReturn, variable: &str) -> Result<(), CypherError> {
+    for item in &ret.items {
+        match item {
+            CypherReturnItem::Star => {}
+            CypherReturnItem::Variable(name) => {
+                if name != variable {
+                    return Err(unsupported_return_variable(name, variable));
+                }
+            }
+            CypherReturnItem::Expression { expr, .. } => match expr {
+                CypherExpr::Variable(name) if name == variable => {}
+                CypherExpr::Variable(name) => {
+                    return Err(unsupported_return_variable(name, variable));
+                }
+                CypherExpr::FunctionCall { name, .. } if is_aggregate_name(name) => {
+                    return Err(CypherError::UnsupportedFeature(format!(
+                        "aggregation ({name}) over an UNWIND result is not \
+                         supported by the standalone UNWIND runtime; RETURN the \
+                         unwound variable '{variable}' directly"
+                    )));
+                }
+                other => {
+                    return Err(CypherError::UnsupportedFeature(format!(
+                        "RETURN item {other:?} is not supported after a standalone \
+                         UNWIND; only the unwound variable '{variable}' (optionally \
+                         aliased) or '*' may be returned"
+                    )));
+                }
+            },
+        }
+    }
+    Ok(())
+}
+
+/// Build the error for a RETURN item naming a variable other than the unwound
+/// one (a standalone UNWIND binds only its own variable).
+fn unsupported_return_variable(name: &str, variable: &str) -> CypherError {
+    CypherError::UnsupportedFeature(format!(
+        "RETURN references variable '{name}', but a standalone UNWIND only binds \
+         the unwound variable '{variable}'"
+    ))
+}
+
+/// Validate the `ORDER BY` clause (if any) references the unwound value, either
+/// by the variable name or by an alias projecting it. Returns whether an
+/// ordering pass is needed.
+fn validate_order_by(ret: &CypherReturn, variable: &str) -> Result<bool, CypherError> {
+    if ret.order_by.is_empty() {
+        return Ok(false);
+    }
+    for order_item in &ret.order_by {
+        let CypherExpr::Variable(name) = &order_item.expr else {
+            return Err(CypherError::UnsupportedFeature(format!(
+                "ORDER BY {:?} is not supported after a standalone UNWIND; order \
+                 by the unwound variable '{variable}'",
+                order_item.expr
+            )));
+        };
+        if name != variable && !alias_projects_variable(ret, name, variable) {
+            return Err(CypherError::UnsupportedFeature(format!(
+                "ORDER BY '{name}' is not supported after a standalone UNWIND; \
+                 order by the unwound variable '{variable}' (or an alias of it)"
+            )));
+        }
+    }
+    Ok(true)
+}
+
+/// Returns `true` if some `RETURN` item projects the unwound variable under the
+/// alias `alias`.
+fn alias_projects_variable(ret: &CypherReturn, alias: &str, variable: &str) -> bool {
+    ret.items.iter().any(|item| {
+        matches!(
+            item,
+            CypherReturnItem::Expression {
+                expr: CypherExpr::Variable(v),
+                alias: Some(a),
+            } if v == variable && a == alias
+        )
+    })
+}
+
+/// Project one unwound element value into its `RETURN` output columns.
+///
+/// Preconditions (guaranteed by [`validate_return_items`]): every item is `*`,
+/// the bare unwound variable, or an expression naming the unwound variable.
+fn project_element(
+    ret: &CypherReturn,
+    variable: &str,
+    value: &PropertyValue,
+) -> Vec<(String, PropertyValue)> {
+    let mut columns = Vec::with_capacity(ret.items.len());
+    for item in &ret.items {
+        match item {
+            CypherReturnItem::Star => {
+                columns.push((variable.to_string(), value.clone()));
+            }
+            CypherReturnItem::Variable(name) => {
+                columns.push((name.clone(), value.clone()));
+            }
+            CypherReturnItem::Expression { alias, .. } => {
+                let column_name = alias.clone().unwrap_or_else(|| variable.to_string());
+                columns.push((column_name, value.clone()));
+            }
+        }
+    }
+    columns
+}
+
+// ---------------------------------------------------------------------------
+// DISTINCT + ORDER BY helpers
+// ---------------------------------------------------------------------------
+
+/// Deduplicate projected rows by their output column tuple (first wins).
+fn distinct_rows(rows: Vec<UnwindRow>) -> Vec<UnwindRow> {
+    let mut seen: Vec<Vec<(String, PropertyValue)>> = Vec::new();
+    let mut out = Vec::with_capacity(rows.len());
+    for (value, columns) in rows {
+        if seen.iter().any(|existing| existing == &columns) {
+            continue;
+        }
+        seen.push(columns.clone());
+        out.push((value, columns));
+    }
+    out
+}
+
+/// Sort projected rows by their unwound value.
+///
+/// Only homogeneous scalar lists (all numeric, all string, or all boolean --
+/// `null`s allowed) are orderable; mixed or non-scalar element types are
+/// rejected. openCypher null placement is honored: nulls last for ascending,
+/// first for descending.
+fn order_rows(rows: &mut Vec<UnwindRow>, descending: bool) -> Result<(), CypherError> {
+    let kind = order_kind(rows)?;
+
+    let (mut nulls, mut non_nulls): (Vec<UnwindRow>, Vec<UnwindRow>) = std::mem::take(rows)
+        .into_iter()
+        .partition(|(value, _)| matches!(value, PropertyValue::Null));
+
+    non_nulls.sort_by(|(a, _), (b, _)| compare_scalar(a, b, kind));
+    if descending {
+        non_nulls.reverse();
+    }
+
+    if descending {
+        // nulls first, then descending values.
+        nulls.append(&mut non_nulls);
+        *rows = nulls;
+    } else {
+        // ascending values, then nulls last.
+        non_nulls.append(&mut nulls);
+        *rows = non_nulls;
+    }
+    Ok(())
+}
+
+/// The scalar kind an `ORDER BY` operates over.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum OrderKind {
+    Numeric,
+    Text,
+    Boolean,
+}
+
+/// Determine (and validate homogeneity of) the orderable scalar kind of a set
+/// of unwound values, ignoring `null`s.
+fn order_kind(rows: &[UnwindRow]) -> Result<OrderKind, CypherError> {
+    let mut kind: Option<OrderKind> = None;
+    for (value, _) in rows {
+        let this = match value {
+            PropertyValue::Null => continue,
+            PropertyValue::Int(_) | PropertyValue::Float(_) => OrderKind::Numeric,
+            PropertyValue::String(_) => OrderKind::Text,
+            PropertyValue::Bool(_) => OrderKind::Boolean,
+            other => {
+                return Err(CypherError::UnsupportedFeature(format!(
+                    "ORDER BY over an UNWIND list supports only scalar values \
+                     (int/float/string/bool); got {other:?}"
+                )));
+            }
+        };
+        match kind {
+            None => kind = Some(this),
+            Some(existing) if existing == this => {}
+            Some(_) => {
+                return Err(CypherError::UnsupportedFeature(
+                    "ORDER BY over an UNWIND list requires homogeneous scalar \
+                     element types (all numeric, all string, or all boolean)"
+                        .to_string(),
+                ));
+            }
+        }
+    }
+    // An all-null (or empty) set has no meaningful kind; Numeric is a harmless
+    // placeholder since `compare_scalar` is never invoked on nulls.
+    Ok(kind.unwrap_or(OrderKind::Numeric))
+}
+
+/// Compare two non-null scalar [`PropertyValue`]s of the given kind.
+fn compare_scalar(a: &PropertyValue, b: &PropertyValue, kind: OrderKind) -> Ordering {
+    match kind {
+        OrderKind::Numeric => scalar_f64(a).total_cmp(&scalar_f64(b)),
+        OrderKind::Text => match (a, b) {
+            (PropertyValue::String(x), PropertyValue::String(y)) => x.as_ref().cmp(y.as_ref()),
+            _ => Ordering::Equal,
+        },
+        OrderKind::Boolean => match (a, b) {
+            (PropertyValue::Bool(x), PropertyValue::Bool(y)) => x.cmp(y),
+            _ => Ordering::Equal,
+        },
+    }
+}
+
+/// Interpret a numeric [`PropertyValue`] as `f64` for ordering.
+fn scalar_f64(value: &PropertyValue) -> f64 {
+    match value {
+        PropertyValue::Int(n) => *n as f64,
+        PropertyValue::Float(f) => *f,
+        _ => 0.0,
+    }
+}
+
+/// Returns `true` if `name` is a case-insensitive aggregate function name.
+fn is_aggregate_name(name: &str) -> bool {
+    matches!(
+        name.to_ascii_uppercase().as_str(),
+        "COUNT" | "SUM" | "AVG" | "MIN" | "MAX" | "COLLECT"
+    )
+}

--- a/src/cypher/exec.rs
+++ b/src/cypher/exec.rs
@@ -181,21 +181,15 @@ fn execute_unwind(
         order_rows(&mut projected, descending)?;
     }
 
-    // SKIP / LIMIT paginate the final rows.
+    // SKIP / LIMIT paginate the final rows. An absent LIMIT is an unbounded
+    // `take`, collapsing the Some/None arms into one pipeline.
     let skip = ret.skip.unwrap_or(0);
-    let rows: Vec<QueryRow> = match ret.limit {
-        Some(limit) => projected
-            .into_iter()
-            .skip(skip)
-            .take(limit)
-            .map(|(_, columns)| QueryRow::from_columns(columns))
-            .collect(),
-        None => projected
-            .into_iter()
-            .skip(skip)
-            .map(|(_, columns)| QueryRow::from_columns(columns))
-            .collect(),
-    };
+    let rows: Vec<QueryRow> = projected
+        .into_iter()
+        .skip(skip)
+        .take(ret.limit.unwrap_or(usize::MAX))
+        .map(|(_, columns)| QueryRow::from_columns(columns))
+        .collect();
 
     Ok(QueryResults::new(Box::new(VecResultIterator::new(rows))))
 }
@@ -233,6 +227,14 @@ fn unwind_source_values(
                         out.push(param_to_property(item, 0)?);
                     }
                     Ok(out)
+                }
+                // A dense vector / embedding parameter is a valid list source:
+                // the MCP layer coerces a bare numeric array (`$arr = [1,2,3]`)
+                // to `Embedding`, so `UNWIND $arr AS x` must behave like the
+                // identical list literal rather than being rejected. Each
+                // component becomes one `Float` row.
+                CypherParameterValue::Embedding(e) => {
+                    Ok(e.iter().map(|c| PropertyValue::Float(*c as f64)).collect())
                 }
                 other => Err(CypherError::SemanticError(format!(
                     "UNWIND requires a list or null, but parameter ${name} is a \
@@ -454,14 +456,16 @@ fn project_element(
 // ---------------------------------------------------------------------------
 
 /// Deduplicate projected rows by their output column tuple (first wins).
+///
+/// Equality is `PropertyValue`'s, so `Int(1)` and `Float(1.0)` are treated as
+/// *distinct* rows -- an intentional divergence from openCypher numeric
+/// coercion, consistent with AletheiaDB's DB-wide `PropertyValue` equality.
 fn distinct_rows(rows: Vec<UnwindRow>) -> Vec<UnwindRow> {
-    let mut seen: Vec<Vec<(String, PropertyValue)>> = Vec::new();
-    let mut out = Vec::with_capacity(rows.len());
+    let mut out: Vec<UnwindRow> = Vec::with_capacity(rows.len());
     for (value, columns) in rows {
-        if seen.iter().any(|existing| existing == &columns) {
+        if out.iter().any(|(_, existing)| existing == &columns) {
             continue;
         }
-        seen.push(columns.clone());
         out.push((value, columns));
     }
     out
@@ -480,10 +484,15 @@ fn order_rows(rows: &mut Vec<UnwindRow>, descending: bool) -> Result<(), CypherE
         .into_iter()
         .partition(|(value, _)| matches!(value, PropertyValue::Null));
 
-    non_nulls.sort_by(|(a, _), (b, _)| compare_scalar(a, b, kind));
-    if descending {
-        non_nulls.reverse();
-    }
+    // Sort directly in the requested direction (a stable sort followed by
+    // `reverse()` would invert the order of equal-key rows).
+    non_nulls.sort_by(|(a, _), (b, _)| {
+        if descending {
+            compare_scalar(b, a, kind)
+        } else {
+            compare_scalar(a, b, kind)
+        }
+    });
 
     if descending {
         // nulls first, then descending values.
@@ -542,7 +551,15 @@ fn order_kind(rows: &[UnwindRow]) -> Result<OrderKind, CypherError> {
 /// Compare two non-null scalar [`PropertyValue`]s of the given kind.
 fn compare_scalar(a: &PropertyValue, b: &PropertyValue, kind: OrderKind) -> Ordering {
     match kind {
-        OrderKind::Numeric => scalar_f64(a).total_cmp(&scalar_f64(b)),
+        // Compare same-typed numerics natively: `i64 -> f64` loses precision
+        // above 2^53, collapsing distinct large integers (nanosecond epoch
+        // timestamps, Snowflake IDs) to spurious ties and mis-ordering them.
+        // Only genuinely mixed Int/Float pairs fall back to `f64` coercion.
+        OrderKind::Numeric => match (a, b) {
+            (PropertyValue::Int(x), PropertyValue::Int(y)) => x.cmp(y),
+            (PropertyValue::Float(x), PropertyValue::Float(y)) => x.total_cmp(y),
+            _ => scalar_f64(a).total_cmp(&scalar_f64(b)),
+        },
         OrderKind::Text => match (a, b) {
             (PropertyValue::String(x), PropertyValue::String(y)) => x.as_ref().cmp(y.as_ref()),
             _ => Ordering::Equal,

--- a/src/cypher/mod.rs
+++ b/src/cypher/mod.rs
@@ -52,6 +52,7 @@
 pub mod ast;
 pub mod converter;
 mod error;
+pub mod exec;
 pub mod lexer;
 pub mod parser;
 
@@ -60,6 +61,7 @@ pub use converter::{
     CypherConverter, CypherParameterValue, parse_cypher, parse_cypher_with_params,
 };
 pub use error::CypherError;
+pub use exec::{CypherExecution, plan_cypher, plan_cypher_with_params};
 pub use lexer::{CypherLexer, Token, TokenKind};
 pub use parser::CypherParser;
 

--- a/src/cypher/parser.rs
+++ b/src/cypher/parser.rs
@@ -698,6 +698,13 @@ impl CypherParser {
                 if !self.at(TokenKind::RBracket) {
                     elements.push(self.parse_expression(depth + 1)?);
                     while self.eat(TokenKind::Comma) {
+                        // Cap the element count (mirroring MAX_EXPRESSION_TERMS
+                        // for AND/OR chains): a pathological multi-MB literal
+                        // would otherwise allocate ~1M AST nodes. Return a
+                        // graceful ParseError instead (issue #3404-adjacent).
+                        if elements.len() >= MAX_EXPRESSION_TERMS {
+                            return Err(self.error("list literal has too many elements (max 4096)"));
+                        }
                         elements.push(self.parse_expression(depth + 1)?);
                     }
                 }

--- a/src/cypher/parser.rs
+++ b/src/cypher/parser.rs
@@ -167,9 +167,44 @@ impl CypherParser {
         // Check for leading temporal clause (AS OF / FOR / BETWEEN).
         let temporal = self.try_parse_temporal()?;
 
+        // A standalone `UNWIND ... AS ... RETURN ...` statement (Issue #559).
+        // A leading temporal clause has no meaning for a listless UNWIND, so
+        // reject the combination rather than silently ignoring the qualifier.
+        if self.at(TokenKind::Unwind) {
+            if temporal.is_some() {
+                return Err(self.error(
+                    "a temporal clause (AS OF / FOR / BETWEEN) cannot precede a standalone UNWIND",
+                ));
+            }
+            return self.parse_unwind();
+        }
+
         // Now expect a MATCH (or OPTIONAL MATCH).
         let stmt = self.parse_match(temporal)?;
         Ok(stmt)
+    }
+
+    /// Parse a standalone `UNWIND <list> AS <var> RETURN ...` statement.
+    ///
+    /// ```text
+    /// unwind_stmt := UNWIND expr AS identifier return_clause
+    /// ```
+    ///
+    /// The list source is parsed as a full expression (so a list literal
+    /// `[...]`, a parameter `$list`, or the `null` literal are all accepted and
+    /// depth-capped through [`Self::parse_expression`]); whether the resolved
+    /// value is actually list-shaped is validated at execution time.
+    fn parse_unwind(&mut self) -> Result<CypherStatement, CypherError> {
+        self.expect(TokenKind::Unwind)?;
+        let source = self.parse_expression(0)?;
+        self.expect(TokenKind::As)?;
+        let var_tok = self.expect(TokenKind::Identifier)?;
+        let return_clause = self.parse_return()?;
+        Ok(CypherStatement::Unwind {
+            source,
+            variable: var_tok.text,
+            return_clause,
+        })
     }
 
     /// ```text
@@ -649,6 +684,25 @@ impl CypherParser {
                 let inner = self.parse_expression(depth + 1)?;
                 self.expect(TokenKind::RParen)?;
                 Ok(CypherExpr::Grouped(Box::new(inner)))
+            }
+
+            // List literal: `[ expr (',' expr)* ]` (empty list allowed).
+            //
+            // Each element is parsed one nesting level deeper so that a
+            // pathologically nested list literal (`[[[ ... ]]]`) is bounded by
+            // MAX_EXPRESSION_DEPTH and returns a parse error instead of
+            // overflowing the stack (issue #3404).
+            TokenKind::LBracket => {
+                self.advance();
+                let mut elements = Vec::new();
+                if !self.at(TokenKind::RBracket) {
+                    elements.push(self.parse_expression(depth + 1)?);
+                    while self.eat(TokenKind::Comma) {
+                        elements.push(self.parse_expression(depth + 1)?);
+                    }
+                }
+                self.expect(TokenKind::RBracket)?;
+                Ok(CypherExpr::List(elements))
             }
 
             // Identifier: could be variable, property access, dot-qualified function call,

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -149,6 +149,7 @@ fn test_parse_simple_match() {
             assert_eq!(pattern[0].elements.len(), 1);
             assert_eq!(return_clause.items.len(), 1);
         }
+        _ => panic!("expected a MATCH statement"),
     }
 }
 
@@ -164,6 +165,7 @@ fn test_parse_match_with_label() {
             assert_eq!(node.variable, Some("n".into()));
             assert_eq!(node.labels, vec!["Person".to_string()]);
         }
+        _ => panic!("expected a MATCH statement"),
     }
 }
 
@@ -185,6 +187,7 @@ fn test_parse_match_with_properties() {
             assert_eq!(node.properties[1].0, "age");
             assert_eq!(node.properties[1].1, CypherValue::Int(30));
         }
+        _ => panic!("expected a MATCH statement"),
     }
 }
 
@@ -201,6 +204,7 @@ fn test_parse_traversal() {
             assert_eq!(rel.rel_types, vec!["KNOWS".to_string()]);
             assert_eq!(rel.direction, CypherDirection::Outgoing);
         }
+        _ => panic!("expected a MATCH statement"),
     }
 }
 
@@ -215,6 +219,7 @@ fn test_parse_incoming_relationship() {
             };
             assert_eq!(rel.direction, CypherDirection::Incoming);
         }
+        _ => panic!("expected a MATCH statement"),
     }
 }
 
@@ -229,6 +234,7 @@ fn test_parse_bidirectional_relationship() {
             };
             assert_eq!(rel.direction, CypherDirection::Both);
         }
+        _ => panic!("expected a MATCH statement"),
     }
 }
 
@@ -243,6 +249,7 @@ fn test_parse_variable_length_path() {
             };
             assert_eq!(rel.depth, Some(CypherDepth::Range { min: 1, max: 3 }));
         }
+        _ => panic!("expected a MATCH statement"),
     }
 }
 
@@ -257,6 +264,7 @@ fn test_parse_unbounded_path() {
             };
             assert_eq!(rel.depth, Some(CypherDepth::Unbounded));
         }
+        _ => panic!("expected a MATCH statement"),
     }
 }
 
@@ -267,6 +275,7 @@ fn test_parse_where_clause() {
         CypherStatement::Match { where_clause, .. } => {
             assert!(where_clause.is_some());
         }
+        _ => panic!("expected a MATCH statement"),
     }
 }
 
@@ -279,6 +288,7 @@ fn test_parse_where_and() {
         CypherStatement::Match { where_clause, .. } => {
             assert!(matches!(where_clause, Some(CypherExpr::And(_, _))));
         }
+        _ => panic!("expected a MATCH statement"),
     }
 }
 
@@ -289,6 +299,7 @@ fn test_parse_limit() {
         CypherStatement::Match { return_clause, .. } => {
             assert_eq!(return_clause.limit, Some(10));
         }
+        _ => panic!("expected a MATCH statement"),
     }
 }
 
@@ -300,6 +311,7 @@ fn test_parse_skip_limit() {
             assert_eq!(return_clause.skip, Some(5));
             assert_eq!(return_clause.limit, Some(10));
         }
+        _ => panic!("expected a MATCH statement"),
     }
 }
 
@@ -311,6 +323,7 @@ fn test_parse_order_by() {
             assert_eq!(return_clause.order_by.len(), 1);
             assert!(return_clause.order_by[0].descending);
         }
+        _ => panic!("expected a MATCH statement"),
     }
 }
 
@@ -321,6 +334,7 @@ fn test_parse_return_distinct() {
         CypherStatement::Match { return_clause, .. } => {
             assert!(return_clause.distinct);
         }
+        _ => panic!("expected a MATCH statement"),
     }
 }
 
@@ -344,6 +358,7 @@ fn test_parse_return_expression_with_alias() {
                 other => panic!("expected Expression without alias, got: {other:?}"),
             }
         }
+        _ => panic!("expected a MATCH statement"),
     }
 }
 
@@ -355,6 +370,7 @@ fn test_parse_return_star() {
             assert_eq!(return_clause.items.len(), 1);
             assert!(matches!(return_clause.items[0], CypherReturnItem::Star));
         }
+        _ => panic!("expected a MATCH statement"),
     }
 }
 
@@ -373,6 +389,7 @@ fn test_parse_parameter() {
                 CypherValue::Parameter("name".to_string())
             );
         }
+        _ => panic!("expected a MATCH statement"),
     }
 }
 
@@ -1338,7 +1355,9 @@ fn test_parse_vector_similarity_in_order_by() {
         "MATCH (d:Document) RETURN d ORDER BY vector.similarity(d.embedding, $query) DESC LIMIT 10",
     )
     .unwrap();
-    let CypherStatement::Match { return_clause, .. } = ast;
+    let CypherStatement::Match { return_clause, .. } = ast else {
+        panic!("expected a MATCH statement");
+    };
     assert_eq!(return_clause.order_by.len(), 1);
     assert!(matches!(
         &return_clause.order_by[0].expr,
@@ -1352,7 +1371,9 @@ fn test_parse_vector_cosine() {
         "MATCH (d:Document) RETURN d, vector.cosine(d.embedding, $query) AS score ORDER BY score DESC",
     )
     .unwrap();
-    let CypherStatement::Match { return_clause, .. } = ast;
+    let CypherStatement::Match { return_clause, .. } = ast else {
+        panic!("expected a MATCH statement");
+    };
     assert!(return_clause.items.len() >= 2);
 }
 
@@ -1419,7 +1440,9 @@ fn test_parse_with_clause() {
          ORDER BY similarity DESC LIMIT 10",
     )
     .unwrap();
-    let CypherStatement::Match { with_clauses, .. } = ast;
+    let CypherStatement::Match { with_clauses, .. } = ast else {
+        panic!("expected a MATCH statement");
+    };
     assert_eq!(with_clauses.len(), 1);
     assert!(with_clauses[0].where_clause.is_some());
     // WITH should have 2 items: b and the function call aliased as similarity
@@ -1430,7 +1453,9 @@ fn test_parse_with_clause() {
 fn test_parse_optional_match() {
     // Plain MATCH is not optional.
     let ast = CypherParser::parse("MATCH (n:Person) RETURN n").unwrap();
-    let CypherStatement::Match { optional, .. } = ast;
+    let CypherStatement::Match { optional, .. } = ast else {
+        panic!("expected a MATCH statement");
+    };
     assert!(!optional);
 
     // A leading OPTIONAL MATCH sets the optional flag.
@@ -1440,7 +1465,10 @@ fn test_parse_optional_match() {
         pattern,
         optional_matches,
         ..
-    } = ast;
+    } = ast
+    else {
+        panic!("expected a MATCH statement");
+    };
     assert!(optional);
     assert_eq!(pattern.len(), 1);
     assert!(optional_matches.is_empty());
@@ -1458,7 +1486,10 @@ fn test_parse_match_then_optional_match() {
         where_clause,
         optional_matches,
         ..
-    } = ast;
+    } = ast
+    else {
+        panic!("expected a MATCH statement");
+    };
     assert!(!optional);
     assert_eq!(pattern.len(), 1);
     // The WHERE belongs to the OPTIONAL MATCH clause, not the base MATCH.
@@ -1484,7 +1515,10 @@ fn test_parse_multiple_optional_matches() {
     .unwrap();
     let CypherStatement::Match {
         optional_matches, ..
-    } = ast;
+    } = ast
+    else {
+        panic!("expected a MATCH statement");
+    };
     assert_eq!(optional_matches.len(), 2);
     assert!(optional_matches[0].where_clause.is_none());
     assert!(optional_matches[1].where_clause.is_none());
@@ -1500,7 +1534,10 @@ fn test_parse_optional_match_after_with() {
         with_clauses,
         optional_matches,
         ..
-    } = ast;
+    } = ast
+    else {
+        panic!("expected a MATCH statement");
+    };
     assert_eq!(with_clauses.len(), 1);
     assert_eq!(optional_matches.len(), 1);
     // The WITH precedes the OPTIONAL MATCH in source order.
@@ -1517,7 +1554,10 @@ fn test_parse_optional_match_base_where_and_clause_where() {
         where_clause,
         optional_matches,
         ..
-    } = ast;
+    } = ast
+    else {
+        panic!("expected a MATCH statement");
+    };
     assert!(where_clause.is_some());
     assert_eq!(optional_matches.len(), 1);
     assert!(optional_matches[0].where_clause.is_some());
@@ -1582,7 +1622,9 @@ fn test_convert_leading_optional_match() {
 #[test]
 fn test_parse_count_aggregation() {
     let ast = CypherParser::parse("MATCH (n:Person)-[:KNOWS]->(m) RETURN count(m)").unwrap();
-    let CypherStatement::Match { return_clause, .. } = ast;
+    let CypherStatement::Match { return_clause, .. } = ast else {
+        panic!("expected a MATCH statement");
+    };
     match &return_clause.items[0] {
         CypherReturnItem::Expression { expr, .. } => {
             assert!(matches!(expr, CypherExpr::FunctionCall { name, .. } if name == "COUNT"));
@@ -1597,7 +1639,9 @@ fn test_parse_multiple_patterns() {
         "MATCH (a:Person), (b:Person) WHERE a.name = 'Alice' AND b.name = 'Bob' RETURN a, b",
     )
     .unwrap();
-    let CypherStatement::Match { pattern, .. } = ast;
+    let CypherStatement::Match { pattern, .. } = ast else {
+        panic!("expected a MATCH statement");
+    };
     assert_eq!(pattern.len(), 2);
 }
 
@@ -4022,5 +4066,350 @@ fn test_e2e_transaction_time_between_rejected() {
         Err(Error::Query(QueryError::UnsupportedFeature { .. })) => {}
         Err(other) => panic!("expected UnsupportedFeature, got {other:?}"),
         Ok(_) => panic!("transaction_time_between must be rejected, not answered"),
+    }
+}
+
+// ============================================================================
+// UNWIND clause (Issue #559)
+// ============================================================================
+
+mod unwind {
+    use super::*;
+    use crate::core::property::PropertyValue;
+    use std::collections::HashMap;
+
+    /// Run a standalone-UNWIND query and return each row's output columns.
+    fn run(query: &str) -> Vec<Vec<(String, PropertyValue)>> {
+        let db = crate::AletheiaDB::new().unwrap();
+        let results = db.execute_cypher(query).unwrap();
+        results
+            .collect_all()
+            .unwrap()
+            .into_iter()
+            .map(|row| row.columns.unwrap_or_default())
+            .collect()
+    }
+
+    /// Extract the single-column value of each row (asserting one column named
+    /// `expected_name`).
+    fn single_column(
+        rows: &[Vec<(String, PropertyValue)>],
+        expected_name: &str,
+    ) -> Vec<PropertyValue> {
+        rows.iter()
+            .map(|cols| {
+                assert_eq!(cols.len(), 1, "expected exactly one output column");
+                assert_eq!(cols[0].0, expected_name, "unexpected column name");
+                cols[0].1.clone()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn list_literal_yields_one_row_per_element() {
+        let rows = run("UNWIND [1, 2, 3] AS x RETURN x");
+        let values = single_column(&rows, "x");
+        assert_eq!(
+            values,
+            vec![
+                PropertyValue::Int(1),
+                PropertyValue::Int(2),
+                PropertyValue::Int(3)
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_list_yields_zero_rows() {
+        let rows = run("UNWIND [] AS x RETURN x");
+        assert!(rows.is_empty(), "empty list must produce zero rows");
+    }
+
+    #[test]
+    fn null_yields_zero_rows() {
+        let rows = run("UNWIND null AS x RETURN x");
+        assert!(rows.is_empty(), "UNWIND null must produce zero rows");
+    }
+
+    #[test]
+    fn parameter_list_yields_rows() {
+        let db = crate::AletheiaDB::new().unwrap();
+        let mut params = HashMap::new();
+        params.insert(
+            "list".to_string(),
+            CypherParameterValue::List(vec![
+                CypherParameterValue::Int(10),
+                CypherParameterValue::Int(20),
+            ]),
+        );
+        let rows: Vec<_> = db
+            .execute_cypher_with_params("UNWIND $list AS item RETURN item", params)
+            .unwrap()
+            .collect_all()
+            .unwrap()
+            .into_iter()
+            .map(|row| row.columns.unwrap())
+            .collect();
+        let values: Vec<_> = rows.iter().map(|c| c[0].1.clone()).collect();
+        assert_eq!(values, vec![PropertyValue::Int(10), PropertyValue::Int(20)]);
+        assert_eq!(rows[0][0].0, "item");
+    }
+
+    #[test]
+    fn parameter_null_yields_zero_rows() {
+        let db = crate::AletheiaDB::new().unwrap();
+        let mut params = HashMap::new();
+        params.insert("list".to_string(), CypherParameterValue::Null);
+        let count = db
+            .execute_cypher_with_params("UNWIND $list AS item RETURN item", params)
+            .unwrap()
+            .count_all()
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn nested_lists_bind_whole_sublists() {
+        let rows = run("UNWIND [[1, 2], [3, 4]] AS pair RETURN pair");
+        let values = single_column(&rows, "pair");
+        assert_eq!(values.len(), 2);
+        assert_eq!(
+            values[0],
+            PropertyValue::Array(std::sync::Arc::new(vec![
+                PropertyValue::Int(1),
+                PropertyValue::Int(2)
+            ]))
+        );
+        assert_eq!(
+            values[1],
+            PropertyValue::Array(std::sync::Arc::new(vec![
+                PropertyValue::Int(3),
+                PropertyValue::Int(4)
+            ]))
+        );
+    }
+
+    #[test]
+    fn string_list_with_alias() {
+        let rows = run("UNWIND ['a', 'b'] AS s RETURN s AS letter");
+        let values = single_column(&rows, "letter");
+        assert_eq!(
+            values,
+            vec![
+                PropertyValue::String("a".into()),
+                PropertyValue::String("b".into())
+            ]
+        );
+    }
+
+    #[test]
+    fn return_star_projects_unwound_variable() {
+        let rows = run("UNWIND [7] AS n RETURN *");
+        let values = single_column(&rows, "n");
+        assert_eq!(values, vec![PropertyValue::Int(7)]);
+    }
+
+    #[test]
+    fn distinct_deduplicates_rows() {
+        let rows = run("UNWIND [1, 1, 2, 2, 3] AS x RETURN DISTINCT x");
+        let values = single_column(&rows, "x");
+        assert_eq!(
+            values,
+            vec![
+                PropertyValue::Int(1),
+                PropertyValue::Int(2),
+                PropertyValue::Int(3)
+            ]
+        );
+    }
+
+    #[test]
+    fn skip_and_limit_paginate() {
+        let rows = run("UNWIND [1, 2, 3, 4, 5] AS x RETURN x SKIP 1 LIMIT 2");
+        let values = single_column(&rows, "x");
+        assert_eq!(values, vec![PropertyValue::Int(2), PropertyValue::Int(3)]);
+    }
+
+    #[test]
+    fn order_by_ascending_and_descending() {
+        let asc = single_column(&run("UNWIND [3, 1, 2] AS x RETURN x ORDER BY x"), "x");
+        assert_eq!(
+            asc,
+            vec![
+                PropertyValue::Int(1),
+                PropertyValue::Int(2),
+                PropertyValue::Int(3)
+            ]
+        );
+        let desc = single_column(&run("UNWIND [3, 1, 2] AS x RETURN x ORDER BY x DESC"), "x");
+        assert_eq!(
+            desc,
+            vec![
+                PropertyValue::Int(3),
+                PropertyValue::Int(2),
+                PropertyValue::Int(1)
+            ]
+        );
+    }
+
+    #[test]
+    fn order_by_places_nulls_last_ascending() {
+        let rows = run("UNWIND [2, null, 1] AS x RETURN x ORDER BY x");
+        let values = single_column(&rows, "x");
+        assert_eq!(
+            values,
+            vec![
+                PropertyValue::Int(1),
+                PropertyValue::Int(2),
+                PropertyValue::Null
+            ]
+        );
+    }
+
+    // ---- reject-not-silently-wrong contract -------------------------------
+
+    #[test]
+    fn scalar_source_is_rejected() {
+        let db = crate::AletheiaDB::new().unwrap();
+        assert!(
+            db.execute_cypher("UNWIND 5 AS x RETURN x").is_err(),
+            "unwinding a scalar must be rejected, not answered"
+        );
+    }
+
+    #[test]
+    fn parameter_scalar_source_is_rejected() {
+        let db = crate::AletheiaDB::new().unwrap();
+        let mut params = HashMap::new();
+        params.insert("list".to_string(), CypherParameterValue::Int(5));
+        assert!(
+            db.execute_cypher_with_params("UNWIND $list AS x RETURN x", params)
+                .is_err(),
+            "a scalar parameter must be rejected"
+        );
+    }
+
+    #[test]
+    fn unwind_after_match_is_rejected() {
+        // `MATCH ... UNWIND ...` needs the graph executor and is not accepted by
+        // the standalone grammar: it must error, never silently drop the UNWIND.
+        let db = crate::AletheiaDB::new().unwrap();
+        assert!(
+            db.execute_cypher("MATCH (n) UNWIND n.tags AS t RETURN t")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn row_dependent_list_element_is_rejected() {
+        let db = crate::AletheiaDB::new().unwrap();
+        assert!(
+            db.execute_cypher("UNWIND [n.x] AS y RETURN y").is_err(),
+            "a property-access list element has no standalone value"
+        );
+    }
+
+    #[test]
+    fn aggregate_in_return_is_rejected() {
+        let db = crate::AletheiaDB::new().unwrap();
+        assert!(
+            db.execute_cypher("UNWIND [1, 2, 3] AS x RETURN count(x)")
+                .is_err(),
+            "aggregation over an UNWIND result is not supported and must error"
+        );
+    }
+
+    #[test]
+    fn foreign_variable_in_return_is_rejected() {
+        let db = crate::AletheiaDB::new().unwrap();
+        assert!(
+            db.execute_cypher("UNWIND [1, 2] AS x RETURN y").is_err(),
+            "RETURN of an unbound variable must be rejected"
+        );
+    }
+
+    // ---- parser / AST shape ------------------------------------------------
+
+    #[test]
+    fn parse_unwind_list_literal_ast() {
+        let stmt = CypherParser::parse("UNWIND [1, 2, 3] AS x RETURN x").unwrap();
+        match stmt {
+            CypherStatement::Unwind {
+                source,
+                variable,
+                return_clause,
+            } => {
+                assert_eq!(variable, "x");
+                match source {
+                    CypherExpr::List(elems) => assert_eq!(elems.len(), 3),
+                    other => panic!("expected list source, got {other:?}"),
+                }
+                assert_eq!(return_clause.items.len(), 1);
+            }
+            other => panic!("expected Unwind, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_unwind_parameter_ast() {
+        let stmt = CypherParser::parse("UNWIND $list AS item RETURN item").unwrap();
+        match stmt {
+            CypherStatement::Unwind {
+                source, variable, ..
+            } => {
+                assert_eq!(variable, "item");
+                assert!(matches!(
+                    source,
+                    CypherExpr::Value(CypherValue::Parameter(ref p)) if p == "list"
+                ));
+            }
+            other => panic!("expected Unwind, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_cypher_query_path_rejects_unwind() {
+        // `parse_cypher` returns a `Query`; a standalone UNWIND has no `Query`
+        // representation and must surface a structured error there.
+        let err = parse_cypher("UNWIND [1] AS x RETURN x");
+        assert!(matches!(err, Err(CypherError::UnsupportedFeature(_))));
+    }
+
+    #[test]
+    fn plan_cypher_routes_unwind_to_rows() {
+        match plan_cypher("UNWIND [1, 2] AS x RETURN x").unwrap() {
+            CypherExecution::Rows(_) => {}
+            CypherExecution::Query(_) => panic!("UNWIND must plan to Rows, not a Query"),
+        }
+        match plan_cypher("MATCH (n:Person) RETURN n").unwrap() {
+            CypherExecution::Query(_) => {}
+            CypherExecution::Rows(_) => panic!("MATCH must plan to a Query"),
+        }
+    }
+
+    // ---- depth / robustness (issue #3404) ----------------------------------
+
+    #[test]
+    fn deeply_nested_list_literal_errors_gracefully() {
+        // ~200 nested list literals exceed the parser's depth cap and must
+        // return a parse error rather than overflowing the stack.
+        let query = format!(
+            "UNWIND {}{}  AS x RETURN x",
+            "[".repeat(200),
+            "]".repeat(200)
+        );
+        let err = CypherParser::parse(&query);
+        assert!(
+            matches!(err, Err(CypherError::ParseError { .. })),
+            "deep nesting must yield a ParseError, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn moderately_nested_list_literal_parses_and_executes() {
+        let query = format!("UNWIND {}{}  AS x RETURN x", "[".repeat(10), "]".repeat(10));
+        let db = crate::AletheiaDB::new().unwrap();
+        let count = db.execute_cypher(&query).unwrap().count_all().unwrap();
+        assert_eq!(count, 1, "one row holding the nested list");
     }
 }

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -4412,4 +4412,125 @@ mod unwind {
         let count = db.execute_cypher(&query).unwrap().count_all().unwrap();
         assert_eq!(count, 1, "one row holding the nested list");
     }
+
+    // ---- ORDER BY large-integer precision (review fix #1) -------------------
+
+    #[test]
+    fn order_by_preserves_large_integer_precision_ascending() {
+        // 2^53 and 2^53+1 both round to 2^53 as f64, so an f64-coerced compare
+        // treats them as equal and keeps input order (WRONG). Native i64
+        // comparison must order them correctly.
+        let asc = single_column(
+            &run("UNWIND [9007199254740993, 9007199254740992] AS x RETURN x ORDER BY x"),
+            "x",
+        );
+        assert_eq!(
+            asc,
+            vec![
+                PropertyValue::Int(9007199254740992),
+                PropertyValue::Int(9007199254740993),
+            ]
+        );
+    }
+
+    #[test]
+    fn order_by_preserves_large_integer_precision_descending() {
+        let desc = single_column(
+            &run("UNWIND [9007199254740992, 9007199254740993] AS x RETURN x ORDER BY x DESC"),
+            "x",
+        );
+        assert_eq!(
+            desc,
+            vec![
+                PropertyValue::Int(9007199254740993),
+                PropertyValue::Int(9007199254740992),
+            ]
+        );
+    }
+
+    #[test]
+    fn order_by_orders_nanosecond_timestamps() {
+        // Nanosecond epoch timestamps (~1.7e18) exceed 2^53 and collide under
+        // f64 coercion; native i64 comparison keeps them distinct and ordered.
+        let asc = single_column(
+            &run(
+                "UNWIND [1700000000000000002, 1700000000000000000, 1700000000000000001] \
+                 AS x RETURN x ORDER BY x",
+            ),
+            "x",
+        );
+        assert_eq!(
+            asc,
+            vec![
+                PropertyValue::Int(1700000000000000000),
+                PropertyValue::Int(1700000000000000001),
+                PropertyValue::Int(1700000000000000002),
+            ]
+        );
+    }
+
+    // ---- embedding parameter as list source (review fix #5) ----------------
+
+    #[test]
+    fn embedding_parameter_unwinds_to_float_rows() {
+        // The MCP layer coerces a bare numeric array to `Embedding`; unwinding
+        // it must yield one Float row per component, not be rejected.
+        let db = crate::AletheiaDB::new().unwrap();
+        let mut params = HashMap::new();
+        params.insert(
+            "arr".to_string(),
+            CypherParameterValue::Embedding(std::sync::Arc::from(
+                vec![1.0f32, 2.0, 3.0].as_slice(),
+            )),
+        );
+        let rows: Vec<_> = db
+            .execute_cypher_with_params("UNWIND $arr AS x RETURN x", params)
+            .unwrap()
+            .collect_all()
+            .unwrap()
+            .into_iter()
+            .map(|row| row.columns.unwrap())
+            .collect();
+        let values: Vec<_> = rows.iter().map(|c| c[0].1.clone()).collect();
+        assert_eq!(
+            values,
+            vec![
+                PropertyValue::Float(1.0),
+                PropertyValue::Float(2.0),
+                PropertyValue::Float(3.0),
+            ]
+        );
+    }
+
+    // ---- list-literal width cap (review fix #6) ----------------------------
+
+    #[test]
+    fn list_literal_at_width_cap_parses() {
+        // Exactly MAX_EXPRESSION_TERMS (4096) elements is allowed.
+        let inner = vec!["1"; 4096].join(", ");
+        let query = format!("UNWIND [{inner}] AS x RETURN x");
+        let count = CypherParser::parse(&query)
+            .map(|stmt| match stmt {
+                CypherStatement::Unwind { source, .. } => match source {
+                    CypherExpr::List(elems) => elems.len(),
+                    other => panic!("expected list source, got {other:?}"),
+                },
+                other => panic!("expected Unwind, got {other:?}"),
+            })
+            .expect("a 4096-element list must parse");
+        assert_eq!(count, 4096);
+    }
+
+    #[test]
+    fn list_literal_over_width_cap_errors_gracefully() {
+        // 4097 elements exceeds the cap and must yield a ParseError instead of
+        // allocating an unbounded AST.
+        let inner = vec!["1"; 4097].join(", ");
+        let query = format!("UNWIND [{inner}] AS x RETURN x");
+        let err = CypherParser::parse(&query);
+        assert!(
+            matches!(err, Err(CypherError::ParseError { .. })),
+            "an over-cap list literal must yield a ParseError, got {err:?}"
+        );
+    }
 }

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -332,8 +332,14 @@ impl AletheiaDB {
     /// ```
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn execute_cypher(&self, query_string: &str) -> Result<QueryResults> {
-        let query = crate::cypher::parse_cypher(query_string)?;
-        self.execute_query(query)
+        // A standalone `UNWIND` (Issue #559) expands a list into scalar rows
+        // that have no `Query`-IR representation, so it is planned into a
+        // pre-computed result stream; every other statement lowers to a `Query`
+        // executed through the standard pipeline.
+        match crate::cypher::plan_cypher(query_string)? {
+            crate::cypher::CypherExecution::Query(query) => self.execute_query(query),
+            crate::cypher::CypherExecution::Rows(results) => Ok(results),
+        }
     }
 
     /// Execute a Cypher query string with parameter bindings.
@@ -374,8 +380,10 @@ impl AletheiaDB {
         query_string: &str,
         params: std::collections::HashMap<String, crate::cypher::CypherParameterValue>,
     ) -> Result<QueryResults> {
-        let query = crate::cypher::parse_cypher_with_params(query_string, params)?;
-        self.execute_query(query)
+        match crate::cypher::plan_cypher_with_params(query_string, params)? {
+            crate::cypher::CypherExecution::Query(query) => self.execute_query(query),
+            crate::cypher::CypherExecution::Rows(results) => Ok(results),
+        }
     }
 }
 

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -3851,6 +3851,7 @@ mod query_tool_tests {
                 label: "Person".to_string(),
                 properties: Some(props),
                 provenance: None,
+                derived_from: None,
             });
             let _: NodeResponse = parse_response(&resp).expect("seed node should succeed");
         }


### PR DESCRIPTION
## Before

Cypher had no `UNWIND`; a list could not be expanded into rows.

## After

Standalone `UNWIND  AS  RETURN ...` works — `UNWIND [1,2,3] AS x RETURN x` yields 3 rows. Supports:

- list literals (including nested sublists)
- `$list` parameters
- empty list and null → zero rows (openCypher semantics)
- `DISTINCT`, `ORDER BY` (openCypher null placement), `SKIP`, `LIMIT`, aliasing, and `RETURN *`

## How

- New `src/cypher/exec.rs` runtime (`plan_cypher` → `CypherExecution::{Query, Rows}`).
- `parse_unwind` in `parser.rs`, with list-literal depth capped at `MAX_EXPRESSION_DEPTH = 128` (preserves the #3404 stack-overflow fix).
- `CypherStatement::Unwind` + `CypherExpr::List` in `ast.rs`.
- Wiring in `converter.rs` / `mod.rs`.
- `execute_cypher` dispatch in `src/db/query.rs`.
- 24 new tests.

## Scope / explicit boundary

House rule: reject rather than be silently wrong.

- `UNWIND` combined with `MATCH` / `WITH` / traversal, or placed after a temporal clause, is **rejected at parse time**.
- Scalar or row-dependent sources (`UNWIND 5`, `UNWIND n.tags`) and `RETURN` items other than the unwound variable / `*` (aggregates, functions, properties, foreign vars) return a structured `CypherError` (`SemanticError` / `UnsupportedFeature`).
- Composition of `UNWIND` with `MATCH` / `WITH` is a documented follow-up.

## Review fixes

Follow-up pass addressing review feedback (all in `src/cypher/exec.rs` + `src/cypher/parser.rs`):

- **ORDER BY large-integer precision (MAJOR).** `compare_scalar` now compares same-typed numerics natively (`i64::cmp` for `(Int, Int)`, `f64::total_cmp` for `(Float, Float)`), coercing to `f64` only for genuinely mixed `Int`/`Float` pairs. The prior all-`f64` path lost precision above 2^53, collapsing distinct large integers (nanosecond epoch timestamps ~1.7e18, Snowflake IDs) into spurious ties that then sorted by input order — an accepted query returning a **wrong** order. RED→GREEN tests cover the ascending case and a nanosecond-timestamp case.
- **DESC stable sort.** `order_rows` now compares directly in the requested direction instead of sorting ascending and calling `reverse()`, which had inverted the relative order of equal-key rows. Null placement (nulls last ASC, first DESC) is unchanged.
- **DISTINCT / pagination simplification.** `distinct_rows` dedups by scanning the output vector directly (dropped the redundant `seen` buffer); `execute_unwind` collapses the duplicated Some/None `LIMIT` arms into one `skip/take` pipeline. Both behavior-preserving.
- **Embedding parameter as a list source.** `UNWIND $arr` where `$arr` is a dense-vector / `Embedding` parameter (the MCP layer coerces bare numeric arrays like `[1,2,3]` to `Embedding`) is now **accepted** — each component becomes one `Float` row — instead of being rejected while the identical list literal worked. Chose accept-and-unwind over a clearer error because the values are unambiguously an ordered numeric list, matching the list-literal path.
- **List-literal width cap.** List literals are now capped at `MAX_EXPRESSION_TERMS` (4096) elements in the parser, mirroring AND/OR chains, so a pathological multi-MB literal returns a graceful `ParseError` instead of allocating ~1M AST nodes. Tests: exactly 4096 parses, 4097 is a `ParseError`.
- Documented the intentional DISTINCT `Int(1)` vs `Float(1.0)` non-coercion divergence (consistent with DB-wide `PropertyValue` equality) in a code comment.

## Note

Includes a one-line unrelated fix — `derived_from: None` added to a cypher-gated `CreateNodeRequest` initializer in `src/mcp/tests.rs` that the #3371 merge left uncompiled under `--features cypher` (blocked the cypher build).

Closes #559.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxsbivDhtB4Wu1VGseDL7m)_