### PR TITLE
Re-land #3416: delete_node #3209 contract (SI write-skew, self-loop counting, cascade dedup)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1134,15 +1134,29 @@ db.between("2024-01-01", "2024-12-31").track_changes(node_id)
 ### Orphaned Edges on Node Deletion
 
 The **low-level Rust** `delete_node` (`src/storage/current/mod.rs`) removes only the
-node itself -- any edges where the deleted node is the source or target remain in
-storage as **orphaned edges**. This edge-preserving behavior is intentional and is
-retained for audit/history use cases where callers manage edge cleanup themselves or
-need to preserve edge records. Traversals that follow these orphaned edges may
-encounter missing endpoints.
+node itself -- any edges where the deleted node is the source or target **and that
+existed at the deleting transaction's snapshot** remain in storage as **orphaned
+edges**. This edge-preserving behavior is intentional and is retained for
+audit/history use cases where callers manage edge cleanup themselves or need to
+preserve edge records. Traversals that follow these orphaned edges may encounter
+missing endpoints.
+
+**Concurrent-write exception (Issue #3416)**: the orphan-preserving behavior applies
+only to *pre-existing* edges. Under snapshot isolation, a `delete_node`/`retract_node`
+(and symmetrically a `create_edge`) that would orphan an edge **committed by a
+concurrent transaction after the deleter's snapshot** now **aborts at commit** with
+`TransactionError::ValidationFailed` (MCP `FAILED_PRECONDITION`, non-retriable),
+first-committer-wins. The check is symmetric under the commit-serialization
+(`historical` write) guard: whichever of the concurrent delete-node / create-edge
+pair applies second aborts, so neither ordering can commit a new dangling edge. A
+single transaction that both creates an edge and deletes its endpoint is unaffected
+(that is the caller's own buffered decision), as are pre-existing edges deleted with
+no concurrent writer.
 
 **Recommended (Rust API)**: Use `delete_node_cascade` instead, which atomically
 deletes the node and all connected edges, preventing orphans. To decide before acting,
-call `db.count_connected_edges(node_id)` to learn how many edges reference a node.
+call `db.count_connected_edges(node_id)` to learn how many edges reference a node
+(DISTINCT edges -- a self-loop counts once, Issue #3416).
 
 **MCP surface is safe-by-default (Issue #3209)**: The MCP `delete_node` tool mirrors
 Cypher's `DETACH DELETE` contract -- it never silently orphans edges:

--- a/src/api/transaction/write/apply.rs
+++ b/src/api/transaction/write/apply.rs
@@ -617,6 +617,18 @@ pub(crate) fn apply_changes<'a>(
     // Acquire lock on historical storage once before processing all operations.
     let mut historical = tx.historical.write();
 
+    // Issue #3416 Pt1 — commit-time write-skew re-check for node deletes/retracts.
+    //
+    // Under snapshot isolation, a node delete/retract that saw 0 connected edges
+    // at op time cannot see a CONCURRENT transaction's create_edge that commits
+    // between this tx's snapshot and its commit (disjoint write sets escape
+    // first-committer-wins). Committing anyway would leave an edge pointing at a
+    // deleted/retracted node — a silent orphan through the #3209 "safe by
+    // default" path. We re-check here because `historical.write()` is the commit
+    // serialization point: no other tx can be applying while we hold it, so
+    // committed adjacency now reflects every earlier-committed transaction.
+    detect_delete_orphan_write_skew(tx)?;
+
     // Issue #3406: the closing-version IDs (delete tombstones + retraction
     // versions) are pre-generated once per commit — BEFORE the WAL log phase —
     // so the identical ids are recorded in the WAL and applied here. We simply
@@ -653,6 +665,103 @@ pub(crate) fn apply_changes<'a>(
     // `finalize_current_commit_timestamps` so a concurrent `historical.read()`
     // snapshot cannot observe a committed node/edge with `commit_timestamp: None`.
     Ok(historical)
+}
+
+/// Commit-time re-check that a buffered node delete/retract does not orphan an
+/// edge that a concurrent transaction committed after this tx's snapshot
+/// (Issue #3416 Pt1 -- snapshot-isolation write-skew).
+///
+/// For each buffered `DeleteNode`/`RetractNode`, we enumerate the victim's
+/// committed connected edges (distinct). An edge trips the abort only when it
+/// is **both**: (1) committed **after** this tx's snapshot (`commit_timestamp >
+/// snapshot_timestamp`) -- i.e. it is a concurrently-appeared edge, the SI
+/// write-skew -- and (2) **not** also being closed (deleted/retracted) by this
+/// same transaction.
+///
+/// The `commit_timestamp > snapshot_timestamp` gate is deliberate: an edge that
+/// was already visible at this tx's snapshot is the documented low-level
+/// orphan-preserving `delete_node` behavior (see CLAUDE.md "Orphaned Edges on
+/// Node Deletion") and must NOT abort. Only a NEW concurrent edge violates the
+/// #3209 "never orphan" guarantee.
+///
+/// On a violation we abort with `TransactionError::ValidationFailed`, which the
+/// MCP layer classifies as `FAILED_PRECONDITION` (non-retriable): the correct
+/// caller response is to re-evaluate (the edge now exists, so a fresh delete
+/// would be refused by #3209 or require detach), not to blindly retry.
+///
+/// # Locking
+///
+/// Called while `historical.write()` (order class 3) is held. It reads the
+/// adjacency indexes (`outgoing`/`incoming`, classes 6/7) and current-storage
+/// edge map -- all LATER than `historical` in the documented lock order -- and
+/// never calls back into `historical`/`wal`/`current_timestamp`, so no
+/// lock-order inversion is introduced.
+///
+/// # Cost
+///
+/// O(degree) committed-adjacency reads per buffered node delete/retract, at
+/// commit only. Zero cost for transactions that delete/retract no nodes.
+fn detect_delete_orphan_write_skew(tx: &WriteTransaction) -> Result<()> {
+    use crate::api::transaction::BufferedWrite;
+
+    // Edges this tx itself closes (delete or retract) never orphan the victim.
+    let mut closed_edges: std::collections::HashSet<EdgeId> = std::collections::HashSet::new();
+    for write in tx.buffer.operations() {
+        match write {
+            BufferedWrite::DeleteEdge { edge_id, .. }
+            | BufferedWrite::RetractEdge { edge_id, .. } => {
+                closed_edges.insert(*edge_id);
+            }
+            _ => {}
+        }
+    }
+
+    let snapshot_ts = tx.snapshot.snapshot_timestamp;
+
+    for write in tx.buffer.operations() {
+        let node_id = match write {
+            BufferedWrite::DeleteNode { node_id, .. }
+            | BufferedWrite::RetractNode { node_id, .. } => *node_id,
+            _ => continue,
+        };
+
+        // Distinct committed connected edges (a self-loop appears in both
+        // directions but is one edge -- mirrors Issue #3416 Pt2/Pt3 counting).
+        let mut edge_ids = tx.current.get_outgoing_edges(node_id);
+        edge_ids.extend(tx.current.get_incoming_edges(node_id));
+        edge_ids.sort_unstable();
+        edge_ids.dedup();
+
+        for edge_id in edge_ids {
+            if closed_edges.contains(&edge_id) {
+                continue; // this tx closes the edge too -- no orphan
+            }
+            // Only a concurrently-committed edge (commit_ts > our snapshot) is a
+            // write-skew; a pre-snapshot edge is the documented orphan-preserving
+            // low-level delete and is left untouched.
+            if let Ok(edge) = tx.current.get_edge(edge_id)
+                && let Some(commit_ts) = edge.metadata.commit_timestamp
+                && commit_ts > snapshot_ts
+            {
+                return Err(crate::core::error::TransactionError::ValidationFailed {
+                    reason: format!(
+                        "Write-skew detected: node {} was deleted/retracted, but edge {} \
+                         referencing it was created by a concurrent transaction (committed at \
+                         {} after this transaction's snapshot at {}). Committing would orphan \
+                         the edge. Re-evaluate the delete (the node now has a connected edge) \
+                         or use a detach/cascade delete.",
+                        node_id.as_u64(),
+                        edge_id.as_u64(),
+                        commit_ts,
+                        snapshot_ts
+                    ),
+                }
+                .into());
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Finalize commit timestamps in current storage after a successful `apply_changes`.

--- a/src/api/transaction/write/apply.rs
+++ b/src/api/transaction/write/apply.rs
@@ -617,17 +617,30 @@ pub(crate) fn apply_changes<'a>(
     // Acquire lock on historical storage once before processing all operations.
     let mut historical = tx.historical.write();
 
-    // Issue #3416 Pt1 — commit-time write-skew re-check for node deletes/retracts.
+    // Issue #3416 Pt1 — commit-time SI write-skew re-checks for node
+    // deletes/retracts AND edge creations, run under the SAME exclusive
+    // `historical.write()` guard so the two orderings are symmetric: whichever
+    // of a concurrent delete-node / create-edge pair applies SECOND aborts, so
+    // exactly one wins and no orphan is committed in EITHER ordering.
     //
-    // Under snapshot isolation, a node delete/retract that saw 0 connected edges
-    // at op time cannot see a CONCURRENT transaction's create_edge that commits
-    // between this tx's snapshot and its commit (disjoint write sets escape
-    // first-committer-wins). Committing anyway would leave an edge pointing at a
-    // deleted/retracted node — a silent orphan through the #3209 "safe by
-    // default" path. We re-check here because `historical.write()` is the commit
-    // serialization point: no other tx can be applying while we hold it, so
-    // committed adjacency now reflects every earlier-committed transaction.
+    // `historical.write()` is the commit serialization point: no other tx can be
+    // applying while we hold it, so committed current state now reflects every
+    // earlier-committed transaction. Both checks read current storage / adjacency
+    // (leaf / order-class 6-7) while holding `historical` (class 3), never call
+    // back into `historical`/`wal`/`current_timestamp`, and touch no adjacency
+    // locks out of order — consistent with the CLAUDE.md lock order.
+    //
+    // Ordering (i): delete/retract applies second. It cannot see a concurrent
+    // create_edge that committed after its snapshot (disjoint write sets escape
+    // first-committer-wins); the delete-side check re-counts committed connected
+    // edges and aborts on a newly-appeared one.
     detect_delete_orphan_write_skew(tx)?;
+    // Ordering (ii): create_edge applies second. Its endpoint existence was
+    // checked by `validate()` BEFORE the timestamp/WAL/apply phase and the apply
+    // path does no endpoint re-check, so a concurrent delete of an endpoint that
+    // commits between validate() and here would leave a dangling edge. The
+    // create-side check re-verifies both endpoints under the guard.
+    detect_create_edge_dangling_endpoint(tx)?;
 
     // Issue #3406: the closing-version IDs (delete tombstones + retraction
     // versions) are pre-generated once per commit — BEFORE the WAL log phase —
@@ -704,6 +717,19 @@ pub(crate) fn apply_changes<'a>(
 fn detect_delete_orphan_write_skew(tx: &WriteTransaction) -> Result<()> {
     use crate::api::transaction::BufferedWrite;
 
+    // Short-circuit (NIT): most transactions delete/retract no nodes; skip
+    // building the closed-edges set and rescanning when there is nothing to
+    // check.
+    let has_node_close = tx.buffer.operations().iter().any(|w| {
+        matches!(
+            w,
+            BufferedWrite::DeleteNode { .. } | BufferedWrite::RetractNode { .. }
+        )
+    });
+    if !has_node_close {
+        return Ok(());
+    }
+
     // Edges this tx itself closes (delete or retract) never orphan the victim.
     let mut closed_edges: std::collections::HashSet<EdgeId> = std::collections::HashSet::new();
     for write in tx.buffer.operations() {
@@ -754,6 +780,101 @@ fn detect_delete_orphan_write_skew(tx: &WriteTransaction) -> Result<()> {
                         edge_id.as_u64(),
                         commit_ts,
                         snapshot_ts
+                    ),
+                }
+                .into());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Commit-time re-check that a buffered `CreateEdge` does not commit with an
+/// endpoint that a concurrent transaction deleted/retracted after this tx's
+/// snapshot (Issue #3416 Pt1 -- the MIRROR of the delete-side write-skew).
+///
+/// This closes the second ordering: the edge creator's endpoints are validated
+/// by [`validation::validate`](super::validation::validate) *before* the
+/// timestamp/WAL/apply phase, and [`apply_edge_write`] does NO endpoint check,
+/// so a concurrent node delete that commits between `validate()` and this point
+/// would leave a dangling edge. Run under the same `historical.write()` guard as
+/// the delete-side check, the two orderings become symmetric: whichever tx
+/// applies second aborts.
+///
+/// An endpoint is considered present iff it is resolvable at apply time --
+/// **either** live in committed current storage **or** created/updated earlier
+/// in THIS transaction's buffer (a same-tx-created endpoint is valid; a same-tx
+/// *delete* of an endpoint under a still-live edge is already rejected by
+/// `validate()`, mirroring that function's `node_exists` logic exactly). A
+/// `CreateEdge` whose edge is itself deleted/retracted later in this same tx is
+/// skipped -- it commits no live edge, so a concurrently-deleted endpoint
+/// orphans nothing (this also keeps a same-tx `create_edge` + cascade / Pt4 from
+/// self-aborting). Because `validate()` already passed, an endpoint absent here
+/// is definitionally a concurrent deletion, so no snapshot-timestamp gate is
+/// needed (unlike the delete side, where a pre-snapshot edge is the documented
+/// orphan-preserving case).
+///
+/// Aborts with `TransactionError::ValidationFailed` (-> MCP `FAILED_PRECONDITION`,
+/// non-retriable).
+///
+/// # Locking
+///
+/// Called while `historical.write()` (order class 3) is held; reads only the
+/// current-storage node map (a leaf) and this tx's buffer, never calling back
+/// into `historical`/`wal`/`current_timestamp`. No lock-order inversion.
+///
+/// # Cost
+///
+/// O(1) buffer/current lookups per buffered `CreateEdge`, at commit only. Zero
+/// cost for transactions that create no edges.
+fn detect_create_edge_dangling_endpoint(tx: &WriteTransaction) -> Result<()> {
+    use crate::api::transaction::BufferedWrite;
+
+    // Resolve an endpoint exactly as `validation::validate` does: a same-tx
+    // buffered node counts as present iff its latest op is a create/update; a
+    // committed node counts as present iff it is still in current storage.
+    let endpoint_present = |node_id: NodeId| -> bool {
+        if tx.buffer.has_modified_node(node_id) {
+            matches!(
+                tx.buffer.get_node_write(node_id),
+                Some(BufferedWrite::CreateNode { .. } | BufferedWrite::UpdateNode { .. })
+            )
+        } else {
+            tx.current.get_node(node_id).is_ok()
+        }
+    };
+
+    for write in tx.buffer.operations() {
+        let (edge_id, source, target) = match write {
+            BufferedWrite::CreateEdge {
+                edge_id,
+                source,
+                target,
+                ..
+            } => (*edge_id, *source, *target),
+            _ => continue,
+        };
+
+        // Skip an edge created and then deleted/retracted within this same tx:
+        // it commits no live edge (mirrors the Pt4 skip in `validation::validate`).
+        if matches!(
+            tx.buffer.get_edge_write(edge_id),
+            Some(BufferedWrite::DeleteEdge { .. } | BufferedWrite::RetractEdge { .. })
+        ) {
+            continue;
+        }
+
+        for endpoint in [source, target] {
+            if !endpoint_present(endpoint) {
+                return Err(crate::core::error::TransactionError::ValidationFailed {
+                    reason: format!(
+                        "Write-skew detected: edge {} references node {}, which was \
+                         deleted or retracted by a concurrent transaction after this \
+                         transaction's snapshot. Committing would create a dangling edge. \
+                         Re-check the endpoint's existence and retry.",
+                        edge_id.as_u64(),
+                        endpoint.as_u64(),
                     ),
                 }
                 .into());

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -918,6 +918,37 @@ impl WriteTransaction {
         }
         self.current.get_edge(id)
     }
+
+    /// Enumerate edges CREATED earlier in THIS transaction that reference
+    /// `node_id` as source or target and are still live in the buffer (Issue
+    /// #3416 Pt4).
+    ///
+    /// `delete_node_cascade` unions this with committed adjacency
+    /// (`self.current.get_outgoing_edges` / `get_incoming_edges`) so a same-tx
+    /// `create_node → create_edge → cascade` reaches the same-tx-created edge,
+    /// which committed adjacency cannot yet see. Only `CreateEdge` ops matter:
+    /// an already-committed edge (including one this tx `UpdateEdge`s) is
+    /// already returned by the current-adjacency read. An edge created then
+    /// deleted/retracted within this tx is filtered out (its latest buffered
+    /// state resolves to Not-Found via [`buffered_edge`](Self::buffered_edge)),
+    /// so the cascade never double-closes it.
+    fn buffered_connected_edges(&self, node_id: NodeId) -> Vec<EdgeId> {
+        let mut edges = Vec::new();
+        for op in self.buffer.operations() {
+            if let super::BufferedWrite::CreateEdge {
+                edge_id,
+                source,
+                target,
+                ..
+            } = op
+                && (*source == node_id || *target == node_id)
+                && matches!(self.buffered_edge(*edge_id), Some(Ok(_)))
+            {
+                edges.push(*edge_id);
+            }
+        }
+        edges
+    }
 }
 
 impl ReadOps for WriteTransaction {
@@ -1454,27 +1485,34 @@ impl WriteOps for WriteTransaction {
         // transaction can be cascade-deleted (read-your-own-writes).
         let _node = self.read_own_node(node_id)?;
 
-        // Collect all edges connected to this node (both outgoing and incoming)
-        // We do this before any deletions to avoid borrowing issues
+        // Collect all edges connected to this node (both outgoing and incoming).
+        // We do this before any deletions to avoid borrowing issues.
         //
-        // LIMITATION (buffer-aware cascade adjacency — tracked for #3416):
-        // the #3417 read-your-own-writes fix makes the node existence check
-        // (above) and per-edge delete_edge reads buffer-aware, but the
-        // adjacency ENUMERATION below still routes through
-        // get_outgoing_edges/get_incoming_edges, which read committed
-        // adjacency only. So a same-tx create_node → create_edge → cascade
-        // does NOT see (and cannot delete) the same-tx-created edge, which can
-        // leave it orphaned. Buffer-aware adjacency is deferred to #3416. Note
-        // this does not affect the MCP #3209 refuse/detach idempotency
-        // contract, which is enforced at the MCP layer over committed
-        // adjacency and is unaffected by this gap.
-        let outgoing_edges = self.get_outgoing_edges(node_id)?;
-        let incoming_edges = self.get_incoming_edges(node_id)?;
+        // Buffer-aware cascade adjacency (Issue #3416 Pt4, folded from the
+        // #3417 review): the committed adjacency (get_outgoing_edges /
+        // get_incoming_edges) is unioned with edges CREATED earlier in THIS
+        // transaction (buffered CreateEdge touching this node), minus edges
+        // already deleted/retracted in this tx. Without the buffer union a
+        // same-tx create_node → create_edge → cascade would leave the
+        // same-tx-created edge orphaned (its endpoint gets a tombstone but the
+        // edge does not).
+        let mut edge_ids = self.get_outgoing_edges(node_id)?;
+        edge_ids.extend(self.get_incoming_edges(node_id)?);
+        edge_ids.extend(self.buffered_connected_edges(node_id));
 
-        // Delete all connected edges first to maintain referential integrity
-        // This prevents orphaned edges that reference a deleted node
-        // Performance: O(degree) where degree is the number of connected edges
-        for edge_id in outgoing_edges.into_iter().chain(incoming_edges) {
+        // Dedup by EdgeId (Issue #3416 Pt3): a self-loop (node -> node) appears
+        // in BOTH the outgoing and incoming lists; without dedup delete_edge
+        // would be called twice for the same edge, buffering two DeleteEdge ops
+        // (double tombstone / double-close at apply time). Sort + dedup means
+        // each distinct connected edge is deleted exactly once. This mirrors
+        // retract_node_detach and apply_batch's manual cascade.
+        edge_ids.sort_unstable();
+        edge_ids.dedup();
+
+        // Delete all connected edges first to maintain referential integrity.
+        // This prevents orphaned edges that reference a deleted node.
+        // Performance: O(degree) where degree is the number of connected edges.
+        for edge_id in edge_ids {
             self.delete_edge(edge_id)?;
         }
 

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -610,6 +610,15 @@ impl WriteTransaction {
         //
         // The pre-generated closing version ids (Issue #3406) are consumed here
         // in the same buffer order they were logged to the WAL.
+        //
+        // Test-only interleaving hook (Issue #3416 Pt1): fires AFTER
+        // validate/detect_conflicts/WAL but BEFORE `apply_changes` acquires the
+        // `historical.write()` guard, so a test can commit a concurrent
+        // delete/create in this window and exercise the commit-time write-skew
+        // re-checks. Production builds compile this away.
+        #[cfg(test)]
+        commit_test_hooks::run_pre_apply_hook();
+
         let historical_guard = apply::apply_changes(self, commit_timestamp, &closing_version_ids)?;
 
         // Test-only interleaving hook (Issue #3425): fires at the exact point
@@ -1935,6 +1944,43 @@ pub(crate) mod commit_test_hooks {
         let hook = PRE_FINALIZE_HOOK
             .lock()
             .expect("pre-finalize hook mutex poisoned")
+            .clone();
+        if let Some(hook) = hook {
+            hook();
+        }
+    }
+
+    static PRE_APPLY_HOOK: Mutex<Option<Hook>> = Mutex::new(None);
+
+    /// Install a hook fired just BEFORE `apply::apply_changes` (i.e. after
+    /// `validate`/`detect_conflicts`/WAL, before the `historical.write()` guard
+    /// is acquired). This is the symmetric counterpart to the pre-finalize hook
+    /// and is the seam that lets a test drive the Issue #3416 Pt1 MIRROR
+    /// interleaving deterministically: a committing edge-creator can be parked
+    /// here (endpoints already validated, guard not yet held) while a concurrent
+    /// node delete commits, so the edge tx then aborts at its own commit-time
+    /// endpoint re-check. Parking here (rather than at pre-finalize) avoids a
+    /// self-deadlock: the guard is not yet held, so the concurrent deleter can
+    /// acquire `historical.write()` and commit.
+    pub(crate) fn set_pre_apply_hook(hook: Hook) {
+        *PRE_APPLY_HOOK
+            .lock()
+            .expect("pre-apply hook mutex poisoned") = Some(hook);
+    }
+
+    /// Remove any installed pre-apply hook.
+    pub(crate) fn clear_pre_apply_hook() {
+        *PRE_APPLY_HOOK
+            .lock()
+            .expect("pre-apply hook mutex poisoned") = None;
+    }
+
+    /// Invoke the installed pre-apply hook, if any (Arc cloned out from under
+    /// the mutex, as with `run_pre_finalize_hook`).
+    pub(crate) fn run_pre_apply_hook() {
+        let hook = PRE_APPLY_HOOK
+            .lock()
+            .expect("pre-apply hook mutex poisoned")
             .clone();
         if let Some(hook) = hook {
             hook();

--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -2301,9 +2301,11 @@ mod conflict_detection_tests {
     /// - Both transactions try to commit concurrently
     ///
     /// Expected behavior (documents actual MVCC implementation):
-    /// - Test Case A: If edge creation commits first, node deletion succeeds because
-    ///   edge addition doesn't modify the node's version (no conflict detected).
-    ///   This creates an orphaned edge, which is acceptable if traversals handle it.
+    /// - Test Case A: If edge creation commits first, the concurrent node
+    ///   deletion is ABORTED at commit by the Issue #3416 Pt1 write-skew
+    ///   re-check: the newly-committed edge (commit_ts after the deleter's
+    ///   snapshot) would be orphaned, so the delete fails with a
+    ///   `FAILED_PRECONDITION`-class error and the node/edge are left intact.
     /// - Test Case B: If node deletion commits first, edge creation fails on commit
     ///   due to referential integrity (endpoint node was deleted after snapshot).
     #[test]
@@ -2344,34 +2346,27 @@ mod conflict_detection_tests {
                 "Edge should be created"
             );
 
-            // tx2 tries to delete node2. According to the current MVCC implementation,
-            // edge addition doesn't modify node2's version, so no conflict is detected
-            // and the deletion succeeds.
+            // tx2 tries to delete node2. Issue #3416 Pt1: the commit-time
+            // write-skew re-check sees the edge tx1 committed after tx2's
+            // snapshot (referencing node2, not closed by tx2) and ABORTS the
+            // delete rather than silently orphaning the edge.
             let result = tx2.commit();
             assert!(
-                result.is_ok(),
-                "tx2 commit should succeed - edge addition doesn't create version conflict on node2"
+                result.is_err(),
+                "tx2 commit must abort - deleting node2 would orphan the concurrently-created edge"
             );
 
-            // Verify node was deleted
+            // Node2 is NOT deleted (write-skew delete was refused).
             assert!(
-                harness.current.get_node(node2).is_err(),
-                "Node should be deleted after successful tx2 commit"
+                harness.current.get_node(node2).is_ok(),
+                "Node2 must remain after the aborted delete"
             );
 
-            // Current implementation: edge becomes orphaned but still exists in storage.
-            // This documents a limitation: the system allows orphaned edges.
-            // TODO(issue): Consider adding cascade delete or stricter referential integrity
-            assert!(
-                harness.current.get_edge(edge_id).is_ok(),
-                "Edge still exists as orphan (documents current behavior)"
-            );
-
-            // Verify the edge references the deleted node (orphaned edge)
+            // The edge is preserved and still references a LIVE node2 — no orphan.
             let edge = harness.current.get_edge(edge_id).unwrap();
             assert_eq!(
                 edge.target, node2,
-                "Edge still references deleted node (orphaned)"
+                "Edge references a live node2 (no orphan created)"
             );
         }
 

--- a/src/api/transaction/write/validation.rs
+++ b/src/api/transaction/write/validation.rs
@@ -69,8 +69,37 @@ pub(crate) fn validate_valid_from_not_before_creation(
 pub(crate) fn validate(tx: &WriteTransaction) -> Result<()> {
     for write in tx.buffer.operations() {
         match write {
-            crate::api::transaction::BufferedWrite::CreateEdge { source, target, .. }
-            | crate::api::transaction::BufferedWrite::UpdateEdge { source, target, .. } => {
+            crate::api::transaction::BufferedWrite::CreateEdge {
+                edge_id,
+                source,
+                target,
+                ..
+            }
+            | crate::api::transaction::BufferedWrite::UpdateEdge {
+                edge_id,
+                source,
+                target,
+                ..
+            } => {
+                // Skip an edge that is created/updated and then deleted or
+                // retracted within THIS SAME transaction (Issue #3416 Pt4): it
+                // has no net referential-integrity requirement because it will
+                // not exist in the committed state. This is what makes a same-tx
+                // create_node → create_edge → delete_node_cascade valid — the
+                // cascade buffers a DeleteEdge for the same-tx edge, so its
+                // source/target node being concurrently deleted is not an
+                // orphan. Without this skip, `get_node_write` would resolve the
+                // victim to its later DeleteNode and spuriously reject the edge.
+                if matches!(
+                    tx.buffer.get_edge_write(*edge_id),
+                    Some(
+                        crate::api::transaction::BufferedWrite::DeleteEdge { .. }
+                            | crate::api::transaction::BufferedWrite::RetractEdge { .. }
+                    )
+                ) {
+                    continue;
+                }
+
                 // Check that source and target nodes exist
                 // They might exist in current storage or be created in this transaction
                 let node_exists = |node_id: &crate::core::NodeId| -> bool {

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -816,16 +816,28 @@ impl AletheiaDB {
     /// Returns [`StorageError::NodeNotFound`](crate::storage::StorageError::NodeNotFound)
     /// if the node does not exist in the current state, so callers never receive
     /// a misleading zero count for a missing node.
+    ///
+    /// # Self-loops count once (Issue #3416)
+    ///
+    /// A self-loop edge (`n -> n`) appears in BOTH the outgoing and incoming
+    /// adjacency lists. This counts **distinct** edge ids, so a self-loop is
+    /// one connected edge, converging with `retract_node` / `retract_node_detach`
+    /// and `apply_batch`'s in-batch delete (all DISTINCT-count) so the #3209
+    /// `details.connected_edges` refusal count means the same thing everywhere.
+    /// A naive `out_degree + in_degree` would double-count a self-loop as 2.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn count_connected_edges(&self, node_id: NodeId) -> Result<usize> {
         // Verify the node exists first; an absent node should error rather than
         // silently report zero connected edges.
         let _ = self.current.get_node_label(node_id)?;
-        // Use degree counters rather than materializing edge-id vectors: this
-        // avoids allocations for high-degree nodes.
-        let outgoing = self.current.out_degree(node_id);
-        let incoming = self.current.in_degree(node_id);
-        Ok(outgoing + incoming)
+        // Materialize + dedup edge ids (rather than summing degree counters) so
+        // a self-loop is counted once — the DISTINCT semantics the retract and
+        // apply_batch cascade paths already use.
+        let mut edge_ids = self.current.get_outgoing_edges(node_id);
+        edge_ids.extend(self.current.get_incoming_edges(node_id));
+        edge_ids.sort_unstable();
+        edge_ids.dedup();
+        Ok(edge_ids.len())
     }
 
     /// Get the number of nodes in the current state.

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -1275,6 +1275,277 @@ fn test_count_connected_edges() {
 }
 
 #[test]
+fn test_count_connected_edges_self_loop_is_distinct() {
+    // Issue #3416 Pt2: a self-loop is ONE edge. `count_connected_edges` must
+    // count DISTINCT edge ids (not out_degree + in_degree, which double-counts
+    // a self-loop as 2), so `details.connected_edges` means the same thing the
+    // retract_node / apply_batch DISTINCT enumeration reports.
+    let db = AletheiaDB::new().unwrap();
+
+    let alice = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // A single self-loop alice -> alice.
+    db.create_edge(alice, alice, "KNOWS", PropertyMapBuilder::new().build())
+        .unwrap();
+    assert_eq!(
+        db.count_connected_edges(alice).unwrap(),
+        1,
+        "a self-loop is one distinct edge, not two"
+    );
+
+    // Mixed: self-loop + a real outgoing + a real incoming = 3 distinct edges.
+    let bob = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    db.create_edge(alice, bob, "OUT", PropertyMapBuilder::new().build())
+        .unwrap();
+    db.create_edge(bob, alice, "IN", PropertyMapBuilder::new().build())
+        .unwrap();
+    assert_eq!(
+        db.count_connected_edges(alice).unwrap(),
+        3,
+        "self-loop counted once alongside two distinct directed edges"
+    );
+}
+
+#[test]
+fn test_delete_node_cascade_self_loop_single_delete() {
+    // Issue #3416 Pt3: a self-loop appears in BOTH the outgoing and incoming
+    // adjacency lists; without dedup, `delete_node_cascade` would `delete_edge`
+    // it twice in the same tx (double tombstone / double-close). Deduping by
+    // EdgeId means each connected edge is deleted exactly once.
+    let db = AletheiaDB::new().unwrap();
+
+    let alice = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    let self_loop = db
+        .create_edge(alice, alice, "KNOWS", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    assert_eq!(db.edge_count(), 1);
+
+    // Cascade must succeed (no double-delete error) and remove node + edge.
+    db.write(|tx| tx.delete_node_cascade(alice)).unwrap();
+
+    assert_eq!(db.node_count(), 0);
+    assert_eq!(db.edge_count(), 0);
+    assert!(db.get_node(alice).is_err());
+    assert!(db.get_edge(self_loop).is_err());
+}
+
+#[test]
+fn test_delete_node_cascade_self_loop_mixed_graph_single_delete() {
+    // Issue #3416 Pt3: self-loop + normal in/out edges — every distinct edge
+    // deleted exactly once, no double-delete on the self-loop.
+    let db = AletheiaDB::new().unwrap();
+
+    let alice = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    let bob = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    db.create_edge(alice, alice, "SELF", PropertyMapBuilder::new().build())
+        .unwrap();
+    db.create_edge(alice, bob, "OUT", PropertyMapBuilder::new().build())
+        .unwrap();
+    db.create_edge(bob, alice, "IN", PropertyMapBuilder::new().build())
+        .unwrap();
+    assert_eq!(db.edge_count(), 3);
+
+    db.write(|tx| tx.delete_node_cascade(alice)).unwrap();
+
+    assert_eq!(db.node_count(), 1); // bob remains
+    assert_eq!(db.edge_count(), 0); // all 3 distinct edges removed once each
+    assert!(db.get_node(alice).is_err());
+}
+
+#[test]
+fn test_delete_node_cascade_removes_same_tx_created_edge() {
+    // Issue #3416 Pt4 (folded from #3417 review): a cascade must see edges
+    // CREATED earlier in the SAME transaction, not just committed adjacency.
+    // create_node -> create_edge(self-loop) -> delete_node_cascade in ONE tx
+    // must leave no orphaned edge after commit.
+    let db = AletheiaDB::new().unwrap();
+
+    let (victim, self_loop) = db
+        .write(|tx| {
+            let victim = tx.create_node("Person", PropertyMapBuilder::new().build())?;
+            let self_loop =
+                tx.create_edge(victim, victim, "KNOWS", PropertyMapBuilder::new().build())?;
+            tx.delete_node_cascade(victim)?;
+            Ok::<_, Error>((victim, self_loop))
+        })
+        .unwrap();
+
+    assert_eq!(db.node_count(), 0);
+    assert_eq!(
+        db.edge_count(),
+        0,
+        "the same-tx-created self-loop must be cascade-deleted, not orphaned"
+    );
+    assert!(db.get_node(victim).is_err());
+    assert!(db.get_edge(self_loop).is_err());
+}
+
+#[test]
+fn test_delete_node_cascade_removes_same_tx_created_directed_edge() {
+    // Issue #3416 Pt4: same-tx create_node(x) already committed, then
+    // create_edge(x -> victim) in the cascade tx; the cascade must delete the
+    // same-tx incoming edge too.
+    let db = AletheiaDB::new().unwrap();
+
+    let x = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    let (victim, edge) = db
+        .write(|tx| {
+            let victim = tx.create_node("Person", PropertyMapBuilder::new().build())?;
+            let edge = tx.create_edge(x, victim, "POINTS_AT", PropertyMapBuilder::new().build())?;
+            tx.delete_node_cascade(victim)?;
+            Ok::<_, Error>((victim, edge))
+        })
+        .unwrap();
+
+    assert_eq!(db.edge_count(), 0, "same-tx incoming edge must be removed");
+    assert!(db.get_node(victim).is_err());
+    assert!(db.get_edge(edge).is_err());
+    assert!(db.get_node(x).is_ok());
+}
+
+#[test]
+fn test_delete_node_write_skew_concurrent_edge_aborts() {
+    // Issue #3416 Pt1: SI write-skew. tx_A stages delete_node(victim) after
+    // seeing 0 connected edges; a SEPARATE tx_B commits create_edge(x ->
+    // victim); tx_A commits. Without a commit-time re-check the disjoint write
+    // sets escape conflict detection and tx_A commits -> a committed edge
+    // pointing at a deleted node (silent orphan). The re-check must ABORT tx_A
+    // with FAILED_PRECONDITION and leave the victim + edge intact.
+    let db = AletheiaDB::new().unwrap();
+
+    let x = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    let victim = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    // victim committed with 0 connected edges.
+    assert_eq!(db.count_connected_edges(victim).unwrap(), 0);
+
+    // tx_A: snapshot captured now (before B's edge exists), stage the delete.
+    let mut tx_a = db.write_transaction().unwrap();
+    tx_a.delete_node(victim).unwrap();
+
+    // tx_B: concurrently create + commit an edge x -> victim.
+    let edge = db
+        .write(|tx| tx.create_edge(x, victim, "POINTS_AT", PropertyMapBuilder::new().build()))
+        .unwrap();
+
+    // tx_A commits -> must be rejected as a write-skew precondition failure.
+    let commit_result = tx_a.commit();
+    assert!(
+        commit_result.is_err(),
+        "delete_node must abort when a concurrent edge would be orphaned"
+    );
+    let err = commit_result.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("orphan") || msg.contains("connected edge"),
+        "abort message should explain the write-skew/orphan: {msg}"
+    );
+
+    // No orphan: victim still present, edge still points at a live node.
+    assert!(db.get_node(victim).is_ok());
+    assert!(db.get_edge(edge).is_ok());
+    assert_eq!(db.get_edge(edge).unwrap().target, victim);
+}
+
+#[test]
+fn test_delete_node_no_concurrent_edge_commits_ok() {
+    // Issue #3416 Pt1 negative: when NO concurrent edge appears, the staged
+    // delete commits fine (the re-check must not abort a legitimate delete).
+    let db = AletheiaDB::new().unwrap();
+
+    let victim = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    let mut tx_a = db.write_transaction().unwrap();
+    tx_a.delete_node(victim).unwrap();
+    // No concurrent writer.
+    tx_a.commit().unwrap();
+
+    assert_eq!(db.node_count(), 0);
+    assert!(db.get_node(victim).is_err());
+}
+
+#[test]
+fn test_delete_node_preexisting_edge_still_orphan_preserving() {
+    // Issue #3416 Pt1 refinement guard: an edge that existed AT tx_A's snapshot
+    // (committed before the snapshot) is the documented low-level
+    // orphan-preserving delete_node behavior and must NOT trip the write-skew
+    // re-check (only edges committed AFTER the snapshot are write-skew).
+    let db = AletheiaDB::new().unwrap();
+
+    let x = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    let victim = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    let edge = db
+        .create_edge(x, victim, "POINTS_AT", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // Snapshot taken AFTER the edge already exists.
+    let mut tx_a = db.write_transaction().unwrap();
+    tx_a.delete_node(victim).unwrap();
+    // Low-level delete preserves the pre-existing edge (documented behavior).
+    tx_a.commit().unwrap();
+
+    assert!(db.get_node(victim).is_err());
+    assert!(db.get_edge(edge).is_ok()); // orphan preserved, no spurious abort
+}
+
+#[test]
+fn test_retract_node_write_skew_concurrent_edge_aborts() {
+    // Issue #3416 Pt1: same write-skew window for retract_node. A concurrent
+    // edge committed after tx_A's snapshot would leave an edge pointing at a
+    // retracted node; the commit-time re-check must abort tx_A.
+    let db = AletheiaDB::new().unwrap();
+
+    let x = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    let victim = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    let mut tx_a = db.write_transaction().unwrap();
+    tx_a.retract_node(victim, crate::core::temporal::time::now())
+        .unwrap();
+
+    let edge = db
+        .write(|tx| tx.create_edge(x, victim, "POINTS_AT", PropertyMapBuilder::new().build()))
+        .unwrap();
+
+    let commit_result = tx_a.commit();
+    assert!(
+        commit_result.is_err(),
+        "retract_node must abort when a concurrent edge would be orphaned"
+    );
+
+    // Victim still valid, edge intact.
+    assert!(db.get_node(victim).is_ok());
+    assert!(db.get_edge(edge).is_ok());
+}
+
+#[test]
 fn test_delete_edge_via_transaction() {
     let db = AletheiaDB::new().unwrap();
 

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -1546,6 +1546,138 @@ fn test_retract_node_write_skew_concurrent_edge_aborts() {
 }
 
 #[test]
+fn test_retract_node_no_concurrent_edge_commits_ok() {
+    // Issue #3416 Pt1 negative (retract side): with NO concurrent edge, a staged
+    // retract commits fine — the commit-time re-check must not abort a
+    // legitimate retract.
+    let db = AletheiaDB::new().unwrap();
+
+    let victim = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    let mut tx_a = db.write_transaction().unwrap();
+    tx_a.retract_node(victim, crate::core::temporal::time::now())
+        .unwrap();
+    // No concurrent writer.
+    tx_a.commit().unwrap();
+
+    // Retract closes valid time but keeps the node out of current state.
+    assert!(db.get_node(victim).is_err());
+}
+
+#[test]
+fn test_create_edge_write_skew_concurrent_delete_aborts() {
+    // Issue #3416 Pt1 MIRROR interleaving (ordering ii). The edge creator
+    // validates endpoints BEFORE the WAL/apply phase; if a concurrent tx
+    // deletes an endpoint in the window between validate() and apply, the
+    // apply-time endpoint re-check must ABORT the edge tx so no dangling edge
+    // is committed. Driven deterministically (single thread) via the
+    // #[cfg(test)] pre-apply hook, which fires after the edge tx has validated
+    // but before it acquires historical.write().
+    use crate::api::transaction::write::commit_test_hooks;
+    use std::cell::Cell;
+    use std::sync::Arc;
+
+    thread_local! {
+        // Only the edge tx's own commit thread arms this; every other commit
+        // in the process (including tx A's nested commit below, and unrelated
+        // concurrent tests) sees the hook as a no-op.
+        static ARMED: Cell<bool> = const { Cell::new(false) };
+    }
+
+    let db = Arc::new(AletheiaDB::new().unwrap());
+    let x = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    let victim = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    // victim committed with 0 connected edges.
+    assert_eq!(db.count_connected_edges(victim).unwrap(), 0);
+
+    // Edge tx B: stage create_edge(x -> victim); do NOT commit yet.
+    let mut tx_b = db.write_transaction().unwrap();
+    let edge = tx_b
+        .create_edge(x, victim, "POINTS_AT", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // Pre-apply hook: exactly once, on the armed (edge-tx) thread, commit the
+    // concurrent tx A that deletes victim. B does not hold historical yet, so A
+    // acquires the guard and commits cleanly (victim has 0 committed edges).
+    {
+        let db_hook = Arc::clone(&db);
+        commit_test_hooks::set_pre_apply_hook(Arc::new(move || {
+            let armed = ARMED.with(|a| a.replace(false));
+            if !armed {
+                return; // no-op for A's own commit and any other tx/thread
+            }
+            db_hook
+                .write(|tx| tx.delete_node(victim))
+                .expect("concurrent delete of victim should commit");
+        }));
+    }
+
+    ARMED.with(|a| a.set(true));
+    let commit_result = tx_b.commit();
+    ARMED.with(|a| a.set(false));
+    commit_test_hooks::clear_pre_apply_hook();
+
+    // The edge tx applied SECOND and must abort — no dangling edge.
+    assert!(
+        commit_result.is_err(),
+        "create_edge must abort when its endpoint was concurrently deleted"
+    );
+    let msg = commit_result.unwrap_err().to_string();
+    assert!(
+        msg.contains("dangling") || msg.contains("deleted or retracted"),
+        "abort message should explain the dangling-edge write-skew: {msg}"
+    );
+
+    // tx A won: victim stays deleted, and NO orphan/dangling edge was committed.
+    assert!(db.get_node(victim).is_err(), "victim was deleted by tx A");
+    assert!(db.get_edge(edge).is_err(), "no dangling edge was committed");
+    assert!(db.get_node(x).is_ok());
+}
+
+#[test]
+fn test_count_connected_edges_parallel_edges_distinct() {
+    // Issue #3416 Pt2 (parallel edges): two DISTINCT edges between the same
+    // ordered pair are two connected edges (dedup is by EdgeId, not by
+    // endpoint pair), and a self-loop adds exactly one more.
+    let db = AletheiaDB::new().unwrap();
+
+    let a = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    let b = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // Two parallel a -> b edges: distinct EdgeIds, so both count.
+    db.create_edge(a, b, "KNOWS", PropertyMapBuilder::new().build())
+        .unwrap();
+    db.create_edge(a, b, "LIKES", PropertyMapBuilder::new().build())
+        .unwrap();
+    assert_eq!(
+        db.count_connected_edges(a).unwrap(),
+        2,
+        "two distinct parallel edges count as 2"
+    );
+
+    // Add a self-loop a -> a: one more distinct edge (counted once, not twice).
+    db.create_edge(a, a, "SELF", PropertyMapBuilder::new().build())
+        .unwrap();
+    assert_eq!(
+        db.count_connected_edges(a).unwrap(),
+        3,
+        "self-loop adds exactly one to the two parallel edges"
+    );
+    // b sees only the two parallel incoming edges.
+    assert_eq!(db.count_connected_edges(b).unwrap(), 2);
+}
+
+#[test]
 fn test_delete_edge_via_transaction() {
     let db = AletheiaDB::new().unwrap();
 


### PR DESCRIPTION
Closes #3416. **Re-land onto `trunk`.**

## Why this PR exists (orphaned work recovery)

The original #3416 PR (#3493) was **stacked** on `feature/issue-3417-buffer-aware-reads` and merged into that already-merged base (merge commit `10c81edd`) **instead of `trunk`**. As a result #3416's fix never landed on `trunk` (`trunk` HEAD was `d426da89`). #3417 itself **is** on trunk (merge `fc819f14`). This PR re-lands #3416's two source commits cleanly onto a fresh branch off `trunk`:

- `4cf5cc90` — SI write-skew delete-side re-check, distinct `count_connected_edges`, cascade dedup, buffer-aware cascade adjacency
- `f1239330` — symmetric `CreateEdge` endpoint re-check + tests + CLAUDE.md doc

Both cherry-picked with **no conflicts** (their base was #3417 content, now on trunk).

## What &amp; why

Three delete-contract bugs from the #3408 review, plus a fourth item folded in from the #3417 review.

### Pt1 — Snapshot-isolation write-skew orphan (closed **symmetrically**, both orderings)
**Before:** two disjoint-write-set transactions could orphan an edge in **either** ordering:
- **(i)** tx_A `delete_node(N)` sees 0 edges; tx_B commits `create_edge(x→N)`; tx_A commits → orphan.
- **(ii)** tx_B `create_edge(x→N)` validates N alive; tx_A commits `delete_node(N)`; tx_B applies (no endpoint re-check at apply) → dangling edge.

**After:** two commit-time re-checks run under the **same exclusive `historical.write()` guard** (the commit serialization point), so whichever tx of the concurrent delete/create pair applies **second** aborts — first-committer-wins, no orphan in **either** ordering:
- `detect_delete_orphan_write_skew` (delete side, ordering i): for each buffered `DeleteNode`/`RetractNode`, abort if a committed connected edge appeared **after this tx's snapshot** (`commit_ts &gt; snapshot_ts`) and isn't closed by this tx. The snapshot gate preserves the documented low-level orphan-preserving delete for pre-existing edges.
- `detect_create_edge_dangling_endpoint` (create side, ordering ii — **the mirror**): for each buffered `CreateEdge` not itself closed in this tx, abort if an endpoint is unresolvable at apply time — absent from committed current storage **and** not same-tx-created.

Abort = `TransactionError::ValidationFailed` → MCP `FAILED_PRECONDITION`, non-retriable. Lock order preserved.

### Pt2 — `count_connected_edges` self-loop divergence
Now counts **distinct** edge ids (materialize out+in, sort, dedup) → self-loop counts 1 everywhere (converges with `retract_node`/`apply_batch`); parallel edges still count as N distinct.

### Pt3 — `delete_node_cascade` self-loop double-delete
Sort + dedup by `EdgeId` before the delete loop → each distinct edge deleted exactly once.

### Pt4 — Buffer-aware cascade adjacency (folded from #3417 review)
Cascade unions committed adjacency with same-tx-created edges (`buffered_connected_edges`); `validate()` skips an edge created-then-deleted within the same tx.

## AC evidence (re-verified on this re-land branch)

| Part / AC | Test | Result |
|---|---|---|
| **Pt1 ordering (i)** delete aborts on concurrent edge | `db::tests::test_delete_node_write_skew_concurrent_edge_aborts` | ✅ |
| **Pt1 ordering (ii) MIRROR** create_edge aborts on concurrent delete | `db::tests::test_create_edge_write_skew_concurrent_delete_aborts` | ✅ |
| Pt1 negative (delete, no concurrent edge) | `db::tests::test_delete_node_no_concurrent_edge_commits_ok` | ✅ |
| Pt1 negative (retract, no concurrent edge) | `db::tests::test_retract_node_no_concurrent_edge_commits_ok` | ✅ |
| Pt1 refinement (pre-existing edge still orphan-preserving) | `db::tests::test_delete_node_preexisting_edge_still_orphan_preserving` | ✅ |
| Pt1 retract variant (ordering i) | `db::tests::test_retract_node_write_skew_concurrent_edge_aborts` | ✅ |
| Pt1 updated concurrency doc-test | `api::…::conflict_detection_tests::test_edge_creation_with_concurrent_node_deletion` | ✅ |
| Pt2 distinct self-loop count | `db::tests::test_count_connected_edges_self_loop_is_distinct` | ✅ |
| Pt2 parallel-edge count | `db::tests::test_count_connected_edges_parallel_edges_distinct` | ✅ |
| Pt3 cascade self-loop once | `db::tests::test_delete_node_cascade_self_loop_single_delete` | ✅ |
| Pt3 mixed graph | `db::tests::test_delete_node_cascade_self_loop_mixed_graph_single_delete` | ✅ |
| Pt4 same-tx self-loop | `db::tests::test_delete_node_cascade_removes_same_tx_created_edge` | ✅ |
| Pt4 same-tx directed edge | `db::tests::test_delete_node_cascade_removes_same_tx_created_directed_edge` | ✅ |

## Docs
- `CLAUDE.md` "Orphaned Edges on Node Deletion" updated: low-level `delete_node`/`retract_node` now **abort** (`ValidationFailed`) when a **concurrent** edge lands after the tx snapshot; **pre-existing** edges remain orphan-preserving. Notes `count_connected_edges` is DISTINCT (self-loop = 1).

## Gates (isolated target dir)
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` — **clean**
- `cargo fmt --all --check` — **clean**
- `cargo test --lib --features mcp-server` — **4144 passed, 0 failed, 2 ignored** (uid-0 havoc sandbox). The Lane 5 #3499 `apply_batch` guessed-id tests and all #3416 write-skew/self-loop/cascade tests **pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F9nforiPb4nfb5z4BhPqK

---
_Generated by [Claude Code](https://claude.ai/code/session_015F9nforiPb4nfb5z4BhPqK)_