### PR TITLE
Cypher WITH semantics — re-land onto trunk (#556)

### DIFF
--- a/src/cypher/ast.rs
+++ b/src/cypher/ast.rs
@@ -407,11 +407,22 @@ pub enum CypherTemporal {
 /// An intermediate `WITH` projection clause.
 ///
 /// `WITH` acts like a sub-`RETURN` that pipes results into subsequent clauses,
-/// optionally filtering with a `WHERE`.
+/// optionally filtering with a `WHERE`. Per openCypher the clause body mirrors
+/// a `RETURN` body -- `WITH [DISTINCT] items [ORDER BY ...] [SKIP n] [LIMIT n]`
+/// -- followed by an optional trailing `WHERE` that filters the *projected*
+/// rows (Issue #556).
 #[derive(Debug, Clone, PartialEq)]
 pub struct CypherWith {
+    /// Whether `DISTINCT` was specified to deduplicate the projected rows.
+    pub distinct: bool,
     /// The items to project through the `WITH`.
     pub items: Vec<CypherReturnItem>,
+    /// Zero or more `ORDER BY` items ordering the projected rows.
+    pub order_by: Vec<CypherOrderItem>,
+    /// An optional `SKIP n` offset applied to the projected rows.
+    pub skip: Option<usize>,
+    /// An optional `LIMIT n` cap applied to the projected rows.
+    pub limit: Option<usize>,
     /// An optional `WHERE` clause that filters after projection.
     pub where_clause: Option<CypherExpr>,
 }

--- a/src/cypher/converter.rs
+++ b/src/cypher/converter.rs
@@ -33,7 +33,7 @@
 //! # }
 //! ```
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use super::ast::*;
@@ -109,6 +109,24 @@ impl CypherParameterValue {
             )),
         }
     }
