### PR TITLE
fix(mcp): explicitly guard update/delete of same-batch-created ids in apply_batch (#3417)

### DIFF
--- a/src/mcp/batch.rs
+++ b/src/mcp/batch.rs
@@ -353,6 +353,21 @@ enum BatchAbort {
         edge_id: u64,
         removed_at_index: usize,
     },
+    /// The op at `index` targets a committed integer id that a `create_node`/
+    /// `create_edge` earlier in THIS batch allocated — a guessed-id write
+    /// against an entity not yet committed. This is the documented v1-scope
+    /// rejection ("no update/delete of batch-created refs") that the static
+    /// `$alias`/`$<index>` prevalidation enforces for the ref *spelling*
+    /// (`batch_committed_node`); enforced explicitly here for the integer-id
+    /// form because buffer-aware transaction reads (Issue #3417) no longer
+    /// surface it incidentally as `NOT_FOUND`.
+    BatchCreatedRefWrite {
+        index: usize,
+        entity: &'static str,
+        id: u64,
+        created_at_index: usize,
+        verb: &'static str,
+    },
     /// A commit-phase failure (no attributable op index).
     Commit { source: Error },
     /// An internal invariant breach in the batch handler itself (never the
@@ -1045,6 +1060,17 @@ impl AletheiaMcpServer {
         // Committed edges updated so far -> (endpoints, op index), to refuse
         // a later cascade silently discarding the update.
         let mut updated_committed_edges: HashMap<u64, (NodeId, NodeId, usize)> = HashMap::new();
+        // Integer ids of nodes/edges CREATED earlier in this batch, mapped to
+        // the op index that created them. An update/delete targeting one of
+        // these is a guessed-id write against an entity not yet committed —
+        // the v1-scope rejection the static `$alias` prevalidation
+        // (`batch_committed_node`) enforces for the ref SPELLING. Enforced
+        // explicitly here because buffer-aware transaction reads (Issue #3417)
+        // removed the incidental `NOT_FOUND` that used to catch the integer-id
+        // form (pinned by
+        // apply_batch_guessed_id_of_batch_created_node_aborts_whole_batch).
+        let mut created_node_ids: HashMap<u64, usize> = HashMap::new();
+        let mut created_edge_ids: HashMap<u64, usize> = HashMap::new();
 
         let mut results = Vec::with_capacity(planned.len());
         let mut ref_map = serde_json::Map::new();
@@ -1066,6 +1092,7 @@ impl AletheiaMcpServer {
                         .map_err(op_err(index))?;
                     let version_id = tx.buffered_node_version(node_id).map(|v| v.as_u64());
                     created_nodes[index] = Some(node_id);
+                    created_node_ids.insert(node_id.as_u64(), index);
                     if let Some(alias) = alias {
                         ref_map.insert(alias.clone(), json!(node_id.as_u64()));
                     }
@@ -1119,6 +1146,7 @@ impl AletheiaMcpServer {
                         )
                         .map_err(op_err(index))?;
                     let version_id = tx.buffered_edge_version(edge_id).map(|v| v.as_u64());
+                    created_edge_ids.insert(edge_id.as_u64(), index);
                     batch_edges.push(BatchEdge {
                         source,
                         target,
@@ -1139,6 +1167,15 @@ impl AletheiaMcpServer {
                     valid_from,
                     provenance,
                 } => {
+                    if let Some(&created_at) = created_node_ids.get(&node_id.as_u64()) {
+                        return Err(BatchAbort::BatchCreatedRefWrite {
+                            index,
+                            entity: "node",
+                            id: node_id.as_u64(),
+                            created_at_index: created_at,
+                            verb: "update",
+                        });
+                    }
                     let options = write_options(*valid_from, provenance.clone());
                     tx.update_node_with_options(*node_id, properties.clone(), options)
                         .map_err(op_err(index))?;
@@ -1156,6 +1193,15 @@ impl AletheiaMcpServer {
                     valid_from,
                     provenance,
                 } => {
+                    if let Some(&created_at) = created_edge_ids.get(&edge_id.as_u64()) {
+                        return Err(BatchAbort::BatchCreatedRefWrite {
+                            index,
+                            entity: "edge",
+                            id: edge_id.as_u64(),
+                            created_at_index: created_at,
+                            verb: "update",
+                        });
+                    }
                     if let Some(&removed_at) = deleted_committed_edges.get(&edge_id.as_u64()) {
                         return Err(BatchAbort::EdgeRemovedByCascade {
                             index,
@@ -1184,6 +1230,15 @@ impl AletheiaMcpServer {
                     detach,
                     valid_from,
                 } => {
+                    if let Some(&created_at) = created_node_ids.get(&node_id.as_u64()) {
+                        return Err(BatchAbort::BatchCreatedRefWrite {
+                            index,
+                            entity: "node",
+                            id: node_id.as_u64(),
+                            created_at_index: created_at,
+                            verb: "delete",
+                        });
+                    }
                     let edges_removed = self.batch_delete_node(
                         tx,
                         index,
@@ -1206,6 +1261,15 @@ impl AletheiaMcpServer {
                     edge_id,
                     valid_from,
                 } => {
+                    if let Some(&created_at) = created_edge_ids.get(&edge_id.as_u64()) {
+                        return Err(BatchAbort::BatchCreatedRefWrite {
+                            index,
+                            entity: "edge",
+                            id: edge_id.as_u64(),
+                            created_at_index: created_at,
+                            verb: "delete",
+                        });
+                    }
                     if let Some(&removed_at) = deleted_committed_edges.get(&edge_id.as_u64()) {
                         return Err(BatchAbort::EdgeRemovedByCascade {
                             index,
@@ -1247,11 +1311,10 @@ impl AletheiaMcpServer {
     ) -> Result<usize, BatchAbort> {
         // Existence check through the transaction (same snapshot the delete
         // will use), so a nonexistent node reports NOT_FOUND at this index.
-        // Note: transaction reads see COMMITTED state only, so a guessed
-        // numeric id that a create earlier in this batch happens to allocate
-        // is still NOT_FOUND here (and in the update/delete core ops) — the
-        // whole batch aborts and zero writes survive (pinned by
-        // apply_batch_guessed_id_of_batch_created_node_aborts_whole_batch).
+        // A guessed numeric id that a create earlier in this batch allocated
+        // is rejected BEFORE reaching here by the explicit batch-created-ref
+        // guard in `execute_batch` (Issue #3417) — this read only sees
+        // genuinely committed nodes.
         tx.get_node(node_id)
             .map_err(|source| BatchAbort::Op { index, source })?;
 
@@ -1424,6 +1487,35 @@ impl AletheiaMcpServer {
                     "removed_at_index": removed_at_index
                 })),
             ),
+            // Mirrors the static `$alias` prevalidation in
+            // `batch_committed_node`: same INVALID_ARGUMENT code and the same
+            // "created in the same batch is not supported in v1" phrasing, for
+            // the guessed integer-id form.
+            BatchAbort::BatchCreatedRefWrite {
+                index,
+                entity,
+                id,
+                created_at_index,
+                verb,
+            } => {
+                let mut details = serde_json::Map::new();
+                details.insert("failed_op_index".to_string(), json!(index));
+                details.insert(format!("{entity}_id"), json!(id));
+                details.insert("created_at_index".to_string(), json!(created_at_index));
+                self.error_result(
+                    McpError::new(
+                        McpErrorCode::InvalidArgument,
+                        format!(
+                            "Operation {index}: cannot {verb} {entity} {id} — updating or \
+                             deleting a {entity} created in the same batch (operation \
+                             {created_at_index}) is not supported in v1. Commit the creation \
+                             first, then {verb} it in a follow-up call. The whole batch was \
+                             rolled back."
+                        ),
+                    )
+                    .details(serde_json::Value::Object(details)),
+                )
+            }
         }
     }
 

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -12413,6 +12413,134 @@ mod apply_batch_tests {
         assert!(server.db().get_node(NodeId::new(guessed).unwrap()).is_err());
     }
 
+    /// The batch-created-ref guard fires BEFORE the `detach` flag is
+    /// consulted: a `delete_node` with `detach: true` targeting the guessed
+    /// integer id of a node created earlier in the SAME batch is rejected with
+    /// the v1-scope INVALID_ARGUMENT (Issue #3417), not routed into the
+    /// cascade/detach path. The whole batch aborts and zero writes survive.
+    #[test]
+    fn apply_batch_detach_delete_of_batch_created_node_aborts_before_detach() {
+        let server = create_test_server();
+        let seeded = seed_person(&server, "Seed");
+        // The batch's create will be allocated `seeded + 1`.
+        let guessed = seeded + 1;
+
+        let value = apply_err(
+            &server,
+            json!([
+                {"op": "create_node", "label": "Person",
+                 "properties": {"name": "Ghost"}},
+                {"op": "delete_node", "node_id": guessed, "detach": true},
+            ]),
+            "INVALID_ARGUMENT",
+        );
+        assert_eq!(value["error"]["details"]["failed_op_index"], json!(1));
+        assert_eq!(value["error"]["details"]["created_at_index"], json!(0));
+        let msg = value["error"]["message"].as_str().unwrap();
+        assert!(
+            msg.contains("created in the same batch") && msg.contains("not supported in v1"),
+            "detach-delete of a batch-created id must get the v1-scope message: {msg}"
+        );
+
+        // Zero writes survived: only the seeded node exists, and the
+        // guessed id resolves to nothing.
+        assert_eq!(server.db().node_count(), 1);
+        assert!(server.db().get_node(NodeId::new(guessed).unwrap()).is_err());
+    }
+
+    /// `created_at_index` reports the ACTUAL originating create op, not always
+    /// `0`: a batch that creates node A (op 0) then node B (op 1) and then
+    /// writes B's guessed integer id (op 2) is rejected naming op 1 as the
+    /// creator. The whole batch aborts and zero writes survive (Issue #3417).
+    #[test]
+    fn apply_batch_guessed_id_of_second_batch_created_node_reports_correct_index() {
+        let server = create_test_server();
+        let seeded = seed_person(&server, "Seed");
+        // Sequential allocation: op 0 gets `seeded + 1` (node A), op 1 gets
+        // `seeded + 2` (node B). Op 2 targets B's guessed id.
+        let guessed_b = seeded + 2;
+
+        let value = apply_err(
+            &server,
+            json!([
+                {"op": "create_node", "label": "Person", "properties": {"name": "A"}},
+                {"op": "create_node", "label": "Person", "properties": {"name": "B"}},
+                {"op": "update_node", "node_id": guessed_b, "properties": {"x": 1}},
+            ]),
+            "INVALID_ARGUMENT",
+        );
+        assert_eq!(value["error"]["details"]["failed_op_index"], json!(2));
+        // Proves the guard names the create op that allocated the guessed id
+        // (op 1), not a hardcoded 0.
+        assert_eq!(value["error"]["details"]["created_at_index"], json!(1));
+        let msg = value["error"]["message"].as_str().unwrap();
+        assert!(
+            msg.contains("created in the same batch") && msg.contains("not supported in v1"),
+            "guessed second-create id write must get the v1-scope message: {msg}"
+        );
+
+        // Zero writes survived: only the seeded node exists; neither guessed id
+        // resolves to a committed node.
+        assert_eq!(server.db().node_count(), 1);
+        assert!(
+            server
+                .db()
+                .get_node(NodeId::new(seeded + 1).unwrap())
+                .is_err()
+        );
+        assert!(
+            server
+                .db()
+                .get_node(NodeId::new(guessed_b).unwrap())
+                .is_err()
+        );
+    }
+
+    /// `delete_edge` against a guessed batch-created edge id emits the SAME
+    /// message substrings the node / `update_edge` variants assert, bringing
+    /// its coverage to parity (Issue #3417). Whole batch aborts, zero writes.
+    #[test]
+    fn apply_batch_guessed_id_delete_edge_message_parity() {
+        let server = create_test_server();
+        let a = seed_person(&server, "A");
+        let b = seed_person(&server, "B");
+
+        // Anchor the guess to reality: the next create_edge (op 0 of the
+        // failing batch) is allocated `anchor + 1`.
+        let anchor = apply_ok(
+            &server,
+            json!([
+                {"op": "create_edge", "source_id": a, "target_id": b, "label": "KNOWS"},
+            ]),
+        );
+        let guessed_edge = anchor["results"][0]["edge_id"].as_u64().unwrap() + 1;
+
+        let value = apply_err(
+            &server,
+            json!([
+                {"op": "create_edge", "source_id": a, "target_id": b, "label": "KNOWS"},
+                {"op": "delete_edge", "edge_id": guessed_edge},
+            ]),
+            "INVALID_ARGUMENT",
+        );
+        assert_eq!(value["error"]["details"]["failed_op_index"], json!(1));
+        assert_eq!(value["error"]["details"]["created_at_index"], json!(0));
+        let msg = value["error"]["message"].as_str().unwrap();
+        assert!(
+            msg.contains("created in the same batch")
+                && msg.contains("not supported in v1")
+                && msg.contains("Commit the creation first"),
+            "delete_edge guard message must match the node/update_edge variants: {msg}"
+        );
+        assert!(
+            server
+                .db()
+                .get_edge(EdgeId::new(guessed_edge).unwrap())
+                .is_err(),
+            "the aborted batch's edge must not be committed"
+        );
+    }
+
     /// The edge counterpart: a guessed integer id of a batch-created EDGE
     /// submitted to `update_edge` / `delete_edge` is rejected by the same
     /// batch-created-ref guard (Issue #3417), whole batch aborts, zero writes.

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -12373,9 +12373,13 @@ mod apply_batch_tests {
 
     /// Pins the behavior when a caller *guesses* the numeric id a batch
     /// create will allocate and submits it as a write target: prevalidation
-    /// accepts it (it is a plain integer), but transaction reads see
-    /// committed state only, so the op fails NOT_FOUND at core op time and
-    /// the whole batch aborts — zero writes survive.
+    /// accepts it (it is a plain integer), but an explicit batch-created-ref
+    /// guard (Issue #3417) rejects it with the same v1-scope INVALID_ARGUMENT
+    /// the static `$alias` prevalidation emits — updating/deleting an entity
+    /// created in the same batch is not supported in v1. The whole batch
+    /// aborts and zero writes survive. Before #3417's buffer-aware reads this
+    /// was caught only incidentally as NOT_FOUND by the committed-only read;
+    /// the guard fires regardless of read semantics.
     #[test]
     fn apply_batch_guessed_id_of_batch_created_node_aborts_whole_batch() {
         let server = create_test_server();
@@ -12392,14 +12396,129 @@ mod apply_batch_tests {
                  "properties": {"name": "Ghost"}},
                 {"op": "update_node", "node_id": guessed, "properties": {"x": 1}},
             ]),
-            "NOT_FOUND",
+            "INVALID_ARGUMENT",
         );
         assert_eq!(value["error"]["details"]["failed_op_index"], json!(1));
+        // The guard names the create op that allocated the guessed id.
+        assert_eq!(value["error"]["details"]["created_at_index"], json!(0));
+        let msg = value["error"]["message"].as_str().unwrap();
+        assert!(
+            msg.contains("created in the same batch") && msg.contains("not supported in v1"),
+            "guessed-id write must get the v1-scope message: {msg}"
+        );
 
         // Zero writes survived: only the seeded node exists, and the
         // guessed id resolves to nothing.
         assert_eq!(server.db().node_count(), 1);
         assert!(server.db().get_node(NodeId::new(guessed).unwrap()).is_err());
+    }
+
+    /// The edge counterpart: a guessed integer id of a batch-created EDGE
+    /// submitted to `update_edge` / `delete_edge` is rejected by the same
+    /// batch-created-ref guard (Issue #3417), whole batch aborts, zero writes.
+    #[test]
+    fn apply_batch_guessed_id_of_batch_created_edge_aborts_whole_batch() {
+        let server = create_test_server();
+        let a = seed_person(&server, "A");
+        let b = seed_person(&server, "B");
+
+        // Anchor the guess to reality: create one committed edge and read its
+        // id. Edge ids are allocated sequentially (including ids consumed by
+        // aborted batches), so the very next create_edge — op 0 of the failing
+        // batch that immediately follows — gets `anchor + 1`, the id a caller
+        // would guess. Each variant re-anchors because the previous aborted
+        // batch consumed an id.
+        let anchor = apply_ok(
+            &server,
+            json!([
+                {"op": "create_edge", "source_id": a, "target_id": b, "label": "KNOWS"},
+            ]),
+        );
+        let guessed_edge = anchor["results"][0]["edge_id"].as_u64().unwrap() + 1;
+
+        let value = apply_err(
+            &server,
+            json!([
+                {"op": "create_edge", "source_id": a, "target_id": b, "label": "KNOWS"},
+                {"op": "update_edge", "edge_id": guessed_edge, "properties": {"x": 1}},
+            ]),
+            "INVALID_ARGUMENT",
+        );
+        assert_eq!(value["error"]["details"]["failed_op_index"], json!(1));
+        assert_eq!(value["error"]["details"]["created_at_index"], json!(0));
+        let msg = value["error"]["message"].as_str().unwrap();
+        assert!(
+            msg.contains("created in the same batch") && msg.contains("edge"),
+            "guessed edge-id write must get the v1-scope message: {msg}"
+        );
+        // Zero writes survived: the batch-created edge was never committed.
+        assert!(
+            server
+                .db()
+                .get_edge(EdgeId::new(guessed_edge).unwrap())
+                .is_err(),
+            "the aborted batch's edge must not be committed"
+        );
+
+        // delete_edge form is guarded identically. Re-anchor: the aborted
+        // batch above consumed an edge id, so recompute the guess.
+        let anchor = apply_ok(
+            &server,
+            json!([
+                {"op": "create_edge", "source_id": a, "target_id": b, "label": "KNOWS"},
+            ]),
+        );
+        let guessed_edge = anchor["results"][0]["edge_id"].as_u64().unwrap() + 1;
+
+        let value = apply_err(
+            &server,
+            json!([
+                {"op": "create_edge", "source_id": a, "target_id": b, "label": "KNOWS"},
+                {"op": "delete_edge", "edge_id": guessed_edge},
+            ]),
+            "INVALID_ARGUMENT",
+        );
+        assert_eq!(value["error"]["details"]["failed_op_index"], json!(1));
+        assert_eq!(value["error"]["details"]["created_at_index"], json!(0));
+        assert!(
+            server
+                .db()
+                .get_edge(EdgeId::new(guessed_edge).unwrap())
+                .is_err(),
+            "the aborted batch's edge must not be committed"
+        );
+    }
+
+    /// The guard does NOT over-fire: updating and deleting a PRE-EXISTING
+    /// committed node/edge within a batch still succeeds — only ids created
+    /// earlier in the SAME batch are refused (Issue #3417).
+    #[test]
+    fn apply_batch_update_delete_of_preexisting_committed_entity_still_succeeds() {
+        let server = create_test_server();
+        let a = seed_person(&server, "A");
+        let b = seed_person(&server, "B");
+        let edge = seed_edge(&server, a, b);
+
+        // Update a committed node + update a committed edge in one batch.
+        let value = apply_ok(
+            &server,
+            json!([
+                {"op": "update_node", "node_id": a, "properties": {"role": "lead"}},
+                {"op": "update_edge", "edge_id": edge, "properties": {"weight": 2}},
+            ]),
+        );
+        assert_eq!(value["operation_count"], json!(2), "got: {value}");
+
+        // Delete a committed edge, then the (now-detached) committed node.
+        let value = apply_ok(
+            &server,
+            json!([
+                {"op": "delete_edge", "edge_id": edge},
+                {"op": "delete_node", "node_id": b},
+            ]),
+        );
+        assert_eq!(value["operation_count"], json!(2), "got: {value}");
+        assert_eq!(server.db().edge_count(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Enforces the `apply_batch` **v1 invariant** — *"no update/delete of batch-created refs"* — **explicitly**, for the guessed-**integer-id** form. This lands **ahead of #3417** (Lane 2's buffer-aware transaction reads) because #3417 removes the incidental enforcement this invariant previously relied on. Safe to land first (the guard fires before the tx read either way) and **unblocks #3485 / #3493**.

## Before / After

**Before.** `apply_batch`'s static prevalidation rejects only the `$alias` / `$<index>` *spelling* of a write against a same-batch-created entity. A caller who instead passed a **guessed integer id** equal to an id an earlier create in the same batch allocated was caught only **incidentally**: transaction reads saw *committed* state only, so `update_node`/`delete_node`/`update_edge`/`delete_edge` failed with `NOT_FOUND` at core-op time and the batch aborted.

**After.** #3417's buffer-aware reads would let that guessed-id write find the just-created (uncommitted) entity and proceed — silently violating the v1 invariant. An **explicit guard** now rejects update/delete of any id created earlier in the *same* batch with the **same v1-scope `INVALID_ARGUMENT`** the `$alias` prevalidation emits, and the whole batch aborts with **zero writes**. Behavior for a **pre-existing committed** entity is unchanged — the guard fires only for same-batch-created ids.

## How

- `execute_batch` maintains two incremental maps — `created_node_ids` / `created_edge_ids` (`id -> creating op index`) — populated as each `create_node`/`create_edge` op commits and yields its assigned id, in input order.
- Before executing an `UpdateNode` / `DeleteNode` / `UpdateEdge` / `DeleteEdge` op, if the target integer id is present in the corresponding batch-created map, the op returns a new `BatchAbort::BatchCreatedRefWrite`.
- `batch_abort_result` renders it as `McpErrorCode::InvalidArgument` (the exact code the static `$alias` prevalidation in `batch_committed_node` uses), mirroring the message phrasing *"...created in the same batch ... is not supported in v1. Commit the creation first..."*, plus `details.failed_op_index` and `details.created_at_index`.
- Abort flows through the existing `db.write` drop-rollback path → all-or-nothing preserved, zero partial state.
- (`retract` is not an `apply_batch` op variant, so no retract path to guard.)

The error **code + message shape match the existing `$alias` prevalidation rejection** exactly (both `INVALID_ARGUMENT`, both non-retriable, same "created in the same batch is not supported in v1" phrasing).

## AC evidence

| Acceptance criterion | Evidence |
|---|---|
| Guessed integer id of a batch-created **node** → v1-scope rejection, not `NOT_FOUND` | `apply_batch_guessed_id_of_batch_created_node_aborts_whole_batch` now asserts `INVALID_ARGUMENT` + `failed_op_index:1` + `created_at_index:0` (was `NOT_FOUND`) — **red→green** verified |
| Same for a batch-created **edge** (`update_edge` **and** `delete_edge`) | New `apply_batch_guessed_id_of_batch_created_edge_aborts_whole_batch` |
| Whole batch aborts, **zero writes** survive | Both guessed-id tests assert the aborted batch's entity is not committed (`node_count`==seeded / `get_edge(...).is_err()`) |
| Guard does **not** over-fire on pre-existing committed entities | New `apply_batch_update_delete_of_preexisting_committed_entity_still_succeeds` (update+delete of committed node/edge in a batch still succeed) |
| Error code + message match `$alias` prevalidation | `BatchCreatedRefWrite` → `InvalidArgument`, mirrors `batch_committed_node`'s message |
| CI-linting clippy clean | `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` → exit 0, 0 warnings |
| Formatted | `cargo fmt --all` → clean (only `src/mcp/batch.rs`, `src/mcp/tests.rs` touched) |
| Tests green | `cargo test --features mcp-server --lib mcp::tests::apply_batch_tests` → `44 passed; 0 failed` |

## Scope

Only `src/mcp/batch.rs` (+ `src/mcp/tests.rs`). No cross-lane files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DcN8fSwm1nCUv1676y6mvc

---
_Generated by [Claude Code](https://claude.ai/code/session_01DcN8fSwm1nCUv1676y6mvc)_