### PR TITLE
Cypher: multi-variable multi-pattern MATCH (#549)

### DIFF
--- a/python/src/query.rs
+++ b/python/src/query.rs
@@ -44,6 +44,22 @@ fn py_to_cypher_param(value: &Bound<'_, PyAny>) -> PyResult<CypherParameterValue
     )))
 }
 
+/// Serialize a single query-result entity into a Python object
+/// (`PyNode` / `PyEdge` / int id / `None`).
+///
+/// Shared by the single-entity row path and the multi-variable binding path
+/// (#549) so both surface nodes/edges identically.
+fn entity_to_py(py: Python<'_>, entity: EntityResult) -> PyResult<PyObject> {
+    Ok(match entity {
+        EntityResult::Node(n) => Py::new(py, PyNode::from_rust(n))?.into_py(py),
+        EntityResult::Edge(e) => Py::new(py, PyEdge::from_rust(e))?.into_py(py),
+        EntityResult::NodeId(id) => id.as_u64().into_py(py),
+        EntityResult::EdgeId(id) => id.as_u64().into_py(py),
+        // Null binding (unmatched OPTIONAL MATCH) or any future variant.
+        _ => py.None(),
+    })
+}
+
 pub fn execute_cypher(
     py: Python<'_>,
     db: &Arc<RustDB>,
@@ -75,6 +91,23 @@ pub fn execute_cypher(
     let list = PyList::empty_bound(py);
     for row in rows {
         let d = PyDict::new_bound(py);
+        // Multi-variable binding row (#549): `MATCH (a),(b) RETURN a,b` binds
+        // several variables that the single `entity` field cannot represent.
+        // Surface them under a `bindings` dict (var -> entity) rather than the
+        // lossy single-entity shape, which would drop every bound entity.
+        if let Some(bindings) = row.bindings {
+            let bd = PyDict::new_bound(py);
+            for (name, entity) in bindings {
+                bd.set_item(name, entity_to_py(py, entity)?)?;
+            }
+            d.set_item("kind", "bindings")?;
+            d.set_item("bindings", bd)?;
+            if let Some(score) = row.score {
+                d.set_item("score", score as f64)?;
+            }
+            list.append(d)?;
+            continue;
+        }
         match row.entity {
             EntityResult::Node(n) => {
                 d.set_item("kind", "node")?;

--- a/src/cypher/exec.rs
+++ b/src/cypher/exec.rs
@@ -154,26 +154,23 @@ pub fn plan_cypher_with_params(
 /// n.name`, `count(*)`, a vector-ranked `RETURN d, score`) stays `false` and is
 /// untouched.
 ///
-/// `OPTIONAL MATCH` / `WITH` statements stay on the existing path (which has its
-/// own handling for them); a multi-variable query combined with those clauses is
-/// out of the v1 evaluator's scope and the evaluator rejects it if it is ever
-/// reached.
+/// A single-terminal-variable query -- including a single-pattern `WITH` /
+/// `OPTIONAL MATCH` query the existing path handles correctly -- stays `false`
+/// and is untouched. But a genuinely multi-variable query IS routed to the
+/// evaluator even when combined with `WITH` / `OPTIONAL MATCH` (FIX #5): those
+/// clauses are out of the v1 evaluator's scope, so it rejects them with a
+/// structured error rather than letting the single-entity path silently return
+/// a wrong row.
 pub fn needs_multi_binding(stmt: &CypherStatement) -> bool {
     let CypherStatement::Match {
-        optional,
         pattern,
         where_clause,
         return_clause,
-        with_clauses,
-        optional_matches,
         ..
     } = stmt
     else {
         return false;
     };
-    if *optional || !with_clauses.is_empty() || !optional_matches.is_empty() {
-        return false;
-    }
 
     // Entity (node + relationship) variables declared across all patterns.
     let mut entity_vars: HashSet<String> = HashSet::new();
@@ -199,6 +196,16 @@ pub fn needs_multi_binding(stmt: &CypherStatement) -> bool {
 
     let terminal = pattern.last().and_then(last_node_variable);
 
+    // The multi-binding decision is made from the pattern shape and the
+    // referenced variables ALONE -- the `WITH` / `OPTIONAL MATCH` clauses are
+    // deliberately NOT consulted here (FIX #5). When a query genuinely binds
+    // more than one entity variable (or joins comma-separated patterns), it
+    // must route to the multi-pattern evaluator EVEN if `WITH`/`OPTIONAL MATCH`
+    // is present: the evaluator then rejects those clauses with a structured
+    // `UnsupportedFeature` error, rather than the single-entity path silently
+    // discarding an earlier scan and returning a wrong row. A genuine
+    // single-terminal-variable query (including single-pattern `WITH` /
+    // `OPTIONAL MATCH` queries the old path handles correctly) stays `false`.
     pattern.len() > 1
         || referenced.len() > 1
         || referenced
@@ -219,16 +226,25 @@ fn collect_pattern_entity_vars(pattern: &CypherPattern, out: &mut HashSet<String
     }
 }
 
-/// The variable of the last node element of a pattern, if named.
+/// The variable of the **last node element** of a pattern, or `None` when that
+/// terminal node is unnamed (FIX #4).
+///
+/// This must return the last node's `.variable` directly -- `None` if the last
+/// node is anonymous -- rather than skipping past an unnamed terminal to an
+/// earlier named node. Skipping would make `MATCH (a)-[:R]->()` report a
+/// terminal of `a`, wrongly classifying it as single-terminal and routing it to
+/// the single-entity path (which returns the anonymous endpoint, not `a`).
+/// Mirrors `converter::last_node_variable`.
 fn last_node_variable(pattern: &CypherPattern) -> Option<String> {
     pattern
         .elements
         .iter()
         .rev()
         .find_map(|element| match element {
-            CypherPatternElement::Node(n) => n.variable.clone(),
+            CypherPatternElement::Node(n) => Some(n.variable.clone()),
             CypherPatternElement::Relationship(_) => None,
         })
+        .flatten()
 }
 
 /// Collect variable references from a `RETURN` item.

--- a/src/cypher/exec.rs
+++ b/src/cypher/exec.rs
@@ -221,10 +221,14 @@ fn collect_pattern_entity_vars(pattern: &CypherPattern, out: &mut HashSet<String
 
 /// The variable of the last node element of a pattern, if named.
 fn last_node_variable(pattern: &CypherPattern) -> Option<String> {
-    pattern.elements.iter().rev().find_map(|element| match element {
-        CypherPatternElement::Node(n) => n.variable.clone(),
-        CypherPatternElement::Relationship(_) => None,
-    })
+    pattern
+        .elements
+        .iter()
+        .rev()
+        .find_map(|element| match element {
+            CypherPatternElement::Node(n) => n.variable.clone(),
+            CypherPatternElement::Relationship(_) => None,
+        })
 }
 
 /// Collect variable references from a `RETURN` item.

--- a/src/cypher/exec.rs
+++ b/src/cypher/exec.rs
@@ -39,7 +39,7 @@
 //!   non-scalar list.
 
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use crate::core::error::Result as CoreResult;
@@ -47,7 +47,10 @@ use crate::core::property::PropertyValue;
 use crate::query::Query;
 use crate::query::executor::{QueryResults, QueryRow, ResultIterator};
 
-use super::ast::{CypherExpr, CypherReturn, CypherReturnItem, CypherStatement, CypherValue};
+use super::ast::{
+    CypherExpr, CypherPattern, CypherPatternElement, CypherReturn, CypherReturnItem,
+    CypherStatement, CypherValue,
+};
 use super::converter::{CypherConverter, CypherParameterValue};
 use super::error::CypherError;
 use super::parser::CypherParser;
@@ -74,6 +77,19 @@ pub enum CypherExecution {
     Query(Query),
     /// Pre-computed result rows (a standalone `UNWIND` expansion).
     Rows(QueryResults),
+    /// A multi-variable, multi-pattern `MATCH` (Issue #549) to be evaluated by
+    /// the dedicated multi-pattern evaluator, which needs the database handle.
+    ///
+    /// The single-entity `Query` IR cannot represent a row that binds several
+    /// variables, so a statement the router classifies as multi-variable
+    /// ([`needs_multi_binding`]) is carried here unconverted; `execute_cypher`
+    /// dispatches it to `AletheiaDB::execute_multi_pattern`.
+    MultiPattern {
+        /// The `MATCH` statement to evaluate.
+        statement: Box<CypherStatement>,
+        /// Parameter bindings for `$param` references.
+        params: HashMap<String, CypherParameterValue>,
+    },
 }
 
 /// Parse and plan a Cypher string with no bound parameters.
@@ -110,9 +126,155 @@ pub fn plan_cypher_with_params(
             let results = execute_unwind(&source, &variable, &return_clause, &params)?;
             Ok(CypherExecution::Rows(results))
         }
+        other if needs_multi_binding(&other) => {
+            // A multi-variable / multi-pattern MATCH has no faithful
+            // single-entity `Query` representation; route it to the dedicated
+            // evaluator (which needs the DB handle) instead of converting.
+            Ok(CypherExecution::MultiPattern {
+                statement: Box::new(other),
+                params,
+            })
+        }
         other => {
             let query = CypherConverter::with_params(params).convert(other)?;
             Ok(CypherExecution::Query(query))
+        }
+    }
+}
+
+/// Classify whether a statement requires multi-variable binding and must be
+/// routed to the multi-pattern evaluator (Issue #549) rather than the
+/// single-entity `Query` pipeline.
+///
+/// Returns `true` only for a base `MATCH` (no `OPTIONAL MATCH`, no `WITH`) that
+/// either joins more than one comma-separated pattern, returns more than one
+/// entity variable, or references a non-terminal entity variable -- exactly the
+/// cases the single-entity row model answers incorrectly. Every query that the
+/// old path already answers correctly (single terminal variable, `RETURN
+/// n.name`, `count(*)`, a vector-ranked `RETURN d, score`) stays `false` and is
+/// untouched.
+///
+/// `OPTIONAL MATCH` / `WITH` statements stay on the existing path (which has its
+/// own handling for them); a multi-variable query combined with those clauses is
+/// out of the v1 evaluator's scope and the evaluator rejects it if it is ever
+/// reached.
+pub fn needs_multi_binding(stmt: &CypherStatement) -> bool {
+    let CypherStatement::Match {
+        optional,
+        pattern,
+        where_clause,
+        return_clause,
+        with_clauses,
+        optional_matches,
+        ..
+    } = stmt
+    else {
+        return false;
+    };
+    if *optional || !with_clauses.is_empty() || !optional_matches.is_empty() {
+        return false;
+    }
+
+    // Entity (node + relationship) variables declared across all patterns.
+    let mut entity_vars: HashSet<String> = HashSet::new();
+    for pattern in pattern {
+        collect_pattern_entity_vars(pattern, &mut entity_vars);
+    }
+    if entity_vars.is_empty() {
+        return false;
+    }
+
+    // Entity variables referenced by RETURN / WHERE / ORDER BY.
+    let mut referenced: HashSet<String> = HashSet::new();
+    for item in &return_clause.items {
+        collect_return_item_refs(item, &mut referenced);
+    }
+    if let Some(where_expr) = where_clause {
+        collect_expr_refs(where_expr, &mut referenced);
+    }
+    for order_item in &return_clause.order_by {
+        collect_expr_refs(&order_item.expr, &mut referenced);
+    }
+    referenced.retain(|v| entity_vars.contains(v));
+
+    let terminal = pattern.last().and_then(last_node_variable);
+
+    pattern.len() > 1
+        || referenced.len() > 1
+        || referenced
+            .iter()
+            .any(|v| Some(v.as_str()) != terminal.as_deref())
+}
+
+/// Collect the node and relationship variable names of one pattern.
+fn collect_pattern_entity_vars(pattern: &CypherPattern, out: &mut HashSet<String>) {
+    for element in &pattern.elements {
+        let var = match element {
+            CypherPatternElement::Node(n) => n.variable.as_ref(),
+            CypherPatternElement::Relationship(r) => r.variable.as_ref(),
+        };
+        if let Some(v) = var {
+            out.insert(v.clone());
+        }
+    }
+}
+
+/// The variable of the last node element of a pattern, if named.
+fn last_node_variable(pattern: &CypherPattern) -> Option<String> {
+    pattern.elements.iter().rev().find_map(|element| match element {
+        CypherPatternElement::Node(n) => n.variable.clone(),
+        CypherPatternElement::Relationship(_) => None,
+    })
+}
+
+/// Collect variable references from a `RETURN` item.
+fn collect_return_item_refs(item: &CypherReturnItem, out: &mut HashSet<String>) {
+    match item {
+        CypherReturnItem::Star => {}
+        CypherReturnItem::Variable(name) => {
+            out.insert(name.clone());
+        }
+        CypherReturnItem::Expression { expr, .. } => collect_expr_refs(expr, out),
+    }
+}
+
+/// Collect the variable names an expression references (bare variables and the
+/// base of a property access), recursing through sub-expressions. Parser-bounded
+/// nesting (Issue #3404) makes unbounded recursion safe here.
+fn collect_expr_refs(expr: &CypherExpr, out: &mut HashSet<String>) {
+    match expr {
+        CypherExpr::Variable(name) => {
+            out.insert(name.clone());
+        }
+        CypherExpr::Property { variable, .. } => {
+            out.insert(variable.clone());
+        }
+        CypherExpr::Value(_) | CypherExpr::Star => {}
+        CypherExpr::Comparison { left, right, .. } => {
+            collect_expr_refs(left, out);
+            collect_expr_refs(right, out);
+        }
+        CypherExpr::And(a, b) | CypherExpr::Or(a, b) => {
+            collect_expr_refs(a, out);
+            collect_expr_refs(b, out);
+        }
+        CypherExpr::Not(inner)
+        | CypherExpr::IsNull(inner)
+        | CypherExpr::IsNotNull(inner)
+        | CypherExpr::Grouped(inner) => collect_expr_refs(inner, out),
+        CypherExpr::In { expr, values } => {
+            collect_expr_refs(expr, out);
+            for value in values {
+                collect_expr_refs(value, out);
+            }
+        }
+        CypherExpr::Contains { expr, .. }
+        | CypherExpr::StartsWith { expr, .. }
+        | CypherExpr::EndsWith { expr, .. } => collect_expr_refs(expr, out),
+        CypherExpr::FunctionCall { args, .. } | CypherExpr::List(args) => {
+            for arg in args {
+                collect_expr_refs(arg, out);
+            }
         }
     }
 }

--- a/src/cypher/mod.rs
+++ b/src/cypher/mod.rs
@@ -54,6 +54,7 @@ pub mod converter;
 mod error;
 pub mod exec;
 pub mod lexer;
+pub mod multi_pattern;
 pub mod parser;
 
 pub use ast::*;

--- a/src/cypher/multi_pattern.rs
+++ b/src/cypher/multi_pattern.rs
@@ -630,14 +630,18 @@ impl MultiEval<'_> {
                 let Some(needle) = self.eval_value(expr, binding)? else {
                     return Ok(Tri::Null);
                 };
+                // Three-valued IN (openCypher): a match short-circuits to True;
+                // otherwise a null list element makes the result Null (not
+                // False), so `5 IN [1, null]` is Null and drops under NOT.
+                let mut saw_null = false;
                 for candidate in values {
-                    if let Some(v) = self.eval_value(candidate, binding)?
-                        && loosely_equal(&needle, &v)
-                    {
-                        return Ok(Tri::True);
+                    match self.eval_value(candidate, binding)? {
+                        Some(v) if loosely_equal(&needle, &v) => return Ok(Tri::True),
+                        Some(_) => {}
+                        None => saw_null = true,
                     }
                 }
-                Ok(Tri::False)
+                Ok(if saw_null { Tri::Null } else { Tri::False })
             }
             // String predicates with a null/non-string subject are Null.
             CypherExpr::Contains { expr, substring } => {

--- a/src/cypher/multi_pattern.rs
+++ b/src/cypher/multi_pattern.rs
@@ -105,26 +105,26 @@ pub fn evaluate(
         ));
     }
     for item in &return_clause.items {
-        if let CypherReturnItem::Expression { expr, .. } = item {
-            if expr_has_aggregate(expr) {
-                return Err(CypherError::UnsupportedFeature(
-                    "aggregation over a multi-variable pattern is not supported; \
-                     RETURN the bound variables or their properties directly"
-                        .to_string(),
-                ));
-            }
+        if let CypherReturnItem::Expression { expr, .. } = item
+            && expr_has_aggregate(expr)
+        {
+            return Err(CypherError::UnsupportedFeature(
+                "aggregation over a multi-variable pattern is not supported; \
+                 RETURN the bound variables or their properties directly"
+                    .to_string(),
+            ));
         }
     }
     for p in pattern {
         for element in &p.elements {
-            if let CypherPatternElement::Relationship(rel) = element {
-                if rel.depth.is_some() {
-                    return Err(CypherError::UnsupportedFeature(
-                        "variable-length relationships inside a multi-variable \
-                         bound pattern are not supported in v1"
-                            .to_string(),
-                    ));
-                }
+            if let CypherPatternElement::Relationship(rel) = element
+                && rel.depth.is_some()
+            {
+                return Err(CypherError::UnsupportedFeature(
+                    "variable-length relationships inside a multi-variable \
+                     bound pattern are not supported in v1"
+                        .to_string(),
+                ));
             }
         }
     }
@@ -222,10 +222,10 @@ impl MultiEval<'_> {
         };
         for node in self.node_candidates(first, base)? {
             let mut binding = base.clone();
-            if let Some(var) = &first.variable {
-                if lookup(&binding, var).is_none() {
-                    binding.push((var.clone(), EntityResult::Node(node.clone())));
-                }
+            if let Some(var) = &first.variable
+                && lookup(&binding, var).is_none()
+            {
+                binding.push((var.clone(), EntityResult::Node(node.clone())));
             }
             self.extend_from(&pattern.elements, 1, binding, node.id, out)?;
         }
@@ -303,18 +303,18 @@ impl MultiEval<'_> {
         patt: &CypherNodePattern,
         base: &Binding,
     ) -> Result<Vec<Node>, CypherError> {
-        if let Some(var) = &patt.variable {
-            if let Some(existing) = lookup(base, var) {
-                if let EntityResult::Node(n) = existing {
-                    return Ok(if self.node_element_matches(n, patt)? {
-                        vec![n.clone()]
-                    } else {
-                        Vec::new()
-                    });
-                }
-                // A variable bound to an edge cannot also be a node.
-                return Ok(Vec::new());
+        if let Some(var) = &patt.variable
+            && let Some(existing) = lookup(base, var)
+        {
+            if let EntityResult::Node(n) = existing {
+                return Ok(if self.node_element_matches(n, patt)? {
+                    vec![n.clone()]
+                } else {
+                    Vec::new()
+                });
             }
+            // A variable bound to an edge cannot also be a node.
+            return Ok(Vec::new());
         }
         let mut out = Vec::new();
         for node in &self.nodes {
@@ -410,7 +410,11 @@ impl MultiEval<'_> {
 
     /// Compare a stored [`PropertyValue`] against a pattern [`CypherValue`]
     /// (resolving parameters), with numeric int/float coercion.
-    fn value_equals(&self, actual: &PropertyValue, want: &CypherValue) -> Result<bool, CypherError> {
+    fn value_equals(
+        &self,
+        actual: &PropertyValue,
+        want: &CypherValue,
+    ) -> Result<bool, CypherError> {
         let want = self.cypher_value_to_property(want)?;
         Ok(loosely_equal(actual, &want))
     }
@@ -460,23 +464,23 @@ impl MultiEval<'_> {
                     return Ok(false);
                 };
                 for candidate in values {
-                    if let Some(v) = self.eval_value(candidate, binding)? {
-                        if loosely_equal(&needle, &v) {
-                            return Ok(true);
-                        }
+                    if let Some(v) = self.eval_value(candidate, binding)?
+                        && loosely_equal(&needle, &v)
+                    {
+                        return Ok(true);
                     }
                 }
                 Ok(false)
             }
-            CypherExpr::Contains { expr, substring } => {
-                Ok(self.eval_string(expr, binding)?.is_some_and(|s| s.contains(substring)))
-            }
-            CypherExpr::StartsWith { expr, prefix } => {
-                Ok(self.eval_string(expr, binding)?.is_some_and(|s| s.starts_with(prefix)))
-            }
-            CypherExpr::EndsWith { expr, suffix } => {
-                Ok(self.eval_string(expr, binding)?.is_some_and(|s| s.ends_with(suffix)))
-            }
+            CypherExpr::Contains { expr, substring } => Ok(self
+                .eval_string(expr, binding)?
+                .is_some_and(|s| s.contains(substring))),
+            CypherExpr::StartsWith { expr, prefix } => Ok(self
+                .eval_string(expr, binding)?
+                .is_some_and(|s| s.starts_with(prefix))),
+            CypherExpr::EndsWith { expr, suffix } => Ok(self
+                .eval_string(expr, binding)?
+                .is_some_and(|s| s.ends_with(suffix))),
             CypherExpr::Grouped(inner) => self.eval_predicate(inner, binding),
             CypherExpr::Value(CypherValue::Bool(b)) => Ok(*b),
             other => match self.eval_value(other, binding)? {
@@ -567,7 +571,9 @@ impl MultiEval<'_> {
                         self.project_variable(binding, v, alias.clone(), &mut bindings_out)?;
                     }
                     _ => {
-                        let value = self.eval_value(expr, binding)?.unwrap_or(PropertyValue::Null);
+                        let value = self
+                            .eval_value(expr, binding)?
+                            .unwrap_or(PropertyValue::Null);
                         let name = alias.clone().unwrap_or_else(|| default_column_name(expr));
                         columns_out.push((name, value));
                     }
@@ -634,8 +640,10 @@ impl MultiEval<'_> {
         index.sort_by(|&a, &b| compare_order_keys(&keys[a], &keys[b], ret));
 
         // Apply the permutation.
-        let mut reordered: Vec<Option<(Binding, QueryRow)>> =
-            rows.iter_mut().map(|slot| Some(std::mem::replace(slot, placeholder_slot()))).collect();
+        let mut reordered: Vec<Option<(Binding, QueryRow)>> = rows
+            .iter_mut()
+            .map(|slot| Some(std::mem::replace(slot, placeholder_slot())))
+            .collect();
         for (dst, &src) in index.iter().enumerate() {
             rows[dst] = reordered[src].take().expect("each source used once");
         }
@@ -686,9 +694,9 @@ fn param_to_property(param: &CypherParameterValue) -> PropertyValue {
         CypherParameterValue::Float(f) => PropertyValue::Float(*f),
         CypherParameterValue::String(s) => PropertyValue::String(std::sync::Arc::from(s.as_str())),
         CypherParameterValue::Embedding(e) => PropertyValue::Vector(std::sync::Arc::clone(e)),
-        CypherParameterValue::List(items) => {
-            PropertyValue::Array(std::sync::Arc::new(items.iter().map(param_to_property).collect()))
-        }
+        CypherParameterValue::List(items) => PropertyValue::Array(std::sync::Arc::new(
+            items.iter().map(param_to_property).collect(),
+        )),
     }
 }
 
@@ -703,10 +711,10 @@ fn entity_var_declaration_order(patterns: &[CypherPattern]) -> Vec<String> {
                 CypherPatternElement::Node(n) => n.variable.as_ref(),
                 CypherPatternElement::Relationship(r) => r.variable.as_ref(),
             };
-            if let Some(v) = var {
-                if seen.insert(v.clone()) {
-                    order.push(v.clone());
-                }
+            if let Some(v) = var
+                && seen.insert(v.clone())
+            {
+                order.push(v.clone());
             }
         }
     }
@@ -745,7 +753,9 @@ fn expr_has_aggregate(expr: &CypherExpr) -> bool {
         | CypherExpr::StartsWith { expr, .. }
         | CypherExpr::EndsWith { expr, .. } => expr_has_aggregate(expr),
         CypherExpr::List(items) => items.iter().any(expr_has_aggregate),
-        CypherExpr::Value(_) | CypherExpr::Variable(_) | CypherExpr::Property { .. }
+        CypherExpr::Value(_)
+        | CypherExpr::Variable(_)
+        | CypherExpr::Property { .. }
         | CypherExpr::Star => false,
     }
 }
@@ -793,10 +803,7 @@ fn compare(a: &PropertyValue, b: &PropertyValue, op: CypherCompOp) -> bool {
         CypherCompOp::Lt => partial_cmp(a, b) == Some(Ordering::Less),
         CypherCompOp::Le => matches!(partial_cmp(a, b), Some(Ordering::Less | Ordering::Equal)),
         CypherCompOp::Gt => partial_cmp(a, b) == Some(Ordering::Greater),
-        CypherCompOp::Ge => matches!(
-            partial_cmp(a, b),
-            Some(Ordering::Greater | Ordering::Equal)
-        ),
+        CypherCompOp::Ge => matches!(partial_cmp(a, b), Some(Ordering::Greater | Ordering::Equal)),
     }
 }
 
@@ -827,11 +834,7 @@ fn compare_order_keys(
             }
             (Some(x), Some(y)) => {
                 let base = partial_cmp(x, y).unwrap_or(Ordering::Equal);
-                if descending {
-                    base.reverse()
-                } else {
-                    base
-                }
+                if descending { base.reverse() } else { base }
             }
         };
         if ord != Ordering::Equal {

--- a/src/cypher/multi_pattern.rs
+++ b/src/cypher/multi_pattern.rs
@@ -1,0 +1,918 @@
+//! Multi-variable, multi-pattern `MATCH` evaluation (Issue #549).
+//!
+//! AletheiaDB's standard query pipeline is a Volcano pull-iterator tree whose
+//! rows carry exactly **one** entity ([`QueryRow::entity`]). That single-entity
+//! shape cannot represent a query that binds and returns more than one variable
+//! (`MATCH (a),(b) RETURN a, b`) or joins several comma-separated patterns, so
+//! routing such a query through the standard converter silently drops variables
+//! or concatenates un-joined scans -- a wrong answer.
+//!
+//! This module is a **contained** Cypher-level evaluator for the read-only
+//! multi-variable subset. It reuses the database's public primitives (label
+//! scans, adjacency, property access) and materializes rows carrying
+//! [`QueryRow::bindings`] (named `variable -> entity`) and/or
+//! [`QueryRow::columns`] (scalar projections). It never disturbs the existing
+//! single-entity path: only queries the router
+//! ([`super::exec::needs_multi_binding`]) classifies as multi-variable reach it.
+//!
+//! # House rule
+//!
+//! Anything this evaluator cannot answer **correctly** is rejected with a
+//! structured [`CypherError::UnsupportedFeature`]; it never returns a
+//! silently-wrong row. v1 rejects: `OPTIONAL MATCH`, `WITH`, temporal `AS OF`,
+//! aggregates in `RETURN`, and variable-length relationships inside a bound
+//! pattern.
+
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+
+use crate::core::error::Result as CoreResult;
+use crate::core::graph::{Edge, Node};
+use crate::core::id::{EdgeId, NodeId};
+use crate::core::property::PropertyValue;
+use crate::db::AletheiaDB;
+use crate::query::executor::{EntityResult, QueryResults, QueryRow, ResultIterator};
+
+use super::ast::{
+    CypherCompOp, CypherDirection, CypherExpr, CypherNodePattern, CypherPattern,
+    CypherPatternElement, CypherRelPattern, CypherReturn, CypherReturnItem, CypherStatement,
+    CypherValue,
+};
+use super::converter::CypherParameterValue;
+use super::error::CypherError;
+
+/// An ordered set of `variable -> entity` bindings for one candidate row.
+type Binding = Vec<(String, EntityResult)>;
+
+/// Entry point: evaluate a multi-variable `MATCH` statement into result rows.
+///
+/// Invoked from `AletheiaDB::execute_multi_pattern` after the router
+/// ([`super::exec::needs_multi_binding`]) has classified the statement as
+/// multi-variable. Returns a materialized [`QueryResults`] stream.
+///
+/// # Errors
+///
+/// Returns [`CypherError::UnsupportedFeature`] for any construct outside the v1
+/// subset (see the module docs), and [`CypherError::SemanticError`] for a
+/// structurally malformed pattern or a reference to an unbound variable.
+pub fn evaluate(
+    db: &AletheiaDB,
+    statement: &CypherStatement,
+    params: &HashMap<String, CypherParameterValue>,
+) -> Result<QueryResults, CypherError> {
+    let CypherStatement::Match {
+        optional,
+        pattern,
+        where_clause,
+        return_clause,
+        temporal,
+        with_clauses,
+        optional_matches,
+    } = statement
+    else {
+        return Err(CypherError::UnsupportedFeature(
+            "multi-pattern evaluator requires a MATCH statement".to_string(),
+        ));
+    };
+
+    // ---- v1 rejections (honest structured error, never a silently-wrong row).
+    if *optional {
+        return Err(CypherError::UnsupportedFeature(
+            "OPTIONAL MATCH as the leading clause is not supported by the \
+             multi-variable evaluator"
+                .to_string(),
+        ));
+    }
+    if !with_clauses.is_empty() {
+        return Err(CypherError::UnsupportedFeature(
+            "WITH projection is not supported alongside multi-variable pattern \
+             binding"
+                .to_string(),
+        ));
+    }
+    if !optional_matches.is_empty() {
+        return Err(CypherError::UnsupportedFeature(
+            "OPTIONAL MATCH is not supported alongside multi-variable pattern \
+             binding"
+                .to_string(),
+        ));
+    }
+    if temporal.is_some() {
+        return Err(CypherError::UnsupportedFeature(
+            "temporal AS OF qualifiers are not supported by the multi-variable \
+             evaluator; multi-pattern binding is current-state only in v1"
+                .to_string(),
+        ));
+    }
+    for item in &return_clause.items {
+        if let CypherReturnItem::Expression { expr, .. } = item {
+            if expr_has_aggregate(expr) {
+                return Err(CypherError::UnsupportedFeature(
+                    "aggregation over a multi-variable pattern is not supported; \
+                     RETURN the bound variables or their properties directly"
+                        .to_string(),
+                ));
+            }
+        }
+    }
+    for p in pattern {
+        for element in &p.elements {
+            if let CypherPatternElement::Relationship(rel) = element {
+                if rel.depth.is_some() {
+                    return Err(CypherError::UnsupportedFeature(
+                        "variable-length relationships inside a multi-variable \
+                         bound pattern are not supported in v1"
+                            .to_string(),
+                    ));
+                }
+            }
+        }
+    }
+
+    // ---- Materialize the current-state node set once (sorted by id for
+    // deterministic candidate enumeration and stable output order).
+    let mut nodes: Vec<Node> = db.current.all_nodes().collect();
+    nodes.sort_by_key(|n| n.id);
+    let mut node_by_id: HashMap<NodeId, usize> = HashMap::with_capacity(nodes.len());
+    for (idx, node) in nodes.iter().enumerate() {
+        node_by_id.insert(node.id, idx);
+    }
+
+    let eval = MultiEval {
+        db,
+        params,
+        nodes,
+        node_by_id,
+    };
+
+    // ---- Nested-loop binding matcher: extend the binding set by each pattern.
+    let mut env: Vec<Binding> = vec![Vec::new()];
+    for p in pattern {
+        let mut next: Vec<Binding> = Vec::new();
+        for base in &env {
+            eval.match_pattern_extends(p, base, &mut next)?;
+        }
+        env = next;
+    }
+
+    // ---- WHERE filter (cross-variable predicates resolve from the binding).
+    if let Some(predicate) = where_clause {
+        let mut filtered = Vec::with_capacity(env.len());
+        for binding in env {
+            if eval.eval_predicate(predicate, &binding)? {
+                filtered.push(binding);
+            }
+        }
+        env = filtered;
+    }
+
+    // ---- Projection: each surviving binding becomes a QueryRow.
+    let entity_order = entity_var_declaration_order(pattern);
+    let mut projected: Vec<(Binding, QueryRow)> = Vec::with_capacity(env.len());
+    for binding in env {
+        let row = eval.project(&binding, return_clause, &entity_order)?;
+        projected.push((binding, row));
+    }
+
+    // ---- DISTINCT (dedupe by projected content) -> ORDER BY -> SKIP -> LIMIT.
+    if return_clause.distinct {
+        projected = distinct_rows(projected);
+    }
+    if !return_clause.order_by.is_empty() {
+        eval.order_rows(&mut projected, return_clause)?;
+    }
+    let skip = return_clause.skip.unwrap_or(0);
+    let rows: Vec<QueryRow> = projected
+        .into_iter()
+        .skip(skip)
+        .take(return_clause.limit.unwrap_or(usize::MAX))
+        .map(|(_, row)| row)
+        .collect();
+
+    Ok(QueryResults::new(Box::new(VecResultIterator::new(rows))))
+}
+
+/// Shared evaluation context: the database handle, bound parameters, and the
+/// materialized node snapshot.
+struct MultiEval<'a> {
+    db: &'a AletheiaDB,
+    params: &'a HashMap<String, CypherParameterValue>,
+    nodes: Vec<Node>,
+    node_by_id: HashMap<NodeId, usize>,
+}
+
+impl MultiEval<'_> {
+    /// Borrow a materialized node by id, if present in the snapshot.
+    fn node_ref(&self, id: NodeId) -> Option<&Node> {
+        self.node_by_id.get(&id).map(|&idx| &self.nodes[idx])
+    }
+
+    /// Extend `base` by every assignment that satisfies `pattern`, appending
+    /// each resulting binding to `out`.
+    fn match_pattern_extends(
+        &self,
+        pattern: &CypherPattern,
+        base: &Binding,
+        out: &mut Vec<Binding>,
+    ) -> Result<(), CypherError> {
+        let Some(CypherPatternElement::Node(first)) = pattern.elements.first() else {
+            return Err(CypherError::SemanticError(
+                "a graph pattern must start with a node".to_string(),
+            ));
+        };
+        for node in self.node_candidates(first, base)? {
+            let mut binding = base.clone();
+            if let Some(var) = &first.variable {
+                if lookup(&binding, var).is_none() {
+                    binding.push((var.clone(), EntityResult::Node(node.clone())));
+                }
+            }
+            self.extend_from(&pattern.elements, 1, binding, node.id, out)?;
+        }
+        Ok(())
+    }
+
+    /// Walk the `(relationship, node)` pairs of a pattern from element `idx`,
+    /// starting at `current` node, emitting a completed binding per full
+    /// consistent traversal.
+    fn extend_from(
+        &self,
+        elements: &[CypherPatternElement],
+        idx: usize,
+        binding: Binding,
+        current: NodeId,
+        out: &mut Vec<Binding>,
+    ) -> Result<(), CypherError> {
+        if idx >= elements.len() {
+            out.push(binding);
+            return Ok(());
+        }
+        let CypherPatternElement::Relationship(rel) = &elements[idx] else {
+            return Err(CypherError::SemanticError(
+                "expected a relationship element in the pattern".to_string(),
+            ));
+        };
+        let Some(CypherPatternElement::Node(next_patt)) = elements.get(idx + 1) else {
+            return Err(CypherError::SemanticError(
+                "a relationship must be followed by a node in the pattern".to_string(),
+            ));
+        };
+
+        for (edge, far_id) in self.adjacent(current, rel)? {
+            let Some(far_node) = self.node_ref(far_id).cloned() else {
+                // Orphaned edge whose endpoint is missing from current state.
+                continue;
+            };
+            if !self.node_element_matches(&far_node, next_patt)? {
+                continue;
+            }
+            let mut binding = binding.clone();
+            // Unify the far-node variable (a repeated variable must resolve to
+            // the same node id).
+            if let Some(nv) = &next_patt.variable {
+                match lookup(&binding, nv) {
+                    Some(existing) => {
+                        if existing.node_id() != Some(far_node.id) {
+                            continue;
+                        }
+                    }
+                    None => binding.push((nv.clone(), EntityResult::Node(far_node.clone()))),
+                }
+            }
+            // Bind (and unify) the relationship variable.
+            if let Some(rv) = &rel.variable {
+                match lookup(&binding, rv) {
+                    Some(existing) => {
+                        if entity_edge_id(existing) != Some(edge.id) {
+                            continue;
+                        }
+                    }
+                    None => binding.push((rv.clone(), EntityResult::Edge(edge.clone()))),
+                }
+            }
+            self.extend_from(elements, idx + 2, binding, far_node.id, out)?;
+        }
+        Ok(())
+    }
+
+    /// Candidate nodes for a node element: the single already-bound node (if the
+    /// element's variable is bound and still satisfies the element), otherwise
+    /// every node satisfying the element's labels and inline properties.
+    fn node_candidates(
+        &self,
+        patt: &CypherNodePattern,
+        base: &Binding,
+    ) -> Result<Vec<Node>, CypherError> {
+        if let Some(var) = &patt.variable {
+            if let Some(existing) = lookup(base, var) {
+                if let EntityResult::Node(n) = existing {
+                    return Ok(if self.node_element_matches(n, patt)? {
+                        vec![n.clone()]
+                    } else {
+                        Vec::new()
+                    });
+                }
+                // A variable bound to an edge cannot also be a node.
+                return Ok(Vec::new());
+            }
+        }
+        let mut out = Vec::new();
+        for node in &self.nodes {
+            if self.node_element_matches(node, patt)? {
+                out.push(node.clone());
+            }
+        }
+        Ok(out)
+    }
+
+    /// Whether a node satisfies a node element's labels and inline properties.
+    fn node_element_matches(
+        &self,
+        node: &Node,
+        patt: &CypherNodePattern,
+    ) -> Result<bool, CypherError> {
+        for label in &patt.labels {
+            if !node.has_label_str(label) {
+                return Ok(false);
+            }
+        }
+        self.props_match(&patt.properties, |k| node.get_property(k))
+    }
+
+    /// Enumerate edges incident to `node_id` honoring the relationship's
+    /// direction, types, and inline properties, paired with the far endpoint.
+    /// For `Both`, a self-loop is emitted once (deduped by edge id).
+    fn adjacent(
+        &self,
+        node_id: NodeId,
+        rel: &CypherRelPattern,
+    ) -> Result<Vec<(Edge, NodeId)>, CypherError> {
+        let want_out = matches!(
+            rel.direction,
+            CypherDirection::Outgoing | CypherDirection::Both
+        );
+        let want_in = matches!(
+            rel.direction,
+            CypherDirection::Incoming | CypherDirection::Both
+        );
+        let mut result = Vec::new();
+        let mut seen: HashSet<u64> = HashSet::new();
+
+        if want_out {
+            for edge_id in self.db.get_outgoing_edges(node_id) {
+                let Ok(edge) = self.db.get_edge(edge_id) else {
+                    continue;
+                };
+                if !self.edge_matches(&edge, rel)? || !seen.insert(edge.id.as_u64()) {
+                    continue;
+                }
+                let far = edge.target;
+                result.push((edge, far));
+            }
+        }
+        if want_in {
+            for edge_id in self.db.get_incoming_edges(node_id) {
+                let Ok(edge) = self.db.get_edge(edge_id) else {
+                    continue;
+                };
+                if !self.edge_matches(&edge, rel)? || !seen.insert(edge.id.as_u64()) {
+                    continue;
+                }
+                let far = edge.source;
+                result.push((edge, far));
+            }
+        }
+        Ok(result)
+    }
+
+    /// Whether an edge satisfies a relationship element's types and properties.
+    fn edge_matches(&self, edge: &Edge, rel: &CypherRelPattern) -> Result<bool, CypherError> {
+        if !rel.rel_types.is_empty() && !rel.rel_types.iter().any(|t| edge.has_label_str(t)) {
+            return Ok(false);
+        }
+        self.props_match(&rel.properties, |k| edge.get_property(k))
+    }
+
+    /// Whether every inline `(key, value)` constraint holds against `get`.
+    fn props_match<'p>(
+        &self,
+        props: &[(String, CypherValue)],
+        get: impl Fn(&str) -> Option<&'p PropertyValue>,
+    ) -> Result<bool, CypherError> {
+        for (key, want) in props {
+            match get(key) {
+                Some(actual) if self.value_equals(actual, want)? => {}
+                _ => return Ok(false),
+            }
+        }
+        Ok(true)
+    }
+
+    /// Compare a stored [`PropertyValue`] against a pattern [`CypherValue`]
+    /// (resolving parameters), with numeric int/float coercion.
+    fn value_equals(&self, actual: &PropertyValue, want: &CypherValue) -> Result<bool, CypherError> {
+        let want = self.cypher_value_to_property(want)?;
+        Ok(loosely_equal(actual, &want))
+    }
+
+    /// Convert a Cypher literal (resolving a `$param`) into a [`PropertyValue`].
+    fn cypher_value_to_property(&self, value: &CypherValue) -> Result<PropertyValue, CypherError> {
+        Ok(match value {
+            CypherValue::Null => PropertyValue::Null,
+            CypherValue::Bool(b) => PropertyValue::Bool(*b),
+            CypherValue::Int(n) => PropertyValue::Int(*n),
+            CypherValue::Float(f) => PropertyValue::Float(*f),
+            CypherValue::String(s) => PropertyValue::String(std::sync::Arc::from(s.as_str())),
+            CypherValue::Vector(v) => PropertyValue::Vector(std::sync::Arc::clone(v)),
+            CypherValue::Parameter(name) => {
+                let param = self.params.get(name).ok_or_else(|| {
+                    CypherError::ParameterError(format!("unbound parameter: ${name}"))
+                })?;
+                param_to_property(param)
+            }
+        })
+    }
+
+    // -- Predicate / scalar evaluation ------------------------------------
+
+    /// Evaluate a `WHERE` predicate against a binding (null-yields-false).
+    fn eval_predicate(&self, expr: &CypherExpr, binding: &Binding) -> Result<bool, CypherError> {
+        match expr {
+            CypherExpr::Comparison { left, op, right } => {
+                let l = self.eval_value(left, binding)?;
+                let r = self.eval_value(right, binding)?;
+                match (l, r) {
+                    (Some(a), Some(b)) => Ok(compare(&a, &b, *op)),
+                    _ => Ok(false),
+                }
+            }
+            CypherExpr::And(a, b) => {
+                Ok(self.eval_predicate(a, binding)? && self.eval_predicate(b, binding)?)
+            }
+            CypherExpr::Or(a, b) => {
+                Ok(self.eval_predicate(a, binding)? || self.eval_predicate(b, binding)?)
+            }
+            CypherExpr::Not(inner) => Ok(!self.eval_predicate(inner, binding)?),
+            CypherExpr::IsNull(inner) => Ok(self.eval_value(inner, binding)?.is_none()),
+            CypherExpr::IsNotNull(inner) => Ok(self.eval_value(inner, binding)?.is_some()),
+            CypherExpr::In { expr, values } => {
+                let Some(needle) = self.eval_value(expr, binding)? else {
+                    return Ok(false);
+                };
+                for candidate in values {
+                    if let Some(v) = self.eval_value(candidate, binding)? {
+                        if loosely_equal(&needle, &v) {
+                            return Ok(true);
+                        }
+                    }
+                }
+                Ok(false)
+            }
+            CypherExpr::Contains { expr, substring } => {
+                Ok(self.eval_string(expr, binding)?.is_some_and(|s| s.contains(substring)))
+            }
+            CypherExpr::StartsWith { expr, prefix } => {
+                Ok(self.eval_string(expr, binding)?.is_some_and(|s| s.starts_with(prefix)))
+            }
+            CypherExpr::EndsWith { expr, suffix } => {
+                Ok(self.eval_string(expr, binding)?.is_some_and(|s| s.ends_with(suffix)))
+            }
+            CypherExpr::Grouped(inner) => self.eval_predicate(inner, binding),
+            CypherExpr::Value(CypherValue::Bool(b)) => Ok(*b),
+            other => match self.eval_value(other, binding)? {
+                Some(PropertyValue::Bool(b)) => Ok(b),
+                None => Ok(false),
+                Some(_) => Err(CypherError::UnsupportedFeature(format!(
+                    "WHERE expression is not a boolean predicate: {other:?}"
+                ))),
+            },
+        }
+    }
+
+    /// Evaluate an expression to an optional scalar value (`None` == null).
+    fn eval_value(
+        &self,
+        expr: &CypherExpr,
+        binding: &Binding,
+    ) -> Result<Option<PropertyValue>, CypherError> {
+        match expr {
+            CypherExpr::Value(value) => {
+                let pv = self.cypher_value_to_property(value)?;
+                Ok(if matches!(pv, PropertyValue::Null) {
+                    None
+                } else {
+                    Some(pv)
+                })
+            }
+            CypherExpr::Property { variable, property } => {
+                let entity = lookup(binding, variable).ok_or_else(|| {
+                    CypherError::SemanticError(format!(
+                        "property access references unbound variable '{variable}'"
+                    ))
+                })?;
+                Ok(entity_property(entity, property))
+            }
+            CypherExpr::Grouped(inner) => self.eval_value(inner, binding),
+            CypherExpr::Variable(name) => Err(CypherError::UnsupportedFeature(format!(
+                "a bare entity variable ('{name}') cannot be used as a scalar \
+                 value; use a property access like {name}.<key>"
+            ))),
+            other => Err(CypherError::UnsupportedFeature(format!(
+                "expression not supported in a scalar position by the \
+                 multi-variable evaluator: {other:?}"
+            ))),
+        }
+    }
+
+    /// Evaluate an expression expecting a string value (else `None`).
+    fn eval_string(
+        &self,
+        expr: &CypherExpr,
+        binding: &Binding,
+    ) -> Result<Option<String>, CypherError> {
+        // `PropertyValue` implements `Drop`, so its `String` payload cannot be
+        // moved out of the owned value by pattern; borrow and clone instead.
+        Ok(match self.eval_value(expr, binding)? {
+            Some(PropertyValue::String(ref s)) => Some(s.to_string()),
+            _ => None,
+        })
+    }
+
+    // -- Projection --------------------------------------------------------
+
+    /// Project one binding into a [`QueryRow`] according to `RETURN`.
+    fn project(
+        &self,
+        binding: &Binding,
+        ret: &CypherReturn,
+        entity_order: &[String],
+    ) -> Result<QueryRow, CypherError> {
+        let mut bindings_out: Binding = Vec::new();
+        let mut columns_out: Vec<(String, PropertyValue)> = Vec::new();
+
+        for item in &ret.items {
+            match item {
+                CypherReturnItem::Star => {
+                    for var in entity_order {
+                        if let Some(entity) = lookup(binding, var) {
+                            bindings_out.push((var.clone(), entity.clone()));
+                        }
+                    }
+                }
+                CypherReturnItem::Variable(v) => {
+                    self.project_variable(binding, v, None, &mut bindings_out)?;
+                }
+                CypherReturnItem::Expression { expr, alias } => match expr {
+                    CypherExpr::Variable(v) => {
+                        self.project_variable(binding, v, alias.clone(), &mut bindings_out)?;
+                    }
+                    _ => {
+                        let value = self.eval_value(expr, binding)?.unwrap_or(PropertyValue::Null);
+                        let name = alias.clone().unwrap_or_else(|| default_column_name(expr));
+                        columns_out.push((name, value));
+                    }
+                },
+            }
+        }
+
+        let columns = if columns_out.is_empty() {
+            None
+        } else {
+            Some(columns_out)
+        };
+        if bindings_out.is_empty() {
+            // Pure scalar projection row (no entity variables returned).
+            Ok(QueryRow::from_columns(columns.unwrap_or_default()))
+        } else {
+            Ok(QueryRow::from_bindings(bindings_out, columns))
+        }
+    }
+
+    /// Project a returned variable: an entity variable becomes a binding entry
+    /// (renamed by `alias` when present); anything else is a scope error.
+    fn project_variable(
+        &self,
+        binding: &Binding,
+        var: &str,
+        alias: Option<String>,
+        bindings_out: &mut Binding,
+    ) -> Result<(), CypherError> {
+        match lookup(binding, var) {
+            Some(entity) => {
+                let name = alias.unwrap_or_else(|| var.to_string());
+                bindings_out.push((name, entity.clone()));
+                Ok(())
+            }
+            None => Err(CypherError::SemanticError(format!(
+                "RETURN references variable '{var}', which is not bound by the \
+                 pattern"
+            ))),
+        }
+    }
+
+    // -- ORDER BY ----------------------------------------------------------
+
+    /// Sort projected rows by the `ORDER BY` keys (openCypher null placement:
+    /// nulls last for ascending, first for descending).
+    fn order_rows(
+        &self,
+        rows: &mut [(Binding, QueryRow)],
+        ret: &CypherReturn,
+    ) -> Result<(), CypherError> {
+        // Pre-compute each row's ordered sort keys so the comparator is
+        // infallible (evaluation errors surface here, before sorting).
+        let mut keys: Vec<Vec<Option<PropertyValue>>> = Vec::with_capacity(rows.len());
+        for (binding, _) in rows.iter() {
+            let mut key = Vec::with_capacity(ret.order_by.len());
+            for item in &ret.order_by {
+                key.push(self.eval_value(&item.expr, binding)?);
+            }
+            keys.push(key);
+        }
+
+        let mut index: Vec<usize> = (0..rows.len()).collect();
+        index.sort_by(|&a, &b| compare_order_keys(&keys[a], &keys[b], ret));
+
+        // Apply the permutation.
+        let mut reordered: Vec<Option<(Binding, QueryRow)>> =
+            rows.iter_mut().map(|slot| Some(std::mem::replace(slot, placeholder_slot()))).collect();
+        for (dst, &src) in index.iter().enumerate() {
+            rows[dst] = reordered[src].take().expect("each source used once");
+        }
+        Ok(())
+    }
+}
+
+/// A throwaway `(Binding, QueryRow)` used only to vacate a slot during the
+/// in-place permutation in [`MultiEval::order_rows`]; every placeholder is
+/// overwritten before the function returns.
+fn placeholder_slot() -> (Binding, QueryRow) {
+    (Vec::new(), QueryRow::from_columns(Vec::new()))
+}
+
+// ---------------------------------------------------------------------------
+// Free helpers
+// ---------------------------------------------------------------------------
+
+/// Look up the entity bound to `var` in a binding.
+fn lookup<'b>(binding: &'b Binding, var: &str) -> Option<&'b EntityResult> {
+    binding.iter().find(|(name, _)| name == var).map(|(_, e)| e)
+}
+
+/// The edge id of an entity, if it is an edge.
+fn entity_edge_id(entity: &EntityResult) -> Option<EdgeId> {
+    match entity {
+        EntityResult::Edge(e) => Some(e.id),
+        EntityResult::EdgeId(id) => Some(*id),
+        _ => None,
+    }
+}
+
+/// A property value of a bound entity (node or edge), cloned.
+fn entity_property(entity: &EntityResult, property: &str) -> Option<PropertyValue> {
+    match entity {
+        EntityResult::Node(n) => n.get_property(property).cloned(),
+        EntityResult::Edge(e) => e.get_property(property).cloned(),
+        _ => None,
+    }
+}
+
+/// Convert a runtime parameter value into a [`PropertyValue`].
+fn param_to_property(param: &CypherParameterValue) -> PropertyValue {
+    match param {
+        CypherParameterValue::Null => PropertyValue::Null,
+        CypherParameterValue::Bool(b) => PropertyValue::Bool(*b),
+        CypherParameterValue::Int(n) => PropertyValue::Int(*n),
+        CypherParameterValue::Float(f) => PropertyValue::Float(*f),
+        CypherParameterValue::String(s) => PropertyValue::String(std::sync::Arc::from(s.as_str())),
+        CypherParameterValue::Embedding(e) => PropertyValue::Vector(std::sync::Arc::clone(e)),
+        CypherParameterValue::List(items) => {
+            PropertyValue::Array(std::sync::Arc::new(items.iter().map(param_to_property).collect()))
+        }
+    }
+}
+
+/// Entity variable names in pattern declaration order (nodes and relationships,
+/// first occurrence wins), used for `RETURN *`.
+fn entity_var_declaration_order(patterns: &[CypherPattern]) -> Vec<String> {
+    let mut order = Vec::new();
+    let mut seen = HashSet::new();
+    for pattern in patterns {
+        for element in &pattern.elements {
+            let var = match element {
+                CypherPatternElement::Node(n) => n.variable.as_ref(),
+                CypherPatternElement::Relationship(r) => r.variable.as_ref(),
+            };
+            if let Some(v) = var {
+                if seen.insert(v.clone()) {
+                    order.push(v.clone());
+                }
+            }
+        }
+    }
+    order
+}
+
+/// Default output column name for a non-aliased scalar expression.
+fn default_column_name(expr: &CypherExpr) -> String {
+    match expr {
+        CypherExpr::Property { variable, property } => format!("{variable}.{property}"),
+        CypherExpr::Variable(name) => name.clone(),
+        other => format!("{other:?}"),
+    }
+}
+
+/// Whether an expression contains an aggregate function call.
+fn expr_has_aggregate(expr: &CypherExpr) -> bool {
+    match expr {
+        CypherExpr::FunctionCall { name, args, .. } => {
+            is_aggregate_name(name) || args.iter().any(expr_has_aggregate)
+        }
+        CypherExpr::Comparison { left, right, .. } => {
+            expr_has_aggregate(left) || expr_has_aggregate(right)
+        }
+        CypherExpr::And(a, b) | CypherExpr::Or(a, b) => {
+            expr_has_aggregate(a) || expr_has_aggregate(b)
+        }
+        CypherExpr::Not(inner)
+        | CypherExpr::IsNull(inner)
+        | CypherExpr::IsNotNull(inner)
+        | CypherExpr::Grouped(inner) => expr_has_aggregate(inner),
+        CypherExpr::In { expr, values } => {
+            expr_has_aggregate(expr) || values.iter().any(expr_has_aggregate)
+        }
+        CypherExpr::Contains { expr, .. }
+        | CypherExpr::StartsWith { expr, .. }
+        | CypherExpr::EndsWith { expr, .. } => expr_has_aggregate(expr),
+        CypherExpr::List(items) => items.iter().any(expr_has_aggregate),
+        CypherExpr::Value(_) | CypherExpr::Variable(_) | CypherExpr::Property { .. }
+        | CypherExpr::Star => false,
+    }
+}
+
+/// Whether `name` is a case-insensitive aggregate function name.
+fn is_aggregate_name(name: &str) -> bool {
+    matches!(
+        name.to_ascii_uppercase().as_str(),
+        "COUNT" | "SUM" | "AVG" | "MIN" | "MAX" | "COLLECT"
+    )
+}
+
+/// Equality with int/float numeric coercion; other types use `PropertyValue`'s
+/// own equality.
+fn loosely_equal(a: &PropertyValue, b: &PropertyValue) -> bool {
+    if is_numeric(a) && is_numeric(b) {
+        return partial_cmp(a, b) == Some(Ordering::Equal);
+    }
+    a == b
+}
+
+/// Whether a value is an integer or float.
+fn is_numeric(v: &PropertyValue) -> bool {
+    matches!(v, PropertyValue::Int(_) | PropertyValue::Float(_))
+}
+
+/// Partial ordering over comparable scalar values (numeric, string, bool).
+fn partial_cmp(a: &PropertyValue, b: &PropertyValue) -> Option<Ordering> {
+    match (a, b) {
+        (PropertyValue::Int(x), PropertyValue::Int(y)) => Some(x.cmp(y)),
+        (PropertyValue::Int(x), PropertyValue::Float(y)) => (*x as f64).partial_cmp(y),
+        (PropertyValue::Float(x), PropertyValue::Int(y)) => x.partial_cmp(&(*y as f64)),
+        (PropertyValue::Float(x), PropertyValue::Float(y)) => x.partial_cmp(y),
+        (PropertyValue::String(x), PropertyValue::String(y)) => Some(x.as_ref().cmp(y.as_ref())),
+        (PropertyValue::Bool(x), PropertyValue::Bool(y)) => Some(x.cmp(y)),
+        _ => None,
+    }
+}
+
+/// Evaluate a comparison operator over two scalar values.
+fn compare(a: &PropertyValue, b: &PropertyValue, op: CypherCompOp) -> bool {
+    match op {
+        CypherCompOp::Eq => loosely_equal(a, b),
+        CypherCompOp::Ne => !loosely_equal(a, b),
+        CypherCompOp::Lt => partial_cmp(a, b) == Some(Ordering::Less),
+        CypherCompOp::Le => matches!(partial_cmp(a, b), Some(Ordering::Less | Ordering::Equal)),
+        CypherCompOp::Gt => partial_cmp(a, b) == Some(Ordering::Greater),
+        CypherCompOp::Ge => matches!(
+            partial_cmp(a, b),
+            Some(Ordering::Greater | Ordering::Equal)
+        ),
+    }
+}
+
+/// Compare two rows' ordered sort keys per the `ORDER BY` directions.
+fn compare_order_keys(
+    a: &[Option<PropertyValue>],
+    b: &[Option<PropertyValue>],
+    ret: &CypherReturn,
+) -> Ordering {
+    for (idx, item) in ret.order_by.iter().enumerate() {
+        let descending = item.descending;
+        let ord = match (&a[idx], &b[idx]) {
+            (None, None) => Ordering::Equal,
+            // Null placement: last for ascending, first for descending.
+            (None, Some(_)) => {
+                if descending {
+                    Ordering::Less
+                } else {
+                    Ordering::Greater
+                }
+            }
+            (Some(_), None) => {
+                if descending {
+                    Ordering::Greater
+                } else {
+                    Ordering::Less
+                }
+            }
+            (Some(x), Some(y)) => {
+                let base = partial_cmp(x, y).unwrap_or(Ordering::Equal);
+                if descending {
+                    base.reverse()
+                } else {
+                    base
+                }
+            }
+        };
+        if ord != Ordering::Equal {
+            return ord;
+        }
+    }
+    Ordering::Equal
+}
+
+/// A comparable identity for a projected row, used for `DISTINCT` dedup:
+/// bound entity ids plus scalar column values.
+type RowKey = (Vec<(String, u8, u64)>, Vec<(String, PropertyValue)>);
+
+/// Compute a row's `DISTINCT` identity key.
+fn row_key(row: &QueryRow) -> RowKey {
+    let binds = row
+        .bindings
+        .as_ref()
+        .map(|b| {
+            b.iter()
+                .map(|(name, entity)| {
+                    let (kind, id) = entity_kind_id(entity);
+                    (name.clone(), kind, id)
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let cols = row.columns.clone().unwrap_or_default();
+    (binds, cols)
+}
+
+/// A `(kind_tag, id)` identity for an entity result.
+fn entity_kind_id(entity: &EntityResult) -> (u8, u64) {
+    match entity {
+        EntityResult::Node(n) => (0, n.id.as_u64()),
+        EntityResult::NodeId(id) => (0, id.as_u64()),
+        EntityResult::Edge(e) => (1, e.id.as_u64()),
+        EntityResult::EdgeId(id) => (1, id.as_u64()),
+        EntityResult::Null => (2, 0),
+    }
+}
+
+/// Deduplicate projected rows by their [`RowKey`] (first occurrence wins).
+fn distinct_rows(rows: Vec<(Binding, QueryRow)>) -> Vec<(Binding, QueryRow)> {
+    let mut seen: Vec<RowKey> = Vec::with_capacity(rows.len());
+    let mut out = Vec::with_capacity(rows.len());
+    for (binding, row) in rows {
+        let key = row_key(&row);
+        if seen.iter().any(|k| k == &key) {
+            continue;
+        }
+        seen.push(key);
+        out.push((binding, row));
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Result iterator
+// ---------------------------------------------------------------------------
+
+/// A vector-backed [`ResultIterator`] wrapping pre-computed rows.
+struct VecResultIterator {
+    rows: std::vec::IntoIter<QueryRow>,
+}
+
+impl VecResultIterator {
+    fn new(rows: Vec<QueryRow>) -> Self {
+        Self {
+            rows: rows.into_iter(),
+        }
+    }
+}
+
+impl ResultIterator for VecResultIterator {
+    fn next(&mut self) -> Option<CoreResult<QueryRow>> {
+        self.rows.next().map(Ok)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let n = self.rows.len();
+        (n, Some(n))
+    }
+}

--- a/src/cypher/multi_pattern.rs
+++ b/src/cypher/multi_pattern.rs
@@ -15,6 +15,25 @@
 //! single-entity path: only queries the router
 //! ([`super::exec::needs_multi_binding`]) classifies as multi-variable reach it.
 //!
+//! # v1 semantics
+//!
+//! * **Relationship-uniqueness (openCypher isomorphism).** Each relationship is
+//!   traversed **at most once** within a single `MATCH` clause -- both inside one
+//!   pattern and across the comma-separated patterns of the clause. The set of
+//!   already-traversed edge ids is threaded through every candidate binding
+//!   branch (see [`PartialBinding`]); reusing an edge yields no match, exactly
+//!   as openCypher requires (`MATCH (x)-[:R]-(y)-[:R]-(z)` over a single edge
+//!   returns zero rows).
+//! * **Three-valued `WHERE`.** Predicate evaluation is Kleene three-valued
+//!   ([`Tri`]): a comparison with a null/absent operand is `Null`, `NOT Null` is
+//!   `Null`, and a row is kept **iff** its predicate evaluates to `True` (both
+//!   `Null` and `False` drop it). This makes `WHERE NOT (a.x = 5)` drop a row
+//!   whose `a.x` is absent, per openCypher.
+//! * **Bounded materialization.** The intermediate binding set is capped at the
+//!   configured `max_schema_as_of_entities` limit (see FIX #6) so a pathological
+//!   Cartesian product (`MATCH (a),(b),(c)`) cannot exhaust memory; exceeding
+//!   the cap is a structured [`CypherError`], never an OOM.
+//!
 //! # House rule
 //!
 //! Anything this evaluator cannot answer **correctly** is rejected with a
@@ -22,6 +41,13 @@
 //! silently-wrong row. v1 rejects: `OPTIONAL MATCH`, `WITH`, temporal `AS OF`,
 //! aggregates in `RETURN`, and variable-length relationships inside a bound
 //! pattern.
+//!
+//! # Remaining v1 limitations
+//!
+//! Bindings carry cloned entities (not ids) through the Cartesian product, so a
+//! wide product clones each entity per branch -- a deliberate simplicity/perf
+//! tradeoff. Carrying ids and resolving lazily is tracked as a follow-up
+//! (`TODO(perf #549-followup)`).
 
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
@@ -42,7 +68,82 @@ use super::converter::CypherParameterValue;
 use super::error::CypherError;
 
 /// An ordered set of `variable -> entity` bindings for one candidate row.
+///
+// TODO(perf #549-followup): carry entity *ids* instead of cloned entities
+// through the Cartesian product; a wide product currently clones each entity
+// once per surviving branch.
 type Binding = Vec<(String, EntityResult)>;
+
+/// A projected row paired with its still-full pattern binding (needed to
+/// evaluate `ORDER BY` expressions and `DISTINCT` keys after projection).
+type ProjectedRow = (Binding, QueryRow);
+
+/// A row's evaluated `ORDER BY` sort key: one optional scalar per key
+/// expression (`None` == null).
+type SortKey = Vec<Option<PropertyValue>>;
+
+/// A projected row paired with its pre-computed sort key, used while sorting.
+type KeyedRow = (SortKey, ProjectedRow);
+
+/// A candidate binding branch during matching: the `variable -> entity`
+/// assignments accumulated so far plus the set of relationship edge ids already
+/// traversed by this branch.
+///
+/// The `used_edges` set enforces openCypher **relationship-uniqueness**: an edge
+/// may be traversed at most once per `MATCH` clause. It is threaded through the
+/// whole clause -- across every pattern element AND across the comma-separated
+/// patterns -- by cloning it into each extended branch.
+#[derive(Clone, Default)]
+struct PartialBinding {
+    vars: Binding,
+    used_edges: HashSet<EdgeId>,
+}
+
+/// Kleene three-valued truth for `WHERE` predicate evaluation.
+///
+/// openCypher predicates are three-valued: a comparison involving a null/absent
+/// operand is `Null`, not `False`. A `WHERE` clause keeps a row **iff** the
+/// predicate is [`Tri::True`]; both [`Tri::False`] and [`Tri::Null`] drop it.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Tri {
+    True,
+    False,
+    Null,
+}
+
+impl Tri {
+    /// A definite boolean lifts to `True`/`False` (never `Null`).
+    fn from_bool(b: bool) -> Tri {
+        if b { Tri::True } else { Tri::False }
+    }
+
+    /// Kleene negation: `NOT Null = Null`.
+    fn not(self) -> Tri {
+        match self {
+            Tri::True => Tri::False,
+            Tri::False => Tri::True,
+            Tri::Null => Tri::Null,
+        }
+    }
+
+    /// Kleene conjunction: any `False` => `False`, else any `Null` => `Null`.
+    fn and(self, other: Tri) -> Tri {
+        match (self, other) {
+            (Tri::False, _) | (_, Tri::False) => Tri::False,
+            (Tri::True, Tri::True) => Tri::True,
+            _ => Tri::Null,
+        }
+    }
+
+    /// Kleene disjunction: any `True` => `True`, else any `Null` => `Null`.
+    fn or(self, other: Tri) -> Tri {
+        match (self, other) {
+            (Tri::True, _) | (_, Tri::True) => Tri::True,
+            (Tri::False, Tri::False) => Tri::False,
+            _ => Tri::Null,
+        }
+    }
+}
 
 /// Entry point: evaluate a multi-variable `MATCH` statement into result rows.
 ///
@@ -138,6 +239,11 @@ pub fn evaluate(
         node_by_id.insert(node.id, idx);
     }
 
+    // Cap on the materialized intermediate binding count (FIX #6): reuse the
+    // configurable `max_schema_as_of_entities` limit so a pathological
+    // Cartesian product cannot exhaust memory. Read once, up front.
+    let binding_cap = db.historical.read().max_schema_as_of_entities();
+
     let eval = MultiEval {
         db,
         params,
@@ -145,21 +251,45 @@ pub fn evaluate(
         node_by_id,
     };
 
-    // ---- Nested-loop binding matcher: extend the binding set by each pattern.
-    let mut env: Vec<Binding> = vec![Vec::new()];
+    // ---- Per-pattern candidate memoization (FIX #6): a pattern's first-node
+    // candidate set (the unbound label/property scan) is base-independent, so
+    // compute it once per pattern and reuse it across every outer binding
+    // instead of re-scanning all nodes per base binding.
+    let mut first_memos: Vec<Vec<Node>> = Vec::with_capacity(pattern.len());
     for p in pattern {
-        let mut next: Vec<Binding> = Vec::new();
+        let memo = match p.elements.first() {
+            Some(CypherPatternElement::Node(first)) => eval.scan_node_candidates(first)?,
+            _ => Vec::new(),
+        };
+        first_memos.push(memo);
+    }
+
+    // ---- Nested-loop binding matcher: extend the binding set by each pattern.
+    // Each branch threads its `used_edges` set forward for relationship
+    // uniqueness across the whole clause (FIX #1).
+    let mut env: Vec<PartialBinding> = vec![PartialBinding::default()];
+    for (p, first_memo) in pattern.iter().zip(first_memos.iter()) {
+        let mut next: Vec<PartialBinding> = Vec::new();
         for base in &env {
-            eval.match_pattern_extends(p, base, &mut next)?;
+            eval.match_pattern_extends(p, base, first_memo, &mut next)?;
+            if next.len() > binding_cap {
+                return Err(CypherError::UnsupportedFeature(format!(
+                    "multi-pattern result exceeds {binding_cap} intermediate \
+                     bindings; add a more selective WHERE filter or labels to \
+                     narrow the Cartesian product (configurable via \
+                     max_schema_as_of_entities)"
+                )));
+            }
         }
         env = next;
     }
 
     // ---- WHERE filter (cross-variable predicates resolve from the binding).
+    // Three-valued (FIX #2): a row survives iff its predicate is `Tri::True`.
     if let Some(predicate) = where_clause {
         let mut filtered = Vec::with_capacity(env.len());
         for binding in env {
-            if eval.eval_predicate(predicate, &binding)? {
+            if eval.eval_predicate(predicate, &binding.vars)? == Tri::True {
                 filtered.push(binding);
             }
         }
@@ -167,11 +297,11 @@ pub fn evaluate(
     }
 
     // ---- Projection: each surviving binding becomes a QueryRow.
-    let entity_order = entity_var_declaration_order(pattern);
+    let entity_order = return_star_var_order(pattern);
     let mut projected: Vec<(Binding, QueryRow)> = Vec::with_capacity(env.len());
     for binding in env {
-        let row = eval.project(&binding, return_clause, &entity_order)?;
-        projected.push((binding, row));
+        let row = eval.project(&binding.vars, return_clause, &entity_order)?;
+        projected.push((binding.vars, row));
     }
 
     // ---- DISTINCT (dedupe by projected content) -> ORDER BY -> SKIP -> LIMIT.
@@ -208,25 +338,57 @@ impl MultiEval<'_> {
     }
 
     /// Extend `base` by every assignment that satisfies `pattern`, appending
-    /// each resulting binding to `out`.
+    /// each resulting [`PartialBinding`] to `out`.
+    ///
+    /// `first_memo` is the pattern's first-node candidate list precomputed by an
+    /// unbound scan (base-independent, so computed once per pattern and reused
+    /// across every outer binding -- FIX #6). It is used only when the first
+    /// node's variable is not already bound by `base`; a bound first-node
+    /// variable resolves to its single existing node instead.
     fn match_pattern_extends(
         &self,
         pattern: &CypherPattern,
-        base: &Binding,
-        out: &mut Vec<Binding>,
+        base: &PartialBinding,
+        first_memo: &[Node],
+        out: &mut Vec<PartialBinding>,
     ) -> Result<(), CypherError> {
         let Some(CypherPatternElement::Node(first)) = pattern.elements.first() else {
             return Err(CypherError::SemanticError(
                 "a graph pattern must start with a node".to_string(),
             ));
         };
-        for node in self.node_candidates(first, base)? {
-            let mut binding = base.clone();
+
+        // Candidate first nodes: the single already-bound node (if the first
+        // variable is bound in `base`), otherwise the memoized unbound scan.
+        let bound_single: Vec<Node>;
+        let candidates: &[Node] = match &first.variable {
+            Some(var) => match lookup(&base.vars, var) {
+                Some(EntityResult::Node(n)) => {
+                    if self.node_element_matches(n, first)? {
+                        bound_single = vec![n.clone()];
+                        &bound_single
+                    } else {
+                        return Ok(());
+                    }
+                }
+                // A variable already bound to an edge cannot also be a node.
+                Some(_) => return Ok(()),
+                None => first_memo,
+            },
+            None => first_memo,
+        };
+
+        for node in candidates {
+            let mut vars = base.vars.clone();
             if let Some(var) = &first.variable
-                && lookup(&binding, var).is_none()
+                && lookup(&vars, var).is_none()
             {
-                binding.push((var.clone(), EntityResult::Node(node.clone())));
+                vars.push((var.clone(), EntityResult::Node(node.clone())));
             }
+            let binding = PartialBinding {
+                vars,
+                used_edges: base.used_edges.clone(),
+            };
             self.extend_from(&pattern.elements, 1, binding, node.id, out)?;
         }
         Ok(())
@@ -239,9 +401,9 @@ impl MultiEval<'_> {
         &self,
         elements: &[CypherPatternElement],
         idx: usize,
-        binding: Binding,
+        binding: PartialBinding,
         current: NodeId,
-        out: &mut Vec<Binding>,
+        out: &mut Vec<PartialBinding>,
     ) -> Result<(), CypherError> {
         if idx >= elements.len() {
             out.push(binding);
@@ -259,6 +421,12 @@ impl MultiEval<'_> {
         };
 
         for (edge, far_id) in self.adjacent(current, rel)? {
+            // Relationship-uniqueness (FIX #1): an edge may be traversed at most
+            // once per MATCH clause. Skip an edge this branch has already used
+            // (named or anonymous relationship element alike).
+            if binding.used_edges.contains(&edge.id) {
+                continue;
+            }
             let Some(far_node) = self.node_ref(far_id).cloned() else {
                 // Orphaned edge whose endpoint is missing from current state.
                 continue;
@@ -266,56 +434,43 @@ impl MultiEval<'_> {
             if !self.node_element_matches(&far_node, next_patt)? {
                 continue;
             }
-            let mut binding = binding.clone();
+            let mut vars = binding.vars.clone();
+            let mut used_edges = binding.used_edges.clone();
+            used_edges.insert(edge.id);
             // Unify the far-node variable (a repeated variable must resolve to
             // the same node id).
             if let Some(nv) = &next_patt.variable {
-                match lookup(&binding, nv) {
+                match lookup(&vars, nv) {
                     Some(existing) => {
                         if existing.node_id() != Some(far_node.id) {
                             continue;
                         }
                     }
-                    None => binding.push((nv.clone(), EntityResult::Node(far_node.clone()))),
+                    None => vars.push((nv.clone(), EntityResult::Node(far_node.clone()))),
                 }
             }
             // Bind (and unify) the relationship variable.
             if let Some(rv) = &rel.variable {
-                match lookup(&binding, rv) {
+                match lookup(&vars, rv) {
                     Some(existing) => {
                         if entity_edge_id(existing) != Some(edge.id) {
                             continue;
                         }
                     }
-                    None => binding.push((rv.clone(), EntityResult::Edge(edge.clone()))),
+                    None => vars.push((rv.clone(), EntityResult::Edge(edge.clone()))),
                 }
             }
-            self.extend_from(elements, idx + 2, binding, far_node.id, out)?;
+            let next = PartialBinding { vars, used_edges };
+            self.extend_from(elements, idx + 2, next, far_node.id, out)?;
         }
         Ok(())
     }
 
-    /// Candidate nodes for a node element: the single already-bound node (if the
-    /// element's variable is bound and still satisfies the element), otherwise
-    /// every node satisfying the element's labels and inline properties.
-    fn node_candidates(
-        &self,
-        patt: &CypherNodePattern,
-        base: &Binding,
-    ) -> Result<Vec<Node>, CypherError> {
-        if let Some(var) = &patt.variable
-            && let Some(existing) = lookup(base, var)
-        {
-            if let EntityResult::Node(n) = existing {
-                return Ok(if self.node_element_matches(n, patt)? {
-                    vec![n.clone()]
-                } else {
-                    Vec::new()
-                });
-            }
-            // A variable bound to an edge cannot also be a node.
-            return Ok(Vec::new());
-        }
+    /// Every node satisfying a node element's labels and inline properties.
+    ///
+    /// Base-independent (it does not consult any binding), so a pattern's first
+    /// node scan is computed once and reused across all outer bindings (FIX #6).
+    fn scan_node_candidates(&self, patt: &CypherNodePattern) -> Result<Vec<Node>, CypherError> {
         let mut out = Vec::new();
         for node in &self.nodes {
             if self.node_element_matches(node, patt)? {
@@ -439,53 +594,73 @@ impl MultiEval<'_> {
 
     // -- Predicate / scalar evaluation ------------------------------------
 
-    /// Evaluate a `WHERE` predicate against a binding (null-yields-false).
-    fn eval_predicate(&self, expr: &CypherExpr, binding: &Binding) -> Result<bool, CypherError> {
+    /// Evaluate a `WHERE` predicate against a binding using Kleene three-valued
+    /// logic (FIX #2): a comparison with a null/absent operand yields
+    /// [`Tri::Null`], `NOT Null` is `Null`, and the caller keeps a row only when
+    /// the result is [`Tri::True`].
+    fn eval_predicate(&self, expr: &CypherExpr, binding: &Binding) -> Result<Tri, CypherError> {
         match expr {
             CypherExpr::Comparison { left, op, right } => {
                 let l = self.eval_value(left, binding)?;
                 let r = self.eval_value(right, binding)?;
                 match (l, r) {
-                    (Some(a), Some(b)) => Ok(compare(&a, &b, *op)),
-                    _ => Ok(false),
+                    (Some(a), Some(b)) => Ok(Tri::from_bool(compare(&a, &b, *op))),
+                    // A comparison with a null/absent operand is Null, not False.
+                    _ => Ok(Tri::Null),
                 }
             }
-            CypherExpr::And(a, b) => {
-                Ok(self.eval_predicate(a, binding)? && self.eval_predicate(b, binding)?)
+            // Both sides are evaluated (no short-circuit) so Kleene logic is
+            // exact: `False AND Null = False`, `True OR Null = True`.
+            CypherExpr::And(a, b) => Ok(self
+                .eval_predicate(a, binding)?
+                .and(self.eval_predicate(b, binding)?)),
+            CypherExpr::Or(a, b) => Ok(self
+                .eval_predicate(a, binding)?
+                .or(self.eval_predicate(b, binding)?)),
+            CypherExpr::Not(inner) => Ok(self.eval_predicate(inner, binding)?.not()),
+            // IS NULL / IS NOT NULL are always definite (never Null).
+            CypherExpr::IsNull(inner) => {
+                Ok(Tri::from_bool(self.eval_value(inner, binding)?.is_none()))
             }
-            CypherExpr::Or(a, b) => {
-                Ok(self.eval_predicate(a, binding)? || self.eval_predicate(b, binding)?)
+            CypherExpr::IsNotNull(inner) => {
+                Ok(Tri::from_bool(self.eval_value(inner, binding)?.is_some()))
             }
-            CypherExpr::Not(inner) => Ok(!self.eval_predicate(inner, binding)?),
-            CypherExpr::IsNull(inner) => Ok(self.eval_value(inner, binding)?.is_none()),
-            CypherExpr::IsNotNull(inner) => Ok(self.eval_value(inner, binding)?.is_some()),
             CypherExpr::In { expr, values } => {
+                // A null subject makes IN Null.
                 let Some(needle) = self.eval_value(expr, binding)? else {
-                    return Ok(false);
+                    return Ok(Tri::Null);
                 };
                 for candidate in values {
                     if let Some(v) = self.eval_value(candidate, binding)?
                         && loosely_equal(&needle, &v)
                     {
-                        return Ok(true);
+                        return Ok(Tri::True);
                     }
                 }
-                Ok(false)
+                Ok(Tri::False)
             }
-            CypherExpr::Contains { expr, substring } => Ok(self
-                .eval_string(expr, binding)?
-                .is_some_and(|s| s.contains(substring))),
-            CypherExpr::StartsWith { expr, prefix } => Ok(self
-                .eval_string(expr, binding)?
-                .is_some_and(|s| s.starts_with(prefix))),
-            CypherExpr::EndsWith { expr, suffix } => Ok(self
-                .eval_string(expr, binding)?
-                .is_some_and(|s| s.ends_with(suffix))),
+            // String predicates with a null/non-string subject are Null.
+            CypherExpr::Contains { expr, substring } => {
+                Ok(match self.eval_string(expr, binding)? {
+                    Some(s) => Tri::from_bool(s.contains(substring)),
+                    None => Tri::Null,
+                })
+            }
+            CypherExpr::StartsWith { expr, prefix } => {
+                Ok(match self.eval_string(expr, binding)? {
+                    Some(s) => Tri::from_bool(s.starts_with(prefix)),
+                    None => Tri::Null,
+                })
+            }
+            CypherExpr::EndsWith { expr, suffix } => Ok(match self.eval_string(expr, binding)? {
+                Some(s) => Tri::from_bool(s.ends_with(suffix)),
+                None => Tri::Null,
+            }),
             CypherExpr::Grouped(inner) => self.eval_predicate(inner, binding),
-            CypherExpr::Value(CypherValue::Bool(b)) => Ok(*b),
+            CypherExpr::Value(CypherValue::Bool(b)) => Ok(Tri::from_bool(*b)),
             other => match self.eval_value(other, binding)? {
-                Some(PropertyValue::Bool(b)) => Ok(b),
-                None => Ok(false),
+                Some(PropertyValue::Bool(b)) => Ok(Tri::from_bool(b)),
+                None => Ok(Tri::Null),
                 Some(_) => Err(CypherError::UnsupportedFeature(format!(
                     "WHERE expression is not a boolean predicate: {other:?}"
                 ))),
@@ -622,40 +797,26 @@ impl MultiEval<'_> {
     /// nulls last for ascending, first for descending).
     fn order_rows(
         &self,
-        rows: &mut [(Binding, QueryRow)],
+        rows: &mut Vec<(Binding, QueryRow)>,
         ret: &CypherReturn,
     ) -> Result<(), CypherError> {
-        // Pre-compute each row's ordered sort keys so the comparator is
-        // infallible (evaluation errors surface here, before sorting).
-        let mut keys: Vec<Vec<Option<PropertyValue>>> = Vec::with_capacity(rows.len());
-        for (binding, _) in rows.iter() {
+        // Pair each row with its pre-computed sort keys, sort the owned tuples
+        // by a stable comparator, then rebuild `rows`. Computing keys up front
+        // keeps the comparator infallible (evaluation errors surface here,
+        // before sorting) and avoids any panicking in-place permutation (FIX #9).
+        let mut keyed: Vec<KeyedRow> = Vec::with_capacity(rows.len());
+        for (binding, row) in rows.drain(..) {
             let mut key = Vec::with_capacity(ret.order_by.len());
             for item in &ret.order_by {
-                key.push(self.eval_value(&item.expr, binding)?);
+                key.push(self.eval_value(&item.expr, &binding)?);
             }
-            keys.push(key);
+            keyed.push((key, (binding, row)));
         }
 
-        let mut index: Vec<usize> = (0..rows.len()).collect();
-        index.sort_by(|&a, &b| compare_order_keys(&keys[a], &keys[b], ret));
-
-        // Apply the permutation.
-        let mut reordered: Vec<Option<(Binding, QueryRow)>> = rows
-            .iter_mut()
-            .map(|slot| Some(std::mem::replace(slot, placeholder_slot())))
-            .collect();
-        for (dst, &src) in index.iter().enumerate() {
-            rows[dst] = reordered[src].take().expect("each source used once");
-        }
+        keyed.sort_by(|a, b| compare_order_keys(&a.0, &b.0, ret));
+        rows.extend(keyed.into_iter().map(|(_, row)| row));
         Ok(())
     }
-}
-
-/// A throwaway `(Binding, QueryRow)` used only to vacate a slot during the
-/// in-place permutation in [`MultiEval::order_rows`]; every placeholder is
-/// overwritten before the function returns.
-fn placeholder_slot() -> (Binding, QueryRow) {
-    (Vec::new(), QueryRow::from_columns(Vec::new()))
 }
 
 // ---------------------------------------------------------------------------
@@ -700,10 +861,12 @@ fn param_to_property(param: &CypherParameterValue) -> PropertyValue {
     }
 }
 
-/// Entity variable names in pattern declaration order (nodes and relationships,
-/// first occurrence wins), used for `RETURN *`.
-fn entity_var_declaration_order(patterns: &[CypherPattern]) -> Vec<String> {
-    let mut order = Vec::new();
+/// Entity variable names for `RETURN *`, sorted **alphabetically** (FIX #7).
+///
+/// openCypher / Neo4j return `*` variables in alphabetical order for a
+/// deterministic, declaration-order-independent projection. The names are the
+/// node and relationship variables declared across every pattern (deduped).
+fn return_star_var_order(patterns: &[CypherPattern]) -> Vec<String> {
     let mut seen = HashSet::new();
     for pattern in patterns {
         for element in &pattern.elements {
@@ -711,13 +874,13 @@ fn entity_var_declaration_order(patterns: &[CypherPattern]) -> Vec<String> {
                 CypherPatternElement::Node(n) => n.variable.as_ref(),
                 CypherPatternElement::Relationship(r) => r.variable.as_ref(),
             };
-            if let Some(v) = var
-                && seen.insert(v.clone())
-            {
-                order.push(v.clone());
+            if let Some(v) = var {
+                seen.insert(v.clone());
             }
         }
     }
+    let mut order: Vec<String> = seen.into_iter().collect();
+    order.sort();
     order
 }
 
@@ -844,26 +1007,26 @@ fn compare_order_keys(
     Ordering::Equal
 }
 
-/// A comparable identity for a projected row, used for `DISTINCT` dedup:
-/// bound entity ids plus scalar column values.
-type RowKey = (Vec<(String, u8, u64)>, Vec<(String, PropertyValue)>);
-
-/// Compute a row's `DISTINCT` identity key.
-fn row_key(row: &QueryRow) -> RowKey {
-    let binds = row
-        .bindings
-        .as_ref()
-        .map(|b| {
-            b.iter()
-                .map(|(name, entity)| {
-                    let (kind, id) = entity_kind_id(entity);
-                    (name.clone(), kind, id)
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-    let cols = row.columns.clone().unwrap_or_default();
-    (binds, cols)
+/// Compute a stable string identity for a projected row, used for `DISTINCT`
+/// dedup: bound entity ids plus scalar column values.
+///
+/// A string key is used because [`PropertyValue`] contains float/vector
+/// payloads and does not implement `Hash`/`Eq`; the `{:?}` rendering is
+/// deterministic, so equal rows produce equal keys.
+fn row_dedup_key(row: &QueryRow) -> String {
+    let mut key = String::new();
+    if let Some(bindings) = &row.bindings {
+        for (name, entity) in bindings {
+            let (kind, id) = entity_kind_id(entity);
+            key.push_str(&format!("b:{name}={kind}:{id};"));
+        }
+    }
+    if let Some(columns) = &row.columns {
+        for (name, value) in columns {
+            key.push_str(&format!("c:{name}={value:?};"));
+        }
+    }
+    key
 }
 
 /// A `(kind_tag, id)` identity for an entity result.
@@ -877,17 +1040,15 @@ fn entity_kind_id(entity: &EntityResult) -> (u8, u64) {
     }
 }
 
-/// Deduplicate projected rows by their [`RowKey`] (first occurrence wins).
+/// Deduplicate projected rows by their stable key (first occurrence wins),
+/// using a [`HashSet`] for O(n) total work (FIX #8).
 fn distinct_rows(rows: Vec<(Binding, QueryRow)>) -> Vec<(Binding, QueryRow)> {
-    let mut seen: Vec<RowKey> = Vec::with_capacity(rows.len());
+    let mut seen: HashSet<String> = HashSet::with_capacity(rows.len());
     let mut out = Vec::with_capacity(rows.len());
     for (binding, row) in rows {
-        let key = row_key(&row);
-        if seen.iter().any(|k| k == &key) {
-            continue;
+        if seen.insert(row_dedup_key(&row)) {
+            out.push((binding, row));
         }
-        seen.push(key);
-        out.push((binding, row));
     }
     out
 }

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -5535,4 +5535,241 @@ mod multi_pattern {
             "MATCH (a),(b) AS OF TIMESTAMP '2020-01-01T00:00:00Z' RETURN a,b",
         );
     }
+
+    // ---- FIX 1: relationship-uniqueness (openCypher isomorphism) ----------
+
+    /// Build a graph with a single directed edge a-[:R]->b and return the db.
+    fn single_edge_db() -> (AletheiaDB, crate::core::id::NodeId, crate::core::id::NodeId) {
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node("N", PropertyMapBuilder::new().insert("name", "A").build())
+            .unwrap();
+        let b = db
+            .create_node("N", PropertyMapBuilder::new().insert("name", "B").build())
+            .unwrap();
+        db.create_edge(a, b, "R", crate::core::property::PropertyMap::new())
+            .unwrap();
+        (db, a, b)
+    }
+
+    #[test]
+    fn test_rel_uniqueness_double_hop_undirected() {
+        // Over the single edge a-R->b, an undirected two-hop pattern would
+        // reuse the same edge to walk a-b-a. openCypher relationship-uniqueness
+        // forbids reusing an edge within a MATCH clause => 0 rows.
+        let (db, _, _) = single_edge_db();
+        let rows = run(&db, "MATCH (x)-[:R]-(y)-[:R]-(z) RETURN x,y,z");
+        assert_eq!(
+            rows.len(),
+            0,
+            "an edge may not be traversed twice: {rows:?}"
+        );
+    }
+
+    #[test]
+    fn test_rel_uniqueness_double_hop_rel_vars() {
+        // Same as above but with named relationship variables; the two edges
+        // resolve to the same underlying edge id, which is forbidden => 0 rows.
+        let (db, _, _) = single_edge_db();
+        let rows = run(&db, "MATCH (x)-[r1:R]-(y)-[r2:R]-(z) RETURN x,y,z");
+        assert_eq!(rows.len(), 0, "r1 and r2 cannot be the same edge: {rows:?}");
+    }
+
+    #[test]
+    fn test_rel_uniqueness_across_comma_patterns() {
+        // Relationship-uniqueness spans the whole clause: the two comma
+        // patterns cannot both consume the single edge => 0 rows.
+        let (db, _, _) = single_edge_db();
+        let rows = run(&db, "MATCH (p)-[:R]->(q),(s)-[:R]->(t) RETURN p,q,s,t");
+        assert_eq!(
+            rows.len(),
+            0,
+            "one edge cannot satisfy both comma patterns: {rows:?}"
+        );
+    }
+
+    #[test]
+    fn test_rel_uniqueness_triangle_positive_control() {
+        // Positive control: a triangle a->b->c->a has three DISTINCT edges, so
+        // a two-hop directed pattern uses two distinct edges and matches.
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node("N", PropertyMapBuilder::new().insert("name", "A").build())
+            .unwrap();
+        let b = db
+            .create_node("N", PropertyMapBuilder::new().insert("name", "B").build())
+            .unwrap();
+        let c = db
+            .create_node("N", PropertyMapBuilder::new().insert("name", "C").build())
+            .unwrap();
+        db.create_edge(a, b, "R", crate::core::property::PropertyMap::new())
+            .unwrap();
+        db.create_edge(b, c, "R", crate::core::property::PropertyMap::new())
+            .unwrap();
+        db.create_edge(c, a, "R", crate::core::property::PropertyMap::new())
+            .unwrap();
+
+        let rows = run(&db, "MATCH (x)-[:R]->(y)-[:R]->(z) RETURN x,y,z");
+        // Three starting points (a,b,c), each a distinct 2-edge directed walk.
+        assert_eq!(
+            rows.len(),
+            3,
+            "each anchor yields one 2-hop walk over distinct edges: {rows:?}"
+        );
+    }
+
+    // ---- FIX 2: three-valued WHERE / NOT over null ------------------------
+
+    /// A db with a node `a` that lacks property `x`, plus a plain node `b`.
+    fn null_prop_db() -> AletheiaDB {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+        )
+        .unwrap();
+        db
+    }
+
+    #[test]
+    fn test_where_not_over_null_drops_row() {
+        // a.x is absent => `a.x = 5` is Null => `NOT Null` is Null => the row
+        // is DROPPED (openCypher three-valued logic), not kept.
+        let db = null_prop_db();
+        let rows = run(&db, "MATCH (a),(b) WHERE NOT (a.x = 5) RETURN a,b");
+        assert_eq!(rows.len(), 0, "NOT over null must drop the row: {rows:?}");
+    }
+
+    #[test]
+    fn test_where_null_comparison_drops_row() {
+        // `a.x = 5` with a.x absent is Null => dropped (unchanged behavior).
+        let db = null_prop_db();
+        let rows = run(&db, "MATCH (a),(b) WHERE a.x = 5 RETURN a,b");
+        assert_eq!(rows.len(), 0, "null comparison drops the row: {rows:?}");
+    }
+
+    #[test]
+    fn test_where_is_null_keeps_rows() {
+        // IS NULL is never Null: it is True for the absent property, so rows
+        // are kept. 2 persons x 2 persons = 4 rows.
+        let db = null_prop_db();
+        let rows = run(&db, "MATCH (a),(b) WHERE a.x IS NULL RETURN a,b");
+        assert_eq!(rows.len(), 4, "IS NULL keeps rows: {rows:?}");
+    }
+
+    #[test]
+    fn test_where_or_with_null_true_kept() {
+        // For the (Alice, *) rows: `a.name = 'Alice'` is True, `a.x = 5` is
+        // Null; True OR Null = True => kept. Two b-candidates => 2 rows.
+        let db = null_prop_db();
+        let rows = run(
+            &db,
+            "MATCH (a),(b) WHERE a.name = 'Alice' OR a.x = 5 RETURN a,b",
+        );
+        assert_eq!(
+            rows.len(),
+            2,
+            "True OR Null = True keeps Alice rows: {rows:?}"
+        );
+        for row in &rows {
+            assert_eq!(node_prop(bound(row, "a"), "name").unwrap(), "Alice");
+        }
+    }
+
+    // ---- FIX 4: router last_node_variable skips unnamed terminal ----------
+
+    #[test]
+    fn test_anon_terminal_routes_and_binds_source() {
+        // `MATCH (a)-[:R]->() RETURN a` has an UNNAMED terminal node. The
+        // router must treat the terminal variable as None, so `a` is a
+        // non-terminal referenced variable => route to the evaluator and
+        // return `a` (Alice), never the anonymous endpoint (Bob).
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Alice").build(),
+            )
+            .unwrap();
+        let b = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Bob").build(),
+            )
+            .unwrap();
+        db.create_edge(a, b, "R", crate::core::property::PropertyMap::new())
+            .unwrap();
+
+        let rows = run(&db, "MATCH (a)-[:R]->() RETURN a");
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert!(
+            row.bindings.is_some(),
+            "anon-terminal query must route to the multi-binding evaluator"
+        );
+        assert_eq!(node_prop(bound(row, "a"), "name").unwrap(), "Alice");
+    }
+
+    // ---- FIX 5: multi-pattern + WITH / OPTIONAL routes to honest error ----
+
+    #[test]
+    fn test_multi_pattern_with_rejected() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node("N", PropertyMapBuilder::new().insert("name", "A").build())
+            .unwrap();
+        // Multi-pattern + WITH must reach the evaluator and be rejected with a
+        // structured error rather than silently discarding a scan.
+        assert_unsupported(&db, "MATCH (a),(b) WITH a RETURN a");
+    }
+
+    #[test]
+    fn test_multi_pattern_optional_rejected() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node("X", PropertyMapBuilder::new().insert("name", "A").build())
+            .unwrap();
+        db.create_node("Y", PropertyMapBuilder::new().insert("name", "B").build())
+            .unwrap();
+        assert_unsupported(
+            &db,
+            "MATCH (a:X),(b:Y) OPTIONAL MATCH (b)-[:R]->(c) RETURN b,c",
+        );
+    }
+
+    // ---- FIX 6: binding cap prevents unbounded Cartesian materialization ---
+
+    #[test]
+    fn test_multi_pattern_binding_cap_enforced() {
+        use crate::config::{AletheiaDBConfig, HistoricalConfigBuilder};
+        // Cap the materialized binding count low via the configurable
+        // `max_schema_as_of_entities` limit, then build enough nodes that the
+        // (a),(b) product exceeds it. Must return a structured error, not OOM.
+        let config = AletheiaDBConfig::builder()
+            .historical(
+                HistoricalConfigBuilder::new()
+                    .max_schema_as_of_entities(5)
+                    .build(),
+            )
+            .build();
+        let db = AletheiaDB::with_unified_config(config).unwrap();
+        for i in 0..3 {
+            db.create_node(
+                "N",
+                PropertyMapBuilder::new()
+                    .insert("name", format!("N{i}"))
+                    .build(),
+            )
+            .unwrap();
+        }
+        // 3 x 3 = 9 intermediate bindings > cap of 5 => structured error.
+        match db.execute_cypher("MATCH (a),(b) RETURN a,b") {
+            Ok(_) => panic!("expected a structured cap error, got Ok"),
+            Err(Error::Query(QueryError::UnsupportedFeature { .. })) => {}
+            Err(other) => panic!("expected UnsupportedFeature cap error, got {other:?}"),
+        }
+    }
 }

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -4843,10 +4843,16 @@ mod unwind {
         match plan_cypher("UNWIND [1, 2] AS x RETURN x").unwrap() {
             CypherExecution::Rows(_) => {}
             CypherExecution::Query(_) => panic!("UNWIND must plan to Rows, not a Query"),
+            CypherExecution::MultiPattern { .. } => {
+                panic!("UNWIND must plan to Rows, not a MultiPattern")
+            }
         }
         match plan_cypher("MATCH (n:Person) RETURN n").unwrap() {
             CypherExecution::Query(_) => {}
             CypherExecution::Rows(_) => panic!("MATCH must plan to a Query"),
+            CypherExecution::MultiPattern { .. } => {
+                panic!("single-variable MATCH must plan to a Query")
+            }
         }
     }
 
@@ -5010,7 +5016,6 @@ mod unwind {
 // answer correctly are rejected with a structured `UnsupportedFeature` error --
 // never a silently-wrong row.
 mod multi_pattern {
-    use super::*;
     use crate::AletheiaDB;
     use crate::core::error::{Error, QueryError};
     use crate::core::property::{PropertyMapBuilder, PropertyValue};

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -4997,3 +4997,447 @@ mod unwind {
         );
     }
 }
+
+// ============================================================================
+// Multi-variable, multi-pattern MATCH (Issue #549)
+// ============================================================================
+//
+// These tests define the contract for correct multi-variable binding: a query
+// that binds and returns more than one entity variable (or references a
+// non-terminal variable) is evaluated by the dedicated multi-pattern evaluator
+// and yields rows carrying `QueryRow::bindings` (named variable -> entity)
+// and/or `QueryRow::columns` (scalar projections). Queries the evaluator cannot
+// answer correctly are rejected with a structured `UnsupportedFeature` error --
+// never a silently-wrong row.
+mod multi_pattern {
+    use super::*;
+    use crate::AletheiaDB;
+    use crate::core::error::{Error, QueryError};
+    use crate::core::property::{PropertyMapBuilder, PropertyValue};
+    use crate::query::executor::{EntityResult, QueryRow};
+
+    /// Run a Cypher query and collect its rows (panicking on error).
+    fn run(db: &AletheiaDB, query: &str) -> Vec<QueryRow> {
+        db.execute_cypher(query).unwrap().collect_all().unwrap()
+    }
+
+    /// Look up the entity bound to `var` in a multi-variable row.
+    fn bound<'a>(row: &'a QueryRow, var: &str) -> &'a EntityResult {
+        row.bindings
+            .as_ref()
+            .unwrap_or_else(|| panic!("row has no bindings: {row:?}"))
+            .iter()
+            .find(|(name, _)| name == var)
+            .map(|(_, entity)| entity)
+            .unwrap_or_else(|| panic!("no binding named '{var}' in {row:?}"))
+    }
+
+    /// The set of variable names bound in a row, in binding order.
+    fn binding_names(row: &QueryRow) -> Vec<String> {
+        row.bindings
+            .as_ref()
+            .map(|b| b.iter().map(|(n, _)| n.clone()).collect())
+            .unwrap_or_default()
+    }
+
+    /// Extract a `String` property from a bound node entity.
+    fn node_prop(entity: &EntityResult, key: &str) -> Option<String> {
+        match entity {
+            EntityResult::Node(n) => n.get_property(key).and_then(|v| match v {
+                PropertyValue::String(s) => Some(s.to_string()),
+                _ => None,
+            }),
+            _ => None,
+        }
+    }
+
+    /// True if the entity is a node carrying the given label.
+    fn has_label(entity: &EntityResult, label: &str) -> bool {
+        matches!(entity, EntityResult::Node(n) if n.has_label_str(label))
+    }
+
+    /// Fetch a projected scalar column value by name.
+    fn column(row: &QueryRow, name: &str) -> Option<PropertyValue> {
+        row.columns
+            .as_ref()?
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, v)| v.clone())
+    }
+
+    /// Assert that executing `query` fails with a structured `UnsupportedFeature`
+    /// error (never a silently-wrong row). `QueryResults` is not `Debug`, so the
+    /// success arm is handled explicitly rather than via `unwrap_err`.
+    fn assert_unsupported(db: &AletheiaDB, query: &str) {
+        match db.execute_cypher(query) {
+            Ok(_) => panic!("expected an UnsupportedFeature error for `{query}`, got Ok"),
+            Err(Error::Query(QueryError::UnsupportedFeature { .. })) => {}
+            Err(other) => panic!("expected UnsupportedFeature for `{query}`, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_multi_pattern_cross_product() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node("Person", PropertyMapBuilder::new().insert("name", "Alice").build())
+            .unwrap();
+        db.create_node("Person", PropertyMapBuilder::new().insert("name", "Bob").build())
+            .unwrap();
+        db.create_node("Company", PropertyMapBuilder::new().insert("name", "Acme").build())
+            .unwrap();
+        db.create_node("Company", PropertyMapBuilder::new().insert("name", "Globex").build())
+            .unwrap();
+
+        let rows = run(&db, "MATCH (a:Person),(b:Company) RETURN a,b");
+        assert_eq!(rows.len(), 4, "2 persons x 2 companies = 4 rows");
+        for row in &rows {
+            assert_eq!(binding_names(row), vec!["a".to_string(), "b".to_string()]);
+            assert!(has_label(bound(row, "a"), "Person"));
+            assert!(has_label(bound(row, "b"), "Company"));
+        }
+    }
+
+    #[test]
+    fn test_multi_pattern_cross_var_where_join() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .insert("company_id", 1i64)
+                .build(),
+        )
+        .unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Bob")
+                .insert("company_id", 2i64)
+                .build(),
+        )
+        .unwrap();
+        db.create_node(
+            "Company",
+            PropertyMapBuilder::new().insert("name", "Acme").insert("id", 1i64).build(),
+        )
+        .unwrap();
+        db.create_node(
+            "Company",
+            PropertyMapBuilder::new().insert("name", "Globex").insert("id", 2i64).build(),
+        )
+        .unwrap();
+
+        let rows = run(
+            &db,
+            "MATCH (a:Person),(b:Company) WHERE a.company_id = b.id RETURN a,b",
+        );
+        assert_eq!(rows.len(), 2, "only matching (person, company) pairs");
+        for row in &rows {
+            let person = node_prop(bound(row, "a"), "name").unwrap();
+            let company = node_prop(bound(row, "b"), "name").unwrap();
+            match person.as_str() {
+                "Alice" => assert_eq!(company, "Acme"),
+                "Bob" => assert_eq!(company, "Globex"),
+                other => panic!("unexpected person {other}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_chain_binds_all_vars() {
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node("Person", PropertyMapBuilder::new().insert("name", "A").build())
+            .unwrap();
+        let b = db
+            .create_node("Person", PropertyMapBuilder::new().insert("name", "B").build())
+            .unwrap();
+        let c = db
+            .create_node("Company", PropertyMapBuilder::new().insert("name", "C").build())
+            .unwrap();
+        db.create_edge(a, b, "KNOWS", crate::core::property::PropertyMap::new())
+            .unwrap();
+        db.create_edge(b, c, "WORKS_AT", crate::core::property::PropertyMap::new())
+            .unwrap();
+
+        let rows = run(
+            &db,
+            "MATCH (a)-[:KNOWS]->(b)-[:WORKS_AT]->(c) RETURN a,b,c",
+        );
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(node_prop(bound(row, "a"), "name").unwrap(), "A");
+        assert_eq!(node_prop(bound(row, "b"), "name").unwrap(), "B");
+        assert_eq!(node_prop(bound(row, "c"), "name").unwrap(), "C");
+    }
+
+    #[test]
+    fn test_shared_variable_unify() {
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node("N", PropertyMapBuilder::new().insert("name", "A").build())
+            .unwrap();
+        let b = db
+            .create_node("N", PropertyMapBuilder::new().insert("name", "B").build())
+            .unwrap();
+        let c = db
+            .create_node("N", PropertyMapBuilder::new().insert("name", "C").build())
+            .unwrap();
+        db.create_edge(a, b, "KNOWS", crate::core::property::PropertyMap::new())
+            .unwrap();
+        db.create_edge(b, c, "KNOWS", crate::core::property::PropertyMap::new())
+            .unwrap();
+
+        let rows = run(
+            &db,
+            "MATCH (a)-[:KNOWS]->(b),(b)-[:KNOWS]->(c) RETURN a,b,c",
+        );
+        assert_eq!(rows.len(), 1, "b must unify across the two patterns");
+        let row = &rows[0];
+        assert_eq!(node_prop(bound(row, "a"), "name").unwrap(), "A");
+        assert_eq!(node_prop(bound(row, "b"), "name").unwrap(), "B");
+        assert_eq!(node_prop(bound(row, "c"), "name").unwrap(), "C");
+    }
+
+    #[test]
+    fn test_multi_var_property_projection() {
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node("Person", PropertyMapBuilder::new().insert("name", "Alice").build())
+            .unwrap();
+        let b = db
+            .create_node("Person", PropertyMapBuilder::new().insert("name", "Bob").build())
+            .unwrap();
+        db.create_edge(a, b, "KNOWS", crate::core::property::PropertyMap::new())
+            .unwrap();
+
+        let rows = run(&db, "MATCH (a:Person)-[:KNOWS]->(b) RETURN a.name, b.name");
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(
+            column(row, "a.name"),
+            Some(PropertyValue::String("Alice".into()))
+        );
+        assert_eq!(
+            column(row, "b.name"),
+            Some(PropertyValue::String("Bob".into()))
+        );
+    }
+
+    #[test]
+    fn test_mixed_pattern_join() {
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node("Person", PropertyMapBuilder::new().insert("name", "A1").build())
+            .unwrap();
+        let b = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "B1").insert("x", 5i64).build(),
+            )
+            .unwrap();
+        db.create_edge(a, b, "R", crate::core::property::PropertyMap::new())
+            .unwrap();
+        db.create_node(
+            "L",
+            PropertyMapBuilder::new().insert("name", "C1").insert("y", 5i64).build(),
+        )
+        .unwrap();
+        // Distractor that must not join.
+        db.create_node(
+            "L",
+            PropertyMapBuilder::new().insert("name", "D1").insert("y", 9i64).build(),
+        )
+        .unwrap();
+
+        let rows = run(
+            &db,
+            "MATCH (a)-[:R]->(b),(c:L) WHERE b.x = c.y RETURN a.name,c.name",
+        );
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(
+            column(row, "a.name"),
+            Some(PropertyValue::String("A1".into()))
+        );
+        assert_eq!(
+            column(row, "c.name"),
+            Some(PropertyValue::String("C1".into()))
+        );
+    }
+
+    #[test]
+    fn test_return_star_multi_var() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node("Person", PropertyMapBuilder::new().insert("name", "Alice").build())
+            .unwrap();
+        db.create_node("Company", PropertyMapBuilder::new().insert("name", "Acme").build())
+            .unwrap();
+
+        let rows = run(&db, "MATCH (a:Person),(b:Company) RETURN *");
+        assert_eq!(rows.len(), 1);
+        let names = binding_names(&rows[0]);
+        assert!(names.contains(&"a".to_string()), "bindings: {names:?}");
+        assert!(names.contains(&"b".to_string()), "bindings: {names:?}");
+        assert!(has_label(bound(&rows[0], "a"), "Person"));
+        assert!(has_label(bound(&rows[0], "b"), "Company"));
+    }
+
+    #[test]
+    fn test_multi_pattern_order_skip_limit_distinct() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "P20").insert("age", 20i64).build(),
+        )
+        .unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "P30").insert("age", 30i64).build(),
+        )
+        .unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "P40").insert("age", 40i64).build(),
+        )
+        .unwrap();
+        db.create_node("Company", PropertyMapBuilder::new().insert("name", "Acme").build())
+            .unwrap();
+
+        // ORDER BY a.age DESC over the 3x1 product -> [40,30,20]; SKIP 1 LIMIT 1 -> 30.
+        let rows = run(
+            &db,
+            "MATCH (a:Person),(b:Company) RETURN a,b ORDER BY a.age DESC SKIP 1 LIMIT 1",
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(node_prop(bound(&rows[0], "a"), "name").unwrap(), "P30");
+
+        // DISTINCT over the shared company collapses the 3 product rows to 1.
+        let distinct = run(&db, "MATCH (a:Person),(b:Company) RETURN DISTINCT b");
+        assert_eq!(distinct.len(), 1);
+        assert!(has_label(bound(&distinct[0], "b"), "Company"));
+    }
+
+    #[test]
+    fn test_multi_pattern_empty_result() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").insert("company_id", 1i64).build(),
+        )
+        .unwrap();
+        db.create_node(
+            "Company",
+            PropertyMapBuilder::new().insert("name", "Acme").insert("id", 99i64).build(),
+        )
+        .unwrap();
+
+        let rows = run(
+            &db,
+            "MATCH (a:Person),(b:Company) WHERE a.company_id = b.id RETURN a,b",
+        );
+        assert_eq!(rows.len(), 0, "no matching join -> zero rows, still Ok");
+    }
+
+    #[test]
+    fn test_undirected_rel_binds_both() {
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node("N", PropertyMapBuilder::new().insert("name", "A").build())
+            .unwrap();
+        let b = db
+            .create_node("N", PropertyMapBuilder::new().insert("name", "B").build())
+            .unwrap();
+        db.create_edge(a, b, "KNOWS", crate::core::property::PropertyMap::new())
+            .unwrap();
+
+        let rows = run(&db, "MATCH (a)-[:KNOWS]-(b) RETURN a,b");
+        assert_eq!(rows.len(), 2, "undirected match binds both traversal directions");
+        let mut pairs: Vec<(String, String)> = rows
+            .iter()
+            .map(|r| {
+                (
+                    node_prop(bound(r, "a"), "name").unwrap(),
+                    node_prop(bound(r, "b"), "name").unwrap(),
+                )
+            })
+            .collect();
+        pairs.sort();
+        assert_eq!(
+            pairs,
+            vec![
+                ("A".to_string(), "B".to_string()),
+                ("B".to_string(), "A".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_self_pattern_product() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node("Person", PropertyMapBuilder::new().insert("name", "Alice").build())
+            .unwrap();
+        db.create_node("Person", PropertyMapBuilder::new().insert("name", "Bob").build())
+            .unwrap();
+
+        let rows = run(&db, "MATCH (a:Person),(b:Person) RETURN a,b");
+        assert_eq!(rows.len(), 4, "2x2 self product includes a==b diagonal");
+    }
+
+    #[test]
+    fn test_single_var_unchanged_still_old_path() {
+        let db = AletheiaDB::new().unwrap();
+        let alice = db
+            .create_node("Person", PropertyMapBuilder::new().insert("name", "Alice").build())
+            .unwrap();
+        let bob = db
+            .create_node("Person", PropertyMapBuilder::new().insert("name", "Bob").build())
+            .unwrap();
+        db.create_edge(alice, bob, "KNOWS", crate::core::property::PropertyMap::new())
+            .unwrap();
+
+        // Single-variable scan stays on the entity path: entity set, bindings None.
+        let rows = run(&db, "MATCH (n:Person) RETURN n");
+        assert_eq!(rows.len(), 2);
+        for row in &rows {
+            assert!(row.bindings.is_none(), "single-var row must not carry bindings");
+            assert!(matches!(row.entity, EntityResult::Node(_)));
+        }
+
+        // Terminal-only traversal projection also stays on the old path.
+        let rows = run(&db, "MATCH (a:Person)-[:KNOWS]->(b) RETURN b");
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].bindings.is_none());
+        assert_eq!(node_prop(&rows[0].entity, "name").unwrap(), "Bob");
+    }
+
+    #[test]
+    fn test_reject_varlength_in_multibinding() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node("N", PropertyMapBuilder::new().insert("name", "A").build())
+            .unwrap();
+        assert_unsupported(&db, "MATCH (a)-[:KNOWS*1..3]->(b),(c) RETURN a,c");
+    }
+
+    #[test]
+    fn test_reject_aggregation_multibinding() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node("N", PropertyMapBuilder::new().insert("name", "A").build())
+            .unwrap();
+        assert_unsupported(&db, "MATCH (a),(b) RETURN count(a)");
+    }
+
+    #[test]
+    fn test_reject_temporal_multibinding() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node("N", PropertyMapBuilder::new().insert("name", "A").build())
+            .unwrap();
+        // A multi-variable pattern with a temporal qualifier reaches the
+        // evaluator, which rejects bi-temporal AS OF in v1 rather than answering
+        // a non-temporal (silently-wrong) result.
+        assert_unsupported(
+            &db,
+            "MATCH (a),(b) AS OF TIMESTAMP '2020-01-01T00:00:00Z' RETURN a,b",
+        );
+    }
+}

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -5681,6 +5681,71 @@ mod multi_pattern {
         }
     }
 
+    /// A db with a node `a` carrying `x = 5` (and NO `y` property), plus a
+    /// plain node `b`. Used to exercise three-valued `IN` over a null list
+    /// element.
+    fn in_prop_db() -> AletheiaDB {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .insert("x", 5i64)
+                .build(),
+        )
+        .unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+        )
+        .unwrap();
+        db
+    }
+
+    #[test]
+    fn test_where_not_in_with_null_element_drops_row() {
+        // a.x = 5, list is [1, a.y] where a.y is absent => null element.
+        // `5 IN [1, null]` is Null (openCypher), so `NOT Null` is Null and the
+        // row is DROPPED. Every candidate `a` either has needle 5 (matches no
+        // non-null element, but a null element makes it Null) or a null needle
+        // (Null directly), so ALL rows drop => 0 rows.
+        let db = in_prop_db();
+        let rows = run(&db, "MATCH (a),(b) WHERE NOT (a.x IN [1, a.y]) RETURN a,b");
+        assert_eq!(
+            rows.len(),
+            0,
+            "NOT (5 IN [1, null]) is NOT Null = Null => row dropped: {rows:?}"
+        );
+    }
+
+    #[test]
+    fn test_where_in_matches_still_true() {
+        // `5 IN [5, 99]` is True regardless of any null: a matching element
+        // short-circuits to True. Only rows where `a` is the x=5 node survive
+        // (the other candidate has a null needle => dropped): 1 such `a` x 2
+        // `b` candidates = 2 rows.
+        let db = in_prop_db();
+        let rows = run(&db, "MATCH (a),(b) WHERE a.x IN [5, 99] RETURN a,b");
+        assert_eq!(rows.len(), 2, "5 IN [5, 99] is True => rows kept: {rows:?}");
+        for row in &rows {
+            assert_eq!(node_prop(bound(row, "a"), "name").unwrap(), "Alice");
+        }
+    }
+
+    #[test]
+    fn test_where_in_no_match_no_null_drops() {
+        // `5 IN [1, 2]` is False (no match, no null element) => row dropped.
+        // The other candidate `a` has a null needle => Null => also dropped.
+        // Unchanged two-valued behavior: 0 rows.
+        let db = in_prop_db();
+        let rows = run(&db, "MATCH (a),(b) WHERE a.x IN [1, 2] RETURN a,b");
+        assert_eq!(
+            rows.len(),
+            0,
+            "5 IN [1, 2] is False (no null element) => row dropped: {rows:?}"
+        );
+    }
+
     // ---- FIX 4: router last_node_variable skips unnamed terminal ----------
 
     #[test]

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -5084,14 +5084,26 @@ mod multi_pattern {
     #[test]
     fn test_multi_pattern_cross_product() {
         let db = AletheiaDB::new().unwrap();
-        db.create_node("Person", PropertyMapBuilder::new().insert("name", "Alice").build())
-            .unwrap();
-        db.create_node("Person", PropertyMapBuilder::new().insert("name", "Bob").build())
-            .unwrap();
-        db.create_node("Company", PropertyMapBuilder::new().insert("name", "Acme").build())
-            .unwrap();
-        db.create_node("Company", PropertyMapBuilder::new().insert("name", "Globex").build())
-            .unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+        )
+        .unwrap();
+        db.create_node(
+            "Company",
+            PropertyMapBuilder::new().insert("name", "Acme").build(),
+        )
+        .unwrap();
+        db.create_node(
+            "Company",
+            PropertyMapBuilder::new().insert("name", "Globex").build(),
+        )
+        .unwrap();
 
         let rows = run(&db, "MATCH (a:Person),(b:Company) RETURN a,b");
         assert_eq!(rows.len(), 4, "2 persons x 2 companies = 4 rows");
@@ -5123,12 +5135,18 @@ mod multi_pattern {
         .unwrap();
         db.create_node(
             "Company",
-            PropertyMapBuilder::new().insert("name", "Acme").insert("id", 1i64).build(),
+            PropertyMapBuilder::new()
+                .insert("name", "Acme")
+                .insert("id", 1i64)
+                .build(),
         )
         .unwrap();
         db.create_node(
             "Company",
-            PropertyMapBuilder::new().insert("name", "Globex").insert("id", 2i64).build(),
+            PropertyMapBuilder::new()
+                .insert("name", "Globex")
+                .insert("id", 2i64)
+                .build(),
         )
         .unwrap();
 
@@ -5152,23 +5170,29 @@ mod multi_pattern {
     fn test_chain_binds_all_vars() {
         let db = AletheiaDB::new().unwrap();
         let a = db
-            .create_node("Person", PropertyMapBuilder::new().insert("name", "A").build())
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "A").build(),
+            )
             .unwrap();
         let b = db
-            .create_node("Person", PropertyMapBuilder::new().insert("name", "B").build())
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "B").build(),
+            )
             .unwrap();
         let c = db
-            .create_node("Company", PropertyMapBuilder::new().insert("name", "C").build())
+            .create_node(
+                "Company",
+                PropertyMapBuilder::new().insert("name", "C").build(),
+            )
             .unwrap();
         db.create_edge(a, b, "KNOWS", crate::core::property::PropertyMap::new())
             .unwrap();
         db.create_edge(b, c, "WORKS_AT", crate::core::property::PropertyMap::new())
             .unwrap();
 
-        let rows = run(
-            &db,
-            "MATCH (a)-[:KNOWS]->(b)-[:WORKS_AT]->(c) RETURN a,b,c",
-        );
+        let rows = run(&db, "MATCH (a)-[:KNOWS]->(b)-[:WORKS_AT]->(c) RETURN a,b,c");
         assert_eq!(rows.len(), 1);
         let row = &rows[0];
         assert_eq!(node_prop(bound(row, "a"), "name").unwrap(), "A");
@@ -5208,10 +5232,16 @@ mod multi_pattern {
     fn test_multi_var_property_projection() {
         let db = AletheiaDB::new().unwrap();
         let a = db
-            .create_node("Person", PropertyMapBuilder::new().insert("name", "Alice").build())
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Alice").build(),
+            )
             .unwrap();
         let b = db
-            .create_node("Person", PropertyMapBuilder::new().insert("name", "Bob").build())
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Bob").build(),
+            )
             .unwrap();
         db.create_edge(a, b, "KNOWS", crate::core::property::PropertyMap::new())
             .unwrap();
@@ -5233,25 +5263,37 @@ mod multi_pattern {
     fn test_mixed_pattern_join() {
         let db = AletheiaDB::new().unwrap();
         let a = db
-            .create_node("Person", PropertyMapBuilder::new().insert("name", "A1").build())
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "A1").build(),
+            )
             .unwrap();
         let b = db
             .create_node(
                 "Person",
-                PropertyMapBuilder::new().insert("name", "B1").insert("x", 5i64).build(),
+                PropertyMapBuilder::new()
+                    .insert("name", "B1")
+                    .insert("x", 5i64)
+                    .build(),
             )
             .unwrap();
         db.create_edge(a, b, "R", crate::core::property::PropertyMap::new())
             .unwrap();
         db.create_node(
             "L",
-            PropertyMapBuilder::new().insert("name", "C1").insert("y", 5i64).build(),
+            PropertyMapBuilder::new()
+                .insert("name", "C1")
+                .insert("y", 5i64)
+                .build(),
         )
         .unwrap();
         // Distractor that must not join.
         db.create_node(
             "L",
-            PropertyMapBuilder::new().insert("name", "D1").insert("y", 9i64).build(),
+            PropertyMapBuilder::new()
+                .insert("name", "D1")
+                .insert("y", 9i64)
+                .build(),
         )
         .unwrap();
 
@@ -5274,10 +5316,16 @@ mod multi_pattern {
     #[test]
     fn test_return_star_multi_var() {
         let db = AletheiaDB::new().unwrap();
-        db.create_node("Person", PropertyMapBuilder::new().insert("name", "Alice").build())
-            .unwrap();
-        db.create_node("Company", PropertyMapBuilder::new().insert("name", "Acme").build())
-            .unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .unwrap();
+        db.create_node(
+            "Company",
+            PropertyMapBuilder::new().insert("name", "Acme").build(),
+        )
+        .unwrap();
 
         let rows = run(&db, "MATCH (a:Person),(b:Company) RETURN *");
         assert_eq!(rows.len(), 1);
@@ -5293,21 +5341,33 @@ mod multi_pattern {
         let db = AletheiaDB::new().unwrap();
         db.create_node(
             "Person",
-            PropertyMapBuilder::new().insert("name", "P20").insert("age", 20i64).build(),
+            PropertyMapBuilder::new()
+                .insert("name", "P20")
+                .insert("age", 20i64)
+                .build(),
         )
         .unwrap();
         db.create_node(
             "Person",
-            PropertyMapBuilder::new().insert("name", "P30").insert("age", 30i64).build(),
+            PropertyMapBuilder::new()
+                .insert("name", "P30")
+                .insert("age", 30i64)
+                .build(),
         )
         .unwrap();
         db.create_node(
             "Person",
-            PropertyMapBuilder::new().insert("name", "P40").insert("age", 40i64).build(),
+            PropertyMapBuilder::new()
+                .insert("name", "P40")
+                .insert("age", 40i64)
+                .build(),
         )
         .unwrap();
-        db.create_node("Company", PropertyMapBuilder::new().insert("name", "Acme").build())
-            .unwrap();
+        db.create_node(
+            "Company",
+            PropertyMapBuilder::new().insert("name", "Acme").build(),
+        )
+        .unwrap();
 
         // ORDER BY a.age DESC over the 3x1 product -> [40,30,20]; SKIP 1 LIMIT 1 -> 30.
         let rows = run(
@@ -5328,12 +5388,18 @@ mod multi_pattern {
         let db = AletheiaDB::new().unwrap();
         db.create_node(
             "Person",
-            PropertyMapBuilder::new().insert("name", "Alice").insert("company_id", 1i64).build(),
+            PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .insert("company_id", 1i64)
+                .build(),
         )
         .unwrap();
         db.create_node(
             "Company",
-            PropertyMapBuilder::new().insert("name", "Acme").insert("id", 99i64).build(),
+            PropertyMapBuilder::new()
+                .insert("name", "Acme")
+                .insert("id", 99i64)
+                .build(),
         )
         .unwrap();
 
@@ -5357,7 +5423,11 @@ mod multi_pattern {
             .unwrap();
 
         let rows = run(&db, "MATCH (a)-[:KNOWS]-(b) RETURN a,b");
-        assert_eq!(rows.len(), 2, "undirected match binds both traversal directions");
+        assert_eq!(
+            rows.len(),
+            2,
+            "undirected match binds both traversal directions"
+        );
         let mut pairs: Vec<(String, String)> = rows
             .iter()
             .map(|r| {
@@ -5380,10 +5450,16 @@ mod multi_pattern {
     #[test]
     fn test_self_pattern_product() {
         let db = AletheiaDB::new().unwrap();
-        db.create_node("Person", PropertyMapBuilder::new().insert("name", "Alice").build())
-            .unwrap();
-        db.create_node("Person", PropertyMapBuilder::new().insert("name", "Bob").build())
-            .unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+        )
+        .unwrap();
 
         let rows = run(&db, "MATCH (a:Person),(b:Person) RETURN a,b");
         assert_eq!(rows.len(), 4, "2x2 self product includes a==b diagonal");
@@ -5393,19 +5469,33 @@ mod multi_pattern {
     fn test_single_var_unchanged_still_old_path() {
         let db = AletheiaDB::new().unwrap();
         let alice = db
-            .create_node("Person", PropertyMapBuilder::new().insert("name", "Alice").build())
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Alice").build(),
+            )
             .unwrap();
         let bob = db
-            .create_node("Person", PropertyMapBuilder::new().insert("name", "Bob").build())
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Bob").build(),
+            )
             .unwrap();
-        db.create_edge(alice, bob, "KNOWS", crate::core::property::PropertyMap::new())
-            .unwrap();
+        db.create_edge(
+            alice,
+            bob,
+            "KNOWS",
+            crate::core::property::PropertyMap::new(),
+        )
+        .unwrap();
 
         // Single-variable scan stays on the entity path: entity set, bindings None.
         let rows = run(&db, "MATCH (n:Person) RETURN n");
         assert_eq!(rows.len(), 2);
         for row in &rows {
-            assert!(row.bindings.is_none(), "single-var row must not carry bindings");
+            assert!(
+                row.bindings.is_none(),
+                "single-var row must not carry bindings"
+            );
             assert!(matches!(row.entity, EntityResult::Node(_)));
         }
 

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -406,7 +406,9 @@ impl AletheiaDB {
         statement: &crate::cypher::ast::CypherStatement,
         params: &std::collections::HashMap<String, crate::cypher::CypherParameterValue>,
     ) -> Result<QueryResults> {
-        Ok(crate::cypher::multi_pattern::evaluate(self, statement, params)?)
+        Ok(crate::cypher::multi_pattern::evaluate(
+            self, statement, params,
+        )?)
     }
 }
 

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -339,6 +339,9 @@ impl AletheiaDB {
         match crate::cypher::plan_cypher(query_string)? {
             crate::cypher::CypherExecution::Query(query) => self.execute_query(query),
             crate::cypher::CypherExecution::Rows(results) => Ok(results),
+            crate::cypher::CypherExecution::MultiPattern { statement, params } => {
+                self.execute_multi_pattern(&statement, &params)
+            }
         }
     }
 
@@ -383,7 +386,27 @@ impl AletheiaDB {
         match crate::cypher::plan_cypher_with_params(query_string, params)? {
             crate::cypher::CypherExecution::Query(query) => self.execute_query(query),
             crate::cypher::CypherExecution::Rows(results) => Ok(results),
+            crate::cypher::CypherExecution::MultiPattern { statement, params } => {
+                self.execute_multi_pattern(&statement, &params)
+            }
         }
+    }
+
+    /// Execute a multi-variable, multi-pattern `MATCH` (Issue #549).
+    ///
+    /// Delegates to the dedicated [`crate::cypher::multi_pattern`] evaluator,
+    /// which binds several named variables per row (carried on
+    /// [`QueryRow::bindings`](crate::query::executor::QueryRow::bindings)) --
+    /// something the single-entity `Query` pipeline cannot represent. Reached
+    /// only for statements the router
+    /// ([`crate::cypher::exec::needs_multi_binding`]) classifies as
+    /// multi-variable.
+    fn execute_multi_pattern(
+        &self,
+        statement: &crate::cypher::ast::CypherStatement,
+        params: &std::collections::HashMap<String, crate::cypher::CypherParameterValue>,
+    ) -> Result<QueryResults> {
+        Ok(crate::cypher::multi_pattern::evaluate(self, statement, params)?)
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -4939,22 +4939,13 @@ impl AletheiaMcpServer {
     /// through `node_to_response`/`edge_to_response`, which would pay a
     /// per-entity version-metadata lookup just to discard the result
     /// (Issue #3391).
-    fn query_row_to_json(&self, row: crate::query::executor::QueryRow) -> serde_json::Value {
-        // Computed/aggregate row (e.g. `RETURN count(*)`, `RETURN n.dept,
-        // count(*)`): the meaningful payload lives in `row.columns`, not
-        // `row.entity` (which is `EntityResult::Null`). Render each named column
-        // via `property_value_to_json` so an LLM sees the aggregate/group value
-        // instead of a lossy `entity: null`. Closes the #558 MCP-surface
-        // follow-up. `include_vectors: true` -- computed aggregate values are
-        // not stored embeddings, so nothing should be elided.
-        if let Some(columns) = row.columns {
-            let mut obj = serde_json::Map::with_capacity(columns.len());
-            for (name, value) in columns {
-                obj.insert(name, self.property_value_to_json(&value, true));
-            }
-            return serde_json::Value::Object(obj);
-        }
-        let entity = match row.entity {
+    /// Serialize a single query-result entity (node/edge/id/null) to JSON.
+    ///
+    /// Shared by the single-entity row path and the multi-variable binding path
+    /// (#549) so both render nodes/edges identically. `include_vectors: true` --
+    /// query rows carry stored properties; vector elision is not applied here.
+    fn query_entity_to_json(&self, entity: &EntityResult) -> serde_json::Value {
+        match entity {
             EntityResult::Node(node) => json!({
                 "type": "node",
                 "id": node.id.as_u64(),
@@ -4974,7 +4965,46 @@ impl AletheiaMcpServer {
             // Null binding from an unmatched OPTIONAL MATCH pattern: surface
             // as JSON null so an LLM/caller sees the preserved row explicitly.
             EntityResult::Null => serde_json::Value::Null,
-        };
+        }
+    }
+
+    fn query_row_to_json(&self, row: crate::query::executor::QueryRow) -> serde_json::Value {
+        // Multi-variable binding row (#549): `MATCH (a),(b) RETURN a,b` binds
+        // several variables, which the single `entity` field cannot represent
+        // (its `entity` is `EntityResult::Null`). Serialize each bound variable
+        // under its name, MERGED with any scalar `columns` (property/alias
+        // projections). Checked BEFORE the columns-only branch because a binding
+        // row can also carry columns. Without this, the row would render as a
+        // lossy `{"entity": null}` and drop every bound entity.
+        if let Some(bindings) = row.bindings {
+            let mut obj = serde_json::Map::with_capacity(
+                bindings.len() + row.columns.as_ref().map_or(0, Vec::len),
+            );
+            for (name, entity) in bindings {
+                obj.insert(name, self.query_entity_to_json(&entity));
+            }
+            if let Some(columns) = row.columns {
+                for (name, value) in columns {
+                    obj.insert(name, self.property_value_to_json(&value, true));
+                }
+            }
+            return serde_json::Value::Object(obj);
+        }
+        // Computed/aggregate row (e.g. `RETURN count(*)`, `RETURN n.dept,
+        // count(*)`): the meaningful payload lives in `row.columns`, not
+        // `row.entity` (which is `EntityResult::Null`). Render each named column
+        // via `property_value_to_json` so an LLM sees the aggregate/group value
+        // instead of a lossy `entity: null`. Closes the #558 MCP-surface
+        // follow-up. `include_vectors: true` -- computed aggregate values are
+        // not stored embeddings, so nothing should be elided.
+        if let Some(columns) = row.columns {
+            let mut obj = serde_json::Map::with_capacity(columns.len());
+            for (name, value) in columns {
+                obj.insert(name, self.property_value_to_json(&value, true));
+            }
+            return serde_json::Value::Object(obj);
+        }
+        let entity = self.query_entity_to_json(&row.entity);
         json!({
             "entity": entity,
             "score": row.score,
@@ -5193,15 +5223,28 @@ impl AletheiaMcpServer {
         // column schema in projection order. Ordinary entity rows leave this
         // `None`, so the static entity/score/path/timestamp schema is retained
         // byte-for-byte.
+        // A multi-variable binding row (#549) advertises its columns
+        // dynamically too: the bound variable names (in binding order) followed
+        // by any scalar projection columns -- mirroring how aggregate rows
+        // derive their dynamic schema -- so a caller can map row keys to
+        // columns instead of seeing the static entity/score/path schema.
         let mut computed_columns: Option<Vec<String>> = None;
         let rows: Vec<serde_json::Value> = collected
             .into_iter()
             .take(limit)
             .map(|row| {
-                if computed_columns.is_none()
-                    && let Some(cols) = &row.columns
-                {
-                    computed_columns = Some(cols.iter().map(|(name, _)| name.clone()).collect());
+                if computed_columns.is_none() {
+                    if let Some(bindings) = &row.bindings {
+                        let mut names: Vec<String> =
+                            bindings.iter().map(|(name, _)| name.clone()).collect();
+                        if let Some(cols) = &row.columns {
+                            names.extend(cols.iter().map(|(name, _)| name.clone()));
+                        }
+                        computed_columns = Some(names);
+                    } else if let Some(cols) = &row.columns {
+                        computed_columns =
+                            Some(cols.iter().map(|(name, _)| name.clone()).collect());
+                    }
                 }
                 self.query_row_to_json(row)
             })
@@ -6362,5 +6405,116 @@ mod server_unit_tests {
         );
         assert!(value["score"].is_null());
         assert!(value["path"].is_null());
+    }
+
+    // --- #549 MCP surface: multi-variable binding rows serialize each bound
+    // entity under its variable name (never a lossy `entity: null`).
+
+    #[test]
+    fn query_row_to_json_bindings_serializes_each_entity() {
+        use crate::core::graph::Node;
+        use crate::core::id::VersionId;
+        use crate::core::{GLOBAL_INTERNER, PropertyMapBuilder};
+
+        let server = make_server();
+        let mk = |id: u64, name: &str| {
+            let label = GLOBAL_INTERNER.intern("Person").unwrap();
+            Node::new(
+                NodeId::new(id).unwrap(),
+                label,
+                PropertyMapBuilder::new().insert("name", name).build(),
+                VersionId::new(1).unwrap(),
+            )
+        };
+        let row = QueryRow::from_bindings(
+            vec![
+                ("a".to_string(), EntityResult::Node(mk(1, "Alice"))),
+                ("b".to_string(), EntityResult::Node(mk(2, "Bob"))),
+            ],
+            None,
+        );
+        let json = server.query_row_to_json(row);
+        let obj = json
+            .as_object()
+            .expect("bindings row must be a JSON object");
+        // Both variables surface as node objects, NOT a lossy null.
+        assert_eq!(obj["a"]["type"].as_str(), Some("node"), "got: {json}");
+        assert_eq!(obj["a"]["id"].as_u64(), Some(1), "got: {json}");
+        assert_eq!(
+            obj["a"]["properties"]["name"].as_str(),
+            Some("Alice"),
+            "got: {json}"
+        );
+        assert_eq!(obj["b"]["type"].as_str(), Some("node"), "got: {json}");
+        assert_eq!(obj["b"]["id"].as_u64(), Some(2), "got: {json}");
+    }
+
+    #[test]
+    fn query_row_to_json_bindings_merged_with_columns() {
+        use crate::core::graph::Node;
+        use crate::core::id::VersionId;
+        use crate::core::{GLOBAL_INTERNER, PropertyMapBuilder};
+
+        let server = make_server();
+        let label = GLOBAL_INTERNER.intern("Person").unwrap();
+        let node = Node::new(
+            NodeId::new(7).unwrap(),
+            label,
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+            VersionId::new(1).unwrap(),
+        );
+        let row = QueryRow::from_bindings(
+            vec![("a".to_string(), EntityResult::Node(node))],
+            Some(vec![(
+                "a.name".to_string(),
+                PropertyValue::String("Alice".into()),
+            )]),
+        );
+        let json = server.query_row_to_json(row);
+        // The bound entity and the scalar column are both present, merged.
+        assert_eq!(json["a"]["type"].as_str(), Some("node"), "got: {json}");
+        assert_eq!(json["a.name"].as_str(), Some("Alice"), "got: {json}");
+    }
+
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn handle_query_multi_pattern_returns_non_null_bindings() {
+        use crate::core::PropertyMapBuilder;
+        let server = make_server();
+        server
+            .db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Alice").build(),
+            )
+            .unwrap();
+        server
+            .db
+            .create_node(
+                "Company",
+                PropertyMapBuilder::new().insert("name", "Acme").build(),
+            )
+            .unwrap();
+        let result = server.handle_query(serde_json::json!({
+            "language": "cypher",
+            "query": "MATCH (a:Person),(b:Company) RETURN a,b"
+        }));
+        let text = AletheiaMcpServer::extract_text(result);
+        let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let rows = val["rows"].as_array().expect("rows array");
+        assert_eq!(rows.len(), 1, "got: {val}");
+        assert_eq!(rows[0]["a"]["type"].as_str(), Some("node"), "got: {val}");
+        assert_eq!(rows[0]["b"]["type"].as_str(), Some("node"), "got: {val}");
+        // The response columns are derived dynamically from the binding names.
+        let cols: Vec<String> = val["columns"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| c["name"].as_str().unwrap().to_string())
+            .collect();
+        assert!(
+            cols.contains(&"a".to_string()) && cols.contains(&"b".to_string()),
+            "columns must name the bound variables: {val}"
+        );
     }
 }

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -175,6 +175,20 @@ pub struct QueryRow {
     /// row's [`entity`](Self::entity) is typically [`EntityResult::Null`]: the
     /// meaningful payload lives here.
     pub columns: Option<Vec<(String, PropertyValue)>>,
+    /// Named variable→entity bindings for a multi-variable row (Issue #549).
+    ///
+    /// The single-entity [`entity`](Self::entity) field can only carry one
+    /// node/edge per row, which cannot represent a query that binds and returns
+    /// several variables (e.g. `MATCH (a),(b) RETURN a, b`). Those queries are
+    /// evaluated by the dedicated multi-pattern evaluator, which populates this
+    /// field with one `(variable_name, entity)` pair per bound variable, in
+    /// declaration order.
+    ///
+    /// `None` for ordinary single-entity rows (the common case), so those rows
+    /// are byte-identical to their prior form. When `Some`, the row's
+    /// [`entity`](Self::entity) is [`EntityResult::Null`]; the bound entities
+    /// live here and any scalar projections live in [`columns`](Self::columns).
+    pub bindings: Option<Vec<(String, EntityResult)>>,
 }
 
 impl QueryRow {
@@ -187,6 +201,7 @@ impl QueryRow {
             path: None,
             timestamp: None,
             columns: None,
+            bindings: None,
         }
     }
 
@@ -216,6 +231,31 @@ impl QueryRow {
             path: None,
             timestamp: None,
             columns: Some(columns),
+            bindings: None,
+        }
+    }
+
+    /// Create a multi-variable row carrying named `variable → entity` bindings
+    /// (Issue #549).
+    ///
+    /// Used by the multi-pattern evaluator for queries that bind and return
+    /// more than one entity variable (e.g. `MATCH (a),(b) RETURN a, b`), which
+    /// the single-entity [`entity`](Self::entity) field cannot represent. The
+    /// row's entity is [`EntityResult::Null`]; consumers read the bound
+    /// entities from [`bindings`](Self::bindings) and any scalar projections
+    /// (property accesses, aliased expressions) from the optional `columns`.
+    #[must_use]
+    pub fn from_bindings(
+        bindings: Vec<(String, EntityResult)>,
+        columns: Option<Vec<(String, PropertyValue)>>,
+    ) -> Self {
+        QueryRow {
+            entity: EntityResult::Null,
+            score: None,
+            path: None,
+            timestamp: None,
+            columns,
+            bindings: Some(bindings),
         }
     }
 
@@ -239,6 +279,7 @@ impl QueryRow {
             path: None,
             timestamp: None,
             columns: None,
+            bindings: None,
         }
     }
 
@@ -251,6 +292,7 @@ impl QueryRow {
             path: Some(path),
             timestamp: None,
             columns: None,
+            bindings: None,
         }
     }
 
@@ -764,6 +806,7 @@ impl QueryResults {
                 path,
                 timestamp,
                 columns: row_columns,
+                bindings: _,
             } = row;
 
             // Extract computed aggregation columns (padding rows without any


### PR DESCRIPTION
## Before / After

**Before:** `MATCH (a)-[:KNOWS]->(b) RETURN a, b` silently returned only Bob — the whole query engine bound a single entity per row, so `a` was dropped and no error was raised. `MATCH (a:Person), (b:Company)` concatenated two independent scans instead of joining them. Multi-variable and multi-pattern reads were silently wrong.

**After:** comma-separated patterns and pattern chains execute with real multi-variable binding. `MATCH (a:Person), (b:Company) WHERE a.company_id = b.id RETURN a, b` returns the joined pairs with both entities bound; `MATCH (a)-[:KNOWS]->(b)-[:WORKS_AT]->(c) RETURN a, b, c` binds all three; variables shared across patterns unify. Anything the v1 evaluator cannot execute correctly returns a structured `UnsupportedFeature` error instead of a wrong row.

Closes #549.

## How

The core query engine is a single-entity-per-row Volcano pipeline with no join operator and no multi-variable binding — a full rewrite would destabilize the whole executor. Instead this adds a **contained Cypher-level multi-binding evaluator** (`src/cypher/multi_pattern.rs`), mirroring the existing standalone UNWIND runtime, that runs only for queries that actually need multi-variable binding:

- **Router** (`src/cypher/exec.rs::needs_multi_binding`): a base `MATCH` routes to the evaluator iff it has >1 pattern, references >1 distinct entity variable, or references a non-terminal variable. Every existing single-terminal-variable query stays on the proven path unchanged.
- **Evaluator**: nested-loop pattern matcher maintaining a `var -> entity` binding environment; unifies shared variables across comma-patterns; evaluates `WHERE` (including cross-variable `a.x = b.y`) in Cypher-expression space; projects multi-variable `RETURN` (whole entities via a new additive `QueryRow.bindings` field, property/expr items via `columns`), with `DISTINCT`/`ORDER BY`/`SKIP`/`LIMIT`.
- **Result shape**: `QueryRow` gains an additive `bindings: Option<Vec<(String, EntityResult)>>` (defaults `None`; existing consumers unaffected). The MCP `query` tool and the Python binding now serialize these bindings.

### openCypher correctness (hardened after three adversarial reviews)
- **Relationship-uniqueness (isomorphism)** enforced across the whole MATCH clause — a relationship is never traversed twice, so `MATCH (x)-[:R]-(y)-[:R]-(z)` over one edge returns 0 rows (not a spurious reuse).
- **Three-valued `WHERE`** (`Tri {True,False,Null}`, Kleene `AND`/`OR`/`NOT`, three-valued `IN`) — `WHERE NOT (a.x = 5)` with `a.x` absent drops the row.
- **Bounded** — the intermediate binding set is capped by the configurable `max_schema_as_of_entities` limit; exceeding it returns a structured error rather than exhausting memory.

## Acceptance Criteria evidence

| # | Criterion | Evidence |
|---|-----------|----------|
| 1 | Multiple comma-separated patterns parse | `test_parse_multiple_patterns` (pre-existing) + now execute (`test_multi_pattern_cross_product`) |
| 2 | Pattern chains with multiple relationships work | `test_chain_binds_all_vars` (binds a,b,c across a 2-hop chain) |
| 3 | Variables shared across patterns correctly bound | `test_shared_variable_unify`, `test_cross_var_where_join`, `test_mixed_pattern_join` |
| 4 | Results contain all matched nodes/relationships | multi-variable RETURN via `bindings` — `test_return_star_multi_var`, `test_multi_var_property_projection`; MCP surface `handle_query_multi_pattern_returns_non_null_bindings` |

## Correctness / robustness tests added
Relationship-uniqueness (double-hop, rel-vars, across comma-patterns, triangle positive control); three-valued WHERE (`NOT` over null, `IS NULL`, `IN` with null element, compound); router (anonymous terminal routes correctly; multi-pattern + WITH/OPTIONAL rejected with structured error); binding cap enforced; undirected binds both orientations; self-product; empty result; ORDER BY/SKIP/LIMIT/DISTINCT over multi-var rows; single-variable regression stays on the old path.

## v1 limitations (structured `UnsupportedFeature`, never silent)
Inside a multi-binding query: `WITH` chaining, `OPTIONAL MATCH`, temporal `AS OF`, aggregation, and variable-length `*` relationships are rejected with a structured error. Multiple plain `MATCH` clauses are not yet parsed (clean parser error). Perf follow-up noted in-code: the Cartesian product carries cloned entities rather than ids (`TODO(perf #549-followup)`).

## Gates
- `cargo test --features cypher --lib`: **3946 passed; 0 failed; 2 ignored**
- `cargo clippy --all-targets --features cypher -- -D warnings`: clean
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings`: clean
- `cargo fmt --all`: clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDxuBsxZU6SLfsTr7jtBbX)_