### PR TITLE
Harden /query ingest: structural parameter cap + production body-limit coverage (#3426)

### DIFF
--- a/docs/guides/http-query-limits.md
+++ b/docs/guides/http-query-limits.md
@@ -229,6 +229,25 @@ the HTTP-layer *input* memory guard: it rejects an oversized request body with
 *response* and the *time*. Together they cover the HTTP layer's input/output/time
 axes.
 
+### Structural parameter/embedding width cap
+
+Complementing the body-size limit, the `/query` parameter path applies a
+*structural* width cap (#3426): a numeric parameter array (an embedding) is
+capped at `MAX_VECTOR_DIMENSIONS` (**100,000**) elements, and an over-cap array
+is rejected with HTTP `400` / `INVALID_ARGUMENT` when the parameters are
+converted (`json_to_parameter_value`). This mirrors the property path's
+structural vector-dimension bound and bounds the converted embedding
+allocation, so a future operator raising `max_request_body_bytes` cannot
+silently reopen a structural amplification vector.
+
+The two limits are complementary, not substitutes: `max_request_body_bytes`
+remains the **aggregate** input-memory bound for a request — total across all
+parameters, the number of parameters, and the length of any string parameter —
+whereas this per-array cap is a structural bound on a single embedding's width.
+Because the width check runs *after* serde has materialized the request body,
+peak parse-time memory is still governed by the body-size limit, not by this
+cap.
+
 ## Coverage matrix
 
 Honest breakdown of #3368 across lanes:

--- a/src/http/converters.rs
+++ b/src/http/converters.rs
@@ -175,26 +175,35 @@ pub fn json_to_parameter_value(value: &serde_json::Value) -> Result<ParameterVal
             Ok(ParameterValue::Value(PredicateValue::String(s.clone())))
         }
         serde_json::Value::Array(arr) => {
-            // Structural width cap (defense-in-depth, Issue #3426). The request
-            // body-size limit (Issue #3108 / #3424) bounds the *bytes* on this
-            // ingest path, but it must not be the sole width bound: a future
-            // operator raising `max_request_body_bytes` should not silently
-            // reopen a structural amplification vector.
+            // Structural width cap (defense-in-depth, Issue #3426). This
+            // mirrors the sibling property path's structural vector-dimension
+            // bound (`json_to_property_value`): it bounds the converted
+            // embedding allocation (the downstream `Arc<[f32]>`) and rejects
+            // absurd dimensions early with a clear error.
+            //
+            // NOTE: this check runs *after* serde_json has already
+            // materialized the full `Vec<serde_json::Value>` for the array, so
+            // it does NOT bound peak parse-time memory for the request body --
+            // that remains governed by `max_request_body_bytes`
+            // (`DefaultBodyLimit`, Issue #3108 / #3424), exactly like the
+            // post-parse property-path cap. The two limits are complementary:
+            // the body-size limit bounds request bytes, this cap bounds the
+            // embedding width we convert to.
             //
             // This path is non-recursive: a parameter array is ALWAYS
             // interpreted as a flat numeric embedding (a nested array or object
             // element yields the float error below, never a general list and
             // never deeper recursion), so depth is bounded at 1 by construction
             // and `MAX_VECTOR_DIMENSIONS` is the single, semantically-precise
-            // structural cap. Unlike the sibling property path
-            // (`json_to_property_value`), which can also produce a generic
-            // `Array` and therefore needs the broader `MAX_ARRAY_ELEMENTS`
-            // bound, that cap would be provably unreachable here: the
-            // compile-time invariant below guarantees `MAX_VECTOR_DIMENSIONS <
-            // MAX_ARRAY_ELEMENTS`, so the vector cap always rejects first. The
-            // assert makes the invariant explicit at the check site (enforced in
-            // every build, not just tests) so nobody re-adds a redundant
-            // array-elements check should the constants ever drift.
+            // structural cap. Unlike the sibling property path, which can also
+            // produce a generic `Array` and therefore needs the broader
+            // `MAX_ARRAY_ELEMENTS` bound, that cap would be provably unreachable
+            // here: the compile-time invariant below guarantees
+            // `MAX_VECTOR_DIMENSIONS < MAX_ARRAY_ELEMENTS`, so the vector cap
+            // always rejects first. The assert makes the invariant explicit at
+            // the check site (enforced in every build, not just tests) so nobody
+            // re-adds a redundant array-elements check should the constants ever
+            // drift.
             const {
                 assert!(
                     crate::core::property::MAX_VECTOR_DIMENSIONS
@@ -568,6 +577,18 @@ mod tests {
             matches!(ok, Ok(ParameterValue::Embedding(_))),
             "an embedding exactly at the dimension cap must be accepted"
         );
+    }
+
+    #[test]
+    fn test_json_to_parameter_value_empty_array_ok() {
+        // The lower boundary: an empty array (len 0) trivially passes the
+        // dimension cap and converts to an empty embedding — the cap only
+        // rejects the upper end.
+        let empty = json_to_parameter_value(&serde_json::Value::Array(vec![]));
+        match empty {
+            Ok(ParameterValue::Embedding(e)) => assert_eq!(e.len(), 0),
+            other => panic!("expected an empty embedding, got {:?}", other.map(|_| ())),
+        }
     }
 
     #[test]

--- a/src/http/converters.rs
+++ b/src/http/converters.rs
@@ -175,28 +175,32 @@ pub fn json_to_parameter_value(value: &serde_json::Value) -> Result<ParameterVal
             Ok(ParameterValue::Value(PredicateValue::String(s.clone())))
         }
         serde_json::Value::Array(arr) => {
-            // Structural width caps (defense-in-depth, Issue #3426). The request
+            // Structural width cap (defense-in-depth, Issue #3426). The request
             // body-size limit (Issue #3108 / #3424) bounds the *bytes* on this
             // ingest path, but it must not be the sole width bound: a future
             // operator raising `max_request_body_bytes` should not silently
-            // reopen a structural amplification vector. Mirror the SAME caps the
-            // sibling property path (`json_to_property_value`) already enforces,
-            // reusing the same constants so the two paths stay in lockstep.
+            // reopen a structural amplification vector.
             //
-            // This path is non-recursive: a parameter array is always
+            // This path is non-recursive: a parameter array is ALWAYS
             // interpreted as a flat numeric embedding (a nested array or object
-            // element yields the float error below, never deeper recursion), so
-            // depth is bounded at 1 by construction and only the width caps
-            // apply. The array cap is the outer structural bound; the vector
-            // cap is the semantically-precise bound for the embedding this array
-            // becomes (and, being smaller, the effective one).
-            if arr.len() > crate::core::property::MAX_ARRAY_ELEMENTS {
-                return Err(format!(
-                    "Array count {} exceeds maximum allowed {}",
-                    arr.len(),
-                    crate::core::property::MAX_ARRAY_ELEMENTS
-                ));
-            }
+            // element yields the float error below, never a general list and
+            // never deeper recursion), so depth is bounded at 1 by construction
+            // and `MAX_VECTOR_DIMENSIONS` is the single, semantically-precise
+            // structural cap. Unlike the sibling property path
+            // (`json_to_property_value`), which can also produce a generic
+            // `Array` and therefore needs the broader `MAX_ARRAY_ELEMENTS`
+            // bound, that cap would be provably unreachable here: the
+            // compile-time invariant below guarantees `MAX_VECTOR_DIMENSIONS <
+            // MAX_ARRAY_ELEMENTS`, so the vector cap always rejects first. The
+            // assert makes the invariant explicit at the check site (enforced in
+            // every build, not just tests) so nobody re-adds a redundant
+            // array-elements check should the constants ever drift.
+            const {
+                assert!(
+                    crate::core::property::MAX_VECTOR_DIMENSIONS
+                        < crate::core::property::MAX_ARRAY_ELEMENTS
+                )
+            };
             if arr.len() > crate::core::property::MAX_VECTOR_DIMENSIONS {
                 return Err(format!(
                     "Vector dimension {} exceeds limit {}",

--- a/src/http/converters.rs
+++ b/src/http/converters.rs
@@ -175,6 +175,36 @@ pub fn json_to_parameter_value(value: &serde_json::Value) -> Result<ParameterVal
             Ok(ParameterValue::Value(PredicateValue::String(s.clone())))
         }
         serde_json::Value::Array(arr) => {
+            // Structural width caps (defense-in-depth, Issue #3426). The request
+            // body-size limit (Issue #3108 / #3424) bounds the *bytes* on this
+            // ingest path, but it must not be the sole width bound: a future
+            // operator raising `max_request_body_bytes` should not silently
+            // reopen a structural amplification vector. Mirror the SAME caps the
+            // sibling property path (`json_to_property_value`) already enforces,
+            // reusing the same constants so the two paths stay in lockstep.
+            //
+            // This path is non-recursive: a parameter array is always
+            // interpreted as a flat numeric embedding (a nested array or object
+            // element yields the float error below, never deeper recursion), so
+            // depth is bounded at 1 by construction and only the width caps
+            // apply. The array cap is the outer structural bound; the vector
+            // cap is the semantically-precise bound for the embedding this array
+            // becomes (and, being smaller, the effective one).
+            if arr.len() > crate::core::property::MAX_ARRAY_ELEMENTS {
+                return Err(format!(
+                    "Array count {} exceeds maximum allowed {}",
+                    arr.len(),
+                    crate::core::property::MAX_ARRAY_ELEMENTS
+                ));
+            }
+            if arr.len() > crate::core::property::MAX_VECTOR_DIMENSIONS {
+                return Err(format!(
+                    "Vector dimension {} exceeds limit {}",
+                    arr.len(),
+                    crate::core::property::MAX_VECTOR_DIMENSIONS
+                ));
+            }
+
             // Check if it's an embedding (vector of floats)
             let floats: Result<Vec<f32>, String> = arr
                 .iter()
@@ -496,6 +526,61 @@ mod tests {
         assert!(res.is_err());
         // Should hit vector limit, not array limit
         assert!(res.unwrap_err().contains("Vector dimension"));
+    }
+
+    #[test]
+    fn test_json_to_parameter_value_vector_dimension_limit() {
+        use crate::core::property::MAX_VECTOR_DIMENSIONS;
+
+        // A parameter/embedding array that exceeds MAX_VECTOR_DIMENSIONS must be
+        // rejected structurally (Issue #3426), independent of the request
+        // body-size limit. One element over the boundary is enough.
+        let too_large = MAX_VECTOR_DIMENSIONS + 1;
+        let large_vec: Vec<serde_json::Value> =
+            std::iter::repeat_n(json!(1.0), too_large).collect();
+        let json_val = serde_json::Value::Array(large_vec);
+
+        let result = json_to_parameter_value(&json_val);
+        match result {
+            Ok(_) => panic!("oversized embedding parameter should have been rejected"),
+            Err(e) => assert!(
+                e.contains("exceeds limit"),
+                "unexpected error message: {}",
+                e
+            ),
+        }
+    }
+
+    #[test]
+    fn test_json_to_parameter_value_dimension_boundary() {
+        use crate::core::property::MAX_VECTOR_DIMENSIONS;
+
+        // Exactly MAX_VECTOR_DIMENSIONS elements is accepted (the cap rejects
+        // strictly-greater, mirroring the property path's boundary).
+        let at_limit: Vec<serde_json::Value> =
+            std::iter::repeat_n(json!(0.5), MAX_VECTOR_DIMENSIONS).collect();
+        let ok = json_to_parameter_value(&serde_json::Value::Array(at_limit));
+        assert!(
+            matches!(ok, Ok(ParameterValue::Embedding(_))),
+            "an embedding exactly at the dimension cap must be accepted"
+        );
+    }
+
+    #[test]
+    fn test_json_to_parameter_value_normal_embedding_ok() {
+        // A small, legitimate embedding parameter must still convert cleanly —
+        // the structural cap must not regress the happy path.
+        let val = json!([0.1, 0.2, 0.3, 0.4]);
+        match json_to_parameter_value(&val) {
+            Ok(ParameterValue::Embedding(e)) => assert_eq!(e.len(), 4),
+            other => panic!("expected an embedding, got {:?}", other.map(|_| ())),
+        }
+
+        // Scalars remain unaffected.
+        assert!(matches!(
+            json_to_parameter_value(&json!(7)),
+            Ok(ParameterValue::Value(PredicateValue::Int(7)))
+        ));
     }
 
     #[test]

--- a/tests/http_run_server_body_limit.rs
+++ b/tests/http_run_server_body_limit.rs
@@ -1,0 +1,184 @@
+//! Production-stack integration test: the `413 Payload Too Large` body-size
+//! limit is enforced through the REAL `run_server` / autumn layer stack, over
+//! a real TCP socket.
+//!
+//! The `warden_http_param_dos.rs` regression test asserts the `413` behavior
+//! through `build_test_router`, which *mirrors* — but is not — the production
+//! router assembled in `src/http/server.rs::run_server`. A future refactor of
+//! the production layer stack (the `DefaultBodyLimit::max(...)` layer) could
+//! drop or disable the limit while the mirrored test router still passes. This
+//! test boots the actual `run_server` on an ephemeral port and behaviorally
+//! asserts an oversized body is rejected with `413` over the wire, so that
+//! regression is caught.
+//!
+//! Regression test for Issue #3426 (item 2).
+//!
+//! Run with: `cargo test --test http_run_server_body_limit --features http-server`
+
+#![cfg(feature = "http-server")]
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::time::{Duration, Instant};
+
+use aletheiadb::auth::AuthMode;
+use aletheiadb::http::{ServerConfig, run_server};
+
+/// Body-size limit for the booted server: small enough that a terse oversized
+/// array trips it, comfortably above the tiny positive-control request.
+const TEST_BODY_LIMIT: usize = 4 * 1024;
+
+/// Reserve an ephemeral localhost port by binding (then dropping) a listener,
+/// returning the port number the OS chose. There is an inherent small race
+/// between releasing the port here and `run_server` re-binding it; on a test
+/// host this is negligible and the readiness loop below tolerates the startup
+/// window.
+fn reserve_ephemeral_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let port = listener.local_addr().expect("read local addr").port();
+    drop(listener);
+    port
+}
+
+/// Send a raw HTTP/1.1 POST and return the numeric status code, or `None` if
+/// the connection could not be established / completed (server not up yet).
+fn post_status(addr: &str, path: &str, body: &[u8]) -> Option<u16> {
+    let mut stream = TcpStream::connect(addr).ok()?;
+    stream.set_read_timeout(Some(Duration::from_secs(5))).ok()?;
+
+    let host = addr;
+    let request_head = format!(
+        "POST {path} HTTP/1.1\r\n\
+         Host: {host}\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {len}\r\n\
+         Connection: close\r\n\
+         \r\n",
+        len = body.len()
+    );
+
+    stream.write_all(request_head.as_bytes()).ok()?;
+    stream.write_all(body).ok()?;
+    stream.flush().ok()?;
+
+    let mut response = Vec::new();
+    // Read until EOF (server sends `Connection: close`) or the read times out.
+    let mut buf = [0u8; 4096];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                response.extend_from_slice(&buf[..n]);
+                // The status line is in the first packet; stop once we have the
+                // full header block to avoid blocking on a large/slow body.
+                if response.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+
+    parse_status_code(&response)
+}
+
+/// Parse the numeric status code from an HTTP/1.x status line
+/// (`HTTP/1.1 413 Payload Too Large`).
+fn parse_status_code(response: &[u8]) -> Option<u16> {
+    let text = String::from_utf8_lossy(response);
+    let first_line = text.lines().next()?;
+    let mut parts = first_line.split_whitespace();
+    let _version = parts.next()?;
+    parts.next()?.parse::<u16>().ok()
+}
+
+/// Poll `post_status` until the server accepts connections, then return the
+/// status of the request. Fails the test if the server never comes up.
+fn post_when_ready(addr: &str, path: &str, body: &[u8]) -> u16 {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if let Some(status) = post_status(addr, path, body) {
+            return status;
+        }
+        if Instant::now() >= deadline {
+            panic!("server at {addr} never became ready within timeout");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Plain (non-tokio) test: the autumn/axum `run_server` future cannot be
+/// `tokio::spawn`ed (its higher-ranked lifetimes trip `FnOnce is not general
+/// enough`), so we run the REAL server on its own OS thread with a dedicated
+/// current-thread runtime and drive it with blocking `std::net` client I/O.
+/// This still exercises the exact production layer stack over a real socket.
+#[test]
+fn run_server_enforces_413_over_the_wire() {
+    let port = reserve_ephemeral_port();
+    let addr = format!("127.0.0.1:{port}");
+
+    // Boot the REAL production server stack on a background thread. Anonymous
+    // mode (Issue #3350) so the body-limit layer — which runs before handler
+    // auth — is what produces the 413, not an auth rejection. No data_dir =>
+    // in-memory.
+    let config = ServerConfig::builder()
+        .host("127.0.0.1")
+        .port(port)
+        .auth_mode(AuthMode::Anonymous)
+        .max_request_body_bytes(TEST_BODY_LIMIT)
+        .build();
+
+    let server_thread = std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build server runtime");
+        // Runs until the process ends / thread is torn down; we never join it.
+        let _ = rt.block_on(run_server(config));
+    });
+
+    // ── Oversized body must be rejected with 413 through the production stack. ──
+    let big_array: Vec<serde_json::Value> = (0..8_000).map(|_| serde_json::json!(1)).collect();
+    let oversized = serde_json::to_vec(&serde_json::json!({
+        "operation": "execute_query",
+        "query": "MATCH (n) RETURN n",
+        "parameters": { "v": big_array }
+    }))
+    .unwrap();
+    assert!(
+        oversized.len() > TEST_BODY_LIMIT && oversized.len() < 2 * 1024 * 1024,
+        "oversized body ({} bytes) must exceed the configured limit but stay \
+         under axum's historical 2 MiB default",
+        oversized.len()
+    );
+
+    let status = post_when_ready(&addr, "/query", &oversized);
+    assert_eq!(
+        status, 413,
+        "the production run_server stack must reject an oversized body with \
+         413 Payload Too Large, got {status}"
+    );
+
+    // ── A small request under the limit must still be served (proves the
+    // server is genuinely up and the limit is not rejecting everything). ──
+    let small = serde_json::to_vec(&serde_json::json!({
+        "operation": "create_node",
+        "label": "Person",
+        "properties": { "name": "Alice" }
+    }))
+    .unwrap();
+    assert!(
+        small.len() < TEST_BODY_LIMIT,
+        "positive-control body ({} bytes) must be under the limit",
+        small.len()
+    );
+    let ok_status = post_when_ready(&addr, "/query", &small);
+    assert_eq!(
+        ok_status, 200,
+        "a legitimate small request must still succeed through run_server, got {ok_status}"
+    );
+
+    // The server thread is detached (it runs `run_server` forever); the test
+    // process exits and reaps it. Nothing to join.
+    drop(server_thread);
+}

--- a/tests/http_run_server_body_limit.rs
+++ b/tests/http_run_server_body_limit.rs
@@ -58,8 +58,20 @@ fn post_status(addr: &str, path: &str, body: &[u8]) -> Option<u16> {
     );
 
     stream.write_all(request_head.as_bytes()).ok()?;
-    stream.write_all(body).ok()?;
-    stream.flush().ok()?;
+    // Race: the server may reject the oversized body and RST/close the
+    // connection before we finish writing it, so `write_all`/`flush` can fail
+    // with BrokenPipe/ConnectionReset even though a valid `413` status line is
+    // already waiting to be read. Tolerate those write errors and still attempt
+    // the read — the status line, not a clean write, is the real assertion.
+    if let Err(e) = stream.write_all(body) {
+        if !matches!(
+            e.kind(),
+            std::io::ErrorKind::BrokenPipe | std::io::ErrorKind::ConnectionReset
+        ) {
+            return None;
+        }
+    }
+    let _ = stream.flush();
 
     let mut response = Vec::new();
     // Read until EOF (server sends `Connection: close`) or the read times out.
@@ -138,7 +150,11 @@ fn run_server_enforces_413_over_the_wire() {
     });
 
     // ── Oversized body must be rejected with 413 through the production stack. ──
-    let big_array: Vec<serde_json::Value> = (0..8_000).map(|_| serde_json::json!(1)).collect();
+    // Kept modest (~8 KiB, just over the 4 KiB limit) so it reliably fits a
+    // single socket send and does not depend on the write completing after the
+    // server has already RST the connection (see the write-tolerance in
+    // `post_status`).
+    let big_array: Vec<serde_json::Value> = (0..4_000).map(|_| serde_json::json!(1)).collect();
     let oversized = serde_json::to_vec(&serde_json::json!({
         "operation": "execute_query",
         "query": "MATCH (n) RETURN n",

--- a/tests/warden_query_param_cap.rs
+++ b/tests/warden_query_param_cap.rs
@@ -1,0 +1,129 @@
+//! Warden: structural parameter/embedding cap on the `/query` ingest path.
+//!
+//! The request body-size limit (Issue #3108 / #3424) bounds the *bytes* a
+//! `/query` request may carry, but it is not the only defense the ingest path
+//! should have. The parameter/embedding deserialization path
+//! (`json_to_parameter_value`) must also enforce a structural element/dimension
+//! cap — mirroring the sibling property path (`json_to_property_value`) — so
+//! that a future operator raising `max_request_body_bytes` cannot silently
+//! reopen a structural amplification vector. The byte-size limit and the
+//! structural cap are complementary bounds, not substitutes.
+//!
+//! This test drives the cap end-to-end through the router with a *generous*
+//! body limit, so the oversized embedding array clears the `413` byte gate and
+//! reaches the converter — where it must be rejected with a `400 Bad Request`
+//! (a caller-fault `4xx`), never a `5xx` and never silently accepted.
+//!
+//! Regression test for Issue #3426 (item 1).
+//!
+//! Run with: `cargo test --test warden_query_param_cap --features http-server`
+
+#![cfg(feature = "http-server")]
+
+use std::sync::Arc;
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::auth::AuthMode;
+use aletheiadb::http::{AppState, ServerConfig, build_test_router};
+use autumn_web::test::{TestApp, TestClient};
+use axum::body::Body;
+use serde_json::json;
+
+/// A body limit far larger than the oversized embedding below, so the request
+/// is NOT rejected by the byte gate (Issue #3108) — the `400` this test asserts
+/// can only come from the structural cap (Issue #3426), proving the two bounds
+/// are independent.
+const GENEROUS_BODY_LIMIT: usize = 8 * 1024 * 1024;
+
+/// Mirror of `crate::core::property::MAX_VECTOR_DIMENSIONS` (100_000). Kept as a
+/// local literal because the constant is `pub` but this integration test drives
+/// only the public HTTP surface; if the real cap changes, the `+ 1` request
+/// below must still exceed it — see the `at_dimension_cap` companion assertion.
+const MAX_VECTOR_DIMENSIONS: usize = 100_000;
+
+fn client_with_limit(max_body: usize) -> TestClient {
+    let db = Arc::new(AletheiaDB::new().expect("create DB"));
+    let state = AppState::new(db);
+    // Anonymous mode (Issue #3350) so auth extraction doesn't 401 before the
+    // handler converts parameters — this test exercises the structural cap in
+    // isolation, exactly as `warden_http_param_dos.rs` does for the byte cap.
+    let config = ServerConfig::builder()
+        .max_request_body_bytes(max_body)
+        .auth_mode(AuthMode::Anonymous)
+        .build();
+    let router = build_test_router(state, &config).expect("build router");
+    TestApp::from_router(router)
+}
+
+/// An embedding parameter array whose element count exceeds
+/// `MAX_VECTOR_DIMENSIONS` must be rejected with `400 Bad Request` — a
+/// structural `4xx`, distinct from the `413` byte gate and never a `5xx`.
+#[tokio::test]
+async fn oversized_embedding_parameter_is_rejected_with_400() {
+    let client = client_with_limit(GENEROUS_BODY_LIMIT);
+
+    // One element over the vector-dimension cap. Encoded as integers to keep
+    // the body compact (~200 KB) — well under GENEROUS_BODY_LIMIT, so the byte
+    // gate cannot fire and the `400` must originate in the converter.
+    let big_embedding: Vec<serde_json::Value> =
+        (0..=MAX_VECTOR_DIMENSIONS).map(|_| json!(1)).collect();
+    let payload = json!({
+        "operation": "execute_query",
+        "query": "MATCH (n) RETURN n",
+        "parameters": { "embedding": big_embedding }
+    });
+    let bytes = serde_json::to_vec(&payload).unwrap();
+    assert!(
+        bytes.len() < GENEROUS_BODY_LIMIT,
+        "test body ({} bytes) must sit under the configured body limit so the \
+         413 byte gate cannot fire — the 400 must come from the structural cap",
+        bytes.len()
+    );
+
+    let resp = client
+        .post("/query")
+        .header("content-type", "application/json")
+        .body(Body::from(bytes))
+        .send()
+        .await;
+
+    assert_eq!(
+        resp.status.as_u16(),
+        400,
+        "an oversized embedding parameter must be rejected with 400 Bad Request \
+         (structural cap), got {}",
+        resp.status.as_u16()
+    );
+    // Explicitly pin that this is neither the byte gate nor a server fault.
+    assert_ne!(resp.status.as_u16(), 413, "must not be the byte-size gate");
+    assert!(
+        !resp.status.is_server_error(),
+        "structural rejection must never be a 5xx"
+    );
+}
+
+/// A legitimately-sized embedding parameter under the cap must still be
+/// accepted — the structural cap must not regress the happy path.
+#[tokio::test]
+async fn normal_embedding_parameter_is_accepted() {
+    let client = client_with_limit(GENEROUS_BODY_LIMIT);
+
+    let payload = json!({
+        "operation": "execute_query",
+        "query": "MATCH (n) RETURN n",
+        "parameters": { "embedding": [0.1, 0.2, 0.3, 0.4] }
+    });
+
+    let resp = client
+        .post("/query")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&payload).unwrap()))
+        .send()
+        .await;
+
+    assert_eq!(
+        resp.status.as_u16(),
+        200,
+        "a legitimate small embedding parameter must still succeed"
+    );
+}

--- a/tests/warden_query_param_cap.rs
+++ b/tests/warden_query_param_cap.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 
 use aletheiadb::AletheiaDB;
 use aletheiadb::auth::AuthMode;
+use aletheiadb::core::property::MAX_VECTOR_DIMENSIONS;
 use aletheiadb::http::{AppState, ServerConfig, build_test_router};
 use autumn_web::test::{TestApp, TestClient};
 use axum::body::Body;
@@ -34,12 +35,6 @@ use serde_json::json;
 /// can only come from the structural cap (Issue #3426), proving the two bounds
 /// are independent.
 const GENEROUS_BODY_LIMIT: usize = 8 * 1024 * 1024;
-
-/// Mirror of `crate::core::property::MAX_VECTOR_DIMENSIONS` (100_000). Kept as a
-/// local literal because the constant is `pub` but this integration test drives
-/// only the public HTTP surface; if the real cap changes, the `+ 1` request
-/// below must still exceed it — see the `at_dimension_cap` companion assertion.
-const MAX_VECTOR_DIMENSIONS: usize = 100_000;
 
 fn client_with_limit(max_body: usize) -> TestClient {
     let db = Arc::new(AletheiaDB::new().expect("create DB"));
@@ -66,7 +61,7 @@ async fn oversized_embedding_parameter_is_rejected_with_400() {
     // the body compact (~200 KB) — well under GENEROUS_BODY_LIMIT, so the byte
     // gate cannot fire and the `400` must originate in the converter.
     let big_embedding: Vec<serde_json::Value> =
-        (0..=MAX_VECTOR_DIMENSIONS).map(|_| json!(1)).collect();
+        (0..MAX_VECTOR_DIMENSIONS + 1).map(|_| json!(1)).collect();
     let payload = json!({
         "operation": "execute_query",
         "query": "MATCH (n) RETURN n",


### PR DESCRIPTION
## Summary

Closes the two hardening gaps on the HTTP `/query` ingest path called out in **Issue #3426**:

1. **Structural parameter/embedding cap** (item 1) — the parameter converter enforced no width cap, unlike its sibling property converter.
2. **Production-stack body-limit coverage** (item 2) — the `413` body-size limit was only tested through the *mirrored* test router, never the real `run_server` stack.

Reference: Issue #3426.

## Before / After (plain language)

**Before**
- The only width defense on `/query` was the request **body-size** limit (`max_request_body_bytes`, #3108 / #3424). The parameter/embedding deserialization path (`json_to_parameter_value`) accepted an array of *any* element count. If an operator raised `max_request_body_bytes`, an oversized embedding array could sail through and be materialized — a structural amplification vector with no independent bound. The sibling property path (`json_to_property_value`) already had structural caps; the parameter path did not, so the two ingest paths were inconsistent.
- The `413 Payload Too Large` limit was regression-tested only through `build_test_router`, which *mirrors* but is **not** the production router assembled in `run_server`. A future refactor of the production `DefaultBodyLimit` layer could silently drop the limit while the mirrored test kept passing.

**After**
- `json_to_parameter_value` enforces a single, binding **`MAX_VECTOR_DIMENSIONS`** width cap (reusing the property path's constant, so the two stay in lockstep). The parameter array path is non-recursive — a parameter array is always a flat numeric embedding — so the vector-dimension cap is the only semantically-meaningful structural bound. The broader `MAX_ARRAY_ELEMENTS` cap the property path also carries would be **provably unreachable** here, so it is not applied as a second runtime check; instead a compile-time `const { assert!(MAX_VECTOR_DIMENSIONS < MAX_ARRAY_ELEMENTS) }` invariant makes the "vector cap always rejects first" property explicit at the check site (enforced in every build), so nobody re-adds a redundant array-elements check should the constants ever drift. An over-cap parameter array is rejected as a caller-fault **`400 Bad Request`** — never a `5xx`, never silently accepted. The byte limit and the structural cap are now **independent, complementary bounds**: raising one cannot reopen the vector the other closes.
- A production-stack integration test boots the real `run_server` on an ephemeral port and asserts an oversized body is rejected with **`413` over a real socket**, plus a small-request positive control (`200`). A silent regression of the production body limit is now caught.

## How

- **`src/http/converters.rs`**: in the `serde_json::Value::Array` arm of `json_to_parameter_value`, add a single width check **before** float conversion — reject when `arr.len() > MAX_VECTOR_DIMENSIONS`. The path is non-recursive (a parameter array is always a flat numeric embedding), so only this one width cap applies; depth is bounded at 1 by construction. A compile-time `const { assert!(MAX_VECTOR_DIMENSIONS < MAX_ARRAY_ELEMENTS) }` guards the invariant that makes a separate array-elements runtime check unreachable (and therefore redundant). Errors mirror the property path&#39;s message wording.
- The constant is reused from `crate::core::property` (no new magic numbers), guaranteeing the parameter and property ingest paths cannot drift.

## Acceptance-criteria evidence

| # | Acceptance criterion (#3426) | Evidence |
|---|------------------------------|----------|
| 1 | Oversized parameter/embedding array is rejected structurally with a `400` (caller-fault `4xx`), **independent of** the byte-size limit | `tests/warden_query_param_cap.rs::oversized_embedding_parameter_is_rejected_with_400` — drives an over-cap embedding through the router with an **8 MiB** body limit so the `413` byte gate cannot fire; asserts `400`, asserts `!= 413`, asserts not `5xx` |
| 2 | Rejection is never a `5xx` and never a silent accept | Same test&#39;s `assert_ne!(413)` + `!is_server_error()`; unit `test_json_to_parameter_value_vector_dimension_limit` asserts the `Err(&#34;exceeds limit&#34;)` |
| 3 | The cap does not regress the happy path (legitimate small embeddings still work) | `tests/warden_query_param_cap.rs::normal_embedding_parameter_is_accepted` (`200`); units `test_json_to_parameter_value_normal_embedding_ok` + `test_json_to_parameter_value_dimension_boundary` (exactly-at-cap accepted) |
| 4 | Cap boundary matches the property path (`&gt; cap` rejected, `== cap` accepted) | `test_json_to_parameter_value_dimension_boundary` — `MAX_VECTOR_DIMENSIONS` elements accepted, `+1` rejected |
| 5 | The `413` body-size limit is enforced through the **real** `run_server` production stack, over the wire | `tests/http_run_server_body_limit.rs::run_server_enforces_413_over_the_wire` — boots real `run_server` on an ephemeral port, raw HTTP/1.1 POST, asserts `413` for oversized body |
| 6 | The production server still serves legitimate requests (limit not rejecting everything) | Same test&#39;s small-request positive control asserts `200` |

## Verification

All decisive gates were run under an **isolated `CARGO_TARGET_DIR`** (separate from the shared workspace target, to avoid cross-lane artifact collisions):

- **CI-linting clippy** — `cargo clippy --all-targets --features &#34;config-toml,mcp-server,sharding-rpc,simulation&#34; -- -D warnings`: **clean (exit 0, 0 warnings)**.
- **`cargo fmt --all`**: clean (no changes).
- **Decisive tests** (`--features http-server`): lib all green (incl. the new converter unit tests), `warden_query_param_cap`, `http_run_server_body_limit`, and `warden_http_param_dos` all passing.
- **Full default `cargo test`**: all green **except** one pre-existing, environment-dependent failure — `havoc_suites::wal::havoc_flush_deadlock::test_flush_deadlock_on_io_error`. That test forces an I/O error by making a temp dir read-only (`0o444`); when the suite runs as **root** (this environment, uid 0), root bypasses directory permission bits, so `flush` succeeds and the test&#39;s own precondition assertion trips. It touches only the WAL flush coordinator — unrelated to this change (HTTP parameter path; no WAL, no filesystem).

### Caveat: `clippy --all-features`

`cargo clippy --all-targets --all-features` fails to compile with exactly **one** pre-existing, unrelated error:

```
error[E0063]: missing field `derived_from` in initializer of `mcp::tools::CreateNodeRequest`
    --&gt; src/mcp/tests.rs:3849:43
```

This originates from the #3371 derivation-lineage merge already on `trunk`, not from this PR — **none of the files in this PR error** (`converters.rs` produces zero diagnostics). The CI-linting clippy set (which excludes `cypher`/the affected path) is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DcN8fSwm1nCUv1676y6mvc

---
_Generated by [Claude Code](https://claude.ai/code/session_01DcN8fSwm1nCUv1676y6mvc)_