### PR TITLE
feat(cli): add `aletheia demo` subcommand for one-command time-to-first-wow (#3380)

### DIFF
--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -40,10 +40,12 @@ directory, no server:
 aletheia demo
 ```
 
-`aletheia demo` seeds the identical ephemeral, story-driven graph in-memory and
-prints the same guided sequence (current-state lookup, `AS OF` time-travel,
-traversal, and version history). It mirrors `cargo run --example demo` and is
-covered by the same CI behavior guard, so the two never drift.
+`aletheia demo` seeds the same ephemeral, story-driven graph in-memory and
+prints an equivalent guided sequence (current-state lookup, `AS OF` time-travel,
+traversal, and version history — the CLI uses a smaller filler count and orders
+the traversal and time-travel queries differently). Both flows are exercised in
+CI (`tests/cli_demo.rs` guards the CLI; `tests/quickstart_demo.rs` guards
+`cargo run --example demo`).
 
 You'll see four guided queries, each with a one-line "what you just saw":
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -32,6 +32,19 @@ written to your working directory) and needs no server and no API key:
 cargo run --example demo
 ```
 
+If you have the `aletheia` CLI binary built (or installed), the same guided
+tour is available as a first-class subcommand — no `--example` flag, no data
+directory, no server:
+
+```bash
+aletheia demo
+```
+
+`aletheia demo` seeds the identical ephemeral, story-driven graph in-memory and
+prints the same guided sequence (current-state lookup, `AS OF` time-travel,
+traversal, and version history). It mirrors `cargo run --example demo` and is
+covered by the same CI behavior guard, so the two never drift.
+
 You'll see four guided queries, each with a one-line "what you just saw":
 
 ```text
@@ -150,12 +163,12 @@ For minting role-scoped keys, the anonymous-mode opt-in for local development
 [Security Quickstart](security-quickstart.md).
 
 > **Seeding data for an agent session:** the guided dataset above is created by
-> the embedded Rust demo. To let an agent explore a *seeded* graph today, run
-> the demo's seed logic against a durable `AletheiaDB::open(path)` database and
-> start the MCP server with the same `ALETHEIADB_DATA_DIR`. A one-command
-> `aletheia demo` binary subcommand that boots a seeded, agent-reachable
-> instance directly is tracked as follow-up (see
-> [Known gaps](#known-gaps--follow-ups)).
+> the embedded Rust demo. The `aletheia demo` subcommand runs that same seed +
+> guided-query tour in one command against an ephemeral database. To let an
+> agent explore a *seeded, persistent* graph, run the demo's seed logic against
+> a durable `AletheiaDB::open(path)` database and start the MCP server with the
+> same `ALETHEIADB_DATA_DIR` (a one-command seeded, agent-reachable *server* is
+> tracked as follow-up — see [Known gaps](#known-gaps--follow-ups)).
 
 ---
 
@@ -178,12 +191,13 @@ Then create a node and issue queries with `curl`. The complete key lifecycle
 
 ## Known gaps / follow-ups
 
-- **Non-Rust binary / container channel.** The fastest non-Rust path — a
-  published binary or container that runs a seeded demo with **no toolchain** —
-  depends on an `aletheia demo` CLI subcommand and the container packaging
-  (owned by the deployment spec). Until it lands, the Rust-native
-  `cargo run --example demo` is the canonical guided demo, and the MCP/HTTP
-  sections above cover the server paths.
+- **Non-Rust binary / container channel.** The `aletheia demo` CLI subcommand
+  now runs the seeded guided demo from the compiled binary (no `--example`
+  flag). The remaining gap is the **container packaging** (owned by the
+  deployment spec) that ships that binary so a non-Rust user can run the demo
+  with **no toolchain at all**. Until the container lands, the Rust-native
+  `cargo run --example demo` / `aletheia demo` are the canonical guided demos,
+  and the MCP/HTTP sections above cover the server paths.
 - **Seeded agent session in one command.** See the note in the MCP section.
 
 ---

--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -46,6 +46,7 @@ fn main() {
 fn run() -> Result<(), String> {
     let mut args = env::args().skip(1);
     match args.next().as_deref() {
+        Some("demo") => handle_demo(args.collect()),
         Some("node") => handle_node(args.collect()),
         Some("edge") => handle_edge(args.collect()),
         Some("traverse") => handle_traverse(args.collect()),
@@ -73,6 +74,7 @@ fn print_usage() {
     println!(
         "AletheiaDB CLI\n\n\
 Usage:\n\
+  aletheia demo\n\
   aletheia node create <label> [--properties '{{\"k\":\"v\"}}']\n\
   aletheia node get <node_id>\n\
   aletheia edge create <source_id> <target_id> <label> [--properties '{{\"k\":\"v\"}}']\n\
@@ -88,6 +90,10 @@ Usage:\n\
   aletheia audit-verify <artifact_path> [--public-key HEX]\n\
   aletheia audit-render <artifact_path>\n\
 \nCommands map to core MCP-style graph operations while using local storage.\n\
+\nGetting started:\n\
+  demo    — Boot a seeded, ephemeral bi-temporal graph and run a guided tour of\n\
+            current-state, AS OF time-travel, traversal, and history queries.\n\
+            No data dir, no server, no network — just `aletheia demo`.\n\
 \nBackup / Restore:\n\
   backup  — Write a portable .albk artifact capturing full bi-temporal state.\n\
             Opens the database via ALETHEIADB_CONFIG or ALETHEIADB_DATA_DIR.\n\
@@ -135,6 +141,218 @@ fn handle_restore(args: Vec<String>) -> Result<(), String> {
     AletheiaDB::restore_to_data_dir(std::path::Path::new(path), &data_dir)
         .map_err(|e| format!("restore failed: {e}"))?;
     println!("{{\"ok\":true,\"data_dir\":\"{}\"}}", data_dir.display());
+    Ok(())
+}
+
+/// `aletheia demo` — boot a seeded, ephemeral bi-temporal graph and print a
+/// guided tour of showcase queries (Issue #3380 AC3).
+///
+/// This mirrors the seed + guided-query flow in `examples/demo.rs` so the
+/// one-command CLI experience stays in sync with the Rust-native example and
+/// the CI behavior guard (`tests/quickstart_demo.rs`). It requires no data
+/// directory, no server, and no network: the database is ephemeral
+/// (`AletheiaDB::new()`), so nothing is written to disk.
+///
+/// Any surplus arguments are ignored; the demo is a zero-configuration,
+/// one-shot showcase.
+fn handle_demo(_args: Vec<String>) -> Result<(), String> {
+    let db = AletheiaDB::new().map_err(|e| format!("failed to initialize demo database: {e}"))?;
+    run_demo(&db)
+}
+
+/// Builds a small string-valued `PropertyMap` for the demo seed. Keeps the
+/// seeding code legible without depending on the `properties!` macro.
+fn demo_props(pairs: &[(&str, &str)]) -> PropertyMap {
+    let mut builder = PropertyMapBuilder::new();
+    for (key, value) in pairs {
+        builder = builder.insert(key, PropertyValue::string(*value));
+    }
+    builder.build()
+}
+
+/// Renders a `PropertyValue` for human-readable demo output (no Debug leakage
+/// for the common scalar cases).
+fn demo_display_value(value: &PropertyValue) -> String {
+    match value {
+        PropertyValue::String(s) => s.to_string(),
+        PropertyValue::Int(i) => i.to_string(),
+        PropertyValue::Float(f) => f.to_string(),
+        PropertyValue::Bool(b) => b.to_string(),
+        other => format!("{other:?}"),
+    }
+}
+
+/// Extracts a string-valued property from a node, or a placeholder if absent.
+fn demo_prop_str(node: &Node, key: &str) -> String {
+    node.properties
+        .get(key)
+        .map(demo_display_value)
+        .unwrap_or_else(|| "<none>".to_string())
+}
+
+/// Seeds a small story-driven bi-temporal dataset into `db` and prints a guided
+/// sequence of showcase queries: a current-state lookup, an `AS OF`
+/// point-in-time lookup, a graph traversal, and the full version history of a
+/// node. Mirrors the narrative in `examples/demo.rs`.
+///
+/// Extracted from [`handle_demo`] so the seed + query flow is unit-testable
+/// against an injected database instance.
+fn run_demo(db: &AletheiaDB) -> Result<(), String> {
+    // The `update_node` transaction method lives on the `WriteOps` trait.
+    use aletheiadb::api::WriteOps;
+
+    // A small, deterministic filler cohort so the graph is more than a toy of a
+    // few nodes, while keeping the one-shot CLI demo well under a second.
+    const FILLER_ENGINEERS: usize = 20;
+
+    println!("════════════════════════════════════════════════════════");
+    println!("  AletheiaDB — bi-temporal graph demo");
+    println!("  Ephemeral demo data (in-memory; nothing written to disk)");
+    println!("════════════════════════════════════════════════════════\n");
+
+    // ── Seed the graph ──────────────────────────────────────────────────────
+    let company = db
+        .create_node("Company", demo_props(&[("name", "Aletheia Labs")]))
+        .map_err(|e| format!("failed to seed Company: {e}"))?;
+
+    let alice = db
+        .create_node(
+            "Person",
+            demo_props(&[("name", "Alice"), ("title", "Engineer")]),
+        )
+        .map_err(|e| format!("failed to seed Alice: {e}"))?;
+    let bob = db
+        .create_node(
+            "Person",
+            demo_props(&[("name", "Bob"), ("title", "Engineer")]),
+        )
+        .map_err(|e| format!("failed to seed Bob: {e}"))?;
+    let carol = db
+        .create_node(
+            "Person",
+            demo_props(&[("name", "Carol"), ("title", "Designer")]),
+        )
+        .map_err(|e| format!("failed to seed Carol: {e}"))?;
+
+    db.create_edge(alice, company, "WORKS_AT", PropertyMap::new())
+        .map_err(|e| format!("failed to seed Alice WORKS_AT: {e}"))?;
+    db.create_edge(bob, company, "WORKS_AT", PropertyMap::new())
+        .map_err(|e| format!("failed to seed Bob WORKS_AT: {e}"))?;
+    db.create_edge(carol, company, "WORKS_AT", PropertyMap::new())
+        .map_err(|e| format!("failed to seed Carol WORKS_AT: {e}"))?;
+    db.create_edge(alice, bob, "KNOWS", PropertyMap::new())
+        .map_err(|e| format!("failed to seed Alice KNOWS Bob: {e}"))?;
+    db.create_edge(bob, carol, "KNOWS", PropertyMap::new())
+        .map_err(|e| format!("failed to seed Bob KNOWS Carol: {e}"))?;
+
+    let mut previous: Option<NodeId> = None;
+    for i in 0..FILLER_ENGINEERS {
+        let person = db
+            .create_node(
+                "Person",
+                demo_props(&[("name", &format!("Engineer {i}")), ("title", "Engineer")]),
+            )
+            .map_err(|e| format!("failed to seed filler engineer {i}: {e}"))?;
+        db.create_edge(person, company, "WORKS_AT", PropertyMap::new())
+            .map_err(|e| format!("failed to seed filler WORKS_AT: {e}"))?;
+        if let Some(prev) = previous {
+            db.create_edge(prev, person, "KNOWS", PropertyMap::new())
+                .map_err(|e| format!("failed to seed filler KNOWS: {e}"))?;
+        }
+        previous = Some(person);
+    }
+
+    // Capture the founding moment *after* the initial hire, so a query "as of
+    // founding" sees Alice as an Engineer.
+    let t_founding = aletheiadb::time::now();
+
+    // The story unfolds: Alice is promoted twice. Each update creates a new
+    // bi-temporal version; the old versions are preserved and stay queryable.
+    // A tiny sleep between writes guarantees strictly-later transaction
+    // timestamps so point-in-time reads resolve to distinct versions.
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    db.write(|tx| {
+        tx.update_node(
+            alice,
+            demo_props(&[("name", "Alice"), ("title", "Staff Engineer")]),
+        )
+    })
+    .map_err(|e| format!("failed to promote Alice to Staff Engineer: {e}"))?;
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    db.write(|tx| tx.update_node(alice, demo_props(&[("name", "Alice"), ("title", "CTO")])))
+        .map_err(|e| format!("failed to promote Alice to CTO: {e}"))?;
+
+    println!(
+        "Seeded {} nodes and {} edges (a Company \"Aletheia Labs\" plus its people)\n\
+         with genuine bi-temporal version history.\n",
+        db.node_count(),
+        db.edge_count()
+    );
+
+    // ── Query 1: current-state lookup ───────────────────────────────────────
+    println!("── Query 1 of 4: Current-state lookup ──");
+    println!("  db.get_node(alice_id)");
+    let alice_now = db
+        .get_node(alice)
+        .map_err(|e| format!("current-state lookup of Alice failed: {e}"))?;
+    let title_now = demo_prop_str(&alice_now, "title");
+    println!("  → Alice is currently: {title_now}");
+    println!("  what you just saw: the *latest* fact — sub-microsecond, no temporal overhead.\n");
+
+    // ── Query 2: AS OF point-in-time (the differentiator) ───────────────────
+    println!("── Query 2 of 4: Time-travel — AS OF the founding day ──");
+    println!("  db.get_node_at_time(alice_id, t_founding, t_founding)");
+    let alice_founding = db
+        .get_node_at_time(alice, t_founding, t_founding)
+        .map_err(|e| format!("AS OF point-in-time lookup of Alice failed: {e}"))?;
+    let title_founding = demo_prop_str(&alice_founding, "title");
+    println!("  → On founding day, Alice was: {title_founding}");
+    println!(
+        "  what you just saw: the SAME node, a different answer — \
+         \"{title_founding}\" then vs \"{title_now}\" now.\n"
+    );
+
+    // ── Query 3: a traversal ────────────────────────────────────────────────
+    println!("── Query 3 of 4: Traversal (who does Alice know?) ──");
+    println!("  db.get_outgoing_edges_with_label(alice_id, \"KNOWS\")");
+    for edge_id in db.get_outgoing_edges_with_label(alice, "KNOWS") {
+        let target = db
+            .get_edge_target(edge_id)
+            .map_err(|e| format!("failed to resolve KNOWS target: {e}"))?;
+        let person = db
+            .get_node(target)
+            .map_err(|e| format!("failed to load known person: {e}"))?;
+        println!(
+            "  → Alice KNOWS {} ({})",
+            demo_prop_str(&person, "name"),
+            demo_prop_str(&person, "title")
+        );
+    }
+    println!("  what you just saw: a single-hop graph traversal over the current graph.\n");
+
+    // ── Query 4: full history / provenance ──────────────────────────────────
+    println!("── Query 4 of 4: History — every version of a fact ──");
+    println!("  db.get_node_history(alice_id)");
+    let history = db
+        .get_node_history(alice)
+        .map_err(|e| format!("failed to load Alice's history: {e}"))?;
+    for version in &history.versions {
+        let title = version
+            .properties
+            .get("title")
+            .map(demo_display_value)
+            .unwrap_or_else(|| "<none>".to_string());
+        println!("  → v{}: title = {title}", version.version_number);
+    }
+    println!(
+        "  what you just saw: {} preserved versions of one node — the audit trail is free.\n",
+        history.versions.len()
+    );
+
+    println!("────────────────────────────────────────────────────────");
+    println!("Next: open a durable database with `AletheiaDB::open(\"./mydb\")`,");
+    println!("or point an MCP client at AletheiaDB — see docs/guides/quickstart.md.");
+
     Ok(())
 }
 
