### PR TITLE
refactor(#3407): keep replay tx-time closures; document why they are NOT redundant

### DIFF
--- a/benches/recovery_benchmarks.rs
+++ b/benches/recovery_benchmarks.rs
@@ -20,6 +20,8 @@
 
 mod common;
 
+use aletheiadb::AletheiaDB;
+use aletheiadb::config::{AletheiaDBConfig, WalConfigBuilder};
 use aletheiadb::core::id::NodeId;
 use aletheiadb::core::interning::GLOBAL_INTERNER;
 use aletheiadb::core::property::PropertyMapBuilder;
@@ -28,6 +30,8 @@ use aletheiadb::index::vector::DistanceMetric;
 use aletheiadb::index::vector::hnsw::HnswConfig;
 use aletheiadb::storage::current::CurrentStorage;
 use aletheiadb::storage::historical::HistoricalStorage;
+use aletheiadb::storage::index_persistence::PersistenceConfig;
+use aletheiadb::storage::wal::DurabilityMode;
 use aletheiadb::storage::wal::WalOperation;
 use aletheiadb::storage::wal::concurrent_system::{ConcurrentWalSystem, ConcurrentWalSystemConfig};
 use aletheiadb::storage::{CheckpointManager, UnifiedCheckpointConfig};
@@ -408,6 +412,84 @@ fn bench_recovery_vector_indexed(c: &mut Criterion) {
 }
 
 // ============================================================================
+// Benchmark 6: Full startup WAL decode (Issue #3429)
+// ============================================================================
+
+/// Populate a WAL directory with `node_count` create operations and no index
+/// snapshot, returning the temp dir that owns it. The WAL is fsync-durable on
+/// drop; because index persistence is disabled here, no snapshot/manifest is
+/// written, so a reopen must replay the WAL in full.
+fn build_cold_wal(node_count: usize) -> TempDir {
+    let temp_dir = TempDir::new().unwrap();
+    let wal_dir = temp_dir.path().join("wal");
+    let config = AletheiaDBConfig::builder()
+        .wal(
+            WalConfigBuilder::new()
+                .wal_dir(wal_dir)
+                .durability_mode(DurabilityMode::Synchronous)
+                .build(),
+        )
+        .persistence(PersistenceConfig {
+            enabled: false,
+            ..PersistenceConfig::default()
+        })
+        .build();
+    let db = AletheiaDB::with_unified_config(config).unwrap();
+    for i in 0..node_count {
+        db.create_node(
+            "BenchNode",
+            PropertyMapBuilder::new()
+                .insert("i", i as i64)
+                .insert("name", format!("node-{i}"))
+                .build(),
+        )
+        .unwrap();
+    }
+    drop(db);
+    temp_dir
+}
+
+/// Issue #3429: measure the full `AletheiaDB::with_unified_config` startup that
+/// replays a cold WAL (no index snapshot). Before the fold, startup decoded the
+/// segment directory in three independent full passes (max-LSN allocator seed,
+/// constraint declaration scan, differential replay); after the fold it decodes
+/// once and reuses the result for all three. This benchmark opens the same
+/// pre-populated WAL directory repeatedly, so the whole cost measured is the
+/// startup decode+replay path the fold optimizes.
+fn bench_startup_full_wal_decode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("recovery_startup_full_wal_decode");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(20));
+
+    for &node_count in &[5_000usize, 25_000usize] {
+        let source = build_cold_wal(node_count);
+        let wal_dir = source.path().join("wal");
+
+        group.bench_function(format!("{node_count}_ops_cold_wal"), |b| {
+            b.iter(|| {
+                let config = AletheiaDBConfig::builder()
+                    .wal(
+                        WalConfigBuilder::new()
+                            .wal_dir(wal_dir.clone())
+                            .durability_mode(DurabilityMode::Synchronous)
+                            .build(),
+                    )
+                    .persistence(PersistenceConfig {
+                        enabled: false,
+                        ..PersistenceConfig::default()
+                    })
+                    .build();
+                let db = AletheiaDB::with_unified_config(config).unwrap();
+                assert_eq!(db.node_count(), node_count);
+                black_box(db);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// ============================================================================
 // Criterion Configuration
 // ============================================================================
 
@@ -418,7 +500,8 @@ criterion_group!(
         bench_recovery_medium_dataset,
         bench_recovery_large_dataset,
         bench_recovery_wal_replay,
-        bench_recovery_vector_indexed
+        bench_recovery_vector_indexed,
+        bench_startup_full_wal_decode
 );
 
 criterion_main!(benches);

--- a/benches/recovery_benchmarks.rs
+++ b/benches/recovery_benchmarks.rs
@@ -450,12 +450,26 @@ fn build_cold_wal(node_count: usize) -> TempDir {
 }
 
 /// Issue #3429: measure the full `AletheiaDB::with_unified_config` startup that
-/// replays a cold WAL (no index snapshot). Before the fold, startup decoded the
-/// segment directory in three independent full passes (max-LSN allocator seed,
-/// constraint declaration scan, differential replay); after the fold it decodes
-/// once and reuses the result for all three. This benchmark opens the same
-/// pre-populated WAL directory repeatedly, so the whole cost measured is the
-/// startup decode+replay path the fold optimizes.
+/// replays a cold WAL (no index snapshot).
+///
+/// This bench runs with `persistence(enabled: false)`, i.e. the **WAL-only**
+/// startup path. On that path the fold is **2 -> 1**: before the fold startup
+/// decoded the segment directory twice (max-LSN allocator seed, then the
+/// differential replay's full read from LSN 0); after the fold it decodes once
+/// and reuses the result for both. There is no constraint-declaration scan on
+/// the WAL-only path (the replay loop applies constraint ops inline), so this
+/// bench does not exercise the 3 -> 1 fold of the index-persistence path.
+///
+/// The index-persistence path's 3 -> 1 fold, and specifically that a constraint
+/// declared BELOW the manifest LSN is still recovered after the fold, is pinned
+/// by the `t3429_below_manifest_constraint_and_tail_survive_single_pass_startup`
+/// regression test (tests/lsn_recovery_regression.rs) rather than this bench — a
+/// persistence-enabled bench variant is deliberately avoided because reopening
+/// the same data_dir per iteration would pollute the measurement via the
+/// drop-time snapshot.
+///
+/// This benchmark opens the same pre-populated WAL directory repeatedly, so the
+/// whole cost measured is the startup decode+replay path the fold optimizes.
 fn bench_startup_full_wal_decode(c: &mut Criterion) {
     let mut group = c.benchmark_group("recovery_startup_full_wal_decode");
     group.sample_size(10);

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -420,7 +420,11 @@ impl AletheiaDB {
                     wal_cipher.as_ref(),
                 )?
             } else {
-                startup_wal_entries.iter().map(|e| e.lsn).max()
+                // `read_from` returns entries globally sorted by LSN
+                // (segment_reader: `entries.sort_by_key(|e| e.lsn)`), so the
+                // last element carries the max LSN in O(1). Empty WAL -> `None`
+                // -> the seed is a no-op.
+                startup_wal_entries.last().map(|e| e.lsn)
             };
             seed_lsn_allocator_from_max(&wal, seed_max_lsn);
 
@@ -575,15 +579,21 @@ impl AletheiaDB {
 
                 // Issue #3429: feed the differential replay the suffix of the
                 // single startup read (entries with LSN >= start_lsn), rather
-                // than re-reading the segment directory a third time. `read_from`
-                // returns entries globally sorted by LSN, so this filtered
-                // suffix is byte-identical to what `read_from(start_lsn)` would
-                // have produced (same contiguous, LSN-ordered tail the framing
-                // resolver expects).
-                let replay_entries: Vec<_> = std::mem::take(&mut startup_wal_entries)
-                    .into_iter()
-                    .filter(|entry| entry.lsn >= start_lsn)
-                    .collect();
+                // than re-reading the segment directory a third time.
+                //
+                // CORRECTNESS: `read_from` returns entries globally sorted by
+                // LSN (segment_reader: `entries.sort_by_key(|e| e.lsn)`), so
+                // `partition_point` finds the first index with LSN >= start_lsn
+                // and `drain(..idx)` discards exactly the entries below it — a
+                // contiguous, in-place split with no extra allocation. This is
+                // byte-identical to what `read_from(start_lsn)` would have
+                // produced (the same LSN-ordered tail the framing resolver
+                // expects). If the sort is ever removed upstream, this
+                // partition (and the O(1) seed above) breaks — keep them
+                // together.
+                let split = startup_wal_entries.partition_point(|entry| entry.lsn < start_lsn);
+                startup_wal_entries.drain(..split);
+                let replay_entries = std::mem::take(&mut startup_wal_entries);
 
                 let mut historical_guard = db.historical.write();
                 let (_final_lsn, max_node_id, max_edge_id, next_version_id) =

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -98,15 +98,28 @@ fn seed_lsn_allocator_from_segments(
     wal: &ConcurrentWalSystem,
     cipher: Option<&Arc<dyn crate::encryption::cipher::Cipher>>,
 ) -> Result<()> {
-    if let Some(max_lsn) =
-        crate::storage::wal::segment_reader::max_lsn_in_dir(wal.wal_dir(), cipher)?
-    {
+    let max_lsn = crate::storage::wal::segment_reader::max_lsn_in_dir(wal.wal_dir(), cipher)?;
+    seed_lsn_allocator_from_max(wal, max_lsn);
+    Ok(())
+}
+
+/// Move the allocator to `max_lsn + 1` (never backwards), given a max LSN that
+/// the caller has already determined (Issue #3429).
+///
+/// Split out of [`seed_lsn_allocator_from_segments`] so the startup path can
+/// seed from the max LSN of the single full WAL read it performs, instead of
+/// scanning the segment directory a second time purely to compute it. See
+/// [`seed_lsn_allocator_from_segments`] for the seeding-policy rationale.
+fn seed_lsn_allocator_from_max(
+    wal: &ConcurrentWalSystem,
+    max_lsn: Option<crate::storage::wal::LSN>,
+) {
+    if let Some(max_lsn) = max_lsn {
         let next = crate::storage::wal::LSN(max_lsn.0.saturating_add(1));
         if next > wal.current_lsn() {
             wal.set_next_lsn(next);
         }
     }
-    Ok(())
 }
 
 /// Extract the effective flush interval from a durability mode, falling back to a default.
@@ -376,13 +389,40 @@ impl AletheiaDB {
 
             let wal = Arc::new(ConcurrentWalSystem::new(wal_system_config)?);
 
+            // Issue #3429: decode the WAL exactly once here and reuse that
+            // single decode for all three startup passes that historically each
+            // re-read every segment: (1) the LSN-allocator seed below, (2) the
+            // constraint declaration net-state, and (3) the differential
+            // node/edge replay. `read_from` mirrors the recovery reader's cipher
+            // behavior (plaintext today), so for an encrypted WAL its max LSN
+            // would omit encrypted entries; the cipher-aware directory scan is
+            // used as a targeted fallback below only when a cipher is
+            // configured, preserving the #3420/#3430 encrypted seed exactly.
+            //
+            // Held (as `mut`, consumed by whichever replay branch runs) across
+            // index load so no later pass re-reads the segment directory.
+            let mut startup_wal_entries = wal.read_from(crate::storage::wal::LSN::initial())?;
+
             // Issue #3420: seed the LSN allocator past every LSN already durable
             // in existing WAL segments, BEFORE any write is accepted. Without
             // this, a restarted process re-allocates LSNs starting at 1,
             // breaking LSN total ordering across segments and placing new
             // writes below the index manifest LSN (so the next startup's
             // differential replay silently skips them).
-            seed_lsn_allocator_from_segments(&wal, wal_cipher.as_ref())?;
+            let seed_max_lsn = if wal_cipher.is_some() {
+                // Encrypted segments are invisible to the cipher-less read
+                // above; fall back to the cipher-aware directory scan so the
+                // seed still accounts for encrypted entries (unchanged #3420
+                // behavior for encrypted WALs; the constraint/replay passes
+                // stay cipher-less exactly as before, per #3430).
+                crate::storage::wal::segment_reader::max_lsn_in_dir(
+                    wal.wal_dir(),
+                    wal_cipher.as_ref(),
+                )?
+            } else {
+                startup_wal_entries.iter().map(|e| e.lsn).max()
+            };
+            seed_lsn_allocator_from_max(&wal, seed_max_lsn);
 
             // Create persistence manager if enabled
             let persistence_manager = if config.persistence.enabled {
@@ -479,10 +519,16 @@ impl AletheiaDB {
                 // Replay constraint declarations from the full WAL history before the
                 // differential node/edge replay.  Constraint WAL entries may predate
                 // the snapshot LSN and would be skipped by the differential replay.
-                crate::storage::recovery::replay_constraint_declarations_from_wal(
-                    &db.wal,
+                //
+                // Issue #3429: fold the constraint net-state out of the single
+                // full read taken at startup (`startup_wal_entries` spans the
+                // whole history from LSN 0), so this no longer re-reads the
+                // segment directory. Below-manifest declarations are still
+                // applied because the borrowed slice includes them.
+                crate::storage::recovery::apply_constraint_declarations(
+                    &startup_wal_entries,
                     &db.constraint_registry,
-                )?;
+                );
 
                 // Replay WAL entries that occurred after the persisted snapshot
                 // This ensures no data loss if the WAL is ahead of the indexes (e.g. crash before persist)
@@ -527,13 +573,25 @@ impl AletheiaDB {
                 // Capture initial version ID before replay
                 let initial_version_id = db.version_id_gen.current();
 
+                // Issue #3429: feed the differential replay the suffix of the
+                // single startup read (entries with LSN >= start_lsn), rather
+                // than re-reading the segment directory a third time. `read_from`
+                // returns entries globally sorted by LSN, so this filtered
+                // suffix is byte-identical to what `read_from(start_lsn)` would
+                // have produced (same contiguous, LSN-ordered tail the framing
+                // resolver expects).
+                let replay_entries: Vec<_> = std::mem::take(&mut startup_wal_entries)
+                    .into_iter()
+                    .filter(|entry| entry.lsn >= start_lsn)
+                    .collect();
+
                 let mut historical_guard = db.historical.write();
                 let (_final_lsn, max_node_id, max_edge_id, next_version_id) =
-                    crate::storage::recovery::replay_wal_into_storage_with_constraints(
+                    crate::storage::recovery::replay_entries_into_storage_with_constraints(
                         &db.wal,
+                        replay_entries,
                         &db.current,
                         &mut historical_guard,
-                        start_lsn,
                         initial_version_id,
                         Some(&db.constraint_registry),
                     )?;
@@ -566,13 +624,23 @@ impl AletheiaDB {
             // WAL from the beginning to restore node/edge data AND constraint declarations.
             if persistence_manager.is_none() {
                 let initial_version_id = db.version_id_gen.current();
+
+                // Issue #3429: replay directly from the single startup read
+                // instead of re-decoding the segment directory. This branch
+                // replays from LSN 0, so it consumes every entry; the inline
+                // constraint arms in the replay loop recover constraint state
+                // (no separate constraint pass is needed here). `std::mem::take`
+                // moves the entries out of the (persistence-branch-shared)
+                // binding; only one of the two branches runs.
+                let replay_entries = std::mem::take(&mut startup_wal_entries);
+
                 let mut historical_guard = db.historical.write();
                 let (_final_lsn, max_node_id, max_edge_id, next_version_id) =
-                    crate::storage::recovery::replay_wal_into_storage_with_constraints(
+                    crate::storage::recovery::replay_entries_into_storage_with_constraints(
                         &db.wal,
+                        replay_entries,
                         &db.current,
                         &mut historical_guard,
-                        crate::storage::wal::LSN::initial(),
                         initial_version_id,
                         Some(&db.constraint_registry),
                     )?;

--- a/src/storage/recovery.rs
+++ b/src/storage/recovery.rs
@@ -277,12 +277,15 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                 }
 
                 if live_head.is_none() {
-                    // Re-creation after a tombstone/retraction: supersede the
-                    // closed head in transaction time (mirroring the
-                    // UpdateNode arm) before appending the new incarnation.
-                    if let Some(prev) = historical_head {
-                        historical.close_node_version_transaction_time(prev, commit_timestamp)?;
-                    }
+                    // Re-creation after a tombstone/retraction: the closed head
+                    // is superseded in transaction time by
+                    // `add_node_version_with_provenance` itself, which routes
+                    // through `close_previous_version_intervals` and closes the
+                    // current head's tx-time at the new version's tx start
+                    // (== `commit_timestamp`) — so no explicit
+                    // `close_node_version_transaction_time` is needed here
+                    // (Issue #3407; the helper is a superset: same target
+                    // version, plus monotonicity guards).
                     historical.add_node_version_with_provenance(
                         node_id,
                         version_id,
@@ -352,9 +355,11 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                 }
 
                 if live_head.is_none() {
-                    if let Some(prev) = historical_head {
-                        historical.close_edge_version_transaction_time(prev, commit_timestamp)?;
-                    }
+                    // Re-creation after a tombstone/retraction: the head's
+                    // tx-time closure happens inside
+                    // `add_edge_version_with_provenance` via
+                    // `close_previous_version_intervals` (Issue #3407) — see
+                    // the CreateNode arm above.
                     historical.add_edge_version_with_provenance(
                         edge_id,
                         version_id,
@@ -404,13 +409,13 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                 // makes history reconstruction loop forever (observed
                 // empirically: get_node_history OOMs after a double replay).
                 if historical.get_node_version(version_id).is_none() {
-                    if let Some(prev_version_id) = historical.get_current_node_version(node_id) {
-                        historical.close_node_version_transaction_time(
-                            prev_version_id,
-                            commit_timestamp,
-                        )?;
-                    }
-
+                    // Appending the successor closes the current head's
+                    // transaction time in `close_previous_version_intervals`
+                    // (reached via `add_node_version_with_provenance`), so an
+                    // explicit `close_node_version_transaction_time` on the
+                    // prior head would be redundant (Issue #3407): the helper
+                    // closes the SAME head (`node_version_heads[node_id]`) at
+                    // the same tx timestamp, and adds monotonicity guards.
                     historical.add_node_version_with_provenance(
                         node_id,
                         version_id,
@@ -455,13 +460,10 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                 // UpdateNode arm above for why an already-present version_id
                 // must not be appended to history a second time.
                 if historical.get_edge_version(version_id).is_none() {
-                    if let Some(prev_version_id) = historical.get_current_edge_version(edge_id) {
-                        historical.close_edge_version_transaction_time(
-                            prev_version_id,
-                            commit_timestamp,
-                        )?;
-                    }
-
+                    // The prior head's tx-time closure is handled inside
+                    // `add_edge_version_with_provenance` via
+                    // `close_previous_version_intervals` (Issue #3407) — see
+                    // the UpdateNode arm above.
                     historical.add_edge_version_with_provenance(
                         edge_id,
                         version_id,
@@ -522,12 +524,14 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                 };
 
                 if let Some((label, properties)) = tombstone_payload {
-                    if let Some(current_version_id) = historical_head {
-                        historical.close_node_version_transaction_time(
-                            current_version_id,
-                            commit_timestamp,
-                        )?;
-                    }
+                    // The current head's transaction time is closed when the
+                    // tombstone is appended below: `add_node_version` routes
+                    // through `close_previous_version_intervals`, which closes
+                    // the SAME head (`node_version_heads[node_id]`) at the
+                    // tombstone's tx start (== `commit_timestamp`). An explicit
+                    // `close_node_version_transaction_time` here would be
+                    // redundant (Issue #3407; the helper is a superset — same
+                    // target version, plus monotonicity guards).
 
                     // Honor the LOGGED tombstone version_id (Issue #3406) so the
                     // recovered version chain is bit-identical to the live one
@@ -605,12 +609,9 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                 };
 
                 if let Some((label, source, target, properties)) = tombstone_payload {
-                    if let Some(current_version_id) = historical_head {
-                        historical.close_edge_version_transaction_time(
-                            current_version_id,
-                            commit_timestamp,
-                        )?;
-                    }
+                    // The current head's tx-time closure happens inside
+                    // `add_edge_version` via `close_previous_version_intervals`
+                    // (Issue #3407) — see the DeleteNode arm above.
 
                     // Honor the LOGGED tombstone version_id (Issue #3406); see
                     // the DeleteNode arm above for rationale and the synthesis
@@ -696,12 +697,17 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                         .map(|v| v.temporal.valid_time().start())
                         .unwrap_or(commit_timestamp);
 
-                    if let Some(current_version_id) = head_version_id {
-                        historical.close_node_version_transaction_time(
-                            current_version_id,
-                            commit_timestamp,
-                        )?;
-                    }
+                    // Step (a) — closing the head version's TRANSACTION time —
+                    // is performed by `add_retracted_node_version` below, which
+                    // routes through `close_previous_version_intervals`: it
+                    // closes the SAME head (`node_version_heads[node_id]`) at
+                    // the retraction's tx start (== `commit_timestamp`) while
+                    // leaving the head's valid interval untouched (the helper's
+                    // valid-time guard is `new start > prev start`, and the
+                    // retraction reuses the head's `valid_from`, so it is not
+                    // rewritten — append-only preserved). An explicit
+                    // `close_node_version_transaction_time` here would be
+                    // redundant (Issue #3407).
 
                     // Honor the LOGGED retraction version_id (Issue #3406); see
                     // the DeleteNode arm for rationale and the pre-v9 synthesis
@@ -777,12 +783,10 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                         .map(|v| v.temporal.valid_time().start())
                         .unwrap_or(commit_timestamp);
 
-                    if let Some(current_version_id) = head_version_id {
-                        historical.close_edge_version_transaction_time(
-                            current_version_id,
-                            commit_timestamp,
-                        )?;
-                    }
+                    // The head version's tx-time closure (step (a)) is handled
+                    // inside `add_retracted_edge_version` via
+                    // `close_previous_version_intervals` (Issue #3407) — see
+                    // the RetractNode arm above.
 
                     // Honor the LOGGED retraction version_id (Issue #3406); see
                     // the DeleteNode arm for rationale and the pre-v9 synthesis

--- a/src/storage/recovery.rs
+++ b/src/storage/recovery.rs
@@ -277,15 +277,27 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                 }
 
                 if live_head.is_none() {
-                    // Re-creation after a tombstone/retraction: the closed head
-                    // is superseded in transaction time by
-                    // `add_node_version_with_provenance` itself, which routes
-                    // through `close_previous_version_intervals` and closes the
-                    // current head's tx-time at the new version's tx start
-                    // (== `commit_timestamp`) — so no explicit
-                    // `close_node_version_transaction_time` is needed here
-                    // (Issue #3407; the helper is a superset: same target
-                    // version, plus monotonicity guards).
+                    // Re-creation after a tombstone/retraction: supersede the
+                    // closed head in transaction time (mirroring the
+                    // UpdateNode arm) before appending the new incarnation.
+                    //
+                    // DELIBERATELY KEPT — NOT redundant (Issue #3407). The
+                    // following `add_node_version_with_provenance` also closes
+                    // the prior head via `close_previous_version_intervals`,
+                    // BUT that helper guards the tx-time close with a STRICT
+                    // `new_tx_start > prev_tx_start`. When a delete/retract and
+                    // this re-creation land in the SAME transaction they share
+                    // one framed `commit_timestamp`, so the strict `>` SKIPS the
+                    // close and the tombstone head would be left open — leaving
+                    // two versions with overlapping open tx-intervals after
+                    // replay. The explicit close is UNCONDITIONAL (matching the
+                    // live write path in `api/transaction/write/apply.rs`),
+                    // producing the empty `[T, T)` tx-interval live and replay
+                    // alike. See the reachability test in
+                    // `tests/recovery/replay_update_tests.rs`.
+                    if let Some(prev) = historical_head {
+                        historical.close_node_version_transaction_time(prev, commit_timestamp)?;
+                    }
                     historical.add_node_version_with_provenance(
                         node_id,
                         version_id,
@@ -355,11 +367,13 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                 }
 
                 if live_head.is_none() {
-                    // Re-creation after a tombstone/retraction: the head's
-                    // tx-time closure happens inside
-                    // `add_edge_version_with_provenance` via
-                    // `close_previous_version_intervals` (Issue #3407) — see
-                    // the CreateNode arm above.
+                    // DELIBERATELY KEPT — NOT redundant (Issue #3407); the
+                    // helper's strict `>` tx-time guard skips the close when a
+                    // same-transaction delete/retract + re-create share one
+                    // framed `commit_timestamp`. See the CreateNode arm above.
+                    if let Some(prev) = historical_head {
+                        historical.close_edge_version_transaction_time(prev, commit_timestamp)?;
+                    }
                     historical.add_edge_version_with_provenance(
                         edge_id,
                         version_id,
@@ -409,13 +423,30 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                 // makes history reconstruction loop forever (observed
                 // empirically: get_node_history OOMs after a double replay).
                 if historical.get_node_version(version_id).is_none() {
-                    // Appending the successor closes the current head's
-                    // transaction time in `close_previous_version_intervals`
-                    // (reached via `add_node_version_with_provenance`), so an
-                    // explicit `close_node_version_transaction_time` on the
-                    // prior head would be redundant (Issue #3407): the helper
-                    // closes the SAME head (`node_version_heads[node_id]`) at
-                    // the same tx timestamp, and adds monotonicity guards.
+                    // DELIBERATELY KEPT — NOT redundant (Issue #3407). The
+                    // `add_node_version_with_provenance` below ALSO closes the
+                    // prior head via `close_previous_version_intervals`, but
+                    // that helper guards the tx-time close with a STRICT
+                    // `new_tx_start > prev_tx_start`. Two updates to the SAME
+                    // node in ONE transaction share a single framed
+                    // `commit_timestamp`, so the successor's tx start EQUALS the
+                    // intermediate version's tx start and the strict `>` SKIPS
+                    // the close — the intermediate would be left OPEN on replay
+                    // while the live path (unconditional close in
+                    // `api/transaction/write/apply.rs`) closes it to the empty
+                    // `[T, T)` interval. Leaving it open produces two versions
+                    // with overlapping open tx-intervals, so an
+                    // `AS OF SYSTEM_TIME = T` read could surface the superseded
+                    // version. This UNCONDITIONAL close keeps replay bit-for-bit
+                    // consistent with the live write path. Regression coverage:
+                    // `replay_double_update_same_node_in_one_tx_closes_intermediate`.
+                    if let Some(prev_version_id) = historical.get_current_node_version(node_id) {
+                        historical.close_node_version_transaction_time(
+                            prev_version_id,
+                            commit_timestamp,
+                        )?;
+                    }
+
                     historical.add_node_version_with_provenance(
                         node_id,
                         version_id,
@@ -460,10 +491,17 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                 // UpdateNode arm above for why an already-present version_id
                 // must not be appended to history a second time.
                 if historical.get_edge_version(version_id).is_none() {
-                    // The prior head's tx-time closure is handled inside
-                    // `add_edge_version_with_provenance` via
-                    // `close_previous_version_intervals` (Issue #3407) — see
-                    // the UpdateNode arm above.
+                    // DELIBERATELY KEPT — NOT redundant (Issue #3407); the
+                    // helper's strict `>` tx-time guard skips the close when two
+                    // updates to the same edge in ONE transaction share a framed
+                    // `commit_timestamp`. See the UpdateNode arm above.
+                    if let Some(prev_version_id) = historical.get_current_edge_version(edge_id) {
+                        historical.close_edge_version_transaction_time(
+                            prev_version_id,
+                            commit_timestamp,
+                        )?;
+                    }
+
                     historical.add_edge_version_with_provenance(
                         edge_id,
                         version_id,
@@ -524,14 +562,22 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                 };
 
                 if let Some((label, properties)) = tombstone_payload {
-                    // The current head's transaction time is closed when the
-                    // tombstone is appended below: `add_node_version` routes
-                    // through `close_previous_version_intervals`, which closes
-                    // the SAME head (`node_version_heads[node_id]`) at the
-                    // tombstone's tx start (== `commit_timestamp`). An explicit
-                    // `close_node_version_transaction_time` here would be
-                    // redundant (Issue #3407; the helper is a superset — same
-                    // target version, plus monotonicity guards).
+                    // DELIBERATELY KEPT — NOT redundant (Issue #3407). The
+                    // tombstone `add_node_version` below also closes the prior
+                    // head via `close_previous_version_intervals`, but that
+                    // helper's STRICT `new_tx_start > prev_tx_start` guard SKIPS
+                    // the tx-time close when an update-then-delete of the same
+                    // node in ONE transaction shares a framed `commit_timestamp`
+                    // — leaving the superseded head open on replay while the
+                    // live path (unconditional close) closes it. This
+                    // UNCONDITIONAL close keeps replay consistent with the live
+                    // write path. See the UpdateNode arm above.
+                    if let Some(current_version_id) = historical_head {
+                        historical.close_node_version_transaction_time(
+                            current_version_id,
+                            commit_timestamp,
+                        )?;
+                    }
 
                     // Honor the LOGGED tombstone version_id (Issue #3406) so the
                     // recovered version chain is bit-identical to the live one
@@ -609,9 +655,17 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                 };
 
                 if let Some((label, source, target, properties)) = tombstone_payload {
-                    // The current head's tx-time closure happens inside
-                    // `add_edge_version` via `close_previous_version_intervals`
-                    // (Issue #3407) — see the DeleteNode arm above.
+                    // DELIBERATELY KEPT — NOT redundant (Issue #3407); the
+                    // helper's strict `>` tx-time guard skips the close when an
+                    // update-then-delete of the same edge in ONE transaction
+                    // shares a framed `commit_timestamp`. See the DeleteNode /
+                    // UpdateNode arms above.
+                    if let Some(current_version_id) = historical_head {
+                        historical.close_edge_version_transaction_time(
+                            current_version_id,
+                            commit_timestamp,
+                        )?;
+                    }
 
                     // Honor the LOGGED tombstone version_id (Issue #3406); see
                     // the DeleteNode arm above for rationale and the synthesis
@@ -697,17 +751,28 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                         .map(|v| v.temporal.valid_time().start())
                         .unwrap_or(commit_timestamp);
 
-                    // Step (a) — closing the head version's TRANSACTION time —
-                    // is performed by `add_retracted_node_version` below, which
-                    // routes through `close_previous_version_intervals`: it
-                    // closes the SAME head (`node_version_heads[node_id]`) at
-                    // the retraction's tx start (== `commit_timestamp`) while
-                    // leaving the head's valid interval untouched (the helper's
-                    // valid-time guard is `new start > prev start`, and the
-                    // retraction reuses the head's `valid_from`, so it is not
-                    // rewritten — append-only preserved). An explicit
-                    // `close_node_version_transaction_time` here would be
-                    // redundant (Issue #3407).
+                    // Step (a): close the head version's TRANSACTION time (its
+                    // valid interval stays untouched — append-only).
+                    //
+                    // DELIBERATELY KEPT — NOT redundant (Issue #3407). The
+                    // `add_retracted_node_version` below also closes the prior
+                    // head via `close_previous_version_intervals`, but that
+                    // helper's tx-time close is guarded by a STRICT
+                    // `new_tx_start > prev_tx_start`. An update-then-retract of
+                    // the same node in ONE transaction shares a framed
+                    // `commit_timestamp`, so the strict `>` SKIPS the close and
+                    // the superseded head would be left open on replay — while
+                    // the live path (unconditional close) closes it. This
+                    // UNCONDITIONAL close keeps replay consistent with live. (The
+                    // helper additionally leaves the head's valid interval
+                    // untouched here, since the retraction reuses the head's
+                    // `valid_from`.) See the UpdateNode arm above.
+                    if let Some(current_version_id) = head_version_id {
+                        historical.close_node_version_transaction_time(
+                            current_version_id,
+                            commit_timestamp,
+                        )?;
+                    }
 
                     // Honor the LOGGED retraction version_id (Issue #3406); see
                     // the DeleteNode arm for rationale and the pre-v9 synthesis
@@ -783,10 +848,18 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                         .map(|v| v.temporal.valid_time().start())
                         .unwrap_or(commit_timestamp);
 
-                    // The head version's tx-time closure (step (a)) is handled
-                    // inside `add_retracted_edge_version` via
-                    // `close_previous_version_intervals` (Issue #3407) — see
-                    // the RetractNode arm above.
+                    // Step (a): close the head version's TRANSACTION time.
+                    // DELIBERATELY KEPT — NOT redundant (Issue #3407); the
+                    // helper's strict `>` tx-time guard skips the close when an
+                    // update-then-retract of the same edge in ONE transaction
+                    // shares a framed `commit_timestamp`. See the RetractNode /
+                    // UpdateNode arms above.
+                    if let Some(current_version_id) = head_version_id {
+                        historical.close_edge_version_transaction_time(
+                            current_version_id,
+                            commit_timestamp,
+                        )?;
+                    }
 
                     // Honor the LOGGED retraction version_id (Issue #3406); see
                     // the DeleteNode arm for rationale and the pre-v9 synthesis
@@ -1624,6 +1697,57 @@ mod tests {
         assert!(
             historical
                 .get_edge_at_time(edge_id, valid_to, time::now())
+                .is_err()
+        );
+
+        // Append-only AS OF SYSTEM_TIME contract, post-replay — symmetric with
+        // the RetractNode twin (Issue #3407 review gap): the PRE-retraction
+        // head must still carry an OPEN valid interval with its TRANSACTION
+        // time closed at the LOGGED RetractEdge entry timestamp (never the
+        // replay time, never rewriting the pre-retraction record). This pins
+        // the `close_edge_version_transaction_time` call in the RetractEdge
+        // replay arm — the one Issue #3407 initially proposed removing.
+        let entries = wal.read_from(LSN::initial()).unwrap();
+        let logged_retract_ts = entries
+            .iter()
+            .find(|e| matches!(e.operation, WalOperation::RetractEdge { .. }))
+            .expect("RetractEdge entry must be in the WAL")
+            .timestamp;
+        let logged_create_ts = entries
+            .iter()
+            .find(|e| matches!(e.operation, WalOperation::CreateEdge { .. }))
+            .expect("CreateEdge entry must be in the WAL")
+            .timestamp;
+
+        let history = historical.get_edge_history(edge_id).unwrap();
+        assert_eq!(history.version_count(), 2, "create + retraction versions");
+        let pre_retraction_head = &history.versions[0];
+        assert!(
+            pre_retraction_head.temporal.valid_time().is_current(),
+            "pre-retraction edge head's valid interval must stay open-ended after replay"
+        );
+        assert!(
+            !pre_retraction_head.temporal.transaction_time().is_current(),
+            "pre-retraction edge head's transaction time must be closed after replay"
+        );
+        assert_eq!(
+            pre_retraction_head.temporal.transaction_time().end(),
+            logged_retract_ts,
+            "edge transaction time must close at the LOGGED entry timestamp, not the replay time"
+        );
+
+        // Anchoring AS OF SYSTEM_TIME before the retraction's logged commit
+        // shows the edge open-ended; anchoring at the retraction's commit does
+        // not.
+        assert!(
+            historical
+                .get_edge_at_time(edge_id, time::now(), logged_create_ts)
+                .is_ok(),
+            "AS OF SYSTEM_TIME before the retraction must show the edge open-ended"
+        );
+        assert!(
+            historical
+                .get_edge_at_time(edge_id, time::now(), logged_retract_ts)
                 .is_err()
         );
     }

--- a/src/storage/recovery.rs
+++ b/src/storage/recovery.rs
@@ -136,6 +136,42 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
     current: &CurrentStorage,
     historical: &mut HistoricalStorage,
     start_lsn: LSN,
+    next_version_id: u64,
+    constraint_registry: Option<&ConstraintRegistry>,
+) -> Result<(LSN, Option<u64>, Option<u64>, u64)> {
+    // Read the segment directory once, then apply. Callers that have already
+    // read the WAL for startup (Issue #3429) skip this read entirely and call
+    // `replay_entries_into_storage_with_constraints` directly with the
+    // pre-decoded entries, avoiding a redundant full decode of the WAL.
+    let wal_entries = wal.read_from(start_lsn)?;
+    replay_entries_into_storage_with_constraints(
+        wal,
+        wal_entries,
+        current,
+        historical,
+        next_version_id,
+        constraint_registry,
+    )
+}
+
+/// Apply an already-decoded WAL entry stream to storage (Issue #3429).
+///
+/// This is the body of [`replay_wal_into_storage_with_constraints`] with the
+/// segment read hoisted out. The startup path decodes the WAL exactly once and
+/// feeds the resulting entries here (filtered to `>= start_lsn`) so recovery no
+/// longer re-reads the segment directory for the differential replay. `wal` is
+/// retained only to report the post-replay `current_lsn()`; every operation
+/// applied comes from `wal_entries`, never from a fresh read.
+///
+/// The caller MUST pass exactly the entries with `LSN >= start_lsn` (in the
+/// same LSN-sorted order [`ConcurrentWalSystem::read_from`] produces): the
+/// transaction-framing resolver below is order-sensitive and expects the same
+/// contiguous suffix a direct `read_from(start_lsn)` would return.
+pub(crate) fn replay_entries_into_storage_with_constraints(
+    wal: &ConcurrentWalSystem,
+    wal_entries: Vec<WalEntry>,
+    current: &CurrentStorage,
+    historical: &mut HistoricalStorage,
     mut next_version_id: u64,
     constraint_registry: Option<&ConstraintRegistry>,
 ) -> Result<(LSN, Option<u64>, Option<u64>, u64)> {
@@ -144,21 +180,11 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
     let mut max_node_id: Option<u64> = None;
     let mut max_edge_id: Option<u64> = None;
 
-    let wal_entries = wal.read_from(start_lsn)?;
-
     if !wal_entries.is_empty() {
         #[cfg(feature = "observability")]
-        tracing::info!(
-            "Replaying {} WAL entries from LSN {}",
-            wal_entries.len(),
-            start_lsn.0
-        );
+        tracing::info!("Replaying {} WAL entries", wal_entries.len());
         #[cfg(not(feature = "observability"))]
-        eprintln!(
-            "Replaying {} WAL entries from LSN {}",
-            wal_entries.len(),
-            start_lsn.0
-        );
+        eprintln!("Replaying {} WAL entries", wal_entries.len());
     }
 
     // Resolve transaction framing (Issue #3413) BEFORE applying: pair every
@@ -1015,18 +1041,43 @@ fn resolve_transaction_frames(entries: Vec<WalEntry>) -> Vec<(WalOperation, Time
 
 /// Replay ONLY constraint declaration/drop entries from the full WAL history.
 ///
-/// Called during index-persistence startup BEFORE the regular snapshot-based
-/// WAL replay.  Because constraint declarations are written to the WAL before
-/// the corresponding node data, they may lie at LSNs below the persisted
-/// snapshot LSN and therefore be skipped by the normal differential replay.
-/// This pass reads every WAL entry from LSN 0 and replays only the two
-/// constraint-related operations, giving us the net constraint state.
+/// Because constraint declarations are written to the WAL before the
+/// corresponding node data, they may lie at LSNs below the persisted snapshot
+/// LSN and therefore be skipped by the normal differential replay. This reads
+/// every WAL entry from LSN 0 and replays only the two constraint-related
+/// operations, giving the net constraint state.
+///
+/// As of Issue #3429 the startup path no longer calls this: it decodes the WAL
+/// once and folds the constraint net-state out of the already-read entries via
+/// [`apply_constraint_declarations`], avoiding a dedicated full read. This
+/// wrapper (a thin `read_from` + `apply_constraint_declarations`) is retained
+/// for the recovery unit tests that exercise the read-and-apply path directly.
+#[cfg(test)]
 pub(crate) fn replay_constraint_declarations_from_wal(
     wal: &ConcurrentWalSystem,
     registry: &ConstraintRegistry,
 ) -> Result<()> {
     let all_entries = wal.read_from(LSN::initial())?;
-    for entry in all_entries {
+    apply_constraint_declarations(&all_entries, registry);
+    Ok(())
+}
+
+/// Fold the constraint declare/drop net-state out of an already-decoded WAL
+/// entry stream (Issue #3429).
+///
+/// Same net effect as [`replay_constraint_declarations_from_wal`] but operates
+/// on entries the startup path has *already* read from disk, so recovery does
+/// not decode the segment directory a second time just to recover constraint
+/// state. `entries` is expected to span the full WAL history (from
+/// [`LSN::initial()`]) so declarations that predate the index snapshot LSN --
+/// and would be skipped by the differential replay -- are still applied.
+///
+/// Declares and drops are replayed in stream order; the net set is
+/// order-dependent (declare then drop == dropped), matching the prior full-read
+/// pass exactly. Borrows the entries (does not consume them) so the same vector
+/// can then be filtered and handed to the differential replay.
+pub(crate) fn apply_constraint_declarations(entries: &[WalEntry], registry: &ConstraintRegistry) {
+    for entry in entries {
         match entry.operation {
             WalOperation::DeclareUniqueConstraint { label, property } => {
                 registry.declare(label, property);
@@ -1037,7 +1088,6 @@ pub(crate) fn replay_constraint_declarations_from_wal(
             _ => {}
         }
     }
-    Ok(())
 }
 
 /// Unit tests for the `resolve_transaction_frames` framing resolver

--- a/tests/lsn_recovery_regression.rs
+++ b/tests/lsn_recovery_regression.rs
@@ -827,3 +827,100 @@ fn t11_constructor_tolerates_torn_wal_tail() {
          < session 1 end {session1_end_lsn}"
     );
 }
+
+// ──────────────────────────────────────────────────────────────
+// Issue #3429 — single-pass WAL startup fold
+// ──────────────────────────────────────────────────────────────
+
+/// Issue #3429: startup folds the three separate full WAL scans (max-LSN
+/// allocator seed, constraint declaration net-state, differential replay) into
+/// a single decode. This test pins the two invariants that fold must preserve
+/// and that a naive fold would break:
+///
+///   1. A unique constraint DECLARED BEFORE the index snapshot LSN — i.e. below
+///      the LSN the differential replay starts at — must still be recovered.
+///      The constraint net-state is folded from the *whole* WAL history
+///      (`apply_constraint_declarations` over every entry from LSN 0), not just
+///      the post-manifest suffix fed to the differential replay. A fold that
+///      only inspected the replay suffix would silently drop it.
+///   2. A node WRITTEN AFTER the persist (a genuine post-snapshot tail) is
+///      recovered by the differential replay driven off the *same* single read
+///      (the LSN-filtered suffix), with no lost or duplicated versions, and the
+///      allocator is seeded past every durable LSN.
+///
+/// Layout: declare constraint → create A → persist_indexes (manifest LSN now
+/// sits above the constraint declaration) → create tail B → hard crash
+/// (mem::forget) → reopen.
+#[test]
+fn t3429_below_manifest_constraint_and_tail_survive_single_pass_startup() {
+    let _g = lock();
+    let tmp = tempdir().unwrap();
+    let db_path = tmp.path();
+
+    let (a, b, manifest_after_persist) = {
+        let db = open(db_path);
+        // Constraint declaration is written to the WAL here, BEFORE the persist.
+        db.unique_constraint("Person", "email")
+            .enable()
+            .expect("enable unique constraint");
+        let a = db
+            .create_node("Person", aletheiadb::properties! { "email" => "a@x" })
+            .expect("create A");
+
+        // Snapshot: the manifest LSN captured here is strictly above the
+        // constraint declaration's LSN, so the next startup's differential
+        // replay begins past it.
+        db.persist_indexes().expect("manual persist");
+        let manifest_after_persist = manifest_lsn(db_path);
+
+        // Genuine post-snapshot tail write, recovered only via differential
+        // replay of the single read's LSN-filtered suffix.
+        let b = db
+            .create_node("Person", aletheiadb::properties! { "email" => "b@x" })
+            .expect("create tail B");
+
+        // Hard crash: no Drop, no shutdown persist.
+        std::mem::forget(db);
+        (a, b, manifest_after_persist)
+    };
+
+    assert!(
+        manifest_after_persist > 1,
+        "manifest LSN must sit above the constraint declaration for this test \
+         to exercise below-manifest constraint recovery (got {manifest_after_persist})"
+    );
+
+    // Reopen: exactly one full WAL decode now feeds seed + constraints + replay.
+    let db = open(db_path);
+
+    // Invariant 1: below-manifest constraint recovered and still ENFORCED.
+    let active = db.list_unique_constraints();
+    assert!(
+        active.iter().any(|(l, p)| l == "Person" && p == "email"),
+        "below-manifest constraint Person.email must survive single-pass startup: {active:?}"
+    );
+    db.create_node("Person", aletheiadb::properties! { "email" => "a@x" })
+        .expect_err("constraint must still reject the duplicate email after reopen");
+
+    // Invariant 2: both the pre-persist node and the post-persist tail recovered
+    // cleanly (no loss, no boundary double-apply), and a distinct email is still
+    // allowed.
+    let node_a = db
+        .get_node(a)
+        .expect("pre-persist node A lost after recovery");
+    assert_eq!(node_a.properties.get("email"), Some(&"a@x".into()));
+    let node_b = db
+        .get_node(b)
+        .expect("post-persist tail node B lost after recovery");
+    assert_eq!(node_b.properties.get("email"), Some(&"b@x".into()));
+    assert_history_len(&db, a, "A", 1);
+    assert_history_len(&db, b, "B", 1);
+    db.create_node("Person", aletheiadb::properties! { "email" => "c@x" })
+        .expect("a distinct email must still be allowed after reopen");
+
+    // Allocator seeded past every durable LSN from the same single read.
+    assert!(
+        db.__test_current_wal_lsn() > manifest_after_persist,
+        "allocator must be seeded past the persisted tail after single-pass startup"
+    );
+}

--- a/tests/recovery/replay_update_tests.rs
+++ b/tests/recovery/replay_update_tests.rs
@@ -698,3 +698,155 @@ fn test_replay_mixed_creates_and_updates() -> Result<()> {
 
     Ok(())
 }
+
+/// Issue #3407 (adversarial-review crux): equal-timestamp intra-transaction
+/// supersession must close the intermediate version's transaction time on
+/// replay, exactly as the live write path does.
+///
+/// Two `update_node` calls to the SAME already-committed node in ONE
+/// transaction produce TWO update versions that share a single framed
+/// `commit_timestamp` T (the CommitTx marker's authoritative time). The live
+/// write path closes the intermediate version's tx-time UNCONDITIONALLY,
+/// yielding the empty interval `[T, T)`. Replay's `add_node_version` path also
+/// closes the prior head, but via `close_previous_version_intervals`, whose
+/// tx-time close is guarded by a STRICT `new_tx_start > prev_tx_start` — and
+/// `T > T` is false, so that guard alone would SKIP the close and leave the
+/// intermediate version OPEN `[T, MAX)`. Two versions with overlapping open
+/// transaction intervals let an `AS OF SYSTEM_TIME = T` read surface the
+/// superseded version — a live-vs-replay bitemporal-integrity divergence.
+///
+/// This pins the UNCONDITIONAL explicit `close_node_version_transaction_time`
+/// in the UpdateNode replay arm: the test PASSES with it and FAILS without it
+/// (empirically, the intermediate version stays open `[T, MAX)` on replay).
+/// It drives the real high-level transaction API (framed WAL commit) and a
+/// real crash + full WAL replay, and compares the recovered intermediate
+/// version against the live one.
+#[test]
+fn replay_double_update_same_node_in_one_tx_closes_intermediate() -> Result<()> {
+    use aletheiadb::config::{AletheiaDBConfig, WalConfigBuilder};
+    use aletheiadb::storage::index_persistence::PersistenceConfig;
+    use aletheiadb::storage::wal::DurabilityMode;
+    use aletheiadb::{AletheiaDB, WriteOps};
+
+    // WAL-only (index persistence disabled) => reopen performs a full WAL
+    // replay, exercising the recovery arm under test.
+    let wal_only = |dir: &std::path::Path| -> AletheiaDBConfig {
+        AletheiaDBConfig::builder()
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(dir.join("wal"))
+                    .durability_mode(DurabilityMode::Synchronous)
+                    .build(),
+            )
+            .persistence(PersistenceConfig {
+                enabled: false,
+                ..PersistenceConfig::default()
+            })
+            .build()
+    };
+
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path();
+
+    // Capture the LIVE (pre-crash) intermediate version's transaction interval
+    // for a direct live-vs-replay comparison, plus the node id.
+    let (node_id, live_intermediate_tx_start, live_intermediate_tx_end) = {
+        let db = AletheiaDB::with_unified_config(wal_only(db_path)).unwrap();
+        let node_id = db.create_node(
+            "Counter",
+            PropertyMapBuilder::new().insert("count", 1_i64).build(),
+        )?;
+
+        // ONE transaction, TWO updates of the SAME node — the two update
+        // versions share the single framed commit timestamp.
+        let mut tx = db.write_transaction()?;
+        tx.update_node(
+            node_id,
+            PropertyMapBuilder::new().insert("count", 2_i64).build(),
+        )?;
+        tx.update_node(
+            node_id,
+            PropertyMapBuilder::new().insert("count", 3_i64).build(),
+        )?;
+        let commit_ts = tx.commit_with_timestamp()?;
+
+        let live = db.get_node_history(node_id)?;
+        assert_eq!(
+            live.versions.len(),
+            3,
+            "create + two same-node updates must yield three distinct versions"
+        );
+        let intermediate = &live.versions[1];
+        // Both update versions share the one framed commit timestamp.
+        assert_eq!(
+            intermediate.temporal.transaction_time().start(),
+            commit_ts,
+            "intermediate update's tx-time must start at the shared framed commit timestamp"
+        );
+        assert_eq!(
+            live.versions[2].temporal.transaction_time().start(),
+            commit_ts,
+            "head update's tx-time must start at the SAME framed commit timestamp \
+             (equal-timestamp case — the whole point)"
+        );
+        // Live path closes the intermediate UNCONDITIONALLY: empty [T, T).
+        assert!(
+            !intermediate.temporal.transaction_time().is_current(),
+            "live: intermediate version's transaction time must be closed"
+        );
+        assert_eq!(
+            intermediate.temporal.transaction_time().end(),
+            commit_ts,
+            "live: intermediate version's tx-time closes at T, forming the empty [T, T) interval"
+        );
+
+        let start = intermediate.temporal.transaction_time().start();
+        let end = intermediate.temporal.transaction_time().end();
+
+        // Hard crash: no clean shutdown / persist; the Synchronous WAL is
+        // already fsynced.
+        std::mem::forget(db);
+        (node_id, start, end)
+    };
+
+    // Reopen => full WAL replay of the framed transaction.
+    let db = AletheiaDB::with_unified_config(wal_only(db_path)).unwrap();
+    let replayed = db.get_node_history(node_id)?;
+
+    assert_eq!(
+        replayed.versions.len(),
+        3,
+        "replay must reproduce all three versions"
+    );
+    let intermediate = &replayed.versions[1];
+
+    // THE CRUX: without the explicit unconditional close in the UpdateNode
+    // replay arm, this intermediate version is left OPEN [T, MAX) because the
+    // helper's strict `>` guard skips the equal-timestamp close.
+    assert!(
+        !intermediate.temporal.transaction_time().is_current(),
+        "replay: intermediate version's transaction time MUST be closed \
+         (equal-timestamp intra-tx supersession) — leaving it open lets an \
+         AS OF SYSTEM_TIME read surface the superseded version"
+    );
+    assert_eq!(
+        intermediate.temporal.transaction_time().end(),
+        live_intermediate_tx_end,
+        "replay must close the intermediate version's tx-time to the SAME point as the live path"
+    );
+    assert_eq!(
+        intermediate.temporal.transaction_time().start(),
+        live_intermediate_tx_start,
+        "replay must preserve the intermediate version's tx-time start"
+    );
+    // The head remains the current version.
+    assert!(
+        replayed.versions[2]
+            .temporal
+            .transaction_time()
+            .is_current(),
+        "replay: head version's transaction time must stay open"
+    );
+
+    Ok(())
+}

--- a/tests/redb_file_locking.rs
+++ b/tests/redb_file_locking.rs
@@ -8,6 +8,7 @@
 use aletheiadb::AletheiaDB;
 use aletheiadb::PropertyMapBuilder;
 use aletheiadb::config::AletheiaDBConfig;
+use aletheiadb::config::WalConfigBuilder;
 use aletheiadb::storage::index_persistence::PersistenceConfig;
 use aletheiadb::storage::redb_cold_storage::{RedbColdStorage, RedbConfig};
 use aletheiadb::storage::tiered_storage::{TieredStorage, TieredStorageConfig};
@@ -39,6 +40,17 @@ fn test_reopen_redb_after_shutdown_with_background_thread() {
     // Phase 1: Create database with persistence enabled (spawns background thread)
     {
         let config = AletheiaDBConfig::builder()
+            // Isolate the WAL under this test's own tempdir. Without an
+            // explicit wal_dir, the config falls back to the default RELATIVE
+            // `aletheiadb/wal` (src/config.rs), which is shared by every such
+            // test in a single `cargo test` process and accumulates segments +
+            // trailing garbage — which #3429's eager startup full-decode then
+            // legitimately hard-errors on ("Unknown WAL operation type: 0").
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(data_dir.join("wal"))
+                    .build(),
+            )
             .persistence(PersistenceConfig {
                 enabled: true,
                 data_dir: data_dir.clone(),


### PR DESCRIPTION
## Summary

Issue #3407 proposed removing the explicit `close_node_version_transaction_time`
/ `close_edge_version_transaction_time` calls from the WAL replay arms in
`src/storage/recovery.rs` as redundant with the `close_previous_version_intervals`
path used by the `add_*_version` helpers. **Adversarial review found the removal
is UNSAFE.** This PR takes issue #3407's **option (B)**: keep the explicit calls
and document precisely why they are *not* redundant.

> **Stacked on #3487 (issue #3429).** Base branch is
> `feature/issue-3429-fold-wal-startup-passes`. **Retarget to `trunk` after
> #3487 merges.**

## The divergence (empirically reproduced)

The explicit calls close the prior head's transaction time **unconditionally**
at `commit_timestamp`. The helper `close_previous_version_intervals` closes only
when `is_currently_recorded() && new_tx_start > prev_tx_start` — a **strict `>`**.
These diverge for exactly one case: **two writes to the SAME already-committed
entity within ONE transaction** (update-then-update / update-then-delete /
update-then-retract). A framed transaction stamps every op with the single
`CommitTx.commit_timestamp` `T`, so the successor's tx start **equals** the
intermediate version's tx start, and the strict `>` **skips** the close.

Reachability was confirmed with a real transaction through the public API, then
a real crash + full WAL replay:

```
Two update_node calls on the same node in ONE transaction  ->  3 versions,
the two update versions sharing commit_timestamp T = ...500106

LIVE  (pre-crash):  v[1] intermediate  tx=[T, T]     tx_current=false   (CLOSED, empty)
                    v[2] head          tx=[T, MAX]   tx_current=true

REPLAY, calls REMOVED:  v[1] intermediate  tx=[T, MAX]  tx_current=true  (LEFT OPEN)  <-- BUG
                        v[2] head          tx=[T, MAX]  tx_current=true

REPLAY, calls KEPT:     v[1] intermediate  tx=[T, T]    tx_current=false (CLOSED)  == live
                        v[2] head          tx=[T, MAX]  tx_current=true
```

With the calls removed, after replay the intermediate and head versions carry
**overlapping open transaction intervals** `[T, MAX)`, so an
`AS OF SYSTEM_TIME = T` read could surface the **superseded** version — a
live-vs-replay bitemporal-integrity divergence. The PR #3403
mutation-equivalence result (the mutant survived) was a **false negative from a
test-coverage gap**: no test exercised the equal-timestamp intra-transaction
case. This PR adds that test.

## Decision: (B) KEEP + document (not (A) remove)

The helper is a superset of the explicit close **only for DISTINCT timestamps**.
For the equal-timestamp intra-transaction case its strict `>` monotonicity guard
makes it a strict *subset* (it skips a close the live path performs). Keeping the
**unconditional** explicit close is what preserves live-vs-replay consistency
(the live path in `src/api/transaction/write/apply.rs` also closes
unconditionally). Each of the 8 replay-arm call sites now carries a comment
explaining this; the call logic is byte-identical to before the issue.

## Evidence (tests)

- **New regression test** `replay_double_update_same_node_in_one_tx_closes_intermediate`
  (`tests/recovery/replay_update_tests.rs`): drives the real framed-transaction
  API (`begin_transaction` → two same-node `update_node` → `commit`), performs a
  real crash (`mem::forget`) + full WAL replay, and asserts the intermediate
  version's tx-time is **closed** after replay, matching the live path.
  - **Verified it FAILS without the explicit close** (throwaway neutralization):
    panics at *"replay: intermediate version's transaction time MUST be closed"*
    because the version is left open `[T, MAX)`.
  - **PASSES with the explicit close** restored.
- **Retract-edge test gap filled**: `replay_retract_edge_honors_valid_to`
  (`src/storage/recovery.rs`) now asserts the symmetric pre-retraction-head
  tx-time closure (`!transaction_time().is_current()` + `end() == logged_retract_ts`
  + the AS-OF-SYSTEM_TIME visibility pair), matching its node twin — pinning the
  `close_edge_version_transaction_time` call in the RetractEdge arm.

## Arms (all 8 KEPT + documented)

CreateNode/CreateEdge (recreate-after-tombstone), UpdateNode, UpdateEdge,
DeleteNode, DeleteEdge, RetractNode, RetractEdge — each keeps its unconditional
explicit tx-time close, now with a comment stating it is deliberately kept
because the helper's strict `>` guard skips the equal-timestamp intra-transaction
close.

## Out of scope

The live write path `src/api/transaction/write/apply.rs` already performs the
unconditional close and is correct — no change needed. This PR touches
`src/storage/recovery.rs` and `tests/recovery/replay_update_tests.rs` only.

## Acceptance criteria

- [x] **Determined reachability empirically** — the equal-timestamp
  same-entity-multi-write-in-one-transaction case is REACHABLE and produces two
  versions sharing one framed `commit_timestamp` (diagnostic + regression test).
- [x] **Divergence reproduced** — removal leaves the intermediate version open
  `[T, MAX)` on replay while the live path closes it to `[T, T)`.
- [x] **Resolution: option (B)** — explicit closes kept (byte-identical logic),
  non-redundancy documented at every site.
- [x] **Reproducing test added** — passes WITH the explicit calls, fails WITHOUT
  (both states verified).
- [x] **Retract-edge test gap filled** — symmetric pre-retraction-head tx-time
  closure assertions added.
- [x] **Gates** — CI-exact clippy
  (`--features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings`)
  clean; `cargo fmt --all` clean; recovery suites green (79 integration + 23
  `storage::recovery` lib).