+}
+
+/// The projection shape of a `WITH` clause, as resolved for the positional
+/// pipeline (Issue #556). The pipeline carries a single entity per row, so a
+/// `WITH` either carries everything (`*`) or carries the current binding under
+/// its original or an aliased name.
+enum WithProjection {
+    /// `WITH *` -- carry every visible variable forward unchanged.
+    All,
+    /// `WITH <source>` or `WITH <source> AS <output>` -- carry the current
+    /// positional binding forward, renaming it to `output`.
+    Single {
+        /// The source variable being projected (must be the current binding).
+        source: String,
+        /// The output name it is bound to downstream (equal to `source` when
+        /// no `AS` alias is given).
+        output: String,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -196,8 +214,21 @@ impl CypherConverter {
                 // last node of each OPTIONAL MATCH pattern (or a WITH
                 // projection). Subsequent OPTIONAL MATCH clauses must
                 // continue from this binding (see convert_optional_pattern).
-                let mut current_var: Option<&str> =
-                    pattern.last().and_then(Self::last_node_variable);
+                let mut current_var: Option<String> = pattern
+                    .last()
+                    .and_then(Self::last_node_variable)
+                    .map(str::to_string);
+
+                // Variable scoping (Issue #556). `visible` holds the names in
+                // scope at the current point; `dropped` accumulates names a
+                // `WITH` has projected away. A downstream reference to a dropped
+                // name is a scope violation (rejected, never answered against a
+                // stale binding). The base pattern's variables seed the scope.
+                let mut visible: HashSet<String> = HashSet::new();
+                for pat in &pattern {
+                    Self::collect_pattern_variables(pat, &mut visible);
+                }
+                let mut dropped: HashSet<String> = HashSet::new();
 
                 // 2. Convert temporal clause → TemporalContext + ops
                 let temporal_context = if let Some(ref temporal_clause) = temporal {
@@ -206,21 +237,25 @@ impl CypherConverter {
                     None
                 };
 
-                // 3. Interleave WITH clauses (→ Filter ops for WITH WHERE) and
-                //    OPTIONAL MATCH clauses (→ Optional ops) in source order.
+                // 3. Interleave WITH clauses (→ projection + Distinct/Sort/Skip/
+                //    Limit/Filter ops) and OPTIONAL MATCH clauses (→ Optional
+                //    ops) in source order.
                 let mut with_idx = 0;
                 for opt_match in &optional_matches {
                     while with_idx < opt_match.preceding_withs && with_idx < with_clauses.len() {
-                        self.convert_with_clause(&with_clauses[with_idx], &mut ops)?;
-                        // A `WITH v` projection makes `v` the current binding
-                        // for the clauses that follow. Other projection shapes
-                        // are not lowered and leave the positional row (and
-                        // therefore the current binding) unchanged.
-                        if let [CypherReturnItem::Variable(name)] =
-                            with_clauses[with_idx].items.as_slice()
-                        {
-                            current_var = Some(name.as_str());
-                        }
+                        let order_by_overridden = Self::order_by_overridden_without_window(
+                            &with_clauses,
+                            with_idx,
+                            &return_clause,
+                        );
+                        self.convert_with_clause(
+                            &with_clauses[with_idx],
+                            &mut ops,
+                            &mut visible,
+                            &mut dropped,
+                            &mut current_var,
+                            order_by_overridden,
+                        )?;
                         with_idx += 1;
                     }
                     // Without variable-binding analysis, comma-separated
@@ -238,22 +273,80 @@ impl CypherConverter {
                     }
                     let mut sub_ops = Vec::new();
                     for pat in &opt_match.pattern {
-                        self.convert_optional_pattern(pat, &mut sub_ops, current_var)?;
+                        self.convert_optional_pattern(pat, &mut sub_ops, current_var.as_deref())?;
+                        // The optional pattern's variables (re-)enter scope: add
+                        // them to `visible` and clear any earlier `dropped` mark.
+                        let mut pat_vars = HashSet::new();
+                        Self::collect_pattern_variables(pat, &mut pat_vars);
+                        for v in &pat_vars {
+                            dropped.remove(v);
+                        }
+                        visible.extend(pat_vars);
                     }
                     // The next clause continues from this pattern's last node.
-                    current_var = opt_match.pattern.last().and_then(Self::last_node_variable);
+                    current_var = opt_match
+                        .pattern
+                        .last()
+                        .and_then(Self::last_node_variable)
+                        .map(str::to_string);
                     if let Some(ref where_expr) = opt_match.where_clause {
                         // Per openCypher, the clause's WHERE is part of the
                         // optional pattern: it must run before the
                         // matched/unmatched decision, hence inside the op.
+                        self.reject_dropped_refs(where_expr, &dropped, "OPTIONAL MATCH ... WHERE")?;
                         let predicate = self.convert_expr_to_predicate(where_expr)?;
                         sub_ops.push(QueryOp::Filter(predicate));
                     }
                     ops.push(QueryOp::Optional { ops: sub_ops });
                 }
                 while with_idx < with_clauses.len() {
-                    self.convert_with_clause(&with_clauses[with_idx], &mut ops)?;
+                    let order_by_overridden = Self::order_by_overridden_without_window(
+                        &with_clauses,
+                        with_idx,
+                        &return_clause,
+                    );
+                    self.convert_with_clause(
+                        &with_clauses[with_idx],
+                        &mut ops,
+                        &mut visible,
+                        &mut dropped,
+                        &mut current_var,
+                        order_by_overridden,
+                    )?;
                     with_idx += 1;
+                }
+
+                // Enforce scoping on the final RETURN: a RETURN item (or its
+                // ORDER BY) that references a variable a `WITH` dropped is a
+                // scope violation. (The positional pipeline returns the current
+                // entity regardless of which in-scope variable is named -- a
+                // pre-existing limitation -- but a reference to an
+                // out-of-scope, dropped variable is unambiguously wrong and is
+                // rejected here rather than answered against the wrong entity.)
+                for item in &return_clause.items {
+                    match item {
+                        CypherReturnItem::Expression { expr, .. } => {
+                            self.reject_dropped_refs(expr, &dropped, "RETURN")?;
+                        }
+                        // Defense-in-depth for a manually-constructed AST: the
+                        // parser currently emits `Expression` for a bare
+                        // variable, but a hand-built `Variable` item must be
+                        // scope-checked too. `Star` binds nothing to reject.
+                        CypherReturnItem::Variable(name) => {
+                            if dropped.contains(name) {
+                                return Err(CypherError::SemanticError(format!(
+                                    "RETURN references variable '{name}', which is not in \
+                                     scope after a WITH projection dropped it; project it \
+                                     through the WITH (e.g. `WITH ..., {name}`) to keep it \
+                                     visible"
+                                )));
+                            }
+                        }
+                        CypherReturnItem::Star => {}
+                    }
+                }
+                for order_item in &return_clause.order_by {
+                    self.reject_dropped_refs(&order_item.expr, &dropped, "RETURN ... ORDER BY")?;
                 }
 
                 // 4. Aggregation (openCypher implicit grouping). If any RETURN
@@ -474,16 +567,321 @@ impl CypherConverter {
             .flatten()
     }
 
-    /// Convert a `WITH` clause into query operations (currently only its
-    /// `WHERE` sub-clause produces a `Filter`; projections are not lowered).
+    /// Convert a `WITH` clause into query operations, threading variable scope
+    /// through the pipeline (Issue #556).
+    ///
+    /// openCypher evaluates a `WITH` body as: project the items, apply
+    /// `DISTINCT`, then `ORDER BY`, `SKIP`, `LIMIT`, and finally the trailing
+    /// `WHERE` (which filters the *projected* rows). This method emits that
+    /// pipeline as ops and updates `visible` / `dropped` / `current_var`.
+    ///
+    /// # Projection boundary (positional pipeline)
+    ///
+    /// AletheiaDB's query pipeline carries exactly one entity per row, so a
+    /// `WITH` can only *carry forward* the current positional binding: a bare
+    /// or aliased reference to `current_var`, or `*` (carry everything). Any
+    /// other projection -- multiple items, a property or computed expression,
+    /// an aggregate, or a re-projection of a non-current variable -- has no
+    /// faithful representation and is **rejected** with a structured
+    /// [`CypherError::UnsupportedFeature`] rather than answered against the
+    /// wrong entity.
     fn convert_with_clause(
         &self,
         with: &CypherWith,
         ops: &mut Vec<QueryOp>,
+        visible: &mut HashSet<String>,
+        dropped: &mut HashSet<String>,
+        current_var: &mut Option<String>,
+        order_by_overridden: bool,
     ) -> Result<(), CypherError> {
+        // 1. Resolve the projection shape and update the scope.
+        match Self::with_projection(with)? {
+            WithProjection::All => {
+                // `WITH *` carries every visible variable forward, but the
+                // positional pipeline carries only ONE entity per row. When
+                // more than one variable is in scope, `*` would silently
+                // forward the wrong entity (e.g. `MATCH (a)-[:KNOWS]->(b)
+                // WITH * RETURN a` returns `b`'s data as `a`). Reject rather
+                // than answer wrongly; `*` with a single visible variable is a
+                // faithful no-op (scope and positional binding unchanged).
+                if visible.len() > 1 {
+                    return Err(CypherError::UnsupportedFeature(format!(
+                        "WITH * with more than one variable in scope ({} visible) is \
+                         not supported: the positional execution pipeline carries a \
+                         single entity per row, so '*' would forward the wrong \
+                         entity. Project the single variable you need (optionally \
+                         aliased) instead.",
+                        visible.len()
+                    )));
+                }
+            }
+            WithProjection::Single { source, output } => {
+                // The pipeline is positioned on `current_var`; it cannot
+                // reposition to a different variable, so only the current
+                // binding (optionally aliased) can be carried forward.
+                if current_var.as_deref() != Some(source.as_str()) {
+                    return Err(CypherError::UnsupportedFeature(match current_var {
+                        Some(cur) => format!(
+                            "WITH can only carry forward the current pattern variable \
+                             '{cur}' (optionally aliased) or '*'; re-projecting \
+                             '{source}' would require repositioning the positional \
+                             pipeline, which is not supported"
+                        ),
+                        None => format!(
+                            "WITH can only carry forward the current pattern variable \
+                             (optionally aliased) or '*', but the preceding clause's \
+                             last node is unnamed; projecting '{source}' is not \
+                             supported"
+                        ),
+                    }));
+                }
+                // Everything except the projected output leaves scope. Drain
+                // `visible` to move the owned names straight into `dropped`
+                // (no clone), then re-seed the scope with the output.
+                for name in visible.drain() {
+                    if name != output {
+                        dropped.insert(name);
+                    }
+                }
+                visible.insert(output.clone());
+                dropped.remove(&output);
+                *current_var = Some(output);
+            }
+        }
+
+        // 2. DISTINCT deduplicates the projected rows.
+        if with.distinct {
+            ops.push(QueryOp::Distinct);
+        }
+
+        // 3. ORDER BY / SKIP / LIMIT on the projected rows.
+        //
+        //    A `WITH` ORDER BY is meaningful when it selects a SKIP/LIMIT
+        //    window (in this clause OR any clause before the next re-sort), or
+        //    when it is the last ordering applied before output. It may be
+        //    dropped ONLY when the next ordering-affecting event is a later
+        //    re-sort with NO intervening SKIP/LIMIT window
+        //    (`order_by_overridden`): that later ordering fully replaces it and
+        //    openCypher leaves the overridden tie order unspecified. Dropping
+        //    the pure-consecutive-sort case also avoids an incorrect fold in
+        //    the physical planner, which merges *consecutive* Sort ops into one
+        //    multi-key Sort; emitting a Sort when a window intervenes is
+        //    fold-safe because the intervening Skip/Limit op breaks that fold.
+        if !with.order_by.is_empty() {
+            for order_item in &with.order_by {
+                self.reject_dropped_refs(&order_item.expr, dropped, "WITH ... ORDER BY")?;
+            }
+            let has_window = with.skip.is_some() || with.limit.is_some();
+            if has_window || !order_by_overridden {
+                for order_item in &with.order_by {
+                    let sort_key = self.convert_order_item_to_sort_key(order_item)?;
+                    ops.push(QueryOp::Sort {
+                        key: sort_key,
+                        descending: order_item.descending,
+                    });
+                }
+            }
+        }
+        if let Some(skip) = with.skip {
+            ops.push(QueryOp::Skip(skip));
+        }
+        if let Some(limit) = with.limit {
+            ops.push(QueryOp::Limit(limit));
+        }
+
+        // 4. The trailing WHERE filters the projected rows.
         if let Some(ref where_expr) = with.where_clause {
+            self.reject_dropped_refs(where_expr, dropped, "WITH ... WHERE")?;
             let predicate = self.convert_expr_to_predicate(where_expr)?;
             ops.push(QueryOp::Filter(predicate));
+        }
+        Ok(())
+    }
+
+    /// Resolve the projection shape of a `WITH` clause, rejecting any shape the
+    /// positional pipeline cannot carry (see [`Self::convert_with_clause`]).
+    fn with_projection(with: &CypherWith) -> Result<WithProjection, CypherError> {
+        match with.items.as_slice() {
+            [CypherReturnItem::Star] => Ok(WithProjection::All),
+            [single] => Self::single_projection(single),
+            _ => Err(CypherError::UnsupportedFeature(
+                "WITH projecting multiple items is not supported: the positional \
+                 execution pipeline carries a single entity per row. Project one \
+                 variable (optionally aliased) or '*'."
+                    .to_string(),
+            )),
+        }
+    }
+
+    /// Resolve a single `WITH` item into its `(source, output)` variable names.
+    ///
+    /// Only a bare variable (`WITH a`) or an aliased variable (`WITH a AS b`)
+    /// is representable; a computed expression, property access, aggregate, or
+    /// `*` in this position is rejected.
+    fn single_projection(item: &CypherReturnItem) -> Result<WithProjection, CypherError> {
+        match item {
+            CypherReturnItem::Variable(v) => Ok(WithProjection::Single {
+                source: v.clone(),
+                output: v.clone(),
+            }),
+            CypherReturnItem::Expression {
+                expr: CypherExpr::Variable(v),
+                alias,
+            } => Ok(WithProjection::Single {
+                source: v.clone(),
+                output: alias.clone().unwrap_or_else(|| v.clone()),
+            }),
+            CypherReturnItem::Star => Err(CypherError::UnsupportedFeature(
+                "WITH '*' cannot be mixed with other projected items".to_string(),
+            )),
+            CypherReturnItem::Expression { expr, .. } => {
+                Err(CypherError::UnsupportedFeature(format!(
+                    "WITH can only project a bound variable (optionally aliased) or \
+                     '*'; projecting the expression {expr:?} is not supported -- \
+                     computed columns and aggregates in WITH are a follow-up"
+                )))
+            }
+        }
+    }
+
+    /// Whether a bare intermediate `WITH ... ORDER BY` (one with no SKIP/LIMIT
+    /// window of its own) at `with_idx` is fully overridden by a later re-sort
+    /// with **no intervening SKIP/LIMIT window**, and may therefore be dropped.
+    ///
+    /// A `WITH`/`RETURN` clause applies its own `ORDER BY` *before* its own
+    /// `SKIP`/`LIMIT`, so scanning forward from the next clause:
+    ///
+    /// - the first later clause carrying its own `ORDER BY` is a **re-sort**
+    ///   that replaces this ordering (droppable) -- its order runs before any
+    ///   paging that clause also has, so it counts as a re-sort, not a window;
+    /// - a `SKIP`/`LIMIT` in a clause *before* that re-sort **consumes** this
+    ///   ordering (it selects a window against these ordered rows), making the
+    ///   sort observable -- do not drop;
+    /// - reaching the `RETURN` with no earlier re-sort: the `RETURN`'s own
+    ///   `ORDER BY` (if any) is the next re-sort (droppable); otherwise this
+    ///   ordering is **terminal** (the final result order) and is observable.
+    ///
+    /// The caller additionally guards on this `WITH`'s *own* SKIP/LIMIT (a
+    /// same-clause window makes its ORDER BY observable); this look-ahead only
+    /// considers the clauses that follow it.
+    fn order_by_overridden_without_window(
+        with_clauses: &[CypherWith],
+        with_idx: usize,
+        return_clause: &CypherReturn,
+    ) -> bool {
+        for later in with_clauses.iter().skip(with_idx + 1) {
+            if !later.order_by.is_empty() {
+                // Next re-sort reached with no intervening window: overridden.
+                return true;
+            }
+            if later.skip.is_some() || later.limit.is_some() {
+                // A window consumes this ordering before any later re-sort.
+                return false;
+            }
+        }
+        // No later `WITH` re-sorts before the `RETURN`: the `RETURN`'s own
+        // `ORDER BY` (applied before its paging) is the next re-sort; absent
+        // that, this ordering is terminal and therefore observable.
+        !return_clause.order_by.is_empty()
+    }
+
+    /// Collect the variable names bound by a graph pattern (node and
+    /// relationship variables) into `out`.
+    fn collect_pattern_variables(pattern: &CypherPattern, out: &mut HashSet<String>) {
+        for element in &pattern.elements {
+            match element {
+                CypherPatternElement::Node(node) => {
+                    if let Some(v) = &node.variable {
+                        out.insert(v.clone());
+                    }
+                }
+                CypherPatternElement::Relationship(rel) => {
+                    if let Some(v) = &rel.variable {
+                        out.insert(v.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    /// Reject an expression that references any variable a `WITH` has dropped
+    /// from scope (Issue #556 scoping enforcement). `context` names the clause
+    /// for the error message.
+    fn reject_dropped_refs(
+        &self,
+        expr: &CypherExpr,
+        dropped: &HashSet<String>,
+        context: &str,
+    ) -> Result<(), CypherError> {
+        let mut refs = HashSet::new();
+        Self::collect_expr_variables(expr, &mut refs, 0)?;
+        for name in &refs {
+            if dropped.contains(name) {
+                return Err(CypherError::SemanticError(format!(
+                    "{context} references variable '{name}', which is not in scope \
+                     after a WITH projection dropped it; project it through the \
+                     WITH (e.g. `WITH ..., {name}`) to keep it visible"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Collect the variable names referenced by an expression (both bare
+    /// variables and the base of a property access) into `out`.
+    ///
+    /// Depth-guarded like the predicate converter: `convert` is `pub`, so a
+    /// hand-built expression could nest past the parser's own cap. The bound
+    /// mirrors [`MAX_CONVERT_DEPTH`] so it never fires for parsed input.
+    fn collect_expr_variables(
+        expr: &CypherExpr,
+        out: &mut HashSet<String>,
+        depth: usize,
+    ) -> Result<(), CypherError> {
+        if depth > MAX_CONVERT_DEPTH {
+            return Err(CypherError::ParseError {
+                position: 0,
+                message: "expression nesting too deep for scope analysis (max 256)".to_string(),
+            });
+        }
+        match expr {
+            CypherExpr::Variable(name) => {
+                out.insert(name.clone());
+            }
+            CypherExpr::Property { variable, .. } => {
+                out.insert(variable.clone());
+            }
+            CypherExpr::Value(_) | CypherExpr::Star => {}
+            CypherExpr::Comparison { left, right, .. } => {
+                Self::collect_expr_variables(left, out, depth + 1)?;
+                Self::collect_expr_variables(right, out, depth + 1)?;
+            }
+            CypherExpr::And(left, right) | CypherExpr::Or(left, right) => {
+                Self::collect_expr_variables(left, out, depth + 1)?;
+                Self::collect_expr_variables(right, out, depth + 1)?;
+            }
+            CypherExpr::Not(inner)
+            | CypherExpr::IsNull(inner)
+            | CypherExpr::IsNotNull(inner)
+            | CypherExpr::Grouped(inner) => {
+                Self::collect_expr_variables(inner, out, depth + 1)?;
+            }
+            CypherExpr::In { expr, values } => {
+                Self::collect_expr_variables(expr, out, depth + 1)?;
+                for value in values {
+                    Self::collect_expr_variables(value, out, depth + 1)?;
+                }
+            }
+            CypherExpr::Contains { expr, .. }
+            | CypherExpr::StartsWith { expr, .. }
+            | CypherExpr::EndsWith { expr, .. } => {
+                Self::collect_expr_variables(expr, out, depth + 1)?;
+            }
+            CypherExpr::FunctionCall { args, .. } | CypherExpr::List(args) => {
+                for arg in args {
+                    Self::collect_expr_variables(arg, out, depth + 1)?;
+                }
+            }
         }
         Ok(())
     }

--- a/src/cypher/parser.rs
+++ b/src/cypher/parser.rs
@@ -10,7 +10,7 @@
 //! ```text
 //! statement    := [temporal] match_stmt
 //! match_stmt   := [OPTIONAL] MATCH pattern_list [where_clause] [temporal] with_clauses return_clause
-//! with_clauses := (WITH return_items [WHERE expr])*
+//! with_clauses := (WITH [DISTINCT] return_items [order_by] [SKIP n] [LIMIT n] [WHERE expr])*
 //! pattern_list := pattern (',' pattern)*
 //! pattern      := node_pattern (rel_pattern node_pattern)*
 //! node_pattern := '(' [var] [':' label]* ['{' props '}'] ')'
@@ -832,12 +832,37 @@ impl CypherParser {
     /// Parse a single `WITH` clause.
     ///
     /// ```text
-    /// with_clause := WITH return_items [WHERE expr]
+    /// with_clause := WITH [DISTINCT] return_items [order_by] [SKIP n] [LIMIT n] [WHERE expr]
     /// ```
+    ///
+    /// The body mirrors a `RETURN` body (`DISTINCT`, items, `ORDER BY`, `SKIP`,
+    /// `LIMIT`); per openCypher a trailing `WHERE` filters the *projected* rows
+    /// and therefore comes after the ordering/pagination sub-clauses (Issue
+    /// #556).
     fn parse_with(&mut self) -> Result<CypherWith, CypherError> {
         self.expect(TokenKind::With)?;
 
+        let distinct = self.eat(TokenKind::Distinct);
+
         let items = self.parse_return_items()?;
+
+        let order_by = if self.at(TokenKind::Order) {
+            self.parse_order_by()?
+        } else {
+            Vec::new()
+        };
+
+        let skip = if self.eat(TokenKind::Skip) {
+            Some(self.parse_usize("expected integer after SKIP")?)
+        } else {
+            None
+        };
+
+        let limit = if self.eat(TokenKind::Limit) {
+            Some(self.parse_usize("expected integer after LIMIT")?)
+        } else {
+            None
+        };
 
         let where_clause = if self.at(TokenKind::Where) {
             Some(self.parse_where()?)
@@ -846,7 +871,11 @@ impl CypherParser {
         };
 
         Ok(CypherWith {
+            distinct,
             items,
+            order_by,
+            skip,
+            limit,
             where_clause,
         })
     }

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -4070,6 +4070,469 @@ fn test_e2e_transaction_time_between_rejected() {
 }
 
 // ============================================================================
+// WITH clause semantics (Issue #556): projection, scoping, ORDER BY/SKIP/LIMIT
+// ============================================================================
+
+mod with_clause {
+    use super::*;
+    use crate::query::ir::QueryOp;
+
+    /// Alice(30), Bob(40), Carol(50), Dave(60); Alice-KNOWS->Bob, Bob-KNOWS->Carol.
+    fn db() -> AletheiaDB {
+        optional_match_test_db()
+    }
+
+    /// Ordered list of `name` values across the result rows (pipeline order).
+    fn names_in_order(db: &AletheiaDB, query: &str) -> Vec<String> {
+        collect_rows(db.execute_cypher(query).unwrap())
+            .iter()
+            .filter_map(row_name)
+            .collect()
+    }
+
+    /// Sorted list of `name` values (order-insensitive assertions).
+    fn names_sorted(db: &AletheiaDB, query: &str) -> Vec<String> {
+        let mut names = names_in_order(db, query);
+        names.sort();
+        names
+    }
+
+    // ---- supported: WHERE after WITH filters projected rows (AC2) ----------
+
+    #[test]
+    fn with_where_filters_projected_rows() {
+        let db = db();
+        assert_eq!(
+            names_sorted(&db, "MATCH (a:Person) WITH a WHERE a.age > 45 RETURN a"),
+            vec!["Carol".to_string(), "Dave".to_string()]
+        );
+    }
+
+    // ---- supported: multiple WITH clauses chain (AC4) ----------------------
+
+    #[test]
+    fn multiple_with_clauses_chain() {
+        let db = db();
+        assert_eq!(
+            names_sorted(
+                &db,
+                "MATCH (a:Person) WITH a WHERE a.age > 35 WITH a WHERE a.age < 55 RETURN a",
+            ),
+            vec!["Bob".to_string(), "Carol".to_string()]
+        );
+    }
+
+    // ---- supported: aliasing renames the carried binding (AC1) -------------
+
+    #[test]
+    fn with_alias_renames_binding_and_downstream_where_uses_new_name() {
+        let db = db();
+        assert_eq!(
+            names_sorted(
+                &db,
+                "MATCH (a:Person) WITH a AS p WHERE p.age > 45 RETURN p"
+            ),
+            vec!["Carol".to_string(), "Dave".to_string()]
+        );
+    }
+
+    #[test]
+    fn with_alias_feeds_subsequent_optional_match() {
+        // `WITH x AS y` makes `y` the current binding for a following
+        // OPTIONAL MATCH that continues from it.
+        let db = db();
+        let rows = collect_rows(
+            db.execute_cypher(
+                "MATCH (a:Person {name: 'Alice'}) WITH a AS p OPTIONAL MATCH (p)-[:KNOWS]->(x) RETURN x",
+            )
+            .unwrap(),
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(row_name(&rows[0]).as_deref(), Some("Bob"));
+    }
+
+    // ---- supported: ORDER BY / SKIP / LIMIT after WITH (AC3) ---------------
+
+    #[test]
+    fn with_order_by_skip_limit_pages_projected_rows() {
+        let db = db();
+        // Ages asc [30,40,50,60] -> SKIP 1 -> [40,50,60] -> LIMIT 2 -> [40,50].
+        assert_eq!(
+            names_in_order(
+                &db,
+                "MATCH (a:Person) WITH a ORDER BY a.age SKIP 1 LIMIT 2 RETURN a",
+            ),
+            vec!["Bob".to_string(), "Carol".to_string()]
+        );
+    }
+
+    #[test]
+    fn with_order_by_desc_limit_selects_top_window() {
+        let db = db();
+        assert_eq!(
+            names_in_order(
+                &db,
+                "MATCH (a:Person) WITH a ORDER BY a.age DESC LIMIT 2 RETURN a"
+            ),
+            vec!["Dave".to_string(), "Carol".to_string()]
+        );
+    }
+
+    #[test]
+    fn with_bare_order_by_is_observable_when_not_overridden() {
+        // A WITH ORDER BY with no later ordering carries its order to output.
+        let db = db();
+        assert_eq!(
+            names_in_order(&db, "MATCH (a:Person) WITH a ORDER BY a.age DESC RETURN a"),
+            vec![
+                "Dave".to_string(),
+                "Carol".to_string(),
+                "Bob".to_string(),
+                "Alice".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn return_order_by_overrides_intermediate_with_order_by() {
+        // The fold-hazard case: `WITH ... ORDER BY age` followed by
+        // `RETURN ... ORDER BY name`. The intermediate ordering is overridden
+        // and must NOT fold into a multi-key sort; final order is by name.
+        let db = db();
+        assert_eq!(
+            names_in_order(
+                &db,
+                "MATCH (a:Person) WITH a ORDER BY a.age DESC RETURN a ORDER BY a.name",
+            ),
+            vec![
+                "Alice".to_string(),
+                "Bob".to_string(),
+                "Carol".to_string(),
+                "Dave".to_string()
+            ]
+        );
+    }
+
+    // ---- supported: WITH * carries everything ------------------------------
+
+    #[test]
+    fn with_star_carries_all_and_where_filters() {
+        let db = db();
+        assert_eq!(
+            names_sorted(&db, "MATCH (a:Person) WITH * WHERE a.age > 55 RETURN a"),
+            vec!["Dave".to_string()]
+        );
+    }
+
+    // ---- supported: DISTINCT deduplicates projected rows -------------------
+
+    #[test]
+    fn with_distinct_deduplicates() {
+        // Two people KNOW the same target: `b` binds to Target twice.
+        let db = AletheiaDB::new().unwrap();
+        let p1 = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "P1").build(),
+            )
+            .unwrap();
+        let p2 = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "P2").build(),
+            )
+            .unwrap();
+        let target = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Target").build(),
+            )
+            .unwrap();
+        db.create_edge(p1, target, "KNOWS", CorePropertyMap::new())
+            .unwrap();
+        db.create_edge(p2, target, "KNOWS", CorePropertyMap::new())
+            .unwrap();
+
+        // Without DISTINCT: Target appears once per incoming edge (2 rows).
+        let without = collect_rows(
+            db.execute_cypher("MATCH (a:Person)-[:KNOWS]->(b) WITH b RETURN b")
+                .unwrap(),
+        );
+        assert_eq!(without.len(), 2);
+
+        // With DISTINCT: a single Target row.
+        let with = collect_rows(
+            db.execute_cypher("MATCH (a:Person)-[:KNOWS]->(b) WITH DISTINCT b RETURN b")
+                .unwrap(),
+        );
+        assert_eq!(with.len(), 1);
+        assert_eq!(row_name(&with[0]).as_deref(), Some("Target"));
+    }
+
+    // ---- supported: composes with a leading AS OF (bi-temporal) ------------
+
+    #[test]
+    fn with_composes_with_leading_as_of() {
+        // A leading temporal qualifier before the WITH pipeline: conversion
+        // yields a temporal context AND lowers the WITH ... WHERE to a Filter.
+        let q = parse_cypher(
+            "AS OF TIMESTAMP '2020-01-01T00:00:00Z' MATCH (a:Person) WITH a WHERE a.age > 45 RETURN a",
+        )
+        .unwrap();
+        assert!(
+            q.temporal_context.is_some(),
+            "AS OF before WITH must set a temporal context"
+        );
+        assert!(
+            q.ops.iter().any(|op| matches!(op, QueryOp::Filter(_))),
+            "WITH ... WHERE must lower to a Filter op"
+        );
+    }
+
+    // ---- rejected: projections the positional pipeline cannot carry --------
+
+    #[test]
+    fn with_multiple_items_rejected() {
+        let err = parse_cypher("MATCH (a:Person)-[:KNOWS]->(b) WITH a, b RETURN b").unwrap_err();
+        assert!(
+            matches!(err, CypherError::UnsupportedFeature(_)),
+            "multi-item WITH must be rejected, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn with_property_projection_rejected() {
+        let err = parse_cypher("MATCH (n:Person) WITH n.age AS x RETURN x").unwrap_err();
+        assert!(
+            matches!(err, CypherError::UnsupportedFeature(_)),
+            "expression/property projection in WITH must be rejected, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn with_aggregate_projection_rejected() {
+        let err = parse_cypher("MATCH (n:Person) WITH count(n) AS c RETURN c").unwrap_err();
+        assert!(
+            matches!(err, CypherError::UnsupportedFeature(_)),
+            "aggregate projection in WITH must be rejected, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn with_reprojecting_noncurrent_variable_rejected() {
+        // Pipeline is positioned on `b`; `WITH a` cannot reposition to `a`.
+        let err = parse_cypher("MATCH (a:Person)-[:KNOWS]->(b) WITH a RETURN a").unwrap_err();
+        assert!(
+            matches!(err, CypherError::UnsupportedFeature(_)),
+            "re-projecting a non-current variable must be rejected, got {err:?}"
+        );
+    }
+
+    // ---- rejected: references to a variable a WITH dropped (AC5) -----------
+
+    #[test]
+    fn return_referencing_dropped_variable_rejected() {
+        let err = parse_cypher("MATCH (a:Person)-[:KNOWS]->(b) WITH b RETURN a").unwrap_err();
+        assert!(
+            matches!(err, CypherError::SemanticError(_)),
+            "RETURN of a dropped variable must be a scope error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn with_where_referencing_dropped_variable_rejected() {
+        let err = parse_cypher("MATCH (a:Person)-[:KNOWS]->(b) WITH b WHERE a.age > 5 RETURN b")
+            .unwrap_err();
+        assert!(
+            matches!(err, CypherError::SemanticError(_)),
+            "WITH ... WHERE referencing a dropped variable must be a scope error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn return_order_by_referencing_dropped_variable_rejected() {
+        let err = parse_cypher("MATCH (a:Person)-[:KNOWS]->(b) WITH b RETURN b ORDER BY a.age")
+            .unwrap_err();
+        assert!(
+            matches!(err, CypherError::SemanticError(_)),
+            "ORDER BY of a dropped variable must be a scope error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn projected_variable_stays_in_scope() {
+        // The projected variable itself remains referenceable downstream.
+        let db = db();
+        assert_eq!(
+            names_sorted(&db, "MATCH (a:Person) WITH a WHERE a.age > 55 RETURN a"),
+            vec!["Dave".to_string()]
+        );
+    }
+
+    // ---- depth / robustness (do not regress the #3404 cap) -----------------
+
+    #[test]
+    fn many_chained_with_clauses_do_not_overflow() {
+        // WITH parts are parsed iteratively (no per-clause recursion), so a
+        // long chain must parse+convert without overflowing the stack.
+        let query = format!("MATCH (n:Person) {} RETURN n", "WITH n ".repeat(500));
+        let result = parse_cypher(&query);
+        assert!(
+            result.is_ok(),
+            "500 chained WITH clauses should convert cleanly, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn deeply_nested_with_where_expression_errors_gracefully() {
+        // A deeply nested expression in a WITH's WHERE shares the parser's
+        // expression-depth cap and must yield a ParseError, not a crash.
+        let query = format!(
+            "MATCH (n:Person) WITH n WHERE {}n.age > 1{} RETURN n",
+            "(".repeat(5000),
+            ")".repeat(5000)
+        );
+        let result = CypherParser::parse(&query);
+        assert!(
+            matches!(result, Err(CypherError::ParseError { .. })),
+            "deeply nested WITH WHERE must be a ParseError, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn with_order_by_skip_limit_parses_into_ast() {
+        // The extended WITH body (DISTINCT/ORDER BY/SKIP/LIMIT/WHERE) is
+        // captured on the AST.
+        let ast = CypherParser::parse(
+            "MATCH (a:Person) WITH DISTINCT a ORDER BY a.age DESC SKIP 1 LIMIT 2 WHERE a.age > 10 RETURN a",
+        )
+        .unwrap();
+        let CypherStatement::Match { with_clauses, .. } = ast else {
+            panic!("expected a MATCH statement");
+        };
+        assert_eq!(with_clauses.len(), 1);
+        let with = &with_clauses[0];
+        assert!(with.distinct);
+        assert_eq!(with.order_by.len(), 1);
+        assert!(with.order_by[0].descending);
+        assert_eq!(with.skip, Some(1));
+        assert_eq!(with.limit, Some(2));
+        assert!(with.where_clause.is_some());
+    }
+
+    // ---- intermediate ORDER BY: drop only when overridden with no window ---
+
+    #[test]
+    fn intermediate_order_by_observable_when_later_limit_intervenes() {
+        // BLOCKER regression: the intermediate `ORDER BY a.age DESC` is
+        // consumed by a LATER clause's `LIMIT 2` before the final re-sort, so
+        // it MUST be emitted. Top-2 by age desc = {Dave(60), Carol(50)}, then
+        // RETURN ORDER BY name -> [Carol, Dave]. Dropping the age sort would
+        // wrongly page {Alice, Bob} and return [Alice, Bob].
+        let db = db();
+        assert_eq!(
+            names_in_order(
+                &db,
+                "MATCH (a:Person) WITH a ORDER BY a.age DESC WITH a LIMIT 2 RETURN a ORDER BY a.name",
+            ),
+            vec!["Carol".to_string(), "Dave".to_string()]
+        );
+    }
+
+    #[test]
+    fn intermediate_order_by_observable_when_later_skip_intervenes() {
+        // As above but a later `SKIP 2` consumes the ordering: age desc
+        // [Dave,Carol,Bob,Alice] -> SKIP 2 -> [Bob,Alice] -> RETURN ORDER BY
+        // name -> [Alice, Bob]. Dropping the age sort would skip an arbitrary
+        // pair and return the wrong rows.
+        let db = db();
+        assert_eq!(
+            names_in_order(
+                &db,
+                "MATCH (a:Person) WITH a ORDER BY a.age DESC WITH a SKIP 2 RETURN a ORDER BY a.name",
+            ),
+            vec!["Alice".to_string(), "Bob".to_string()]
+        );
+    }
+
+    #[test]
+    fn consecutive_bare_with_order_bys_collapse_to_last() {
+        // Override-safe case (no intervening window): a later bare `ORDER BY`
+        // fully replaces the earlier one, so only the last sort is emitted.
+        // Final order is by age (the second re-sort), ascending.
+        let db = db();
+        assert_eq!(
+            names_in_order(
+                &db,
+                "MATCH (a:Person) WITH a ORDER BY a.name DESC WITH a ORDER BY a.age RETURN a",
+            ),
+            vec![
+                "Alice".to_string(),
+                "Bob".to_string(),
+                "Carol".to_string(),
+                "Dave".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn consecutive_bare_with_order_bys_emit_single_sort() {
+        // Structural guard: the overridden first ORDER BY is dropped, so the
+        // pipeline holds exactly one Sort (no multi-key fold hazard).
+        let q = parse_cypher(
+            "MATCH (a:Person) WITH a ORDER BY a.name DESC WITH a ORDER BY a.age RETURN a",
+        )
+        .unwrap();
+        let sorts = q
+            .ops
+            .iter()
+            .filter(|op| matches!(op, QueryOp::Sort { .. }))
+            .count();
+        assert_eq!(
+            sorts, 1,
+            "override-safe consecutive sorts must collapse to one"
+        );
+    }
+
+    #[test]
+    fn same_clause_with_order_by_limit_still_selects_window() {
+        // Over-correction guard: a same-clause window keeps working exactly as
+        // before (top-2 by age desc, in age-desc order).
+        let db = db();
+        assert_eq!(
+            names_in_order(
+                &db,
+                "MATCH (a:Person) WITH a ORDER BY a.age DESC LIMIT 2 RETURN a"
+            ),
+            vec!["Dave".to_string(), "Carol".to_string()]
+        );
+    }
+
+    // ---- rejected: `WITH *` with more than one variable visible ------------
+
+    #[test]
+    fn with_star_rejected_when_multiple_variables_visible() {
+        // Two variables (`a`, `b`) are in scope; `WITH *` cannot faithfully
+        // carry both through the single-entity positional pipeline.
+        let err = parse_cypher("MATCH (a:Person)-[:KNOWS]->(b) WITH * RETURN a").unwrap_err();
+        assert!(
+            matches!(err, CypherError::UnsupportedFeature(_)),
+            "WITH * with >1 visible variable must be rejected, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn with_star_ok_when_single_variable_visible() {
+        // Exactly one variable in scope: `WITH *` is a faithful no-op.
+        let db = db();
+        assert_eq!(
+            names_sorted(&db, "MATCH (a:Person) WITH * WHERE a.age > 55 RETURN a"),
+            vec!["Dave".to_string()]
+        );
+    }
+}
+
+// ============================================================================
 // UNWIND clause (Issue #559)
 // ============================================================================
 


### PR DESCRIPTION
## Why this PR exists

PR #3494 shows as "merged" on GitHub but its code **never reached trunk**. It was a stacked PR whose base was the already-merged `#559` UNWIND feature branch, so merging it landed the WITH work into that branch instead of trunk. Trunk HEAD (`e687b16`) has **no** `#556` content — `converter.rs` was at its pre-`#556` state (0 occurrences of `WithProjection`).

This PR re-lands the **identical, fixed** WITH work directly onto trunk via a **fresh branch** off `origin/trunk` (the mis-merged branch is not reused as the PR head). Trunk already contains the `#559` UNWIND content via squash-merge #3488, so the re-land is exactly the WITH-only delta (924 insertions across `src/cypher/{ast,converter,parser,tests}.rs`), applied cleanly with no conflicts.

## What's included (unchanged from the original fixed work)

- WITH projection (single variable, optional alias) and `WITH *` carry-forward
- Scope tracking: dropped variables rejected in later `WHERE` / `RETURN` / `ORDER BY`
- `WITH DISTINCT` deduplication
- `ORDER BY` / `SKIP` / `LIMIT` windowing, including multi-clause chaining
- **Intermediate-ORDER-BY look-ahead blocker fix** (`order_by_overridden_without_window`): an intermediate `ORDER BY` stays observable when a later `SKIP`/`LIMIT` intervenes, and is elided only when a subsequent `ORDER BY` fully overrides it with no window between
- **`WITH *` rejected when more than one variable is visible** (the positional execution pipeline carries a single entity per row, so `*` would otherwise forward the wrong entity)
- Gemini review nits from the original PR

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` — clean
- `cargo test --features cypher` — all 30 `with_clause` tests pass (`470 passed; 0 failed` on the `with` lib filter), including the three blocker-regression tests: `intermediate_order_by_observable_when_later_limit_intervenes`, `intermediate_order_by_observable_when_later_skip_intervenes`, and `with_star_rejected_when_multiple_variables_visible`

Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxsbivDhtB4Wu1VGseDL7m

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxsbivDhtB4Wu1VGseDL7m)_