### PR TITLE
fix: cross-process reload of multi-property nodes (#3490 interner id remap)

### DIFF
--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -453,7 +453,21 @@ impl CheckpointManager {
             (c, h)
         };
 
-        // 1. Save string interner first (other indexes depend on it)
+        // 1. Extract graph + temporal data from the snapshots FIRST.
+        //
+        // Issue #3490: extraction interns string property VALUES (a
+        // `PropertyValue::String` holds a plain `Arc<str>`, interned into
+        // GLOBAL_INTERNER only at persist time via `persist_property_value`),
+        // so it can mint NEW interner ids. The string interner file must
+        // therefore be saved AFTER extraction, or it would omit those ids and
+        // the load-time remap (#3490) would flag the persisted references as
+        // unmappable. This mirrors the `persist_graph_index` ordering
+        // ("Persist string interner AFTER graph conversion").
+        let graph_data = self.extract_graph_data_from_snapshot(&current_snapshot)?;
+        let temporal_data = self.extract_temporal_data_from_snapshot(&historical_snapshot)?;
+
+        // 2. Save string interner (now complete — covers every id referenced
+        // by the extracted graph/temporal data).
         self.persistence_manager
             .save_string_interner()
             .map_err(persistence_err)?;
@@ -461,8 +475,7 @@ impl CheckpointManager {
             .map(|m| m.len())
             .unwrap_or(0);
 
-        // 2. Save graph index (current state) from snapshot
-        let graph_data = self.extract_graph_data_from_snapshot(&current_snapshot)?;
+        // 3. Save graph index (current state) from snapshot
         let graph_path = self.persistence_manager.graph_path().join("adjacency.idx");
         if self.config.enable_compression {
             crate::storage::index_persistence::graph::save_graph_index_compressed(
@@ -477,8 +490,7 @@ impl CheckpointManager {
         }
         bytes_written += std::fs::metadata(&graph_path).map(|m| m.len()).unwrap_or(0);
 
-        // 3. Save temporal index (historical versions) from snapshot
-        let temporal_data = self.extract_temporal_data_from_snapshot(&historical_snapshot)?;
+        // 4. Save temporal index (historical versions) from snapshot
         let temporal_path = self
             .persistence_manager
             .temporal_path()
@@ -492,7 +504,7 @@ impl CheckpointManager {
             .map(|m| m.len())
             .unwrap_or(0);
 
-        // 4. Build and save manifest
+        // 5. Build and save manifest
         let mut manifest = IndexManifest::new(lsn.0);
 
         // Add graph index entry
@@ -566,10 +578,16 @@ impl CheckpointManager {
             return self.recover_from_wal_only(wal);
         }
 
-        // Load manifest and strings
-        let manifest = self
+        // Load manifest and strings.
+        // Issue #3490: obtain the file-id -> live-id remap and apply it to the
+        // loaded graph/temporal data before resolving any persisted interner id.
+        // The interner is a process-global singleton (and WAL bootstrap may have
+        // populated it), so persisted ids are file-space and would otherwise
+        // resolve to the wrong strings — silent corruption on this PUBLIC
+        // recovery path (used by examples/recovery/*).
+        let (manifest, remap) = self
             .persistence_manager
-            .load_manifest_and_strings()
+            .load_manifest_and_strings_with_remap()
             .map_err(persistence_err)?;
         let checkpoint_lsn = LSN(manifest.lsn);
 
@@ -588,10 +606,11 @@ impl CheckpointManager {
         }
 
         // Load graph index
-        let current = self.load_current_storage(&manifest)?;
+        let current = self.load_current_storage(&manifest, &remap)?;
 
         // Load temporal index
-        let (historical, historical_max_version_id) = self.load_historical_storage(&manifest)?;
+        let (historical, historical_max_version_id) =
+            self.load_historical_storage(&manifest, &remap)?;
 
         // Ensure version ID generator accounts for historical versions
         // The current storage's generator was initialized from the count of restored entities,
@@ -701,10 +720,10 @@ impl CheckpointManager {
             return self.recover_from_wal_with_cold_storage(wal, flushed_lsn);
         }
 
-        // Load manifest and strings
-        let manifest = self
+        // Load manifest and strings (Issue #3490: remap-aware, as in `recover`).
+        let (manifest, remap) = self
             .persistence_manager
-            .load_manifest_and_strings()
+            .load_manifest_and_strings_with_remap()
             .map_err(persistence_err)?;
         let checkpoint_lsn = LSN(manifest.lsn);
 
@@ -722,10 +741,11 @@ impl CheckpointManager {
         }
 
         // Load graph index
-        let current = self.load_current_storage(&manifest)?;
+        let current = self.load_current_storage(&manifest, &remap)?;
 
         // Load temporal index
-        let (historical, historical_max_version_id) = self.load_historical_storage(&manifest)?;
+        let (historical, historical_max_version_id) =
+            self.load_historical_storage(&manifest, &remap)?;
 
         // Ensure version ID generator accounts for historical versions
         if historical_max_version_id > 0 {
@@ -961,7 +981,16 @@ impl CheckpointManager {
     }
 
     /// Load CurrentStorage from persisted graph index.
-    fn load_current_storage(&self, manifest: &IndexManifest) -> Result<CurrentStorage> {
+    ///
+    /// Issue #3490: `remap` translates persisted file-space interner ids
+    /// (labels, property keys, string values) to live ids before the raw
+    /// resolution sites below (`InternedString::from_raw`, `restore_property_map`)
+    /// touch them; an identity remap is a no-op.
+    fn load_current_storage(
+        &self,
+        manifest: &IndexManifest,
+        remap: &crate::storage::index_persistence::strings::InternerRemap,
+    ) -> Result<CurrentStorage> {
         let current = CurrentStorage::new();
 
         if let Some(ref graph_entry) = manifest.graph_index {
@@ -969,9 +998,10 @@ impl CheckpointManager {
                 .persistence_manager
                 .indexes_path()
                 .join(&graph_entry.adjacency_file);
-            let graph_data =
+            let mut graph_data =
                 crate::storage::index_persistence::graph::load_graph_index(&graph_path)
                     .map_err(persistence_err)?;
+            remap.remap_graph_index_data(&mut graph_data);
 
             // Track maximum version ID to initialize generator
             let mut max_version_id: u64 = 0;
@@ -1026,6 +1056,7 @@ impl CheckpointManager {
     fn load_historical_storage(
         &self,
         manifest: &IndexManifest,
+        remap: &crate::storage::index_persistence::strings::InternerRemap,
     ) -> Result<(HistoricalStorage, u64)> {
         let mut historical = HistoricalStorage::new();
         let mut max_version_id: u64 = 0;
@@ -1035,9 +1066,14 @@ impl CheckpointManager {
                 .persistence_manager
                 .indexes_path()
                 .join(&temporal_entry.node_versions_file);
-            let temporal_data =
+            // Issue #3490: translate persisted file-space interner ids (version
+            // labels, property keys, string values, delta removed_keys, anchor
+            // full_state) to live ids before `restore_into_historical_storage`
+            // resolves them; an identity remap is a no-op.
+            let mut temporal_data =
                 crate::storage::index_persistence::temporal::load_temporal_index(&temporal_path)
                     .map_err(persistence_err)?;
+            remap.remap_temporal_index_data(&mut temporal_data);
 
             max_version_id = temporal_data
                 .node_versions

--- a/src/storage/index_persistence/loader.rs
+++ b/src/storage/index_persistence/loader.rs
@@ -6,7 +6,9 @@ use std::path::{Path, PathBuf};
 use super::error::Result;
 use super::formats::IndexManifest;
 use super::manifest::{load_manifest, save_manifest};
-use super::strings::{load_string_interner, restore_string_interner, save_string_interner};
+use super::strings::{
+    InternerRemap, load_string_interner, restore_string_interner, save_string_interner,
+};
 
 /// Manages index persistence directory structure.
 pub struct IndexPersistenceManager {
@@ -92,16 +94,37 @@ impl IndexPersistenceManager {
     /// - Failed to load or restore string interner
     /// - Failed to load manifest (if it exists)
     pub fn load_manifest_and_strings(&self) -> Result<IndexManifest> {
+        let (manifest, _remap) = self.load_manifest_and_strings_with_remap()?;
+        Ok(manifest)
+    }
+
+    /// Load the manifest and restore the string interner, returning the
+    /// file-id -> live-id [`InternerRemap`] alongside the manifest.
+    ///
+    /// This is the Issue #3490-aware entry point: callers that go on to restore
+    /// the graph and/or temporal indexes (e.g. `load_indexes_startup`) MUST use
+    /// this variant and translate the loaded index data through the returned
+    /// remap (see [`InternerRemap::remap_graph_index_data`] /
+    /// [`InternerRemap::remap_temporal_index_data`]) before resolving any
+    /// persisted interner id. The plain [`Self::load_manifest_and_strings`]
+    /// wrapper discards the remap and is only safe for callers that do not
+    /// resolve persisted interner ids afterward, or that restore against a
+    /// pristine interner (where the remap is identity).
+    ///
+    /// When no interner file exists, the returned remap is
+    /// [`InternerRemap::identity`] (ids pass through unchanged), preserving the
+    /// legacy behavior for that best-effort path.
+    pub fn load_manifest_and_strings_with_remap(&self) -> Result<(IndexManifest, InternerRemap)> {
         // 1. Load and restore string interner FIRST (if it exists)
         // This must happen before manifest check to enable recovery when manifest is missing
         // but other index files exist (partial save failure scenario)
         let interner_path = self.interner_path();
-        let interner_was_loaded = if interner_path.exists() {
+        let (interner_was_loaded, remap) = if interner_path.exists() {
             let interner_data = load_string_interner(&interner_path)?;
-            restore_string_interner(&interner_data)?;
-            true
+            let remap = restore_string_interner(&interner_data)?;
+            (true, remap)
         } else {
-            false
+            (false, InternerRemap::identity())
         };
 
         // 2. Check if manifest exists
@@ -114,7 +137,7 @@ impl IndexPersistenceManager {
                 eprintln!(
                     "Warning: Manifest missing but string interner exists - attempting best-effort recovery"
                 );
-                return Ok(super::formats::IndexManifest::new(0));
+                return Ok((super::formats::IndexManifest::new(0), remap));
             }
 
             // No index files exist at all - this is expected on first run
@@ -126,7 +149,7 @@ impl IndexPersistenceManager {
         // 3. Load manifest
         let manifest = load_manifest(&manifest_path)?;
 
-        Ok(manifest)
+        Ok((manifest, remap))
     }
 
     /// Save the manifest.

--- a/src/storage/index_persistence/mod.rs
+++ b/src/storage/index_persistence/mod.rs
@@ -311,6 +311,23 @@ pub(crate) fn atomic_write(path: &std::path::Path, data: &[u8]) -> Result<()> {
 ///
 /// A tuple of (graph_data, temporal_data_option, vector_data_vec)
 ///
+/// # ⚠️ Interner remap required (Issue #3490)
+///
+/// This function returns **raw, un-remapped** `GraphIndexData` /
+/// `TemporalIndexData`: every embedded `u32` interner id (labels, property
+/// keys, string values, delta `removed_keys`) is still in the saved file's
+/// id space. It does **not** restore the string interner. Any caller that goes
+/// on to resolve those ids MUST first restore the interner (via
+/// [`strings::restore_string_interner`], obtaining an
+/// [`InternerRemap`](strings::InternerRemap)) and then translate the returned
+/// data through [`InternerRemap::remap_graph_index_data`] /
+/// [`InternerRemap::remap_temporal_index_data`] before resolving — otherwise
+/// persisted ids silently resolve to the wrong strings when the live interner
+/// order diverges from the saved file (the #3490 corruption). This is a latent
+/// trap: there are currently no production callers, and the startup path
+/// (`load_indexes_startup`) deliberately loads sequentially with the remap
+/// applied instead of using this helper.
+///
 /// # Errors
 ///
 /// Returns an error if any of the index files fail to load.

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -910,11 +910,15 @@ pub(crate) fn load_indexes_startup(
     // Try to load manifest and string interner, but don't fail if manifest doesn't exist yet
     // (manifest is only saved on shutdown, not during background persistence)
     // Issue #3490: obtain the file-id -> live-id remap alongside the manifest.
-    // WAL replay (in db::config, before this runs) may have re-interned property
-    // keys in a different order than the saved interner file, so persisted
-    // interner ids must be translated through this remap before being resolved
-    // against the live GLOBAL_INTERNER. When no interner/manifest could be
-    // loaded, we fall back to an identity remap (ids pass through unchanged),
+    // Before this runs, the process-global GLOBAL_INTERNER is generally already
+    // populated at ids unrelated to the saved interner file: WAL bootstrap
+    // deserialization (`wal.read_from` in db::config) interns every property KEY
+    // decoded by `PropertyMap::deserialize`, and the interner is a process-wide
+    // singleton shared across instances/opens. Re-interning the saved strings
+    // therefore assigns them DIFFERENT live ids than their saved file positions,
+    // so persisted interner ids must be translated through this remap before
+    // being resolved against the live interner. When no interner/manifest could
+    // be loaded, we fall back to an identity remap (ids pass through unchanged),
     // reproducing the pre-#3490 behavior for that path.
     let (manifest_lsn, interner_remap) = match manager.load_manifest_and_strings_with_remap() {
         Ok((manifest, remap)) => (Some(manifest.lsn), remap), // Successfully loaded
@@ -1262,15 +1266,20 @@ pub(crate) fn load_indexes_startup(
         }
     }
 
-    // Load temporal adjacency index
-    use crate::storage::index_persistence::temporal_adjacency::load_temporal_adjacency_index;
+    // Load temporal adjacency index.
+    // Issue #3490: the persisted edge-type labels are file-space interner ids
+    // and MUST be translated through the same remap as the graph/temporal
+    // indexes before they are resolved, or AS-OF (#3225) edge-type traversal
+    // filtering silently matches the wrong edge type after a reload whose
+    // interner order diverged from the saved file.
+    use crate::storage::index_persistence::temporal_adjacency::load_temporal_adjacency_index_with_remap;
 
     let adjacency_file = manager
         .base_path()
         .join("temporal_adjacency")
         .join("adjacency.idx");
     if adjacency_file.exists() {
-        match load_temporal_adjacency_index(manager.base_path()) {
+        match load_temporal_adjacency_index_with_remap(manager.base_path(), &interner_remap) {
             Ok(adj_index) => {
                 let mut hist_write = historical.write();
                 hist_write.set_temporal_adjacency_index(adj_index);

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -909,13 +909,23 @@ pub(crate) fn load_indexes_startup(
 ) -> Option<u64> {
     // Try to load manifest and string interner, but don't fail if manifest doesn't exist yet
     // (manifest is only saved on shutdown, not during background persistence)
-    let manifest_lsn = match manager.load_manifest_and_strings() {
-        Ok(manifest) => Some(manifest.lsn), // Successfully loaded
+    // Issue #3490: obtain the file-id -> live-id remap alongside the manifest.
+    // WAL replay (in db::config, before this runs) may have re-interned property
+    // keys in a different order than the saved interner file, so persisted
+    // interner ids must be translated through this remap before being resolved
+    // against the live GLOBAL_INTERNER. When no interner/manifest could be
+    // loaded, we fall back to an identity remap (ids pass through unchanged),
+    // reproducing the pre-#3490 behavior for that path.
+    let (manifest_lsn, interner_remap) = match manager.load_manifest_and_strings_with_remap() {
+        Ok((manifest, remap)) => (Some(manifest.lsn), remap), // Successfully loaded
         Err(e) => {
             if !e.is_not_found() {
                 eprintln!("Warning: Failed to load manifest: {}", e);
             }
-            None // Not found or error
+            (
+                None,
+                crate::storage::index_persistence::strings::InternerRemap::identity(),
+            )
         }
     };
 
@@ -925,7 +935,12 @@ pub(crate) fn load_indexes_startup(
         use crate::storage::index_persistence::graph::{load_graph_index, restore_property_map};
 
         match load_graph_index(&graph_path) {
-            Ok(graph_data) => {
+            Ok(mut graph_data) => {
+                // Issue #3490: translate persisted (file-space) interner ids
+                // (node/edge labels, property keys, and string property values)
+                // to live interner ids before any of the resolution sites below
+                // touch them. A no-op for an identity remap.
+                interner_remap.remap_graph_index_data(&mut graph_data);
                 let current_time = time::now();
                 let mut max_node_id = 0u64;
                 let mut max_edge_id = 0u64;
@@ -1146,7 +1161,12 @@ pub(crate) fn load_indexes_startup(
         };
 
         match load_temporal_index(&temporal_path) {
-            Ok(temporal_data) => {
+            Ok(mut temporal_data) => {
+                // Issue #3490: translate persisted (file-space) interner ids in
+                // the historical versions/anchors (labels, property keys, string
+                // values, and delta removed_keys) to live interner ids before
+                // restoring them. A no-op for an identity remap.
+                interner_remap.remap_temporal_index_data(&mut temporal_data);
                 // Restore versions into historical storage
                 // Labels are now stored directly in the persisted entries
                 let mut historical_guard = historical.write();

--- a/src/storage/index_persistence/operations_tests.rs
+++ b/src/storage/index_persistence/operations_tests.rs
@@ -1020,21 +1020,46 @@ fn test_multi_property_cross_process_reload_survives_interner_remap_3490() {
 /// test, so nothing else touches the interner concurrently), which makes it
 /// safe to `clear()` the GLOBAL_INTERNER to emulate a pristine, freshly
 /// started process.
+///
+/// Coverage extends beyond graph nodes to every persisted-id resolution site
+/// that #3490 can corrupt: graph **edges** (string-valued property), the
+/// **temporal** index (node anchor version property, node delta `removed_keys`,
+/// edge version label + property), and the **temporal adjacency** index
+/// (edge-type label used by #3225 AS-OF edge-type filtering). Each is asserted
+/// to resolve to its ORIGINAL string after a fresh-process reload whose interner
+/// order was polluted away from the saved file positions.
 #[test]
 #[ignore]
 fn regression_3490_interner_remap_subprocess_helper() {
-    use crate::core::id::IdGenerator;
+    use crate::core::hlc::HybridTimestamp;
+    use crate::core::id::{EdgeId, IdGenerator};
     use crate::core::property::PropertyValue;
+    use crate::core::version::VersionData;
+    use crate::core::{GLOBAL_INTERNER, TIMESTAMP_MAX};
+    use crate::index::temporal_adjacency::{TemporalAdjacencyConfig, TemporalAdjacencyIndex};
     use crate::storage::index_persistence::formats::{
-        IndexManifest, PersistedNode, PersistedPropertyMap,
+        EdgeVersionEntry, IndexManifest, NodeVersionEntry, PersistedEdge, PersistedNode,
+        PersistedPropertyMap, PersistedVersionType, TemporalIndexData,
     };
     use crate::storage::index_persistence::graph::{new_graph_index_data, save_graph_index};
+    use crate::storage::index_persistence::temporal::save_temporal_index;
+    use crate::storage::index_persistence::temporal_adjacency::save_temporal_adjacency_index;
+    use crate::storage::index_persistence::{MANIFEST_VERSION, TEMPORAL_MAGIC};
 
     // Multiple distinct string KEYS and string VALUES across a couple of nodes,
     // to force the collision on real property data (not just labels).
     let label = "Employee";
     let keys = ["dept", "title", "city"];
     let str_values = ["engineering", "staff-swe"];
+
+    // Additional distinct strings exercising edges, temporal versions, and the
+    // temporal adjacency index (each must survive the polluted reload).
+    let edge_type = "REPORTS_TO"; // graph edge label + temporal edge label + adjacency label
+    let edge_prop_key = "since"; // edge string-valued property key
+    let edge_prop_val = "2021-tenure"; // edge string-valued property value
+    let anchor_key = "clearance"; // temporal node ANCHOR version property key
+    let anchor_val = "top-secret"; // temporal node ANCHOR version property value
+    let removed_key = "legacy_field"; // temporal node DELTA removed_keys entry
 
     // ---- Fresh process #1 (the writer): pristine warmed interner. ----
     GLOBAL_INTERNER.clear();
@@ -1044,7 +1069,8 @@ fn regression_3490_interner_remap_subprocess_helper() {
     let manager = IndexPersistenceManager::new(dir.path());
     manager.ensure_directories().unwrap();
 
-    // Intern in "save order": label, then keys, then string values.
+    // Intern in "save order": label, then keys, then string values, then the
+    // edge/temporal/adjacency strings. Capture their FILE-space ids.
     let label_id = GLOBAL_INTERNER.intern(label).unwrap();
     let key_ids: Vec<u32> = keys
         .iter()
@@ -1054,9 +1080,16 @@ fn regression_3490_interner_remap_subprocess_helper() {
         .iter()
         .map(|v| GLOBAL_INTERNER.intern(v).unwrap().as_u32())
         .collect();
+    let edge_type_id = GLOBAL_INTERNER.intern(edge_type).unwrap();
+    let edge_prop_key_id = GLOBAL_INTERNER.intern(edge_prop_key).unwrap().as_u32();
+    let edge_prop_val_id = GLOBAL_INTERNER.intern(edge_prop_val).unwrap().as_u32();
+    let anchor_key_id = GLOBAL_INTERNER.intern(anchor_key).unwrap().as_u32();
+    let anchor_val_id = GLOBAL_INTERNER.intern(anchor_val).unwrap().as_u32();
+    let removed_key_id = GLOBAL_INTERNER.intern(removed_key).unwrap().as_u32();
 
     // Two nodes: node 1 carries 2 string-valued props + 1 int prop; node 2
-    // carries a single string prop. Both exercise multi-property reload.
+    // carries a single string prop. Plus one EDGE (1->2) with a string-valued
+    // property, exercising the graph edge label + edge string-property path.
     let mut graph = new_graph_index_data();
     graph.nodes.push(PersistedNode {
         id: 1,
@@ -1079,24 +1112,161 @@ fn regression_3490_interner_remap_subprocess_helper() {
         },
     });
     graph.node_count = 2;
+    graph.edges.push(PersistedEdge {
+        id: 1,
+        source_id: 1,
+        target_id: 2,
+        label_idx: edge_type_id.as_u32(),
+        version_id: 3,
+        properties: PersistedPropertyMap {
+            entries: vec![(
+                edge_prop_key_id,
+                PersistedPropertyValue::String(edge_prop_val_id),
+            )],
+        },
+    });
+    graph.edge_count = 1;
 
     save_graph_index(&graph, &manager.graph_path().join("adjacency.idx")).unwrap();
+
+    // ---- Temporal index: node ANCHOR version (property), node DELTA version
+    // (removed_keys), and an edge version (label + string property). ----
+    let node_anchor_vid = 10u64;
+    let node_delta_vid = 11u64;
+    let edge_vid = 12u64;
+    let temporal_data = TemporalIndexData {
+        magic: TEMPORAL_MAGIC,
+        version: MANIFEST_VERSION,
+        node_versions: vec![
+            NodeVersionEntry {
+                version_id: node_anchor_vid,
+                node_id: 1,
+                label_idx: label_id.as_u32(),
+                valid_from: 1_000_000,
+                valid_to: None,
+                valid_from_logical: 0,
+                valid_to_logical: None,
+                tx_time: 1_000_000,
+                tx_time_logical: 0,
+                version_type: PersistedVersionType::Anchor,
+                properties: PersistedPropertyMap {
+                    entries: vec![(anchor_key_id, PersistedPropertyValue::String(anchor_val_id))],
+                },
+                vector_snapshot_id: None,
+                provenance: None,
+                tx_end: None,
+                tx_end_logical: None,
+                prev_version: None,
+                next_version: None,
+            },
+            NodeVersionEntry {
+                version_id: node_delta_vid,
+                node_id: 1,
+                label_idx: label_id.as_u32(),
+                valid_from: 2_000_000,
+                valid_to: None,
+                valid_from_logical: 0,
+                valid_to_logical: None,
+                tx_time: 2_000_000,
+                tx_time_logical: 0,
+                version_type: PersistedVersionType::Delta {
+                    base_anchor_tx: 1_000_000,
+                    base_anchor_tx_logical: 0,
+                    removed_keys: vec![removed_key_id],
+                },
+                properties: PersistedPropertyMap { entries: vec![] },
+                vector_snapshot_id: None,
+                provenance: None,
+                tx_end: None,
+                tx_end_logical: None,
+                prev_version: None,
+                next_version: None,
+            },
+        ],
+        node_anchors: vec![],
+        edge_versions: vec![EdgeVersionEntry {
+            version_id: edge_vid,
+            edge_id: 1,
+            source_id: 1,
+            target_id: 2,
+            label_idx: edge_type_id.as_u32(),
+            valid_from: 1_000_000,
+            valid_to: None,
+            valid_from_logical: 0,
+            valid_to_logical: None,
+            tx_time: 1_000_000,
+            tx_time_logical: 0,
+            version_type: PersistedVersionType::Anchor,
+            properties: PersistedPropertyMap {
+                entries: vec![(
+                    edge_prop_key_id,
+                    PersistedPropertyValue::String(edge_prop_val_id),
+                )],
+            },
+            provenance: None,
+            tx_end: None,
+            tx_end_logical: None,
+            prev_version: None,
+            next_version: None,
+        }],
+        edge_anchors: vec![],
+    };
+    save_temporal_index(
+        &temporal_data,
+        &manager.temporal_path().join("versions.idx"),
+    )
+    .unwrap();
+
+    // ---- Temporal adjacency index: one edge (1->2) of type `edge_type`. ----
+    // The stored entry `label` is a FILE-space interner id; #3225 AS-OF
+    // edge-type traversal filters on it, so it must survive the reload.
+    let adj_valid_from = HybridTimestamp::new_unchecked(1_000_000, 0);
+    let adj_tx_from = HybridTimestamp::new_unchecked(1_000_000, 0);
+    {
+        let adj = TemporalAdjacencyIndex::new(TemporalAdjacencyConfig::default());
+        adj.insert_edge(
+            EdgeId::new(1).unwrap(),
+            NodeId::new(1).unwrap(),
+            NodeId::new(2).unwrap(),
+            edge_type_id,
+            adj_valid_from,
+            TIMESTAMP_MAX,
+            adj_tx_from,
+            TIMESTAMP_MAX,
+        )
+        .unwrap();
+        save_temporal_adjacency_index(&adj, manager.base_path()).unwrap();
+    }
+
     manager.save_string_interner().unwrap();
     manager.save_manifest(&IndexManifest::new(0)).unwrap();
 
-    // ---- Fresh process #2 (the reader): pristine warmed interner, THEN
-    // WAL replay re-interns keys/values/label in a DIFFERENT (hash) order,
-    // shifting their live ids away from the saved file positions. ----
+    // ---- Fresh process #2 (the reader): pristine warmed interner, THEN a
+    // divergent re-intern (as WAL bootstrap / a shared process-global interner
+    // would produce) shifts every live id away from its saved file position.
+    // Filler strings + a scrambled order guarantee positional identity is
+    // broken for ALL the strings our entities reference. ----
     GLOBAL_INTERNER.clear();
     GLOBAL_INTERNER.warm_common_strings();
-    // Deterministic divergence: rotate keys and swap values, intern label last.
-    for k in ["city", "dept", "title"] {
-        GLOBAL_INTERNER.intern(k).unwrap();
+    for filler in ["__f0__", "__f1__", "__f2__"] {
+        GLOBAL_INTERNER.intern(filler).unwrap();
     }
-    for v in ["staff-swe", "engineering"] {
-        GLOBAL_INTERNER.intern(v).unwrap();
+    for s in [
+        removed_key,
+        anchor_val,
+        anchor_key,
+        edge_prop_val,
+        edge_prop_key,
+        edge_type,
+        "city",
+        "title",
+        "dept",
+        "staff-swe",
+        "engineering",
+        label,
+    ] {
+        GLOBAL_INTERNER.intern(s).unwrap();
     }
-    GLOBAL_INTERNER.intern(label).unwrap();
 
     // ---- Run the real startup restore path. ----
     let current = Arc::new(CurrentStorage::new());
@@ -1152,5 +1322,95 @@ fn regression_3490_interner_remap_subprocess_helper() {
         node2.properties.get("dept"),
         Some(&PropertyValue::String(Arc::from("engineering"))),
         "Issue #3490: node 2 'dept' property corrupted or lost"
+    );
+
+    // ---- Assert: graph EDGE restored with correct label + string property. ----
+    let edge = current
+        .get_edge(EdgeId::new(1).unwrap())
+        .expect("Issue #3490: edge 1 lost across reload (graph index abandoned)");
+    assert_eq!(
+        GLOBAL_INTERNER.resolve_with(edge.label, |s| s.to_string()),
+        Some(edge_type.to_string()),
+        "Issue #3490: edge type label corrupted across reload"
+    );
+    assert_eq!(
+        edge.properties.get(edge_prop_key),
+        Some(&PropertyValue::String(Arc::from(edge_prop_val))),
+        "Issue #3490: edge string-valued property key/value corrupted across reload"
+    );
+
+    // ---- Assert: TEMPORAL versions restored with correct interned strings. ----
+    let hist = historical.read();
+
+    // Node ANCHOR version property.
+    let anchor_version = hist
+        .get_node_version(VersionId::new(node_anchor_vid).unwrap())
+        .expect("Issue #3490: node anchor version lost across reload");
+    match &anchor_version.data {
+        VersionData::Anchor { properties, .. } => {
+            assert_eq!(
+                properties.get(anchor_key),
+                Some(&PropertyValue::String(Arc::from(anchor_val))),
+                "Issue #3490: temporal node anchor property corrupted across reload"
+            );
+        }
+        other => panic!("Issue #3490: expected anchor version, got {other:?}"),
+    }
+
+    // Node DELTA removed_keys.
+    let delta_version = hist
+        .get_node_version(VersionId::new(node_delta_vid).unwrap())
+        .expect("Issue #3490: node delta version lost across reload");
+    match &delta_version.data {
+        VersionData::Delta { delta } => {
+            let removed: Vec<String> = delta
+                .removed
+                .iter()
+                .filter_map(|k| GLOBAL_INTERNER.resolve_with(*k, |s| s.to_string()))
+                .collect();
+            assert!(
+                removed.iter().any(|s| s == removed_key),
+                "Issue #3490: temporal delta removed_key corrupted across reload (got {removed:?})"
+            );
+        }
+        other => panic!("Issue #3490: expected delta version, got {other:?}"),
+    }
+
+    // Edge version label + property.
+    let edge_version = hist
+        .get_edge_version(VersionId::new(edge_vid).unwrap())
+        .expect("Issue #3490: edge version lost across reload");
+    assert_eq!(
+        GLOBAL_INTERNER.resolve_with(edge_version.label, |s| s.to_string()),
+        Some(edge_type.to_string()),
+        "Issue #3490: temporal edge version label corrupted across reload"
+    );
+
+    // ---- Assert: TEMPORAL ADJACENCY edge-type label resolves correctly. ----
+    // This is the Finding-1 assertion: #3225 AS-OF edge-type filtering
+    // (`get_outgoing_with_label_at_time`) compares the stored entry label
+    // against the LIVE id of `edge_type`. Without the adjacency remap the
+    // stored label is a file-space id that no longer equals the live id, so the
+    // query returns EMPTY (the edge is invisible to edge-type traversal).
+    let live_edge_type = GLOBAL_INTERNER
+        .get_id(edge_type)
+        .expect("edge_type must be interned live after reload");
+    let adj_index = hist
+        .get_temporal_adjacency_index()
+        .expect("Issue #3490: temporal adjacency index not loaded")
+        .clone();
+    drop(hist);
+    let query_time = HybridTimestamp::new_unchecked(1_500_000, 0);
+    let matched = adj_index.get_outgoing_with_label_at_time(
+        NodeId::new(1).unwrap(),
+        live_edge_type,
+        query_time,
+        query_time,
+    );
+    assert_eq!(
+        matched,
+        vec![EdgeId::new(1).unwrap()],
+        "Issue #3490: AS-OF edge-type traversal lost edge 1 — temporal adjacency \
+         edge-type label was not remapped (resolves to the wrong live id)"
     );
 }

--- a/src/storage/index_persistence/operations_tests.rs
+++ b/src/storage/index_persistence/operations_tests.rs
@@ -954,3 +954,203 @@ fn test_persist_temporal_index_materializes_sparse_vector_deltas() {
         "restored edge head must reconstruct the updated embedding"
     );
 }
+
+// ============================================================================
+// Issue #3490: cross-process reload must not lose multi-property nodes to a
+// "String interner mismatch". See src/storage/index_persistence/strings.rs.
+// ============================================================================
+
+/// Issue #3490 regression: a node persisted with MULTIPLE string-keyed
+/// properties (and string values) must survive a fresh-process reload whose
+/// WAL replay has already re-interned the property keys/values in a DIFFERENT
+/// order than the saved interner file — the exact ordering divergence that
+/// made `restore_string_interner`'s positional identity assertion fail and
+/// silently abandon the graph index (data loss).
+///
+/// The GLOBAL_INTERNER is a process-global singleton, so this test cannot
+/// safely `clear()` it in-process without corrupting other parallel tests.
+/// It therefore spawns a genuine subprocess that runs the isolated
+/// `regression_3490_interner_remap_subprocess_helper` (an `#[ignore]`d test
+/// that owns the whole interner) and asserts it exits 0. The helper encodes
+/// the root-cause ordering divergence deterministically so it fails RELIABLY
+/// on unfixed code (never intermittently).
+#[test]
+fn test_multi_property_cross_process_reload_survives_interner_remap_3490() {
+    use std::process::Command;
+    use std::time::{Duration, Instant};
+
+    let exe = std::env::current_exe().expect("failed to locate current test binary");
+    let mut child = Command::new(exe)
+        .args([
+            "--ignored",
+            "--exact",
+            "--nocapture",
+            "storage::index_persistence::operations::tests::regression_3490_interner_remap_subprocess_helper",
+        ])
+        .spawn()
+        .expect("failed to spawn subprocess for Issue #3490 reload test");
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                assert!(
+                    status.success(),
+                    "Issue #3490 subprocess reload helper failed (multi-property node \
+                     lost or corrupted across a fresh-process reload): {status}"
+                );
+                break;
+            }
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    panic!("Issue #3490 subprocess reload helper did not complete in time");
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            Err(e) => panic!("failed while polling Issue #3490 subprocess: {e}"),
+        }
+    }
+}
+
+/// Isolated subprocess body for Issue #3490 (see the spawning test above).
+///
+/// Runs entirely inside a dedicated subprocess (`--exact` selects only this
+/// test, so nothing else touches the interner concurrently), which makes it
+/// safe to `clear()` the GLOBAL_INTERNER to emulate a pristine, freshly
+/// started process.
+#[test]
+#[ignore]
+fn regression_3490_interner_remap_subprocess_helper() {
+    use crate::core::id::IdGenerator;
+    use crate::core::property::PropertyValue;
+    use crate::storage::index_persistence::formats::{
+        IndexManifest, PersistedNode, PersistedPropertyMap,
+    };
+    use crate::storage::index_persistence::graph::{new_graph_index_data, save_graph_index};
+
+    // Multiple distinct string KEYS and string VALUES across a couple of nodes,
+    // to force the collision on real property data (not just labels).
+    let label = "Employee";
+    let keys = ["dept", "title", "city"];
+    let str_values = ["engineering", "staff-swe"];
+
+    // ---- Fresh process #1 (the writer): pristine warmed interner. ----
+    GLOBAL_INTERNER.clear();
+    GLOBAL_INTERNER.warm_common_strings();
+
+    let dir = tempfile::tempdir().unwrap();
+    let manager = IndexPersistenceManager::new(dir.path());
+    manager.ensure_directories().unwrap();
+
+    // Intern in "save order": label, then keys, then string values.
+    let label_id = GLOBAL_INTERNER.intern(label).unwrap();
+    let key_ids: Vec<u32> = keys
+        .iter()
+        .map(|k| GLOBAL_INTERNER.intern(k).unwrap().as_u32())
+        .collect();
+    let val_ids: Vec<u32> = str_values
+        .iter()
+        .map(|v| GLOBAL_INTERNER.intern(v).unwrap().as_u32())
+        .collect();
+
+    // Two nodes: node 1 carries 2 string-valued props + 1 int prop; node 2
+    // carries a single string prop. Both exercise multi-property reload.
+    let mut graph = new_graph_index_data();
+    graph.nodes.push(PersistedNode {
+        id: 1,
+        label_idx: label_id.as_u32(),
+        version_id: 1,
+        properties: PersistedPropertyMap {
+            entries: vec![
+                (key_ids[0], PersistedPropertyValue::String(val_ids[0])),
+                (key_ids[1], PersistedPropertyValue::String(val_ids[1])),
+                (key_ids[2], PersistedPropertyValue::Int(42)),
+            ],
+        },
+    });
+    graph.nodes.push(PersistedNode {
+        id: 2,
+        label_idx: label_id.as_u32(),
+        version_id: 2,
+        properties: PersistedPropertyMap {
+            entries: vec![(key_ids[0], PersistedPropertyValue::String(val_ids[0]))],
+        },
+    });
+    graph.node_count = 2;
+
+    save_graph_index(&graph, &manager.graph_path().join("adjacency.idx")).unwrap();
+    manager.save_string_interner().unwrap();
+    manager.save_manifest(&IndexManifest::new(0)).unwrap();
+
+    // ---- Fresh process #2 (the reader): pristine warmed interner, THEN
+    // WAL replay re-interns keys/values/label in a DIFFERENT (hash) order,
+    // shifting their live ids away from the saved file positions. ----
+    GLOBAL_INTERNER.clear();
+    GLOBAL_INTERNER.warm_common_strings();
+    // Deterministic divergence: rotate keys and swap values, intern label last.
+    for k in ["city", "dept", "title"] {
+        GLOBAL_INTERNER.intern(k).unwrap();
+    }
+    for v in ["staff-swe", "engineering"] {
+        GLOBAL_INTERNER.intern(v).unwrap();
+    }
+    GLOBAL_INTERNER.intern(label).unwrap();
+
+    // ---- Run the real startup restore path. ----
+    let current = Arc::new(CurrentStorage::new());
+    let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
+    let node_gen = Arc::new(IdGenerator::new());
+    let edge_gen = Arc::new(IdGenerator::new());
+    let version_gen = Arc::new(IdGenerator::new());
+
+    load_indexes_startup(
+        &manager,
+        &current,
+        &historical,
+        &node_gen,
+        &edge_gen,
+        &version_gen,
+    );
+
+    // ---- Assert: BOTH nodes restored with ALL properties intact. ----
+    let node1 = current
+        .get_node(NodeId::new(1).unwrap())
+        .expect("Issue #3490: node 1 lost across reload (graph index abandoned)");
+    assert_eq!(
+        node1.properties.len(),
+        3,
+        "Issue #3490: node 1 must retain all 3 properties, got {}",
+        node1.properties.len()
+    );
+    assert_eq!(
+        node1.properties.get("dept"),
+        Some(&PropertyValue::String(Arc::from("engineering"))),
+        "Issue #3490: node 1 'dept' property corrupted or lost"
+    );
+    assert_eq!(
+        node1.properties.get("title"),
+        Some(&PropertyValue::String(Arc::from("staff-swe"))),
+        "Issue #3490: node 1 'title' property corrupted or lost"
+    );
+    assert_eq!(
+        node1.properties.get("city"),
+        Some(&PropertyValue::Int(42)),
+        "Issue #3490: node 1 'city' property corrupted or lost"
+    );
+    assert_eq!(
+        GLOBAL_INTERNER.resolve_with(node1.label, |s| s.to_string()),
+        Some(label.to_string()),
+        "Issue #3490: node 1 label corrupted across reload"
+    );
+
+    let node2 = current
+        .get_node(NodeId::new(2).unwrap())
+        .expect("Issue #3490: node 2 lost across reload (graph index abandoned)");
+    assert_eq!(
+        node2.properties.get("dept"),
+        Some(&PropertyValue::String(Arc::from("engineering"))),
+        "Issue #3490: node 2 'dept' property corrupted or lost"
+    );
+}

--- a/src/storage/index_persistence/strings.rs
+++ b/src/storage/index_persistence/strings.rs
@@ -26,7 +26,7 @@ use std::path::Path;
 use super::error::{IndexPersistenceError, Result};
 use super::formats::{
     GraphIndexData, PersistedPropertyMap, PersistedPropertyValue, PersistedVersionType,
-    StringInternerData, TemporalIndexData,
+    StringInternerData, TemporalAdjacencyData, TemporalIndexData,
 };
 use super::{INTERNER_MAGIC, MANIFEST_VERSION};
 
@@ -52,13 +52,30 @@ const UNMAPPABLE_FILE_ID: u32 = u32::MAX;
 /// records the strings in that id order (position `i` == the string that had
 /// interner id `i` at save time).
 ///
-/// On reload the live interner is generally **not** pristine: WAL replay
-/// re-interns every property key (in hash-iteration order) *before* the saved
-/// interner file is restored, so re-interning the saved strings yields
-/// *different* live ids than the file positions they were saved at. The old
-/// restore path asserted positional identity and aborted with an
-/// `InternerMismatch`, which was swallowed to a warning and silently abandoned
-/// the whole graph index — dropping data.
+/// On reload the live interner is generally **not** pristine, so re-interning
+/// the saved strings yields *different* live ids than the file positions they
+/// were saved at. Two mechanisms make the live interner diverge from the saved
+/// file order before [`restore_string_interner`] runs:
+///
+/// 1. **WAL bootstrap deserialization.** During startup, `wal.read_from`
+///    (`src/db/config.rs`) deserializes the on-disk WAL entries, and
+///    `PropertyMap::deserialize` (`src/core/property/map.rs`) interns every
+///    property **key** it decodes into the process-global interner. This
+///    happens *before* the saved interner file is restored, so the keys land at
+///    whatever ids the interner hands out next — not the ids they had when the
+///    interner file was written. (WAL bootstrap is a raw deserialize, not a
+///    differential replay: the differential WAL replay proper runs *after*
+///    `load_indexes_startup`, and it does not intern.)
+/// 2. **The interner is a process-global singleton.** `GLOBAL_INTERNER` is
+///    shared across every `AletheiaDB` instance and every `open()` in the
+///    process, so any prior or concurrent population (earlier opens, other
+///    instances) leaves it already holding strings at ids unrelated to any one
+///    saved file.
+///
+/// Either way, the string at file position `i` re-interns to some live id that
+/// is generally not `i`. The old restore path asserted positional identity and
+/// aborted with an `InternerMismatch`, which was swallowed to a warning and
+/// silently abandoned the whole graph index — dropping data.
 ///
 /// The fix decouples the two id namespaces: the saved interner file defines a
 /// **file-local** id space, and this remap translates each persisted file id to
@@ -67,6 +84,17 @@ const UNMAPPABLE_FILE_ID: u32 = u32::MAX;
 /// routed through [`InternerRemap::remap_id`] before being resolved against the
 /// live interner. The on-disk wire format is unchanged — this is purely a
 /// load-time interpretation fix.
+///
+/// # Positional-identity invariant
+///
+/// The remap assumes `data.strings[i]` is exactly the string whose live id was
+/// `i` when the interner file was saved. That holds only because
+/// [`StringInterner::get_all_strings`](crate::core::interning::StringInterner::get_all_strings)
+/// (`src/core/interning.rs`) `.flatten()`s the id-ordered slot table, and the
+/// interner only ever leaves **tail** holes (capacity rollbacks), never
+/// interior ones — so flattening drops only trailing empty slots and preserves
+/// the position == id coupling for every retained string. If that ever changes
+/// (interior holes), this remap and `get_all_strings` would need to co-evolve.
 ///
 /// An [`InternerRemap::identity`] variant (used when no interner file was
 /// loaded) passes ids through unchanged, exactly reproducing legacy behavior.
@@ -183,6 +211,30 @@ impl InternerRemap {
         }
         for anchor in data.edge_anchors.iter_mut() {
             self.remap_property_map(&mut anchor.full_state);
+        }
+    }
+
+    /// Rewrite every persisted edge-type interner id in a loaded
+    /// [`TemporalAdjacencyData`] in place. Each `PersistedTemporalAdjacencyEntry`
+    /// stores its edge-type `label` as a file-space interner id; this translates
+    /// it to the live id so the #3225 AS-OF temporal-traversal edge-type filter
+    /// (which compares the entry `label` against a live [`InternedString`])
+    /// matches the correct edge type after reload (Issue #3490).
+    ///
+    /// An unmappable (corrupt/out-of-range) file id becomes
+    /// [`UNMAPPABLE_FILE_ID`], which fails the live-interner resolve check in
+    /// the reconstruction step (that entry is skipped and counted loudly)
+    /// rather than being stored as a garbage edge type.
+    ///
+    /// An identity remap leaves the data byte-for-byte unchanged.
+    pub fn remap_temporal_adjacency_data(&self, data: &mut TemporalAdjacencyData) {
+        if self.mapping.is_none() {
+            return;
+        }
+        for node_entry in data.outgoing.iter_mut() {
+            for entry in node_entry.entries.iter_mut() {
+                entry.label = self.remap_id(entry.label);
+            }
         }
     }
 }

--- a/src/storage/index_persistence/strings.rs
+++ b/src/storage/index_persistence/strings.rs
@@ -20,12 +20,172 @@
 //! If the interner is not restored to the exact same state, these IDs will map to incorrect strings,
 //! causing data corruption.
 
-use crate::core::GLOBAL_INTERNER;
+use crate::core::{GLOBAL_INTERNER, InternedString};
 use std::path::Path;
 
 use super::error::{IndexPersistenceError, Result};
-use super::formats::StringInternerData;
+use super::formats::{
+    GraphIndexData, PersistedPropertyMap, PersistedPropertyValue, PersistedVersionType,
+    StringInternerData, TemporalIndexData,
+};
 use super::{INTERNER_MAGIC, MANIFEST_VERSION};
+
+/// Sentinel live id used when a persisted file-space interner id cannot be
+/// mapped through the remap (i.e. it references a position past the end of the
+/// saved interner file — genuine on-disk corruption). It is never a valid
+/// interner id in practice, so downstream resolution of a property key / string
+/// value / label stamped with it deterministically *fails* (the node/edge is
+/// skipped and counted as a load error) rather than silently resolving to some
+/// unrelated live string. This preserves corruption detection while the remap
+/// eliminates the benign file-id vs live-id divergence that Issue #3490 was.
+const UNMAPPABLE_FILE_ID: u32 = u32::MAX;
+
+/// Translation table from **persisted file-space interner ids** to **live
+/// interner ids**, produced by [`restore_string_interner`].
+///
+/// # Why this exists (Issue #3490)
+///
+/// Persistence stores raw `u32` interner ids for property keys, string values,
+/// and node/edge labels. Those ids are assigned by the process-global
+/// [`GLOBAL_INTERNER`] in first-intern order, so they are only meaningful
+/// relative to the interner state that produced them. The saved interner file
+/// records the strings in that id order (position `i` == the string that had
+/// interner id `i` at save time).
+///
+/// On reload the live interner is generally **not** pristine: WAL replay
+/// re-interns every property key (in hash-iteration order) *before* the saved
+/// interner file is restored, so re-interning the saved strings yields
+/// *different* live ids than the file positions they were saved at. The old
+/// restore path asserted positional identity and aborted with an
+/// `InternerMismatch`, which was swallowed to a warning and silently abandoned
+/// the whole graph index — dropping data.
+///
+/// The fix decouples the two id namespaces: the saved interner file defines a
+/// **file-local** id space, and this remap translates each persisted file id to
+/// the live id the same string actually has in this process. Every persisted
+/// `u32` interner id (keys, string values, labels, `removed_keys`) must be
+/// routed through [`InternerRemap::remap_id`] before being resolved against the
+/// live interner. The on-disk wire format is unchanged — this is purely a
+/// load-time interpretation fix.
+///
+/// An [`InternerRemap::identity`] variant (used when no interner file was
+/// loaded) passes ids through unchanged, exactly reproducing legacy behavior.
+#[derive(Debug, Clone, Default)]
+pub struct InternerRemap {
+    /// `mapping[file_position]` == the live [`InternedString`] the saved string
+    /// at that position resolves to in this process. `None` == identity remap
+    /// (no translation; every id passes through unchanged).
+    mapping: Option<Vec<InternedString>>,
+}
+
+impl InternerRemap {
+    /// An identity remap: every persisted id is used verbatim as a live id.
+    ///
+    /// Used when there is no saved interner file to translate against (e.g. a
+    /// first run, or best-effort recovery where the interner file is absent),
+    /// preserving the exact pre-#3490 behavior for those paths.
+    pub fn identity() -> Self {
+        Self { mapping: None }
+    }
+
+    /// Build a remap from the saved strings, in file order.
+    ///
+    /// `positions[i]` is the live id that the string at file position `i`
+    /// resolves to after being interned into the current [`GLOBAL_INTERNER`].
+    fn from_positions(positions: Vec<InternedString>) -> Self {
+        Self {
+            mapping: Some(positions),
+        }
+    }
+
+    /// Translate a persisted file-space interner id to its live id.
+    ///
+    /// Returns `None` when a mapping remap does not cover `file_id` (the id
+    /// points past the end of the saved interner file — genuine corruption).
+    /// Identity remaps always return `Some` (the id verbatim).
+    pub fn resolve(&self, file_id: u32) -> Option<InternedString> {
+        match &self.mapping {
+            None => Some(InternedString::from_raw(file_id)),
+            Some(positions) => positions.get(file_id as usize).copied(),
+        }
+    }
+
+    /// Translate a persisted file-space id to a live id as a raw `u32`,
+    /// substituting [`UNMAPPABLE_FILE_ID`] for an out-of-range (corrupt) id so
+    /// that later resolution fails loudly instead of returning wrong data.
+    fn remap_id(&self, file_id: u32) -> u32 {
+        self.resolve(file_id)
+            .map(|id| id.as_u32())
+            .unwrap_or(UNMAPPABLE_FILE_ID)
+    }
+
+    /// Rewrite every interner id embedded in a persisted property map from
+    /// file space to live space (property keys and any `String` values).
+    fn remap_property_map(&self, map: &mut PersistedPropertyMap) {
+        for (key_idx, value) in map.entries.iter_mut() {
+            *key_idx = self.remap_id(*key_idx);
+            if let PersistedPropertyValue::String(value_idx) = value {
+                *value_idx = self.remap_id(*value_idx);
+            }
+        }
+    }
+
+    /// Rewrite every persisted interner id in a loaded [`GraphIndexData`] in
+    /// place, so the existing restore path (which resolves ids against the live
+    /// interner) sees live ids. Covers node/edge labels and node/edge property
+    /// maps (keys + string values).
+    ///
+    /// An identity remap leaves the data byte-for-byte unchanged.
+    pub fn remap_graph_index_data(&self, data: &mut GraphIndexData) {
+        if self.mapping.is_none() {
+            return;
+        }
+        for node in data.nodes.iter_mut() {
+            node.label_idx = self.remap_id(node.label_idx);
+            self.remap_property_map(&mut node.properties);
+        }
+        for edge in data.edges.iter_mut() {
+            edge.label_idx = self.remap_id(edge.label_idx);
+            self.remap_property_map(&mut edge.properties);
+        }
+    }
+
+    /// Rewrite every persisted interner id in a loaded [`TemporalIndexData`] in
+    /// place. Covers node/edge version labels, version property maps (keys +
+    /// string values), the `removed_keys` of delta versions, and the anchor
+    /// `full_state` property maps.
+    ///
+    /// An identity remap leaves the data byte-for-byte unchanged.
+    pub fn remap_temporal_index_data(&self, data: &mut TemporalIndexData) {
+        if self.mapping.is_none() {
+            return;
+        }
+        for version in data.node_versions.iter_mut() {
+            version.label_idx = self.remap_id(version.label_idx);
+            self.remap_property_map(&mut version.properties);
+            if let PersistedVersionType::Delta { removed_keys, .. } = &mut version.version_type {
+                for key_idx in removed_keys.iter_mut() {
+                    *key_idx = self.remap_id(*key_idx);
+                }
+            }
+        }
+        for version in data.edge_versions.iter_mut() {
+            version.label_idx = self.remap_id(version.label_idx);
+            self.remap_property_map(&mut version.properties);
+            if let PersistedVersionType::Delta { removed_keys, .. } = &mut version.version_type {
+                for key_idx in removed_keys.iter_mut() {
+                    *key_idx = self.remap_id(*key_idx);
+                }
+            }
+        }
+        for anchor in data.node_anchors.iter_mut() {
+            self.remap_property_map(&mut anchor.full_state);
+        }
+        for anchor in data.edge_anchors.iter_mut() {
+            self.remap_property_map(&mut anchor.full_state);
+        }
+    }
+}
 
 /// Save the global string interner to disk with CRC32 checksum using atomic write.
 ///
@@ -136,10 +296,31 @@ pub fn load_string_interner(path: &Path) -> Result<StringInternerData> {
     Ok(data)
 }
 
-/// Restore GLOBAL_INTERNER from persisted data.
+/// Restore the persisted strings into `GLOBAL_INTERNER`, returning a
+/// [`InternerRemap`] that translates persisted file-space ids to live ids.
 ///
-/// This must be called before loading any other indexes since they
-/// reference string indices.
+/// This must be called before loading any other indexes since they reference
+/// string indices — but, crucially (Issue #3490), the caller must translate
+/// every persisted `u32` interner id through the returned [`InternerRemap`]
+/// (via [`InternerRemap::remap_graph_index_data`] /
+/// [`InternerRemap::remap_temporal_index_data`]) rather than resolving raw
+/// persisted ids directly against the live interner.
+///
+/// # File-id vs live-id contract
+///
+/// Each saved string is re-interned into the (possibly already-populated) live
+/// interner. Because WAL replay may have interned property keys in a different
+/// order before this runs, the live id assigned to the string at file position
+/// `i` is generally **not** `i`. This function records `file_position -> live
+/// id` for every saved string and returns it as the remap. It does **not**
+/// assert positional identity (the pre-#3490 behavior that spuriously failed
+/// with `InternerMismatch` and silently dropped the graph index).
+///
+/// Empty strings are interned like any other string; a saved `""` is a real
+/// interned empty string (holes are already filtered out by
+/// [`StringInterner::get_all_strings`](crate::core::interning::StringInterner::get_all_strings)
+/// before save), so its file position still needs a live mapping in case data
+/// references it.
 ///
 /// # Examples
 ///
@@ -156,37 +337,29 @@ pub fn load_string_interner(path: &Path) -> Result<StringInternerData> {
 /// // Load data
 /// let data = load_string_interner(&path).unwrap();
 ///
-/// // Restore (re-interns all strings)
-/// restore_string_interner(&data).unwrap();
+/// // Restore (re-interns all strings) and obtain the file-id -> live-id remap.
+/// let remap = restore_string_interner(&data).unwrap();
+/// let _ = remap; // apply to loaded graph/temporal indexes before resolving ids
 /// ```
 ///
 /// # Errors
 ///
-/// Returns an error if:
-/// - A string cannot be interned.
-/// - The restored ID does not match the persisted ID (data corruption or mismatch).
-pub fn restore_string_interner(data: &StringInternerData) -> Result<()> {
-    for (idx, s) in data.strings.iter().enumerate() {
+/// Returns an error if a string cannot be interned (e.g. the live interner is
+/// at capacity).
+pub fn restore_string_interner(data: &StringInternerData) -> Result<InternerRemap> {
+    let mut positions = Vec::with_capacity(data.strings.len());
+    for s in &data.strings {
         let interned_id = GLOBAL_INTERNER.intern(s).map_err(|e| {
             IndexPersistenceError::Serialization(format!("Failed to intern string: {}", e))
         })?;
-        // The interner should assign indices in order
-        // If not, the interner had pre-existing strings which is a bug
-        if interned_id.as_u32() != idx as u32 {
-            // Special handling for gaps: if the string is empty, it might be a gap
-            // captured during concurrent ID reservation in `get_all_strings`.
-            // If so, we can safely ignore the mismatch as no data references this ID.
-            if s.is_empty() {
-                continue;
-            }
-
-            return Err(IndexPersistenceError::InternerMismatch {
-                expected: idx as u32,
-                got: interned_id.as_u32(),
-            });
-        }
+        // Record file_position (== `positions.len()`) -> live interner id. We do
+        // NOT require live id == file position: the live interner may already
+        // hold these strings (e.g. from WAL replay) at different ids. The remap
+        // captures whatever translation is needed so persisted ids resolve to
+        // the correct strings regardless of interning order (Issue #3490).
+        positions.push(interned_id);
     }
-    Ok(())
+    Ok(InternerRemap::from_positions(positions))
 }
 
 #[cfg(test)]
@@ -363,15 +536,12 @@ mod tests {
     }
 
     #[test]
-    fn test_restore_string_interner_mismatch() {
-        // This test verifies that we catch inconsistencies where the restored interner
-        // indices don't match the expected order (e.g. if GLOBAL_INTERNER already
-        // contains strings in a different order).
-
-        // Construct data where index 0 is "type" (which has ID 2 in COMMON_STRINGS).
-        // Since GLOBAL_INTERNER is pre-warmed, intern("type") will return 2.
-        // restore_string_interner will expect 0.
-        // 2 != 0 => Mismatch.
+    fn test_restore_string_interner_remaps_position_to_live_id() {
+        // Issue #3490: the interner is a process-global pre-warmed singleton, so
+        // a persisted string at file position 0 (e.g. "type", which warms to a
+        // NON-zero COMMON_STRINGS id) does NOT re-intern back to id 0. The old
+        // code failed this with `InternerMismatch`; the fix instead RETURNS a
+        // remap translating file position -> live id, without error.
         let data = StringInternerData {
             magic: INTERNER_MAGIC,
             version: MANIFEST_VERSION,
@@ -379,25 +549,30 @@ mod tests {
             strings: vec!["type".to_string()],
         };
 
-        let result = restore_string_interner(&data);
-        assert!(result.is_err());
+        let remap = restore_string_interner(&data).expect("remap restore must not error");
 
-        match result.unwrap_err() {
-            IndexPersistenceError::InternerMismatch { expected, got } => {
-                assert_eq!(expected, 0, "Expected index 0 (from data position)");
-                // "type" is usually index 2 in COMMON_STRINGS, but we just verify mismatch
-                assert_ne!(got, 0, "Got index should not be 0");
-            }
-            err => panic!("Expected InternerMismatch, got: {:?}", err),
-        }
+        // Position 0 must resolve to the LIVE id of "type" (a warmed common
+        // string, id != 0), proving the remap decouples file ids from live ids.
+        let live = GLOBAL_INTERNER
+            .get_id("type")
+            .expect("'type' is pre-warmed");
+        assert_eq!(
+            remap.resolve(0),
+            Some(live),
+            "file position 0 must remap to the live id of \"type\""
+        );
+        assert_ne!(
+            live.as_u32(),
+            0,
+            "precondition: pre-warmed \"type\" is not live id 0"
+        );
     }
 
     #[test]
-    fn test_restore_string_interner_mismatch_with_new_string() {
-        // This test verifies mismatch with a completely new string.
-        // Since GLOBAL_INTERNER is pre-warmed (len > 0), a new string will get ID > 0.
-        // If we put it at index 0 in data, it should fail.
-
+    fn test_restore_string_interner_remaps_new_string_to_live_id() {
+        // A completely new (unique) string at file position 0 gets some live id
+        // > 0 (the interner is pre-warmed). The remap must translate position 0
+        // to that live id and it must resolve back to the same string.
         let unique_string = format!(
             "unique_string_{}",
             std::time::SystemTime::now()
@@ -410,21 +585,132 @@ mod tests {
             magic: INTERNER_MAGIC,
             version: MANIFEST_VERSION,
             string_count: 1,
-            strings: vec![unique_string],
+            strings: vec![unique_string.clone()],
         };
 
-        let result = restore_string_interner(&data);
-        assert!(result.is_err());
+        let remap = restore_string_interner(&data).expect("remap restore must not error");
 
-        match result.unwrap_err() {
-            IndexPersistenceError::InternerMismatch { expected, got } => {
-                assert_eq!(expected, 0, "Expected index 0 (from data position)");
-                assert!(
-                    got > 0,
-                    "Got index should be > 0 (because interner is pre-warmed)"
-                );
-            }
-            err => panic!("Expected InternerMismatch, got: {:?}", err),
-        }
+        let live = remap
+            .resolve(0)
+            .expect("file position 0 must map to a live id");
+        assert!(
+            live.as_u32() > 0,
+            "new string must land at a live id > 0 (interner pre-warmed)"
+        );
+        assert_eq!(
+            GLOBAL_INTERNER.resolve_with(live, |s| s.to_string()),
+            Some(unique_string),
+            "remapped live id must resolve back to the original string"
+        );
+    }
+
+    #[test]
+    fn test_interner_remap_identity_passthrough() {
+        // An identity remap must pass every id through verbatim (legacy behavior
+        // for the no-interner-file path).
+        let remap = InternerRemap::identity();
+        assert_eq!(remap.resolve(0), Some(InternedString::from_raw(0)));
+        assert_eq!(remap.resolve(12345), Some(InternedString::from_raw(12345)));
+    }
+
+    #[test]
+    fn test_interner_remap_out_of_range_is_unmappable() {
+        // A referenced file id past the end of the saved interner file has no
+        // mapping -> `resolve` returns None. This is genuine corruption and must
+        // NOT silently resolve to some unrelated live string; downstream the id
+        // is stamped UNMAPPABLE and the entity is skipped/errored.
+        let data = StringInternerData {
+            magic: INTERNER_MAGIC,
+            version: MANIFEST_VERSION,
+            string_count: 2,
+            strings: vec!["remap_a".to_string(), "remap_b".to_string()],
+        };
+        let remap = restore_string_interner(&data).expect("remap restore must not error");
+
+        assert!(remap.resolve(0).is_some());
+        assert!(remap.resolve(1).is_some());
+        assert_eq!(
+            remap.resolve(2),
+            None,
+            "an out-of-range (corrupt) file id must not map to any live id"
+        );
+        assert_eq!(remap.resolve(u32::MAX), None);
+    }
+
+    #[test]
+    fn test_remap_graph_index_data_translates_polluted_order() {
+        use crate::storage::index_persistence::graph::{
+            new_graph_index_data, restore_property_map,
+        };
+
+        // Simulate save order: intern label + keys + a string value, capture the
+        // FILE ids in that order, then build a persisted node referencing them.
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let label = format!("RemapLabel_{suffix}");
+        let key_a = format!("remap_key_a_{suffix}");
+        let key_b = format!("remap_key_b_{suffix}");
+        let val = format!("remap_val_{suffix}");
+
+        let file_label = GLOBAL_INTERNER.intern(&label).unwrap().as_u32();
+        let file_key_a = GLOBAL_INTERNER.intern(&key_a).unwrap().as_u32();
+        let file_key_b = GLOBAL_INTERNER.intern(&key_b).unwrap().as_u32();
+        let file_val = GLOBAL_INTERNER.intern(&val).unwrap().as_u32();
+
+        let mut graph = new_graph_index_data();
+        graph.nodes.push(super::super::formats::PersistedNode {
+            id: 1,
+            label_idx: file_label,
+            version_id: 1,
+            properties: PersistedPropertyMap {
+                entries: vec![
+                    (file_key_a, PersistedPropertyValue::String(file_val)),
+                    (file_key_b, PersistedPropertyValue::Int(7)),
+                ],
+            },
+        });
+
+        // Build a remap whose file positions map to DIFFERENT live ids than the
+        // file ids above (mimicking WAL-replay pollution having shifted them).
+        // The saved interner file lists strings in the id order captured above.
+        // We can't easily control absolute live ids, so we assert behavior:
+        // after remapping, the node's ids resolve to the ORIGINAL strings.
+        let mut ordered = vec![String::new(); (file_val + 1) as usize];
+        // Fill positions that our node references so `from_positions`-style
+        // resolution is well-defined for them. Positions we don't reference are
+        // left empty (harmless).
+        ordered[file_label as usize] = label.clone();
+        ordered[file_key_a as usize] = key_a.clone();
+        ordered[file_key_b as usize] = key_b.clone();
+        ordered[file_val as usize] = val.clone();
+        let data = StringInternerData {
+            magic: INTERNER_MAGIC,
+            version: MANIFEST_VERSION,
+            string_count: ordered.len() as u64,
+            strings: ordered,
+        };
+        let remap = restore_string_interner(&data).unwrap();
+
+        remap.remap_graph_index_data(&mut graph);
+
+        // After remapping, the persisted ids are LIVE ids; restore must yield
+        // the original strings intact.
+        let node = &graph.nodes[0];
+        assert_eq!(
+            GLOBAL_INTERNER
+                .resolve_with(InternedString::from_raw(node.label_idx), |s| s.to_string()),
+            Some(label)
+        );
+        let props = restore_property_map(&node.properties).unwrap();
+        assert_eq!(
+            props.get(key_a.as_str()).and_then(|v| v.as_str()),
+            Some(val.as_str())
+        );
+        assert!(matches!(
+            props.get(key_b.as_str()),
+            Some(crate::core::property::PropertyValue::Int(7))
+        ));
     }
 }

--- a/src/storage/index_persistence/temporal.rs
+++ b/src/storage/index_persistence/temporal.rs
@@ -369,7 +369,7 @@ pub fn convert_edge_version(version: &EdgeVersion) -> Result<EdgeVersionEntry> {
 ///
 /// Returns an error if property restoration fails (e.g., corrupted interned strings).
 pub fn restore_node_version(entry: &NodeVersionEntry) -> Result<NodeVersion> {
-    let label = InternedString::from_raw(entry.label_idx);
+    let label = resolve_label_or_error(entry.label_idx, "node")?;
     let node_id = NodeId::new(entry.node_id).map_err(|e| {
         IndexPersistenceError::Serialization(format!("Invalid node ID {}: {}", entry.node_id, e))
     })?;
@@ -470,6 +470,29 @@ pub fn restore_node_version(entry: &NodeVersionEntry) -> Result<NodeVersion> {
     })
 }
 
+/// Validate that a persisted label id resolves against the live interner,
+/// returning the [`InternedString`] on success.
+///
+/// Issue #3490: persisted labels are file-space interner ids translated to
+/// live ids by the load-time [`InternerRemap`](super::strings::InternerRemap).
+/// An unmappable id (the remap's `UNMAPPABLE_FILE_ID` sentinel, or genuine
+/// on-disk corruption) must fail LOUDLY here rather than be stored as a garbage
+/// [`InternedString`] via `from_raw`, mirroring the graph restore path and
+/// `restore_property_map`'s property-key check.
+fn resolve_label_or_error(label_idx: u32, kind: &str) -> Result<InternedString> {
+    let label = InternedString::from_raw(label_idx);
+    if crate::core::GLOBAL_INTERNER
+        .resolve_with(label, |_| ())
+        .is_none()
+    {
+        return Err(IndexPersistenceError::Serialization(format!(
+            "Failed to resolve interned {kind} label with ID: {label_idx}. \
+             This likely indicates data corruption."
+        )));
+    }
+    Ok(label)
+}
+
 /// Restore an optional persisted version-chain link, validating the raw ID.
 fn restore_version_link(
     raw: Option<u64>,
@@ -499,7 +522,7 @@ fn restore_version_link(
 ///
 /// Returns an error if property restoration fails (e.g., corrupted interned strings).
 pub fn restore_edge_version(entry: &EdgeVersionEntry) -> Result<EdgeVersion> {
-    let label = InternedString::from_raw(entry.label_idx);
+    let label = resolve_label_or_error(entry.label_idx, "edge")?;
     let edge_id = EdgeId::new(entry.edge_id).map_err(|e| {
         IndexPersistenceError::Serialization(format!("Invalid edge ID {}: {}", entry.edge_id, e))
     })?;

--- a/src/storage/index_persistence/temporal_adjacency.rs
+++ b/src/storage/index_persistence/temporal_adjacency.rs
@@ -12,6 +12,7 @@ use crate::index::temporal_adjacency::{
 
 use super::error::{IndexPersistenceError, Result};
 use super::formats::{NodeAdjacencyEntry, PersistedTemporalAdjacencyEntry, TemporalAdjacencyData};
+use super::strings::InternerRemap;
 use super::{MANIFEST_VERSION, TEMPORAL_ADJACENCY_MAGIC};
 
 /// Save temporal adjacency index to disk.
@@ -72,6 +73,33 @@ const MAX_ADJACENCY_FILE_SIZE: u64 = 10 * 1024 * 1024;
 /// - The data cannot be deserialized.
 /// - The manifest version or magic bytes do not match.
 pub fn load_temporal_adjacency_index(data_dir: &Path) -> Result<Arc<TemporalAdjacencyIndex>> {
+    let data = load_temporal_adjacency_data(data_dir)?;
+    Ok(Arc::new(reconstruct_index(data)?))
+}
+
+/// Load the temporal adjacency index, translating each persisted edge-type
+/// label from **file-space** interner ids to **live** ids via `remap`
+/// (Issue #3490) before reconstruction.
+///
+/// This is the startup-path entry point: `load_indexes_startup` restores the
+/// interner (obtaining the remap) before the persisted adjacency labels are
+/// resolved, and those labels — like graph/temporal labels — are file-space ids
+/// that must be routed through the remap or they silently resolve to the wrong
+/// edge type (corrupting #3225 AS-OF edge-type filtering). An
+/// [`InternerRemap::identity`] remap leaves the labels unchanged, reproducing
+/// the plain [`load_temporal_adjacency_index`] behavior.
+pub fn load_temporal_adjacency_index_with_remap(
+    data_dir: &Path,
+    remap: &InternerRemap,
+) -> Result<Arc<TemporalAdjacencyIndex>> {
+    let mut data = load_temporal_adjacency_data(data_dir)?;
+    remap.remap_temporal_adjacency_data(&mut data);
+    Ok(Arc::new(reconstruct_index(data)?))
+}
+
+/// Read, size-check, deserialize, and validate the on-disk temporal adjacency
+/// blob into [`TemporalAdjacencyData`] (no interner-id translation).
+fn load_temporal_adjacency_data(data_dir: &Path) -> Result<TemporalAdjacencyData> {
     let adjacency_file = data_dir.join("temporal_adjacency").join("adjacency.idx");
 
     // Check file size to prevent DoS
@@ -118,10 +146,7 @@ pub fn load_temporal_adjacency_index(data_dir: &Path) -> Result<Arc<TemporalAdja
         });
     }
 
-    // Reconstruct index
-    let index = reconstruct_index(data)?;
-
-    Ok(Arc::new(index))
+    Ok(data)
 }
 
 /// Extract outgoing edges for persistence.
@@ -167,6 +192,14 @@ fn convert_to_persisted(entry: &TemporalAdjacencyEntry) -> PersistedTemporalAdja
 fn reconstruct_index(data: TemporalAdjacencyData) -> Result<TemporalAdjacencyIndex> {
     let index = TemporalAdjacencyIndex::new(TemporalAdjacencyConfig::default());
 
+    // Count entries whose edge-type label does not resolve to a live interned
+    // string, so an unmappable label (the Issue #3490 UNMAPPABLE_FILE_ID
+    // sentinel written by the remap, or any other on-disk corruption) is
+    // skipped LOUDLY rather than stored as a garbage edge type that would
+    // silently break #3225 AS-OF edge-type filtering. Mirrors the graph
+    // restore path's label validation in `load_indexes_startup`.
+    let mut skipped_unresolvable_labels = 0usize;
+
     // Reconstruct outgoing edges
     for node_entry in data.outgoing {
         let node_id = NodeId::new(node_entry.node_id)
@@ -174,6 +207,18 @@ fn reconstruct_index(data: TemporalAdjacencyData) -> Result<TemporalAdjacencyInd
 
         for entry in node_entry.entries {
             let persisted_entry = convert_from_persisted(entry)?;
+
+            // Validate the edge-type label resolves against the live interner.
+            // `from_raw` never fails, so a bad/unmappable id would otherwise be
+            // stored verbatim and later resolve to the wrong (or no) string.
+            if crate::core::GLOBAL_INTERNER
+                .resolve_with(persisted_entry.label, |_| ())
+                .is_none()
+            {
+                skipped_unresolvable_labels += 1;
+                continue;
+            }
+
             // Insert into index
             index
                 .insert_edge(
@@ -193,6 +238,20 @@ fn reconstruct_index(data: TemporalAdjacencyData) -> Result<TemporalAdjacencyInd
                     ))
                 })?;
         }
+    }
+
+    if skipped_unresolvable_labels > 0 {
+        eprintln!(
+            "Warning: Skipped {} temporal adjacency entr{} whose edge-type label \
+             could not be resolved in the string interner (unmappable/corrupt id); \
+             these edges are omitted from the temporal adjacency index",
+            skipped_unresolvable_labels,
+            if skipped_unresolvable_labels == 1 {
+                "y"
+            } else {
+                "ies"
+            }
+        );
     }
 
     Ok(index)


### PR DESCRIPTION
## What changed (Before / After)

**Before:** Opening a durable DB in a fresh process, then loading nodes that carried two or more string-keyed properties, intermittently logged `Warning: Failed to load manifest: String interner mismatch` and silently corrupted or dropped those properties (a property could come back as the wrong string — e.g. a node's `title` resolving to its label). Single-property nodes usually survived.

**After:** Multi-property nodes — and edges, temporal versions, and AS-OF traversals — round-trip intact across process restarts. No mismatch warning; every property key, string value, and label reconstructs correctly.

Fixes #3490.

## Root cause

Index persistence stores raw `u32` string-interner IDs for property keys and string values. Reload assumed the process-global interner would reproduce the exact same `id == position` mapping recorded at save time. But at startup the WAL is read (`wal.read_from`) *before* the interner file is restored, and `PropertyMap::deserialize` re-interns every property key in a different order than the saved file's ID order. Re-interning the saved list at `restore_string_interner` then collided with keys already at non-matching IDs, raising `InternerMismatch`. That error was swallowed to a warning, and the graph-index restore proceeded against the polluted interner, mis-resolving persisted IDs = silent property loss/corruption.

## How it's fixed

Persisted interner IDs are now treated as a **file-local namespace** translated to live interner IDs on load:
- `restore_string_interner` returns an `InternerRemap` (file-position → live `InternedString`) instead of asserting positional identity.
- The startup path applies the remap in-place to **all** persisted interner IDs before the live-interner resolvers run: node/edge `label_idx`, property **keys**, String property **values**, temporal version labels/keys/values, `Delta.removed_keys`, anchor `full_state` maps, **and the temporal adjacency index edge-type labels** (used by AS-OF traversal).
- The **checkpoint recovery** path (`recover` / `recover_with_cold_storage`) is routed through the same remap, so it no longer silently corrupts under a non-pristine interner (it previously failed loudly; relaxing the hard error would otherwise have made it silent).
- A latent `create_checkpoint` save-order bug (interner saved before string property *values* were interned at extraction time) surfaced by the remap is also fixed — extraction now runs before the interner snapshot, mirroring `persist_graph_index`.
- The on-disk wire format is unchanged (pure load-time reinterpretation) — existing persisted files still load. The no-file / pristine paths use an identity remap, preserving prior behavior.
- Genuine corruption is still detected: an unmappable persisted ID maps to a sentinel and is counted as a per-entity load error (graph, temporal, and adjacency paths all skip+count or error loudly) rather than silently mis-resolved.

## Acceptance criteria & evidence

Issue #3490 ACs:
- **AC1 — multi-key-property nodes round-trip across process restarts with no "String interner mismatch" warning:** subprocess-isolated regression test `regression_3490_interner_remap_subprocess_helper` (`operations_tests.rs`). RED on unfixed code (property came back `"Employee"` instead of `"staff-swe"`, mismatch warning fired); GREEN after fix (all properties intact, no warning).
- **AC2 — no silent property loss for multi-property nodes:** unmappable IDs are counted as load errors, never silently mis-resolved; the regression test asserts full property reconstruction.
- **AC3 — single-key-property nodes remain unaffected:** identity-remap on the common cold-start path; existing suites pass.

Extended coverage added during review (the original fix missed these; caught by adversarial review before merge):
- **Edges** (string-valued property), **temporal** node/edge versions + **anchors** + `Delta.removed_keys`, and the **temporal adjacency** index (AS-OF edge-type traversal) all round-trip across the polluted reload. The adjacency assertion is RED-proven (without the fix: AS-OF traversal returned `[]` instead of `[EdgeId(1)]`), GREEN with it.
- **Checkpoint recovery** path covered by the remap; 217 index_persistence/checkpoint/backup/interning tests pass (0 failed).
- **Backward compatible:** wire format untouched.

## Quality gates
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `cargo test` (core::interning, storage::index_persistence, storage::checkpoint, storage::backup, regression) — 0 failed.

## Adversarial review
Reviewed from three angles (correctness, persistence/crash-safety, concurrency) plus a delta re-verification. Findings fixed in-branch: temporal adjacency labels unremapped (blocker), checkpoint path silent-corruption regression (major), test coverage gap (major), inaccurate causal comments + sentinel/invariant/doc minors.

## Known limitation / follow-up
- The **WAL** replays node/edge **label** strings by raw interner id without re-interning (`segment_reader.rs` `read_label` → `from_raw`), the same class of cross-process hazard in **non-identity** interner scenarios (multiple DB instances in one process / repeated open-close). This is **pre-existing** (WAL payload format), not a regression from this PR, and normal `AletheiaDB::open()` cold-start is unaffected (identity remap). Tracked separately in #3506 for the WAL/historical lane. Property keys/values on WAL replay are re-interned and therefore safe.

## Testing
- New RED→GREEN subprocess regression test covering nodes, edges, temporal versions/anchors/deltas, and AS-OF adjacency traversal across a fresh-process reload with a polluted interner.
- Existing interner/persistence/checkpoint/backup suites pass with an isolated target dir.