### PR TITLE
fix(backup): restore writes index at canonical layout so open_from_env can reopen

### DIFF
--- a/src/db/backup.rs
+++ b/src/db/backup.rs
@@ -143,11 +143,23 @@ impl AletheiaDB {
 
     /// Restore a backup artifact into a **durable** database at `data_dir`.
     ///
-    /// The target directory must be empty (no `indexes/manifest.idx` present)
-    /// to prevent overwriting existing data.
+    /// The target directory must be empty (no index manifest present) to
+    /// prevent overwriting existing data.
     ///
-    /// After restoration, the DB is persisted to `data_dir` and can be
-    /// reopened with `AletheiaDB::with_unified_config(durable_config_for_data_dir(data_dir))`.
+    /// After restoration, the DB is persisted under `data_dir` in the canonical
+    /// durable layout and can be reopened with either
+    /// [`AletheiaDB::open`]`(data_dir)` /
+    /// [`AletheiaDB::open_from_env`] or the equivalent
+    /// `AletheiaDB::with_unified_config(durable_config_for_data_dir(data_dir))`.
+    ///
+    /// The restored index artifacts are materialised at the same on-disk depth
+    /// that [`crate::config::durable_config_for_data_dir`] reads them from: the
+    /// index-persistence root is `data_dir/indexes` (the value that config
+    /// assigns to `PersistenceConfig::data_dir`), and the
+    /// `IndexPersistenceManager` appends its own `indexes/` beneath that base.
+    /// Writing at any other depth (e.g. using `data_dir` directly as the base)
+    /// leaves the manifest where `open`/`open_from_env` cannot find it, so a
+    /// reopen silently comes up empty.
     ///
     /// # Errors
     ///
@@ -155,14 +167,31 @@ impl AletheiaDB {
     /// - `Error::Backup(BackupError::BadMagic)` — invalid artifact.
     /// - `Error::Backup(BackupError::IncompatibleVersion { .. })` — format too new.
     pub fn restore_to_data_dir(path: &Path, data_dir: &Path) -> Result<AletheiaDB> {
-        check_target_empty(data_dir).map_err(Error::Backup)?;
+        // Canonical index-persistence root: the same base that
+        // `durable_config_for_data_dir` assigns to `PersistenceConfig::data_dir`
+        // (the `IndexPersistenceManager` appends its own `indexes/` under this).
+        let index_root = index_persistence_root(data_dir);
+
+        check_target_empty(&index_root).map_err(Error::Backup)?;
 
         let payload = read_artifact(path).map_err(Error::Backup)?;
-        materialize_to_dir(&payload, data_dir).map_err(Error::Backup)?;
+        materialize_to_dir(&payload, &index_root).map_err(Error::Backup)?;
 
-        let config = build_restore_config(data_dir, data_dir.join("wal"));
+        // Reopen through the canonical durable config so the layout written above
+        // is exactly the layout `open`/`open_from_env` will read on restart.
+        let config = crate::config::durable_config_for_data_dir(data_dir);
         AletheiaDB::with_unified_config(config)
     }
+}
+
+/// The index-persistence base directory under a durable data root.
+///
+/// This mirrors [`crate::config::durable_config_for_data_dir`], which sets
+/// `PersistenceConfig::data_dir = data_dir/indexes`. Keeping the join in one
+/// place ensures restore materialises artifacts at the exact depth the durable
+/// reopen path reads them from.
+fn index_persistence_root(data_dir: &Path) -> std::path::PathBuf {
+    data_dir.join("indexes")
 }
 
 /// Build an `AletheiaDBConfig` that loads from an existing persistence directory.

--- a/tests/backup_restore.rs
+++ b/tests/backup_restore.rs
@@ -344,10 +344,15 @@ fn restore_rejects_nonempty_target() {
     db.backup(&backup_path).unwrap();
 
     // Simulate a non-empty target: write a fake manifest at the path that
-    // IndexPersistenceManager checks (data_dir/indexes/manifest.idx).
+    // IndexPersistenceManager checks. `restore_to_data_dir` roots the index
+    // persistence base at `data_dir/indexes` (matching
+    // `durable_config_for_data_dir`), and the manager appends its own
+    // `indexes/`, so the manifest it checks lives at
+    // `data_dir/indexes/indexes/manifest.idx`.
     let data_dir = tmp.path().join("target_data");
-    std::fs::create_dir_all(data_dir.join("indexes")).unwrap();
-    std::fs::write(data_dir.join("indexes").join("manifest.idx"), b"fake").unwrap();
+    let manifest_dir = data_dir.join("indexes").join("indexes");
+    std::fs::create_dir_all(&manifest_dir).unwrap();
+    std::fs::write(manifest_dir.join("manifest.idx"), b"fake").unwrap();
 
     let err = AletheiaDB::restore_to_data_dir(&backup_path, &data_dir).unwrap_err();
 

--- a/tests/cli_restore_reopen.rs
+++ b/tests/cli_restore_reopen.rs
@@ -1,0 +1,104 @@
+#![cfg(test)]
+
+//! Regression test for `restore_to_data_dir` index-persistence layout.
+//!
+//! A directory produced by `AletheiaDB::restore_to_data_dir` (the durable
+//! restore path used by the `aletheia restore <backup.albk>` CLI) must be
+//! reopenable via the canonical durable entry point
+//! `AletheiaDB::open` / `open_from_env` (which build their config through
+//! `durable_config_for_data_dir`).
+//!
+//! Before the fix, `restore_to_data_dir` materialised the restored index
+//! artifacts at `data_dir/indexes/...` while `durable_config_for_data_dir`
+//! reads them from `data_dir/indexes/indexes/...` (the manager appends its own
+//! `indexes/` under the configured base). The depth mismatch meant a reopen via
+//! `open` found no manifest and came up empty, silently losing the restored
+//! graph.
+//!
+//! We deliberately use single-key string properties (no vector embeddings) to
+//! avoid the separate, known GLOBAL_INTERNER-mismatch flake.
+
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+use serial_test::serial;
+use tempfile::TempDir;
+
+/// A `.albk` backup restored into a fresh data dir must be reopenable through
+/// the canonical `AletheiaDB::open` path with the full graph intact.
+#[test]
+#[serial]
+fn restore_to_data_dir_is_reopenable_via_open() {
+    // 1. Build a small source graph (string-only properties).
+    let (backup_path, alice_id, bob_id, _tmp_src) = {
+        let db = AletheiaDB::new().unwrap();
+
+        let alice_id = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Alice").build(),
+            )
+            .unwrap();
+        let bob_id = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Bob").build(),
+            )
+            .unwrap();
+        db.create_edge(alice_id, bob_id, "KNOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        assert_eq!(db.node_count(), 2);
+        assert_eq!(db.edge_count(), 1);
+
+        let tmp_src = TempDir::new().unwrap();
+        let backup_path = tmp_src.path().join("graph.albk");
+        db.backup(&backup_path).unwrap();
+
+        // Drop the source DB before restoring: materialize_to_dir clears and
+        // repopulates the process-global interner, so no live DB may share it.
+        drop(db);
+
+        (backup_path, alice_id, bob_id, tmp_src)
+    };
+
+    // 2. Restore into a fresh, empty data dir (the CLI `restore` path).
+    let tmp_dst = TempDir::new().unwrap();
+    let data_dir = tmp_dst.path().join("restored_db");
+
+    {
+        let restored = AletheiaDB::restore_to_data_dir(&backup_path, &data_dir).unwrap();
+        assert_eq!(restored.node_count(), 2, "restore must reconstruct nodes");
+        assert_eq!(restored.edge_count(), 1, "restore must reconstruct edges");
+        // Drop the restored handle to flush/persist final state before reopening.
+    }
+
+    // 3. Reopen the restored dir through the canonical durable entry point.
+    //    This is what `open_from_env`/the CLI reopen uses.
+    let reopened = AletheiaDB::open(&data_dir).unwrap();
+
+    assert_eq!(
+        reopened.node_count(),
+        2,
+        "reopened DB must see the restored nodes (layout must match durable_config_for_data_dir)"
+    );
+    assert_eq!(
+        reopened.edge_count(),
+        1,
+        "reopened DB must see the restored edge"
+    );
+
+    let alice = reopened.get_node(alice_id).unwrap();
+    assert_eq!(
+        alice.get_property("name").and_then(|v| v.as_str()),
+        Some("Alice"),
+        "Alice's restored property must survive reopen"
+    );
+    let bob = reopened.get_node(bob_id).unwrap();
+    assert_eq!(
+        bob.get_property("name").and_then(|v| v.as_str()),
+        Some("Bob"),
+        "Bob's restored property must survive reopen"
+    );
+
+    let outgoing = reopened.get_outgoing_edges(alice_id);
+    assert_eq!(outgoing.len(), 1, "restored KNOWS edge must survive reopen");
+}


### PR DESCRIPTION
## Before / After
Before: a directory produced by `aletheia restore <backup.albk>` could **not** be reopened by `aletheia` / `AletheiaDB::open` / `open_from_env` — the restored index manifest was written one directory level too shallow (`data_dir/indexes/manifest.idx`), so reopen found no persisted index and came up empty. After: restore writes at the **canonical** `data_dir/indexes/indexes/…` depth that `durable_config_for_data_dir`/`open` reads, so a restored dir reopens with all data intact.

## How
`src/db/backup.rs` only: added a single-sourced `index_persistence_root(data_dir) = data_dir/indexes` helper; `restore_to_data_dir` now materializes and empty-checks against that root and reopens via `crate::config::durable_config_for_data_dir` instead of the self-inconsistent `build_restore_config` (retained for the ephemeral `restore()` path). WAL and cold-tier restore behavior unchanged; blast radius kept to `backup.rs`. New `tests/cli_restore_reopen.rs`: backup → `restore_to_data_dir` → `AletheiaDB::open` → assert node/edge counts + spot-checked properties (RED before the fix, GREEN after). Full `tests/backup_restore.rs` suite green (8/8). Backward-compat for pre-existing wrong-depth restore artifacts is noted as a follow-up (not a clean/cheap change).

## Gates
`tests/cli_restore_reopen.rs` + `tests/backup_restore.rs` green; CI-subset clippy zero warnings. `--all-features` clippy pre-broken on trunk (#3371, out of lane).

Closes #3489.

---
_Generated by [Claude Code](https://claude.ai/code/session_016YW8DD8i2PmhoxgFa9YFVq)_