### PR TITLE
Issue #3427: record acting principal in provenance for delete/retract (WAL v11/v12 + write-path + MCP)

### DIFF
--- a/examples/recovery/basic_recovery.rs
+++ b/examples/recovery/basic_recovery.rs
@@ -152,6 +152,7 @@ fn main() -> Result<()> {
         node_id: node_id_25,
         valid_from: time::now(),
         version_id: None,
+        provenance: None,
     })?;
     println!("✓ Deleted node 25");
 

--- a/fuzz/fuzz_targets/wal_replay.rs
+++ b/fuzz/fuzz_targets/wal_replay.rs
@@ -83,6 +83,7 @@ fuzz_target!(|case: WalReplayCase| {
                             .expect("bounded fuzz node ID must be valid"),
                         valid_from: timestamp_from_step(step),
                         version_id: None,
+                        provenance: None,
                     })
                 } else {
                     None

--- a/src/api/transaction/mod.rs
+++ b/src/api/transaction/mod.rs
@@ -873,6 +873,37 @@ pub trait WriteOps: ReadOps {
         &mut self,
         node_id: NodeId,
         valid_from: Option<Timestamp>,
+    ) -> Result<()> {
+        self.delete_node_with_options(
+            node_id,
+            WriteRequestOptions {
+                valid_from,
+                provenance: None,
+            },
+        )
+    }
+
+    /// Delete a node with an optional [`WriteRequestOptions`] bundle: a
+    /// backdated deletion `valid_from` and/or a write-time [`Provenance`]
+    /// bundle recording the acting principal on the tombstone version
+    /// (Issue #3427).
+    ///
+    /// This is the most general non-cascade node-delete method; all other
+    /// `delete_node*` (non-cascade) methods delegate to it. Passing
+    /// `WriteRequestOptions::default()` is identical to
+    /// [`delete_node`](Self::delete_node) — no provenance, `valid_from`
+    /// defaults to the transaction start time.
+    ///
+    /// # Warning
+    ///
+    /// Like [`delete_node`](Self::delete_node), this does NOT delete connected
+    /// edges. Prefer [`delete_node_cascade`](Self::delete_node_cascade) /
+    /// [`delete_node_cascade_with_options`](Self::delete_node_cascade_with_options)
+    /// for referential safety.
+    fn delete_node_with_options(
+        &mut self,
+        node_id: NodeId,
+        options: WriteRequestOptions,
     ) -> Result<()>;
 
     /// Delete a node (leaves connected edges).
@@ -930,7 +961,24 @@ pub trait WriteOps: ReadOps {
     /// # Ok(())
     /// # }
     /// ```
-    fn delete_node_cascade(&mut self, node_id: NodeId) -> Result<()>;
+    fn delete_node_cascade(&mut self, node_id: NodeId) -> Result<()> {
+        self.delete_node_cascade_with_options(node_id, WriteRequestOptions::default())
+    }
+
+    /// Delete a node and all connected edges (cascade delete) with an optional
+    /// [`WriteRequestOptions`] bundle (Issue #3427).
+    ///
+    /// The same `options` (backdated `valid_from` and/or a write-time
+    /// [`Provenance`] bundle recording the acting principal) is stamped onto
+    /// the node's tombstone **and every co-deleted edge's tombstone**, so a
+    /// cascade delete attributes every tombstone it creates, not just the node.
+    /// Passing `WriteRequestOptions::default()` is identical to
+    /// [`delete_node_cascade`](Self::delete_node_cascade).
+    fn delete_node_cascade_with_options(
+        &mut self,
+        node_id: NodeId,
+        options: WriteRequestOptions,
+    ) -> Result<()>;
 
     /// Delete an edge with optional backdated valid_from time
     ///
@@ -954,6 +1002,28 @@ pub trait WriteOps: ReadOps {
         &mut self,
         edge_id: EdgeId,
         valid_from: Option<Timestamp>,
+    ) -> Result<()> {
+        self.delete_edge_with_options(
+            edge_id,
+            WriteRequestOptions {
+                valid_from,
+                provenance: None,
+            },
+        )
+    }
+
+    /// Delete an edge with an optional [`WriteRequestOptions`] bundle: a
+    /// backdated deletion `valid_from` and/or a write-time [`Provenance`]
+    /// bundle recording the acting principal on the tombstone version
+    /// (Issue #3427).
+    ///
+    /// This is the most general edge-delete method; all other `delete_edge*`
+    /// methods delegate to it. Passing `WriteRequestOptions::default()` is
+    /// identical to [`delete_edge`](Self::delete_edge).
+    fn delete_edge_with_options(
+        &mut self,
+        edge_id: EdgeId,
+        options: WriteRequestOptions,
     ) -> Result<()>;
 
     /// Delete an edge (delegates to `delete_edge_with_valid_time` with `None`).

--- a/src/api/transaction/write/apply.rs
+++ b/src/api/transaction/write/apply.rs
@@ -213,6 +213,7 @@ pub(crate) fn apply_node_delete(
     commit_timestamp: Timestamp,
     tombstone_id: VersionId,
     historical: &mut HistoricalStorage,
+    provenance: Option<Arc<Provenance>>,
 ) -> Result<()> {
     // Get the node before deleting
     let node = tx.current.get_node(node_id)?;
@@ -225,8 +226,9 @@ pub(crate) fn apply_node_delete(
     // Create tombstone interval using centralized logic
     let tombstone_temporal = create_temporal_interval(valid_from, commit_timestamp, true)?;
 
-    // Add tombstone version to historical storage
-    historical.add_node_version(
+    // Add tombstone version to historical storage, stamping the acting
+    // principal's provenance onto the tombstone (Issue #3427).
+    historical.add_node_version_with_provenance(
         node_id,
         tombstone_id,
         valid_from,
@@ -234,6 +236,7 @@ pub(crate) fn apply_node_delete(
         node.label,
         node.properties.clone(),
         true, // is_tombstone
+        provenance,
     )?;
 
     // Index the tombstone version with the same interval
@@ -256,6 +259,7 @@ pub(crate) fn apply_edge_delete(
     commit_timestamp: Timestamp,
     tombstone_id: VersionId,
     historical: &mut HistoricalStorage,
+    provenance: Option<Arc<Provenance>>,
 ) -> Result<()> {
     // Get the edge before deleting
     let edge = tx.current.get_edge(edge_id)?;
@@ -268,8 +272,9 @@ pub(crate) fn apply_edge_delete(
     // Create tombstone interval using centralized logic
     let tombstone_temporal = create_temporal_interval(valid_from, commit_timestamp, true)?;
 
-    // Add tombstone version to historical storage
-    historical.add_edge_version(
+    // Add tombstone version to historical storage, stamping the acting
+    // principal's provenance onto the tombstone (Issue #3427).
+    historical.add_edge_version_with_provenance(
         edge_id,
         tombstone_id,
         valid_from,
@@ -279,6 +284,7 @@ pub(crate) fn apply_edge_delete(
         edge.target,
         edge.properties.clone(),
         true, // is_tombstone
+        provenance,
     )?;
 
     // Index the tombstone version with the same interval
@@ -312,6 +318,7 @@ pub(crate) fn apply_node_retract(
     commit_timestamp: Timestamp,
     retraction_version_id: VersionId,
     historical: &mut HistoricalStorage,
+    provenance: Option<Arc<Provenance>>,
 ) -> Result<()> {
     // Get the node before removing it from current storage
     let node = tx.current.get_node(node_id)?;
@@ -329,8 +336,9 @@ pub(crate) fn apply_node_retract(
         historical.close_node_version_transaction_time(current_version_id, commit_timestamp)?;
     }
 
-    // (2) Append the retraction version with the closed valid interval.
-    historical.add_retracted_node_version(
+    // (2) Append the retraction version with the closed valid interval,
+    // stamping the acting principal's provenance onto it (Issue #3427).
+    historical.add_retracted_node_version_with_provenance(
         node_id,
         retraction_version_id,
         valid_from,
@@ -338,6 +346,7 @@ pub(crate) fn apply_node_retract(
         commit_timestamp,
         node.label,
         node.properties.clone(),
+        provenance,
     )?;
 
     // Index the retraction version with the same closed interval.
@@ -362,6 +371,7 @@ pub(crate) fn apply_edge_retract(
     commit_timestamp: Timestamp,
     retraction_version_id: VersionId,
     historical: &mut HistoricalStorage,
+    provenance: Option<Arc<Provenance>>,
 ) -> Result<()> {
     // Get the edge before removing it from current storage
     let edge = tx.current.get_edge(edge_id)?;
@@ -377,8 +387,9 @@ pub(crate) fn apply_edge_retract(
         historical.close_edge_version_transaction_time(current_version_id, commit_timestamp)?;
     }
 
-    // (2) Append the retraction version with the closed valid interval.
-    historical.add_retracted_edge_version(
+    // (2) Append the retraction version with the closed valid interval,
+    // stamping the acting principal's provenance onto it (Issue #3427).
+    historical.add_retracted_edge_version_with_provenance(
         edge_id,
         retraction_version_id,
         valid_from,
@@ -388,6 +399,7 @@ pub(crate) fn apply_edge_retract(
         edge.source,
         edge.target,
         edge.properties.clone(),
+        provenance,
     )?;
 
     let temporal = BiTemporalInterval::with_valid_time(valid_from, commit_timestamp)
@@ -493,6 +505,7 @@ pub(crate) fn apply_single_write(
         crate::api::transaction::BufferedWrite::DeleteNode {
             node_id,
             valid_from,
+            provenance,
         } => {
             // Use pre-generated tombstone version ID (no lock needed)
             let tombstone_version_id = VersionId::new_unchecked(tombstone_ids.next().ok_or_else(|| {
@@ -511,11 +524,13 @@ pub(crate) fn apply_single_write(
                 commit_timestamp,
                 tombstone_version_id,
                 historical,
+                provenance.clone(),
             )?;
         }
         crate::api::transaction::BufferedWrite::DeleteEdge {
             edge_id,
             valid_from,
+            provenance,
         } => {
             // Use pre-generated tombstone version ID (no lock needed)
             let tombstone_version_id = VersionId::new_unchecked(tombstone_ids.next().ok_or_else(|| {
@@ -534,9 +549,14 @@ pub(crate) fn apply_single_write(
                 commit_timestamp,
                 tombstone_version_id,
                 historical,
+                provenance.clone(),
             )?;
         }
-        crate::api::transaction::BufferedWrite::RetractNode { node_id, valid_to } => {
+        crate::api::transaction::BufferedWrite::RetractNode {
+            node_id,
+            valid_to,
+            provenance,
+        } => {
             // Retractions draw from the same pre-generated version ID pool
             // as deletes (both append exactly one closing version).
             let retraction_version_id = VersionId::new_unchecked(tombstone_ids.next().ok_or_else(|| {
@@ -555,9 +575,14 @@ pub(crate) fn apply_single_write(
                 commit_timestamp,
                 retraction_version_id,
                 historical,
+                provenance.clone(),
             )?;
         }
-        crate::api::transaction::BufferedWrite::RetractEdge { edge_id, valid_to } => {
+        crate::api::transaction::BufferedWrite::RetractEdge {
+            edge_id,
+            valid_to,
+            provenance,
+        } => {
             let retraction_version_id = VersionId::new_unchecked(tombstone_ids.next().ok_or_else(|| {
                 StorageError::InconsistentState {
                     reason: format!(
@@ -574,6 +599,7 @@ pub(crate) fn apply_single_write(
                 commit_timestamp,
                 retraction_version_id,
                 historical,
+                provenance.clone(),
             )?;
         }
     }

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -22,6 +22,7 @@ use crate::core::hlc::{
 use crate::core::id::{EdgeId, IdGenerator, NodeId, VersionId};
 use crate::core::interning::GLOBAL_INTERNER;
 use crate::core::property::{PropertyMap, PropertyMapBuilder};
+use crate::core::provenance::Provenance;
 use crate::core::temporal::{Timestamp, time};
 use crate::core::version::VersionMetadata;
 use crate::index::temporal::TemporalIndexes;
@@ -1421,10 +1422,10 @@ impl WriteOps for WriteTransaction {
         result.record_error_metric()
     }
 
-    fn delete_node_with_valid_time(
+    fn delete_node_with_options(
         &mut self,
         node_id: NodeId,
-        valid_from: Option<Timestamp>,
+        options: WriteRequestOptions,
     ) -> Result<()> {
         let result = (|| {
             // Check transaction state
@@ -1449,7 +1450,7 @@ impl WriteOps for WriteTransaction {
 
             // Get timestamp: use provided valid_from or default to transaction start time
             let timestamp = self.start_timestamp;
-            let valid_from = valid_from.unwrap_or(timestamp);
+            let valid_from = options.valid_from.unwrap_or(timestamp);
 
             // Validate valid_from is not too far in future
             validation::validate_valid_from_future(valid_from)?;
@@ -1467,10 +1468,18 @@ impl WriteOps for WriteTransaction {
                 )?;
             }
 
+            // Normalize an all-absent provenance bundle to `None` -- never
+            // persist a fabricated empty object (Issue #3224/#3427).
+            let provenance = options
+                .provenance
+                .filter(|p| !p.is_empty())
+                .map(std::sync::Arc::new);
+
             // Buffer the write
             self.buffer.add(super::BufferedWrite::DeleteNode {
                 node_id,
                 valid_from,
+                provenance,
             })?;
 
             Ok(())
@@ -1479,7 +1488,11 @@ impl WriteOps for WriteTransaction {
         result.record_error_metric()
     }
 
-    fn delete_node_cascade(&mut self, node_id: NodeId) -> Result<()> {
+    fn delete_node_cascade_with_options(
+        &mut self,
+        node_id: NodeId,
+        options: WriteRequestOptions,
+    ) -> Result<()> {
         // Check transaction state
         if self.state != TxState::Active {
             return Err(TransactionError::InvalidState {
@@ -1521,21 +1534,26 @@ impl WriteOps for WriteTransaction {
         // Delete all connected edges first to maintain referential integrity.
         // This prevents orphaned edges that reference a deleted node.
         // Performance: O(degree) where degree is the number of connected edges.
+        //
+        // Issue #3427: stamp the SAME options (backdated valid_from and/or the
+        // acting principal's provenance) onto every co-deleted edge's tombstone,
+        // not just the node — a cascade delete attributes every tombstone it
+        // creates. `options` is cloned per edge; the node takes the final move.
         for edge_id in edge_ids {
-            self.delete_edge(edge_id)?;
+            self.delete_edge_with_options(edge_id, options.clone())?;
         }
 
         // Finally, delete the node itself
         // This is safe now because all edges referencing this node have been removed
-        self.delete_node(node_id)?;
+        self.delete_node_with_options(node_id, options)?;
 
         Ok(())
     }
 
-    fn delete_edge_with_valid_time(
+    fn delete_edge_with_options(
         &mut self,
         edge_id: EdgeId,
-        valid_from: Option<Timestamp>,
+        options: WriteRequestOptions,
     ) -> Result<()> {
         let result = (|| {
             // Check transaction state
@@ -1560,7 +1578,7 @@ impl WriteOps for WriteTransaction {
 
             // Get timestamp: use provided valid_from or default to transaction start time
             let timestamp = self.start_timestamp;
-            let valid_from = valid_from.unwrap_or(timestamp);
+            let valid_from = options.valid_from.unwrap_or(timestamp);
 
             // Validate valid_from is not too far in future
             validation::validate_valid_from_future(valid_from)?;
@@ -1578,10 +1596,18 @@ impl WriteOps for WriteTransaction {
                 )?;
             }
 
+            // Normalize an all-absent provenance bundle to `None` -- never
+            // persist a fabricated empty object (Issue #3224/#3427).
+            let provenance = options
+                .provenance
+                .filter(|p| !p.is_empty())
+                .map(std::sync::Arc::new);
+
             // Buffer the write
             self.buffer.add(super::BufferedWrite::DeleteEdge {
                 edge_id,
                 valid_from,
+                provenance,
             })?;
 
             Ok(())
@@ -1637,6 +1663,27 @@ impl WriteTransaction {
         &mut self,
         node_id: NodeId,
         valid_to: Timestamp,
+    ) -> Result<super::RetractionResult> {
+        self.retract_node_with_provenance(node_id, valid_to, None)
+    }
+
+    /// Buffer a valid-time retraction of a node, stamping a write-time
+    /// [`Provenance`](crate::core::provenance::Provenance) bundle recording the
+    /// acting principal onto the retraction version (Issue #3427).
+    ///
+    /// Behaves identically to [`retract_node`](Self::retract_node) other than
+    /// persisting `provenance` on the appended retraction version. Passing
+    /// `None` is exactly [`retract_node`](Self::retract_node). An all-absent
+    /// bundle is normalized to no provenance (never a fabricated empty object).
+    /// On the idempotent no-op path (already retracted/deleted) no version is
+    /// appended, so the provenance is not recorded — matching the "no new
+    /// version, no WAL entry" contract.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn retract_node_with_provenance(
+        &mut self,
+        node_id: NodeId,
+        valid_to: Timestamp,
+        provenance: Option<Provenance>,
     ) -> Result<super::RetractionResult> {
         let result = (|| {
             // Check transaction state
@@ -1706,8 +1753,17 @@ impl WriteTransaction {
                         valid_to,
                     )?;
 
-                    self.buffer
-                        .add(super::BufferedWrite::RetractNode { node_id, valid_to })?;
+                    // Normalize an all-absent provenance bundle to `None` --
+                    // never persist a fabricated empty object (Issue #3224/#3427).
+                    let provenance = provenance
+                        .filter(|p| !p.is_empty())
+                        .map(std::sync::Arc::new);
+
+                    self.buffer.add(super::BufferedWrite::RetractNode {
+                        node_id,
+                        valid_to,
+                        provenance,
+                    })?;
 
                     Ok(super::RetractionResult {
                         valid_from,
@@ -1746,6 +1802,23 @@ impl WriteTransaction {
         &mut self,
         edge_id: EdgeId,
         valid_to: Timestamp,
+    ) -> Result<super::RetractionResult> {
+        self.retract_edge_with_provenance(edge_id, valid_to, None)
+    }
+
+    /// Buffer a valid-time retraction of an edge, stamping a write-time
+    /// [`Provenance`](crate::core::provenance::Provenance) bundle recording the
+    /// acting principal onto the retraction version (Issue #3427).
+    ///
+    /// See [`retract_node_with_provenance`](Self::retract_node_with_provenance)
+    /// for the provenance-normalization and idempotency contract, and
+    /// [`retract_edge`](Self::retract_edge) for the bi-temporal semantics.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn retract_edge_with_provenance(
+        &mut self,
+        edge_id: EdgeId,
+        valid_to: Timestamp,
+        provenance: Option<Provenance>,
     ) -> Result<super::RetractionResult> {
         let result = (|| {
             // Check transaction state
@@ -1806,8 +1879,17 @@ impl WriteTransaction {
                         valid_to,
                     )?;
 
-                    self.buffer
-                        .add(super::BufferedWrite::RetractEdge { edge_id, valid_to })?;
+                    // Normalize an all-absent provenance bundle to `None` --
+                    // never persist a fabricated empty object (Issue #3224/#3427).
+                    let provenance = provenance
+                        .filter(|p| !p.is_empty())
+                        .map(std::sync::Arc::new);
+
+                    self.buffer.add(super::BufferedWrite::RetractEdge {
+                        edge_id,
+                        valid_to,
+                        provenance,
+                    })?;
 
                     Ok(super::RetractionResult {
                         valid_from,

--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -57,6 +57,7 @@ mod tombstone_tests {
         let op = crate::api::transaction::BufferedWrite::DeleteNode {
             node_id: NodeId::new(1).unwrap(),
             valid_from: time::now(),
+            provenance: None,
         };
 
         // Try to apply it

--- a/src/api/transaction/write_buffer.rs
+++ b/src/api/transaction/write_buffer.rs
@@ -508,6 +508,10 @@ impl From<&BufferedWrite> for crate::storage::wal::WalOperation {
                 node_id: *node_id,
                 valid_from: *valid_from,
                 version_id: None,
+                // Issue #3427 Phase A: the WAL format now carries destructive-op
+                // provenance, but the live write path does not yet thread it
+                // (Phase B, gated on #3416). Emit `None` here as a compile shim.
+                provenance: None,
             },
             BufferedWrite::DeleteEdge {
                 edge_id,
@@ -516,12 +520,16 @@ impl From<&BufferedWrite> for crate::storage::wal::WalOperation {
                 edge_id: *edge_id,
                 valid_from: *valid_from,
                 version_id: None,
+                // Issue #3427 Phase A compile shim; see DeleteNode above.
+                provenance: None,
             },
             BufferedWrite::RetractNode { node_id, valid_to } => {
                 crate::storage::wal::WalOperation::RetractNode {
                     node_id: *node_id,
                     valid_to: *valid_to,
                     version_id: None,
+                    // Issue #3427 Phase A compile shim; see DeleteNode above.
+                    provenance: None,
                 }
             }
             BufferedWrite::RetractEdge { edge_id, valid_to } => {
@@ -529,6 +537,8 @@ impl From<&BufferedWrite> for crate::storage::wal::WalOperation {
                     edge_id: *edge_id,
                     valid_to: *valid_to,
                     version_id: None,
+                    // Issue #3427 Phase A compile shim; see DeleteNode above.
+                    provenance: None,
                 }
             }
         }

--- a/src/api/transaction/write_buffer.rs
+++ b/src/api/transaction/write_buffer.rs
@@ -100,6 +100,9 @@ pub enum BufferedWrite {
         node_id: NodeId,
         /// When the deletion became valid in reality (user-controlled)
         valid_from: Timestamp,
+        /// Write-time provenance bundle recording the acting principal on the
+        /// tombstone version (Issue #3427), if supplied.
+        provenance: Option<Arc<Provenance>>,
     },
     /// Delete an edge
     DeleteEdge {
@@ -107,6 +110,9 @@ pub enum BufferedWrite {
         edge_id: EdgeId,
         /// When the deletion became valid in reality (user-controlled)
         valid_from: Timestamp,
+        /// Write-time provenance bundle recording the acting principal on the
+        /// tombstone version (Issue #3427), if supplied.
+        provenance: Option<Arc<Provenance>>,
     },
     /// Retract a node: close its valid-time interval at `valid_to` without
     /// deleting its history (Issue #3230).
@@ -115,6 +121,9 @@ pub enum BufferedWrite {
         node_id: NodeId,
         /// When the fact stopped being true in reality (user-controlled)
         valid_to: Timestamp,
+        /// Write-time provenance bundle recording the acting principal on the
+        /// retraction version (Issue #3427), if supplied.
+        provenance: Option<Arc<Provenance>>,
     },
     /// Retract an edge: close its valid-time interval at `valid_to` without
     /// deleting its history (Issue #3230).
@@ -123,6 +132,9 @@ pub enum BufferedWrite {
         edge_id: EdgeId,
         /// When the relationship stopped being true in reality (user-controlled)
         valid_to: Timestamp,
+        /// Write-time provenance bundle recording the acting principal on the
+        /// retraction version (Issue #3427), if supplied.
+        provenance: Option<Arc<Provenance>>,
     },
 }
 
@@ -500,47 +512,53 @@ impl From<&BufferedWrite> for crate::storage::wal::WalOperation {
             // The tombstone/retraction `version_id` (Issue #3406) is not known
             // at the buffer level — it is pre-generated at commit time and
             // stamped onto the WAL op by `log_operations_to_wal`. This blanket
-            // conversion therefore emits `None`; see that function.
+            // conversion therefore emits `None` for it; see that function.
+            //
+            // Issue #3427 Phase B: the caller-supplied destructive-op
+            // provenance (acting principal) IS known at the buffer level, so we
+            // thread it into the WAL op here, converting `Arc<Provenance>` to the
+            // owned `Provenance` the WAL payload carries — exactly as the
+            // create/update arms above do.
             BufferedWrite::DeleteNode {
                 node_id,
                 valid_from,
+                provenance,
             } => crate::storage::wal::WalOperation::DeleteNode {
                 node_id: *node_id,
                 valid_from: *valid_from,
                 version_id: None,
-                // Issue #3427 Phase A: the WAL format now carries destructive-op
-                // provenance, but the live write path does not yet thread it
-                // (Phase B, gated on #3416). Emit `None` here as a compile shim.
-                provenance: None,
+                provenance: provenance.as_deref().cloned(),
             },
             BufferedWrite::DeleteEdge {
                 edge_id,
                 valid_from,
+                provenance,
             } => crate::storage::wal::WalOperation::DeleteEdge {
                 edge_id: *edge_id,
                 valid_from: *valid_from,
                 version_id: None,
-                // Issue #3427 Phase A compile shim; see DeleteNode above.
-                provenance: None,
+                provenance: provenance.as_deref().cloned(),
             },
-            BufferedWrite::RetractNode { node_id, valid_to } => {
-                crate::storage::wal::WalOperation::RetractNode {
-                    node_id: *node_id,
-                    valid_to: *valid_to,
-                    version_id: None,
-                    // Issue #3427 Phase A compile shim; see DeleteNode above.
-                    provenance: None,
-                }
-            }
-            BufferedWrite::RetractEdge { edge_id, valid_to } => {
-                crate::storage::wal::WalOperation::RetractEdge {
-                    edge_id: *edge_id,
-                    valid_to: *valid_to,
-                    version_id: None,
-                    // Issue #3427 Phase A compile shim; see DeleteNode above.
-                    provenance: None,
-                }
-            }
+            BufferedWrite::RetractNode {
+                node_id,
+                valid_to,
+                provenance,
+            } => crate::storage::wal::WalOperation::RetractNode {
+                node_id: *node_id,
+                valid_to: *valid_to,
+                version_id: None,
+                provenance: provenance.as_deref().cloned(),
+            },
+            BufferedWrite::RetractEdge {
+                edge_id,
+                valid_to,
+                provenance,
+            } => crate::storage::wal::WalOperation::RetractEdge {
+                edge_id: *edge_id,
+                valid_to: *valid_to,
+                version_id: None,
+                provenance: provenance.as_deref().cloned(),
+            },
         }
     }
 }
@@ -1171,6 +1189,7 @@ mod tests {
             .add(BufferedWrite::DeleteEdge {
                 edge_id,
                 valid_from: crate::core::temporal::time::now(),
+                provenance: None,
             })
             .unwrap();
 
@@ -1374,6 +1393,7 @@ mod tests {
             .add(BufferedWrite::DeleteEdge {
                 edge_id: edge_id_1,
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -318,6 +318,50 @@ impl AletheiaDB {
         self.write(|tx| tx.delete_edge_with_valid_time(edge_id, valid_from))
     }
 
+    /// Delete a node with an optional
+    /// [`WriteRequestOptions`](crate::api::transaction::WriteRequestOptions)
+    /// bundle: a backdated deletion `valid_from` and/or a write-time
+    /// [`Provenance`] bundle recording the acting principal on the tombstone
+    /// version (Issue #3427). Does NOT delete connected edges — see
+    /// [`delete_node_cascade_with_options`](Self::delete_node_cascade_with_options).
+    ///
+    /// Passing `WriteRequestOptions::default()` is identical to
+    /// [`delete_node`](crate::api::transaction::WriteOps::delete_node).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn delete_node_with_options(
+        &self,
+        node_id: NodeId,
+        options: crate::api::transaction::WriteRequestOptions,
+    ) -> Result<()> {
+        self.write(|tx| tx.delete_node_with_options(node_id, options))
+    }
+
+    /// Delete an edge with an optional
+    /// [`WriteRequestOptions`](crate::api::transaction::WriteRequestOptions)
+    /// bundle. See [`delete_node_with_options`](Self::delete_node_with_options).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn delete_edge_with_options(
+        &self,
+        edge_id: EdgeId,
+        options: crate::api::transaction::WriteRequestOptions,
+    ) -> Result<()> {
+        self.write(|tx| tx.delete_edge_with_options(edge_id, options))
+    }
+
+    /// Delete a node and all connected edges (cascade) with an optional
+    /// [`WriteRequestOptions`](crate::api::transaction::WriteRequestOptions)
+    /// bundle. The same options (backdated `valid_from` and/or the acting
+    /// principal's provenance) are stamped onto the node's tombstone AND every
+    /// co-deleted edge's tombstone (Issue #3427).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn delete_node_cascade_with_options(
+        &self,
+        node_id: NodeId,
+        options: crate::api::transaction::WriteRequestOptions,
+    ) -> Result<()> {
+        self.write(|tx| tx.delete_node_cascade_with_options(node_id, options))
+    }
+
     /// Retract a node as of valid time `valid_to` (Issue #3230): close its
     /// valid-time interval at `valid_to` without deleting its history.
     ///
@@ -368,6 +412,24 @@ impl AletheiaDB {
         node_id: NodeId,
         valid_to: Timestamp,
     ) -> Result<crate::api::transaction::RetractionResult> {
+        self.retract_node_with_provenance(node_id, valid_to, None)
+    }
+
+    /// Retract a node (Issue #3230), stamping a write-time [`Provenance`]
+    /// bundle recording the acting principal onto the retraction version
+    /// (Issue #3427).
+    ///
+    /// Behaves identically to [`retract_node`](Self::retract_node) — including
+    /// the #3209 connected-edge refusal contract — other than persisting
+    /// `provenance` on the appended retraction version. Passing `None` is
+    /// exactly [`retract_node`](Self::retract_node).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn retract_node_with_provenance(
+        &self,
+        node_id: NodeId,
+        valid_to: Timestamp,
+        provenance: Option<crate::core::provenance::Provenance>,
+    ) -> Result<crate::api::transaction::RetractionResult> {
         // The connected-edge check and the retraction run inside a single
         // write transaction so they observe the same storage state — no
         // check-then-act gap for a concurrent writer to slip an edge into
@@ -398,7 +460,7 @@ impl AletheiaDB {
                     .into());
                 }
             }
-            tx.retract_node(node_id, valid_to)
+            tx.retract_node_with_provenance(node_id, valid_to, provenance.clone())
         })
     }
 
@@ -424,6 +486,25 @@ impl AletheiaDB {
         node_id: NodeId,
         valid_to: Timestamp,
     ) -> Result<crate::api::transaction::RetractionResult> {
+        self.retract_node_detach_with_provenance(node_id, valid_to, None)
+    }
+
+    /// Retract a node and co-retract every connected edge at the same
+    /// `valid_to` (Issue #3230), stamping a write-time [`Provenance`] bundle
+    /// recording the acting principal onto the node's retraction version AND
+    /// every co-retracted edge's retraction version (Issue #3427).
+    ///
+    /// Behaves identically to
+    /// [`retract_node_detach`](Self::retract_node_detach) other than persisting
+    /// `provenance`. Passing `None` is exactly
+    /// [`retract_node_detach`](Self::retract_node_detach).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn retract_node_detach_with_provenance(
+        &self,
+        node_id: NodeId,
+        valid_to: Timestamp,
+        provenance: Option<crate::core::provenance::Provenance>,
+    ) -> Result<crate::api::transaction::RetractionResult> {
         self.write(|tx| {
             use crate::api::transaction::ReadOps;
             // Enumerate connected edges INSIDE the write transaction (same
@@ -441,13 +522,17 @@ impl AletheiaDB {
 
             let mut edges_retracted = 0;
             for edge_id in edge_ids {
-                let edge_result = tx.retract_edge(edge_id, valid_to)?;
+                // Issue #3427: co-retracted edges carry the SAME acting
+                // principal as the node retraction.
+                let edge_result =
+                    tx.retract_edge_with_provenance(edge_id, valid_to, provenance.clone())?;
                 if !edge_result.already_retracted {
                     edges_retracted += 1;
                 }
             }
 
-            let mut result = tx.retract_node(node_id, valid_to)?;
+            let mut result =
+                tx.retract_node_with_provenance(node_id, valid_to, provenance.clone())?;
             result.edges_retracted = edges_retracted;
             Ok(result)
         })
@@ -469,7 +554,24 @@ impl AletheiaDB {
         edge_id: EdgeId,
         valid_to: Timestamp,
     ) -> Result<crate::api::transaction::RetractionResult> {
-        self.write(|tx| tx.retract_edge(edge_id, valid_to))
+        self.retract_edge_with_provenance(edge_id, valid_to, None)
+    }
+
+    /// Retract an edge (Issue #3230), stamping a write-time [`Provenance`]
+    /// bundle recording the acting principal onto the retraction version
+    /// (Issue #3427).
+    ///
+    /// Behaves identically to [`retract_edge`](Self::retract_edge) other than
+    /// persisting `provenance`. Passing `None` is exactly
+    /// [`retract_edge`](Self::retract_edge).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn retract_edge_with_provenance(
+        &self,
+        edge_id: EdgeId,
+        valid_to: Timestamp,
+        provenance: Option<crate::core::provenance::Provenance>,
+    ) -> Result<crate::api::transaction::RetractionResult> {
+        self.write(|tx| tx.retract_edge_with_provenance(edge_id, valid_to, provenance.clone()))
     }
 
     /// Create a node with an optional [`WriteRequestOptions`](crate::api::transaction::WriteRequestOptions)

--- a/src/fuzzing.rs
+++ b/src/fuzzing.rs
@@ -158,21 +158,25 @@ mod tests {
                 node_id: NodeId::new(1).unwrap(),
                 valid_from: now,
                 version_id: Some(VersionId::new(6).unwrap()),
+                provenance: None,
             },
             WalOperation::DeleteEdge {
                 edge_id: EdgeId::new(2).unwrap(),
                 valid_from: now,
                 version_id: Some(VersionId::new(7).unwrap()),
+                provenance: None,
             },
             WalOperation::RetractNode {
                 node_id: NodeId::new(1).unwrap(),
                 valid_to: now,
                 version_id: Some(VersionId::new(8).unwrap()),
+                provenance: None,
             },
             WalOperation::RetractEdge {
                 edge_id: EdgeId::new(2).unwrap(),
                 valid_to: now,
                 version_id: Some(VersionId::new(9).unwrap()),
+                provenance: None,
             },
             // Transaction-framing markers (#3413).
             WalOperation::BeginTx { tx_id: 42 },
@@ -221,6 +225,7 @@ mod tests {
                 node_id: NodeId::new(1).unwrap(),
                 valid_to: time::now(),
                 version_id: Some(VersionId::new(1).unwrap()),
+                provenance: None,
             },
         );
         let canonical = serialize_entry(&entry).expect("retract entry must serialize");

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -579,6 +579,7 @@ async fn handle_bulk_delete_nodes(
     db: Arc<crate::AletheiaDB>,
     node_ids: Vec<u64>,
     cascade: bool,
+    principal: Option<String>,
 ) -> Result<Value, AletheiaHttpError> {
     validate_bulk_size(&node_ids, "node_ids")?;
     blocking(move || {
@@ -587,9 +588,12 @@ async fn handle_bulk_delete_nodes(
                 for node_id in &node_ids {
                     let nid = NodeId::new(*node_id)?;
                     if cascade {
-                        tx.delete_node_cascade(nid)?;
+                        tx.delete_node_cascade_with_options(
+                            nid,
+                            write_options_for(principal.as_deref()),
+                        )?;
                     } else {
-                        tx.delete_node(nid)?;
+                        tx.delete_node_with_options(nid, write_options_for(principal.as_deref()))?;
                     }
                 }
                 Ok::<_, crate::core::error::Error>(node_ids.len())
@@ -913,7 +917,7 @@ pub async fn handle_query(
                     handle_bulk_update_nodes(db, updates, principal).await
                 }
                 QueryRequest::BulkDeleteNodes { node_ids, cascade } => {
-                    handle_bulk_delete_nodes(db, node_ids, cascade).await
+                    handle_bulk_delete_nodes(db, node_ids, cascade, principal).await
                 }
                 QueryRequest::FindNode {
                     label,

--- a/src/mcp/auth_tests.rs
+++ b/src/mcp/auth_tests.rs
@@ -772,6 +772,240 @@ fn authenticated_apply_batch_stamps_principal_on_creates_and_updates() {
 }
 
 // ============================================================================
+// 5b. Destructive-op principal stamping (Issue #3427, Phase C route-through)
+//
+// The four destructive tools (delete_node, delete_edge, retract_node,
+// retract_edge) stamp the AUTHENTICATED SESSION principal onto the
+// tombstone / retraction version's provenance -- server-derived and
+// unforgeable, matching the create/update convention. A deleted/retracted
+// node is gone from current state, so the principal is asserted end-to-end
+// through the read path (get_node_history / get_edge_history), on the last
+// (tombstone/retraction) version.
+// ============================================================================
+
+/// The last version in a node history response (the tombstone / retraction
+/// version for a destructive op).
+fn last_node_version(server: &AletheiaMcpServer, node_id: u64) -> serde_json::Value {
+    let (history, is_error) = dispatch(server, "get_node_history", json!({ "node_id": node_id }));
+    assert!(!is_error, "get_node_history must succeed: {history}");
+    let versions = history["versions"].as_array().expect("history versions");
+    versions.last().expect("at least one version").clone()
+}
+
+/// The last version in an edge history response.
+fn last_edge_version(server: &AletheiaMcpServer, edge_id: u64) -> serde_json::Value {
+    let (history, is_error) = dispatch(server, "get_edge_history", json!({ "edge_id": edge_id }));
+    assert!(!is_error, "get_edge_history must succeed: {history}");
+    let versions = history["versions"].as_array().expect("history versions");
+    versions.last().expect("at least one version").clone()
+}
+
+/// Authenticated `delete_node` stamps the session principal onto the
+/// tombstone version's provenance.
+#[test]
+fn authenticated_delete_node_stamps_principal() {
+    let (server, _store, _id) = server_with_role(Role::Writer);
+    let (created, _) = dispatch(&server, "create_node", json!({"label": "Doc"}));
+    let node_id = created["id"].as_u64().expect("node id");
+
+    let (deleted, is_error) = dispatch(&server, "delete_node", json!({"node_id": node_id}));
+    assert!(!is_error, "delete_node must succeed: {deleted}");
+
+    let tombstone = last_node_version(&server, node_id);
+    assert_eq!(
+        tombstone["provenance"]["principal"],
+        json!("test-writer"),
+        "delete tombstone must carry the session principal: {tombstone}"
+    );
+}
+
+/// Authenticated `delete_edge` stamps the session principal onto the
+/// tombstone version's provenance.
+#[test]
+fn authenticated_delete_edge_stamps_principal() {
+    let (server, _store, _id) = server_with_role(Role::Writer);
+    let (a, _) = dispatch(&server, "create_node", json!({"label": "Person"}));
+    let (b, _) = dispatch(&server, "create_node", json!({"label": "Person"}));
+    let (edge, _) = dispatch(
+        &server,
+        "create_edge",
+        json!({"source_id": a["id"], "target_id": b["id"], "label": "KNOWS"}),
+    );
+    let edge_id = edge["id"].as_u64().expect("edge id");
+
+    let (deleted, is_error) = dispatch(&server, "delete_edge", json!({"edge_id": edge_id}));
+    assert!(!is_error, "delete_edge must succeed: {deleted}");
+
+    let tombstone = last_edge_version(&server, edge_id);
+    assert_eq!(
+        tombstone["provenance"]["principal"],
+        json!("test-writer"),
+        "delete-edge tombstone must carry the session principal: {tombstone}"
+    );
+}
+
+/// Authenticated `retract_node` stamps the session principal onto the
+/// retraction version's provenance.
+#[test]
+fn authenticated_retract_node_stamps_principal() {
+    let (server, _store, _id) = server_with_role(Role::Writer);
+    let (created, _) = dispatch(&server, "create_node", json!({"label": "Doc"}));
+    let node_id = created["id"].as_u64().expect("node id");
+
+    let (retracted, is_error) = dispatch(&server, "retract_node", json!({"node_id": node_id}));
+    assert!(!is_error, "retract_node must succeed: {retracted}");
+
+    let retraction = last_node_version(&server, node_id);
+    assert_eq!(
+        retraction["provenance"]["principal"],
+        json!("test-writer"),
+        "retraction version must carry the session principal: {retraction}"
+    );
+}
+
+/// Authenticated `retract_edge` stamps the session principal onto the
+/// retraction version's provenance.
+#[test]
+fn authenticated_retract_edge_stamps_principal() {
+    let (server, _store, _id) = server_with_role(Role::Writer);
+    let (a, _) = dispatch(&server, "create_node", json!({"label": "Person"}));
+    let (b, _) = dispatch(&server, "create_node", json!({"label": "Person"}));
+    let (edge, _) = dispatch(
+        &server,
+        "create_edge",
+        json!({"source_id": a["id"], "target_id": b["id"], "label": "KNOWS"}),
+    );
+    let edge_id = edge["id"].as_u64().expect("edge id");
+
+    let (retracted, is_error) = dispatch(&server, "retract_edge", json!({"edge_id": edge_id}));
+    assert!(!is_error, "retract_edge must succeed: {retracted}");
+
+    let retraction = last_edge_version(&server, edge_id);
+    assert_eq!(
+        retraction["provenance"]["principal"],
+        json!("test-writer"),
+        "edge retraction version must carry the session principal: {retraction}"
+    );
+}
+
+/// A detach (cascade) `delete_node` attributes EVERY tombstone it creates --
+/// the node AND every co-deleted edge -- with the session principal.
+#[test]
+fn authenticated_detach_delete_stamps_principal_on_co_deleted_edges() {
+    let (server, _store, _id) = server_with_role(Role::Writer);
+    let (a, _) = dispatch(&server, "create_node", json!({"label": "Person"}));
+    let (b, _) = dispatch(&server, "create_node", json!({"label": "Person"}));
+    let a_id = a["id"].as_u64().expect("a id");
+    let (edge, _) = dispatch(
+        &server,
+        "create_edge",
+        json!({"source_id": a["id"], "target_id": b["id"], "label": "KNOWS"}),
+    );
+    let edge_id = edge["id"].as_u64().expect("edge id");
+
+    let (deleted, is_error) = dispatch(
+        &server,
+        "delete_node",
+        json!({"node_id": a_id, "detach": true}),
+    );
+    assert!(!is_error, "detach delete_node must succeed: {deleted}");
+    assert_eq!(deleted["edges_removed"], json!(1), "{deleted}");
+
+    // The node's tombstone carries the principal.
+    let node_tombstone = last_node_version(&server, a_id);
+    assert_eq!(
+        node_tombstone["provenance"]["principal"],
+        json!("test-writer"),
+        "node tombstone must carry the principal: {node_tombstone}"
+    );
+    // AND the co-deleted edge's tombstone carries the SAME principal.
+    let edge_tombstone = last_edge_version(&server, edge_id);
+    assert_eq!(
+        edge_tombstone["provenance"]["principal"],
+        json!("test-writer"),
+        "co-deleted edge tombstone must carry the principal: {edge_tombstone}"
+    );
+}
+
+/// Anonymous-mode destructive ops record NO principal: the tombstone /
+/// retraction version's provenance carries no principal field.
+#[test]
+fn anonymous_destructive_ops_record_no_principal() {
+    let server = AletheiaMcpServer::new(db());
+
+    // delete_node
+    let (n, _) = dispatch(&server, "create_node", json!({"label": "Doc"}));
+    let nid = n["id"].as_u64().expect("node id");
+    let (_, is_error) = dispatch(&server, "delete_node", json!({"node_id": nid}));
+    assert!(!is_error);
+    let tombstone = last_node_version(&server, nid);
+    assert!(
+        tombstone
+            .get("provenance")
+            .and_then(|p| p.get("principal"))
+            .is_none(),
+        "anonymous delete must not record a principal: {tombstone}"
+    );
+
+    // retract_edge
+    let (a, _) = dispatch(&server, "create_node", json!({"label": "Person"}));
+    let (b, _) = dispatch(&server, "create_node", json!({"label": "Person"}));
+    let (edge, _) = dispatch(
+        &server,
+        "create_edge",
+        json!({"source_id": a["id"], "target_id": b["id"], "label": "KNOWS"}),
+    );
+    let eid = edge["id"].as_u64().expect("edge id");
+    let (_, is_error) = dispatch(&server, "retract_edge", json!({"edge_id": eid}));
+    assert!(!is_error);
+    let retraction = last_edge_version(&server, eid);
+    assert!(
+        retraction
+            .get("provenance")
+            .and_then(|p| p.get("principal"))
+            .is_none(),
+        "anonymous retract must not record a principal: {retraction}"
+    );
+}
+
+/// A caller attempting to smuggle a `provenance` / `principal` field into a
+/// destructive-op request must NOT have it honored: these tools take no
+/// caller provenance (serde ignores the unknown field), and the recorded
+/// principal is always the verified SESSION principal, never the forged
+/// value. Unforgeability holds regardless of what the request JSON contains.
+#[test]
+fn forged_principal_on_destructive_op_is_ignored() {
+    let (server, _store, _id) = server_with_role(Role::Writer);
+    let (created, _) = dispatch(&server, "create_node", json!({"label": "Doc"}));
+    let node_id = created["id"].as_u64().expect("node id");
+
+    // Inject bogus provenance/principal fields the tool schema does not accept.
+    let (deleted, is_error) = dispatch(
+        &server,
+        "delete_node",
+        json!({
+            "node_id": node_id,
+            "provenance": {"source": "forged", "principal": "forged-admin"},
+            "principal": "forged-admin"
+        }),
+    );
+    assert!(!is_error, "delete_node must still succeed: {deleted}");
+
+    let tombstone = last_node_version(&server, node_id);
+    assert_eq!(
+        tombstone["provenance"]["principal"],
+        json!("test-writer"),
+        "principal must be the verified session's, never the forged value: {tombstone}"
+    );
+    // The forged `source` must not have been honored either (these tools
+    // carry no caller provenance at all).
+    assert!(
+        tombstone["provenance"].get("source").is_none(),
+        "destructive tools accept no caller provenance source: {tombstone}"
+    );
+}
+
+// ============================================================================
 // AccessClass sanity: the classification only uses classes the role matrix
 // covers (guards against a future class being added without matrix review).
 // ============================================================================

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2047,6 +2047,24 @@ impl AletheiaMcpServer {
             );
         }
 
+        // Issue #3427: stamp the authenticated session principal onto the
+        // tombstone version's provenance. These destructive tools take NO
+        // caller-supplied provenance (pass `None`), so the bundle is
+        // principal-only and unforgeable from request fields — the principal
+        // is server-derived by `parse_opt_provenance`, never read from the
+        // request JSON. Anonymous sessions yield `None` (no principal field).
+        let provenance = match self.parse_opt_provenance(None) {
+            Ok(p) => p,
+            Err(result) => return result,
+        };
+        let mut options = crate::api::transaction::WriteRequestOptions::new();
+        if let Some(valid_from) = valid_from {
+            options = options.with_valid_from(valid_from);
+        }
+        if let Some(provenance) = provenance {
+            options = options.with_provenance(provenance);
+        }
+
         // Perform the connected-edge check and the deletion inside a single write
         // transaction so they observe the same storage state. Splitting the count
         // into a separate transaction (or doing it before opening one) leaves a
@@ -2072,14 +2090,18 @@ impl AletheiaMcpServer {
 
             if detach {
                 // Cascade-equivalent delete: remove the node and all connected
-                // edges, reporting exactly how many edges were removed.
-                tx.delete_node_cascade(node_id)?;
+                // edges, reporting exactly how many edges were removed. The
+                // options (principal provenance) stamp every co-deleted edge
+                // tombstone too, not just the node (Issue #3427).
+                tx.delete_node_cascade_with_options(node_id, options.clone())?;
                 Ok(Outcome::Deleted {
                     edges_removed: connected_edges,
                 })
             } else {
                 // No connected edges: a plain delete cannot orphan anything.
-                tx.delete_node_with_valid_time(node_id, valid_from)?;
+                // `options` carries the backdated valid_from (if any) and the
+                // acting principal's provenance (Issue #3427).
+                tx.delete_node_with_options(node_id, options.clone())?;
                 Ok(Outcome::Deleted { edges_removed: 0 })
             }
         });
@@ -2144,6 +2166,14 @@ impl AletheiaMcpServer {
             Err(result) => return result,
         };
 
+        // Issue #3427: principal-only, unforgeable provenance (see
+        // handle_delete_node) stamped onto the retraction version — and onto
+        // every co-retracted edge in the detach branch below.
+        let provenance = match self.parse_opt_provenance(None) {
+            Ok(p) => p,
+            Err(result) => return result,
+        };
+
         // Perform the connected-edge check and the retraction inside a single
         // write transaction so they observe the same storage state — no
         // check-then-act gap for a concurrent writer to slip an edge into
@@ -2181,22 +2211,30 @@ impl AletheiaMcpServer {
                 }
 
                 if detach && connected_edges > 0 {
-                    // Co-retract every connected edge at the same valid time.
+                    // Co-retract every connected edge at the same valid time,
+                    // stamping the SAME acting principal onto each edge's
+                    // retraction version as the node's (Issue #3427).
                     let mut edges_retracted = 0;
                     for edge_id in edge_ids {
-                        let edge_result = tx.retract_edge(edge_id, valid_to)?;
+                        let edge_result =
+                            tx.retract_edge_with_provenance(edge_id, valid_to, provenance.clone())?;
                         if !edge_result.already_retracted {
                             edges_retracted += 1;
                         }
                     }
 
-                    let mut result = tx.retract_node(node_id, valid_to)?;
+                    let mut result =
+                        tx.retract_node_with_provenance(node_id, valid_to, provenance.clone())?;
                     result.edges_retracted = edges_retracted;
                     return Ok(Outcome::Retracted(result));
                 }
             }
 
-            Ok(Outcome::Retracted(tx.retract_node(node_id, valid_to)?))
+            Ok(Outcome::Retracted(tx.retract_node_with_provenance(
+                node_id,
+                valid_to,
+                provenance.clone(),
+            )?))
         });
 
         let outcome = match outcome {
@@ -2261,7 +2299,17 @@ impl AletheiaMcpServer {
             Err(result) => return result,
         };
 
-        match self.db.retract_edge(edge_id, valid_to) {
+        // Issue #3427: principal-only, unforgeable provenance (see
+        // handle_delete_node) stamped onto the retraction version.
+        let provenance = match self.parse_opt_provenance(None) {
+            Ok(p) => p,
+            Err(result) => return result,
+        };
+
+        match self
+            .db
+            .retract_edge_with_provenance(edge_id, valid_to, provenance)
+        {
             Ok(result) => self.success_json(json!({
                 "success": true,
                 "edge_id": req.edge_id,
@@ -2289,7 +2337,22 @@ impl AletheiaMcpServer {
             Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
-        match self.db.write(|tx| tx.delete_node_cascade(node_id)) {
+        // Issue #3427: principal-only, unforgeable provenance (see
+        // handle_delete_node) stamped onto the node's tombstone AND every
+        // co-deleted edge's tombstone.
+        let provenance = match self.parse_opt_provenance(None) {
+            Ok(p) => p,
+            Err(result) => return result,
+        };
+        let mut options = crate::api::transaction::WriteRequestOptions::new();
+        if let Some(provenance) = provenance {
+            options = options.with_provenance(provenance);
+        }
+
+        match self
+            .db
+            .write(|tx| tx.delete_node_cascade_with_options(node_id, options.clone()))
+        {
             Ok(()) => self.success_json(json!({
                 "success": true,
                 "deleted_node_id": req.node_id,
@@ -2764,9 +2827,23 @@ impl AletheiaMcpServer {
             Err(result) => return result,
         };
 
+        // Issue #3427: principal-only, unforgeable provenance (see
+        // handle_delete_node) stamped onto the tombstone version.
+        let provenance = match self.parse_opt_provenance(None) {
+            Ok(p) => p,
+            Err(result) => return result,
+        };
+        let mut options = crate::api::transaction::WriteRequestOptions::new();
+        if let Some(valid_from) = valid_from {
+            options = options.with_valid_from(valid_from);
+        }
+        if let Some(provenance) = provenance {
+            options = options.with_provenance(provenance);
+        }
+
         match self
             .db
-            .write(|tx| tx.delete_edge_with_valid_time(edge_id, valid_from))
+            .write(|tx| tx.delete_edge_with_options(edge_id, options.clone()))
         {
             Ok(()) => self.success_json(json!({
                 "success": true,

--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -2014,6 +2014,7 @@ mod tests {
             node_id,
             valid_from: time::now(),
             version_id: None,
+            provenance: None,
         })?;
         wal.flush()?;
 
@@ -2073,6 +2074,7 @@ mod tests {
             edge_id,
             valid_from: time::now(),
             version_id: None,
+            provenance: None,
         })?;
         wal.flush()?;
 

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -604,9 +604,35 @@ impl HistoricalStorage {
         label: InternedString,
         properties: PropertyMap,
     ) -> Result<()> {
+        self.add_retracted_node_version_with_provenance(
+            node_id, version_id, valid_from, valid_to, tx_time, label, properties, None,
+        )
+    }
+
+    /// Add a *retraction* version of a node (Issue #3230), optionally attaching a
+    /// write-time [`Provenance`](crate::core::provenance::Provenance) bundle
+    /// recording the acting principal (Issue #3427).
+    ///
+    /// Behaves identically to
+    /// [`add_retracted_node_version`](Self::add_retracted_node_version) other
+    /// than persisting `provenance` on the created retraction version.
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_retracted_node_version_with_provenance(
+        &mut self,
+        node_id: NodeId,
+        version_id: VersionId,
+        valid_from: Timestamp,
+        valid_to: Timestamp,
+        tx_time: Timestamp,
+        label: InternedString,
+        properties: PropertyMap,
+        provenance: Option<Arc<Provenance>>,
+    ) -> Result<()> {
         let temporal =
             BiTemporalInterval::with_valid_time(valid_from, tx_time).close_valid_time(valid_to)?;
-        self.add_node_version_with_interval(node_id, version_id, temporal, label, properties, None)
+        self.add_node_version_with_interval(
+            node_id, version_id, temporal, label, properties, provenance,
+        )
     }
 
     /// Shared implementation for appending a node version with a fully
@@ -886,12 +912,36 @@ impl HistoricalStorage {
         target: NodeId,
         properties: PropertyMap,
     ) -> Result<()> {
+        self.add_retracted_edge_version_with_provenance(
+            edge_id, version_id, valid_from, valid_to, tx_time, label, source, target, properties,
+            None,
+        )
+    }
+
+    /// Add a *retraction* version of an edge (Issue #3230), optionally attaching a
+    /// write-time [`Provenance`](crate::core::provenance::Provenance) bundle
+    /// recording the acting principal (Issue #3427). See
+    /// [`add_retracted_node_version_with_provenance`](Self::add_retracted_node_version_with_provenance).
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_retracted_edge_version_with_provenance(
+        &mut self,
+        edge_id: EdgeId,
+        version_id: VersionId,
+        valid_from: Timestamp,
+        valid_to: Timestamp,
+        tx_time: Timestamp,
+        label: InternedString,
+        source: NodeId,
+        target: NodeId,
+        properties: PropertyMap,
+        provenance: Option<Arc<Provenance>>,
+    ) -> Result<()> {
         let temporal =
             BiTemporalInterval::with_valid_time(valid_from, tx_time).close_valid_time(valid_to)?;
         self.add_edge_version_with_interval(
             edge_id, version_id, temporal, label, source, target, properties,
             false, // not a tombstone: the closed interval must stay traversable pre-valid_to
-            None,
+            provenance,
         )
     }
 

--- a/src/storage/recovery.rs
+++ b/src/storage/recovery.rs
@@ -520,6 +520,7 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                 node_id,
                 valid_from,
                 version_id: logged_tombstone_id,
+                provenance,
             } => {
                 // Idempotent re-application guard, per store (review round 2,
                 // #3428). Background persistence may snapshot current and
@@ -596,7 +597,7 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                     // `apply_node_delete` — while tx_time comes from the WAL
                     // entry. The is_tombstone=true flag closes the valid_time
                     // immediately at valid_from (empty interval).
-                    historical.add_node_version(
+                    historical.add_node_version_with_provenance(
                         node_id,
                         tombstone_version_id,
                         valid_from,
@@ -604,6 +605,10 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                         label,
                         properties,
                         true, // is_tombstone
+                        // Issue #3427: thread the acting-principal provenance
+                        // logged with the delete so recovery reproduces the
+                        // attribution instead of dropping it.
+                        provenance.map(std::sync::Arc::new),
                     )?;
                 }
 
@@ -615,6 +620,7 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                 edge_id,
                 valid_from,
                 version_id: logged_tombstone_id,
+                provenance,
             } => {
                 // Per-store re-application guard — see the DeleteNode arm
                 // above (review round 2, #3428).
@@ -681,7 +687,7 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                     // `apply_edge_delete` — while tx_time comes from the WAL
                     // entry. The is_tombstone=true flag closes the valid_time
                     // immediately at valid_from (empty interval).
-                    historical.add_edge_version(
+                    historical.add_edge_version_with_provenance(
                         edge_id,
                         tombstone_version_id,
                         valid_from,
@@ -691,6 +697,8 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                         target,
                         properties,
                         true, // is_tombstone
+                        // Issue #3427: thread the acting-principal provenance.
+                        provenance.map(std::sync::Arc::new),
                     )?;
                 }
 
@@ -702,6 +710,7 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                 node_id,
                 valid_to,
                 version_id: logged_retraction_id,
+                provenance,
             } => {
                 // Valid-time retraction (Issue #3230). Reconstruct exactly what
                 // the original commit did:
@@ -783,7 +792,7 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                     };
                     next_version_id = next_version_id.max(retraction_version_id.as_u64() + 1);
 
-                    historical.add_retracted_node_version(
+                    historical.add_retracted_node_version_with_provenance(
                         node_id,
                         retraction_version_id,
                         valid_from,
@@ -791,6 +800,8 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                         commit_timestamp,
                         label,
                         properties,
+                        // Issue #3427: thread the acting-principal provenance.
+                        provenance.map(std::sync::Arc::new),
                     )?;
                 }
 
@@ -802,6 +813,7 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                 edge_id,
                 valid_to,
                 version_id: logged_retraction_id,
+                provenance,
             } => {
                 // Valid-time retraction of an edge (Issue #3230); mirrors the
                 // RetractNode arm above, honoring the logged `valid_to`, with
@@ -870,7 +882,7 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                     };
                     next_version_id = next_version_id.max(retraction_version_id.as_u64() + 1);
 
-                    historical.add_retracted_edge_version(
+                    historical.add_retracted_edge_version_with_provenance(
                         edge_id,
                         retraction_version_id,
                         valid_from,
@@ -880,6 +892,8 @@ pub(crate) fn replay_entries_into_storage_with_constraints(
                         source,
                         target,
                         properties,
+                        // Issue #3427: thread the acting-principal provenance.
+                        provenance.map(std::sync::Arc::new),
                     )?;
                 }
 
@@ -1540,6 +1554,7 @@ mod tests {
             node_id,
             valid_to,
             version_id: None,
+            provenance: None,
         })
         .unwrap();
         wal.flush().unwrap();
@@ -1630,6 +1645,196 @@ mod tests {
         );
     }
 
+    /// Issue #3427 (R6): a WAL segment containing a `DeleteNode` and a
+    /// `RetractNode` that carry a `Some(Provenance)` bundle (v11 format) replays
+    /// so the reconstructed tombstone/retraction historical versions carry the
+    /// acting principal — the attribution now survives crash recovery, closing
+    /// the #3427 gap.
+    #[test]
+    fn replay_delete_and_retract_preserve_provenance_principal() {
+        use crate::core::interning::GLOBAL_INTERNER;
+        use crate::core::property::PropertyMap;
+        use crate::core::provenance::Provenance;
+        use crate::core::temporal::time;
+
+        let dir = tempdir().unwrap();
+        let config = ConcurrentWalSystemConfig::new(dir.path());
+        let wal = ConcurrentWalSystem::new(config).unwrap();
+
+        let del_node = crate::core::NodeId::new(1).unwrap();
+        let ret_node = crate::core::NodeId::new(2).unwrap();
+        let label = GLOBAL_INTERNER.intern("RcvProv3427").unwrap();
+        let now = time::now().wallclock();
+        let valid_from = crate::core::hlc::HybridTimestamp::new(now - 3_600_000_000, 0).unwrap();
+        let valid_to = crate::core::hlc::HybridTimestamp::new(now - 1_800_000_000, 0).unwrap();
+
+        let del_prov = Provenance::builder()
+            .source("mcp")
+            .principal("svc-deleter")
+            .build()
+            .unwrap();
+        let ret_prov = Provenance::builder()
+            .principal("svc-retractor")
+            .build()
+            .unwrap();
+
+        // Delete path.
+        wal.append(WalOperation::CreateNode {
+            node_id: del_node,
+            label,
+            properties: PropertyMap::new(),
+            valid_from,
+            provenance: None,
+        })
+        .unwrap();
+        wal.append(WalOperation::DeleteNode {
+            node_id: del_node,
+            valid_from: time::now(),
+            version_id: None,
+            provenance: Some(del_prov),
+        })
+        .unwrap();
+
+        // Retract path.
+        wal.append(WalOperation::CreateNode {
+            node_id: ret_node,
+            label,
+            properties: PropertyMap::new(),
+            valid_from,
+            provenance: None,
+        })
+        .unwrap();
+        wal.append(WalOperation::RetractNode {
+            node_id: ret_node,
+            valid_to,
+            version_id: None,
+            provenance: Some(ret_prov),
+        })
+        .unwrap();
+        wal.flush().unwrap();
+
+        let current = CurrentStorage::new();
+        let mut historical = HistoricalStorage::new();
+        replay_wal_into_storage(&wal, &current, &mut historical, LSN::initial(), 1).unwrap();
+
+        // The delete tombstone version (versions[1]) carries the deleter's
+        // principal after WAL replay.
+        let del_history = historical.get_node_history(del_node).unwrap();
+        assert_eq!(del_history.version_count(), 2, "create + tombstone");
+        let tombstone_vid = del_history.versions[1].version_id;
+        let tombstone_prov = historical
+            .get_node_version_provenance(tombstone_vid)
+            .unwrap()
+            .expect("tombstone version must carry provenance after replay");
+        assert_eq!(
+            tombstone_prov.principal(),
+            Some("svc-deleter"),
+            "delete principal must survive WAL replay (#3427)"
+        );
+        assert_eq!(tombstone_prov.source(), Some("mcp"));
+
+        // The retraction version (versions[1]) carries the retractor's principal.
+        let ret_history = historical.get_node_history(ret_node).unwrap();
+        assert_eq!(ret_history.version_count(), 2, "create + retraction");
+        let retraction_vid = ret_history.versions[1].version_id;
+        let retraction_prov = historical
+            .get_node_version_provenance(retraction_vid)
+            .unwrap()
+            .expect("retraction version must carry provenance after replay");
+        assert_eq!(
+            retraction_prov.principal(),
+            Some("svc-retractor"),
+            "retract principal must survive WAL replay (#3427)"
+        );
+    }
+
+    /// Issue #3427 (R7) / #3407 / #3492 regression: threading provenance through
+    /// the delete replay arm must NOT disturb the DELIBERATELY-KEPT explicit
+    /// transaction-time close. An in-ONE-framed-transaction create+delete of the
+    /// same node shares a single `commit_timestamp`, so the `add_node_version`
+    /// helper's strict `new_tx_start > prev_tx_start` guard would SKIP closing
+    /// the superseded create head — the explicit close keeps it consistent with
+    /// the live path. Assert the pre-delete head's transaction time is closed.
+    #[test]
+    fn replay_framed_create_then_delete_still_closes_superseded_tx_time() {
+        use crate::core::interning::GLOBAL_INTERNER;
+        use crate::core::property::PropertyMap;
+        use crate::core::provenance::Provenance;
+        use crate::core::temporal::time;
+
+        let dir = tempdir().unwrap();
+        let config = ConcurrentWalSystemConfig::new(dir.path());
+        let wal = ConcurrentWalSystem::new(config).unwrap();
+
+        let node_id = crate::core::NodeId::new(1).unwrap();
+        let label = GLOBAL_INTERNER.intern("RcvFramedDel3427").unwrap();
+        let now = time::now().wallclock();
+        let valid_from = crate::core::hlc::HybridTimestamp::new(now - 3_600_000_000, 0).unwrap();
+        // One shared commit timestamp for the whole framed transaction.
+        let commit_ts = crate::core::hlc::HybridTimestamp::new(now, 0).unwrap();
+        let tx_id = 77u64;
+
+        // Frame: BeginTx, CreateNode, DeleteNode, CommitTx — LSN-contiguous so
+        // resolve_transaction_frames pairs both data ops with `commit_ts`.
+        wal.append(WalOperation::BeginTx { tx_id }).unwrap();
+        wal.append(WalOperation::CreateNode {
+            node_id,
+            label,
+            properties: PropertyMap::new(),
+            valid_from,
+            provenance: None,
+        })
+        .unwrap();
+        wal.append(WalOperation::DeleteNode {
+            node_id,
+            valid_from: commit_ts,
+            version_id: None,
+            provenance: Some(
+                Provenance::builder()
+                    .principal("svc-deleter")
+                    .build()
+                    .unwrap(),
+            ),
+        })
+        .unwrap();
+        wal.append(WalOperation::CommitTx {
+            tx_id,
+            entry_count: 2,
+            commit_timestamp: commit_ts,
+        })
+        .unwrap();
+        wal.flush().unwrap();
+
+        let current = CurrentStorage::new();
+        let mut historical = HistoricalStorage::new();
+        replay_wal_into_storage(&wal, &current, &mut historical, LSN::initial(), 1).unwrap();
+
+        let history = historical.get_node_history(node_id).unwrap();
+        assert_eq!(history.version_count(), 2, "create + tombstone");
+        let pre_delete_head = &history.versions[0];
+        assert!(
+            !pre_delete_head.temporal.transaction_time().is_current(),
+            "superseded create head's transaction time must be CLOSED even when \
+             create+delete share one framed commit_timestamp (#3407/#3492 kept close)"
+        );
+        assert_eq!(
+            pre_delete_head.temporal.transaction_time().end(),
+            commit_ts,
+            "must close at the shared framed commit timestamp"
+        );
+        // The delete principal still lands on the tombstone (provenance threaded
+        // orthogonally to the kept close).
+        let tombstone_vid = history.versions[1].version_id;
+        assert_eq!(
+            historical
+                .get_node_version_provenance(tombstone_vid)
+                .unwrap()
+                .and_then(|p| p.principal().map(String::from))
+                .as_deref(),
+            Some("svc-deleter"),
+        );
+    }
+
     /// Issue #3230: RetractEdge replay — same contract as RetractNode.
     #[test]
     fn replay_retract_edge_honors_valid_to() {
@@ -1674,6 +1879,7 @@ mod tests {
             edge_id,
             valid_to,
             version_id: None,
+            provenance: None,
         })
         .unwrap();
         wal.flush().unwrap();
@@ -1930,6 +2136,7 @@ mod tests {
             node_id,
             valid_from: time::now(),
             version_id: None,
+            provenance: None,
         })
         .unwrap();
         wal.append(WalOperation::CreateNode {
@@ -2038,6 +2245,7 @@ mod tests {
             edge_id,
             valid_from: time::now(),
             version_id: None,
+            provenance: None,
         })
         .unwrap();
         wal.append(WalOperation::CreateEdge {
@@ -2178,12 +2386,14 @@ mod tests {
             edge_id,
             valid_from: time::now(),
             version_id: None,
+            provenance: None,
         })
         .unwrap();
         wal.append(WalOperation::DeleteNode {
             node_id,
             valid_from: time::now(),
             version_id: None,
+            provenance: None,
         })
         .unwrap();
         wal.flush().unwrap();
@@ -2265,12 +2475,14 @@ mod tests {
             edge_id,
             valid_from: time::now(),
             version_id: None,
+            provenance: None,
         })
         .unwrap();
         wal.append(WalOperation::DeleteNode {
             node_id,
             valid_from: time::now(),
             version_id: None,
+            provenance: None,
         })
         .unwrap();
         wal.flush().unwrap();

--- a/src/storage/wal/entry.rs
+++ b/src/storage/wal/entry.rs
@@ -110,6 +110,11 @@ pub enum WalOperation {
         /// segments written before `WAL_VERSION_DELETE_VERSION_ID` (v9/v10),
         /// which fall back to synthesis during replay.
         version_id: Option<VersionId>,
+        /// Write-time provenance bundle recording the acting principal for the
+        /// deletion (Issue #3427), if supplied. `None` for segments written
+        /// before `WAL_VERSION_DESTRUCTIVE_PROVENANCE` (v11/v12), which carry no
+        /// provenance blob on the delete/retract payloads.
+        provenance: Option<Provenance>,
     },
     /// Delete an edge
     DeleteEdge {
@@ -120,6 +125,9 @@ pub enum WalOperation {
         /// The tombstone version ID assigned by the live write path (Issue
         /// #3406). See [`WalOperation::DeleteNode`]'s `version_id`.
         version_id: Option<VersionId>,
+        /// Write-time provenance bundle (Issue #3427). See
+        /// [`WalOperation::DeleteNode`]'s `provenance`.
+        provenance: Option<Provenance>,
     },
     /// Retract a node: close its valid-time interval at `valid_to` without
     /// deleting its history (Issue #3230).
@@ -131,6 +139,9 @@ pub enum WalOperation {
         /// The retraction (closing) version ID assigned by the live write path
         /// (Issue #3406). See [`WalOperation::DeleteNode`]'s `version_id`.
         version_id: Option<VersionId>,
+        /// Write-time provenance bundle (Issue #3427). See
+        /// [`WalOperation::DeleteNode`]'s `provenance`.
+        provenance: Option<Provenance>,
     },
     /// Retract an edge: close its valid-time interval at `valid_to` without
     /// deleting its history (Issue #3230).
@@ -142,6 +153,9 @@ pub enum WalOperation {
         /// The retraction (closing) version ID assigned by the live write path
         /// (Issue #3406). See [`WalOperation::DeleteNode`]'s `version_id`.
         version_id: Option<VersionId>,
+        /// Write-time provenance bundle (Issue #3427). See
+        /// [`WalOperation::DeleteNode`]'s `provenance`.
+        provenance: Option<Provenance>,
     },
     /// Checkpoint marker - indicates a snapshot was taken
     Checkpoint {

--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -432,16 +432,19 @@ impl FlushCoordinator {
             return Ok(());
         }
 
-        // New segments use the delete-version-id format (Issue #3406), a strict
-        // superset of the transaction-framing format (Issue #3413) which is in
-        // turn a superset of the principal-carrying provenance format (Issues
-        // #3224 + #3350): version 10 for encrypted segments, version 9 for
-        // plaintext. It keeps the BeginTx/CommitTx framing markers AND appends
-        // the tombstone/retraction version_id to delete/retract payloads.
-        // Non-transactional producers simply omit the framing markers; the
-        // version bump signals both the markers AND the extended payload MAY be
-        // present so old readers reject the segment cleanly rather than
-        // misparsing.
+        // New segments use the destructive-op provenance format (Issue #3427):
+        // WAL_VERSION_ENCRYPTED_DESTRUCTIVE_PROVENANCE (v12) for encrypted
+        // segments, WAL_VERSION_DESTRUCTIVE_PROVENANCE (v11) for plaintext. It
+        // is a strict superset of the delete-version-id format (Issue #3406,
+        // v9/v10) — itself a superset of the transaction-framing format (Issue
+        // #3413) and the principal-carrying provenance format (Issues #3224 +
+        // #3350) — additionally appending an optional provenance blob to the
+        // delete/retract payloads so the acting principal on a destructive op
+        // survives crash recovery. It keeps the BeginTx/CommitTx framing
+        // markers AND the tombstone/retraction version_id. Non-transactional
+        // producers simply omit the framing markers; the version bump signals
+        // that the markers AND the extended payloads MAY be present so old
+        // readers reject the segment cleanly rather than misparsing.
         let write_version = if self.config.wal_cipher.is_some() {
             WAL_VERSION_ENCRYPTED_DESTRUCTIVE_PROVENANCE
         } else {

--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -45,8 +45,8 @@ use super::ring_buffer::PendingEntry;
 use crate::core::error::{Error, Result, StorageError};
 
 use super::segment_reader::{
-    WAL_HEADER_SIZE, WAL_MAGIC, WAL_VERSION_DELETE_VERSION_ID,
-    WAL_VERSION_ENCRYPTED_DELETE_VERSION_ID,
+    WAL_HEADER_SIZE, WAL_MAGIC, WAL_VERSION_DESTRUCTIVE_PROVENANCE,
+    WAL_VERSION_ENCRYPTED_DESTRUCTIVE_PROVENANCE,
 };
 
 /// Metadata about a WAL segment's LSN range.
@@ -443,9 +443,9 @@ impl FlushCoordinator {
         // present so old readers reject the segment cleanly rather than
         // misparsing.
         let write_version = if self.config.wal_cipher.is_some() {
-            WAL_VERSION_ENCRYPTED_DELETE_VERSION_ID
+            WAL_VERSION_ENCRYPTED_DESTRUCTIVE_PROVENANCE
         } else {
-            WAL_VERSION_DELETE_VERSION_ID
+            WAL_VERSION_DESTRUCTIVE_PROVENANCE
         };
 
         // Allocate the next segment id, rolling past any existing non-empty
@@ -1197,11 +1197,11 @@ mod tests {
         );
 
         // ...the write must have rolled forward to a fresh segment with the
-        // current writer (v9 delete-version-id) header...
+        // current writer (v11 destructive-provenance) header...
         assert_eq!(coordinator.current_segment_id(), 2);
         let new_segment = std::fs::read(dir.path().join("000002.log")).unwrap();
         assert_eq!(&new_segment[0..4], &WAL_MAGIC);
-        assert_eq!(new_segment[4], WAL_VERSION_DELETE_VERSION_ID);
+        assert_eq!(new_segment[4], WAL_VERSION_DESTRUCTIVE_PROVENANCE);
 
         // ...and a full-directory replay succeeds, with the new entry's
         // principal intact.
@@ -1521,7 +1521,7 @@ mod tests {
 
         assert!(data.len() >= WAL_HEADER_SIZE);
         assert_eq!(&data[0..4], &WAL_MAGIC);
-        assert_eq!(data[4], WAL_VERSION_DELETE_VERSION_ID);
+        assert_eq!(data[4], WAL_VERSION_DESTRUCTIVE_PROVENANCE);
     }
 
     #[test]

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -3098,6 +3098,256 @@ mod tests {
         }
     }
 
+    /// Round-trip a destructive `WalOperation` through an encrypted (v12)
+    /// segment via the cipher-aware read path, returning the decrypted+parsed
+    /// operation. Shared by the RetractNode/DeleteEdge/RetractEdge hardening
+    /// tests below (DeleteNode is covered by
+    /// `test_v12_encrypted_destructive_provenance_survives_decrypt`).
+    fn roundtrip_encrypted_v12_op(op: WalOperation) -> WalOperation {
+        use std::io::Write;
+        let dir = TempDir::new().unwrap();
+        let cipher = aes_cipher();
+        let path = dir.path().join("0.log");
+        {
+            let mut file = File::create(&path).unwrap();
+            file.write_all(&WAL_MAGIC).unwrap();
+            file.write_all(&[WAL_VERSION_ENCRYPTED_DESTRUCTIVE_PROVENANCE])
+                .unwrap();
+            file.sync_all().unwrap();
+        }
+        let entry = WalEntry::new(LSN(5), op);
+        let mut plaintext = Vec::new();
+        serialize_entry_into(&entry, &mut plaintext).unwrap();
+        let ct =
+            crate::encryption::wal_encryption::encrypt_wal_payload(&plaintext, &cipher).unwrap();
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&(ct.len() as u32).to_le_bytes());
+        frame.extend_from_slice(&ct);
+        append_bytes(&path, &frame);
+
+        let mut entries = read_entries_from_dir_with_cipher(dir.path(), LSN(1), Some(&cipher))
+            .expect("encrypted v12 destructive-provenance segment must decrypt+parse");
+        assert_eq!(entries.len(), 1);
+        entries.remove(0).operation
+    }
+
+    /// Issue #3427 (R4, hardening): encrypted-v12 `RetractNode` provenance
+    /// survives the cipher-aware decrypt+parse path.
+    #[test]
+    fn test_v12_encrypted_retract_node_survives_decrypt() {
+        let op = roundtrip_encrypted_v12_op(WalOperation::RetractNode {
+            node_id: NodeId::new(7).unwrap(),
+            valid_to: HybridTimestamp::new(1_700_000, 3).unwrap(),
+            version_id: Some(VersionId::new(321).unwrap()),
+            provenance: Some(full_destructive_provenance()),
+        });
+        match op {
+            WalOperation::RetractNode { provenance, .. } => assert_full_destructive_provenance(
+                provenance
+                    .as_ref()
+                    .expect("RetractNode provenance must survive encrypted v12 decrypt+parse"),
+            ),
+            other => panic!("Expected RetractNode, got {other:?}"),
+        }
+    }
+
+    /// Issue #3427 (R4, hardening): encrypted-v12 `DeleteEdge` provenance
+    /// survives the cipher-aware decrypt+parse path.
+    #[test]
+    fn test_v12_encrypted_delete_edge_survives_decrypt() {
+        let op = roundtrip_encrypted_v12_op(WalOperation::DeleteEdge {
+            edge_id: EdgeId::new(100).unwrap(),
+            valid_from: HybridTimestamp::new(9_876_543, 1).unwrap(),
+            version_id: Some(VersionId::new(556).unwrap()),
+            provenance: Some(full_destructive_provenance()),
+        });
+        match op {
+            WalOperation::DeleteEdge { provenance, .. } => assert_full_destructive_provenance(
+                provenance
+                    .as_ref()
+                    .expect("DeleteEdge provenance must survive encrypted v12 decrypt+parse"),
+            ),
+            other => panic!("Expected DeleteEdge, got {other:?}"),
+        }
+    }
+
+    /// Issue #3427 (R4, hardening): encrypted-v12 `RetractEdge` provenance
+    /// survives the cipher-aware decrypt+parse path.
+    #[test]
+    fn test_v12_encrypted_retract_edge_survives_decrypt() {
+        let op = roundtrip_encrypted_v12_op(WalOperation::RetractEdge {
+            edge_id: EdgeId::new(11).unwrap(),
+            valid_to: HybridTimestamp::new(2_500_000, 5).unwrap(),
+            version_id: Some(VersionId::new(654).unwrap()),
+            provenance: Some(full_destructive_provenance()),
+        });
+        match op {
+            WalOperation::RetractEdge { provenance, .. } => assert_full_destructive_provenance(
+                provenance
+                    .as_ref()
+                    .expect("RetractEdge provenance must survive encrypted v12 decrypt+parse"),
+            ),
+            other => panic!("Expected RetractEdge, got {other:?}"),
+        }
+    }
+
+    /// Issue #3427 (hardening): a v11 destructive entry whose trailing
+    /// provenance blob is truncated must fail to parse with a
+    /// `CorruptedData` error (NEVER a panic — a torn provenance string must
+    /// be a bounds-checked read, not an out-of-bounds slice), and the
+    /// torn-tail machinery must classify it correctly:
+    ///
+    /// * tolerated as a crash-torn tail when it is the FINAL segment's last
+    ///   entry (the torn write was never acknowledged), but
+    /// * a HARD error when the same torn bytes sit in a NON-final (mid-log)
+    ///   segment — acknowledged data lies past it, so silently dropping it is
+    ///   forbidden.
+    #[test]
+    fn test_v11_torn_provenance_blob_is_corrupt_not_panic_and_classified() {
+        use std::io::Write;
+
+        // A fully-serialized v11 RetractNode carrying provenance. The blob's
+        // last field is the principal string, so dropping trailing bytes
+        // truncates it mid-field.
+        let entry = WalEntry::new(
+            LSN(5),
+            WalOperation::RetractNode {
+                node_id: NodeId::new(7).unwrap(),
+                valid_to: HybridTimestamp::new(1_700_000, 3).unwrap(),
+                version_id: Some(VersionId::new(321).unwrap()),
+                provenance: Some(full_destructive_provenance()),
+            },
+        );
+        let mut full = Vec::new();
+        serialize_entry_into(&entry, &mut full).unwrap();
+        let torn = &full[..full.len() - 4];
+
+        // (1) Direct parse of the truncated buffer: CorruptedData, no panic.
+        let err = parse_entry_at(torn, 0, WAL_VERSION_DESTRUCTIVE_PROVENANCE)
+            .expect_err("a truncated trailing provenance blob must fail to parse");
+        assert!(
+            matches!(err, Error::Storage(StorageError::CorruptedData(_))),
+            "a torn provenance blob must surface as CorruptedData (no panic), got {err:?}"
+        );
+
+        // (2) As the sole/final segment: tolerated as a crash-torn tail.
+        let dir = TempDir::new().unwrap();
+        let seg0 = dir.path().join("0.log");
+        {
+            let mut f = File::create(&seg0).unwrap();
+            f.write_all(&WAL_MAGIC).unwrap();
+            f.write_all(&[WAL_VERSION_DESTRUCTIVE_PROVENANCE]).unwrap();
+            f.write_all(torn).unwrap();
+            f.sync_all().unwrap();
+        }
+        let tolerated = read_entries_from_dir_with_options(dir.path(), LSN(1), None, true)
+            .expect("a torn provenance blob in the FINAL segment is a tolerable torn tail");
+        assert!(
+            tolerated.is_empty(),
+            "the torn (never-acknowledged) entry is dropped, not applied: {tolerated:?}"
+        );
+
+        // (3) Same torn bytes in a NON-final (mid-log) segment: hard error. A
+        // valid, higher-LSN entry lives in a later segment (1.log), so 0.log
+        // is no longer the final segment and torn-tail tolerance does not
+        // apply to it — mid-log corruption must fail-stop.
+        let seg1 = dir.path().join("1.log");
+        {
+            let mut f = File::create(&seg1).unwrap();
+            f.write_all(&WAL_MAGIC).unwrap();
+            f.write_all(&[WAL_VERSION_DESTRUCTIVE_PROVENANCE]).unwrap();
+            let good = WalEntry::new(
+                LSN(9),
+                WalOperation::DeleteNode {
+                    node_id: NodeId::new(1).unwrap(),
+                    valid_from: HybridTimestamp::new(2000, 0).unwrap(),
+                    version_id: Some(VersionId::new(2).unwrap()),
+                    provenance: None,
+                },
+            );
+            let mut buf = Vec::new();
+            serialize_entry_into(&good, &mut buf).unwrap();
+            f.write_all(&buf).unwrap();
+            f.sync_all().unwrap();
+        }
+        let err = read_entries_from_dir_with_options(dir.path(), LSN(1), None, true)
+            .expect_err("a torn blob in a non-final segment is mid-log corruption -> hard error");
+        assert!(
+            matches!(err, Error::Storage(StorageError::CorruptedData(_))),
+            "mid-log torn provenance must hard-error as CorruptedData, got {err:?}"
+        );
+    }
+
+    /// Issue #3427 (hardening): an empty-string principal (`Some("")`) is a
+    /// distinct, meaningful value from an absent principal (`None`) and must
+    /// round-trip as such — the field's presence byte (1 vs 0) carries the
+    /// distinction, so a zero-length string is not collapsed into `None`.
+    #[test]
+    fn test_v11_empty_string_principal_roundtrips_distinct_from_none() {
+        // Bundle A: principal explicitly the empty string.
+        let empty_principal = Provenance::builder()
+            .source("mcp")
+            .principal("")
+            .build()
+            .unwrap();
+        let entry_a = WalEntry::new(
+            LSN(1),
+            WalOperation::DeleteNode {
+                node_id: NodeId::new(1).unwrap(),
+                valid_from: HybridTimestamp::new(1000, 0).unwrap(),
+                version_id: Some(VersionId::new(1).unwrap()),
+                provenance: Some(empty_principal),
+            },
+        );
+        let mut buf_a = Vec::new();
+        serialize_entry_into(&entry_a, &mut buf_a).unwrap();
+        let (parsed_a, _) = parse_entry_at(&buf_a, 0, WAL_VERSION_DESTRUCTIVE_PROVENANCE).unwrap();
+        match parsed_a.operation {
+            WalOperation::DeleteNode { provenance, .. } => {
+                let p = provenance.expect("bundle with source+empty-principal must be present");
+                assert_eq!(
+                    p.principal(),
+                    Some(""),
+                    "an empty-string principal must round-trip as Some(\"\"), not None"
+                );
+            }
+            other => panic!("Expected DeleteNode, got {other:?}"),
+        }
+
+        // Bundle B: no principal at all (source only).
+        let no_principal = Provenance::builder().source("mcp").build().unwrap();
+        let entry_b = WalEntry::new(
+            LSN(2),
+            WalOperation::DeleteNode {
+                node_id: NodeId::new(2).unwrap(),
+                valid_from: HybridTimestamp::new(1000, 0).unwrap(),
+                version_id: Some(VersionId::new(2).unwrap()),
+                provenance: Some(no_principal),
+            },
+        );
+        let mut buf_b = Vec::new();
+        serialize_entry_into(&entry_b, &mut buf_b).unwrap();
+        let (parsed_b, _) = parse_entry_at(&buf_b, 0, WAL_VERSION_DESTRUCTIVE_PROVENANCE).unwrap();
+        match parsed_b.operation {
+            WalOperation::DeleteNode { provenance, .. } => {
+                let p = provenance.expect("bundle with source must be present");
+                assert_eq!(
+                    p.principal(),
+                    None,
+                    "an absent principal must round-trip as None"
+                );
+            }
+            other => panic!("Expected DeleteNode, got {other:?}"),
+        }
+
+        // The two serializations differ (presence byte 1+len vs 0), proving
+        // the distinction is carried on the wire, not just in the parsed type.
+        assert_ne!(
+            buf_a, buf_b,
+            "Some(\"\") and None principals must serialize to different bytes"
+        );
+    }
+
     #[test]
     fn test_parse_entry_at_update_node() {
         // Create an UpdateNode entry

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -145,8 +145,31 @@ pub(crate) const WAL_VERSION_DELETE_VERSION_ID: u8 = 9;
 /// delete-version-id entry format (i.e. [`WAL_VERSION_DELETE_VERSION_ID`]).
 pub(crate) const WAL_VERSION_ENCRYPTED_DELETE_VERSION_ID: u8 = 10;
 
+/// WAL format version for plaintext segments whose delete/retract payloads
+/// additionally carry an optional [`Provenance`] bundle recording the acting
+/// principal for the destructive op (Issue #3427).
+///
+/// A strict superset of [`WAL_VERSION_DELETE_VERSION_ID`]: it keeps the tx
+/// framing markers and the tombstone/retraction `version_id`, and appends the
+/// same `[presence][source][confidence][note][correlation_id][principal]`
+/// provenance blob used by create/update after the `version_id` tail on the
+/// `DeleteNode`/`DeleteEdge`/`RetractNode`/`RetractEdge` payloads. This lets
+/// crash recovery reconstruct the tombstone/retraction version WITH its
+/// acting-principal attribution instead of dropping it. The
+/// [`carries_destructive_provenance`] gate is an independent monotonic `>=`
+/// boolean on the same version byte, composing with the framing and
+/// delete-version-id gates. Bumping the header version makes an older reader
+/// reject the file cleanly rather than mis-length the extended payload,
+/// following the #3224/#3406/#3413 precedent.
+pub(crate) const WAL_VERSION_DESTRUCTIVE_PROVENANCE: u8 = 11;
+
+/// WAL format version for encrypted segments whose decrypted payload uses the
+/// destructive-op provenance entry format (i.e.
+/// [`WAL_VERSION_DESTRUCTIVE_PROVENANCE`]).
+pub(crate) const WAL_VERSION_ENCRYPTED_DESTRUCTIVE_PROVENANCE: u8 = 12;
+
 /// Maximum supported WAL version (inclusive).
-const WAL_VERSION_MAX: u8 = WAL_VERSION_ENCRYPTED_DELETE_VERSION_ID;
+const WAL_VERSION_MAX: u8 = WAL_VERSION_ENCRYPTED_DESTRUCTIVE_PROVENANCE;
 
 /// Returns `true` if `version` denotes an encrypted segment (the original
 /// encrypted format or one of its provenance/framing-carrying successors).
@@ -157,6 +180,7 @@ fn is_encrypted_version(version: u8) -> bool {
         || version == WAL_VERSION_ENCRYPTED_PROVENANCE_PRINCIPAL
         || version == WAL_VERSION_ENCRYPTED_TX_FRAMING
         || version == WAL_VERSION_ENCRYPTED_DELETE_VERSION_ID
+        || version == WAL_VERSION_ENCRYPTED_DESTRUCTIVE_PROVENANCE
 }
 
 /// Returns `true` if `version` (a plaintext/payload version) supports the
@@ -178,6 +202,19 @@ fn carries_delete_version_id(version: u8) -> bool {
     version >= WAL_VERSION_DELETE_VERSION_ID
 }
 
+/// Returns `true` if `version` (a plaintext/payload version) carries the
+/// optional [`Provenance`] blob trailing the delete/retract payloads (Issue
+/// #3427).
+///
+/// Independent of [`is_framed_version`] / [`carries_delete_version_id`]: all
+/// three are monotonic `>=` predicates on the same version byte, so v11/v12
+/// segments are simultaneously framed, delete-version-id-carrying, AND
+/// destructive-provenance-carrying.
+#[inline]
+fn carries_destructive_provenance(version: u8) -> bool {
+    version >= WAL_VERSION_DESTRUCTIVE_PROVENANCE
+}
+
 /// Map a segment/container format version to the logical *payload* version
 /// used to gate field parsing (e.g. `version >= WAL_VERSION_PROVENANCE`).
 ///
@@ -192,6 +229,7 @@ fn payload_version(version: u8) -> u8 {
         WAL_VERSION_ENCRYPTED_PROVENANCE_PRINCIPAL => WAL_VERSION_PROVENANCE_PRINCIPAL,
         WAL_VERSION_ENCRYPTED_TX_FRAMING => WAL_VERSION_TX_FRAMING,
         WAL_VERSION_ENCRYPTED_DELETE_VERSION_ID => WAL_VERSION_DELETE_VERSION_ID,
+        WAL_VERSION_ENCRYPTED_DESTRUCTIVE_PROVENANCE => WAL_VERSION_DESTRUCTIVE_PROVENANCE,
         v => v,
     }
 }
@@ -212,7 +250,7 @@ fn payload_version(version: u8) -> u8 {
 /// and fails the entry checksum.
 ///
 /// History of the newest plaintext version: #3224→3, #3421→5, #3413→7,
-/// #3406→9. Bump on every WAL plaintext format increase.
+/// #3406→9, #3427→11. Bump on every WAL plaintext format increase.
 #[inline]
 // Only referenced by the fuzz-only `crate::fuzzing` module, so it is compiled
 // only under `any(fuzzing, feature = "fuzzing")`; on non-fuzzing builds it is
@@ -1538,10 +1576,19 @@ fn parse_delete_node_op(
         tx_timestamp
     };
     let version_id = parse_opt_tombstone_version_id(buffer, offset, version, "DeleteNode")?;
+    // Issue #3427: v11+ segments append the same provenance blob create/update
+    // carry. Older (v9/v10/legacy) segments stop at the version_id tail and must
+    // parse byte-identically, so gate the read on `carries_destructive_provenance`.
+    let provenance = if carries_destructive_provenance(version) {
+        read_provenance(buffer, offset, version)?
+    } else {
+        None
+    };
     Ok(WalOperation::DeleteNode {
         node_id,
         valid_from,
         version_id,
+        provenance,
     })
 }
 
@@ -1561,10 +1608,17 @@ fn parse_delete_edge_op(
         tx_timestamp
     };
     let version_id = parse_opt_tombstone_version_id(buffer, offset, version, "DeleteEdge")?;
+    // Issue #3427: version-gated trailing provenance blob (see parse_delete_node_op).
+    let provenance = if carries_destructive_provenance(version) {
+        read_provenance(buffer, offset, version)?
+    } else {
+        None
+    };
     Ok(WalOperation::DeleteEdge {
         edge_id,
         valid_from,
         version_id,
+        provenance,
     })
 }
 
@@ -1581,10 +1635,17 @@ fn parse_retract_node_op(buffer: &[u8], offset: &mut usize, version: u8) -> Resu
     let (valid_to, ts_len) = HybridTimestamp::deserialize(&buffer[*offset..])?;
     advance(offset, ts_len)?;
     let version_id = parse_opt_tombstone_version_id(buffer, offset, version, "RetractNode")?;
+    // Issue #3427: version-gated trailing provenance blob (see parse_delete_node_op).
+    let provenance = if carries_destructive_provenance(version) {
+        read_provenance(buffer, offset, version)?
+    } else {
+        None
+    };
     Ok(WalOperation::RetractNode {
         node_id,
         valid_to,
         version_id,
+        provenance,
     })
 }
 
@@ -1598,10 +1659,17 @@ fn parse_retract_edge_op(buffer: &[u8], offset: &mut usize, version: u8) -> Resu
     let (valid_to, ts_len) = HybridTimestamp::deserialize(&buffer[*offset..])?;
     advance(offset, ts_len)?;
     let version_id = parse_opt_tombstone_version_id(buffer, offset, version, "RetractEdge")?;
+    // Issue #3427: version-gated trailing provenance blob (see parse_delete_node_op).
+    let provenance = if carries_destructive_provenance(version) {
+        read_provenance(buffer, offset, version)?
+    } else {
+        None
+    };
     Ok(WalOperation::RetractEdge {
         edge_id,
         valid_to,
         version_id,
+        provenance,
     })
 }
 
@@ -2630,14 +2698,17 @@ mod tests {
             node_id,
             valid_to,
             version_id,
+            provenance: None,
         };
         let entry = WalEntry::new(LSN(10), operation);
 
         let mut buffer = Vec::new();
         serialize_entry_into(&entry, &mut buffer).unwrap();
 
+        // Serialization always writes the newest (v11+) payload shape, which now
+        // trails a provenance blob (Issue #3427), so parse at that version.
         let (parsed_entry, bytes_consumed) =
-            parse_entry_at(&buffer, 0, WAL_VERSION_DELETE_VERSION_ID).unwrap();
+            parse_entry_at(&buffer, 0, WAL_VERSION_DESTRUCTIVE_PROVENANCE).unwrap();
 
         assert_eq!(parsed_entry.lsn, LSN(10));
         assert_eq!(bytes_consumed, buffer.len());
@@ -2646,10 +2717,12 @@ mod tests {
                 node_id: parsed_id,
                 valid_to: parsed_valid_to,
                 version_id: parsed_version_id,
+                provenance,
             } => {
                 assert_eq!(parsed_id, node_id);
                 assert_eq!(parsed_valid_to, valid_to, "valid_to must survive verbatim");
                 assert_eq!(parsed_version_id, version_id, "version_id must round-trip");
+                assert_eq!(provenance, None, "absent provenance round-trips as None");
             }
             other => panic!("Expected RetractNode operation, got {other:?}"),
         }
@@ -2666,6 +2739,7 @@ mod tests {
             edge_id,
             valid_to,
             version_id,
+            provenance: None,
         };
         let entry = WalEntry::new(LSN(11), operation);
 
@@ -2673,7 +2747,7 @@ mod tests {
         serialize_entry_into(&entry, &mut buffer).unwrap();
 
         let (parsed_entry, bytes_consumed) =
-            parse_entry_at(&buffer, 0, WAL_VERSION_DELETE_VERSION_ID).unwrap();
+            parse_entry_at(&buffer, 0, WAL_VERSION_DESTRUCTIVE_PROVENANCE).unwrap();
 
         assert_eq!(parsed_entry.lsn, LSN(11));
         assert_eq!(bytes_consumed, buffer.len());
@@ -2682,12 +2756,345 @@ mod tests {
                 edge_id: parsed_id,
                 valid_to: parsed_valid_to,
                 version_id: parsed_version_id,
+                provenance,
             } => {
                 assert_eq!(parsed_id, edge_id);
                 assert_eq!(parsed_valid_to, valid_to, "valid_to must survive verbatim");
                 assert_eq!(parsed_version_id, version_id, "version_id must round-trip");
+                assert_eq!(provenance, None, "absent provenance round-trips as None");
             }
             other => panic!("Expected RetractEdge operation, got {other:?}"),
+        }
+    }
+
+    // ---- Issue #3427: destructive-op provenance (v11 / v12) ----
+
+    /// A fully-populated provenance bundle used by the #3427 round-trip tests.
+    fn full_destructive_provenance() -> Provenance {
+        Provenance::builder()
+            .source("mcp")
+            .confidence(0.9)
+            .note("closed by operator")
+            .correlation_id("req-3427")
+            .principal("svc-deleter")
+            .build()
+            .unwrap()
+    }
+
+    fn assert_full_destructive_provenance(p: &Provenance) {
+        assert_eq!(p.source(), Some("mcp"));
+        assert_eq!(p.confidence(), Some(0.9));
+        assert_eq!(p.note(), Some("closed by operator"));
+        assert_eq!(p.correlation_id(), Some("req-3427"));
+        assert_eq!(
+            p.principal(),
+            Some("svc-deleter"),
+            "the acting principal must survive WAL round-trip (#3427)"
+        );
+    }
+
+    /// Issue #3427 (R1): a `DeleteNode` carrying a `Some(Provenance)` bundle
+    /// round-trips serialize -> parse at v11 with the full bundle intact.
+    #[test]
+    fn test_v11_delete_node_roundtrips_provenance() {
+        let node_id = NodeId::new(42).unwrap();
+        let valid_from = HybridTimestamp::new(1_234_567, 7).unwrap();
+        let operation = WalOperation::DeleteNode {
+            node_id,
+            valid_from,
+            version_id: Some(VersionId::new(555).unwrap()),
+            provenance: Some(full_destructive_provenance()),
+        };
+        let entry = WalEntry::new(LSN(5), operation);
+
+        let mut buffer = Vec::new();
+        serialize_entry_into(&entry, &mut buffer).unwrap();
+        let (parsed, consumed) =
+            parse_entry_at(&buffer, 0, WAL_VERSION_DESTRUCTIVE_PROVENANCE).unwrap();
+
+        assert_eq!(consumed, buffer.len(), "v11 delete must consume all bytes");
+        match parsed.operation {
+            WalOperation::DeleteNode {
+                node_id: parsed_id,
+                valid_from: parsed_vf,
+                version_id,
+                provenance,
+            } => {
+                assert_eq!(parsed_id, node_id);
+                assert_eq!(parsed_vf, valid_from);
+                assert_eq!(version_id, Some(VersionId::new(555).unwrap()));
+                assert_full_destructive_provenance(
+                    &provenance.expect("DeleteNode provenance must round-trip"),
+                );
+            }
+            other => panic!("Expected DeleteNode, got {other:?}"),
+        }
+    }
+
+    /// Issue #3427 (R1): `DeleteEdge` provenance round-trips at v11.
+    #[test]
+    fn test_v11_delete_edge_roundtrips_provenance() {
+        let edge_id = EdgeId::new(100).unwrap();
+        let valid_from = HybridTimestamp::new(9_876_543, 1).unwrap();
+        let operation = WalOperation::DeleteEdge {
+            edge_id,
+            valid_from,
+            version_id: Some(VersionId::new(556).unwrap()),
+            provenance: Some(full_destructive_provenance()),
+        };
+        let entry = WalEntry::new(LSN(6), operation);
+
+        let mut buffer = Vec::new();
+        serialize_entry_into(&entry, &mut buffer).unwrap();
+        let (parsed, consumed) =
+            parse_entry_at(&buffer, 0, WAL_VERSION_DESTRUCTIVE_PROVENANCE).unwrap();
+
+        assert_eq!(consumed, buffer.len());
+        match parsed.operation {
+            WalOperation::DeleteEdge {
+                edge_id: parsed_id,
+                valid_from: parsed_vf,
+                version_id,
+                provenance,
+            } => {
+                assert_eq!(parsed_id, edge_id);
+                assert_eq!(parsed_vf, valid_from);
+                assert_eq!(version_id, Some(VersionId::new(556).unwrap()));
+                assert_full_destructive_provenance(
+                    &provenance.expect("DeleteEdge provenance must round-trip"),
+                );
+            }
+            other => panic!("Expected DeleteEdge, got {other:?}"),
+        }
+    }
+
+    /// Issue #3427 (R1): `RetractNode` provenance round-trips at v11.
+    #[test]
+    fn test_v11_retract_node_roundtrips_provenance() {
+        let node_id = NodeId::new(7).unwrap();
+        let valid_to = HybridTimestamp::new(1_700_000, 3).unwrap();
+        let operation = WalOperation::RetractNode {
+            node_id,
+            valid_to,
+            version_id: Some(VersionId::new(321).unwrap()),
+            provenance: Some(full_destructive_provenance()),
+        };
+        let entry = WalEntry::new(LSN(10), operation);
+
+        let mut buffer = Vec::new();
+        serialize_entry_into(&entry, &mut buffer).unwrap();
+        let (parsed, consumed) =
+            parse_entry_at(&buffer, 0, WAL_VERSION_DESTRUCTIVE_PROVENANCE).unwrap();
+
+        assert_eq!(consumed, buffer.len());
+        match parsed.operation {
+            WalOperation::RetractNode {
+                node_id: parsed_id,
+                valid_to: parsed_vt,
+                version_id,
+                provenance,
+            } => {
+                assert_eq!(parsed_id, node_id);
+                assert_eq!(parsed_vt, valid_to);
+                assert_eq!(version_id, Some(VersionId::new(321).unwrap()));
+                assert_full_destructive_provenance(
+                    &provenance.expect("RetractNode provenance must round-trip"),
+                );
+            }
+            other => panic!("Expected RetractNode, got {other:?}"),
+        }
+    }
+
+    /// Issue #3427 (R1): `RetractEdge` provenance round-trips at v11.
+    #[test]
+    fn test_v11_retract_edge_roundtrips_provenance() {
+        let edge_id = EdgeId::new(11).unwrap();
+        let valid_to = HybridTimestamp::new(2_500_000, 5).unwrap();
+        let operation = WalOperation::RetractEdge {
+            edge_id,
+            valid_to,
+            version_id: Some(VersionId::new(654).unwrap()),
+            provenance: Some(full_destructive_provenance()),
+        };
+        let entry = WalEntry::new(LSN(11), operation);
+
+        let mut buffer = Vec::new();
+        serialize_entry_into(&entry, &mut buffer).unwrap();
+        let (parsed, consumed) =
+            parse_entry_at(&buffer, 0, WAL_VERSION_DESTRUCTIVE_PROVENANCE).unwrap();
+
+        assert_eq!(consumed, buffer.len());
+        match parsed.operation {
+            WalOperation::RetractEdge {
+                edge_id: parsed_id,
+                valid_to: parsed_vt,
+                version_id,
+                provenance,
+            } => {
+                assert_eq!(parsed_id, edge_id);
+                assert_eq!(parsed_vt, valid_to);
+                assert_eq!(version_id, Some(VersionId::new(654).unwrap()));
+                assert_full_destructive_provenance(
+                    &provenance.expect("RetractEdge provenance must round-trip"),
+                );
+            }
+            other => panic!("Expected RetractEdge, got {other:?}"),
+        }
+    }
+
+    /// Issue #3427 (R2): a v11 `DeleteNode` with `provenance: None` writes a
+    /// single presence byte (0) and parses back to `None`.
+    #[test]
+    fn test_v11_delete_node_none_provenance_roundtrips() {
+        let operation = WalOperation::DeleteNode {
+            node_id: NodeId::new(1).unwrap(),
+            valid_from: HybridTimestamp::new(1000, 0).unwrap(),
+            version_id: Some(VersionId::new(9).unwrap()),
+            provenance: None,
+        };
+        let entry = WalEntry::new(LSN(1), operation);
+        let mut buffer = Vec::new();
+        serialize_entry_into(&entry, &mut buffer).unwrap();
+        assert_eq!(
+            *buffer.last().unwrap(),
+            0,
+            "None provenance must serialize as a single absent presence byte"
+        );
+        let (parsed, consumed) =
+            parse_entry_at(&buffer, 0, WAL_VERSION_DESTRUCTIVE_PROVENANCE).unwrap();
+        assert_eq!(consumed, buffer.len());
+        match parsed.operation {
+            WalOperation::DeleteNode { provenance, .. } => {
+                assert_eq!(provenance, None, "absent provenance must parse as None");
+            }
+            other => panic!("Expected DeleteNode, got {other:?}"),
+        }
+    }
+
+    /// Issue #3427 (R3): a hand-assembled v9 `DeleteNode` payload (node_id +
+    /// valid_from + tombstone version_id, NO trailing provenance blob — the
+    /// pre-#3427 on-disk shape shared by plaintext v9 and the decrypted payload
+    /// of encrypted v10) parses under the v9 reader with `provenance: None` and
+    /// NO over-read of the trailing bytes.
+    #[test]
+    fn test_v9_delete_node_parses_without_provenance() {
+        let timestamp = time::now();
+        let node_id = NodeId::new(77).unwrap();
+        let valid_from = HybridTimestamp::new(time::now().wallclock() - 3_600_000_000, 0).unwrap();
+        let version_id = VersionId::new(999).unwrap();
+
+        // v9 DeleteNode op_data: node_id (8) + valid_from (12) + version_id (8).
+        let mut op_data = Vec::new();
+        op_data.extend_from_slice(&node_id.as_u64().to_le_bytes());
+        valid_from.serialize_into(&mut op_data);
+        op_data.extend_from_slice(&version_id.as_u64().to_le_bytes());
+        let buf = make_v0_buffer(6, &op_data, timestamp); // OP_DELETE_NODE = 6
+
+        let (entry, consumed) = parse_entry_at(&buf, 0, WAL_VERSION_DELETE_VERSION_ID).unwrap();
+        assert_eq!(
+            consumed,
+            buf.len(),
+            "v9 reader must consume exactly the v9 payload — no phantom provenance blob"
+        );
+        match entry.operation {
+            WalOperation::DeleteNode {
+                node_id: parsed_id,
+                valid_from: parsed_vf,
+                version_id: parsed_vid,
+                provenance,
+            } => {
+                assert_eq!(parsed_id, node_id);
+                assert_eq!(parsed_vf, valid_from);
+                assert_eq!(parsed_vid, Some(version_id));
+                assert_eq!(
+                    provenance, None,
+                    "a pre-#3427 (v9/v10) delete carries no provenance"
+                );
+            }
+            other => panic!("Expected DeleteNode, got {other:?}"),
+        }
+    }
+
+    /// Issue #3427 (R3): same as above for a v9 `RetractNode` payload.
+    #[test]
+    fn test_v9_retract_node_parses_without_provenance() {
+        let timestamp = time::now();
+        let node_id = NodeId::new(88).unwrap();
+        let valid_to = HybridTimestamp::new(1_700_000_000_000_000, 0).unwrap();
+        let version_id = VersionId::new(1000).unwrap();
+
+        // v9 RetractNode op_data: node_id (8) + valid_to (12) + version_id (8).
+        let mut op_data = Vec::new();
+        op_data.extend_from_slice(&node_id.as_u64().to_le_bytes());
+        valid_to.serialize_into(&mut op_data);
+        op_data.extend_from_slice(&version_id.as_u64().to_le_bytes());
+        let buf = make_v0_buffer(10, &op_data, timestamp); // OP_RETRACT_NODE = 10
+
+        let (entry, consumed) = parse_entry_at(&buf, 0, WAL_VERSION_DELETE_VERSION_ID).unwrap();
+        assert_eq!(consumed, buf.len());
+        match entry.operation {
+            WalOperation::RetractNode {
+                version_id: parsed_vid,
+                provenance,
+                ..
+            } => {
+                assert_eq!(parsed_vid, Some(version_id));
+                assert_eq!(provenance, None);
+            }
+            other => panic!("Expected RetractNode, got {other:?}"),
+        }
+    }
+
+    /// Issue #3427 (R4): an encrypted v12 segment carrying a `DeleteNode` with a
+    /// provenance bundle survives the cipher-aware read path — the trailing
+    /// provenance blob is parsed downstream of decrypt.
+    #[test]
+    fn test_v12_encrypted_destructive_provenance_survives_decrypt() {
+        use std::io::Write;
+        let dir = TempDir::new().unwrap();
+        let cipher = aes_cipher();
+        let path = dir.path().join("0.log");
+
+        // Write an encrypted (v12) segment header.
+        {
+            let mut file = File::create(&path).unwrap();
+            file.write_all(&WAL_MAGIC).unwrap();
+            file.write_all(&[WAL_VERSION_ENCRYPTED_DESTRUCTIVE_PROVENANCE])
+                .unwrap();
+            file.sync_all().unwrap();
+        }
+
+        // Build a v11 DeleteNode-with-provenance entry, encrypt it into a frame.
+        let entry = WalEntry::new(
+            LSN(5),
+            WalOperation::DeleteNode {
+                node_id: NodeId::new(42).unwrap(),
+                valid_from: HybridTimestamp::new(1_234_567, 0).unwrap(),
+                version_id: Some(VersionId::new(555).unwrap()),
+                provenance: Some(full_destructive_provenance()),
+            },
+        );
+        let mut plaintext = Vec::new();
+        serialize_entry_into(&entry, &mut plaintext).unwrap();
+        let ct =
+            crate::encryption::wal_encryption::encrypt_wal_payload(&plaintext, &cipher).unwrap();
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&(ct.len() as u32).to_le_bytes());
+        frame.extend_from_slice(&ct);
+        append_bytes(&path, &frame);
+
+        let entries = read_entries_from_dir_with_cipher(dir.path(), LSN(1), Some(&cipher))
+            .expect("encrypted v12 destructive-provenance segment must decrypt+parse");
+        assert_eq!(entries.len(), 1);
+        match &entries[0].operation {
+            WalOperation::DeleteNode { provenance, .. } => {
+                assert_full_destructive_provenance(
+                    provenance
+                        .as_ref()
+                        .expect("provenance must survive encrypted v12 decrypt+parse"),
+                );
+            }
+            other => panic!("Expected DeleteNode, got {other:?}"),
         }
     }
 
@@ -2792,6 +3199,7 @@ mod tests {
             node_id,
             valid_from,
             version_id,
+            provenance: None,
         };
         let entry = WalEntry::new(LSN(5), operation);
 
@@ -2799,9 +3207,10 @@ mod tests {
         let mut buffer = Vec::new();
         serialize_entry_into(&entry, &mut buffer).unwrap();
 
-        // Parse it back
+        // Parse it back at the newest (v11+) payload version, which trails a
+        // provenance blob (Issue #3427).
         let (parsed_entry, bytes_consumed) =
-            parse_entry_at(&buffer, 0, WAL_VERSION_DELETE_VERSION_ID).unwrap();
+            parse_entry_at(&buffer, 0, WAL_VERSION_DESTRUCTIVE_PROVENANCE).unwrap();
 
         // Verify
         assert_eq!(parsed_entry.lsn, LSN(5));
@@ -2811,6 +3220,7 @@ mod tests {
                 node_id: parsed_id,
                 valid_from: parsed_valid_from,
                 version_id: parsed_version_id,
+                provenance,
             } => {
                 assert_eq!(parsed_id, node_id);
                 assert_eq!(
@@ -2818,6 +3228,7 @@ mod tests {
                     "backdated delete valid_from must roundtrip exactly"
                 );
                 assert_eq!(parsed_version_id, version_id, "version_id must round-trip");
+                assert_eq!(provenance, None, "absent provenance round-trips as None");
             }
             _ => panic!("Expected DeleteNode operation"),
         }
@@ -2836,6 +3247,7 @@ mod tests {
             edge_id,
             valid_from,
             version_id,
+            provenance: None,
         };
         let entry = WalEntry::new(LSN(6), operation);
 
@@ -2843,9 +3255,9 @@ mod tests {
         let mut buffer = Vec::new();
         serialize_entry_into(&entry, &mut buffer).unwrap();
 
-        // Parse it back
+        // Parse it back at the newest (v11+) payload version (Issue #3427).
         let (parsed_entry, bytes_consumed) =
-            parse_entry_at(&buffer, 0, WAL_VERSION_DELETE_VERSION_ID).unwrap();
+            parse_entry_at(&buffer, 0, WAL_VERSION_DESTRUCTIVE_PROVENANCE).unwrap();
 
         // Verify
         assert_eq!(parsed_entry.lsn, LSN(6));
@@ -2855,6 +3267,7 @@ mod tests {
                 edge_id: parsed_id,
                 valid_from: parsed_valid_from,
                 version_id: parsed_version_id,
+                provenance,
             } => {
                 assert_eq!(parsed_id, edge_id);
                 assert_eq!(
@@ -2862,6 +3275,7 @@ mod tests {
                     "backdated delete valid_from must roundtrip exactly"
                 );
                 assert_eq!(parsed_version_id, version_id, "version_id must round-trip");
+                assert_eq!(provenance, None, "absent provenance round-trips as None");
             }
             _ => panic!("Expected DeleteEdge operation"),
         }
@@ -3751,12 +4165,15 @@ mod tests {
                 node_id: parsed_id,
                 valid_from,
                 version_id,
+                provenance,
             } => {
                 assert_eq!(parsed_id, node_id);
                 assert_eq!(valid_from, timestamp);
                 // v0 segments carry no tombstone version_id (Issue #3406);
                 // replay synthesizes it.
                 assert_eq!(version_id, None);
+                // v0 segments carry no provenance blob (Issue #3427).
+                assert_eq!(provenance, None);
             }
             _ => panic!("Expected DeleteNode"),
         }
@@ -3774,11 +4191,14 @@ mod tests {
                 edge_id: parsed_id,
                 valid_from,
                 version_id,
+                provenance,
             } => {
                 assert_eq!(parsed_id, edge_id);
                 assert_eq!(valid_from, timestamp);
                 // v0 segments carry no tombstone version_id (Issue #3406).
                 assert_eq!(version_id, None);
+                // v0 segments carry no provenance blob (Issue #3427).
+                assert_eq!(provenance, None);
             }
             _ => panic!("Expected DeleteEdge"),
         }
@@ -3824,12 +4244,17 @@ mod tests {
                 node_id: parsed_id,
                 valid_from: parsed_vf,
                 version_id,
+                provenance,
             } => {
                 assert_eq!(parsed_id, node_id);
                 assert_eq!(parsed_vf, valid_from, "v7 delete carries valid_from");
                 assert_eq!(
                     version_id, None,
                     "a genuine pre-v9 delete carries no tombstone version_id"
+                );
+                assert_eq!(
+                    provenance, None,
+                    "a genuine pre-v11 delete carries no provenance blob"
                 );
             }
             _ => panic!("Expected DeleteNode"),
@@ -3862,12 +4287,17 @@ mod tests {
                 node_id: parsed_id,
                 valid_to: parsed_vt,
                 version_id,
+                provenance,
             } => {
                 assert_eq!(parsed_id, node_id);
                 assert_eq!(parsed_vt, valid_to, "v7 retract carries valid_to");
                 assert_eq!(
                     version_id, None,
                     "a genuine pre-v9 retract carries no version_id"
+                );
+                assert_eq!(
+                    provenance, None,
+                    "a genuine pre-v11 retract carries no provenance blob"
                 );
             }
             _ => panic!("Expected RetractNode"),

--- a/src/storage/wal/serialization.rs
+++ b/src/storage/wal/serialization.rs
@@ -222,6 +222,7 @@ fn provenance_serialized_size(provenance: Option<&Provenance>) -> usize {
 ///     node_id: NodeId::try_from(1).unwrap(),
 ///     valid_from: Timestamp::from(12345),
 ///     version_id: None, // no logged tombstone id (synthesized on replay)
+///     provenance: None, // no acting-principal attribution (#3427)
 /// };
 ///
 /// // Fixed overhead (24 bytes) + DeleteNode payload (21 bytes)
@@ -345,6 +346,7 @@ pub(crate) fn estimate_entry_capacity(operation: &WalOperation) -> usize {
 ///     node_id: NodeId::try_from(42).unwrap(),
 ///     valid_from: Timestamp::from(100),
 ///     version_id: None, // no logged tombstone id (synthesized on replay)
+///     provenance: None, // no acting-principal attribution (#3427)
 /// };
 ///
 /// // 1. Pre-allocate the buffer using our estimate

--- a/src/storage/wal/serialization.rs
+++ b/src/storage/wal/serialization.rs
@@ -272,21 +272,25 @@ pub(crate) fn estimate_entry_capacity(operation: &WalOperation) -> usize {
             let base = 1 + 8 + 8 + 4 + TIMESTAMP_SIZE;
             base + properties.serialized_size() + provenance_serialized_size(provenance.as_ref())
         }
-        WalOperation::DeleteNode { .. } => {
+        WalOperation::DeleteNode { provenance, .. } => {
             // op type (1) + node_id (8) + valid_from (12) + version_id (8, #3406)
-            1 + 8 + TIMESTAMP_SIZE + 8
+            // + provenance blob (#3427)
+            1 + 8 + TIMESTAMP_SIZE + 8 + provenance_serialized_size(provenance.as_ref())
         }
-        WalOperation::DeleteEdge { .. } => {
+        WalOperation::DeleteEdge { provenance, .. } => {
             // op type (1) + edge_id (8) + valid_from (12) + version_id (8, #3406)
-            1 + 8 + TIMESTAMP_SIZE + 8
+            // + provenance blob (#3427)
+            1 + 8 + TIMESTAMP_SIZE + 8 + provenance_serialized_size(provenance.as_ref())
         }
-        WalOperation::RetractNode { .. } => {
+        WalOperation::RetractNode { provenance, .. } => {
             // op type (1) + node_id (8) + valid_to (12) + version_id (8, #3406)
-            1 + 8 + TIMESTAMP_SIZE + 8
+            // + provenance blob (#3427)
+            1 + 8 + TIMESTAMP_SIZE + 8 + provenance_serialized_size(provenance.as_ref())
         }
-        WalOperation::RetractEdge { .. } => {
+        WalOperation::RetractEdge { provenance, .. } => {
             // op type (1) + edge_id (8) + valid_to (12) + version_id (8, #3406)
-            1 + 8 + TIMESTAMP_SIZE + 8
+            // + provenance blob (#3427)
+            1 + 8 + TIMESTAMP_SIZE + 8 + provenance_serialized_size(provenance.as_ref())
         }
         WalOperation::Checkpoint { .. } => {
             // op type (1) + lsn (8) + timestamp (12)
@@ -444,6 +448,7 @@ pub(crate) fn serialize_operation_into(
             node_id,
             valid_from,
             version_id,
+            provenance,
         } => {
             buffer.push(OP_DELETE_NODE);
             buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
@@ -453,36 +458,48 @@ pub(crate) fn serialize_operation_into(
             // present on disk; the sentinel handles a `None` (never produced by
             // the live path) so the encoding is total.
             serialize_tombstone_version_id(*version_id, buffer);
+            // Issue #3427: append the acting-principal provenance blob (v11+),
+            // byte-identical to the create/update encoding.
+            serialize_provenance_into(provenance.as_ref(), buffer);
         }
         WalOperation::DeleteEdge {
             edge_id,
             valid_from,
             version_id,
+            provenance,
         } => {
             buffer.push(OP_DELETE_EDGE);
             buffer.extend_from_slice(&edge_id.as_u64().to_le_bytes());
             valid_from.serialize_into(buffer);
             serialize_tombstone_version_id(*version_id, buffer);
+            // Issue #3427: append the acting-principal provenance blob (v11+).
+            serialize_provenance_into(provenance.as_ref(), buffer);
         }
         WalOperation::RetractNode {
             node_id,
             valid_to,
             version_id,
+            provenance,
         } => {
             buffer.push(OP_RETRACT_NODE);
             buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
             valid_to.serialize_into(buffer);
             serialize_tombstone_version_id(*version_id, buffer);
+            // Issue #3427: append the acting-principal provenance blob (v11+).
+            serialize_provenance_into(provenance.as_ref(), buffer);
         }
         WalOperation::RetractEdge {
             edge_id,
             valid_to,
             version_id,
+            provenance,
         } => {
             buffer.push(OP_RETRACT_EDGE);
             buffer.extend_from_slice(&edge_id.as_u64().to_le_bytes());
             valid_to.serialize_into(buffer);
             serialize_tombstone_version_id(*version_id, buffer);
+            // Issue #3427: append the acting-principal provenance blob (v11+).
+            serialize_provenance_into(provenance.as_ref(), buffer);
         }
         WalOperation::Checkpoint { lsn, timestamp } => {
             buffer.push(OP_CHECKPOINT);
@@ -580,17 +597,19 @@ mod tests {
 
     #[test]
     fn test_estimate_capacity_delete_node() {
-        // DeleteNode: op type (1) + node_id (8) + valid_from (12) + version_id (8) = 29 bytes
+        // DeleteNode: op type (1) + node_id (8) + valid_from (12) + version_id (8)
+        // + absent-provenance presence byte (1, #3427) = 30 bytes
         // Fixed overhead: 24 bytes
-        // Total: 53 bytes (Issue #3406 added the 8-byte tombstone version_id)
+        // Total: 54 bytes
         let op = WalOperation::DeleteNode {
             node_id: NodeId::new(1).unwrap(),
             valid_from: test_timestamp(),
             version_id: Some(VersionId::new(7).unwrap()),
+            provenance: None,
         };
 
         let estimated = estimate_entry_capacity(&op);
-        assert_eq!(estimated, 53, "DeleteNode should be exactly 53 bytes");
+        assert_eq!(estimated, 54, "DeleteNode should be exactly 54 bytes");
 
         // Verify by actually serializing
         let entry = WalEntry::new(LSN(1), op);
@@ -606,16 +625,18 @@ mod tests {
 
     #[test]
     fn test_estimate_capacity_retract_node() {
-        // RetractNode: op type (1) + node_id (8) + valid_to (12) + version_id (8) = 29 bytes
-        // Fixed overhead: 24 bytes => 53 total (same shape as DeleteNode, #3406).
+        // RetractNode: op type (1) + node_id (8) + valid_to (12) + version_id (8)
+        // + absent-provenance presence byte (1, #3427) = 30 bytes
+        // Fixed overhead: 24 bytes => 54 total (same shape as DeleteNode).
         let op = WalOperation::RetractNode {
             node_id: NodeId::new(1).unwrap(),
             valid_to: test_timestamp(),
             version_id: Some(VersionId::new(7).unwrap()),
+            provenance: None,
         };
 
         let estimated = estimate_entry_capacity(&op);
-        assert_eq!(estimated, 53, "RetractNode should be exactly 53 bytes");
+        assert_eq!(estimated, 54, "RetractNode should be exactly 54 bytes");
 
         let entry = WalEntry::new(LSN(1), op);
         let mut buffer = Vec::new();
@@ -630,16 +651,18 @@ mod tests {
 
     #[test]
     fn test_estimate_capacity_retract_edge() {
-        // RetractEdge: op type (1) + edge_id (8) + valid_to (12) + version_id (8) = 29 bytes
-        // Fixed overhead: 24 bytes => 53 total (same shape as DeleteEdge, #3406).
+        // RetractEdge: op type (1) + edge_id (8) + valid_to (12) + version_id (8)
+        // + absent-provenance presence byte (1, #3427) = 30 bytes
+        // Fixed overhead: 24 bytes => 54 total (same shape as DeleteEdge).
         let op = WalOperation::RetractEdge {
             edge_id: EdgeId::new(1).unwrap(),
             valid_to: test_timestamp(),
             version_id: Some(VersionId::new(7).unwrap()),
+            provenance: None,
         };
 
         let estimated = estimate_entry_capacity(&op);
-        assert_eq!(estimated, 53, "RetractEdge should be exactly 53 bytes");
+        assert_eq!(estimated, 54, "RetractEdge should be exactly 54 bytes");
 
         let entry = WalEntry::new(LSN(1), op);
         let mut buffer = Vec::new();
@@ -654,17 +677,19 @@ mod tests {
 
     #[test]
     fn test_estimate_capacity_delete_edge() {
-        // DeleteEdge: op type (1) + edge_id (8) + valid_from (12) + version_id (8) = 29 bytes
+        // DeleteEdge: op type (1) + edge_id (8) + valid_from (12) + version_id (8)
+        // + absent-provenance presence byte (1, #3427) = 30 bytes
         // Fixed overhead: 24 bytes
-        // Total: 53 bytes (Issue #3406 added the 8-byte tombstone version_id)
+        // Total: 54 bytes
         let op = WalOperation::DeleteEdge {
             edge_id: EdgeId::new(1).unwrap(),
             valid_from: test_timestamp(),
             version_id: Some(VersionId::new(7).unwrap()),
+            provenance: None,
         };
 
         let estimated = estimate_entry_capacity(&op);
-        assert_eq!(estimated, 53, "DeleteEdge should be exactly 53 bytes");
+        assert_eq!(estimated, 54, "DeleteEdge should be exactly 54 bytes");
 
         // Verify by actually serializing
         let entry = WalEntry::new(LSN(1), op);
@@ -675,6 +700,40 @@ mod tests {
             "Actual size {} should not exceed estimate {}",
             buffer.len(),
             estimated
+        );
+    }
+
+    /// Issue #3427 (R5): `estimate_entry_capacity` for a destructive op carrying
+    /// a LARGE provenance bundle (long principal/source/note) must be an upper
+    /// bound on the actual serialized length, so the pre-allocated buffer never
+    /// reallocs mid-serialization.
+    #[test]
+    fn test_estimate_capacity_delete_node_with_large_provenance() {
+        let big = "x".repeat(4096);
+        let provenance = Provenance::builder()
+            .source(big.clone())
+            .note(big.clone())
+            .correlation_id(big.clone())
+            .principal(big)
+            .confidence(0.5)
+            .build()
+            .unwrap();
+        let op = WalOperation::DeleteNode {
+            node_id: NodeId::new(1).unwrap(),
+            valid_from: test_timestamp(),
+            version_id: Some(VersionId::new(7).unwrap()),
+            provenance: Some(provenance),
+        };
+
+        let estimated = estimate_entry_capacity(&op);
+        let entry = WalEntry::new(LSN(1), op);
+        let mut buffer = Vec::new();
+        serialize_entry_into(&entry, &mut buffer).unwrap();
+        assert!(
+            estimated >= buffer.len(),
+            "estimate {} must be >= actual serialized length {} (no under-alloc)",
+            estimated,
+            buffer.len()
         );
     }
 
@@ -966,6 +1025,7 @@ mod prop_tests {
                         node_id,
                         valid_from,
                         version_id,
+                        provenance: None,
                     }
                 }),
             // Checkpoint
@@ -1022,28 +1082,32 @@ mod prop_tests {
             ts in 1i64..1_000_000_000_000i64,
             version_id in arb_opt_version_id(),
         ) {
-            use crate::storage::wal::segment_reader::{parse_entry_at, WAL_VERSION_DELETE_VERSION_ID};
+            use crate::storage::wal::segment_reader::{parse_entry_at, WAL_VERSION_DESTRUCTIVE_PROVENANCE};
             let ts = HybridTimestamp::new_unchecked(ts, 0);
             let ops = [
                 WalOperation::DeleteNode {
                     node_id: NodeId::new(id).unwrap(),
                     valid_from: ts,
                     version_id,
+                    provenance: None,
                 },
                 WalOperation::DeleteEdge {
                     edge_id: EdgeId::new(id).unwrap(),
                     valid_from: ts,
                     version_id,
+                    provenance: None,
                 },
                 WalOperation::RetractNode {
                     node_id: NodeId::new(id).unwrap(),
                     valid_to: ts,
                     version_id,
+                    provenance: None,
                 },
                 WalOperation::RetractEdge {
                     edge_id: EdgeId::new(id).unwrap(),
                     valid_to: ts,
                     version_id,
+                    provenance: None,
                 },
             ];
             for op in ops {
@@ -1051,7 +1115,7 @@ mod prop_tests {
                 let mut buffer = Vec::new();
                 serialize_entry_into(&entry, &mut buffer).unwrap();
                 let (parsed, consumed) =
-                    parse_entry_at(&buffer, 0, WAL_VERSION_DELETE_VERSION_ID).unwrap();
+                    parse_entry_at(&buffer, 0, WAL_VERSION_DESTRUCTIVE_PROVENANCE).unwrap();
                 prop_assert_eq!(consumed, buffer.len());
                 prop_assert_eq!(parsed.operation, op);
             }

--- a/tests/destructive_provenance_recovery.rs
+++ b/tests/destructive_provenance_recovery.rs
@@ -1,0 +1,210 @@
+//! Issue #3427 (Phase B) — end-to-end crash-recovery proof that a
+//! caller-supplied provenance principal on a *destructive* operation
+//! (delete / retract) survives real WAL replay.
+//!
+//! Mirrors the `tests/auth_recovery.rs::crash_recovery_via_wal_replay_*`
+//! pattern: a durable database (real WAL + index persistence) records the
+//! writes, then the database is dropped **without persisting indexes** so a
+//! reopen is forced to reconstruct state purely from WAL replay. Before
+//! Phase B the four destructive WAL payloads carried no provenance blob, so a
+//! RAM-only principal evaporated on replay; these tests pin that it now
+//! survives on the tombstone / retraction version.
+
+use aletheiadb::api::transaction::WriteRequestOptions;
+use aletheiadb::core::temporal::time;
+use aletheiadb::core::{EdgeId, NodeId};
+use aletheiadb::{AletheiaDB, PropertyMapBuilder, Provenance};
+
+fn person(name: &str) -> aletheiadb::core::PropertyMap {
+    PropertyMapBuilder::new().insert("name", name).build()
+}
+
+/// Delete a node and retract a node/edge — each stamped with a distinct
+/// acting principal via the new #3427 write-path API — then crash-recover
+/// from the WAL alone and assert every principal survived on the
+/// tombstone / retraction version.
+#[test]
+fn crash_recovery_preserves_delete_and_retract_provenance_principal() {
+    let tempdir = tempfile::tempdir().expect("create tempdir");
+    let data_dir = tempdir.path().join("db");
+
+    let del_node: u64;
+    let ret_node: u64;
+    let ret_edge: u64;
+
+    // ── Round 1: durable DB, destructive writes with provenance, then
+    //    "crash" (drop with NO index checkpoint) ──
+    {
+        let db = AletheiaDB::open(&data_dir).expect("open durable db");
+
+        // Delete path: isolated node deleted with a principal.
+        let a = db
+            .create_node("Person", person("DeleteMe"))
+            .expect("create A");
+        del_node = a.as_u64();
+        let del_prov = Provenance::builder()
+            .source("mcp")
+            .principal("svc-deleter")
+            .build()
+            .expect("build delete provenance");
+        db.delete_node_with_options(a, WriteRequestOptions::new().with_provenance(del_prov))
+            .expect("delete node with provenance");
+
+        // Retract-node path: isolated node retracted with a principal.
+        let b = db
+            .create_node("Person", person("RetractMe"))
+            .expect("create B");
+        ret_node = b.as_u64();
+        let ret_prov = Provenance::builder()
+            .principal("svc-retractor")
+            .build()
+            .expect("build retract provenance");
+        db.retract_node_with_provenance(b, time::now(), Some(ret_prov))
+            .expect("retract node with provenance");
+
+        // Retract-edge path: an edge retracted with a principal (its endpoint
+        // nodes survive).
+        let c = db
+            .create_node("Person", person("EdgeSrc"))
+            .expect("create C");
+        let d = db
+            .create_node("Person", person("EdgeDst"))
+            .expect("create D");
+        let e = db
+            .create_edge(c, d, "KNOWS", PropertyMapBuilder::new().build())
+            .expect("create edge");
+        ret_edge = e.as_u64();
+        let edge_prov = Provenance::builder()
+            .principal("svc-edge-retractor")
+            .build()
+            .expect("build edge retract provenance");
+        db.retract_edge_with_provenance(e, time::now(), Some(edge_prov))
+            .expect("retract edge with provenance");
+
+        // Deliberately NO db.persist_indexes(): recovery must come from the
+        // WAL alone (group-commit WAL has fsynced by the time each call
+        // returned).
+        drop(db);
+    }
+
+    // ── Round 2: reopen — forces WAL replay (no index snapshot exists) ──
+    let db = AletheiaDB::open(&data_dir).expect("reopen durable db");
+
+    // Delete tombstone carries the deleter's principal after WAL replay.
+    let del_nid = NodeId::new(del_node).expect("del node id");
+    let del_history = db.get_node_history(del_nid).expect("delete history");
+    assert_eq!(del_history.version_count(), 2, "create + tombstone");
+    let tombstone = del_history
+        .current_version()
+        .expect("tombstone version")
+        .provenance
+        .as_ref()
+        .expect("tombstone must carry provenance after WAL replay (#3427)");
+    assert_eq!(tombstone.principal(), Some("svc-deleter"));
+    assert_eq!(tombstone.source(), Some("mcp"));
+
+    // Retraction version carries the retractor's principal after WAL replay.
+    let ret_nid = NodeId::new(ret_node).expect("ret node id");
+    let ret_history = db.get_node_history(ret_nid).expect("retract history");
+    assert_eq!(ret_history.version_count(), 2, "create + retraction");
+    let retraction = ret_history
+        .current_version()
+        .expect("retraction version")
+        .provenance
+        .as_ref()
+        .expect("retraction must carry provenance after WAL replay (#3427)");
+    assert_eq!(retraction.principal(), Some("svc-retractor"));
+
+    // Edge retraction version carries its principal too.
+    let ret_eid = EdgeId::new(ret_edge).expect("ret edge id");
+    let edge_history = db.get_edge_history(ret_eid).expect("edge history");
+    let edge_retraction = edge_history
+        .current_version()
+        .expect("edge retraction version")
+        .provenance
+        .as_ref()
+        .expect("edge retraction must carry provenance after WAL replay (#3427)");
+    assert_eq!(edge_retraction.principal(), Some("svc-edge-retractor"));
+}
+
+/// A cascade (detach) delete must attribute EVERY tombstone it creates — the
+/// node AND every co-deleted edge — with the same acting principal, and all
+/// of them must survive WAL replay.
+#[test]
+fn crash_recovery_cascade_delete_stamps_provenance_on_co_deleted_edges() {
+    let tempdir = tempfile::tempdir().expect("create tempdir");
+    let data_dir = tempdir.path().join("db");
+
+    let victim: u64;
+    let edge1: u64;
+    let edge2: u64;
+
+    {
+        let db = AletheiaDB::open(&data_dir).expect("open durable db");
+
+        // A hub node with two connected edges (one outgoing, one incoming).
+        let hub = db.create_node("Person", person("Hub")).expect("create hub");
+        let leaf_a = db
+            .create_node("Person", person("LeafA"))
+            .expect("create leaf A");
+        let leaf_b = db
+            .create_node("Person", person("LeafB"))
+            .expect("create leaf B");
+        victim = hub.as_u64();
+        let e1 = db
+            .create_edge(hub, leaf_a, "KNOWS", PropertyMapBuilder::new().build())
+            .expect("edge 1");
+        let e2 = db
+            .create_edge(leaf_b, hub, "KNOWS", PropertyMapBuilder::new().build())
+            .expect("edge 2");
+        edge1 = e1.as_u64();
+        edge2 = e2.as_u64();
+
+        let prov = Provenance::builder()
+            .source("mcp")
+            .principal("svc-cascader")
+            .build()
+            .expect("build cascade provenance");
+        db.delete_node_cascade_with_options(hub, WriteRequestOptions::new().with_provenance(prov))
+            .expect("cascade delete with provenance");
+
+        // Crash: no index checkpoint.
+        drop(db);
+    }
+
+    let db = AletheiaDB::open(&data_dir).expect("reopen durable db");
+
+    // Node tombstone carries the principal.
+    let hub_nid = NodeId::new(victim).expect("hub node id");
+    let hub_tombstone = db
+        .get_node_history(hub_nid)
+        .expect("hub history")
+        .current_version()
+        .expect("hub tombstone")
+        .provenance
+        .clone()
+        .expect("hub tombstone must carry provenance after WAL replay (#3427)");
+    assert_eq!(hub_tombstone.principal(), Some("svc-cascader"));
+
+    // Both co-deleted edge tombstones carry the SAME principal.
+    for eid in [edge1, edge2] {
+        let edge_id = EdgeId::new(eid).expect("edge id");
+        let edge_tombstone = db
+            .get_edge_history(edge_id)
+            .expect("edge history")
+            .current_version()
+            .expect("edge tombstone")
+            .provenance
+            .clone()
+            .unwrap_or_else(|| {
+                panic!(
+                    "co-deleted edge {eid} tombstone must carry provenance after WAL replay (#3427)"
+                )
+            });
+        assert_eq!(
+            edge_tombstone.principal(),
+            Some("svc-cascader"),
+            "co-deleted edge {eid} must carry the cascade principal"
+        );
+    }
+}

--- a/tests/http_auth.rs
+++ b/tests/http_auth.rs
@@ -791,3 +791,163 @@ async fn anonymous_http_write_records_no_principal() {
         "anonymous write must not fabricate provenance: {provenance:?}"
     );
 }
+
+/// A destructive `bulk_delete_nodes` through the authenticated HTTP surface
+/// stamps the verified principal's name onto the tombstone version each
+/// deleted node produces (Issue #3427). The node is gone from current state,
+/// so attribution is read off the tombstone in history, not the live node.
+#[tokio::test]
+async fn authenticated_http_bulk_delete_stamps_principal_on_tombstone() {
+    use aletheiadb::core::NodeId;
+
+    let (client, store, db) = required_client();
+    let key = mint(&store, "http-deleter", Role::Writer);
+
+    // Create two nodes to delete.
+    let bulk = json!({
+        "operation": "bulk_create_nodes",
+        "nodes": [{"label": "Person"}, {"label": "Person"}]
+    });
+    let (status, body) = post_query_with_key(&client, &key, &bulk).await;
+    assert_eq!(status, 200, "{body}");
+    let ids: Vec<u64> = body["data"]
+        .as_array()
+        .expect("created array")
+        .iter()
+        .map(|n| n["id"].as_u64().expect("id"))
+        .collect();
+    assert_eq!(ids.len(), 2);
+
+    // Delete them (non-cascade) through the authenticated surface.
+    let del = json!({ "operation": "bulk_delete_nodes", "node_ids": ids });
+    let (status, body) = post_query_with_key(&client, &key, &del).await;
+    assert_eq!(status, 200, "{body}");
+    assert_eq!(body["data"]["deleted_count"], 2, "{body}");
+
+    // Each node's tombstone version carries the deleter's principal.
+    for id in ids {
+        let history = db
+            .get_node_history(NodeId::new(id).expect("node id"))
+            .expect("node history");
+        let tombstone = history
+            .current_version()
+            .expect("tombstone version")
+            .provenance
+            .as_ref()
+            .expect("tombstone must carry provenance for an authenticated delete (#3427)");
+        assert_eq!(tombstone.principal(), Some("http-deleter"));
+    }
+}
+
+/// A cascade `bulk_delete_nodes` through the authenticated HTTP surface
+/// stamps the principal onto the hub-node tombstone AND every co-deleted
+/// edge's tombstone (Issue #3427). Edges are created via the embedded API
+/// (the HTTP `/query` surface has no edge-creation operation).
+#[tokio::test]
+async fn authenticated_http_bulk_delete_cascade_stamps_principal_on_edges() {
+    use aletheiadb::PropertyMapBuilder;
+    use aletheiadb::core::{EdgeId, NodeId};
+
+    let (client, store, db) = required_client();
+    let key = mint(&store, "http-cascader", Role::Writer);
+
+    // hub + two leaves, created through the authenticated HTTP surface.
+    let bulk = json!({
+        "operation": "bulk_create_nodes",
+        "nodes": [{"label": "Person"}, {"label": "Person"}, {"label": "Person"}]
+    });
+    let (status, body) = post_query_with_key(&client, &key, &bulk).await;
+    assert_eq!(status, 200, "{body}");
+    let ids: Vec<u64> = body["data"]
+        .as_array()
+        .expect("created array")
+        .iter()
+        .map(|n| n["id"].as_u64().expect("id"))
+        .collect();
+    let hub = NodeId::new(ids[0]).expect("hub id");
+    let leaf_a = NodeId::new(ids[1]).expect("leaf a id");
+    let leaf_b = NodeId::new(ids[2]).expect("leaf b id");
+
+    // One outgoing and one incoming edge on the hub (embedded API).
+    let e1 = db
+        .create_edge(hub, leaf_a, "KNOWS", PropertyMapBuilder::new().build())
+        .expect("edge 1");
+    let e2 = db
+        .create_edge(leaf_b, hub, "KNOWS", PropertyMapBuilder::new().build())
+        .expect("edge 2");
+
+    // Cascade delete the hub through the authenticated surface.
+    let del = json!({
+        "operation": "bulk_delete_nodes",
+        "node_ids": [hub.as_u64()],
+        "cascade": true
+    });
+    let (status, body) = post_query_with_key(&client, &key, &del).await;
+    assert_eq!(status, 200, "{body}");
+    assert_eq!(body["data"]["cascade"], true, "{body}");
+
+    // Hub node tombstone carries the principal.
+    let hub_tombstone = db
+        .get_node_history(hub)
+        .expect("hub history")
+        .current_version()
+        .expect("hub tombstone")
+        .provenance
+        .clone()
+        .expect("hub tombstone must carry provenance (#3427)");
+    assert_eq!(hub_tombstone.principal(), Some("http-cascader"));
+
+    // Both co-deleted edge tombstones carry the SAME principal.
+    for eid in [e1, e2] {
+        let edge_tombstone = db
+            .get_edge_history(EdgeId::new(eid.as_u64()).expect("edge id"))
+            .expect("edge history")
+            .current_version()
+            .expect("edge tombstone")
+            .provenance
+            .clone()
+            .unwrap_or_else(|| {
+                panic!(
+                    "co-deleted edge {} tombstone must carry provenance (#3427)",
+                    eid.as_u64()
+                )
+            });
+        assert_eq!(edge_tombstone.principal(), Some("http-cascader"));
+    }
+}
+
+/// Anonymous-mode `bulk_delete_nodes` records no provenance principal on the
+/// tombstone (absent, not an empty string) — matching the anonymous
+/// create/update contract.
+#[tokio::test]
+async fn anonymous_http_bulk_delete_records_no_principal() {
+    use aletheiadb::core::NodeId;
+
+    let (client, _store, db) = client_with_auth(AuthMode::Anonymous);
+
+    // Create a node anonymously.
+    let resp = client.post("/query").json(&create_node_op()).send().await;
+    assert_eq!(resp.status.as_u16(), 200);
+    let body: Value = serde_json::from_slice(&resp.body).expect("json");
+    let node_id = body["data"]["id"].as_u64().expect("id");
+
+    // Delete it anonymously.
+    let del = json!({ "operation": "bulk_delete_nodes", "node_ids": [node_id] });
+    let resp = client.post("/query").json(&del).send().await;
+    assert_eq!(resp.status.as_u16(), 200);
+    let body: Value = serde_json::from_slice(&resp.body).expect("json");
+    assert_eq!(body["data"]["deleted_count"], 1, "{body}");
+
+    // The tombstone must not fabricate a principal.
+    let tombstone = db
+        .get_node_history(NodeId::new(node_id).expect("node id"))
+        .expect("node history")
+        .current_version()
+        .expect("tombstone version")
+        .provenance
+        .clone();
+    assert!(
+        tombstone.is_none(),
+        "anonymous delete must not fabricate provenance: {tombstone:?}"
+    );
+}

--- a/tests/recovery/checkpoint_recovery_tests.rs
+++ b/tests/recovery/checkpoint_recovery_tests.rs
@@ -390,6 +390,7 @@ fn test_checkpoint_recovery_with_deletes() -> Result<()> {
         node_id: NodeId::new(2)?,
         valid_from: time::now(),
         version_id: None,
+        provenance: None,
     })?;
 
     wal.flush()?;
@@ -519,6 +520,7 @@ fn test_retraction_then_checkpoint_survives_recovery() -> Result<()> {
         node_id,
         valid_to,
         version_id: None,
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -623,6 +625,7 @@ fn test_retraction_replayed_after_checkpoint() -> Result<()> {
         node_id,
         valid_to,
         version_id: None,
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -745,6 +748,7 @@ fn test_checkpoint_restore_only_preserves_node_bitemporal_fidelity() -> Result<(
         node_id,
         valid_to,
         version_id: None,
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -933,6 +937,7 @@ fn test_checkpoint_restore_only_preserves_edge_bitemporal_fidelity() -> Result<(
         edge_id,
         valid_to,
         version_id: None,
+        provenance: None,
     })?;
     wal.flush()?;
 

--- a/tests/recovery/large_dataset_recovery.rs
+++ b/tests/recovery/large_dataset_recovery.rs
@@ -516,6 +516,7 @@ fn test_large_dataset_with_deletions() -> Result<()> {
             node_id: NodeId::new(node_id).unwrap(),
             valid_from: time::now(),
             version_id: None,
+            provenance: None,
         })?;
     }
 

--- a/tests/recovery/property_based_tests.rs
+++ b/tests/recovery/property_based_tests.rs
@@ -256,6 +256,7 @@ impl RecoveryTestHarness {
                             node_id: NodeId::new(*id)?,
                             valid_from: timestamp_counter,
                             version_id: None,
+                            provenance: None,
                         })?;
                         created_nodes.remove(id);
                     }
@@ -304,6 +305,7 @@ impl RecoveryTestHarness {
                             edge_id: EdgeId::new(*id)?,
                             valid_from: timestamp_counter,
                             version_id: None,
+                            provenance: None,
                         })?;
                         created_edges.remove(id);
                     }

--- a/tests/recovery/replay_delete_tests.rs
+++ b/tests/recovery/replay_delete_tests.rs
@@ -69,6 +69,7 @@ fn test_replay_delete_node_basic() -> Result<()> {
         node_id,
         valid_from: timestamp2,
         version_id: None,
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -126,6 +127,7 @@ fn test_replay_delete_node_after_update() -> Result<()> {
         node_id,
         valid_from: time::now(),
         version_id: None,
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -190,6 +192,7 @@ fn test_replay_delete_edge_basic() -> Result<()> {
         edge_id,
         valid_from: time::now(),
         version_id: None,
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -247,6 +250,7 @@ fn test_replay_delete_node_preserves_temporal_intervals() -> Result<()> {
         node_id,
         valid_from: delete_vf,
         version_id: None,
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -368,6 +372,7 @@ fn test_replay_delete_edge_preserves_temporal_intervals() -> Result<()> {
         edge_id,
         valid_from: delete_vf,
         version_id: None,
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -483,6 +488,7 @@ fn test_replay_delete_node_honors_logged_valid_from() -> Result<()> {
         node_id,
         valid_from: delete_vf,
         version_id: None,
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -570,6 +576,7 @@ fn test_replay_delete_edge_honors_logged_valid_from() -> Result<()> {
         edge_id,
         valid_from: delete_vf,
         version_id: None,
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -645,6 +652,7 @@ fn test_replay_multiple_deletes() -> Result<()> {
             node_id: NodeId::new(id).unwrap(),
             valid_from: time::now(),
             version_id: None,
+            provenance: None,
         })?;
     }
 
@@ -698,6 +706,7 @@ fn test_replay_delete_with_vector() -> Result<()> {
         node_id,
         valid_from: time::now(),
         version_id: None,
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -758,6 +767,7 @@ fn test_replay_mixed_creates_updates_deletes() -> Result<()> {
         node_id: NodeId::new(2).unwrap(),
         valid_from: time::now(),
         version_id: None,
+        provenance: None,
     })?;
 
     // Create node 3

--- a/tests/recovery/replay_id_tracking_tests.rs
+++ b/tests/recovery/replay_id_tracking_tests.rs
@@ -236,6 +236,7 @@ fn test_recover_with_deletes_tracks_max_ids() -> Result<()> {
         node_id: NodeId::new(2).unwrap(),
         valid_from: time::now(),
         version_id: None,
+        provenance: None,
     })?;
     wal.flush()?;
 

--- a/tests/recovery/replay_loop_tests.rs
+++ b/tests/recovery/replay_loop_tests.rs
@@ -253,6 +253,7 @@ fn test_recover_handles_non_sequential_version_ids() -> Result<()> {
         node_id,
         valid_from: time::now(),
         version_id: None,
+        provenance: None,
     })?;
 
     wal.flush()?;
@@ -320,6 +321,7 @@ fn test_recover_with_multiple_operation_types() -> Result<()> {
         node_id,
         valid_from: time::now(),
         version_id: None,
+        provenance: None,
     })?;
 
     wal.flush()?;

--- a/tests/recovery/tombstone_version_id_tests.rs
+++ b/tests/recovery/tombstone_version_id_tests.rs
@@ -95,6 +95,7 @@ fn honor_logged_delete_node_version_id() -> Result<()> {
         node_id,
         valid_from: time::now(),
         version_id: Some(live_tombstone),
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -147,6 +148,7 @@ fn honor_logged_delete_edge_version_id() -> Result<()> {
         edge_id,
         valid_from: time::now(),
         version_id: Some(live_tombstone),
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -186,6 +188,7 @@ fn honor_logged_retract_node_version_id() -> Result<()> {
         node_id,
         valid_to: retract_valid_to,
         version_id: Some(live_retraction),
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -255,6 +258,7 @@ fn honor_logged_retract_edge_version_id() -> Result<()> {
         edge_id,
         valid_to: retract_valid_to,
         version_id: Some(live_retraction),
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -334,6 +338,7 @@ fn collision_does_not_clobber_history() -> Result<()> {
         node_id: a,
         valid_from: time::now(),
         version_id: Some(a_tombstone),
+        provenance: None,
     })?;
     wal.append(WalOperation::UpdateNode {
         node_id: b,
@@ -421,12 +426,14 @@ fn synthesized_delete_after_honored_high_id_skips_past_it() -> Result<()> {
         node_id: a,
         valid_from: time::now(),
         version_id: Some(honored_high),
+        provenance: None,
     })?;
     // Delete C with NO logged id -> replay must SYNTHESIZE its tombstone.
     wal.append(WalOperation::DeleteNode {
         node_id: c,
         valid_from: time::now(),
         version_id: None,
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -483,12 +490,14 @@ fn synthesized_delete_after_honored_retract_high_id_skips_past_it() -> Result<()
         node_id: a,
         valid_to: time::now(),
         version_id: Some(honored_high),
+        provenance: None,
     })?;
     // Delete C with NO logged id -> synthesis; must skip past the retract's id.
     wal.append(WalOperation::DeleteNode {
         node_id: c,
         valid_from: time::now(),
         version_id: None,
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -533,6 +542,7 @@ fn repeated_replay_is_stable() -> Result<()> {
         node_id,
         valid_from: time::now(),
         version_id: Some(live_tombstone),
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -577,6 +587,7 @@ fn back_compat_synthesizes_when_version_id_absent() -> Result<()> {
         node_id,
         valid_from: time::now(),
         version_id: None,
+        provenance: None,
     })?;
     wal.flush()?;
 


### PR DESCRIPTION
## Issue #3427: record acting principal in provenance for delete/retract operations

Follow-up to #3350. Closes the crash-recovery attribution gap for **destructive**
operations end-to-end: from the MCP surface, through the write path, into the
WAL format, and back out through crash recovery.

### Before / After (plain language)

- **Before:** `delete_node`, `delete_edge`, `retract_node`, `retract_edge` were
  the only unattributed writes. #3350 stamps `provenance.principal` on
  create/update, but the four destructive WAL payloads were a fixed
  `[op][id][ts][version_id]` shape with **no provenance field**. Crash recovery
  reconstructs the tombstone/retraction version *solely* from the WAL entry, so
  even a RAM-only principal would **vanish on WAL replay** — a crash-path-only
  attribution loss. That is why #3350 deliberately did **not** attribute deletes/retracts.
- **After:** the four destructive WAL payloads carry the same optional
  `Provenance` blob create/update already carry (source / confidence / note /
  correlation_id / **principal**), gated behind a new WAL version pair. The MCP
  destructive tools stamp the authenticated session principal; the write path
  threads it to the WAL; crash recovery threads it into the reconstructed
  tombstone/retraction historical version. The acting principal now **survives
  WAL replay**, and detach/cascade attribute every co-deleted / co-retracted edge too.

### Scope — all three phases now in this PR

- **Phase A** — WAL format (v11/v12) + serialization + version-gated parsing +
  recovery replay arms + historical `add_retracted_*_with_provenance` API.
- **Phase B** — live write-path threading: `provenance` on the four
  `BufferedWrite` variants + `From<&BufferedWrite> for WalOperation`, `apply.rs`
  delete/retract fns, and additive `*_with_options` / `*_with_provenance` public
  API on `WriteOps` / `AletheiaDB` (existing signatures delegate with defaults —
  source-compatible). Detach/cascade stamp every co-affected edge.
- **Phase C** — MCP route-through: the five destructive handlers resolve a
  **principal-only, unforgeable** bundle via `parse_opt_provenance(None)` and
  pass it through the Phase B API. The tool schemas are unchanged — they accept
  no caller provenance, so the principal can never originate from request JSON.
  Anonymous sessions record no principal (field absent).

### WAL version ladder

| Version | Const | Meaning |
|---|---|---|
| 9 / 10 | `WAL_VERSION_DELETE_VERSION_ID` / `..._ENCRYPTED_...` | #3406 tombstone version_id |
| **11 / 12** | `WAL_VERSION_DESTRUCTIVE_PROVENANCE` / `..._ENCRYPTED_...` | **#3427 destructive-op provenance blob** |

New payload layout (append **after** the existing `version_id` tail):

```
[op:1][id:8][ts:12][tombstone_version_id:8][provenance blob]   // v11/v12
[op:1][id:8][ts:12][tombstone_version_id:8]                    // v9/v10 (unchanged)
[op:1][id:8][ts:12]                                            // <=v8 (unchanged)
```

The provenance blob is byte-identical to the create/update encoding
(`serialize_provenance_into` / `read_provenance`). Readers gate the trailing
read on `carries_destructive_provenance(version)` (`version >= 11`), so v9/v10
and legacy segments parse **byte-identically to today** (`provenance: None`, no
over-read). The plaintext writer stamps v11 (v12 when a WAL cipher is
configured). On an encryption-at-rest DB the blob is parsed downstream of the
cipher decrypt via the #3483 cipher-aware reader.

### Backward compatibility

- Old WAL segments (≤ v10) parse unchanged as `provenance: None`.
- Snapshot layers (index-persistence / checkpoint / backup / cold-storage) already
  serialize whole version structs, so a provenance-carrying tombstone/retraction
  round-trips there with **zero** additional format work — only the WAL needed extending.
- The DELIBERATELY-KEPT explicit transaction-time closes in the recovery arms
  (#3407 / #3492) are preserved verbatim; provenance is threaded orthogonally.

### Out of scope (not in this PR)

One HTTP-surface item remains **out** of this PR:

- **Mutating AQL via HTTP `execute_query` / `bulk_execute_query`** — the issue
  explicitly flags this as a "related deferred sibling": it needs identity
  threaded into the AQL query executor (a separate seam) and possibly a further
  WAL payload extension. This is genuinely out of #3427's core scope and is a
  distinct follow-up.

(HTTP `bulk_delete_nodes` attribution — issue sketch step 5 — **is now wired in
this PR**; see the AC-evidence table below. No issue number is asserted for the
mutating-AQL follow-up here; the previously-cited **#3506 is unrelated** — it
tracks a WAL label-interner-id serialization bug, not principal attribution.)

### AC-evidence table

Every acceptance criterion is drawn from the issue body's "Proposed
implementation sketch" (steps 1–6) and the design-comment §6 test requirements.

| AC | Status | Evidence (file:line / test / commit) |
|---|---|---|
| **AC1 — WAL: version-gated provenance blob on the 4 destructive payloads; version bump; old segments parse the fixed shape as `None`** | ✅ | `WAL_VERSION_DESTRUCTIVE_PROVENANCE=11` / `_ENCRYPTED_=12`, `WAL_VERSION_MAX` bump, `carries_destructive_provenance()` — `src/storage/wal/segment_reader.rs:164,169,172,214`; serialize arms append the blob — `src/storage/wal/serialization.rs:447-486`; version-gated parse in the 4 `parse_*_op` fns. Tests: `test_v11_{delete_node,delete_edge,retract_node,retract_edge}_roundtrips_provenance`, `test_v9_{delete,retract}_node_parses_without_provenance` |
| **AC2 — `provenance` on the 4 `BufferedWrite` variants + `From` conversion** | ✅ | `src/api/transaction/write_buffer.rs` (fields at `:42,61,76,95,…`); `From<&BufferedWrite> for WalOperation` maps `provenance.as_deref().cloned()`. Commit `3aa505f` (Phase B) |
| **AC3 — Apply + replay thread the bundle** | ✅ | apply: `src/api/transaction/write/apply.rs` delete → `add_node/edge_version_with_provenance` (`:108,:176`), retract → new `add_retracted_*_version_with_provenance`; recovery replay arms `src/storage/recovery.rs:600,690,795,885`; new historical fns `src/storage/historical/mod.rs:620,926`. #3407/#3492 tx-time closes preserved |
| **AC4 — Additive `*_with_options` public API, source-compatible** | ✅ | `WriteOps::{delete_node,delete_node_cascade,delete_edge}_with_options` + `retract_{node,edge}_with_provenance` — `src/api/transaction/write/mod.rs:1425,1491,1553,1682,1817`; `AletheiaDB` wrappers + `retract_node_detach_with_provenance` — `src/db/ops.rs:331,343,357,427,502,568`. Existing signatures delegate with defaults |
| **AC5 — MCP destructive tools stamp the session principal; unforgeable; anonymous stamps nothing** | ✅ | 5 handlers route through `parse_opt_provenance(None)` — `src/mcp/server.rs` `handle_delete_node` / `handle_delete_edge` / `handle_delete_node_cascade` / `handle_retract_node` / `handle_retract_edge`. Tests: `authenticated_{delete,retract}_{node,edge}_stamps_principal`, `anonymous_destructive_ops_record_no_principal`, `forged_principal_on_destructive_op_is_ignored` (`src/mcp/auth_tests.rs`) |
| **AC6 — principal survives WAL replay (crash path); attribution visible via history; anonymous none; old segments parse** | ✅ | `tests/destructive_provenance_recovery.rs::crash_recovery_preserves_delete_and_retract_provenance_principal` (delete + retract-node + retract-edge survive real WAL replay, asserted via `get_node_history` / `get_edge_history`); MCP history-read assertions; `test_v9_*_parses_without_provenance` |
| **AC (design §6) — detach co-delete / co-retract attribute connected edges** | ✅ | `authenticated_detach_delete_stamps_principal_on_co_deleted_edges` (MCP), `crash_recovery_cascade_delete_stamps_provenance_on_co_deleted_edges` (recovery). Cascade stamps the same options per edge (`write/mod.rs:1542`); detach retract per edge (`db/ops.rs:527`) |
| **AC (design §6) — encrypted (v12) round-trip; cipher-aware replay** | ✅ | `test_v12_encrypted_destructive_provenance_survives_decrypt` (DeleteNode, Phase A) + new `test_v12_encrypted_{retract_node,delete_edge,retract_edge}_survives_decrypt`; routes through the #3483 cipher-aware reader |
| **AC (hardening) — torn/corrupt provenance blob is panic-free + correctly classified** | ✅ | `test_v11_torn_provenance_blob_is_corrupt_not_panic_and_classified`: `read_provenance` → `CorruptedData` (no panic), tolerated as torn tail on the final segment, hard-errors mid-log |
| **AC (hardening) — empty-string principal distinct from absent** | ✅ | `test_v11_empty_string_principal_roundtrips_distinct_from_none` (presence-byte distinction: `Some("")` ≠ `None`) |
| **HTTP `bulk_delete_nodes` attribution (issue sketch step 5)** | ✅ | HTTP `handle_bulk_delete_nodes` now stamps the verified session principal via `write_options_for(principal)` — swaps `delete_node`/`delete_node_cascade` for their `*_with_options` counterparts (`src/http/handlers.rs:591,596`) and threads `principal` through the `/query` dispatch arm (`src/http/handlers.rs:578,920`). Principal comes only from the verified session, never the request body. Tests (`tests/http_auth.rs`): `authenticated_http_bulk_delete_stamps_principal_on_tombstone`, `authenticated_http_bulk_delete_cascade_stamps_principal_on_edges`, `anonymous_http_bulk_delete_records_no_principal`. Commit `0e505ac` |
| **Mutating AQL via HTTP `execute_query` / `bulk_execute_query` attribution** | ⛔ Deferred sibling — out of #3427 core scope | The issue explicitly names this a "related deferred sibling": needs identity threaded into the AQL query executor (separate seam) and possibly a further WAL extension. Distinct follow-up. **Not** tracked by #3506 (that issue is an unrelated WAL label-interner-id serialization bug) |

### Local validation

Run under an isolated `CARGO_TARGET_DIR` (shared `/workspace/target` collides
across worktrees; `--all-features` and coverage builds hit ENOSPC in this env):

- `cargo fmt --all` — clean
- **CI-subset clippy** `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` — **clean (exit 0)**
- lib tests `cargo test --lib --features "config-toml,mcp-server" -- storage::wal:: storage::recovery:: storage::historical:: mcp::` — **853 passed, 0 failed** (includes all new v11/v12/torn/empty-principal WAL tests and the 7 Phase C MCP auth tests)
- integration `cargo test --features "config-toml,mcp-server" --test destructive_provenance_recovery` — **2 passed, 0 failed**
- **HTTP surface** `cargo clippy --lib --features "config-toml,mcp-server,http-server" -- -D warnings` — **clean (exit 0)**; `cargo test --features "config-toml,mcp-server,http-server" --test http_auth` — **27 passed, 0 failed** (includes the 3 new `bulk_delete_nodes` attribution tests)

The full `--all-features` clippy is **deferred to CI** (ENOSPC/time-prohibitive
in this sandbox); the CI Linting feature subset above is green locally, and CI
runs the complete `--all-features` gate on this PR.

Refs #3427. Depends on #3483 (cipher-aware replay reader, on trunk). The one
remaining deferred sibling surface (mutating AQL via HTTP) is a follow-up — not
tracked by #3506 (unrelated bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### CI note — the ubuntu-stable Test Suite red is #3504, not this PR

The failing test `read_tx_edge_listing_ok_for_node_deleted_after_snapshot` (`tests/readops_snapshot_isolation.rs`) is the known valid-time snapshot-isolation bug **#3504** (delete closes the prior version's `valid_to` in place; #3437 fixed only the tx-time half; it surfaces when the delete's HLC timestamp collides with the read snapshot's, more likely under slow/instrumented CI runners). It is **not** introduced by this PR:

- The four deterministic frozen-clock siblings pinning the same delete→historical-fallback path all **pass** in the same run; only the single real-clock variant flakes.
- `tests/readops_snapshot_isolation.rs` is **not modified** by this PR.
- **#3427 is payload-only for delete timing:** HLC timestamp acquisition (`write/mod.rs:435-595`) and the `valid_to` close (`apply.rs:223/227/336`) are byte-for-byte unchanged; provenance is assembled *pre-commit* and threaded through as a trailing `Arc`-clone argument. The only in-critical-section effect is additive WAL-entry bytes for **authenticated** deletes — empty (one `Option`-tag byte) on the **anonymous** path this test exercises — which don't affect HLC value generation or ordering, so #3427 cannot widen #3504's timestamp-equality collision window.

The #3504 production fix is scheduled immediately after this PR merges.
---