@@ -834,6 +1052,34 @@ mod audit {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn run_demo_seeds_and_runs_all_showcase_queries() {
+        let db = AletheiaDB::new().expect("ephemeral demo database should open");
+        // The guided sequence must complete without error against the seed.
+        run_demo(&db).expect("run_demo should succeed end-to-end");
+
+        // Seeding must have produced a realistic graph, and the temporal
+        // narrative must hold: Alice's latest title differs from her founding
+        // title (this is the AS OF differentiator the demo showcases).
+        assert!(db.node_count() >= 4, "expected the core cast plus filler");
+        assert!(
+            db.edge_count() >= 4,
+            "expected WORKS_AT/KNOWS relationships"
+        );
+    }
+
+    #[test]
+    fn handle_demo_runs_to_completion() {
+        // The one-shot demo needs no arguments and must exit Ok.
+        handle_demo(vec![]).expect("aletheia demo should run to completion");
+    }
+
+    #[test]
+    fn demo_props_builds_expected_map() {
+        let map = demo_props(&[("name", "Alice"), ("title", "Engineer")]);
+        assert!(!map.is_empty());
+    }
 
     #[test]
     fn handle_backup_missing_arg_returns_usage_error() {

--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -193,7 +193,8 @@ fn demo_prop_str(node: &Node, key: &str) -> String {
 /// Seeds a small story-driven bi-temporal dataset into `db` and prints a guided
 /// sequence of showcase queries: a current-state lookup, an `AS OF`
 /// point-in-time lookup, a graph traversal, and the full version history of a
-/// node. Mirrors the narrative in `examples/demo.rs`.
+/// node. Tells the same story as `examples/demo.rs` (the query ordering and
+/// filler count differ; both flows are exercised in CI).
 ///
 /// Extracted from [`handle_demo`] so the seed + query flow is unit-testable
 /// against an injected database instance.
@@ -311,6 +312,16 @@ fn run_demo(db: &AletheiaDB) -> Result<(), String> {
         "  what you just saw: the SAME node, a different answer — \
          \"{title_founding}\" then vs \"{title_now}\" now.\n"
     );
+
+    // Guard the demo's headline invariant: the AS OF reconstruction must return
+    // the *founding-day* fact, not silently regress to current state. Uses the
+    // demo's `Result<(), String>` convention rather than a panic to match the
+    // CLI error style (cf. the `assert_ne!` guard in examples/demo.rs:140).
+    if title_founding == title_now {
+        return Err(format!(
+            "demo invariant broken: AS OF returned current state ({title_now})"
+        ));
+    }
 
     // ── Query 3: a traversal ────────────────────────────────────────────────
     println!("── Query 3 of 4: Traversal (who does Alice know?) ──");
@@ -1078,7 +1089,17 @@ mod tests {
     #[test]
     fn demo_props_builds_expected_map() {
         let map = demo_props(&[("name", "Alice"), ("title", "Engineer")]);
-        assert!(!map.is_empty());
+        // Round-trip the inserted values, not just non-emptiness.
+        assert_eq!(
+            map.get("name").map(demo_display_value).as_deref(),
+            Some("Alice"),
+            "name should round-trip"
+        );
+        assert_eq!(
+            map.get("title").map(demo_display_value).as_deref(),
+            Some("Engineer"),
+            "title should round-trip"
+        );
     }
 
     #[test]

--- a/tests/cli_demo.rs
+++ b/tests/cli_demo.rs
@@ -61,13 +61,20 @@ fn demo_time_travel_answer_differs_from_current_state() {
     let (_success, stdout) = run_demo();
 
     // The AS OF differentiator: Alice is a "CTO" now but was an "Engineer" on
-    // the founding day. Both must appear in the guided output.
+    // the founding day. Assert on the exact founding-day line — a marker UNIQUE
+    // to the point-in-time (AS OF) reconstruction — so the test fails if AS OF
+    // silently regresses to returning the CURRENT (CTO) state. (A bare
+    // "Engineer" substring is printed anyway by Bob/Carol/the filler engineers
+    // in the traversal section, so it cannot guard this claim.)
     assert!(
-        stdout.contains("CTO"),
-        "expected current-state title 'CTO'.\nfull output:\n{stdout}"
+        stdout.contains("→ On founding day, Alice was: Engineer"),
+        "expected the AS OF founding-day line to report 'Engineer' (the \
+         point-in-time reconstruction must not return current state).\n\
+         full output:\n{stdout}"
     );
+    // And the current-state line must still show the latest title.
     assert!(
-        stdout.contains("Engineer"),
-        "expected founding-day title 'Engineer'.\nfull output:\n{stdout}"
+        stdout.contains("→ Alice is currently: CTO"),
+        "expected the current-state line to report 'CTO'.\nfull output:\n{stdout}"
     );
 }

--- a/tests/cli_demo.rs
+++ b/tests/cli_demo.rs
@@ -1,0 +1,73 @@
+//! Integration test for the `aletheia demo` CLI subcommand (Issue #3380 AC3).
+//!
+//! Invokes the built `aletheia` binary via `CARGO_BIN_EXE_aletheia` and asserts
+//! that `aletheia demo` boots a seeded, ephemeral bi-temporal graph and prints
+//! the guided showcase (current-state, AS OF point-in-time, traversal, and
+//! history) — exiting 0 with no data dir, no server, and no network.
+//!
+//! This locks the one-command experience so it can never silently drift from
+//! `examples/demo.rs` / `tests/quickstart_demo.rs`.
+
+use std::process::Command;
+
+/// Runs `aletheia demo` and returns (success, stdout).
+fn run_demo() -> (bool, String) {
+    let output = Command::new(env!("CARGO_BIN_EXE_aletheia"))
+        .arg("demo")
+        // Intentionally provide no ALETHEIADB_DATA_DIR / config: the demo must
+        // be self-contained and ephemeral.
+        .output()
+        .expect("failed to spawn `aletheia demo`");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        panic!("`aletheia demo` exited non-zero.\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+    (output.status.success(), stdout)
+}
+
+#[test]
+fn demo_exits_zero_and_prints_all_showcase_sections() {
+    let (success, stdout) = run_demo();
+    assert!(success, "`aletheia demo` should exit 0");
+
+    // Each of the three required showcase queries must be present, plus the
+    // history section.
+    let expected_markers = ["Current-state lookup", "AS OF", "Traversal", "History"];
+    for marker in expected_markers {
+        assert!(
+            stdout.contains(marker),
+            "demo output missing showcase marker {marker:?}.\nfull output:\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn demo_output_names_the_seeded_cast() {
+    let (_success, stdout) = run_demo();
+
+    // The seeded narrative must be visible in the output.
+    for key in ["Alice", "Company", "KNOWS"] {
+        assert!(
+            stdout.contains(key),
+            "demo output missing seeded key {key:?}.\nfull output:\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn demo_time_travel_answer_differs_from_current_state() {
+    let (_success, stdout) = run_demo();
+
+    // The AS OF differentiator: Alice is a "CTO" now but was an "Engineer" on
+    // the founding day. Both must appear in the guided output.
+    assert!(
+        stdout.contains("CTO"),
+        "expected current-state title 'CTO'.\nfull output:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Engineer"),
+        "expected founding-day title 'Engineer'.\nfull output:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Before / After
Before: seeing AletheiaDB's bi-temporal features required `cargo run --example demo` (needs a Rust toolchain and checkout). After: **`aletheia demo`** boots a seeded temporal graph and prints four guided showcase queries in one command — ephemeral, no data dir, no network, exits 0:
```
Seeded 24 nodes and 44 edges (a Company "Aletheia Labs" plus its people)
── Query 1 of 4: Current-state lookup ──
  → Alice is currently: CTO
── Query 2 of 4: Time-travel — AS OF the founding day ──
  → On founding day, Alice was: Engineer
  what you just saw: the SAME node, a different answer — "Engineer" then vs "CTO" now.
── Query 3 of 4: Traversal (who does Alice know?) ──
  → Alice KNOWS Bob (Engineer)
── Query 4 of 4: History — every version of a fact ──
  → v1: title = Engineer   → v2: title = Staff Engineer   → v3: title = CTO
```

## How
- New `demo` arm in `run()`, listed in `print_usage()`; logic in a testable `run_demo(&db)` over an ephemeral `AletheiaDB::new()`. Seeds a Company + Alice/Bob/Carol with Alice promoted Engineer→Staff→CTO to build real bi-temporal history, then prints current-state, AS-OF-founding-day, traversal, and version-history queries with narration.
- `run_demo` guards the AS-OF differentiator with a `Result`-style invariant (fails loudly if point-in-time silently returns current state); `tests/cli_demo.rs` asserts the exact founding-day vs current markers + exit 0.
- Doc section added to `docs/guides/quickstart.md` (reframes the old "deferred follow-up" note to shipped). `examples/demo.rs` untouched, so `tests/quickstart_demo.rs` still guards the reference flow.

## Note on the aletheia-mcp warning
The lane brief mentioned a possible cosmetic `aletheia-mcp` manifest warning to fix "if still present." A clean `cargo build --bin aletheia-mcp --features mcp-server` emits **zero** warnings; the default startup prints an auth-refusal *error* (not a warning) and the only runtime notice is the intentional uppercase anonymous-mode banner. Nothing to fix — documented for the record.

## Gates
`tests/cli_demo.rs` 3 / `--bin aletheia` 17 / `tests/quickstart_demo.rs` 1 green (isolated `CARGO_TARGET_DIR`); CI-subset clippy zero warnings. `--all-features` clippy pre-broken on trunk (#3371, out of lane).

Addresses #3380 (the deferred AC3 `aletheia demo` subcommand).

---
_Generated by [Claude Code](https://claude.ai/code/session_016YW8DD8i2PmhoxgFa9YFVq)_