### PR TITLE
feat(import/export): Parquet import & export (#3364)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "serde",
@@ -82,6 +83,7 @@ dependencies = [
  "aes-gcm",
  "arbitrary",
  "arc-swap",
+ "arrow",
  "autumn-web",
  "aws-sdk-kms",
  "axum",
@@ -112,6 +114,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "parking_lot",
+ "parquet",
  "proptest",
  "quick_cache",
  "rand 0.8.6",
@@ -297,6 +300,179 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "arrow"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b952ca5a8046ad741b60f142d6eca4aeebcad615694202bc64c5341f23e32c5b"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a13b8d3008c4e9063c597a08f46446fe3fd5789277127672d6c0bdbb43b1ff"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9486151b2f0785bafc6fa04fc5c99fcb4495455662e58787ea32eaaed33c4192"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.17.0",
+ "num-complex 0.4.6",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4776577a87794bfdf0b4e90e2ea12454fa7738ea2823c4be5b9d1851da7b434"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint 0.4.6",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9ad451ce4f98710828a455b96991b8f031deb2e67f5fcad6773f017e4a69c3a"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38fe43e2e8704360f1464e6e8cc4fc381ef02cc4fb0192afa8df1aaa0115c66"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29dac499fcbc6ba74ee0324057821d381929a48526a3966bd9dffb44aa06d98c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e13dbdc2a9c053c10c7baa6e30faee04a180aa7ce88e471835850ce37abd20b"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d5a1f8c733d15260b305683472ee8ad89c62cbd706703ca873b90d051b41592"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9e4969dc350d571766247143ab36a5187d095d3d3690970408bc630d47c69e5"
+
+[[package]]
+name = "arrow-select"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402770dba90865359d98d1ef92ef16e23d75c0cca9c2c880c8a05468b7743bf9"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b0afbb8b9016700938291123df30838b89decc3213dba00852021988b170d3"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
 name = "as-slice"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +502,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1696,6 +1881,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2720,6 +2925,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustc_version",
+]
 
 [[package]]
 name = "flate2"
@@ -4201,6 +4416,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5166,6 +5438,33 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec 1.15.1",
  "windows-link",
+]
+
+[[package]]
+name = "parquet"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5302d4da74d6596a1f11f9928767995b53bca657cbeea1e4e8c5074f8a1157dd"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "half",
+ "hashbrown 0.17.0",
+ "num-bigint 0.4.6",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "snap",
+ "twox-hash",
 ]
 
 [[package]]
@@ -6903,6 +7202,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d44cfb396c3caf6fbfd0ab422af02631b69ddd96d2eff0b0f0724f9024051b"
 
 [[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7314,6 +7619,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -7794,6 +8108,12 @@ dependencies = [
  "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "type1-encoding-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,18 @@ sqlparser = { version = "0.40", optional = true }
 # CSV parsing for the bulk graph importer (optional, Issue #3211)
 csv = { version = "1.3", optional = true }
 
+# Parquet columnar import/export for analytics interoperability (optional, Issue #3364).
+# arrow-rs `parquet` crate with the `arrow` integration (ArrowWriter /
+# ParquetRecordBatchReader, list<float32> embedding columns, streaming row groups)
+# and `snap` (Snappy) compression. Default features are disabled to keep the
+# dependency surface minimal; enabled via the `parquet` feature flag only.
+parquet = { version = "59", default-features = false, features = ["arrow", "snap"], optional = true }
+# arrow-rs umbrella crate: gives `arrow::array` (RecordBatch, typed arrays) and
+# `arrow::datatypes` used to physically decode Parquet columns on import. Kept in
+# lockstep with the `parquet` version. Default features off; `array`/`datatypes`
+# are unconditional so the compute/csv/json/ipc kernels are not pulled in.
+arrow = { version = "59", default-features = false, optional = true }
+
 # Parallel iteration for sharded vector index
 rayon = "1.12"
 comfy-table = "7.2.2"
@@ -259,6 +271,12 @@ cypher = []
 # serde_json (JSONL) and chrono (timestamp parsing) are already non-optional deps,
 # so the only extra dependency is the `csv` reader.
 import = ["dep:csv"]
+
+# Parquet columnar import/export for analytics interoperability (Issue #3364).
+# Builds on the #3211 import layer (shares NodeMapping/EdgeMapping/ColumnType) and
+# adds a columnar codec via the arrow-rs `parquet` crate. Off by default so the
+# arrow/parquet dependency stays out of default builds.
+parquet = ["dep:parquet", "dep:arrow", "import"]
 
 # HTTP server support (Issue #465) — built on autumn-web.
 http-server = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -588,6 +588,13 @@ harness = false
 path = "benches/import_throughput.rs"
 required-features = ["import"]
 
+# Parquet import/export throughput (Issue #3364)
+[[bench]]
+name = "parquet_throughput"
+harness = false
+path = "benches/parquet_throughput.rs"
+required-features = ["parquet"]
+
 [[bench]]
 name = "node_scan"
 harness = false

--- a/benches/parquet_throughput.rs
+++ b/benches/parquet_throughput.rs
@@ -1,0 +1,200 @@
+//! Parquet import/export throughput benchmark (Issue #3364).
+//!
+//! Two axes are measured:
+//!
+//! 1. **Import**: the batched Parquet importer against the batched CSV importer over the
+//!    *same* row data, so the ratio answers "how much faster is native columnar Parquet
+//!    decode than string-parsing CSV?".
+//! 2. **Export**: current-state node/edge export and full bi-temporal history export,
+//!    exercising the two-pass schema-discovery + streaming row-group writer.
+//!
+//! Success metric (from the issue): a 1M-node export completes well under 1 GB of peak
+//! memory and streams without buffering the whole graph. This bench measures directional
+//! throughput on a smaller, CI-friendly row count; scale `ROWS` (or `BENCH_PARQUET_ROWS`)
+//! up to reproduce the production target (do not run 1M casually — it is slow and heavy).
+
+#![cfg(feature = "parquet")]
+
+mod common;
+
+use std::hint::black_box;
+use std::io::Write;
+use std::path::PathBuf;
+
+use arrow::array::{ArrayRef, Int64Array, RecordBatch, StringArray};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use parquet::arrow::ArrowWriter;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::PropertyMapBuilder;
+use aletheiadb::api::import::{ColumnType, LabelSource, NodeMapping};
+
+/// Default row count for the benchmark (override with `BENCH_PARQUET_ROWS`).
+const ROWS: usize = 10_000;
+
+fn rows() -> usize {
+    std::env::var("BENCH_PARQUET_ROWS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(ROWS)
+}
+
+fn node_mapping() -> NodeMapping {
+    NodeMapping::new(LabelSource::fixed("Person"), "id")
+        .property("name", "name", ColumnType::String)
+        .property("age", "age", ColumnType::Int)
+}
+
+/// Build a node CSV with `n` rows and return `(dir, path)`.
+fn make_node_csv(n: usize) -> (TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("nodes.csv");
+    let mut file = std::fs::File::create(&path).expect("create csv");
+    writeln!(file, "id,name,age").unwrap();
+    for i in 0..n {
+        writeln!(file, "n{i},Name{i},{}", i % 100).unwrap();
+    }
+    file.flush().unwrap();
+    (dir, path)
+}
+
+/// Build a node Parquet file with the *same* `n` rows as [`make_node_csv`] and return
+/// `(dir, path)`. `id`/`name` are string columns, `age` is a native int64 column.
+fn make_node_parquet(n: usize) -> (TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("nodes.parquet");
+
+    let ids: Vec<String> = (0..n).map(|i| format!("n{i}")).collect();
+    let names: Vec<String> = (0..n).map(|i| format!("Name{i}")).collect();
+    let ages: Vec<i64> = (0..n).map(|i| (i % 100) as i64).collect();
+
+    let batch = RecordBatch::try_from_iter(vec![
+        ("id", Arc::new(StringArray::from(ids)) as ArrayRef),
+        ("name", Arc::new(StringArray::from(names)) as ArrayRef),
+        ("age", Arc::new(Int64Array::from(ages)) as ArrayRef),
+    ])
+    .expect("record batch");
+
+    let file = std::fs::File::create(&path).expect("create parquet");
+    let mut writer = ArrowWriter::try_new(file, batch.schema(), None).expect("arrow writer");
+    writer.write(&batch).expect("write batch");
+    writer.close().expect("close writer");
+    (dir, path)
+}
+
+/// Import throughput: native Parquet decode vs CSV string-parsing over identical rows.
+fn bench_parquet_import(c: &mut Criterion) {
+    let n = rows();
+    let (_csv_dir, csv_path) = make_node_csv(n);
+    let (_pq_dir, pq_path) = make_node_parquet(n);
+
+    let mut group = c.benchmark_group("parquet_import_nodes");
+    group.throughput(Throughput::Elements(n as u64));
+
+    group.bench_function("parquet", |b| {
+        b.iter(|| {
+            let db = AletheiaDB::new().expect("db");
+            let mut importer = db.import();
+            let report = importer
+                .nodes_from_parquet(&pq_path, node_mapping())
+                .expect("parquet import");
+            black_box(report.nodes_imported);
+        });
+    });
+
+    group.bench_function("csv", |b| {
+        b.iter(|| {
+            let db = AletheiaDB::new().expect("db");
+            let mut importer = db.import();
+            let report = importer
+                .nodes_from_csv(&csv_path, node_mapping())
+                .expect("csv import");
+            black_box(report.nodes_imported);
+        });
+    });
+
+    group.finish();
+}
+
+/// Build a database of `n` two-version nodes plus a sparse set of edges, so both
+/// current-state and history export have real work to do. Built once and reused across
+/// iterations (export is read-only).
+fn build_export_db(n: usize) -> AletheiaDB {
+    let db = AletheiaDB::new().expect("db");
+    let mut ids = Vec::with_capacity(n);
+    for i in 0..n {
+        let props = PropertyMapBuilder::new()
+            .insert("name", format!("Name{i}"))
+            .insert("age", (i % 100) as i64)
+            .build();
+        ids.push(db.create_node("Person", props).expect("create_node"));
+    }
+    // A second version of every node so history export streams two versions per node.
+    for (i, &id) in ids.iter().enumerate() {
+        let props = PropertyMapBuilder::new()
+            .insert("name", format!("Name{i}"))
+            .insert("age", ((i % 100) + 1) as i64)
+            .build();
+        db.update_node_with_valid_time(id, props, None)
+            .expect("update_node");
+    }
+    // A sparse spray of edges (one per 100 nodes) for the edge-export path.
+    let mut i = 0;
+    while i + 1 < ids.len() {
+        let props = PropertyMapBuilder::new().insert("since", 2020i64).build();
+        db.create_edge(ids[i], ids[i + 1], "KNOWS", props)
+            .expect("create_edge");
+        i += 100;
+    }
+    db
+}
+
+/// Export throughput: current-state node/edge export and full history export.
+fn bench_parquet_export(c: &mut Criterion) {
+    let n = rows();
+    let db = build_export_db(n);
+
+    let mut group = c.benchmark_group("parquet_export");
+    group.throughput(Throughput::Elements(n as u64));
+
+    group.bench_function("current_nodes", |b| {
+        b.iter(|| {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = dir.path().join("nodes.parquet");
+            let report = db.export().nodes_to_parquet(&path).expect("export nodes");
+            black_box(report.nodes_exported);
+        });
+    });
+
+    group.bench_function("current_edges", |b| {
+        b.iter(|| {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = dir.path().join("edges.parquet");
+            let report = db.export().edges_to_parquet(&path).expect("export edges");
+            black_box(report.edges_exported);
+        });
+    });
+
+    group.bench_function("history_nodes", |b| {
+        b.iter(|| {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = dir.path().join("node_history.parquet");
+            let report = db
+                .export()
+                .node_history_to_parquet(&path)
+                .expect("export node history");
+            black_box(report.node_versions_exported);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = common::configure_criterion();
+    targets = bench_parquet_import, bench_parquet_export
+);
+criterion_main!(benches);

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -22,6 +22,9 @@ After those four, pick the guides relevant to what you're building.
 - [Tiered Storage Guide](tiered-storage-guide.md) — Hot/warm/cold architecture for unlimited history
 - [Index Persistence Guide](index-persistence-guide.md) — Fast cold starts with Zstd-compressed index snapshots
 
+### Interoperability
+- [Parquet Import / Export](parquet-import-export.md) — Columnar import/export of nodes, edges, and full bi-temporal history for DuckDB / pandas / analytics pipelines
+
 ### Querying
 - [Hybrid Query Guide](hybrid-query-guide.md) — Combine graph traversal + vector similarity + temporal in one query
 - [Query Pipeline Guide](query-pipeline-guide.md) — How queries are planned and executed internally

--- a/docs/guides/parquet-import-export.md
+++ b/docs/guides/parquet-import-export.md
@@ -82,6 +82,20 @@ db.export()
 Each method returns an `ExportReport` with `nodes_exported` / `edges_exported` (current
 state) or `node_versions_exported` / `edge_versions_exported` (history).
 
+**Compression:** exported files are written with **Snappy** compression (the de-facto
+default Parquet codec). Snappy is fast, splittable, and read transparently by DuckDB /
+pandas / pyarrow / Spark with no reader-side configuration, and keeps exports comfortably
+under the <1 GB file-size target.
+
+**Consistency caveat (concurrent writes):** export is a **two-pass** scan (pass 1
+discovers the property schema, pass 2 streams the rows) and is **not** snapshot-atomic —
+it does not pin an MVCC snapshot across the two passes. It is therefore only
+point-in-time-consistent on a **quiescent** database. If writes land during an export,
+the result is best-effort (a row committed between the passes may be included with a
+schema discovered before it existed, or missed entirely). For a consistent artifact,
+export from a quiescent database (or a restored backup), or accept best-effort
+consistency.
+
 ---
 
 ## CLI
@@ -159,7 +173,13 @@ temporal + provenance tail. Edge history is the same with `id`, `edge_type`,
 `source_key` (nullable), `target_key` (nullable) leading, then the property columns and
 the tail.
 
-Shared tail columns:
+The **property columns** are the one-per-key native typed columns plus, when needed, the
+`properties_json` overflow column (string, nullable). The `properties_json` column — like
+in the current-state files — is emitted as the **last of the property columns**, i.e.
+immediately *before* `version`, not at the end of the row. The shared tail always begins
+at `version`.
+
+Shared tail columns (all appear **after** the property columns):
 
 | Column | Type | Nullable | Notes |
 |--------|------|----------|-------|
@@ -174,7 +194,6 @@ Shared tail columns:
 | `provenance_note` | string | yes | |
 | `provenance_correlation_id` | string | yes | |
 | `provenance_principal` | string | yes | #3350 authenticated principal. |
-| `properties_json` | string | yes | Overflow column (present only when needed). |
 
 **Open-interval convention:** an open (still-valid or still-current) interval is written
 as a JSON/Parquet **null** `valid_to` (and, for the transaction dimension, a null
@@ -269,14 +288,17 @@ of each label were valid on 2024-01-01?"*:
 ```sql
 SELECT label, count(*) AS facts_valid
 FROM 'node_history.parquet'
-WHERE valid_from <= TIMESTAMP '2024-01-01 00:00:00+00'
-  AND (valid_to IS NULL OR valid_to > TIMESTAMP '2024-01-01 00:00:00+00')
+WHERE valid_from <= TIMESTAMPTZ '2024-01-01 00:00:00+00'
+  AND (valid_to IS NULL OR valid_to > TIMESTAMPTZ '2024-01-01 00:00:00+00')
 GROUP BY label
 ORDER BY facts_valid DESC;
 ```
 
-Because open intervals are `NULL` (not a sentinel), the `valid_to IS NULL OR valid_to >
-...` predicate reads naturally as "still valid, or closed after the probe instant".
+The timestamp columns carry a UTC zone (`timestamp(µs, UTC)`), so DuckDB reads them as
+`TIMESTAMPTZ`; compare against a `TIMESTAMPTZ` literal (not a plain `TIMESTAMP`) so the
+comparison stays zone-aware. Because open intervals are `NULL` (not a sentinel), the
+`valid_to IS NULL OR valid_to > ...` predicate reads naturally as "still valid, or closed
+after the probe instant".
 
 ---
 

--- a/docs/guides/parquet-import-export.md
+++ b/docs/guides/parquet-import-export.md
@@ -1,0 +1,254 @@
+# Parquet Import / Export (Issue #3364)
+
+AletheiaDB can import and export nodes and edges as [Apache Parquet](https://parquet.apache.org/)
+columnar files for analytics interoperability — load a graph from a data-engineering
+pipeline, or export the current graph (or its full bi-temporal history) for downstream
+analysis in DuckDB, pandas/pyarrow, Spark, or any Parquet-aware tool.
+
+The columnar schema is **stable and documented** (below), and the export/import halves
+share it, so an **export → import round-trip reproduces the graph** for scalars,
+timestamps, and dense-vector embeddings.
+
+## Feature flag
+
+Both directions live behind the optional `parquet` feature (off by default, so the
+`arrow`/`parquet` dependency stays out of default builds):
+
+```toml
+[dependencies]
+aletheiadb = { version = "0.3", features = ["parquet"] }
+```
+
+The `parquet` feature implies the `import` feature (Issue #3211), whose
+`NodeMapping` / `EdgeMapping` / `ColumnType` types drive the import side.
+
+---
+
+## Rust API
+
+### Import
+
+Import reuses the #3211 [`Importer`](../../src/api/import/mod.rs) with two extra methods:
+
+```rust
+use aletheiadb::AletheiaDB;
+use aletheiadb::api::import::{ColumnType, EdgeMapping, LabelSource, NodeMapping};
+
+let db = AletheiaDB::new()?;
+let mut importer = db.import();
+
+let nodes = NodeMapping::new(LabelSource::column("label"), "id")
+    .property_same("name", ColumnType::String)
+    .property_same("age", ColumnType::Int)
+    .property_same("embedding", ColumnType::Embedding) // list<float32>, exact bits
+    .valid_time_column("valid_time");
+importer.nodes_from_parquet("nodes.parquet", nodes)?;
+
+let edges = EdgeMapping::new(LabelSource::column("edge_type"), "source_key", "target_key")
+    .property_same("since", ColumnType::Int);
+importer.edges_from_parquet("edges.parquet", edges)?;
+```
+
+Column values are decoded **natively** from their Arrow types — integers, floats,
+booleans, timestamps, and `list<float32>` embeddings never round-trip through a string.
+A SQL null cell yields an **absent** property (not a stored null). All #3211
+abort/skip-and-report semantics, precise `row N:` errors, and per-row `valid_time`
+backfill apply. `ColumnType` values: `String`, `Int`, `Float`, `Bool`, `Timestamp`,
+`Embedding`.
+
+### Export
+
+Export is driven by the [`Exporter`](../../src/api/export/mod.rs), obtained via
+`db.export()`:
+
+```rust
+use aletheiadb::api::export::{ExportConfig, Exporter};
+
+// Current-state export
+db.export().nodes_to_parquet("nodes.parquet")?;
+db.export().edges_to_parquet("edges.parquet")?;
+
+// Full bi-temporal history export (one row per version)
+db.export().node_history_to_parquet("node_history.parquet")?;
+db.export().edge_history_to_parquet("edge_history.parquet")?;
+
+// Tune the row-group / batch size (bounds peak memory)
+db.export()
+    .batch_size(16_384)
+    .nodes_to_parquet("nodes.parquet")?;
+```
+
+Each method returns an `ExportReport` with `nodes_exported` / `edges_exported` (current
+state) or `node_versions_exported` / `edge_versions_exported` (history).
+
+---
+
+## CLI
+
+```bash
+# Import nodes (and optionally edges) from Parquet
+aletheia import nodes.parquet --format parquet --label Person --key id \
+    --property name:string --property age:int --valid-time-column valid_time \
+    --edges edges.parquet --edge-label KNOWS --source-key source_key --target-key target_key
+
+# Export the current graph (writes <prefix>.nodes.parquet and <prefix>.edges.parquet)
+aletheia export mygraph --format parquet --mode current
+
+# Export full bi-temporal history
+# (writes <prefix>.node_history.parquet and <prefix>.edge_history.parquet)
+aletheia export mygraph --format parquet --mode history
+```
+
+`--label` sets a fixed label; use `--label-column COL` to read the label from a column.
+Repeated `--property name:type` map columns to same-named properties
+(`type` ∈ `string|int|float|bool|timestamp|embedding`). The export `<out_prefix>`
+positional is a **path prefix**; the two files are derived from it. Both commands open
+the database via `ALETHEIADB_CONFIG` / `ALETHEIADB_DATA_DIR` (like `backup`/`restore`).
+
+---
+
+## Schema
+
+All timestamp columns are `timestamp(microseconds, UTC)`. Property columns are the
+**union of all keys** discovered by scanning the database; each key gets one native
+typed column decided by its value type. A key whose type **conflicts across rows**, or
+whose value has no natural columnar form (bytes, heterogeneous array, sparse vector), is
+routed to the `properties_json` overflow column instead (see below). An absent property
+is written as a Parquet **null**.
+
+File-level metadata records `aletheiadb.schema_version` (`"1"`), `aletheiadb.mode`
+(`current` | `history`), and `aletheiadb.entity` (`node` | `edge`).
+
+### Current-state node file
+
+| Column | Type | Nullable | Notes |
+|--------|------|----------|-------|
+| `id` | int64 | no | Node id (business key). |
+| `label` | string | no | Node label. |
+| `valid_time` | timestamp(µs, UTC) | yes | Current version's valid-from. |
+| *(one per property key)* | int64 / double / bool / string / list&lt;float32&gt; | yes | Scalars, or a dense embedding as `list<float32>`. |
+| `properties_json` | string | yes | Overflow column (present only when needed). |
+
+### Current-state edge file
+
+| Column | Type | Nullable | Notes |
+|--------|------|----------|-------|
+| `edge_type` | string | no | Edge type / label. |
+| `source_key` | int64 | no | Source node id (matches a node file's `id`). |
+| `target_key` | int64 | no | Target node id. |
+| `valid_time` | timestamp(µs, UTC) | yes | Current version's valid-from. |
+| *(one per property key)* | int64 / double / bool / string / list&lt;float32&gt; | yes | |
+| `properties_json` | string | yes | Overflow column (present only when needed). |
+
+### History files (one row per version)
+
+Node history: `id` (int64), `label` (string), the property columns, then the shared
+temporal + provenance tail. Edge history is the same with `id`, `edge_type`,
+`source_key` (nullable), `target_key` (nullable) leading, then the property columns and
+the tail.
+
+Shared tail columns:
+
+| Column | Type | Nullable | Notes |
+|--------|------|----------|-------|
+| `version` | int64 | no | Sequential version number (1, 2, 3, …). |
+| `valid_from` | timestamp(µs, UTC) | yes | Start of the version's valid interval. |
+| `valid_to` | timestamp(µs, UTC) | yes | **Null = still-open interval** (never a sentinel). |
+| `transaction_time` | timestamp(µs, UTC) | yes | When the version was recorded. |
+| `tombstone` | bool | no | `true` when the version's valid interval is closed (the fact was deleted or retracted, ending its validity). |
+| `provenance_source` | string | yes | #3224 provenance. |
+| `provenance_confidence` | double | yes | |
+| `provenance_note` | string | yes | |
+| `provenance_correlation_id` | string | yes | |
+| `provenance_principal` | string | yes | #3350 authenticated principal. |
+| `properties_json` | string | yes | Overflow column (present only when needed). |
+
+**Open-interval convention:** an open (still-valid or still-current) interval is written
+as a JSON/Parquet **null** `valid_to`, never the internal `TIMESTAMP_MAX` sentinel, so a
+downstream reader never mistakes it for a real far-future timestamp.
+
+---
+
+## The `properties_json` overflow column
+
+Values that have no natural single-column form — `bytes`, heterogeneous `array`, and
+`sparse_vector` — and any property **key whose observed type conflicts across rows** are
+written to a single `properties_json` string column as a reversible **tagged-JSON**
+object, e.g.:
+
+```json
+{
+  "blob":   {"t": "bytes",  "v": [1, 2, 3, 255]},
+  "tags":   {"t": "array",  "v": [{"t": "int", "v": 7}, {"t": "str", "v": "mixed"}]},
+  "vec":    {"t": "sparse", "indices": [1, 5], "values": [0.5, -0.25], "dim": 16}
+}
+```
+
+The default importer decodes the **native** columns; re-importing the overflow column
+requires custom decoding of this tagged JSON (a documented follow-up). The encoding is
+lossless and reversible.
+
+---
+
+## Streaming and memory
+
+Both directions stream. Export scans the database once to discover the property schema,
+then a second time to emit rows in `batch_size`-row Arrow `RecordBatch`es (default
+8192), each flushed as one Parquet row group before the next is built. Import decodes
+one `RecordBatch` at a time. Peak memory is therefore bounded to roughly one batch of
+cells plus the set of distinct property keys — not the whole graph (target: 1M nodes in
+well under 1 GB).
+
+---
+
+## Documented lossy items
+
+- The HLC **logical counter** (the sub-microsecond tiebreaker inside a timestamp) is
+  dropped; only the microsecond wallclock is written.
+- The `properties_json` **overflow** column preserves bytes / arrays / sparse vectors /
+  type-conflicting keys losslessly, but the default importer does not auto-expand it —
+  custom decoding is required to re-import those values.
+- **History enumeration** uses the whole-window changefeed, so deleted/retracted
+  entities *are* exported with their full version history and tombstone. A deleted
+  **edge**'s endpoints are not carried on a historical version, so `source_key` /
+  `target_key` are written null for an edge no longer in current state.
+
+---
+
+## Reading the files: DuckDB and pandas
+
+The files are ordinary Parquet — no AletheiaDB dependency needed to read them.
+
+**pandas / pyarrow:**
+
+```python
+import pandas as pd
+nodes = pd.read_parquet("nodes.parquet")
+history = pd.read_parquet("node_history.parquet")
+```
+
+**DuckDB** — a worked bi-temporal query over an exported history file, *"how many facts
+of each label were valid on 2024-01-01?"*:
+
+```sql
+SELECT label, count(*) AS facts_valid
+FROM 'node_history.parquet'
+WHERE valid_from <= TIMESTAMP '2024-01-01 00:00:00+00'
+  AND (valid_to IS NULL OR valid_to > TIMESTAMP '2024-01-01 00:00:00+00')
+GROUP BY label
+ORDER BY facts_valid DESC;
+```
+
+Because open intervals are `NULL` (not a sentinel), the `valid_to IS NULL OR valid_to >
+...` predicate reads naturally as "still valid, or closed after the probe instant".
+
+---
+
+## Round-trip
+
+Exporting the current state and re-importing into a fresh database reproduces an
+equivalent graph — same node/edge counts and equal property values, including dense
+embeddings by exact bits. Point the import's `valid_time_column` at the exported
+`valid_time` column to preserve valid-time so `AS OF VALID_TIME` answers match. See the
+export tests in [`src/api/export/tests.rs`](../../src/api/export/tests.rs) for the
+verified round-trip invariants.

--- a/docs/guides/parquet-import-export.md
+++ b/docs/guides/parquet-import-export.md
@@ -7,7 +7,8 @@ analysis in DuckDB, pandas/pyarrow, Spark, or any Parquet-aware tool.
 
 The columnar schema is **stable and documented** (below), and the export/import halves
 share it, so an **export → import round-trip reproduces the graph** for scalars,
-timestamps, and dense-vector embeddings.
+timestamps, dense-vector embeddings, and — via the auto-expanded `properties_json`
+overflow column — bytes / heterogeneous arrays / sparse vectors / type-conflicting keys.
 
 ## Feature flag
 
@@ -86,10 +87,14 @@ state) or `node_versions_exported` / `edge_versions_exported` (history).
 ## CLI
 
 ```bash
-# Import nodes (and optionally edges) from Parquet
+# Import nodes (and optionally edges) from Parquet.
+# Node property/valid-time flags (--property / --valid-time-column) are scoped to nodes;
+# edge property/valid-time flags (--edge-property / --edge-valid-time-column) are scoped
+# to edges, so a node-only column is never applied to the edge file.
 aletheia import nodes.parquet --format parquet --label Person --key id \
     --property name:string --property age:int --valid-time-column valid_time \
-    --edges edges.parquet --edge-label KNOWS --source-key source_key --target-key target_key
+    --edges edges.parquet --edge-label KNOWS --source-key source_key --target-key target_key \
+    --edge-property since:int --edge-valid-time-column since_ts
 
 # Export the current graph (writes <prefix>.nodes.parquet and <prefix>.edges.parquet)
 aletheia export mygraph --format parquet --mode current
@@ -100,10 +105,17 @@ aletheia export mygraph --format parquet --mode history
 ```
 
 `--label` sets a fixed label; use `--label-column COL` to read the label from a column.
-Repeated `--property name:type` map columns to same-named properties
-(`type` ∈ `string|int|float|bool|timestamp|embedding`). The export `<out_prefix>`
-positional is a **path prefix**; the two files are derived from it. Both commands open
-the database via `ALETHEIADB_CONFIG` / `ALETHEIADB_DATA_DIR` (like `backup`/`restore`).
+Repeated `--property name:type` map columns to same-named **node** properties
+(`type` ∈ `string|int|float|bool|timestamp|embedding`); the parallel `--edge-property
+name:type` and `--edge-valid-time-column COL` scope **edge** properties/valid-time
+independently, so the two mappings never collide in a mixed import. The export
+`<out_prefix>` positional is a **path prefix**; the two files are derived from it. Both
+commands open the database via `ALETHEIADB_CONFIG` / `ALETHEIADB_DATA_DIR` (like
+`backup`/`restore`).
+
+**Partial-commit note:** import commits in chunks (one ACID transaction per chunk), so an
+error mid-import can leave earlier chunks committed. On failure the CLI reports how many
+nodes were committed before the error so the operator knows the database is partial.
 
 ---
 
@@ -154,8 +166,9 @@ Shared tail columns:
 | `version` | int64 | no | Sequential version number (1, 2, 3, …). |
 | `valid_from` | timestamp(µs, UTC) | yes | Start of the version's valid interval. |
 | `valid_to` | timestamp(µs, UTC) | yes | **Null = still-open interval** (never a sentinel). |
-| `transaction_time` | timestamp(µs, UTC) | yes | When the version was recorded. |
-| `tombstone` | bool | no | `true` when the version's valid interval is closed (the fact was deleted or retracted, ending its validity). |
+| `transaction_time` | timestamp(µs, UTC) | yes | When the version was recorded (transaction-interval start). |
+| `transaction_to` | timestamp(µs, UTC) | yes | End of the transaction interval; **null = still-recorded (open)**. A non-null value marks a version superseded in transaction time. |
+| `tombstone` | bool | no | `true` iff the version's valid interval is **closed** (see the note below). |
 | `provenance_source` | string | yes | #3224 provenance. |
 | `provenance_confidence` | double | yes | |
 | `provenance_note` | string | yes | |
@@ -164,8 +177,18 @@ Shared tail columns:
 | `properties_json` | string | yes | Overflow column (present only when needed). |
 
 **Open-interval convention:** an open (still-valid or still-current) interval is written
-as a JSON/Parquet **null** `valid_to`, never the internal `TIMESTAMP_MAX` sentinel, so a
-downstream reader never mistakes it for a real far-future timestamp.
+as a JSON/Parquet **null** `valid_to` (and, for the transaction dimension, a null
+`transaction_to`), never the internal `TIMESTAMP_MAX` sentinel, so a downstream reader
+never mistakes it for a real far-future timestamp.
+
+**`tombstone` semantics (v1 limitation):** `tombstone` is exactly *"this version's
+valid interval is closed"* (`valid_to` is non-null). This flags deletions and
+retractions, **but also ordinary valid-time supersessions** — an update that closes the
+prior version's valid interval sets `tombstone = true` on that superseded version even
+though nothing was deleted. The changefeed's delete signal only marks empty (zero-width)
+valid ranges, so it cannot distinguish a non-empty retraction from a supersession either;
+a precise delete/retract-only flag is a tracked follow-up. Read `tombstone` as
+"validity ended here", not strictly "deleted here".
 
 ---
 
@@ -184,9 +207,19 @@ object, e.g.:
 }
 ```
 
-The default importer decodes the **native** columns; re-importing the overflow column
-requires custom decoding of this tagged JSON (a documented follow-up). The encoding is
-lossless and reversible.
+Non-finite floats (`NaN`, `±Infinity`) — which JSON cannot represent natively — are
+encoded as a string sentinel (`"NaN"` / `"Infinity"` / `"-Infinity"`) inside the tagged
+value, so they round-trip losslessly too.
+
+The Parquet importer **auto-expands** this column: when it reads a file carrying the
+AletheiaDB export metadata (`aletheiadb.schema_version`) **and** a `properties_json`
+column, each tagged value is decoded back to its native `PropertyValue` and injected as a
+property on the imported row — you do **not** need to map the overflow keys explicitly
+(an explicit mapping column of the same name still takes precedence). A foreign Parquet
+file that merely happens to have a `properties_json` column is left untouched (no export
+metadata → no auto-expansion). The encoding is lossless and reversible, so an export →
+import round trip reproduces bytes / heterogeneous arrays / sparse vectors /
+type-conflicting keys exactly.
 
 ---
 
@@ -205,13 +238,16 @@ well under 1 GB).
 
 - The HLC **logical counter** (the sub-microsecond tiebreaker inside a timestamp) is
   dropped; only the microsecond wallclock is written.
-- The `properties_json` **overflow** column preserves bytes / arrays / sparse vectors /
-  type-conflicting keys losslessly, but the default importer does not auto-expand it —
-  custom decoding is required to re-import those values.
 - **History enumeration** uses the whole-window changefeed, so deleted/retracted
   entities *are* exported with their full version history and tombstone. A deleted
-  **edge**'s endpoints are not carried on a historical version, so `source_key` /
-  `target_key` are written null for an edge no longer in current state.
+  **edge**'s endpoints are recovered by reconstructing the edge at one of its own
+  versions' coordinates, so `source_key` / `target_key` are populated even for an edge no
+  longer in current state (they are only null in the rare case no version reconstructs).
+
+The `properties_json` **overflow** column is **no longer lossy**: it preserves bytes /
+arrays / sparse vectors / type-conflicting keys (including non-finite floats) losslessly,
+and the Parquet importer auto-expands it on re-import (see above), so those values survive
+a full round trip.
 
 ---
 
@@ -248,7 +284,8 @@ Because open intervals are `NULL` (not a sentinel), the `valid_to IS NULL OR val
 
 Exporting the current state and re-importing into a fresh database reproduces an
 equivalent graph — same node/edge counts and equal property values, including dense
-embeddings by exact bits. Point the import's `valid_time_column` at the exported
+embeddings by exact bits and overflow-column values (bytes / arrays / sparse vectors)
+auto-expanded from `properties_json`. Point the import's `valid_time_column` at the exported
 `valid_time` column to preserve valid-time so `AS OF VALID_TIME` answers match. See the
 export tests in [`src/api/export/tests.rs`](../../src/api/export/tests.rs) for the
 verified round-trip invariants.

--- a/justfile
+++ b/justfile
@@ -69,6 +69,7 @@ check-features:
     @echo "=== encryption (standalone) ===" && cargo check --no-default-features --tests --features encryption
     @echo "=== encryption-vault (standalone) ===" && cargo check --no-default-features --tests --features encryption-vault
     @echo "=== encryption-aws-kms (standalone) ===" && cargo check --no-default-features --tests --features encryption-aws-kms
+    @echo "=== parquet (standalone) ===" && cargo check --no-default-features --tests --features parquet
 
 # Format code
 fmt:

--- a/src/api/export/mod.rs
+++ b/src/api/export/mod.rs
@@ -1,0 +1,164 @@
+//! Columnar Parquet export of the graph for analytics interoperability (Issue #3364).
+//!
+//! This is the export half of the Parquet import/export layer; the import half lives
+//! in [`crate::api::import`] and shares the same columnar schema so that an
+//! export → import round-trip reproduces the graph. Two modes are offered:
+//!
+//! - **Current-state export** ([`Exporter::nodes_to_parquet`] /
+//!   [`Exporter::edges_to_parquet`]) writes the live graph with a stable, documented
+//!   schema: an `id`/`label` (or `edge_type`/`source_key`/`target_key`) header, a
+//!   nullable `valid_time` column, and one typed column per property key discovered by
+//!   scanning the database. The column layout is identical to what the importer's
+//!   [`NodeMapping`](crate::api::import::NodeMapping) /
+//!   [`EdgeMapping`](crate::api::import::EdgeMapping) expect, so the file re-imports
+//!   losslessly for scalars, timestamps, and `list<float32>` embeddings.
+//! - **Full bi-temporal history export** ([`Exporter::node_history_to_parquet`] /
+//!   [`Exporter::edge_history_to_parquet`]) writes **one row per version** with
+//!   `valid_from`, `valid_to` (**null = open interval**, never a sentinel),
+//!   `transaction_time`, a `tombstone` marker, and the five provenance columns.
+//!
+//! # Streaming and memory
+//!
+//! Both modes stream: the database is scanned once to discover the property schema,
+//! then a second time to emit rows in [`ExportConfig::batch_size`]-row Arrow
+//! `RecordBatch`es, each flushed as a Parquet row group before the next is built. Peak
+//! memory is therefore bounded to roughly one batch of decoded cells plus the set of
+//! distinct property keys, not the whole graph (target: 1M nodes in well under 1 GB).
+//!
+//! # Documented lossy items
+//!
+//! - The HLC **logical counter** (the sub-microsecond tiebreaker of a
+//!   [`HybridTimestamp`](crate::core::hlc::HybridTimestamp)) is dropped; only the
+//!   microsecond wallclock is written.
+//! - Property values that have no natural columnar type — [`PropertyValue::Bytes`],
+//!   heterogeneous [`PropertyValue::Array`], and [`PropertyValue::SparseVector`] — and
+//!   any property **key whose observed type conflicts across rows** are routed to a
+//!   single `properties_json` overflow column (a reversible tagged-JSON encoding), not
+//!   a native typed column. The default importer decodes native columns; re-importing
+//!   the overflow column requires custom mapping (see the guide).
+//! - History export enumerates entities through the whole-window **changefeed**, so an
+//!   entity that was deleted or retracted (and is no longer in current state) is still
+//!   exported with its full version history and tombstone. A deleted **edge**'s
+//!   endpoints are not carried on a historical version, so `source_key`/`target_key` are
+//!   written as null for an edge that is no longer live; the residual completeness caveat
+//!   is the changefeed's own (see the guide).
+
+#[cfg(feature = "parquet")]
+mod parquet;
+
+#[cfg(all(test, feature = "parquet"))]
+mod tests;
+
+use std::path::Path;
+
+use crate::core::error::Result;
+use crate::db::AletheiaDB;
+
+/// Tunables for an export run.
+#[derive(Debug, Clone)]
+pub struct ExportConfig {
+    /// Number of rows per Arrow `RecordBatch` / Parquet row group (default `8192`).
+    ///
+    /// Bounds peak export memory: a larger batch amortizes write overhead, a smaller
+    /// batch lowers the memory high-water mark. Clamped to at least `1`.
+    pub batch_size: usize,
+}
+
+impl Default for ExportConfig {
+    fn default() -> Self {
+        ExportConfig { batch_size: 8192 }
+    }
+}
+
+/// Summary of a single `*_to_parquet` call.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ExportReport {
+    /// Number of current-state nodes written (current-state node export).
+    pub nodes_exported: usize,
+    /// Number of current-state edges written (current-state edge export).
+    pub edges_exported: usize,
+    /// Number of node **versions** written (history node export).
+    pub node_versions_exported: usize,
+    /// Number of edge **versions** written (history edge export).
+    pub edge_versions_exported: usize,
+}
+
+/// A stateless Parquet exporter obtained via [`AletheiaDB::export`].
+pub struct Exporter<'a> {
+    db: &'a AletheiaDB,
+    config: ExportConfig,
+}
+
+impl AletheiaDB {
+    /// Begin a Parquet export session.
+    ///
+    /// Returns an [`Exporter`] bound to this database. See the [module docs](self) for
+    /// the schema, streaming behavior, and documented lossy items.
+    pub fn export(&self) -> Exporter<'_> {
+        Exporter {
+            db: self,
+            config: ExportConfig::default(),
+        }
+    }
+}
+
+impl<'a> Exporter<'a> {
+    /// Override the full export configuration.
+    #[must_use]
+    pub fn with_config(mut self, config: ExportConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Set the per-row-group batch size (clamped to at least `1`).
+    #[must_use]
+    pub fn batch_size(mut self, batch_size: usize) -> Self {
+        self.config.batch_size = batch_size.max(1);
+        self
+    }
+
+    /// Export the current state of every node to a Parquet file (Issue #3364).
+    ///
+    /// Columns: `id: int64`, `label: string`, `valid_time: timestamp(µs, UTC)`
+    /// (nullable), then one typed column per property key (scalars → int64 / double /
+    /// bool / string, embeddings → `list<float32>`), plus a `properties_json` overflow
+    /// column when any key needs it. See the [module docs](self).
+    #[cfg(feature = "parquet")]
+    pub fn nodes_to_parquet(&self, path: impl AsRef<Path>) -> Result<ExportReport> {
+        parquet::export_nodes(self.db, path.as_ref(), self.config.batch_size.max(1))
+    }
+
+    /// Export the current state of every edge to a Parquet file (Issue #3364).
+    ///
+    /// Columns: `edge_type: string`, `source_key: int64`, `target_key: int64`,
+    /// `valid_time: timestamp(µs, UTC)` (nullable), then one typed column per property
+    /// key plus the `properties_json` overflow column when needed. Endpoint keys are
+    /// the endpoints' node ids, matching the `id` column of a node export.
+    #[cfg(feature = "parquet")]
+    pub fn edges_to_parquet(&self, path: impl AsRef<Path>) -> Result<ExportReport> {
+        parquet::export_edges(self.db, path.as_ref(), self.config.batch_size.max(1))
+    }
+
+    /// Export the full bi-temporal history of every node — one row per version.
+    ///
+    /// Columns: `id: int64`, `label: string`, `version: int64`, the typed property
+    /// columns, `valid_from`/`valid_to` (`valid_to` null = still-open interval),
+    /// `transaction_time`, `tombstone: bool`, and the five nullable `provenance_*`
+    /// columns. See the [module docs](self) for the tombstone convention and the
+    /// deleted-edge enumeration caveat (which applies to
+    /// [`edge_history_to_parquet`](Self::edge_history_to_parquet)).
+    #[cfg(feature = "parquet")]
+    pub fn node_history_to_parquet(&self, path: impl AsRef<Path>) -> Result<ExportReport> {
+        parquet::export_node_history(self.db, path.as_ref(), self.config.batch_size.max(1))
+    }
+
+    /// Export the full bi-temporal history of every edge — one row per version.
+    ///
+    /// Same shape as [`node_history_to_parquet`](Self::node_history_to_parquet) plus
+    /// `edge_type`/`source_key`/`target_key`. Edges are enumerated through
+    /// current-state adjacency; see the [module docs](self) for the deleted-edge gap.
+    #[cfg(feature = "parquet")]
+    pub fn edge_history_to_parquet(&self, path: impl AsRef<Path>) -> Result<ExportReport> {
+        parquet::export_edge_history(self.db, path.as_ref(), self.config.batch_size.max(1))
+    }
+}

--- a/src/api/export/mod.rs
+++ b/src/api/export/mod.rs
@@ -46,6 +46,11 @@
 #[cfg(feature = "parquet")]
 mod parquet;
 
+/// Re-export the overflow decoder so the Parquet importer can auto-expand the
+/// `properties_json` column of an AletheiaDB export back into native properties.
+#[cfg(feature = "parquet")]
+pub(crate) use parquet::overflow_json_to_value;
+
 #[cfg(all(test, feature = "parquet"))]
 mod tests;
 

--- a/src/api/export/parquet.rs
+++ b/src/api/export/parquet.rs
@@ -24,6 +24,7 @@ use arrow::array::{
 };
 use arrow::datatypes::{DataType, Field, Float32Type, Schema, TimeUnit};
 use parquet::arrow::ArrowWriter;
+use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
 
 use crate::core::changefeed::{ChangeFeedQuery, EntityKind};
@@ -31,7 +32,7 @@ use crate::core::error::{Error, Result};
 use crate::core::history::VersionInfo;
 use crate::core::id::{EdgeId, NodeId};
 use crate::core::interning::GLOBAL_INTERNER;
-use crate::core::property::{PropertyMap, PropertyValue};
+use crate::core::property::{PropertyKey, PropertyMap, PropertyValue};
 use crate::core::provenance::Provenance;
 use crate::core::temporal::{TIMESTAMP_MAX, Timestamp};
 use crate::db::AletheiaDB;
@@ -112,6 +113,13 @@ fn key_name(key: &crate::core::interning::InternedString) -> Option<String> {
 }
 
 /// Accumulates the per-key routing decision over a discovery scan.
+///
+/// Schema discovery is a **full extra scan** of the database: pass 1 reconstructs every
+/// node/edge (or every historical version) solely to observe its property keys and
+/// value types so the emitted columns can be dynamically typed, then pass 2 re-scans to
+/// stream the rows. There is no lighter way to learn the per-key columnar type without a
+/// typed-property-key index, so the doubled reconstruction cost is an accepted tradeoff
+/// (a typed-key catalog that would let pass 1 be skipped is a tracked follow-up).
 struct SchemaBuilder<'a> {
     routes: BTreeMap<String, Route>,
     reserved: &'a [&'a str],
@@ -196,6 +204,14 @@ fn col_kind_datatype(kind: ColKind) -> DataType {
     }
 }
 
+/// Drain a per-batch column buffer, leaving a fresh empty `Vec` that keeps the drained
+/// buffer's capacity so the next batch reuses the same allocation instead of re-growing
+/// from zero.
+fn drain_keep_cap<T>(v: &mut Vec<T>) -> Vec<T> {
+    let cap = v.capacity();
+    std::mem::replace(v, Vec::with_capacity(cap))
+}
+
 /// A per-column value accumulator for one in-flight batch.
 enum ColumnBuf {
     Int(Vec<Option<i64>>),
@@ -206,13 +222,13 @@ enum ColumnBuf {
 }
 
 impl ColumnBuf {
-    fn new(kind: ColKind) -> Self {
+    fn new(kind: ColKind, batch_size: usize) -> Self {
         match kind {
-            ColKind::Int => ColumnBuf::Int(Vec::new()),
-            ColKind::Float => ColumnBuf::Float(Vec::new()),
-            ColKind::Bool => ColumnBuf::Bool(Vec::new()),
-            ColKind::Str => ColumnBuf::Str(Vec::new()),
-            ColKind::Embedding => ColumnBuf::Embedding(Vec::new()),
+            ColKind::Int => ColumnBuf::Int(Vec::with_capacity(batch_size)),
+            ColKind::Float => ColumnBuf::Float(Vec::with_capacity(batch_size)),
+            ColKind::Bool => ColumnBuf::Bool(Vec::with_capacity(batch_size)),
+            ColKind::Str => ColumnBuf::Str(Vec::with_capacity(batch_size)),
+            ColKind::Embedding => ColumnBuf::Embedding(Vec::with_capacity(batch_size)),
         }
     }
 
@@ -243,16 +259,17 @@ impl ColumnBuf {
         }
     }
 
-    /// Build the Arrow array for the accumulated batch, draining the buffer.
+    /// Build the Arrow array for the accumulated batch, draining the buffer (and keeping
+    /// its capacity so the next batch reuses the allocation).
     fn finish(&mut self) -> ArrayRef {
         match self {
-            ColumnBuf::Int(v) => Arc::new(Int64Array::from(std::mem::take(v))),
-            ColumnBuf::Float(v) => Arc::new(Float64Array::from(std::mem::take(v))),
-            ColumnBuf::Bool(v) => Arc::new(BooleanArray::from(std::mem::take(v))),
-            ColumnBuf::Str(v) => Arc::new(StringArray::from_iter(std::mem::take(v))),
+            ColumnBuf::Int(v) => Arc::new(Int64Array::from(drain_keep_cap(v))),
+            ColumnBuf::Float(v) => Arc::new(Float64Array::from(drain_keep_cap(v))),
+            ColumnBuf::Bool(v) => Arc::new(BooleanArray::from(drain_keep_cap(v))),
+            ColumnBuf::Str(v) => Arc::new(StringArray::from_iter(drain_keep_cap(v))),
             ColumnBuf::Embedding(v) => {
                 let arr = ListArray::from_iter_primitive::<Float32Type, _, _>(
-                    std::mem::take(v).into_iter().map(|opt| {
+                    drain_keep_cap(v).into_iter().map(|opt| {
                         opt.map(|floats| floats.into_iter().map(Some).collect::<Vec<_>>())
                     }),
                 );
@@ -263,22 +280,44 @@ impl ColumnBuf {
 }
 
 /// Accumulates the property columns (native + JSON overflow) for one in-flight batch.
+///
+/// Every column key is **interned once** at construction (the schema keys were resolved
+/// from the interner during discovery, so they are already present) and the per-row hot
+/// loop then looks values up by the interned [`PropertyKey`] via
+/// [`PropertyMap::get_by_interned_key`], avoiding a global-interner probe per cell.
 struct PropColumns {
-    native: Vec<(String, ColumnBuf)>,
-    overflow: Vec<String>,
+    /// Native typed columns, each paired with its pre-interned key (in schema order).
+    native: Vec<(PropertyKey, ColumnBuf)>,
+    /// Overflow keys, each paired with its pre-interned key. The `String` name is
+    /// retained because it is the JSON object key in the emitted overflow column.
+    overflow: Vec<(String, PropertyKey)>,
     json: Vec<Option<String>>,
 }
 
 impl PropColumns {
-    fn new(schema: &PropSchema) -> Self {
+    fn new(schema: &PropSchema, batch_size: usize) -> Self {
+        // The schema's key names were produced by resolving interned keys during
+        // discovery, so re-interning here is a lookup (never an insert) and is done once
+        // per column rather than once per cell. `intern` (not `get_id`) is used so the
+        // key is guaranteed present even in the (impossible) event it was evicted; it
+        // cannot fail for an already-interned string.
         PropColumns {
             native: schema
                 .native
                 .iter()
-                .map(|(name, kind)| (name.clone(), ColumnBuf::new(*kind)))
+                .filter_map(|(name, kind)| {
+                    GLOBAL_INTERNER
+                        .intern(name)
+                        .ok()
+                        .map(|key| (key, ColumnBuf::new(*kind, batch_size)))
+                })
                 .collect(),
-            overflow: schema.overflow.clone(),
-            json: Vec::new(),
+            overflow: schema
+                .overflow
+                .iter()
+                .filter_map(|name| GLOBAL_INTERNER.intern(name).ok().map(|k| (name.clone(), k)))
+                .collect(),
+            json: Vec::with_capacity(batch_size),
         }
     }
 
@@ -288,16 +327,16 @@ impl PropColumns {
 
     /// Push one row's properties into every column.
     fn push(&mut self, props: &PropertyMap) {
-        for (name, buf) in &mut self.native {
-            buf.push(props.get(name));
+        for (key, buf) in &mut self.native {
+            buf.push(props.get_by_interned_key(key));
         }
         if self.has_overflow() {
             let mut obj = serde_json::Map::new();
-            for key in &self.overflow {
-                if let Some(value) = props.get(key)
+            for (name, key) in &self.overflow {
+                if let Some(value) = props.get_by_interned_key(key)
                     && !matches!(value, PropertyValue::Null)
                 {
-                    obj.insert(key.clone(), overflow_value_to_json(value));
+                    obj.insert(name.clone(), overflow_value_to_json(value));
                 }
             }
             if obj.is_empty() {
@@ -316,7 +355,7 @@ impl PropColumns {
             arrays.push(buf.finish());
         }
         if self.has_overflow() {
-            arrays.push(Arc::new(StringArray::from_iter(std::mem::take(
+            arrays.push(Arc::new(StringArray::from_iter(drain_keep_cap(
                 &mut self.json,
             ))));
         }
@@ -498,8 +537,12 @@ impl StreamWriter {
     fn create(path: &Path, schema: Arc<Schema>, batch_size: usize) -> Result<Self> {
         let file = File::create(path)
             .map_err(|e| Error::other(format!("creating {}: {e}", path.display())))?;
+        // Snappy is the de-facto default Parquet codec: fast, splittable, and read
+        // transparently by DuckDB / pandas / pyarrow with no reader-side config. It keeps
+        // exports well under the <1 GB file-size target without a compatibility cost.
         let props = WriterProperties::builder()
             .set_max_row_group_row_count(Some(batch_size.max(1)))
+            .set_compression(Compression::SNAPPY)
             .build();
         let writer = ArrowWriter::try_new(file, schema.clone(), Some(props))
             .map_err(|e| Error::other(format!("opening parquet writer: {e}")))?;
@@ -561,10 +604,10 @@ pub(super) fn export_nodes(
     let mut report = ExportReport::default();
 
     // Pass 2: stream rows.
-    let mut ids: Vec<i64> = Vec::new();
-    let mut labels: Vec<Option<String>> = Vec::new();
-    let mut valid_times: Vec<Option<i64>> = Vec::new();
-    let mut props = PropColumns::new_from_prop_schema(&prop_schema);
+    let mut ids: Vec<i64> = Vec::with_capacity(batch_size);
+    let mut labels: Vec<Option<String>> = Vec::with_capacity(batch_size);
+    let mut valid_times: Vec<Option<i64>> = Vec::with_capacity(batch_size);
+    let mut props = PropColumns::new(&prop_schema, batch_size);
 
     for &id in &node_ids {
         let Ok(node) = db.get_node(id) else { continue };
@@ -607,11 +650,10 @@ fn flush_current(
     valid_times: &mut Vec<Option<i64>>,
     props: &mut PropColumns,
 ) -> Result<()> {
-    let mut arrays: Vec<ArrayRef> = vec![
-        Arc::new(Int64Array::from(std::mem::take(ids))),
-        Arc::new(StringArray::from_iter(std::mem::take(labels))),
-        ts_array(std::mem::take(valid_times)),
-    ];
+    let mut arrays: Vec<ArrayRef> = Vec::with_capacity(3 + props.native.len() + 1);
+    arrays.push(Arc::new(Int64Array::from(drain_keep_cap(ids))));
+    arrays.push(Arc::new(StringArray::from_iter(drain_keep_cap(labels))));
+    arrays.push(ts_array(drain_keep_cap(valid_times)));
     props.finish_into(&mut arrays);
     writer.write(arrays)
 }
@@ -661,11 +703,11 @@ pub(super) fn export_edges(
     let mut writer = StreamWriter::create(path, schema, batch_size)?;
     let mut report = ExportReport::default();
 
-    let mut edge_types: Vec<Option<String>> = Vec::new();
-    let mut sources: Vec<i64> = Vec::new();
-    let mut targets: Vec<i64> = Vec::new();
-    let mut valid_times: Vec<Option<i64>> = Vec::new();
-    let mut props = PropColumns::new_from_prop_schema(&prop_schema);
+    let mut edge_types: Vec<Option<String>> = Vec::with_capacity(batch_size);
+    let mut sources: Vec<i64> = Vec::with_capacity(batch_size);
+    let mut targets: Vec<i64> = Vec::with_capacity(batch_size);
+    let mut valid_times: Vec<Option<i64>> = Vec::with_capacity(batch_size);
+    let mut props = PropColumns::new(&prop_schema, batch_size);
 
     for &nid in &node_ids {
         for eid in db.get_outgoing_edges(nid) {
@@ -713,12 +755,11 @@ fn flush_edges(
     valid_times: &mut Vec<Option<i64>>,
     props: &mut PropColumns,
 ) -> Result<()> {
-    let mut arrays: Vec<ArrayRef> = vec![
-        Arc::new(StringArray::from_iter(std::mem::take(edge_types))),
-        Arc::new(Int64Array::from(std::mem::take(sources))),
-        Arc::new(Int64Array::from(std::mem::take(targets))),
-        ts_array(std::mem::take(valid_times)),
-    ];
+    let mut arrays: Vec<ArrayRef> = Vec::with_capacity(4 + props.native.len() + 1);
+    arrays.push(Arc::new(StringArray::from_iter(drain_keep_cap(edge_types))));
+    arrays.push(Arc::new(Int64Array::from(drain_keep_cap(sources))));
+    arrays.push(Arc::new(Int64Array::from(drain_keep_cap(targets))));
+    arrays.push(ts_array(drain_keep_cap(valid_times)));
     props.finish_into(&mut arrays);
     writer.write(arrays)
 }
@@ -781,7 +822,6 @@ fn history_tail_fields() -> Vec<Field> {
 }
 
 /// Column accumulators for the shared history tail.
-#[derive(Default)]
 struct HistoryTail {
     versions: Vec<i64>,
     valid_from: Vec<Option<i64>>,
@@ -797,6 +837,24 @@ struct HistoryTail {
 }
 
 impl HistoryTail {
+    /// Create a tail with every column buffer pre-sized to one batch, so the buffers do
+    /// not re-grow from zero on the first batch.
+    fn with_capacity(batch_size: usize) -> Self {
+        HistoryTail {
+            versions: Vec::with_capacity(batch_size),
+            valid_from: Vec::with_capacity(batch_size),
+            valid_to: Vec::with_capacity(batch_size),
+            transaction_time: Vec::with_capacity(batch_size),
+            transaction_to: Vec::with_capacity(batch_size),
+            tombstone: Vec::with_capacity(batch_size),
+            prov_source: Vec::with_capacity(batch_size),
+            prov_confidence: Vec::with_capacity(batch_size),
+            prov_note: Vec::with_capacity(batch_size),
+            prov_correlation_id: Vec::with_capacity(batch_size),
+            prov_principal: Vec::with_capacity(batch_size),
+        }
+    }
+
     fn push(&mut self, version: &VersionInfo) {
         let valid = version.temporal.valid_time();
         let tx = version.temporal.transaction_time();
@@ -845,29 +903,29 @@ impl HistoryTail {
     }
 
     fn finish_into(&mut self, arrays: &mut Vec<ArrayRef>) {
-        arrays.push(Arc::new(Int64Array::from(std::mem::take(
+        arrays.push(Arc::new(Int64Array::from(drain_keep_cap(
             &mut self.versions,
         ))));
-        arrays.push(ts_array(std::mem::take(&mut self.valid_from)));
-        arrays.push(ts_array(std::mem::take(&mut self.valid_to)));
-        arrays.push(ts_array(std::mem::take(&mut self.transaction_time)));
-        arrays.push(ts_array(std::mem::take(&mut self.transaction_to)));
-        arrays.push(Arc::new(BooleanArray::from(std::mem::take(
+        arrays.push(ts_array(drain_keep_cap(&mut self.valid_from)));
+        arrays.push(ts_array(drain_keep_cap(&mut self.valid_to)));
+        arrays.push(ts_array(drain_keep_cap(&mut self.transaction_time)));
+        arrays.push(ts_array(drain_keep_cap(&mut self.transaction_to)));
+        arrays.push(Arc::new(BooleanArray::from(drain_keep_cap(
             &mut self.tombstone,
         ))));
-        arrays.push(Arc::new(StringArray::from_iter(std::mem::take(
+        arrays.push(Arc::new(StringArray::from_iter(drain_keep_cap(
             &mut self.prov_source,
         ))));
-        arrays.push(Arc::new(Float64Array::from(std::mem::take(
+        arrays.push(Arc::new(Float64Array::from(drain_keep_cap(
             &mut self.prov_confidence,
         ))));
-        arrays.push(Arc::new(StringArray::from_iter(std::mem::take(
+        arrays.push(Arc::new(StringArray::from_iter(drain_keep_cap(
             &mut self.prov_note,
         ))));
-        arrays.push(Arc::new(StringArray::from_iter(std::mem::take(
+        arrays.push(Arc::new(StringArray::from_iter(drain_keep_cap(
             &mut self.prov_correlation_id,
         ))));
-        arrays.push(Arc::new(StringArray::from_iter(std::mem::take(
+        arrays.push(Arc::new(StringArray::from_iter(drain_keep_cap(
             &mut self.prov_principal,
         ))));
     }
@@ -911,10 +969,10 @@ pub(super) fn export_node_history(
     let mut writer = StreamWriter::create(path, schema, batch_size)?;
     let mut report = ExportReport::default();
 
-    let mut ids: Vec<i64> = Vec::new();
-    let mut labels: Vec<Option<String>> = Vec::new();
-    let mut props = PropColumns::new_from_prop_schema(&prop_schema);
-    let mut tail = HistoryTail::default();
+    let mut ids: Vec<i64> = Vec::with_capacity(batch_size);
+    let mut labels: Vec<Option<String>> = Vec::with_capacity(batch_size);
+    let mut props = PropColumns::new(&prop_schema, batch_size);
+    let mut tail = HistoryTail::with_capacity(batch_size);
 
     for &id in &node_ids {
         let Ok(history) = db.get_node_history(id) else {
@@ -928,28 +986,31 @@ pub(super) fn export_node_history(
             report.node_versions_exported += 1;
 
             if ids.len() >= batch_size {
-                let mut arrays: Vec<ArrayRef> = vec![
-                    Arc::new(Int64Array::from(std::mem::take(&mut ids))),
-                    Arc::new(StringArray::from_iter(std::mem::take(&mut labels))),
-                ];
-                props.finish_into(&mut arrays);
-                tail.finish_into(&mut arrays);
-                writer.write(arrays)?;
+                flush_node_history(&mut writer, &mut ids, &mut labels, &mut props, &mut tail)?;
             }
         }
     }
     if !ids.is_empty() || tail.len() > 0 {
-        let mut arrays: Vec<ArrayRef> = vec![
-            Arc::new(Int64Array::from(std::mem::take(&mut ids))),
-            Arc::new(StringArray::from_iter(std::mem::take(&mut labels))),
-        ];
-        props.finish_into(&mut arrays);
-        tail.finish_into(&mut arrays);
-        writer.write(arrays)?;
+        flush_node_history(&mut writer, &mut ids, &mut labels, &mut props, &mut tail)?;
     }
 
     writer.close()?;
     Ok(report)
+}
+
+fn flush_node_history(
+    writer: &mut StreamWriter,
+    ids: &mut Vec<i64>,
+    labels: &mut Vec<Option<String>>,
+    props: &mut PropColumns,
+    tail: &mut HistoryTail,
+) -> Result<()> {
+    let mut arrays: Vec<ArrayRef> = Vec::with_capacity(2 + props.native.len() + 12);
+    arrays.push(Arc::new(Int64Array::from(drain_keep_cap(ids))));
+    arrays.push(Arc::new(StringArray::from_iter(drain_keep_cap(labels))));
+    props.finish_into(&mut arrays);
+    tail.finish_into(&mut arrays);
+    writer.write(arrays)
 }
 
 pub(super) fn export_edge_history(
@@ -993,12 +1054,12 @@ pub(super) fn export_edge_history(
     let mut writer = StreamWriter::create(path, schema, batch_size)?;
     let mut report = ExportReport::default();
 
-    let mut ids: Vec<i64> = Vec::new();
-    let mut edge_types: Vec<Option<String>> = Vec::new();
-    let mut sources: Vec<Option<i64>> = Vec::new();
-    let mut targets: Vec<Option<i64>> = Vec::new();
-    let mut props = PropColumns::new_from_prop_schema(&prop_schema);
-    let mut tail = HistoryTail::default();
+    let mut ids: Vec<i64> = Vec::with_capacity(batch_size);
+    let mut edge_types: Vec<Option<String>> = Vec::with_capacity(batch_size);
+    let mut sources: Vec<Option<i64>> = Vec::with_capacity(batch_size);
+    let mut targets: Vec<Option<i64>> = Vec::with_capacity(batch_size);
+    let mut props = PropColumns::new(&prop_schema, batch_size);
+    let mut tail = HistoryTail::with_capacity(batch_size);
 
     for &eid in &edge_ids {
         let Ok(history) = db.get_edge_history(eid) else {
@@ -1057,12 +1118,11 @@ fn flush_edge_history(
     props: &mut PropColumns,
     tail: &mut HistoryTail,
 ) -> Result<()> {
-    let mut arrays: Vec<ArrayRef> = vec![
-        Arc::new(Int64Array::from(std::mem::take(ids))),
-        Arc::new(StringArray::from_iter(std::mem::take(edge_types))),
-        Arc::new(Int64Array::from(std::mem::take(sources))),
-        Arc::new(Int64Array::from(std::mem::take(targets))),
-    ];
+    let mut arrays: Vec<ArrayRef> = Vec::with_capacity(4 + props.native.len() + 12);
+    arrays.push(Arc::new(Int64Array::from(drain_keep_cap(ids))));
+    arrays.push(Arc::new(StringArray::from_iter(drain_keep_cap(edge_types))));
+    arrays.push(Arc::new(Int64Array::from(drain_keep_cap(sources))));
+    arrays.push(Arc::new(Int64Array::from(drain_keep_cap(targets))));
     props.finish_into(&mut arrays);
     tail.finish_into(&mut arrays);
     writer.write(arrays)
@@ -1072,13 +1132,6 @@ fn flush_edge_history(
 // Shared helpers
 // ============================================================================
 
-impl PropColumns {
-    /// Convenience constructor used by the export pipelines.
-    fn new_from_prop_schema(schema: &PropSchema) -> Self {
-        PropColumns::new(schema)
-    }
-}
-
 /// Page size for the changefeed enumeration driving history export.
 const CHANGEFEED_PAGE: usize = 4096;
 
@@ -1086,11 +1139,15 @@ const CHANGEFEED_PAGE: usize = 4096;
 /// history — including entities that were deleted or retracted and are therefore no
 /// longer in current state — by paging the whole-window changefeed.
 ///
-/// Returned ids are ascending (deterministic). Any residual completeness caveat is the
-/// changefeed's own (a version's transaction time must fall inside `[0, TIMESTAMP_MAX)`,
-/// which every committed version does; cold-tier versions are merged by `list_changes`).
+/// Returned ids are ascending and deduped (deterministic). Any residual completeness
+/// caveat is the changefeed's own (a version's transaction time must fall inside
+/// `[0, TIMESTAMP_MAX)`, which every committed version does; cold-tier versions are
+/// merged by `list_changes`).
+///
+/// This buffers all matching ids in a `Vec` then sorts+dedups (cheaper per element than a
+/// `BTreeSet`'s per-node allocation); it is O(total entities of `kind`) transient memory.
 fn collect_history_ids(db: &AletheiaDB, kind: EntityKind) -> Result<Vec<u64>> {
-    let mut ids = std::collections::BTreeSet::new();
+    let mut ids: Vec<u64> = Vec::new();
     let mut cursor: Option<String> = None;
     loop {
         let mut query = ChangeFeedQuery::new(Timestamp::from(0), TIMESTAMP_MAX, CHANGEFEED_PAGE);
@@ -1098,7 +1155,7 @@ fn collect_history_ids(db: &AletheiaDB, kind: EntityKind) -> Result<Vec<u64>> {
         let page = db.list_changes(&query)?;
         for record in &page.changes {
             if record.kind == kind {
-                ids.insert(record.entity_id);
+                ids.push(record.entity_id);
             }
         }
         match page.next_cursor {
@@ -1106,7 +1163,9 @@ fn collect_history_ids(db: &AletheiaDB, kind: EntityKind) -> Result<Vec<u64>> {
             None => break,
         }
     }
-    Ok(ids.into_iter().collect())
+    ids.sort_unstable();
+    ids.dedup();
+    Ok(ids)
 }
 
 /// Resolve an edge's `(source, target)` node ids for the history export.

--- a/src/api/export/parquet.rs
+++ b/src/api/export/parquet.rs
@@ -9,7 +9,9 @@
 //!
 //! The emitted column layout mirrors what the importer
 //! ([`crate::api::import`]) expects, so an export re-imports losslessly for scalars,
-//! timestamps, and `list<float32>` embeddings.
+//! timestamps, and `list<float32>` embeddings — and, via the importer's auto-expansion
+//! of the `properties_json` column, for the overflow values (bytes, heterogeneous
+//! arrays, sparse vectors, and type-conflicting keys) as well.
 
 use std::collections::{BTreeMap, HashMap};
 use std::fs::File;
@@ -50,6 +52,7 @@ const COL_VERSION: &str = "version";
 const COL_VALID_FROM: &str = "valid_from";
 const COL_VALID_TO: &str = "valid_to";
 const COL_TRANSACTION_TIME: &str = "transaction_time";
+const COL_TRANSACTION_TO: &str = "transaction_to";
 const COL_TOMBSTONE: &str = "tombstone";
 const COL_PROV_SOURCE: &str = "provenance_source";
 const COL_PROV_CONFIDENCE: &str = "provenance_confidence";
@@ -323,20 +326,22 @@ impl PropColumns {
 /// Reversible tagged-JSON encoding of a property value routed to the overflow column.
 ///
 /// The inverse is [`overflow_json_to_value`]; together they let bytes, heterogeneous
-/// arrays, sparse vectors, and type-conflicting keys survive an export → decode round
-/// trip losslessly even though the default importer does not auto-expand the column.
+/// arrays, sparse vectors, and type-conflicting keys survive an export → import round
+/// trip losslessly. The Parquet importer auto-expands this column back into native
+/// properties when it recognizes an AletheiaDB export (see `crate::api::import`).
 fn overflow_value_to_json(value: &PropertyValue) -> serde_json::Value {
     use serde_json::json;
     match value {
         PropertyValue::Null => serde_json::Value::Null,
         PropertyValue::Bool(b) => json!({ "t": "bool", "v": b }),
         PropertyValue::Int(i) => json!({ "t": "int", "v": i }),
-        PropertyValue::Float(f) => json!({ "t": "float", "v": f }),
+        PropertyValue::Float(f) => json!({ "t": "float", "v": f64_to_json(*f) }),
         PropertyValue::String(s) => json!({ "t": "str", "v": s.as_ref() }),
         PropertyValue::Bytes(b) => json!({ "t": "bytes", "v": b.as_ref() }),
-        PropertyValue::Vector(v) => {
-            json!({ "t": "vector", "v": v.iter().copied().collect::<Vec<f32>>() })
-        }
+        PropertyValue::Vector(v) => json!({
+            "t": "vector",
+            "v": v.iter().map(|x| f64_to_json(*x as f64)).collect::<Vec<_>>(),
+        }),
         PropertyValue::Array(items) => json!({
             "t": "array",
             "v": items.iter().map(overflow_value_to_json).collect::<Vec<_>>(),
@@ -344,16 +349,50 @@ fn overflow_value_to_json(value: &PropertyValue) -> serde_json::Value {
         PropertyValue::SparseVector(sv) => json!({
             "t": "sparse",
             "indices": sv.indices(),
-            "values": sv.values(),
+            "values": sv.values().iter().map(|x| f64_to_json(*x as f64)).collect::<Vec<_>>(),
             "dim": sv.dimension(),
         }),
     }
 }
 
-/// Inverse of [`overflow_value_to_json`]. Used by tests (and available to custom
-/// re-import tooling) to reconstruct the exact [`PropertyValue`] from its tagged JSON.
-#[cfg(test)]
-pub(super) fn overflow_json_to_value(
+/// Encode an `f64` as JSON that survives a `serde_json` round trip.
+///
+/// `serde_json` serializes a non-finite float (`NaN`, `±Infinity`) to JSON `null`,
+/// which would then fail to decode. Non-finite values are therefore encoded as a
+/// string sentinel and decoded back by [`json_to_f64`], keeping the overflow column
+/// lossless even for non-finite floats.
+fn f64_to_json(f: f64) -> serde_json::Value {
+    use serde_json::json;
+    if f.is_finite() {
+        json!(f)
+    } else if f.is_nan() {
+        json!("NaN")
+    } else if f > 0.0 {
+        json!("Infinity")
+    } else {
+        json!("-Infinity")
+    }
+}
+
+/// Inverse of [`f64_to_json`]: accepts either a JSON number or the string sentinel
+/// used for non-finite floats.
+fn json_to_f64(value: &serde_json::Value) -> Option<f64> {
+    if let Some(f) = value.as_f64() {
+        return Some(f);
+    }
+    match value.as_str()? {
+        "NaN" => Some(f64::NAN),
+        "Infinity" => Some(f64::INFINITY),
+        "-Infinity" => Some(f64::NEG_INFINITY),
+        _ => None,
+    }
+}
+
+/// Inverse of [`overflow_value_to_json`]. Reconstructs the exact [`PropertyValue`]
+/// from its tagged JSON. Used by the Parquet importer to auto-expand the
+/// `properties_json` overflow column of an AletheiaDB export back into native
+/// properties (and by tests).
+pub(crate) fn overflow_json_to_value(
     value: &serde_json::Value,
 ) -> std::result::Result<PropertyValue, String> {
     let obj = value
@@ -371,7 +410,7 @@ pub(super) fn overflow_json_to_value(
             obj.get("v").and_then(|v| v.as_i64()).ok_or("bad int")?,
         )),
         "float" => Ok(PropertyValue::Float(
-            obj.get("v").and_then(|v| v.as_f64()).ok_or("bad float")?,
+            obj.get("v").and_then(json_to_f64).ok_or("bad float")?,
         )),
         "str" => Ok(PropertyValue::string(
             obj.get("v").and_then(|v| v.as_str()).ok_or("bad str")?,
@@ -391,7 +430,7 @@ pub(super) fn overflow_json_to_value(
                 .ok_or("bad vector")?;
             let floats: Vec<f32> = arr
                 .iter()
-                .map(|n| n.as_f64().map(|f| f as f32).ok_or("bad float elem"))
+                .map(|n| json_to_f64(n).map(|f| f as f32).ok_or("bad float elem"))
                 .collect::<std::result::Result<_, _>>()?;
             PropertyValue::try_vector(&floats).map_err(|e| e.to_string())
         }
@@ -416,7 +455,7 @@ pub(super) fn overflow_json_to_value(
                 .and_then(|v| v.as_array())
                 .ok_or("bad values")?
                 .iter()
-                .map(|n| n.as_f64().map(|f| f as f32).ok_or("bad value"))
+                .map(|n| json_to_f64(n).map(|f| f as f32).ok_or("bad value"))
                 .collect::<std::result::Result<_, _>>()?;
             let dim = obj.get("dim").and_then(|v| v.as_u64()).ok_or("bad dim")? as u32;
             let sv = crate::core::vector::SparseVec::new(indices, values, dim)
@@ -695,6 +734,7 @@ const NODE_HISTORY_RESERVED: &[&str] = &[
     COL_VALID_FROM,
     COL_VALID_TO,
     COL_TRANSACTION_TIME,
+    COL_TRANSACTION_TO,
     COL_TOMBSTONE,
     COL_PROV_SOURCE,
     COL_PROV_CONFIDENCE,
@@ -713,6 +753,7 @@ const EDGE_HISTORY_RESERVED: &[&str] = &[
     COL_VALID_FROM,
     COL_VALID_TO,
     COL_TRANSACTION_TIME,
+    COL_TRANSACTION_TO,
     COL_TOMBSTONE,
     COL_PROV_SOURCE,
     COL_PROV_CONFIDENCE,
@@ -729,6 +770,7 @@ fn history_tail_fields() -> Vec<Field> {
         Field::new(COL_VALID_FROM, ts_datatype(), true),
         Field::new(COL_VALID_TO, ts_datatype(), true),
         Field::new(COL_TRANSACTION_TIME, ts_datatype(), true),
+        Field::new(COL_TRANSACTION_TO, ts_datatype(), true),
         Field::new(COL_TOMBSTONE, DataType::Boolean, false),
         Field::new(COL_PROV_SOURCE, DataType::Utf8, true),
         Field::new(COL_PROV_CONFIDENCE, DataType::Float64, true),
@@ -745,6 +787,7 @@ struct HistoryTail {
     valid_from: Vec<Option<i64>>,
     valid_to: Vec<Option<i64>>,
     transaction_time: Vec<Option<i64>>,
+    transaction_to: Vec<Option<i64>>,
     tombstone: Vec<bool>,
     prov_source: Vec<Option<String>>,
     prov_confidence: Vec<Option<f64>>,
@@ -766,8 +809,20 @@ impl HistoryTail {
             Some(valid.end().wallclock())
         });
         self.transaction_time.push(Some(tx.start().wallclock()));
-        // A closed valid interval marks the fact's real-world validity as ended
-        // (deletion / retraction). See the module docs for the exact convention.
+        // Open transaction interval => null (never the TIMESTAMP_MAX sentinel). A closed
+        // transaction interval marks a version superseded in transaction time.
+        self.transaction_to.push(if tx.is_current() {
+            None
+        } else {
+            Some(tx.end().wallclock())
+        });
+        // `tombstone` == "this version's valid interval is closed". This is a v1
+        // heuristic: it flags every version whose real-world validity has an end,
+        // which includes deletions and retractions BUT ALSO ordinary valid-time
+        // supersessions (an update that closes the prior version's valid interval).
+        // The changefeed's `ChangeType::Deleted` only marks empty (zero-width) valid
+        // ranges, so it cannot distinguish a non-empty retraction from a supersession
+        // either; deriving a precise delete/retract-only flag is a tracked follow-up.
         self.tombstone.push(!valid.is_current());
 
         let prov = version.provenance.as_ref();
@@ -796,6 +851,7 @@ impl HistoryTail {
         arrays.push(ts_array(std::mem::take(&mut self.valid_from)));
         arrays.push(ts_array(std::mem::take(&mut self.valid_to)));
         arrays.push(ts_array(std::mem::take(&mut self.transaction_time)));
+        arrays.push(ts_array(std::mem::take(&mut self.transaction_to)));
         arrays.push(Arc::new(BooleanArray::from(std::mem::take(
             &mut self.tombstone,
         ))));
@@ -948,15 +1004,11 @@ pub(super) fn export_edge_history(
         let Ok(history) = db.get_edge_history(eid) else {
             continue;
         };
-        // Endpoints come from the current edge when it is still live; a deleted edge's
-        // endpoints are not carried on a historical version, so they are null.
-        let (source, target) = match db.get_edge(eid) {
-            Ok(edge) => (
-                Some(edge.source.as_u64() as i64),
-                Some(edge.target.as_u64() as i64),
-            ),
-            Err(_) => (None, None),
-        };
+        // Endpoints come from the current edge when it is still live; for a deleted
+        // edge (no current state) they are recovered by reconstructing the edge at one
+        // of its own versions' bi-temporal coordinates. Only when neither resolves are
+        // they written null.
+        let (source, target) = resolve_edge_endpoints(db, eid, &history.versions);
         for version in &history.versions {
             ids.push(eid.as_u64() as i64);
             edge_types.push(Some(version.label.clone()));
@@ -1055,6 +1107,38 @@ fn collect_history_ids(db: &AletheiaDB, kind: EntityKind) -> Result<Vec<u64>> {
         }
     }
     Ok(ids.into_iter().collect())
+}
+
+/// Resolve an edge's `(source, target)` node ids for the history export.
+///
+/// Live edges answer directly via `get_edge`. A deleted edge has no current state and
+/// its endpoints are not carried on a historical `VersionInfo`, but they are
+/// recoverable by reconstructing the edge at one of its own versions' bi-temporal
+/// coordinates (`get_edge_at_time`). Endpoints never change across an edge's versions,
+/// so the first version that reconstructs yields the correct pair. `(None, None)` is
+/// returned only when no version reconstructs.
+fn resolve_edge_endpoints(
+    db: &AletheiaDB,
+    eid: EdgeId,
+    versions: &[VersionInfo],
+) -> (Option<i64>, Option<i64>) {
+    if let Ok(edge) = db.get_edge(eid) {
+        return (
+            Some(edge.source.as_u64() as i64),
+            Some(edge.target.as_u64() as i64),
+        );
+    }
+    for version in versions {
+        let valid_from = version.temporal.valid_time().start();
+        let tx_from = version.temporal.transaction_time().start();
+        if let Ok(edge) = db.get_edge_at_time(eid, valid_from, tx_from) {
+            return (
+                Some(edge.source.as_u64() as i64),
+                Some(edge.target.as_u64() as i64),
+            );
+        }
+    }
+    (None, None)
 }
 
 /// The current node version's valid-time start (epoch micros), if resolvable.

--- a/src/api/export/parquet.rs
+++ b/src/api/export/parquet.rs
@@ -1,0 +1,1074 @@
+//! Streaming Parquet writer for the graph exporter (Issue #3364).
+//!
+//! The property schema is dynamic (each node/edge carries its own keys), so a first
+//! scan over the database discovers, per property key, a single native columnar type —
+//! or routes the key to a `properties_json` overflow column when its type conflicts
+//! across rows or has no natural columnar form (bytes, heterogeneous arrays, sparse
+//! vectors). A second scan then streams rows into fixed-size Arrow `RecordBatch`es,
+//! each written as one Parquet row group so peak memory stays bounded.
+//!
+//! The emitted column layout mirrors what the importer
+//! ([`crate::api::import`]) expects, so an export re-imports losslessly for scalars,
+//! timestamps, and `list<float32>` embeddings.
+
+use std::collections::{BTreeMap, HashMap};
+use std::fs::File;
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::array::{
+    ArrayRef, BooleanArray, Float64Array, Int64Array, ListArray, RecordBatch, StringArray,
+    TimestampMicrosecondArray,
+};
+use arrow::datatypes::{DataType, Field, Float32Type, Schema, TimeUnit};
+use parquet::arrow::ArrowWriter;
+use parquet::file::properties::WriterProperties;
+
+use crate::core::changefeed::{ChangeFeedQuery, EntityKind};
+use crate::core::error::{Error, Result};
+use crate::core::history::VersionInfo;
+use crate::core::id::{EdgeId, NodeId};
+use crate::core::interning::GLOBAL_INTERNER;
+use crate::core::property::{PropertyMap, PropertyValue};
+use crate::core::provenance::Provenance;
+use crate::core::temporal::{TIMESTAMP_MAX, Timestamp};
+use crate::db::AletheiaDB;
+
+use super::ExportReport;
+
+/// Schema version stamped into the file-level metadata.
+const SCHEMA_VERSION: &str = "1";
+
+// Fixed column names (the documented, stable schema).
+const COL_ID: &str = "id";
+const COL_LABEL: &str = "label";
+const COL_VALID_TIME: &str = "valid_time";
+const COL_EDGE_TYPE: &str = "edge_type";
+const COL_SOURCE_KEY: &str = "source_key";
+const COL_TARGET_KEY: &str = "target_key";
+const COL_VERSION: &str = "version";
+const COL_VALID_FROM: &str = "valid_from";
+const COL_VALID_TO: &str = "valid_to";
+const COL_TRANSACTION_TIME: &str = "transaction_time";
+const COL_TOMBSTONE: &str = "tombstone";
+const COL_PROV_SOURCE: &str = "provenance_source";
+const COL_PROV_CONFIDENCE: &str = "provenance_confidence";
+const COL_PROV_NOTE: &str = "provenance_note";
+const COL_PROV_CORRELATION_ID: &str = "provenance_correlation_id";
+const COL_PROV_PRINCIPAL: &str = "provenance_principal";
+const COL_PROPERTIES_JSON: &str = "properties_json";
+
+/// The native columnar type chosen for a property key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ColKind {
+    Int,
+    Float,
+    Bool,
+    Str,
+    Embedding,
+}
+
+/// How a property key is routed in the exported schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Route {
+    /// A dedicated native typed column.
+    Native(ColKind),
+    /// The reversible tagged-JSON `properties_json` overflow column.
+    Overflow,
+}
+
+/// Classify a single value into its column route, or `None` for a null (absent) value.
+fn classify(value: &PropertyValue) -> Option<Route> {
+    match value {
+        PropertyValue::Null => None,
+        PropertyValue::Bool(_) => Some(Route::Native(ColKind::Bool)),
+        PropertyValue::Int(_) => Some(Route::Native(ColKind::Int)),
+        PropertyValue::Float(_) => Some(Route::Native(ColKind::Float)),
+        PropertyValue::String(_) => Some(Route::Native(ColKind::Str)),
+        PropertyValue::Vector(_) => Some(Route::Native(ColKind::Embedding)),
+        // No natural single-column form: route to the JSON overflow column.
+        PropertyValue::Bytes(_) | PropertyValue::Array(_) | PropertyValue::SparseVector(_) => {
+            Some(Route::Overflow)
+        }
+    }
+}
+
+/// Merge a newly-observed route into the running decision for a key. Any conflict
+/// between two native kinds, or the presence of an overflow value, makes the key an
+/// overflow column (absorbing).
+fn merge(existing: Route, incoming: Route) -> Route {
+    match (existing, incoming) {
+        (Route::Native(a), Route::Native(b)) if a == b => Route::Native(a),
+        _ => Route::Overflow,
+    }
+}
+
+/// Resolve an interned property key to its string name.
+fn key_name(key: &crate::core::interning::InternedString) -> Option<String> {
+    GLOBAL_INTERNER.resolve_with(*key, |s| s.to_string())
+}
+
+/// Accumulates the per-key routing decision over a discovery scan.
+struct SchemaBuilder<'a> {
+    routes: BTreeMap<String, Route>,
+    reserved: &'a [&'a str],
+}
+
+impl<'a> SchemaBuilder<'a> {
+    fn new(reserved: &'a [&'a str]) -> Self {
+        SchemaBuilder {
+            routes: BTreeMap::new(),
+            reserved,
+        }
+    }
+
+    fn observe(&mut self, props: &PropertyMap) {
+        for (key, value) in props.iter() {
+            let Some(name) = key_name(key) else { continue };
+            // A key colliding with a fixed column name is always overflow-routed so
+            // the emitted schema stays unambiguous.
+            let incoming = if self.reserved.contains(&name.as_str()) {
+                Route::Overflow
+            } else {
+                match classify(value) {
+                    Some(route) => route,
+                    None => continue,
+                }
+            };
+            self.routes
+                .entry(name)
+                .and_modify(|r| *r = merge(*r, incoming))
+                .or_insert(incoming);
+        }
+    }
+
+    fn finish(self) -> PropSchema {
+        let mut native = Vec::new();
+        let mut overflow = Vec::new();
+        for (name, route) in self.routes {
+            match route {
+                Route::Native(kind) => native.push((name, kind)),
+                Route::Overflow => overflow.push(name),
+            }
+        }
+        PropSchema { native, overflow }
+    }
+}
+
+/// The resolved property schema: native typed columns (sorted by key) plus the set of
+/// overflow keys (sorted).
+struct PropSchema {
+    native: Vec<(String, ColKind)>,
+    overflow: Vec<String>,
+}
+
+impl PropSchema {
+    fn has_overflow(&self) -> bool {
+        !self.overflow.is_empty()
+    }
+
+    /// Arrow fields for the property columns, in emission order (native columns, then
+    /// the `properties_json` overflow column when present).
+    fn fields(&self) -> Vec<Field> {
+        let mut fields = Vec::with_capacity(self.native.len() + 1);
+        for (name, kind) in &self.native {
+            fields.push(Field::new(name, col_kind_datatype(*kind), true));
+        }
+        if self.has_overflow() {
+            fields.push(Field::new(COL_PROPERTIES_JSON, DataType::Utf8, true));
+        }
+        fields
+    }
+}
+
+/// The Arrow `DataType` for a native column kind. Kept in sync with [`ColumnBuf`] so
+/// the up-front schema matches the arrays produced at flush time.
+fn col_kind_datatype(kind: ColKind) -> DataType {
+    match kind {
+        ColKind::Int => DataType::Int64,
+        ColKind::Float => DataType::Float64,
+        ColKind::Bool => DataType::Boolean,
+        ColKind::Str => DataType::Utf8,
+        ColKind::Embedding => DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+    }
+}
+
+/// A per-column value accumulator for one in-flight batch.
+enum ColumnBuf {
+    Int(Vec<Option<i64>>),
+    Float(Vec<Option<f64>>),
+    Bool(Vec<Option<bool>>),
+    Str(Vec<Option<String>>),
+    Embedding(Vec<Option<Vec<f32>>>),
+}
+
+impl ColumnBuf {
+    fn new(kind: ColKind) -> Self {
+        match kind {
+            ColKind::Int => ColumnBuf::Int(Vec::new()),
+            ColKind::Float => ColumnBuf::Float(Vec::new()),
+            ColKind::Bool => ColumnBuf::Bool(Vec::new()),
+            ColKind::Str => ColumnBuf::Str(Vec::new()),
+            ColKind::Embedding => ColumnBuf::Embedding(Vec::new()),
+        }
+    }
+
+    /// Push a value for this row. A missing value, or one whose type does not match the
+    /// column (which discovery would have routed to overflow), becomes a null slot.
+    fn push(&mut self, value: Option<&PropertyValue>) {
+        match self {
+            ColumnBuf::Int(v) => v.push(match value {
+                Some(PropertyValue::Int(i)) => Some(*i),
+                _ => None,
+            }),
+            ColumnBuf::Float(v) => v.push(match value {
+                Some(PropertyValue::Float(f)) => Some(*f),
+                _ => None,
+            }),
+            ColumnBuf::Bool(v) => v.push(match value {
+                Some(PropertyValue::Bool(b)) => Some(*b),
+                _ => None,
+            }),
+            ColumnBuf::Str(v) => v.push(match value {
+                Some(PropertyValue::String(s)) => Some(s.to_string()),
+                _ => None,
+            }),
+            ColumnBuf::Embedding(v) => v.push(match value {
+                Some(PropertyValue::Vector(vec)) => Some(vec.to_vec()),
+                _ => None,
+            }),
+        }
+    }
+
+    /// Build the Arrow array for the accumulated batch, draining the buffer.
+    fn finish(&mut self) -> ArrayRef {
+        match self {
+            ColumnBuf::Int(v) => Arc::new(Int64Array::from(std::mem::take(v))),
+            ColumnBuf::Float(v) => Arc::new(Float64Array::from(std::mem::take(v))),
+            ColumnBuf::Bool(v) => Arc::new(BooleanArray::from(std::mem::take(v))),
+            ColumnBuf::Str(v) => Arc::new(StringArray::from_iter(std::mem::take(v))),
+            ColumnBuf::Embedding(v) => {
+                let arr = ListArray::from_iter_primitive::<Float32Type, _, _>(
+                    std::mem::take(v).into_iter().map(|opt| {
+                        opt.map(|floats| floats.into_iter().map(Some).collect::<Vec<_>>())
+                    }),
+                );
+                Arc::new(arr)
+            }
+        }
+    }
+}
+
+/// Accumulates the property columns (native + JSON overflow) for one in-flight batch.
+struct PropColumns {
+    native: Vec<(String, ColumnBuf)>,
+    overflow: Vec<String>,
+    json: Vec<Option<String>>,
+}
+
+impl PropColumns {
+    fn new(schema: &PropSchema) -> Self {
+        PropColumns {
+            native: schema
+                .native
+                .iter()
+                .map(|(name, kind)| (name.clone(), ColumnBuf::new(*kind)))
+                .collect(),
+            overflow: schema.overflow.clone(),
+            json: Vec::new(),
+        }
+    }
+
+    fn has_overflow(&self) -> bool {
+        !self.overflow.is_empty()
+    }
+
+    /// Push one row's properties into every column.
+    fn push(&mut self, props: &PropertyMap) {
+        for (name, buf) in &mut self.native {
+            buf.push(props.get(name));
+        }
+        if self.has_overflow() {
+            let mut obj = serde_json::Map::new();
+            for key in &self.overflow {
+                if let Some(value) = props.get(key)
+                    && !matches!(value, PropertyValue::Null)
+                {
+                    obj.insert(key.clone(), overflow_value_to_json(value));
+                }
+            }
+            if obj.is_empty() {
+                self.json.push(None);
+            } else {
+                self.json
+                    .push(Some(serde_json::Value::Object(obj).to_string()));
+            }
+        }
+    }
+
+    /// Append the finished property arrays (native columns, then the JSON overflow
+    /// column when present) to `arrays`.
+    fn finish_into(&mut self, arrays: &mut Vec<ArrayRef>) {
+        for (_, buf) in &mut self.native {
+            arrays.push(buf.finish());
+        }
+        if self.has_overflow() {
+            arrays.push(Arc::new(StringArray::from_iter(std::mem::take(
+                &mut self.json,
+            ))));
+        }
+    }
+}
+
+/// Reversible tagged-JSON encoding of a property value routed to the overflow column.
+///
+/// The inverse is [`overflow_json_to_value`]; together they let bytes, heterogeneous
+/// arrays, sparse vectors, and type-conflicting keys survive an export → decode round
+/// trip losslessly even though the default importer does not auto-expand the column.
+fn overflow_value_to_json(value: &PropertyValue) -> serde_json::Value {
+    use serde_json::json;
+    match value {
+        PropertyValue::Null => serde_json::Value::Null,
+        PropertyValue::Bool(b) => json!({ "t": "bool", "v": b }),
+        PropertyValue::Int(i) => json!({ "t": "int", "v": i }),
+        PropertyValue::Float(f) => json!({ "t": "float", "v": f }),
+        PropertyValue::String(s) => json!({ "t": "str", "v": s.as_ref() }),
+        PropertyValue::Bytes(b) => json!({ "t": "bytes", "v": b.as_ref() }),
+        PropertyValue::Vector(v) => {
+            json!({ "t": "vector", "v": v.iter().copied().collect::<Vec<f32>>() })
+        }
+        PropertyValue::Array(items) => json!({
+            "t": "array",
+            "v": items.iter().map(overflow_value_to_json).collect::<Vec<_>>(),
+        }),
+        PropertyValue::SparseVector(sv) => json!({
+            "t": "sparse",
+            "indices": sv.indices(),
+            "values": sv.values(),
+            "dim": sv.dimension(),
+        }),
+    }
+}
+
+/// Inverse of [`overflow_value_to_json`]. Used by tests (and available to custom
+/// re-import tooling) to reconstruct the exact [`PropertyValue`] from its tagged JSON.
+#[cfg(test)]
+pub(super) fn overflow_json_to_value(
+    value: &serde_json::Value,
+) -> std::result::Result<PropertyValue, String> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| "overflow value must be a JSON object".to_string())?;
+    let tag = obj
+        .get("t")
+        .and_then(|t| t.as_str())
+        .ok_or_else(|| "overflow value missing 't' tag".to_string())?;
+    match tag {
+        "bool" => Ok(PropertyValue::Bool(
+            obj.get("v").and_then(|v| v.as_bool()).ok_or("bad bool")?,
+        )),
+        "int" => Ok(PropertyValue::Int(
+            obj.get("v").and_then(|v| v.as_i64()).ok_or("bad int")?,
+        )),
+        "float" => Ok(PropertyValue::Float(
+            obj.get("v").and_then(|v| v.as_f64()).ok_or("bad float")?,
+        )),
+        "str" => Ok(PropertyValue::string(
+            obj.get("v").and_then(|v| v.as_str()).ok_or("bad str")?,
+        )),
+        "bytes" => {
+            let arr = obj.get("v").and_then(|v| v.as_array()).ok_or("bad bytes")?;
+            let bytes: Vec<u8> = arr
+                .iter()
+                .map(|n| n.as_u64().map(|u| u as u8).ok_or("bad byte"))
+                .collect::<std::result::Result<_, _>>()?;
+            Ok(PropertyValue::bytes(bytes))
+        }
+        "vector" => {
+            let arr = obj
+                .get("v")
+                .and_then(|v| v.as_array())
+                .ok_or("bad vector")?;
+            let floats: Vec<f32> = arr
+                .iter()
+                .map(|n| n.as_f64().map(|f| f as f32).ok_or("bad float elem"))
+                .collect::<std::result::Result<_, _>>()?;
+            PropertyValue::try_vector(&floats).map_err(|e| e.to_string())
+        }
+        "array" => {
+            let arr = obj.get("v").and_then(|v| v.as_array()).ok_or("bad array")?;
+            let items: Vec<PropertyValue> = arr
+                .iter()
+                .map(overflow_json_to_value)
+                .collect::<std::result::Result<_, _>>()?;
+            Ok(PropertyValue::array(items))
+        }
+        "sparse" => {
+            let indices: Vec<u32> = obj
+                .get("indices")
+                .and_then(|v| v.as_array())
+                .ok_or("bad indices")?
+                .iter()
+                .map(|n| n.as_u64().map(|u| u as u32).ok_or("bad index"))
+                .collect::<std::result::Result<_, _>>()?;
+            let values: Vec<f32> = obj
+                .get("values")
+                .and_then(|v| v.as_array())
+                .ok_or("bad values")?
+                .iter()
+                .map(|n| n.as_f64().map(|f| f as f32).ok_or("bad value"))
+                .collect::<std::result::Result<_, _>>()?;
+            let dim = obj.get("dim").and_then(|v| v.as_u64()).ok_or("bad dim")? as u32;
+            let sv = crate::core::vector::SparseVec::new(indices, values, dim)
+                .map_err(|e| e.to_string())?;
+            Ok(PropertyValue::sparse_vector(sv))
+        }
+        other => Err(format!("unknown overflow tag '{other}'")),
+    }
+}
+
+/// Build a UTC microsecond-timestamp array from optional epoch micros.
+fn ts_array(values: Vec<Option<i64>>) -> ArrayRef {
+    Arc::new(TimestampMicrosecondArray::from(values).with_timezone("UTC"))
+}
+
+/// The Arrow `DataType` of a UTC microsecond-timestamp column.
+fn ts_datatype() -> DataType {
+    DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()))
+}
+
+/// File-level metadata describing the export.
+fn file_metadata(mode: &str, entity: &str) -> HashMap<String, String> {
+    let mut md = HashMap::new();
+    md.insert(
+        "aletheiadb.schema_version".to_string(),
+        SCHEMA_VERSION.to_string(),
+    );
+    md.insert("aletheiadb.mode".to_string(), mode.to_string());
+    md.insert("aletheiadb.entity".to_string(), entity.to_string());
+    md
+}
+
+/// A streaming Parquet writer that flushes one row group per batch.
+struct StreamWriter {
+    schema: Arc<Schema>,
+    writer: ArrowWriter<File>,
+}
+
+impl StreamWriter {
+    fn create(path: &Path, schema: Arc<Schema>, batch_size: usize) -> Result<Self> {
+        let file = File::create(path)
+            .map_err(|e| Error::other(format!("creating {}: {e}", path.display())))?;
+        let props = WriterProperties::builder()
+            .set_max_row_group_row_count(Some(batch_size.max(1)))
+            .build();
+        let writer = ArrowWriter::try_new(file, schema.clone(), Some(props))
+            .map_err(|e| Error::other(format!("opening parquet writer: {e}")))?;
+        Ok(StreamWriter { schema, writer })
+    }
+
+    fn write(&mut self, arrays: Vec<ArrayRef>) -> Result<()> {
+        let batch = RecordBatch::try_new(self.schema.clone(), arrays)
+            .map_err(|e| Error::other(format!("building record batch: {e}")))?;
+        self.writer
+            .write(&batch)
+            .map_err(|e| Error::other(format!("writing parquet batch: {e}")))
+    }
+
+    fn close(self) -> Result<()> {
+        self.writer
+            .close()
+            .map_err(|e| Error::other(format!("closing parquet writer: {e}")))?;
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Current-state node export
+// ============================================================================
+
+/// Reserved fixed-column names for current-state node export.
+const NODE_RESERVED: &[&str] = &[COL_ID, COL_LABEL, COL_VALID_TIME, COL_PROPERTIES_JSON];
+
+pub(super) fn export_nodes(
+    db: &AletheiaDB,
+    path: &Path,
+    batch_size: usize,
+) -> Result<ExportReport> {
+    let node_ids = db.get_all_node_ids();
+
+    // Pass 1: discover the property schema.
+    let mut builder = SchemaBuilder::new(NODE_RESERVED);
+    for &id in &node_ids {
+        if let Ok(node) = db.get_node(id) {
+            builder.observe(&node.properties);
+        }
+    }
+    let prop_schema = builder.finish();
+
+    // Fixed columns, then property columns.
+    let mut fields = vec![
+        Field::new(COL_ID, DataType::Int64, false),
+        Field::new(COL_LABEL, DataType::Utf8, false),
+        Field::new(COL_VALID_TIME, ts_datatype(), true),
+    ];
+    fields.extend(prop_schema.fields());
+    let schema = Arc::new(Schema::new_with_metadata(
+        fields,
+        file_metadata("current", "node"),
+    ));
+
+    let mut writer = StreamWriter::create(path, schema, batch_size)?;
+    let mut report = ExportReport::default();
+
+    // Pass 2: stream rows.
+    let mut ids: Vec<i64> = Vec::new();
+    let mut labels: Vec<Option<String>> = Vec::new();
+    let mut valid_times: Vec<Option<i64>> = Vec::new();
+    let mut props = PropColumns::new_from_prop_schema(&prop_schema);
+
+    for &id in &node_ids {
+        let Ok(node) = db.get_node(id) else { continue };
+        ids.push(id.as_u64() as i64);
+        labels.push(GLOBAL_INTERNER.resolve_with(node.label, |s| s.to_string()));
+        valid_times.push(current_valid_from_node(db, node.current_version));
+        props.push(&node.properties);
+        report.nodes_exported += 1;
+
+        if ids.len() >= batch_size {
+            flush_current(
+                &mut writer,
+                &mut ids,
+                &mut labels,
+                &mut valid_times,
+                &mut props,
+            )?;
+        }
+    }
+    if !ids.is_empty() {
+        flush_current(
+            &mut writer,
+            &mut ids,
+            &mut labels,
+            &mut valid_times,
+            &mut props,
+        )?;
+    }
+
+    writer.close()?;
+    Ok(report)
+}
+
+/// Flush the accumulated current-state node/edge shared tail (id-ish header handled by
+/// caller-provided vecs) — used by the node current-state path.
+fn flush_current(
+    writer: &mut StreamWriter,
+    ids: &mut Vec<i64>,
+    labels: &mut Vec<Option<String>>,
+    valid_times: &mut Vec<Option<i64>>,
+    props: &mut PropColumns,
+) -> Result<()> {
+    let mut arrays: Vec<ArrayRef> = vec![
+        Arc::new(Int64Array::from(std::mem::take(ids))),
+        Arc::new(StringArray::from_iter(std::mem::take(labels))),
+        ts_array(std::mem::take(valid_times)),
+    ];
+    props.finish_into(&mut arrays);
+    writer.write(arrays)
+}
+
+// ============================================================================
+// Current-state edge export
+// ============================================================================
+
+const EDGE_RESERVED: &[&str] = &[
+    COL_EDGE_TYPE,
+    COL_SOURCE_KEY,
+    COL_TARGET_KEY,
+    COL_VALID_TIME,
+    COL_PROPERTIES_JSON,
+];
+
+pub(super) fn export_edges(
+    db: &AletheiaDB,
+    path: &Path,
+    batch_size: usize,
+) -> Result<ExportReport> {
+    let node_ids = db.get_all_node_ids();
+
+    // Pass 1: discover property schema over all edges (reached via outgoing adjacency).
+    let mut builder = SchemaBuilder::new(EDGE_RESERVED);
+    for &nid in &node_ids {
+        for eid in db.get_outgoing_edges(nid) {
+            if let Ok(edge) = db.get_edge(eid) {
+                builder.observe(&edge.properties);
+            }
+        }
+    }
+    let prop_schema = builder.finish();
+
+    let mut fields = vec![
+        Field::new(COL_EDGE_TYPE, DataType::Utf8, false),
+        Field::new(COL_SOURCE_KEY, DataType::Int64, false),
+        Field::new(COL_TARGET_KEY, DataType::Int64, false),
+        Field::new(COL_VALID_TIME, ts_datatype(), true),
+    ];
+    fields.extend(prop_schema.fields());
+    let schema = Arc::new(Schema::new_with_metadata(
+        fields,
+        file_metadata("current", "edge"),
+    ));
+
+    let mut writer = StreamWriter::create(path, schema, batch_size)?;
+    let mut report = ExportReport::default();
+
+    let mut edge_types: Vec<Option<String>> = Vec::new();
+    let mut sources: Vec<i64> = Vec::new();
+    let mut targets: Vec<i64> = Vec::new();
+    let mut valid_times: Vec<Option<i64>> = Vec::new();
+    let mut props = PropColumns::new_from_prop_schema(&prop_schema);
+
+    for &nid in &node_ids {
+        for eid in db.get_outgoing_edges(nid) {
+            let Ok(edge) = db.get_edge(eid) else { continue };
+            edge_types.push(GLOBAL_INTERNER.resolve_with(edge.label, |s| s.to_string()));
+            sources.push(edge.source.as_u64() as i64);
+            targets.push(edge.target.as_u64() as i64);
+            valid_times.push(current_valid_from_edge(db, edge.current_version));
+            props.push(&edge.properties);
+            report.edges_exported += 1;
+
+            if edge_types.len() >= batch_size {
+                flush_edges(
+                    &mut writer,
+                    &mut edge_types,
+                    &mut sources,
+                    &mut targets,
+                    &mut valid_times,
+                    &mut props,
+                )?;
+            }
+        }
+    }
+    if !edge_types.is_empty() {
+        flush_edges(
+            &mut writer,
+            &mut edge_types,
+            &mut sources,
+            &mut targets,
+            &mut valid_times,
+            &mut props,
+        )?;
+    }
+
+    writer.close()?;
+    Ok(report)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn flush_edges(
+    writer: &mut StreamWriter,
+    edge_types: &mut Vec<Option<String>>,
+    sources: &mut Vec<i64>,
+    targets: &mut Vec<i64>,
+    valid_times: &mut Vec<Option<i64>>,
+    props: &mut PropColumns,
+) -> Result<()> {
+    let mut arrays: Vec<ArrayRef> = vec![
+        Arc::new(StringArray::from_iter(std::mem::take(edge_types))),
+        Arc::new(Int64Array::from(std::mem::take(sources))),
+        Arc::new(Int64Array::from(std::mem::take(targets))),
+        ts_array(std::mem::take(valid_times)),
+    ];
+    props.finish_into(&mut arrays);
+    writer.write(arrays)
+}
+
+// ============================================================================
+// History export (nodes and edges)
+// ============================================================================
+
+const NODE_HISTORY_RESERVED: &[&str] = &[
+    COL_ID,
+    COL_LABEL,
+    COL_VERSION,
+    COL_VALID_FROM,
+    COL_VALID_TO,
+    COL_TRANSACTION_TIME,
+    COL_TOMBSTONE,
+    COL_PROV_SOURCE,
+    COL_PROV_CONFIDENCE,
+    COL_PROV_NOTE,
+    COL_PROV_CORRELATION_ID,
+    COL_PROV_PRINCIPAL,
+    COL_PROPERTIES_JSON,
+];
+
+const EDGE_HISTORY_RESERVED: &[&str] = &[
+    COL_ID,
+    COL_EDGE_TYPE,
+    COL_SOURCE_KEY,
+    COL_TARGET_KEY,
+    COL_VERSION,
+    COL_VALID_FROM,
+    COL_VALID_TO,
+    COL_TRANSACTION_TIME,
+    COL_TOMBSTONE,
+    COL_PROV_SOURCE,
+    COL_PROV_CONFIDENCE,
+    COL_PROV_NOTE,
+    COL_PROV_CORRELATION_ID,
+    COL_PROV_PRINCIPAL,
+    COL_PROPERTIES_JSON,
+];
+
+/// The bi-temporal + provenance tail columns shared by node and edge history.
+fn history_tail_fields() -> Vec<Field> {
+    vec![
+        Field::new(COL_VERSION, DataType::Int64, false),
+        Field::new(COL_VALID_FROM, ts_datatype(), true),
+        Field::new(COL_VALID_TO, ts_datatype(), true),
+        Field::new(COL_TRANSACTION_TIME, ts_datatype(), true),
+        Field::new(COL_TOMBSTONE, DataType::Boolean, false),
+        Field::new(COL_PROV_SOURCE, DataType::Utf8, true),
+        Field::new(COL_PROV_CONFIDENCE, DataType::Float64, true),
+        Field::new(COL_PROV_NOTE, DataType::Utf8, true),
+        Field::new(COL_PROV_CORRELATION_ID, DataType::Utf8, true),
+        Field::new(COL_PROV_PRINCIPAL, DataType::Utf8, true),
+    ]
+}
+
+/// Column accumulators for the shared history tail.
+#[derive(Default)]
+struct HistoryTail {
+    versions: Vec<i64>,
+    valid_from: Vec<Option<i64>>,
+    valid_to: Vec<Option<i64>>,
+    transaction_time: Vec<Option<i64>>,
+    tombstone: Vec<bool>,
+    prov_source: Vec<Option<String>>,
+    prov_confidence: Vec<Option<f64>>,
+    prov_note: Vec<Option<String>>,
+    prov_correlation_id: Vec<Option<String>>,
+    prov_principal: Vec<Option<String>>,
+}
+
+impl HistoryTail {
+    fn push(&mut self, version: &VersionInfo) {
+        let valid = version.temporal.valid_time();
+        let tx = version.temporal.transaction_time();
+        self.versions.push(version.version_number as i64);
+        self.valid_from.push(Some(valid.start().wallclock()));
+        // Open interval => null (never the TIMESTAMP_MAX sentinel).
+        self.valid_to.push(if valid.is_current() {
+            None
+        } else {
+            Some(valid.end().wallclock())
+        });
+        self.transaction_time.push(Some(tx.start().wallclock()));
+        // A closed valid interval marks the fact's real-world validity as ended
+        // (deletion / retraction). See the module docs for the exact convention.
+        self.tombstone.push(!valid.is_current());
+
+        let prov = version.provenance.as_ref();
+        self.prov_source
+            .push(prov.and_then(Provenance::source).map(str::to_string));
+        self.prov_confidence
+            .push(prov.and_then(Provenance::confidence));
+        self.prov_note
+            .push(prov.and_then(Provenance::note).map(str::to_string));
+        self.prov_correlation_id.push(
+            prov.and_then(Provenance::correlation_id)
+                .map(str::to_string),
+        );
+        self.prov_principal
+            .push(prov.and_then(Provenance::principal).map(str::to_string));
+    }
+
+    fn len(&self) -> usize {
+        self.versions.len()
+    }
+
+    fn finish_into(&mut self, arrays: &mut Vec<ArrayRef>) {
+        arrays.push(Arc::new(Int64Array::from(std::mem::take(
+            &mut self.versions,
+        ))));
+        arrays.push(ts_array(std::mem::take(&mut self.valid_from)));
+        arrays.push(ts_array(std::mem::take(&mut self.valid_to)));
+        arrays.push(ts_array(std::mem::take(&mut self.transaction_time)));
+        arrays.push(Arc::new(BooleanArray::from(std::mem::take(
+            &mut self.tombstone,
+        ))));
+        arrays.push(Arc::new(StringArray::from_iter(std::mem::take(
+            &mut self.prov_source,
+        ))));
+        arrays.push(Arc::new(Float64Array::from(std::mem::take(
+            &mut self.prov_confidence,
+        ))));
+        arrays.push(Arc::new(StringArray::from_iter(std::mem::take(
+            &mut self.prov_note,
+        ))));
+        arrays.push(Arc::new(StringArray::from_iter(std::mem::take(
+            &mut self.prov_correlation_id,
+        ))));
+        arrays.push(Arc::new(StringArray::from_iter(std::mem::take(
+            &mut self.prov_principal,
+        ))));
+    }
+}
+
+pub(super) fn export_node_history(
+    db: &AletheiaDB,
+    path: &Path,
+    batch_size: usize,
+) -> Result<ExportReport> {
+    // Enumerate every node ever recorded (incl. deleted/retracted) via the changefeed.
+    let node_ids: Vec<NodeId> = collect_history_ids(db, EntityKind::Node)?
+        .into_iter()
+        .filter_map(|id| NodeId::new(id).ok())
+        .collect();
+
+    // Pass 1: property schema over all versions of all nodes.
+    let mut builder = SchemaBuilder::new(NODE_HISTORY_RESERVED);
+    for &id in &node_ids {
+        if let Ok(history) = db.get_node_history(id) {
+            for version in &history.versions {
+                builder.observe(&version.properties);
+            }
+        }
+    }
+    let prop_schema = builder.finish();
+
+    // Schema: id, label, [props], <tail>.
+    let mut fields = vec![
+        Field::new(COL_ID, DataType::Int64, false),
+        Field::new(COL_LABEL, DataType::Utf8, false),
+    ];
+    let prop_fields = prop_schema.fields();
+    fields.extend(prop_fields.clone());
+    fields.extend(history_tail_fields());
+    let schema = Arc::new(Schema::new_with_metadata(
+        fields,
+        file_metadata("history", "node"),
+    ));
+
+    let mut writer = StreamWriter::create(path, schema, batch_size)?;
+    let mut report = ExportReport::default();
+
+    let mut ids: Vec<i64> = Vec::new();
+    let mut labels: Vec<Option<String>> = Vec::new();
+    let mut props = PropColumns::new_from_prop_schema(&prop_schema);
+    let mut tail = HistoryTail::default();
+
+    for &id in &node_ids {
+        let Ok(history) = db.get_node_history(id) else {
+            continue;
+        };
+        for version in &history.versions {
+            ids.push(id.as_u64() as i64);
+            labels.push(Some(version.label.clone()));
+            props.push(&version.properties);
+            tail.push(version);
+            report.node_versions_exported += 1;
+
+            if ids.len() >= batch_size {
+                let mut arrays: Vec<ArrayRef> = vec![
+                    Arc::new(Int64Array::from(std::mem::take(&mut ids))),
+                    Arc::new(StringArray::from_iter(std::mem::take(&mut labels))),
+                ];
+                props.finish_into(&mut arrays);
+                tail.finish_into(&mut arrays);
+                writer.write(arrays)?;
+            }
+        }
+    }
+    if !ids.is_empty() || tail.len() > 0 {
+        let mut arrays: Vec<ArrayRef> = vec![
+            Arc::new(Int64Array::from(std::mem::take(&mut ids))),
+            Arc::new(StringArray::from_iter(std::mem::take(&mut labels))),
+        ];
+        props.finish_into(&mut arrays);
+        tail.finish_into(&mut arrays);
+        writer.write(arrays)?;
+    }
+
+    writer.close()?;
+    Ok(report)
+}
+
+pub(super) fn export_edge_history(
+    db: &AletheiaDB,
+    path: &Path,
+    batch_size: usize,
+) -> Result<ExportReport> {
+    // Enumerate every edge ever recorded (incl. deleted) via the changefeed, so a
+    // deleted edge's history is still exported. Endpoints for an edge no longer in
+    // current state are written as null (they are not carried on a historical version).
+    let edge_ids: Vec<EdgeId> = collect_history_ids(db, EntityKind::Edge)?
+        .into_iter()
+        .filter_map(|id| EdgeId::new(id).ok())
+        .collect();
+
+    // Pass 1: property schema over all versions of all edges.
+    let mut builder = SchemaBuilder::new(EDGE_HISTORY_RESERVED);
+    for &eid in &edge_ids {
+        if let Ok(history) = db.get_edge_history(eid) {
+            for version in &history.versions {
+                builder.observe(&version.properties);
+            }
+        }
+    }
+    let prop_schema = builder.finish();
+
+    // Schema: id, edge_type, source_key, target_key, [props], <tail>.
+    let mut fields = vec![
+        Field::new(COL_ID, DataType::Int64, false),
+        Field::new(COL_EDGE_TYPE, DataType::Utf8, false),
+        Field::new(COL_SOURCE_KEY, DataType::Int64, true),
+        Field::new(COL_TARGET_KEY, DataType::Int64, true),
+    ];
+    fields.extend(prop_schema.fields());
+    fields.extend(history_tail_fields());
+    let schema = Arc::new(Schema::new_with_metadata(
+        fields,
+        file_metadata("history", "edge"),
+    ));
+
+    let mut writer = StreamWriter::create(path, schema, batch_size)?;
+    let mut report = ExportReport::default();
+
+    let mut ids: Vec<i64> = Vec::new();
+    let mut edge_types: Vec<Option<String>> = Vec::new();
+    let mut sources: Vec<Option<i64>> = Vec::new();
+    let mut targets: Vec<Option<i64>> = Vec::new();
+    let mut props = PropColumns::new_from_prop_schema(&prop_schema);
+    let mut tail = HistoryTail::default();
+
+    for &eid in &edge_ids {
+        let Ok(history) = db.get_edge_history(eid) else {
+            continue;
+        };
+        // Endpoints come from the current edge when it is still live; a deleted edge's
+        // endpoints are not carried on a historical version, so they are null.
+        let (source, target) = match db.get_edge(eid) {
+            Ok(edge) => (
+                Some(edge.source.as_u64() as i64),
+                Some(edge.target.as_u64() as i64),
+            ),
+            Err(_) => (None, None),
+        };
+        for version in &history.versions {
+            ids.push(eid.as_u64() as i64);
+            edge_types.push(Some(version.label.clone()));
+            sources.push(source);
+            targets.push(target);
+            props.push(&version.properties);
+            tail.push(version);
+            report.edge_versions_exported += 1;
+
+            if ids.len() >= batch_size {
+                flush_edge_history(
+                    &mut writer,
+                    &mut ids,
+                    &mut edge_types,
+                    &mut sources,
+                    &mut targets,
+                    &mut props,
+                    &mut tail,
+                )?;
+            }
+        }
+    }
+    if !ids.is_empty() || tail.len() > 0 {
+        flush_edge_history(
+            &mut writer,
+            &mut ids,
+            &mut edge_types,
+            &mut sources,
+            &mut targets,
+            &mut props,
+            &mut tail,
+        )?;
+    }
+
+    writer.close()?;
+    Ok(report)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn flush_edge_history(
+    writer: &mut StreamWriter,
+    ids: &mut Vec<i64>,
+    edge_types: &mut Vec<Option<String>>,
+    sources: &mut Vec<Option<i64>>,
+    targets: &mut Vec<Option<i64>>,
+    props: &mut PropColumns,
+    tail: &mut HistoryTail,
+) -> Result<()> {
+    let mut arrays: Vec<ArrayRef> = vec![
+        Arc::new(Int64Array::from(std::mem::take(ids))),
+        Arc::new(StringArray::from_iter(std::mem::take(edge_types))),
+        Arc::new(Int64Array::from(std::mem::take(sources))),
+        Arc::new(Int64Array::from(std::mem::take(targets))),
+    ];
+    props.finish_into(&mut arrays);
+    tail.finish_into(&mut arrays);
+    writer.write(arrays)
+}
+
+// ============================================================================
+// Shared helpers
+// ============================================================================
+
+impl PropColumns {
+    /// Convenience constructor used by the export pipelines.
+    fn new_from_prop_schema(schema: &PropSchema) -> Self {
+        PropColumns::new(schema)
+    }
+}
+
+/// Page size for the changefeed enumeration driving history export.
+const CHANGEFEED_PAGE: usize = 4096;
+
+/// Enumerate the **distinct** entity ids of the requested `kind` across all recorded
+/// history — including entities that were deleted or retracted and are therefore no
+/// longer in current state — by paging the whole-window changefeed.
+///
+/// Returned ids are ascending (deterministic). Any residual completeness caveat is the
+/// changefeed's own (a version's transaction time must fall inside `[0, TIMESTAMP_MAX)`,
+/// which every committed version does; cold-tier versions are merged by `list_changes`).
+fn collect_history_ids(db: &AletheiaDB, kind: EntityKind) -> Result<Vec<u64>> {
+    let mut ids = std::collections::BTreeSet::new();
+    let mut cursor: Option<String> = None;
+    loop {
+        let mut query = ChangeFeedQuery::new(Timestamp::from(0), TIMESTAMP_MAX, CHANGEFEED_PAGE);
+        query.cursor = cursor.take();
+        let page = db.list_changes(&query)?;
+        for record in &page.changes {
+            if record.kind == kind {
+                ids.insert(record.entity_id);
+            }
+        }
+        match page.next_cursor {
+            Some(next) => cursor = Some(next),
+            None => break,
+        }
+    }
+    Ok(ids.into_iter().collect())
+}
+
+/// The current node version's valid-time start (epoch micros), if resolvable.
+fn current_valid_from_node(db: &AletheiaDB, version_id: crate::core::id::VersionId) -> Option<i64> {
+    match db.get_node_version_read_metadata(version_id) {
+        Ok(Some((_, interval))) => Some(interval.valid_time().start().wallclock()),
+        _ => None,
+    }
+}
+
+/// The current edge version's valid-time start (epoch micros), if resolvable.
+fn current_valid_from_edge(db: &AletheiaDB, version_id: crate::core::id::VersionId) -> Option<i64> {
+    match db.get_edge_version_read_metadata(version_id) {
+        Ok(Some((_, interval))) => Some(interval.valid_time().start().wallclock()),
+        _ => None,
+    }
+}

--- a/src/api/export/tests.rs
+++ b/src/api/export/tests.rs
@@ -361,6 +361,104 @@ fn type_conflicting_key_routes_to_overflow() {
 }
 
 // ---------------------------------------------------------------------------
+// Overflow column auto-expands on re-import (end-to-end, no manual key mapping)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn overflow_column_auto_expands_on_reimport_end_to_end() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let bytes = PropertyValue::bytes(vec![1u8, 2, 3, 255, 0, 128]);
+    let array = PropertyValue::array(vec![
+        PropertyValue::Int(7),
+        PropertyValue::string("mixed"),
+        PropertyValue::Bool(false),
+        PropertyValue::Float(2.5),
+    ]);
+    let sparse = PropertyValue::sparse_vector(
+        SparseVec::new(vec![1u32, 5, 9], vec![0.5f32, -0.25, 1.75], 16).unwrap(),
+    );
+
+    let doc = db
+        .create_node(
+            "Doc",
+            PropertyMapBuilder::new()
+                .insert("title", "keep-native")
+                .insert("blob", bytes.clone())
+                .insert("tags", array.clone())
+                .insert("sparse", sparse.clone())
+                .build(),
+        )
+        .unwrap();
+
+    let path = files.path().join("nodes.parquet");
+    db.export().nodes_to_parquet(&path).unwrap();
+
+    // Re-import into a fresh database. The mapping declares ONLY the native `title`
+    // column; the exotic overflow keys are auto-expanded from `properties_json`.
+    let (_tmp2, db2) = create_test_db().unwrap();
+    let mut importer = db2.import();
+    let mapping = NodeMapping::new(LabelSource::column("label"), "id")
+        .property_same("title", ColumnType::String);
+    importer.nodes_from_parquet(&path, mapping).unwrap();
+
+    let id = importer.resolve_key(&doc.as_u64().to_string()).unwrap();
+    let node = db2.get_node(id).unwrap();
+    assert_eq!(
+        node.properties.get("title"),
+        Some(&PropertyValue::string("keep-native"))
+    );
+    // Byte / element-identical round trip of the overflow values.
+    assert_eq!(node.properties.get("blob"), Some(&bytes));
+    assert_eq!(node.properties.get("tags"), Some(&array));
+    assert_eq!(node.properties.get("sparse"), Some(&sparse));
+}
+
+#[test]
+fn overflow_non_finite_floats_round_trip() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    // A heterogeneous array (overflow-routed) carrying non-finite floats, which
+    // serde_json would otherwise map to `null`.
+    let array = PropertyValue::array(vec![
+        PropertyValue::Float(f64::NAN),
+        PropertyValue::Float(f64::INFINITY),
+        PropertyValue::Float(f64::NEG_INFINITY),
+        PropertyValue::Float(1.5),
+    ]);
+    let doc = db
+        .create_node(
+            "Doc",
+            PropertyMapBuilder::new().insert("arr", array).build(),
+        )
+        .unwrap();
+
+    let path = files.path().join("nodes.parquet");
+    db.export().nodes_to_parquet(&path).unwrap();
+
+    let (_tmp2, db2) = create_test_db().unwrap();
+    let mut importer = db2.import();
+    importer
+        .nodes_from_parquet(&path, NodeMapping::new(LabelSource::column("label"), "id"))
+        .unwrap();
+    let id = importer.resolve_key(&doc.as_u64().to_string()).unwrap();
+    let node = db2.get_node(id).unwrap();
+
+    let items = node
+        .properties
+        .get("arr")
+        .and_then(PropertyValue::as_array)
+        .expect("array present");
+    assert_eq!(items.len(), 4);
+    assert!(matches!(items[0], PropertyValue::Float(f) if f.is_nan()));
+    assert!(matches!(items[1], PropertyValue::Float(f) if f == f64::INFINITY));
+    assert!(matches!(items[2], PropertyValue::Float(f) if f == f64::NEG_INFINITY));
+    assert!(matches!(items[3], PropertyValue::Float(f) if f == 1.5));
+}
+
+// ---------------------------------------------------------------------------
 // History export: one row per version, open valid_to null, tombstone, provenance
 // ---------------------------------------------------------------------------
 
@@ -540,6 +638,155 @@ fn node_history_export_carries_provenance_columns() {
         .unwrap();
     assert_eq!(src.value(0), "ingest");
     assert!((conf.value(0) - 0.9).abs() < 1e-9);
+}
+
+// ---------------------------------------------------------------------------
+// Deleted-edge history recovers its endpoints (not null)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deleted_edge_history_recovers_source_and_target_keys() {
+    use crate::api::transaction::WriteOps;
+
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let alice = db.create_node("Person", PropertyMap::new()).unwrap();
+    let bob = db.create_node("Person", PropertyMap::new()).unwrap();
+    let edge = db
+        .create_edge(alice, bob, "KNOWS", PropertyMap::new())
+        .unwrap();
+    // Delete the edge: it leaves current state but keeps its history.
+    db.write(|tx| tx.delete_edge(edge)).unwrap();
+
+    let path = files.path().join("edge_history.parquet");
+    let report = db.export().edge_history_to_parquet(&path).unwrap();
+    assert!(report.edge_versions_exported >= 1);
+
+    let (schema, batches) = read_parquet(&path);
+    let src_idx = schema.index_of("source_key").unwrap();
+    let tgt_idx = schema.index_of("target_key").unwrap();
+
+    let mut rows = 0usize;
+    for batch in &batches {
+        let src = batch
+            .column(src_idx)
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap();
+        let tgt = batch
+            .column(tgt_idx)
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap();
+        for i in 0..src.len() {
+            rows += 1;
+            assert!(!src.is_null(i), "deleted edge source_key must be recovered");
+            assert!(!tgt.is_null(i), "deleted edge target_key must be recovered");
+            assert_eq!(src.value(i), alice.as_u64() as i64);
+            assert_eq!(tgt.value(i), bob.as_u64() as i64);
+        }
+    }
+    assert!(rows >= 1, "expected at least one historical edge version");
+}
+
+// ---------------------------------------------------------------------------
+// History export carries the transaction-interval END (transaction_to)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn node_history_export_has_transaction_to_column_null_for_open() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    db.create_node(
+        "Person",
+        PropertyMapBuilder::new().insert("name", "Alice").build(),
+    )
+    .unwrap();
+
+    let path = files.path().join("node_history.parquet");
+    db.export().node_history_to_parquet(&path).unwrap();
+
+    let (schema, batches) = read_parquet(&path);
+    let names = field_names(&schema);
+    assert!(
+        names.contains(&"transaction_to".to_string()),
+        "history schema must expose transaction_to"
+    );
+
+    // The current, still-recorded version has an OPEN transaction interval => null.
+    let tx_to_idx = schema.index_of("transaction_to").unwrap();
+    let open_rows: usize = batches
+        .iter()
+        .map(|batch| {
+            let col = batch
+                .column(tx_to_idx)
+                .as_any()
+                .downcast_ref::<TimestampMicrosecondArray>()
+                .unwrap();
+            (0..col.len()).filter(|&i| col.is_null(i)).count()
+        })
+        .sum();
+    assert!(
+        open_rows >= 1,
+        "the current version must have a null (open) transaction_to"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tombstone pin: tombstone == "this version's valid interval is closed" (v1)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn node_history_tombstone_equals_closed_valid_interval() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("title", "Engineer")
+                .build(),
+        )
+        .unwrap();
+    // A valid-time supersession (ordinary update, NOT a delete/retract).
+    db.write(|tx| {
+        tx.update_node(
+            id,
+            PropertyMapBuilder::new().insert("title", "Staff").build(),
+        )
+    })
+    .unwrap();
+
+    let path = files.path().join("node_history.parquet");
+    db.export().node_history_to_parquet(&path).unwrap();
+
+    let (schema, batches) = read_parquet(&path);
+    let tomb_idx = schema.index_of("tombstone").unwrap();
+    let valid_to_idx = schema.index_of("valid_to").unwrap();
+
+    // Pin the documented v1 semantics exactly: a row is a tombstone iff its valid
+    // interval is closed (non-null valid_to) — which also flags valid-time-superseded
+    // versions, not only deletes/retractions.
+    for batch in &batches {
+        let tomb = batch
+            .column(tomb_idx)
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap();
+        let valid_to = batch
+            .column(valid_to_idx)
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap();
+        for i in 0..tomb.len() {
+            assert_eq!(
+                tomb.value(i),
+                !valid_to.is_null(i),
+                "tombstone must equal (valid interval closed)"
+            );
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/api/export/tests.rs
+++ b/src/api/export/tests.rs
@@ -1,0 +1,614 @@
+//! Tests for the Parquet export path (Issue #3364).
+//!
+//! Coverage: current-state round-trip (export → import → identical graph, including
+//! int/float/bool/string/embedding exact bits and valid-time AS OF), absent property →
+//! null → absent, the `properties_json` overflow column for bytes/array/sparse and
+//! type-conflicting keys (with a decode round-trip), history export shape (one row per
+//! version, open `valid_to` = null not sentinel, tombstone, provenance columns),
+//! streaming a large export, and an empty database producing a valid empty file.
+
+use std::fs::File;
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::array::{
+    Array, BooleanArray, Float64Array, RecordBatch, StringArray, TimestampMicrosecondArray,
+};
+use arrow::datatypes::Schema;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use tempfile::TempDir;
+
+use super::parquet::overflow_json_to_value;
+use crate::api::import::{ColumnType, EdgeMapping, LabelSource, NodeMapping};
+use crate::api::transaction::WriteOps;
+use crate::core::property::{PropertyMap, PropertyMapBuilder, PropertyValue};
+use crate::core::temporal::{TIMESTAMP_MAX, time};
+use crate::core::vector::SparseVec;
+use crate::test_utils::create_test_db;
+
+/// Read a Parquet file back into its schema and all record batches.
+fn read_parquet(path: &Path) -> (Arc<Schema>, Vec<RecordBatch>) {
+    let file = File::open(path).expect("open parquet");
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file).expect("parquet reader builder");
+    let schema = builder.schema().clone();
+    let reader = builder.build().expect("parquet reader");
+    let batches = reader
+        .map(|b| b.expect("read batch"))
+        .collect::<Vec<RecordBatch>>();
+    (schema, batches)
+}
+
+/// Total row count across all batches.
+fn total_rows(batches: &[RecordBatch]) -> usize {
+    batches.iter().map(RecordBatch::num_rows).sum()
+}
+
+/// Names of the columns in schema order.
+fn field_names(schema: &Schema) -> Vec<String> {
+    schema.fields().iter().map(|f| f.name().clone()).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Current-state round-trip: export → import → identical graph
+// ---------------------------------------------------------------------------
+
+#[test]
+fn current_state_round_trip_all_scalar_types_and_embedding() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let embedding: Vec<f32> = vec![1.5, -2.25, 3.0, 0.125];
+    let alice = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .insert("age", 30i64)
+                .insert("score", 3.5f64)
+                .insert("active", true)
+                .insert_vector("embedding", &embedding)
+                .build(),
+        )
+        .unwrap();
+    let bob = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Bob")
+                .insert("age", 25i64)
+                .build(),
+        )
+        .unwrap();
+    db.create_edge(
+        alice,
+        bob,
+        "KNOWS",
+        PropertyMapBuilder::new().insert("since", 2020i64).build(),
+    )
+    .unwrap();
+
+    let nodes_path = files.path().join("nodes.parquet");
+    let edges_path = files.path().join("edges.parquet");
+    let node_report = db.export().nodes_to_parquet(&nodes_path).unwrap();
+    let edge_report = db.export().edges_to_parquet(&edges_path).unwrap();
+    assert_eq!(node_report.nodes_exported, 2);
+    assert_eq!(edge_report.edges_exported, 1);
+
+    // Re-import into a fresh database and assert equivalence.
+    let (_tmp2, db2) = create_test_db().unwrap();
+    let mut importer = db2.import();
+    let node_mapping = NodeMapping::new(LabelSource::column("label"), "id")
+        .property_same("name", ColumnType::String)
+        .property_same("age", ColumnType::Int)
+        .property_same("score", ColumnType::Float)
+        .property_same("active", ColumnType::Bool)
+        .property_same("embedding", ColumnType::Embedding)
+        .valid_time_column("valid_time");
+    importer
+        .nodes_from_parquet(&nodes_path, node_mapping)
+        .unwrap();
+
+    let edge_mapping =
+        EdgeMapping::new(LabelSource::column("edge_type"), "source_key", "target_key")
+            .property_same("since", ColumnType::Int)
+            .valid_time_column("valid_time");
+    importer
+        .edges_from_parquet(&edges_path, edge_mapping)
+        .unwrap();
+
+    assert_eq!(db2.node_count(), 2);
+    assert_eq!(db2.edge_count(), 1);
+
+    // Business keys are the original node ids (stringified).
+    let alice2 = importer.resolve_key(&alice.as_u64().to_string()).unwrap();
+    let node = db2.get_node(alice2).unwrap();
+    assert_eq!(
+        node.properties.get("name"),
+        Some(&PropertyValue::string("Alice"))
+    );
+    assert_eq!(node.properties.get("age"), Some(&PropertyValue::Int(30)));
+    assert_eq!(
+        node.properties.get("score"),
+        Some(&PropertyValue::Float(3.5))
+    );
+    assert_eq!(
+        node.properties.get("active"),
+        Some(&PropertyValue::Bool(true))
+    );
+    let stored = node
+        .properties
+        .get("embedding")
+        .and_then(|v| v.as_vector())
+        .expect("embedding present");
+    assert_eq!(
+        stored.iter().map(|f| f.to_bits()).collect::<Vec<_>>(),
+        embedding.iter().map(|f| f.to_bits()).collect::<Vec<_>>(),
+        "embedding must round-trip with exact bits"
+    );
+}
+
+#[test]
+fn current_state_export_stamps_file_metadata() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    db.create_node("Person", PropertyMap::new()).unwrap();
+
+    let path = files.path().join("nodes.parquet");
+    db.export().nodes_to_parquet(&path).unwrap();
+
+    let (schema, _batches) = read_parquet(&path);
+    let md = schema.metadata();
+    assert_eq!(
+        md.get("aletheiadb.schema_version").map(String::as_str),
+        Some("1")
+    );
+    assert_eq!(
+        md.get("aletheiadb.mode").map(String::as_str),
+        Some("current")
+    );
+    assert_eq!(
+        md.get("aletheiadb.entity").map(String::as_str),
+        Some("node")
+    );
+}
+
+#[test]
+fn valid_time_column_reimports_and_answers_as_of() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .unwrap();
+    let created_valid_from = db
+        .get_node_version_read_metadata(db.get_node(id).unwrap().current_version)
+        .unwrap()
+        .map(|(_, interval)| interval.valid_time().start())
+        .unwrap();
+
+    let path = files.path().join("nodes.parquet");
+    db.export().nodes_to_parquet(&path).unwrap();
+
+    let (_tmp2, db2) = create_test_db().unwrap();
+    let mut importer = db2.import();
+    let mapping = NodeMapping::new(LabelSource::column("label"), "id")
+        .property_same("name", ColumnType::String)
+        .valid_time_column("valid_time");
+    importer.nodes_from_parquet(&path, mapping).unwrap();
+    let reimported = importer.resolve_key(&id.as_u64().to_string()).unwrap();
+
+    // The reimported node is valid at/after its original valid_from.
+    let now = time::now();
+    assert!(
+        db2.get_node_at_time(reimported, created_valid_from, now)
+            .is_ok()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Absent property → Parquet null → absent on re-import
+// ---------------------------------------------------------------------------
+
+#[test]
+fn absent_property_is_null_and_reimports_absent() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    // A has age; B does not.
+    let a = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "A")
+                .insert("age", 1i64)
+                .build(),
+        )
+        .unwrap();
+    let b = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "B").build(),
+        )
+        .unwrap();
+
+    let path = files.path().join("nodes.parquet");
+    db.export().nodes_to_parquet(&path).unwrap();
+
+    // The age column exists and is null for exactly one row.
+    let (schema, batches) = read_parquet(&path);
+    assert!(field_names(&schema).contains(&"age".to_string()));
+    let age_idx = schema.index_of("age").unwrap();
+    let null_count: usize = batches
+        .iter()
+        .map(|batch| {
+            let col = batch.column(age_idx);
+            (0..col.len()).filter(|&i| col.is_null(i)).count()
+        })
+        .sum();
+    assert_eq!(null_count, 1, "exactly B's age must be null");
+
+    // Re-import: B has no age property (absent, not a stored null).
+    let (_tmp2, db2) = create_test_db().unwrap();
+    let mut importer = db2.import();
+    let mapping = NodeMapping::new(LabelSource::column("label"), "id")
+        .property_same("name", ColumnType::String)
+        .property_same("age", ColumnType::Int);
+    importer.nodes_from_parquet(&path, mapping).unwrap();
+
+    let b2 = importer.resolve_key(&b.as_u64().to_string()).unwrap();
+    assert_eq!(db2.get_node(b2).unwrap().properties.get("age"), None);
+    let a2 = importer.resolve_key(&a.as_u64().to_string()).unwrap();
+    assert_eq!(
+        db2.get_node(a2).unwrap().properties.get("age"),
+        Some(&PropertyValue::Int(1))
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Overflow column: bytes / array / sparse vector round-trip through JSON
+// ---------------------------------------------------------------------------
+
+#[test]
+fn overflow_column_round_trips_bytes_array_and_sparse() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let bytes = PropertyValue::bytes(vec![1u8, 2, 3, 255]);
+    let array = PropertyValue::array(vec![
+        PropertyValue::Int(7),
+        PropertyValue::string("mixed"),
+        PropertyValue::Bool(false),
+    ]);
+    let sparse = PropertyValue::sparse_vector(
+        SparseVec::new(vec![1u32, 5], vec![0.5f32, -0.25], 16).unwrap(),
+    );
+
+    db.create_node(
+        "Doc",
+        PropertyMapBuilder::new()
+            .insert("blob", bytes.clone())
+            .insert("tags", array.clone())
+            .insert("sparse", sparse.clone())
+            .insert("title", "keep-native")
+            .build(),
+    )
+    .unwrap();
+
+    let path = files.path().join("nodes.parquet");
+    db.export().nodes_to_parquet(&path).unwrap();
+
+    let (schema, batches) = read_parquet(&path);
+    let names = field_names(&schema);
+    // The exotic keys are NOT native columns; the native scalar still is.
+    assert!(names.contains(&"properties_json".to_string()));
+    assert!(names.contains(&"title".to_string()));
+    assert!(!names.contains(&"blob".to_string()));
+    assert!(!names.contains(&"sparse".to_string()));
+
+    // Decode properties_json and confirm each value round-trips exactly.
+    let json_idx = schema.index_of("properties_json").unwrap();
+    let col = batches[0]
+        .column(json_idx)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    let obj: serde_json::Value = serde_json::from_str(col.value(0)).unwrap();
+    let map = obj.as_object().unwrap();
+
+    assert_eq!(overflow_json_to_value(&map["blob"]).unwrap(), bytes);
+    assert_eq!(overflow_json_to_value(&map["tags"]).unwrap(), array);
+    assert_eq!(overflow_json_to_value(&map["sparse"]).unwrap(), sparse);
+}
+
+#[test]
+fn type_conflicting_key_routes_to_overflow() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    // Same key "x" is Int on one node, String on another => conflict => overflow.
+    db.create_node("T", PropertyMapBuilder::new().insert("x", 42i64).build())
+        .unwrap();
+    db.create_node("T", PropertyMapBuilder::new().insert("x", "hello").build())
+        .unwrap();
+
+    let path = files.path().join("nodes.parquet");
+    db.export().nodes_to_parquet(&path).unwrap();
+
+    let (schema, batches) = read_parquet(&path);
+    let names = field_names(&schema);
+    assert!(
+        !names.contains(&"x".to_string()),
+        "conflicting key must not be a native column"
+    );
+    assert!(names.contains(&"properties_json".to_string()));
+
+    // Both rows carry a decodable tagged value under "x".
+    let json_idx = schema.index_of("properties_json").unwrap();
+    let mut decoded = Vec::new();
+    for batch in &batches {
+        let col = batch
+            .column(json_idx)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        for i in 0..col.len() {
+            let v: serde_json::Value = serde_json::from_str(col.value(i)).unwrap();
+            decoded.push(overflow_json_to_value(&v.as_object().unwrap()["x"]).unwrap());
+        }
+    }
+    assert!(decoded.contains(&PropertyValue::Int(42)));
+    assert!(decoded.contains(&PropertyValue::string("hello")));
+}
+
+// ---------------------------------------------------------------------------
+// History export: one row per version, open valid_to null, tombstone, provenance
+// ---------------------------------------------------------------------------
+
+#[test]
+fn node_history_export_one_row_per_version_with_open_valid_to_null() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("title", "Engineer")
+                .build(),
+        )
+        .unwrap();
+    // Second version.
+    db.write(|tx| {
+        tx.update_node(
+            id,
+            PropertyMapBuilder::new().insert("title", "Staff").build(),
+        )
+    })
+    .unwrap();
+
+    let versions = db.get_node_history(id).unwrap().versions.len();
+    assert!(versions >= 2, "expected at least two versions");
+
+    let path = files.path().join("node_history.parquet");
+    let report = db.export().node_history_to_parquet(&path).unwrap();
+    assert_eq!(report.node_versions_exported, versions);
+
+    let (schema, batches) = read_parquet(&path);
+    assert_eq!(total_rows(&batches), versions, "one row per version");
+
+    let names = field_names(&schema);
+    for expected in [
+        "id",
+        "label",
+        "version",
+        "valid_from",
+        "valid_to",
+        "transaction_time",
+        "tombstone",
+        "provenance_source",
+        "provenance_confidence",
+        "provenance_note",
+        "provenance_correlation_id",
+        "provenance_principal",
+    ] {
+        assert!(
+            names.contains(&expected.to_string()),
+            "missing column {expected}"
+        );
+    }
+
+    // The still-open current version has a null valid_to (never the sentinel).
+    let valid_to_idx = schema.index_of("valid_to").unwrap();
+    let batch = &batches[0];
+    let valid_to = batch
+        .column(valid_to_idx)
+        .as_any()
+        .downcast_ref::<TimestampMicrosecondArray>()
+        .unwrap();
+    let open_rows = (0..valid_to.len()).filter(|&i| valid_to.is_null(i)).count();
+    assert!(
+        open_rows >= 1,
+        "the open current version must have null valid_to"
+    );
+    // No row encodes the open-interval sentinel as a real timestamp.
+    for i in 0..valid_to.len() {
+        if !valid_to.is_null(i) {
+            assert_ne!(valid_to.value(i), TIMESTAMP_MAX.wallclock());
+            assert_ne!(valid_to.value(i), i64::MAX);
+        }
+    }
+
+    // tombstone is false for the still-valid versions.
+    let tomb_idx = schema.index_of("tombstone").unwrap();
+    let tomb = batch
+        .column(tomb_idx)
+        .as_any()
+        .downcast_ref::<BooleanArray>()
+        .unwrap();
+    assert!(
+        (0..tomb.len()).any(|i| !tomb.value(i)),
+        "at least one non-tombstone version"
+    );
+}
+
+#[test]
+fn node_history_export_marks_tombstone_and_closes_valid_to_on_retract() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .unwrap();
+    // Close the valid interval (retraction / tombstone).
+    // A tiny sleep so the retraction's valid_to is strictly after the creation.
+    std::thread::sleep(std::time::Duration::from_millis(3));
+    let cutoff = time::now();
+    db.retract_node(id, cutoff).unwrap();
+
+    let path = files.path().join("node_history.parquet");
+    db.export().node_history_to_parquet(&path).unwrap();
+
+    let (schema, batches) = read_parquet(&path);
+    let tomb_idx = schema.index_of("tombstone").unwrap();
+    let valid_to_idx = schema.index_of("valid_to").unwrap();
+
+    let mut any_tombstone = false;
+    for batch in &batches {
+        let tomb = batch
+            .column(tomb_idx)
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap();
+        let valid_to = batch
+            .column(valid_to_idx)
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap();
+        for i in 0..tomb.len() {
+            if tomb.value(i) {
+                any_tombstone = true;
+                assert!(
+                    !valid_to.is_null(i),
+                    "a tombstone row must have a closed (non-null) valid_to"
+                );
+            }
+        }
+    }
+    assert!(any_tombstone, "retraction must produce a tombstone version");
+}
+
+#[test]
+fn node_history_export_carries_provenance_columns() {
+    use crate::api::transaction::WriteRequestOptions;
+    use crate::core::provenance::Provenance;
+
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let prov = Provenance::from_parts(
+        Some("ingest".to_string()),
+        Some(0.9),
+        Some("seed".to_string()),
+        None,
+        None,
+    )
+    .unwrap();
+    db.write(|tx| {
+        tx.create_node_with_options(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+            WriteRequestOptions::new().with_provenance(prov.clone()),
+        )
+    })
+    .unwrap();
+
+    let path = files.path().join("node_history.parquet");
+    db.export().node_history_to_parquet(&path).unwrap();
+
+    let (schema, batches) = read_parquet(&path);
+    let src_idx = schema.index_of("provenance_source").unwrap();
+    let conf_idx = schema.index_of("provenance_confidence").unwrap();
+    let src = batches[0]
+        .column(src_idx)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    let conf = batches[0]
+        .column(conf_idx)
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .unwrap();
+    assert_eq!(src.value(0), "ingest");
+    assert!((conf.value(0) - 0.9).abs() < 1e-9);
+}
+
+// ---------------------------------------------------------------------------
+// Streaming / large export and empty database
+// ---------------------------------------------------------------------------
+
+#[test]
+fn large_export_streams_all_rows_across_row_groups() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    // Create 50_000 nodes in a single transaction (fast), then stream-export them
+    // with a small batch so many row groups are produced with bounded memory.
+    const N: usize = 50_000;
+    db.write(|tx| {
+        for i in 0..N {
+            tx.create_node("N", PropertyMapBuilder::new().insert("i", i as i64).build())?;
+        }
+        Ok::<(), crate::core::error::Error>(())
+    })
+    .unwrap();
+
+    let path = files.path().join("big.parquet");
+    let report = db
+        .export()
+        .batch_size(1000)
+        .nodes_to_parquet(&path)
+        .unwrap();
+    assert_eq!(report.nodes_exported, N);
+
+    let (_schema, batches) = read_parquet(&path);
+    assert_eq!(total_rows(&batches), N);
+    // Small batch => many row groups (each written batch is one row group).
+    assert!(batches.len() >= 2, "expected multiple row groups");
+}
+
+#[test]
+fn empty_database_produces_valid_empty_file() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let path = files.path().join("empty.parquet");
+    let report = db.export().nodes_to_parquet(&path).unwrap();
+    assert_eq!(report.nodes_exported, 0);
+
+    let (schema, batches) = read_parquet(&path);
+    assert_eq!(total_rows(&batches), 0);
+    // The fixed schema is still present and readable.
+    let names = field_names(&schema);
+    assert!(names.contains(&"id".to_string()));
+    assert!(names.contains(&"label".to_string()));
+    assert!(names.contains(&"valid_time".to_string()));
+}
+
+#[test]
+fn empty_edge_history_produces_valid_empty_file() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    // Nodes but no edges.
+    db.create_node("Person", PropertyMap::new()).unwrap();
+
+    let path = files.path().join("edge_history.parquet");
+    let report = db.export().edge_history_to_parquet(&path).unwrap();
+    assert_eq!(report.edge_versions_exported, 0);
+
+    let (schema, batches) = read_parquet(&path);
+    assert_eq!(total_rows(&batches), 0);
+    let names = field_names(&schema);
+    assert!(names.contains(&"edge_type".to_string()));
+    assert!(names.contains(&"source_key".to_string()));
+    assert!(names.contains(&"valid_to".to_string()));
+}

--- a/src/api/import/mapping.rs
+++ b/src/api/import/mapping.rs
@@ -17,6 +17,21 @@ pub enum ColumnType {
     Float,
     /// Parse the value as a boolean (`true`/`false`, case-insensitive, or `1`/`0`).
     Bool,
+    /// A timestamp column stored as microseconds since the Unix epoch.
+    ///
+    /// Text/JSON inputs accept the same formats as the per-row `valid_time` column
+    /// (RFC 3339 / ISO 8601, a bare date, or bare integer microseconds); a native
+    /// Parquet `timestamp` column is decoded to microseconds without a string
+    /// round-trip. The value is stored as [`PropertyValue::Int`](crate::core::property::PropertyValue::Int)
+    /// microseconds since the epoch (the property model has no dedicated timestamp
+    /// variant).
+    Timestamp,
+    /// A dense embedding column stored as a
+    /// [`PropertyValue::Vector`](crate::core::property::PropertyValue::Vector).
+    ///
+    /// A native Parquet `list<float32>` column is decoded to the exact `f32` bits
+    /// with no string round-trip; a JSON array of numbers is also accepted.
+    Embedding,
 }
 
 /// Where a node's or edge's label comes from.

--- a/src/api/import/mod.rs
+++ b/src/api/import/mod.rs
@@ -271,6 +271,14 @@ impl<'a> Importer<'a> {
         self.key_to_id.get(key).copied()
     }
 
+    /// Number of nodes committed so far in this session (one per resolved business key).
+    ///
+    /// Useful after an import error to report how much was persisted before the failure,
+    /// since chunks commit incrementally (see the [module docs](self) on atomicity).
+    pub fn imported_node_count(&self) -> usize {
+        self.key_to_id.len()
+    }
+
     // ---- Nodes -----------------------------------------------------------------
 
     /// Import nodes from a CSV file.
@@ -521,6 +529,10 @@ fn build_properties(
     properties: &[PropertyMapping],
 ) -> std::result::Result<PropertyMap, RowError> {
     let mut builder = PropertyMapBuilder::new();
+    // Names inserted from explicit mapping columns; they take precedence over any
+    // auto-expanded overflow key of the same name (Parquet import only).
+    #[cfg(feature = "parquet")]
+    let mut explicit: std::collections::HashSet<String> = std::collections::HashSet::new();
     for mapping in properties {
         let cell = row.cells.get(&mapping.column).ok_or_else(|| RowError {
             row: row.index,
@@ -530,12 +542,28 @@ fn build_properties(
             row: row.index,
             message: format!("column '{}': {message}", mapping.column),
         })?;
+        #[cfg(feature = "parquet")]
+        explicit.insert(mapping.name.clone());
         // Skip nulls so blank cells become absent properties rather than stored nulls.
         if matches!(value, PropertyValue::Null) {
             continue;
         }
         builder = builder
             .try_insert(&mapping.name, value)
+            .map_err(|e| RowError {
+                row: row.index,
+                message: e.to_string(),
+            })?;
+    }
+    // Merge overflow properties auto-expanded from a `properties_json` column of an
+    // AletheiaDB export, so the caller need not map the exotic keys explicitly.
+    #[cfg(feature = "parquet")]
+    for (key, value) in &row.overflow {
+        if explicit.contains(key) || matches!(value, PropertyValue::Null) {
+            continue;
+        }
+        builder = builder
+            .try_insert(key, value.clone())
             .map_err(|e| RowError {
                 row: row.index,
                 message: e.to_string(),

--- a/src/api/import/mod.rs
+++ b/src/api/import/mod.rs
@@ -45,8 +45,14 @@
 mod mapping;
 mod parse;
 
+#[cfg(feature = "parquet")]
+mod parquet;
+
 #[cfg(test)]
 mod tests;
+
+#[cfg(all(test, feature = "parquet"))]
+mod parquet_tests;
 
 pub use mapping::{ColumnType, EdgeMapping, LabelSource, NodeMapping, PropertyMapping};
 
@@ -277,6 +283,24 @@ impl<'a> Importer<'a> {
         self.import_nodes(rows, &mapping)
     }
 
+    /// Import nodes from a Parquet file (Issue #3364).
+    ///
+    /// Columns are decoded natively from their Parquet/Arrow types — integers,
+    /// floats, booleans, timestamps, and `list<float32>` embeddings never
+    /// round-trip through a string. A SQL null cell yields an absent property, and
+    /// a native `timestamp` column can drive per-row `valid_time` backfill exactly
+    /// like the CSV path. All #3211 abort/skip and `row N:` semantics apply, with a
+    /// stable 1-based row index across row groups.
+    #[cfg(feature = "parquet")]
+    pub fn nodes_from_parquet(
+        &mut self,
+        path: impl AsRef<Path>,
+        mapping: NodeMapping,
+    ) -> Result<ImportReport> {
+        let rows = parquet::parquet_rows(path.as_ref())?;
+        self.import_nodes(rows, &mapping)
+    }
+
     /// Import nodes from a JSONL file (one JSON object per line).
     pub fn nodes_from_jsonl(
         &mut self,
@@ -358,6 +382,21 @@ impl<'a> Importer<'a> {
         mapping: EdgeMapping,
     ) -> Result<ImportReport> {
         let rows = parse::csv_rows(path.as_ref())?;
+        self.import_edges(rows, &mapping)
+    }
+
+    /// Import edges from a Parquet file, resolving endpoints by business key (Issue #3364).
+    ///
+    /// Endpoints are resolved against nodes imported earlier in the same session,
+    /// exactly like the CSV/JSONL edge readers; unresolved endpoints are reported
+    /// (or abort) per the [`FailureMode`]. Property columns are decoded natively.
+    #[cfg(feature = "parquet")]
+    pub fn edges_from_parquet(
+        &mut self,
+        path: impl AsRef<Path>,
+        mapping: EdgeMapping,
+    ) -> Result<ImportReport> {
+        let rows = parquet::parquet_rows(path.as_ref())?;
         self.import_edges(rows, &mapping)
     }
 

--- a/src/api/import/parquet.rs
+++ b/src/api/import/parquet.rs
@@ -44,6 +44,14 @@ const PARQUET_BATCH_SIZE: usize = 8192;
 /// Microseconds in one day, used to widen `Date32` (days since epoch) to micros.
 const MICROS_PER_DAY: i64 = 86_400_000_000;
 
+/// File-metadata key stamped by the AletheiaDB exporter. Its presence marks a file as
+/// our own export, enabling auto-expansion of the `properties_json` overflow column.
+const EXPORT_SCHEMA_VERSION_KEY: &str = "aletheiadb.schema_version";
+
+/// The overflow column name written by the exporter (bytes / heterogeneous arrays /
+/// sparse vectors / type-conflicting keys, as reversible tagged JSON).
+const OVERFLOW_COLUMN: &str = "properties_json";
+
 /// Build a streaming row reader over a Parquet file.
 ///
 /// The file is opened up front (open / metadata-parse failure is fatal, matching the
@@ -53,12 +61,13 @@ pub(crate) fn parquet_rows(path: &Path) -> Result<RowIter, ImportError> {
         .map_err(|e| ImportError::Io(format!("opening {}: {e}", path.display())))?;
     let builder = ParquetRecordBatchReaderBuilder::try_new(file)
         .map_err(|e| ImportError::Io(format!("opening parquet {}: {e}", path.display())))?;
-    let field_names: Vec<String> = builder
-        .schema()
-        .fields()
-        .iter()
-        .map(|f| f.name().clone())
-        .collect();
+    let schema = builder.schema();
+    let field_names: Vec<String> = schema.fields().iter().map(|f| f.name().clone()).collect();
+    // Auto-expand the overflow column only for our own exports (identified by the
+    // schema-version file metadata) that actually carry a `properties_json` column, so a
+    // foreign file with a same-named column is never reinterpreted.
+    let expand_overflow = schema.metadata().contains_key(EXPORT_SCHEMA_VERSION_KEY)
+        && field_names.iter().any(|n| n == OVERFLOW_COLUMN);
     let reader = builder
         .with_batch_size(PARQUET_BATCH_SIZE)
         .build()
@@ -67,6 +76,7 @@ pub(crate) fn parquet_rows(path: &Path) -> Result<RowIter, ImportError> {
     Ok(Box::new(ParquetRowIter {
         reader,
         field_names,
+        expand_overflow,
         batch: None,
         row_in_batch: 0,
         logical_row: 0,
@@ -79,6 +89,9 @@ struct ParquetRowIter {
     reader: ParquetRecordBatchReader,
     /// Column names in schema order; the cell map is keyed by these.
     field_names: Vec<String>,
+    /// Whether to auto-expand the `properties_json` overflow column into native
+    /// properties (true only for an AletheiaDB export carrying that column).
+    expand_overflow: bool,
     /// The batch currently being drained, if any.
     batch: Option<RecordBatch>,
     /// Next row to emit within `batch`.
@@ -148,11 +161,49 @@ impl Iterator for ParquetRowIter {
             }
         }
 
-        Some(Ok(Row {
-            index: row_num,
-            cells,
-        }))
+        let mut row = Row::new(row_num, cells);
+
+        // Auto-expand the overflow column of an AletheiaDB export back into native
+        // properties, so callers need not map the exotic keys explicitly.
+        if self.expand_overflow {
+            match decode_overflow(row.cells.get(OVERFLOW_COLUMN)) {
+                Ok(overflow) => row.overflow = overflow,
+                Err(message) => {
+                    return Some(Err(ImportError::Row(RowError {
+                        row: row_num,
+                        message: format!("column '{OVERFLOW_COLUMN}': {message}"),
+                    })));
+                }
+            }
+        }
+
+        Some(Ok(row))
     }
+}
+
+/// Decode the `properties_json` overflow cell of an AletheiaDB export into native
+/// key → [`PropertyValue`] pairs (the inverse of the exporter's tagged-JSON encoding).
+///
+/// An absent or SQL-null cell yields no properties. A malformed cell (non-string, or a
+/// string that is not a JSON object of tagged values) is a clean decode error carried up
+/// as a `row N:` [`RowError`], never a panic.
+fn decode_overflow(cell: Option<&Cell>) -> Result<Vec<(String, PropertyValue)>, String> {
+    let json = match cell {
+        None | Some(Cell::Native(PropertyValue::Null)) => return Ok(Vec::new()),
+        Some(Cell::Native(PropertyValue::String(s))) => s.to_string(),
+        Some(_) => return Err("expected a JSON string overflow column".to_string()),
+    };
+    let value: serde_json::Value =
+        serde_json::from_str(&json).map_err(|e| format!("invalid overflow JSON: {e}"))?;
+    let obj = value
+        .as_object()
+        .ok_or_else(|| "overflow column must be a JSON object".to_string())?;
+    let mut out = Vec::with_capacity(obj.len());
+    for (key, tagged) in obj {
+        let decoded = crate::api::export::overflow_json_to_value(tagged)?;
+        out.push((key.clone(), decoded));
+    }
+    Ok(out)
 }
 
 /// Downcast an Arrow array to a concrete typed array, erroring on mismatch.
@@ -198,9 +249,14 @@ fn decode_value(array: &dyn Array, row: usize) -> Result<PropertyValue, String> 
         DataType::UInt32 => Ok(PropertyValue::Int(
             downcast::<UInt32Array>(array)?.value(row) as i64,
         )),
-        DataType::UInt64 => Ok(PropertyValue::Int(
-            downcast::<UInt64Array>(array)?.value(row) as i64,
-        )),
+        DataType::UInt64 => {
+            let v = downcast::<UInt64Array>(array)?.value(row);
+            // A UInt64 above i64::MAX cannot be represented losslessly; reject rather
+            // than silently wrapping to a negative i64.
+            let as_i64 =
+                i64::try_from(v).map_err(|_| format!("UInt64 value {v} exceeds the i64 range"))?;
+            Ok(PropertyValue::Int(as_i64))
+        }
         DataType::Float32 => Ok(PropertyValue::Float(
             downcast::<Float32Array>(array)?.value(row) as f64,
         )),
@@ -219,11 +275,20 @@ fn decode_value(array: &dyn Array, row: usize) -> Result<PropertyValue, String> 
         }
         DataType::Date32 => {
             let days = downcast::<Date32Array>(array)?.value(row) as i64;
-            Ok(PropertyValue::Int(days * MICROS_PER_DAY))
+            // A hostile far-future/past date must not panic (debug) or wrap (release).
+            let micros = days.checked_mul(MICROS_PER_DAY).ok_or_else(|| {
+                format!(
+                    "date value {days} (days since epoch) out of representable microsecond range"
+                )
+            })?;
+            Ok(PropertyValue::Int(micros))
         }
         DataType::Date64 => {
             let millis = downcast::<Date64Array>(array)?.value(row);
-            Ok(PropertyValue::Int(millis * 1_000))
+            let micros = millis.checked_mul(1_000).ok_or_else(|| {
+                format!("date value {millis}ms out of representable microsecond range")
+            })?;
+            Ok(PropertyValue::Int(micros))
         }
         DataType::Binary => Ok(PropertyValue::bytes(
             downcast::<BinaryArray>(array)?.value(row),
@@ -240,8 +305,18 @@ fn decode_value(array: &dyn Array, row: usize) -> Result<PropertyValue, String> 
 /// Convert a timestamp value at `row` to microseconds since the Unix epoch.
 fn timestamp_to_micros(array: &dyn Array, row: usize, unit: &TimeUnit) -> Result<i64, String> {
     let micros = match unit {
-        TimeUnit::Second => downcast::<TimestampSecondArray>(array)?.value(row) * 1_000_000,
-        TimeUnit::Millisecond => downcast::<TimestampMillisecondArray>(array)?.value(row) * 1_000,
+        TimeUnit::Second => {
+            let secs = downcast::<TimestampSecondArray>(array)?.value(row);
+            secs.checked_mul(1_000_000).ok_or_else(|| {
+                format!("timestamp value {secs}s out of representable microsecond range")
+            })?
+        }
+        TimeUnit::Millisecond => {
+            let millis = downcast::<TimestampMillisecondArray>(array)?.value(row);
+            millis.checked_mul(1_000).ok_or_else(|| {
+                format!("timestamp value {millis}ms out of representable microsecond range")
+            })?
+        }
         TimeUnit::Microsecond => downcast::<TimestampMicrosecondArray>(array)?.value(row),
         TimeUnit::Nanosecond => downcast::<TimestampNanosecondArray>(array)?.value(row) / 1_000,
     };
@@ -269,10 +344,16 @@ fn decode_embedding<O: OffsetSizeTrait>(
     let mut floats = Vec::with_capacity(len);
     if let Some(f32s) = values.as_any().downcast_ref::<Float32Array>() {
         for i in 0..len {
+            if f32s.is_null(i) {
+                return Err("embedding contains null element".to_string());
+            }
             floats.push(f32s.value(i));
         }
     } else if let Some(f64s) = values.as_any().downcast_ref::<Float64Array>() {
         for i in 0..len {
+            if f64s.is_null(i) {
+                return Err("embedding contains null element".to_string());
+            }
             floats.push(f64s.value(i) as f32);
         }
     } else {

--- a/src/api/import/parquet.rs
+++ b/src/api/import/parquet.rs
@@ -1,0 +1,282 @@
+//! Streaming Parquet row reader for the bulk importer (Issue #3364).
+//!
+//! Produces the same `Result<Row, ImportError>` stream the CSV/JSONL readers in
+//! [`super::parse`] yield, so the format-agnostic import loop
+//! ([`Importer::import_nodes`](super::Importer) / `import_edges`) is reused verbatim
+//! — inheriting the #3211 abort/skip semantics, precise `row N:` errors,
+//! chunk-boundary partial-commit, null-as-absent, and per-row `valid_time` backfill.
+//!
+//! Columns are decoded **physically** from their Arrow array to a native
+//! [`PropertyValue`] (numbers, booleans, timestamps, and `list<float32>` embeddings
+//! never round-trip through a string), wrapped in [`Cell::Native`]. A SQL null cell
+//! decodes to [`PropertyValue::Null`], which the property builder treats as an absent
+//! property — matching the CSV blank-cell contract.
+//!
+//! Reading is chunked in Arrow `RecordBatch`es of [`PARQUET_BATCH_SIZE`] rows, so a
+//! multi-row-group file is streamed with bounded memory rather than fully
+//! materialized. A stable 1-based logical row index runs across every row group, so
+//! `row N:` error messages stay precise.
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::path::Path;
+
+use arrow::array::{
+    Array, ArrayRef, BinaryArray, BooleanArray, Date32Array, Date64Array, Float32Array,
+    Float64Array, Int8Array, Int16Array, Int32Array, Int64Array, LargeBinaryArray,
+    LargeStringArray, RecordBatch, StringArray, TimestampMicrosecondArray,
+    TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
+    UInt16Array, UInt32Array, UInt64Array,
+};
+use arrow::array::{GenericListArray, OffsetSizeTrait};
+use arrow::datatypes::{DataType, TimeUnit};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReader;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+use super::parse::{Cell, Row, RowIter};
+use super::{ImportError, RowError};
+use crate::core::property::PropertyValue;
+
+/// Rows per Arrow `RecordBatch` decoded from the Parquet file. Bounds peak import
+/// memory to roughly one batch of decoded cells rather than the whole file.
+const PARQUET_BATCH_SIZE: usize = 8192;
+
+/// Microseconds in one day, used to widen `Date32` (days since epoch) to micros.
+const MICROS_PER_DAY: i64 = 86_400_000_000;
+
+/// Build a streaming row reader over a Parquet file.
+///
+/// The file is opened up front (open / metadata-parse failure is fatal, matching the
+/// CSV/JSONL readers); rows are then decoded lazily one `RecordBatch` at a time.
+pub(crate) fn parquet_rows(path: &Path) -> Result<RowIter, ImportError> {
+    let file = File::open(path)
+        .map_err(|e| ImportError::Io(format!("opening {}: {e}", path.display())))?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)
+        .map_err(|e| ImportError::Io(format!("opening parquet {}: {e}", path.display())))?;
+    let field_names: Vec<String> = builder
+        .schema()
+        .fields()
+        .iter()
+        .map(|f| f.name().clone())
+        .collect();
+    let reader = builder
+        .with_batch_size(PARQUET_BATCH_SIZE)
+        .build()
+        .map_err(|e| ImportError::Io(format!("reading parquet {}: {e}", path.display())))?;
+
+    Ok(Box::new(ParquetRowIter {
+        reader,
+        field_names,
+        batch: None,
+        row_in_batch: 0,
+        logical_row: 0,
+        stopped: false,
+    }))
+}
+
+/// A streaming iterator over the rows of a Parquet file, one `RecordBatch` at a time.
+struct ParquetRowIter {
+    reader: ParquetRecordBatchReader,
+    /// Column names in schema order; the cell map is keyed by these.
+    field_names: Vec<String>,
+    /// The batch currently being drained, if any.
+    batch: Option<RecordBatch>,
+    /// Next row to emit within `batch`.
+    row_in_batch: usize,
+    /// 1-based logical row number across every row group (for `row N:` errors).
+    logical_row: usize,
+    /// Set once a fatal reader error has been surfaced, to stop iteration.
+    stopped: bool,
+}
+
+impl Iterator for ParquetRowIter {
+    type Item = Result<Row, ImportError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.stopped {
+            return None;
+        }
+
+        // Advance to a batch that still has rows to emit, pulling new batches as needed.
+        loop {
+            let needs_batch = match &self.batch {
+                Some(batch) => self.row_in_batch >= batch.num_rows(),
+                None => true,
+            };
+            if needs_batch {
+                match self.reader.next() {
+                    None => return None,
+                    Some(Ok(batch)) => {
+                        if batch.num_rows() == 0 {
+                            // Empty batch (possible for an empty row group): skip it.
+                            self.batch = None;
+                            continue;
+                        }
+                        self.batch = Some(batch);
+                        self.row_in_batch = 0;
+                    }
+                    Some(Err(e)) => {
+                        // A mid-stream reader error is fatal even in skip mode.
+                        self.stopped = true;
+                        return Some(Err(ImportError::Io(format!("reading parquet batch: {e}"))));
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+
+        let batch = self.batch.as_ref()?;
+        let i = self.row_in_batch;
+        self.row_in_batch += 1;
+        self.logical_row += 1;
+        let row_num = self.logical_row;
+
+        let mut cells = HashMap::with_capacity(self.field_names.len());
+        for (col_idx, name) in self.field_names.iter().enumerate() {
+            let array = batch.column(col_idx);
+            match decode_value(array.as_ref(), i) {
+                Ok(value) => {
+                    cells.insert(name.clone(), Cell::Native(value));
+                }
+                Err(message) => {
+                    return Some(Err(ImportError::Row(RowError {
+                        row: row_num,
+                        message: format!("column '{name}': {message}"),
+                    })));
+                }
+            }
+        }
+
+        Some(Ok(Row {
+            index: row_num,
+            cells,
+        }))
+    }
+}
+
+/// Downcast an Arrow array to a concrete typed array, erroring on mismatch.
+fn downcast<A: Array + 'static>(array: &dyn Array) -> Result<&A, String> {
+    array
+        .as_any()
+        .downcast_ref::<A>()
+        .ok_or_else(|| "internal error: unexpected Arrow array layout".to_string())
+}
+
+/// Physically decode the cell at `row` of an Arrow column into a [`PropertyValue`].
+///
+/// A null slot decodes to [`PropertyValue::Null`] (treated as an absent property by
+/// the caller). Timestamps and dates widen to microseconds since the Unix epoch and
+/// are stored as [`PropertyValue::Int`]; `list<float32>`/`list<float64>` become a
+/// [`PropertyValue::Vector`] embedding.
+fn decode_value(array: &dyn Array, row: usize) -> Result<PropertyValue, String> {
+    if array.is_null(row) {
+        return Ok(PropertyValue::Null);
+    }
+    match array.data_type() {
+        DataType::Boolean => Ok(PropertyValue::Bool(
+            downcast::<BooleanArray>(array)?.value(row),
+        )),
+        DataType::Int8 => Ok(PropertyValue::Int(
+            downcast::<Int8Array>(array)?.value(row) as i64
+        )),
+        DataType::Int16 => Ok(PropertyValue::Int(
+            downcast::<Int16Array>(array)?.value(row) as i64,
+        )),
+        DataType::Int32 => Ok(PropertyValue::Int(
+            downcast::<Int32Array>(array)?.value(row) as i64,
+        )),
+        DataType::Int64 => Ok(PropertyValue::Int(
+            downcast::<Int64Array>(array)?.value(row),
+        )),
+        DataType::UInt8 => Ok(PropertyValue::Int(
+            downcast::<UInt8Array>(array)?.value(row) as i64,
+        )),
+        DataType::UInt16 => Ok(PropertyValue::Int(
+            downcast::<UInt16Array>(array)?.value(row) as i64,
+        )),
+        DataType::UInt32 => Ok(PropertyValue::Int(
+            downcast::<UInt32Array>(array)?.value(row) as i64,
+        )),
+        DataType::UInt64 => Ok(PropertyValue::Int(
+            downcast::<UInt64Array>(array)?.value(row) as i64,
+        )),
+        DataType::Float32 => Ok(PropertyValue::Float(
+            downcast::<Float32Array>(array)?.value(row) as f64,
+        )),
+        DataType::Float64 => Ok(PropertyValue::Float(
+            downcast::<Float64Array>(array)?.value(row),
+        )),
+        DataType::Utf8 => Ok(PropertyValue::string(
+            downcast::<StringArray>(array)?.value(row),
+        )),
+        DataType::LargeUtf8 => Ok(PropertyValue::string(
+            downcast::<LargeStringArray>(array)?.value(row),
+        )),
+        DataType::Timestamp(unit, _) => {
+            let micros = timestamp_to_micros(array, row, unit)?;
+            Ok(PropertyValue::Int(micros))
+        }
+        DataType::Date32 => {
+            let days = downcast::<Date32Array>(array)?.value(row) as i64;
+            Ok(PropertyValue::Int(days * MICROS_PER_DAY))
+        }
+        DataType::Date64 => {
+            let millis = downcast::<Date64Array>(array)?.value(row);
+            Ok(PropertyValue::Int(millis * 1_000))
+        }
+        DataType::Binary => Ok(PropertyValue::bytes(
+            downcast::<BinaryArray>(array)?.value(row),
+        )),
+        DataType::LargeBinary => Ok(PropertyValue::bytes(
+            downcast::<LargeBinaryArray>(array)?.value(row),
+        )),
+        DataType::List(field) => decode_embedding::<i32>(array, row, field.data_type()),
+        DataType::LargeList(field) => decode_embedding::<i64>(array, row, field.data_type()),
+        other => Err(format!("unsupported Parquet column type {other}")),
+    }
+}
+
+/// Convert a timestamp value at `row` to microseconds since the Unix epoch.
+fn timestamp_to_micros(array: &dyn Array, row: usize, unit: &TimeUnit) -> Result<i64, String> {
+    let micros = match unit {
+        TimeUnit::Second => downcast::<TimestampSecondArray>(array)?.value(row) * 1_000_000,
+        TimeUnit::Millisecond => downcast::<TimestampMillisecondArray>(array)?.value(row) * 1_000,
+        TimeUnit::Microsecond => downcast::<TimestampMicrosecondArray>(array)?.value(row),
+        TimeUnit::Nanosecond => downcast::<TimestampNanosecondArray>(array)?.value(row) / 1_000,
+    };
+    Ok(micros)
+}
+
+/// Decode a list cell into a [`PropertyValue::Vector`] embedding, requiring a
+/// float element type.
+fn decode_embedding<O: OffsetSizeTrait>(
+    array: &dyn Array,
+    row: usize,
+    element_type: &DataType,
+) -> Result<PropertyValue, String> {
+    match element_type {
+        DataType::Float32 | DataType::Float64 => {}
+        other => {
+            return Err(format!(
+                "unsupported list element type {other} (only float lists map to embeddings)"
+            ));
+        }
+    }
+    let list = downcast::<GenericListArray<O>>(array)?;
+    let values: ArrayRef = list.value(row);
+    let len = values.len();
+    let mut floats = Vec::with_capacity(len);
+    if let Some(f32s) = values.as_any().downcast_ref::<Float32Array>() {
+        for i in 0..len {
+            floats.push(f32s.value(i));
+        }
+    } else if let Some(f64s) = values.as_any().downcast_ref::<Float64Array>() {
+        for i in 0..len {
+            floats.push(f64s.value(i) as f32);
+        }
+    } else {
+        return Err("unsupported embedding element layout".to_string());
+    }
+    PropertyValue::try_vector(&floats).map_err(|e| e.to_string())
+}

--- a/src/api/import/parquet_tests.rs
+++ b/src/api/import/parquet_tests.rs
@@ -11,8 +11,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use arrow::array::{
-    ArrayRef, BooleanArray, Float64Array, Int64Array, ListArray, RecordBatch, StringArray,
-    TimestampMicrosecondArray,
+    ArrayRef, BooleanArray, Date32Array, Float64Array, Int64Array, ListArray, RecordBatch,
+    StringArray, TimestampMicrosecondArray, TimestampSecondArray, UInt64Array,
 };
 use arrow::datatypes::Float32Type;
 // `::parquet` (the crate) is disambiguated from the sibling `super::parquet` module.
@@ -473,6 +473,118 @@ fn empty_file_imports_nothing_without_error() {
         .unwrap();
     assert_eq!(report.rows_read, 0);
     assert_eq!(report.nodes_imported, 0);
+    assert_eq!(db.node_count(), 0);
+}
+
+// --- Hostile Date32 value overflows micros → clean row error, not a panic -------
+
+#[test]
+fn date32_overflow_is_clean_row_error_not_panic() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    // i32::MAX days * 86_400_000_000 µs/day overflows i64.
+    let dates = Date32Array::from(vec![i32::MAX]);
+    let batch = RecordBatch::try_from_iter(vec![
+        ("id", str_col(vec![Some("n1")])),
+        ("d", Arc::new(dates) as ArrayRef),
+    ])
+    .unwrap();
+    let path = write_parquet(&files, "date_overflow.parquet", &batch, None);
+
+    let mut importer = db.import();
+    let err = importer
+        .nodes_from_parquet(&path, NodeMapping::new(LabelSource::fixed("T"), "id"))
+        .expect_err("overflowing Date32 must produce a clean error, not a panic");
+    let msg = err.to_string();
+    assert!(msg.contains("row 1"), "got: {msg}");
+    assert!(msg.contains("out of representable"), "got: {msg}");
+    assert_eq!(db.node_count(), 0);
+}
+
+// --- Hostile TimestampSecond value overflows micros → clean row error -----------
+
+#[test]
+fn timestamp_second_overflow_is_clean_row_error() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    // i64::MAX seconds * 1_000_000 overflows i64.
+    let ts = TimestampSecondArray::from(vec![i64::MAX]);
+    let batch = RecordBatch::try_from_iter(vec![
+        ("id", str_col(vec![Some("n1")])),
+        ("t", Arc::new(ts) as ArrayRef),
+    ])
+    .unwrap();
+    let path = write_parquet(&files, "ts_overflow.parquet", &batch, None);
+
+    let mut importer = db.import();
+    let err = importer
+        .nodes_from_parquet(&path, NodeMapping::new(LabelSource::fixed("T"), "id"))
+        .expect_err("overflowing TimestampSecond must produce a clean error");
+    let msg = err.to_string();
+    assert!(msg.contains("row 1"), "got: {msg}");
+    assert!(msg.contains("out of representable"), "got: {msg}");
+    assert_eq!(db.node_count(), 0);
+}
+
+// --- UInt64 above i64::MAX is a clean error (no silent wrap) --------------------
+
+#[test]
+fn uint64_above_i64_max_is_clean_error() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let vals = UInt64Array::from(vec![u64::MAX]);
+    let batch = RecordBatch::try_from_iter(vec![
+        ("id", str_col(vec![Some("n1")])),
+        ("big", Arc::new(vals) as ArrayRef),
+    ])
+    .unwrap();
+    let path = write_parquet(&files, "u64.parquet", &batch, None);
+
+    let mut importer = db.import();
+    let err = importer
+        .nodes_from_parquet(&path, NodeMapping::new(LabelSource::fixed("T"), "id"))
+        .expect_err("UInt64 > i64::MAX must error, not wrap");
+    let msg = err.to_string();
+    assert!(msg.contains("row 1"), "got: {msg}");
+    assert!(msg.contains("i64"), "got: {msg}");
+    assert_eq!(db.node_count(), 0);
+}
+
+// --- A null element inside a list<float> embedding is a clean error ------------
+
+#[test]
+fn null_element_in_embedding_list_is_clean_error() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    // Middle element of the embedding list is null.
+    let list = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![Some(vec![
+        Some(1.0f32),
+        None,
+        Some(3.0f32),
+    ])]);
+    let batch = RecordBatch::try_from_iter(vec![
+        ("id", str_col(vec![Some("doc1")])),
+        ("embedding", Arc::new(list) as ArrayRef),
+    ])
+    .unwrap();
+    let path = write_parquet(&files, "null_elem.parquet", &batch, None);
+
+    let mapping = NodeMapping::new(LabelSource::fixed("Document"), "id").property(
+        "embedding",
+        "embedding",
+        ColumnType::Embedding,
+    );
+    let mut importer = db.import();
+    let err = importer
+        .nodes_from_parquet(&path, mapping)
+        .expect_err("null embedding element must error, not become 0.0");
+    let msg = err.to_string();
+    assert!(msg.contains("row 1"), "got: {msg}");
+    assert!(msg.contains("null element"), "got: {msg}");
     assert_eq!(db.node_count(), 0);
 }
 

--- a/src/api/import/parquet_tests.rs
+++ b/src/api/import/parquet_tests.rs
@@ -1,0 +1,501 @@
+//! Tests for the Parquet import path (Issue #3364).
+//!
+//! These re-assert the #3211 / PR #3495 invariants for Parquet input (abort vs
+//! skip-and-report, precise `row N:` numbering, unresolved-endpoint side, valid-time
+//! backfill, chunk boundaries, null-as-absent) and add Parquet-native coverage:
+//! int/float/bool/string round-trip, `list<float32>` embedding round-trip with exact
+//! bits, native `timestamp` valid-time at microsecond precision, multi-row-group
+//! files, malformed/non-parquet input, and empty files.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use arrow::array::{
+    ArrayRef, BooleanArray, Float64Array, Int64Array, ListArray, RecordBatch, StringArray,
+    TimestampMicrosecondArray,
+};
+use arrow::datatypes::Float32Type;
+// `::parquet` (the crate) is disambiguated from the sibling `super::parquet` module.
+use ::parquet::arrow::ArrowWriter;
+use ::parquet::file::properties::WriterProperties;
+use tempfile::TempDir;
+
+use super::*;
+use crate::core::property::PropertyValue;
+use crate::core::temporal::time;
+use crate::test_utils::create_test_db;
+
+/// Write a single `RecordBatch` to a Parquet file, optionally forcing a small
+/// max row-group size (to exercise multi-row-group reads).
+fn write_parquet(
+    dir: &TempDir,
+    name: &str,
+    batch: &RecordBatch,
+    max_row_group_size: Option<usize>,
+) -> PathBuf {
+    let path = dir.path().join(name);
+    let file = std::fs::File::create(&path).expect("create parquet file");
+    let props = max_row_group_size.map(|n| {
+        WriterProperties::builder()
+            .set_max_row_group_row_count(Some(n))
+            .build()
+    });
+    let mut writer = ArrowWriter::try_new(file, batch.schema(), props).expect("arrow writer");
+    writer.write(batch).expect("write batch");
+    writer.close().expect("close writer");
+    path
+}
+
+fn str_col(values: Vec<Option<&str>>) -> ArrayRef {
+    Arc::new(StringArray::from(values))
+}
+
+fn person_nodes(key_col: &str) -> NodeMapping {
+    NodeMapping::new(LabelSource::fixed("Person"), key_col)
+        .property("name", "name", ColumnType::String)
+        .property("age", "age", ColumnType::Int)
+}
+
+// --- Happy path: nodes + edges, native typed coercion --------------------------
+
+#[test]
+fn happy_path_nodes_and_edges_parquet() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let node_batch = RecordBatch::try_from_iter(vec![
+        ("id", str_col(vec![Some("alice"), Some("bob")])),
+        ("name", str_col(vec![Some("Alice"), Some("Bob")])),
+        ("age", Arc::new(Int64Array::from(vec![30, 25])) as ArrayRef),
+    ])
+    .unwrap();
+    let nodes = write_parquet(&files, "nodes.parquet", &node_batch, None);
+
+    let edge_batch = RecordBatch::try_from_iter(vec![
+        ("src", str_col(vec![Some("alice")])),
+        ("dst", str_col(vec![Some("bob")])),
+        ("since", Arc::new(Int64Array::from(vec![2020])) as ArrayRef),
+    ])
+    .unwrap();
+    let edges = write_parquet(&files, "edges.parquet", &edge_batch, None);
+
+    let mut importer = db.import();
+    let node_report = importer
+        .nodes_from_parquet(&nodes, person_nodes("id"))
+        .expect("nodes import");
+    assert_eq!(node_report.rows_read, 2);
+    assert_eq!(node_report.nodes_imported, 2);
+    assert!(node_report.skipped.is_empty());
+
+    let edge_mapping = EdgeMapping::new(LabelSource::fixed("KNOWS"), "src", "dst").property(
+        "since",
+        "since",
+        ColumnType::Int,
+    );
+    let edge_report = importer
+        .edges_from_parquet(&edges, edge_mapping)
+        .expect("edges import");
+    assert_eq!(edge_report.edges_imported, 1);
+    assert!(edge_report.unresolved_endpoints.is_empty());
+
+    assert_eq!(db.node_count(), 2);
+    assert_eq!(db.edge_count(), 1);
+
+    let alice = importer.resolve_key("alice").expect("alice resolved");
+    let node = db.get_node(alice).unwrap();
+    assert_eq!(
+        node.properties.get("name"),
+        Some(&PropertyValue::string("Alice"))
+    );
+    assert_eq!(node.properties.get("age"), Some(&PropertyValue::Int(30)));
+}
+
+// --- Native scalar round-trip: int / float / bool / string ---------------------
+
+#[test]
+fn scalar_types_round_trip_natively() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let batch = RecordBatch::try_from_iter(vec![
+        ("id", str_col(vec![Some("n1")])),
+        ("name", str_col(vec![Some("Widget")])),
+        ("age", Arc::new(Int64Array::from(vec![42])) as ArrayRef),
+        ("score", Arc::new(Float64Array::from(vec![3.5])) as ArrayRef),
+        (
+            "active",
+            Arc::new(BooleanArray::from(vec![true])) as ArrayRef,
+        ),
+    ])
+    .unwrap();
+    let path = write_parquet(&files, "scalars.parquet", &batch, None);
+
+    let mapping = NodeMapping::new(LabelSource::fixed("Thing"), "id")
+        .property("name", "name", ColumnType::String)
+        .property("age", "age", ColumnType::Int)
+        .property("score", "score", ColumnType::Float)
+        .property("active", "active", ColumnType::Bool);
+
+    let mut importer = db.import();
+    importer.nodes_from_parquet(&path, mapping).unwrap();
+    let id = importer.resolve_key("n1").unwrap();
+    let node = db.get_node(id).unwrap();
+
+    assert_eq!(
+        node.properties.get("name"),
+        Some(&PropertyValue::string("Widget"))
+    );
+    assert_eq!(node.properties.get("age"), Some(&PropertyValue::Int(42)));
+    assert_eq!(
+        node.properties.get("score"),
+        Some(&PropertyValue::Float(3.5))
+    );
+    assert_eq!(
+        node.properties.get("active"),
+        Some(&PropertyValue::Bool(true))
+    );
+}
+
+// --- Embedding round-trip with exact f32 bits ----------------------------------
+
+#[test]
+fn embedding_list_float32_round_trips_exact_bits() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let expected: Vec<f32> = vec![1.5, -2.25, 3.0, 0.1];
+    let list = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![Some(
+        expected.iter().copied().map(Some).collect::<Vec<_>>(),
+    )]);
+
+    let batch = RecordBatch::try_from_iter(vec![
+        ("id", str_col(vec![Some("doc1")])),
+        ("embedding", Arc::new(list) as ArrayRef),
+    ])
+    .unwrap();
+    let path = write_parquet(&files, "emb.parquet", &batch, None);
+
+    let mapping = NodeMapping::new(LabelSource::fixed("Document"), "id").property(
+        "embedding",
+        "embedding",
+        ColumnType::Embedding,
+    );
+    let mut importer = db.import();
+    importer.nodes_from_parquet(&path, mapping).unwrap();
+    let id = importer.resolve_key("doc1").unwrap();
+    let node = db.get_node(id).unwrap();
+
+    let stored = node
+        .properties
+        .get("embedding")
+        .and_then(|v| v.as_vector())
+        .expect("embedding stored as vector");
+    // Exact bit equality — no lossy string round-trip.
+    assert_eq!(stored, expected.as_slice());
+    assert_eq!(
+        stored.iter().map(|f| f.to_bits()).collect::<Vec<_>>(),
+        expected.iter().map(|f| f.to_bits()).collect::<Vec<_>>()
+    );
+}
+
+// --- Native timestamp valid-time backfill at microsecond precision -------------
+
+#[test]
+fn native_timestamp_valid_time_round_trips_with_as_of() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    // 2021-01-01T00:00:00Z in microseconds since the epoch.
+    let micros_2021 = 1_609_459_200_i64 * 1_000_000;
+    let ts = TimestampMicrosecondArray::from(vec![micros_2021]);
+    let batch = RecordBatch::try_from_iter(vec![
+        ("id", str_col(vec![Some("alice")])),
+        ("name", str_col(vec![Some("Alice")])),
+        ("age", Arc::new(Int64Array::from(vec![30])) as ArrayRef),
+        ("known_since", Arc::new(ts) as ArrayRef),
+    ])
+    .unwrap();
+    let path = write_parquet(&files, "ts.parquet", &batch, None);
+
+    let mapping = person_nodes("id").valid_time_column("known_since");
+    let mut importer = db.import();
+    importer.nodes_from_parquet(&path, mapping).unwrap();
+    let alice = importer.resolve_key("alice").unwrap();
+
+    let now = time::now();
+    let after = time::from_secs(1_622_505_600); // 2021-06-01
+    assert!(
+        db.get_node_at_time(alice, after, now).is_ok(),
+        "node should be valid after its valid_from"
+    );
+    let before = time::from_secs(1_590_969_600); // 2020-06-01
+    assert!(
+        db.get_node_at_time(alice, before, now).is_err(),
+        "node should not be valid before its valid_from"
+    );
+}
+
+// --- A null cell becomes an ABSENT property, not a stored null -----------------
+
+#[test]
+fn null_cell_becomes_absent_property_not_null() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let batch = RecordBatch::try_from_iter(vec![
+        ("id", str_col(vec![Some("n1")])),
+        ("name", str_col(vec![Some("HasName")])),
+        // age is null for this row.
+        (
+            "age",
+            Arc::new(Int64Array::from(vec![None::<i64>])) as ArrayRef,
+        ),
+    ])
+    .unwrap();
+    let path = write_parquet(&files, "nullage.parquet", &batch, None);
+
+    let mut importer = db.import();
+    importer
+        .nodes_from_parquet(&path, person_nodes("id"))
+        .unwrap();
+    let id = importer.resolve_key("n1").unwrap();
+    let node = db.get_node(id).unwrap();
+
+    assert_eq!(
+        node.properties.get("name"),
+        Some(&PropertyValue::string("HasName"))
+    );
+    assert_eq!(node.properties.get("age"), None, "null age must be absent");
+}
+
+// --- Malformed / non-parquet input is a clean error, no partial writes ---------
+
+#[test]
+fn non_parquet_file_is_clean_error_no_writes() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let path = files.path().join("garbage.parquet");
+    std::fs::write(&path, b"this is definitely not a parquet file").unwrap();
+
+    // Fatal even in skip mode (open/metadata failure is always fatal).
+    let mut importer = db.import().failure_mode(FailureMode::SkipAndReport);
+    let result = importer.nodes_from_parquet(&path, person_nodes("id"));
+    assert!(result.is_err(), "non-parquet file must error");
+    assert_eq!(db.node_count(), 0, "no partial writes on open failure");
+}
+
+// --- Missing required label column errors --------------------------------------
+
+#[test]
+fn missing_label_column_errors_with_row_number() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    // No "kind" column present in the file.
+    let batch = RecordBatch::try_from_iter(vec![
+        ("id", str_col(vec![Some("n1")])),
+        ("name", str_col(vec![Some("A")])),
+    ])
+    .unwrap();
+    let path = write_parquet(&files, "nolabel.parquet", &batch, None);
+
+    let mapping = NodeMapping::new(LabelSource::column("kind"), "id");
+    let mut importer = db.import();
+    let err = importer
+        .nodes_from_parquet(&path, mapping)
+        .expect_err("missing label column must error");
+    assert!(err.to_string().contains("row 1"), "got: {err}");
+    assert!(err.to_string().contains("kind"), "got: {err}");
+    assert_eq!(db.node_count(), 0);
+}
+
+// --- Wrong column type vs mapping: abort reports row, skip collects it ----------
+
+#[test]
+fn wrong_column_type_abort_reports_row_number() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    // age column is a String that is not an integer; mapping asks for Int.
+    let batch = RecordBatch::try_from_iter(vec![
+        ("id", str_col(vec![Some("alice"), Some("bob")])),
+        ("name", str_col(vec![Some("Alice"), Some("Bob")])),
+        ("age", str_col(vec![Some("30"), Some("notanumber")])),
+    ])
+    .unwrap();
+    let path = write_parquet(&files, "badage.parquet", &batch, None);
+
+    // batch_size(1) so row 1 commits before the abort at row 2 (mirrors the CSV test).
+    let mut importer = db.import().batch_size(1);
+    let err = importer
+        .nodes_from_parquet(&path, person_nodes("id"))
+        .expect_err("bad Int coercion must abort");
+    let msg = err.to_string();
+    assert!(msg.contains("row 2"), "got: {msg}");
+    assert!(msg.contains("Int"), "got: {msg}");
+    // Row 1 committed before the abort at row 2.
+    assert_eq!(db.node_count(), 1);
+}
+
+#[test]
+fn wrong_column_type_skip_and_report() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let batch = RecordBatch::try_from_iter(vec![
+        ("id", str_col(vec![Some("alice"), Some("bob")])),
+        ("name", str_col(vec![Some("Alice"), Some("Bob")])),
+        ("age", str_col(vec![Some("30"), Some("notanumber")])),
+    ])
+    .unwrap();
+    let path = write_parquet(&files, "badage2.parquet", &batch, None);
+
+    let mut importer = db.import().failure_mode(FailureMode::SkipAndReport);
+    let report = importer
+        .nodes_from_parquet(&path, person_nodes("id"))
+        .unwrap();
+    assert_eq!(report.rows_read, 2);
+    assert_eq!(report.nodes_imported, 1);
+    assert_eq!(report.skipped.len(), 1);
+    assert_eq!(report.skipped[0].row, 2);
+    assert_eq!(db.node_count(), 1);
+}
+
+// --- Unresolved edge endpoint reports the correct side -------------------------
+
+#[test]
+fn unresolved_target_endpoint_reported() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let node_batch = RecordBatch::try_from_iter(vec![
+        ("id", str_col(vec![Some("alice")])),
+        ("name", str_col(vec![Some("Alice")])),
+        ("age", Arc::new(Int64Array::from(vec![30])) as ArrayRef),
+    ])
+    .unwrap();
+    let nodes = write_parquet(&files, "n.parquet", &node_batch, None);
+
+    // Edge references "bob" as target, which was never imported.
+    let edge_batch = RecordBatch::try_from_iter(vec![
+        ("src", str_col(vec![Some("alice")])),
+        ("dst", str_col(vec![Some("bob")])),
+    ])
+    .unwrap();
+    let edges = write_parquet(&files, "e.parquet", &edge_batch, None);
+
+    let mut importer = db.import().failure_mode(FailureMode::SkipAndReport);
+    importer
+        .nodes_from_parquet(&nodes, person_nodes("id"))
+        .unwrap();
+    let report = importer
+        .edges_from_parquet(
+            &edges,
+            EdgeMapping::new(LabelSource::fixed("KNOWS"), "src", "dst"),
+        )
+        .unwrap();
+    assert_eq!(report.edges_imported, 0);
+    assert_eq!(report.unresolved_endpoints.len(), 1);
+    assert_eq!(report.unresolved_endpoints[0].side, Endpoint::Target);
+    assert_eq!(report.unresolved_endpoints[0].key, "bob");
+    assert_eq!(report.unresolved_endpoints[0].row, 1);
+}
+
+// --- Multi-row-group file: all rows imported -----------------------------------
+
+#[test]
+fn multi_row_group_imports_all_rows() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let ids: Vec<String> = (0..25).map(|i| format!("n{i}")).collect();
+    let id_col = str_col(ids.iter().map(|s| Some(s.as_str())).collect());
+    let name_col = str_col((0..25).map(|_| Some("X")).collect());
+    let age_col = Arc::new(Int64Array::from((0..25).collect::<Vec<i64>>())) as ArrayRef;
+    let batch =
+        RecordBatch::try_from_iter(vec![("id", id_col), ("name", name_col), ("age", age_col)])
+            .unwrap();
+    // Force a row-group boundary every 10 rows => 3 row groups.
+    let path = write_parquet(&files, "multi.parquet", &batch, Some(10));
+
+    let mut importer = db.import().batch_size(10);
+    let report = importer
+        .nodes_from_parquet(&path, person_nodes("id"))
+        .unwrap();
+    assert_eq!(report.rows_read, 25);
+    assert_eq!(report.nodes_imported, 25);
+    assert_eq!(db.node_count(), 25);
+}
+
+// --- Reader spans multiple internal read batches (> PARQUET_BATCH_SIZE) ---------
+
+#[test]
+fn reader_spans_multiple_read_batches() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    // 9000 rows > the 8192-row internal batch size, exercising batch advancement.
+    let n = 9000;
+    let ids: Vec<String> = (0..n).map(|i| format!("n{i}")).collect();
+    let id_col = str_col(ids.iter().map(|s| Some(s.as_str())).collect());
+    let name_col = str_col((0..n).map(|_| Some("X")).collect());
+    let batch = RecordBatch::try_from_iter(vec![("id", id_col), ("name", name_col)]).unwrap();
+    let path = write_parquet(&files, "big.parquet", &batch, None);
+
+    let mapping = NodeMapping::new(LabelSource::fixed("Person"), "id").property(
+        "name",
+        "name",
+        ColumnType::String,
+    );
+    let mut importer = db.import();
+    let report = importer.nodes_from_parquet(&path, mapping).unwrap();
+    assert_eq!(report.rows_read, n);
+    assert_eq!(report.nodes_imported, n);
+    assert_eq!(db.node_count(), n);
+}
+
+// --- Empty file (schema, zero rows) imports nothing, no error ------------------
+
+#[test]
+fn empty_file_imports_nothing_without_error() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let batch =
+        RecordBatch::try_from_iter(vec![("id", str_col(vec![])), ("name", str_col(vec![]))])
+            .unwrap();
+    let path = write_parquet(&files, "empty.parquet", &batch, None);
+
+    let mut importer = db.import();
+    let report = importer
+        .nodes_from_parquet(&path, person_nodes("id"))
+        .unwrap();
+    assert_eq!(report.rows_read, 0);
+    assert_eq!(report.nodes_imported, 0);
+    assert_eq!(db.node_count(), 0);
+}
+
+// --- Empty key column errors with a row number ---------------------------------
+
+#[test]
+fn empty_key_column_errors_with_row_number() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    // id is null on the (only) row => empty business key.
+    let batch = RecordBatch::try_from_iter(vec![
+        ("id", str_col(vec![None])),
+        ("name", str_col(vec![Some("A")])),
+        ("age", Arc::new(Int64Array::from(vec![1])) as ArrayRef),
+    ])
+    .unwrap();
+    let path = write_parquet(&files, "nokey.parquet", &batch, None);
+
+    let mut importer = db.import();
+    let err = importer
+        .nodes_from_parquet(&path, person_nodes("id"))
+        .expect_err("empty key must error");
+    assert!(err.to_string().contains("row 1"), "got: {err}");
+    assert_eq!(db.node_count(), 0);
+}

--- a/src/api/import/parse.rs
+++ b/src/api/import/parse.rs
@@ -32,16 +32,33 @@ pub(crate) enum Cell {
 }
 
 /// One parsed input row: the 1-based row/line number plus its named cells.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct Row {
     pub(crate) index: usize,
     pub(crate) cells: HashMap<String, Cell>,
+    /// Already-decoded properties injected into the row independently of the caller's
+    /// column mapping. Populated only by the Parquet reader when it auto-expands the
+    /// `properties_json` overflow column of an AletheiaDB export (Issue #3364); always
+    /// empty for CSV/JSONL. Merged into the built [`PropertyMap`] by
+    /// [`super::build_properties`], with explicit mapping columns taking precedence.
+    #[cfg(feature = "parquet")]
+    pub(crate) overflow: Vec<(String, PropertyValue)>,
 }
 
 /// A boxed, streaming iterator of parsed rows.
 pub(crate) type RowIter = Box<dyn Iterator<Item = Result<Row, ImportError>>>;
 
 impl Row {
+    /// Construct a row from its 1-based index and named cells (no overflow properties).
+    pub(crate) fn new(index: usize, cells: HashMap<String, Cell>) -> Self {
+        Row {
+            index,
+            cells,
+            #[cfg(feature = "parquet")]
+            overflow: Vec::new(),
+        }
+    }
+
     /// Fetch a cell as a string, erroring if the column is absent.
     pub(crate) fn get_str(&self, column: &str) -> Result<String, String> {
         match self.cells.get(column) {
@@ -289,10 +306,7 @@ pub(crate) fn csv_rows(path: &Path) -> Result<RowIter, ImportError> {
                 for (header, value) in headers.iter().zip(record.iter()) {
                     cells.insert(header.to_string(), Cell::Str(value.to_string()));
                 }
-                Ok(Row {
-                    index: row_num,
-                    cells,
-                })
+                Ok(Row::new(row_num, cells))
             }
             Err(e) => Err(ImportError::Row(RowError {
                 row: row_num,
@@ -326,10 +340,7 @@ pub(crate) fn jsonl_rows(path: &Path) -> Result<RowIter, ImportError> {
                             .into_iter()
                             .map(|(k, v)| (k, Cell::Json(v)))
                             .collect::<HashMap<_, _>>();
-                        Some(Ok(Row {
-                            index: line_num,
-                            cells,
-                        }))
+                        Some(Ok(Row::new(line_num, cells)))
                     }
                     Ok(_) => Some(Err(ImportError::Row(RowError {
                         row: line_num,

--- a/src/api/import/parse.rs
+++ b/src/api/import/parse.rs
@@ -18,11 +18,17 @@ use crate::core::property::PropertyValue;
 use crate::core::temporal::Timestamp;
 
 /// A raw cell value, before coercion. CSV cells are always strings; JSONL cells
-/// preserve their parsed JSON type.
+/// preserve their parsed JSON type; Parquet cells arrive already decoded to a
+/// native [`PropertyValue`] (physical decode from the Arrow array), so numeric,
+/// boolean, timestamp, and embedding columns never round-trip through a string.
 #[derive(Debug, Clone)]
 pub(crate) enum Cell {
     Str(String),
     Json(serde_json::Value),
+    /// A Parquet cell physically decoded from its Arrow array. `Null` here means
+    /// the column value was absent (SQL null) for this row.
+    #[cfg(feature = "parquet")]
+    Native(PropertyValue),
 }
 
 /// One parsed input row: the 1-based row/line number plus its named cells.
@@ -52,6 +58,24 @@ fn cell_to_string(cell: &Cell) -> String {
         Cell::Json(serde_json::Value::String(s)) => s.clone(),
         Cell::Json(serde_json::Value::Null) => String::new(),
         Cell::Json(other) => other.to_string(),
+        #[cfg(feature = "parquet")]
+        Cell::Native(value) => property_value_to_string(value),
+    }
+}
+
+/// Render a physically-decoded Parquet [`PropertyValue`] as a plain string for the
+/// label / business-key / valid-time paths. `Null` renders empty (so a null cell is
+/// treated exactly like a blank CSV cell); an integer timestamp renders as its
+/// microseconds, which `parse_valid_time` re-reads losslessly.
+#[cfg(feature = "parquet")]
+fn property_value_to_string(value: &PropertyValue) -> String {
+    match value {
+        PropertyValue::Null => String::new(),
+        PropertyValue::Bool(b) => b.to_string(),
+        PropertyValue::Int(i) => i.to_string(),
+        PropertyValue::Float(f) => f.to_string(),
+        PropertyValue::String(s) => s.to_string(),
+        other => format!("{other:?}"),
     }
 }
 
@@ -63,6 +87,8 @@ pub(crate) fn coerce(cell: &Cell, ty: ColumnType) -> Result<PropertyValue, Strin
     match cell {
         Cell::Str(s) => coerce_str(s, ty),
         Cell::Json(value) => coerce_json(value, ty),
+        #[cfg(feature = "parquet")]
+        Cell::Native(value) => coerce_native(value, ty),
     }
 }
 
@@ -96,7 +122,36 @@ fn coerce_str(raw: &str, ty: ColumnType) -> Result<PropertyValue, String> {
                 .map(PropertyValue::Bool)
                 .ok_or_else(|| format!("cannot coerce '{raw}' to Bool"))
         }
+        ColumnType::Timestamp => {
+            if trimmed.is_empty() {
+                return Ok(PropertyValue::Null);
+            }
+            parse_valid_time(trimmed).map(|ts| PropertyValue::Int(ts.wallclock()))
+        }
+        ColumnType::Embedding => {
+            if trimmed.is_empty() {
+                return Ok(PropertyValue::Null);
+            }
+            let json: serde_json::Value = serde_json::from_str(trimmed)
+                .map_err(|_| format!("cannot coerce '{raw}' to Embedding (expected JSON array)"))?;
+            json_to_embedding(&json)
+        }
     }
+}
+
+/// Convert a JSON array of numbers into a [`PropertyValue::Vector`].
+fn json_to_embedding(value: &serde_json::Value) -> Result<PropertyValue, String> {
+    let serde_json::Value::Array(items) = value else {
+        return Err("cannot coerce non-array JSON to Embedding".to_string());
+    };
+    let mut floats = Vec::with_capacity(items.len());
+    for item in items {
+        let f = item
+            .as_f64()
+            .ok_or_else(|| format!("embedding element {item} is not a number"))?;
+        floats.push(f as f32);
+    }
+    PropertyValue::try_vector(&floats).map_err(|e| e.to_string())
 }
 
 fn coerce_json(value: &serde_json::Value, ty: ColumnType) -> Result<PropertyValue, String> {
@@ -117,7 +172,55 @@ fn coerce_json(value: &serde_json::Value, ty: ColumnType) -> Result<PropertyValu
         (ColumnType::Float, Value::String(s)) => coerce_str(s, ColumnType::Float),
         (ColumnType::Bool, Value::Bool(b)) => Ok(PropertyValue::Bool(*b)),
         (ColumnType::Bool, Value::String(s)) => coerce_str(s, ColumnType::Bool),
+        (ColumnType::Timestamp, Value::Number(n)) => n
+            .as_i64()
+            .map(PropertyValue::Int)
+            .ok_or_else(|| format!("cannot coerce '{n}' to Timestamp")),
+        (ColumnType::Timestamp, Value::String(s)) => coerce_str(s, ColumnType::Timestamp),
+        (ColumnType::Embedding, arr @ Value::Array(_)) => json_to_embedding(arr),
+        (ColumnType::Embedding, Value::String(s)) => coerce_str(s, ColumnType::Embedding),
         (ty, other) => Err(format!("cannot coerce JSON {other} to {ty:?}")),
+    }
+}
+
+/// Coerce a physically-decoded Parquet [`PropertyValue`] to the mapping's requested
+/// [`ColumnType`], widening/reconciling where the physical and logical types differ.
+#[cfg(feature = "parquet")]
+fn coerce_native(value: &PropertyValue, ty: ColumnType) -> Result<PropertyValue, String> {
+    // A null column value is "absent" for every target type.
+    if matches!(value, PropertyValue::Null) {
+        return Ok(PropertyValue::Null);
+    }
+    match ty {
+        ColumnType::String => match value {
+            PropertyValue::String(_) => Ok(value.clone()),
+            other => Ok(PropertyValue::string(property_value_to_string(other))),
+        },
+        ColumnType::Int => match value {
+            PropertyValue::Int(_) => Ok(value.clone()),
+            PropertyValue::String(s) => coerce_str(s, ColumnType::Int),
+            other => Err(format!("cannot coerce {} to Int", other.type_name())),
+        },
+        ColumnType::Float => match value {
+            PropertyValue::Float(_) => Ok(value.clone()),
+            PropertyValue::Int(i) => Ok(PropertyValue::Float(*i as f64)),
+            PropertyValue::String(s) => coerce_str(s, ColumnType::Float),
+            other => Err(format!("cannot coerce {} to Float", other.type_name())),
+        },
+        ColumnType::Bool => match value {
+            PropertyValue::Bool(_) => Ok(value.clone()),
+            PropertyValue::String(s) => coerce_str(s, ColumnType::Bool),
+            other => Err(format!("cannot coerce {} to Bool", other.type_name())),
+        },
+        ColumnType::Timestamp => match value {
+            PropertyValue::Int(_) => Ok(value.clone()),
+            PropertyValue::String(s) => coerce_str(s, ColumnType::Timestamp),
+            other => Err(format!("cannot coerce {} to Timestamp", other.type_name())),
+        },
+        ColumnType::Embedding => match value {
+            PropertyValue::Vector(_) => Ok(value.clone()),
+            other => Err(format!("cannot coerce {} to Embedding", other.type_name())),
+        },
     }
 }
 

--- a/src/api/import/tests.rs
+++ b/src/api/import/tests.rs
@@ -373,7 +373,7 @@ fn handle_row_failure_io_is_fatal_in_skip_mode() {
     let importer = db.import().failure_mode(FailureMode::SkipAndReport);
 
     // Build a synthetic Io error by wrapping a std::io::Error (the variant holds its string).
-    let io_err = std::io::Error::new(std::io::ErrorKind::Other, "synthetic mid-stream I/O");
+    let io_err = std::io::Error::other("synthetic mid-stream I/O");
     let mut report = ImportReport::default();
     let result = importer.handle_row_failure(ImportError::Io(io_err.to_string()), &mut report);
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -95,6 +95,10 @@ pub mod transaction;
 #[cfg(feature = "import")]
 pub mod import;
 
+/// Columnar Parquet export of the graph for analytics interoperability (Issue #3364).
+#[cfg(feature = "parquet")]
+pub mod export;
+
 // Re-export commonly used types
 pub use transaction::{ReadOps, ReadTransaction, TxId, TxState, WriteOps, WriteTransaction};
 
@@ -103,3 +107,6 @@ pub use import::{
     ColumnType, EdgeMapping, Endpoint, FailureMode, ImportConfig, ImportError, ImportReport,
     Importer, LabelSource, NodeMapping, PropertyMapping, RowError, UnresolvedEndpoint,
 };
+
+#[cfg(feature = "parquet")]
+pub use export::{ExportConfig, ExportReport, Exporter};

--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -88,12 +88,21 @@ Usage:\n\
   aletheia daemon stop [--pid-file PATH]\n\
   aletheia daemon status [--pid-file PATH]\n\
   aletheia backup <output_path>\n\
-  aletheia restore <input_path>\n\
-  aletheia import <nodes_file> --format parquet --label L --key COL [--property name:type ...]\n\
+  aletheia restore <input_path>"
+    );
+    // The import/export verbs are gated behind the `parquet` feature; only advertise
+    // them when they are actually compiled in (a default build returns "unknown
+    // command" for them otherwise).
+    #[cfg(feature = "parquet")]
+    println!(
+        "  aletheia import <nodes_file> --format parquet --label L --key COL [--property name:type ...]\n\
                   [--label-column COL] [--valid-time-column COL]\n\
-                  [--edges FILE --edge-label L --source-key COL --target-key COL [--property name:type ...]]\n\
-  aletheia export <out_prefix> --format parquet [--mode current|history]\n\
-  aletheia audit-keygen <key_file>\n\
+                  [--edges FILE --edge-label L --source-key COL --target-key COL\n\
+                   [--edge-property name:type ...] [--edge-valid-time-column COL]]\n\
+  aletheia export <out_prefix> --format parquet [--mode current|history]"
+    );
+    println!(
+        "  aletheia audit-keygen <key_file>\n\
   aletheia audit-export <node|edge> <id> --key <key_file> --out <path> [--db-id ID] [--redact k1,k2]\n\
   aletheia audit-verify <artifact_path> [--public-key HEX]\n\
   aletheia audit-render <artifact_path>\n\
@@ -983,17 +992,32 @@ mod parquet_io {
         let node_mapping = build_node_mapping(&args)?;
         let db = open_db()?;
         let mut importer = db.import();
-        let node_report = importer
-            .nodes_from_parquet(&nodes_file, node_mapping)
-            .map_err(|e| format!("node import failed: {e}"))?;
+        // Rows commit in chunks, so an error can leave earlier chunks committed. Report
+        // the count committed so far so the operator knows the database is partial.
+        let node_report = match importer.nodes_from_parquet(&nodes_file, node_mapping) {
+            Ok(report) => report,
+            Err(e) => {
+                return Err(format!(
+                    "node import failed after committing {} node(s): {e} \
+                     (import commits in chunks; the database may be partially written)",
+                    importer.imported_node_count()
+                ));
+            }
+        };
 
         let mut edges_imported = 0usize;
         if let Some(edges_file) = arg_value(&args, "--edges") {
             let edge_mapping = build_edge_mapping(&args)?;
-            let edge_report = importer
-                .edges_from_parquet(&edges_file, edge_mapping)
-                .map_err(|e| format!("edge import failed: {e}"))?;
-            edges_imported = edge_report.edges_imported;
+            match importer.edges_from_parquet(&edges_file, edge_mapping) {
+                Ok(edge_report) => edges_imported = edge_report.edges_imported,
+                Err(e) => {
+                    return Err(format!(
+                        "edge import failed: {e} ({} node(s) committed; edges commit in \
+                         chunks, so the database may be partially written)",
+                        importer.imported_node_count()
+                    ));
+                }
+            }
         }
 
         let value = serde_json::json!({
@@ -1108,16 +1132,18 @@ mod parquet_io {
         }
     }
 
-    /// Parse repeated `--property name:type` flags into `(column, type)` pairs. The
-    /// column and property name are the same (`name`), matching a column-per-key export.
-    fn parse_properties(args: &[String]) -> Result<Vec<(String, ColumnType)>, String> {
+    /// Parse repeated `<flag> name:type` flags into `(column, type)` pairs. The column
+    /// and property name are the same (`name`), matching a column-per-key export. `flag`
+    /// is `--property` for nodes and `--edge-property` for edges so the two mappings are
+    /// scoped independently.
+    fn parse_properties(args: &[String], flag: &str) -> Result<Vec<(String, ColumnType)>, String> {
         let mut out = Vec::new();
-        for spec in arg_values(args, "--property") {
+        for spec in arg_values(args, flag) {
             let (name, ty) = spec
                 .split_once(':')
-                .ok_or_else(|| format!("invalid --property '{spec}' (expected name:type)"))?;
+                .ok_or_else(|| format!("invalid {flag} '{spec}' (expected name:type)"))?;
             if name.is_empty() {
-                return Err(format!("invalid --property '{spec}' (empty name)"));
+                return Err(format!("invalid {flag} '{spec}' (empty name)"));
             }
             out.push((name.to_string(), parse_column_type(ty)?));
         }
@@ -1140,7 +1166,7 @@ mod parquet_io {
         let label = label_source(args)?;
         let key = arg_value(args, "--key").ok_or_else(|| "missing required --key".to_string())?;
         let mut mapping = NodeMapping::new(label, key);
-        for (name, ty) in parse_properties(args)? {
+        for (name, ty) in parse_properties(args, "--property")? {
             mapping = mapping.property_same(name, ty);
         }
         if let Some(col) = arg_value(args, "--valid-time-column") {
@@ -1158,10 +1184,12 @@ mod parquet_io {
         let target = arg_value(args, "--target-key")
             .ok_or_else(|| "missing required --target-key for --edges".to_string())?;
         let mut mapping = EdgeMapping::new(label, source, target);
-        for (name, ty) in parse_properties(args)? {
+        // Edge properties/valid-time use their own flags so they are scoped independently
+        // from the node `--property` / `--valid-time-column` in a mixed import.
+        for (name, ty) in parse_properties(args, "--edge-property")? {
             mapping = mapping.property_same(name, ty);
         }
-        if let Some(col) = arg_value(args, "--valid-time-column") {
+        if let Some(col) = arg_value(args, "--edge-valid-time-column") {
             mapping = mapping.valid_time_column(col);
         }
         Ok(mapping)
@@ -1170,7 +1198,10 @@ mod parquet_io {
     fn usage_import() -> String {
         "usage: aletheia import <nodes_file> --format parquet --label L --key COL \
          [--property name:type ...] [--label-column COL] [--valid-time-column COL] \
-         [--edges FILE --edge-label L --source-key COL --target-key COL]"
+         [--edges FILE --edge-label L --source-key COL --target-key COL \
+         [--edge-property name:type ...] [--edge-valid-time-column COL]] \
+         (note: rows commit in chunks, so an error mid-import can leave the database \
+         partially written)"
             .to_string()
     }
 
@@ -1881,6 +1912,74 @@ mod parquet_cli_tests {
         .expect("history export should succeed");
         assert!(std::path::Path::new(&format!("{prefix}.node_history.parquet")).exists());
         assert!(std::path::Path::new(&format!("{prefix}.edge_history.parquet")).exists());
+    }
+
+    /// A mixed node+edge import where a node `--property` is present must succeed:
+    /// node and edge property mappings are scoped independently (`--property` vs
+    /// `--edge-property`), so the node-only `name` column is not applied to edges
+    /// (which have no such column). Regression test for the guide's mixed example.
+    #[test]
+    fn import_mixed_nodes_and_edges_with_node_property_succeeds() {
+        use arrow::array::{ArrayRef, RecordBatch, StringArray};
+        use std::sync::Arc;
+
+        fn write_parquet(path: &std::path::Path, batch: &RecordBatch) {
+            let file = std::fs::File::create(path).unwrap();
+            let mut writer =
+                ::parquet::arrow::ArrowWriter::try_new(file, batch.schema(), None).unwrap();
+            writer.write(batch).unwrap();
+            writer.close().unwrap();
+        }
+
+        let dir = TempDir::new().unwrap();
+        let nodes_path = dir.path().join("nodes.parquet");
+        let edges_path = dir.path().join("edges.parquet");
+
+        // Node file has a `name` column (a node-only property).
+        let node_batch = RecordBatch::try_from_iter(vec![
+            (
+                "id",
+                Arc::new(StringArray::from(vec!["alice", "bob"])) as ArrayRef,
+            ),
+            (
+                "name",
+                Arc::new(StringArray::from(vec!["Alice", "Bob"])) as ArrayRef,
+            ),
+        ])
+        .unwrap();
+        write_parquet(&nodes_path, &node_batch);
+
+        // Edge file has NO `name` column; a shared node `--property name` would abort.
+        let edge_batch = RecordBatch::try_from_iter(vec![
+            (
+                "src",
+                Arc::new(StringArray::from(vec!["alice"])) as ArrayRef,
+            ),
+            ("dst", Arc::new(StringArray::from(vec!["bob"])) as ArrayRef),
+        ])
+        .unwrap();
+        write_parquet(&edges_path, &edge_batch);
+
+        parquet_io::handle_import(vec![
+            s(nodes_path.to_str().unwrap()),
+            s("--format"),
+            s("parquet"),
+            s("--label"),
+            s("Person"),
+            s("--key"),
+            s("id"),
+            s("--property"),
+            s("name:string"),
+            s("--edges"),
+            s(edges_path.to_str().unwrap()),
+            s("--edge-label"),
+            s("KNOWS"),
+            s("--source-key"),
+            s("src"),
+            s("--target-key"),
+            s("dst"),
+        ])
+        .expect("mixed import with a node --property must succeed");
     }
 
     #[test]

--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -53,6 +53,10 @@ fn run() -> Result<(), String> {
         Some("daemon") => handle_daemon(args.collect()),
         Some("backup") => handle_backup(args.collect()),
         Some("restore") => handle_restore(args.collect()),
+        #[cfg(feature = "parquet")]
+        Some("import") => parquet_io::handle_import(args.collect()),
+        #[cfg(feature = "parquet")]
+        Some("export") => parquet_io::handle_export(args.collect()),
         #[cfg(feature = "audit-export")]
         Some("audit-keygen") => audit::handle_keygen(args.collect()),
         #[cfg(feature = "audit-export")]
@@ -85,6 +89,10 @@ Usage:\n\
   aletheia daemon status [--pid-file PATH]\n\
   aletheia backup <output_path>\n\
   aletheia restore <input_path>\n\
+  aletheia import <nodes_file> --format parquet --label L --key COL [--property name:type ...]\n\
+                  [--label-column COL] [--valid-time-column COL]\n\
+                  [--edges FILE --edge-label L --source-key COL --target-key COL [--property name:type ...]]\n\
+  aletheia export <out_prefix> --format parquet [--mode current|history]\n\
   aletheia audit-keygen <key_file>\n\
   aletheia audit-export <node|edge> <id> --key <key_file> --out <path> [--db-id ID] [--redact k1,k2]\n\
   aletheia audit-verify <artifact_path> [--public-key HEX]\n\
@@ -784,6 +792,22 @@ fn arg_value(args: &[String], flag: &str) -> Option<String> {
     None
 }
 
+/// Collects the values of every occurrence of a repeatable flag (e.g. all
+/// `--property name:type` pairs).
+#[cfg(feature = "parquet")]
+fn arg_values(args: &[String], flag: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    let mut iter = args.iter();
+    while let Some(token) = iter.next() {
+        if token == flag
+            && let Some(value) = iter.next()
+        {
+            values.push(value.clone());
+        }
+    }
+    values
+}
+
 /// Parses the `--properties` JSON argument if present, converting it to a `PropertyMap`.
 fn parse_optional_properties(args: &[String]) -> Result<PropertyMap, String> {
     match arg_value(args, "--properties") {
@@ -937,6 +961,221 @@ fn print_json_pretty(value: &serde_json::Value) -> Result<(), String> {
         Ok(_) => Ok(()),
         Err(e) if e.kind() == ErrorKind::BrokenPipe => Ok(()),
         Err(e) => Err(format!("error writing JSON output: {e}")),
+    }
+}
+
+/// Parquet columnar import/export subcommands (Issue #3364).
+#[cfg(feature = "parquet")]
+mod parquet_io {
+    use super::{arg_value, arg_values, open_db};
+    use aletheiadb::api::import::{ColumnType, EdgeMapping, LabelSource, NodeMapping};
+
+    /// `aletheia import <nodes_file> --format parquet --label L --key COL ...`
+    ///
+    /// Loads nodes (and optionally edges) from Parquet using the #3211 mapping
+    /// contract. `--label`/`--label-column` choose the label source; `--key` names the
+    /// business-key column; repeated `--property name:type` add typed property columns
+    /// (`type` in string|int|float|bool|timestamp|embedding).
+    pub(super) fn handle_import(args: Vec<String>) -> Result<(), String> {
+        let nodes_file = positional(&args).ok_or_else(usage_import)?;
+        require_parquet_format(&args)?;
+
+        let node_mapping = build_node_mapping(&args)?;
+        let db = open_db()?;
+        let mut importer = db.import();
+        let node_report = importer
+            .nodes_from_parquet(&nodes_file, node_mapping)
+            .map_err(|e| format!("node import failed: {e}"))?;
+
+        let mut edges_imported = 0usize;
+        if let Some(edges_file) = arg_value(&args, "--edges") {
+            let edge_mapping = build_edge_mapping(&args)?;
+            let edge_report = importer
+                .edges_from_parquet(&edges_file, edge_mapping)
+                .map_err(|e| format!("edge import failed: {e}"))?;
+            edges_imported = edge_report.edges_imported;
+        }
+
+        let value = serde_json::json!({
+            "ok": true,
+            "nodes_imported": node_report.nodes_imported,
+            "edges_imported": edges_imported,
+            "rows_read": node_report.rows_read,
+        });
+        println!(
+            "{}",
+            serde_json::to_string(&value).map_err(|e| format!("failed to render JSON: {e}"))?
+        );
+        Ok(())
+    }
+
+    /// `aletheia export <out_prefix> --format parquet [--mode current|history]`
+    ///
+    /// Writes two files: for `current` (the default) `<out_prefix>.nodes.parquet` and
+    /// `<out_prefix>.edges.parquet`; for `history` `<out_prefix>.node_history.parquet`
+    /// and `<out_prefix>.edge_history.parquet`.
+    pub(super) fn handle_export(args: Vec<String>) -> Result<(), String> {
+        let prefix = positional(&args).ok_or_else(usage_export)?;
+        require_parquet_format(&args)?;
+        let mode = arg_value(&args, "--mode").unwrap_or_else(|| "current".to_string());
+
+        let db = open_db()?;
+        let exporter = db.export();
+
+        let value = match mode.as_str() {
+            "current" => {
+                let nodes_path = format!("{prefix}.nodes.parquet");
+                let edges_path = format!("{prefix}.edges.parquet");
+                let nodes = exporter
+                    .nodes_to_parquet(&nodes_path)
+                    .map_err(|e| format!("node export failed: {e}"))?;
+                let edges = exporter
+                    .edges_to_parquet(&edges_path)
+                    .map_err(|e| format!("edge export failed: {e}"))?;
+                serde_json::json!({
+                    "ok": true,
+                    "mode": "current",
+                    "nodes_file": nodes_path,
+                    "edges_file": edges_path,
+                    "nodes_exported": nodes.nodes_exported,
+                    "edges_exported": edges.edges_exported,
+                })
+            }
+            "history" => {
+                let nodes_path = format!("{prefix}.node_history.parquet");
+                let edges_path = format!("{prefix}.edge_history.parquet");
+                let nodes = exporter
+                    .node_history_to_parquet(&nodes_path)
+                    .map_err(|e| format!("node history export failed: {e}"))?;
+                let edges = exporter
+                    .edge_history_to_parquet(&edges_path)
+                    .map_err(|e| format!("edge history export failed: {e}"))?;
+                serde_json::json!({
+                    "ok": true,
+                    "mode": "history",
+                    "node_history_file": nodes_path,
+                    "edge_history_file": edges_path,
+                    "node_versions_exported": nodes.node_versions_exported,
+                    "edge_versions_exported": edges.edge_versions_exported,
+                })
+            }
+            other => {
+                return Err(format!(
+                    "unknown --mode '{other}' (expected current|history)"
+                ));
+            }
+        };
+        println!(
+            "{}",
+            serde_json::to_string(&value).map_err(|e| format!("failed to render JSON: {e}"))?
+        );
+        Ok(())
+    }
+
+    /// The first non-flag, non-flag-value token (the required output/input path).
+    fn positional(args: &[String]) -> Option<String> {
+        let mut iter = args.iter();
+        while let Some(token) = iter.next() {
+            if token.starts_with("--") {
+                // Skip this flag's value too.
+                iter.next();
+            } else {
+                return Some(token.clone());
+            }
+        }
+        None
+    }
+
+    fn require_parquet_format(args: &[String]) -> Result<(), String> {
+        match arg_value(args, "--format").as_deref() {
+            Some("parquet") => Ok(()),
+            Some(other) => Err(format!("unsupported --format '{other}' (only 'parquet')")),
+            None => Err("missing required --format parquet".to_string()),
+        }
+    }
+
+    fn parse_column_type(spec: &str) -> Result<ColumnType, String> {
+        match spec {
+            "string" => Ok(ColumnType::String),
+            "int" => Ok(ColumnType::Int),
+            "float" => Ok(ColumnType::Float),
+            "bool" => Ok(ColumnType::Bool),
+            "timestamp" => Ok(ColumnType::Timestamp),
+            "embedding" => Ok(ColumnType::Embedding),
+            other => Err(format!(
+                "unknown property type '{other}' (expected string|int|float|bool|timestamp|embedding)"
+            )),
+        }
+    }
+
+    /// Parse repeated `--property name:type` flags into `(column, type)` pairs. The
+    /// column and property name are the same (`name`), matching a column-per-key export.
+    fn parse_properties(args: &[String]) -> Result<Vec<(String, ColumnType)>, String> {
+        let mut out = Vec::new();
+        for spec in arg_values(args, "--property") {
+            let (name, ty) = spec
+                .split_once(':')
+                .ok_or_else(|| format!("invalid --property '{spec}' (expected name:type)"))?;
+            if name.is_empty() {
+                return Err(format!("invalid --property '{spec}' (empty name)"));
+            }
+            out.push((name.to_string(), parse_column_type(ty)?));
+        }
+        Ok(out)
+    }
+
+    fn label_source(args: &[String]) -> Result<LabelSource, String> {
+        match (
+            arg_value(args, "--label"),
+            arg_value(args, "--label-column"),
+        ) {
+            (Some(_), Some(_)) => Err("use only one of --label / --label-column".to_string()),
+            (Some(fixed), None) => Ok(LabelSource::fixed(fixed)),
+            (None, Some(col)) => Ok(LabelSource::column(col)),
+            (None, None) => Err("missing required --label or --label-column".to_string()),
+        }
+    }
+
+    fn build_node_mapping(args: &[String]) -> Result<NodeMapping, String> {
+        let label = label_source(args)?;
+        let key = arg_value(args, "--key").ok_or_else(|| "missing required --key".to_string())?;
+        let mut mapping = NodeMapping::new(label, key);
+        for (name, ty) in parse_properties(args)? {
+            mapping = mapping.property_same(name, ty);
+        }
+        if let Some(col) = arg_value(args, "--valid-time-column") {
+            mapping = mapping.valid_time_column(col);
+        }
+        Ok(mapping)
+    }
+
+    fn build_edge_mapping(args: &[String]) -> Result<EdgeMapping, String> {
+        let label = arg_value(args, "--edge-label")
+            .map(LabelSource::fixed)
+            .ok_or_else(|| "missing required --edge-label for --edges".to_string())?;
+        let source = arg_value(args, "--source-key")
+            .ok_or_else(|| "missing required --source-key for --edges".to_string())?;
+        let target = arg_value(args, "--target-key")
+            .ok_or_else(|| "missing required --target-key for --edges".to_string())?;
+        let mut mapping = EdgeMapping::new(label, source, target);
+        for (name, ty) in parse_properties(args)? {
+            mapping = mapping.property_same(name, ty);
+        }
+        if let Some(col) = arg_value(args, "--valid-time-column") {
+            mapping = mapping.valid_time_column(col);
+        }
+        Ok(mapping)
+    }
+
+    fn usage_import() -> String {
+        "usage: aletheia import <nodes_file> --format parquet --label L --key COL \
+         [--property name:type ...] [--label-column COL] [--valid-time-column COL] \
+         [--edges FILE --edge-label L --source-key COL --target-key COL]"
+            .to_string()
+    }
+
+    fn usage_export() -> String {
+        "usage: aletheia export <out_prefix> --format parquet [--mode current|history]".to_string()
     }
 }
 
@@ -1580,5 +1819,82 @@ mod tests {
         let err = parse_optional_properties(&["--properties".to_string(), "not json".to_string()])
             .unwrap_err();
         assert!(err.contains("invalid JSON"), "unexpected error: {err}");
+    }
+}
+
+/// CLI smoke tests for the Parquet import/export verbs (Issue #3364).
+#[cfg(all(test, feature = "parquet"))]
+mod parquet_cli_tests {
+    use super::parquet_io;
+    use tempfile::TempDir;
+
+    fn s(v: &str) -> String {
+        v.to_string()
+    }
+
+    #[test]
+    fn import_missing_args_returns_usage_error() {
+        let err = parquet_io::handle_import(vec![]).unwrap_err();
+        assert!(err.contains("usage"), "got: {err}");
+    }
+
+    #[test]
+    fn export_missing_args_returns_usage_error() {
+        let err = parquet_io::handle_export(vec![]).unwrap_err();
+        assert!(err.contains("usage"), "got: {err}");
+    }
+
+    #[test]
+    fn import_requires_parquet_format() {
+        let err = parquet_io::handle_import(vec![
+            s("nodes.parquet"),
+            s("--label"),
+            s("Person"),
+            s("--key"),
+            s("id"),
+        ])
+        .unwrap_err();
+        assert!(err.contains("--format"), "got: {err}");
+    }
+
+    #[test]
+    fn export_current_writes_both_files() {
+        let dir = TempDir::new().unwrap();
+        let prefix = dir.path().join("out").display().to_string();
+        parquet_io::handle_export(vec![prefix.clone(), s("--format"), s("parquet")])
+            .expect("export should succeed");
+        assert!(std::path::Path::new(&format!("{prefix}.nodes.parquet")).exists());
+        assert!(std::path::Path::new(&format!("{prefix}.edges.parquet")).exists());
+    }
+
+    #[test]
+    fn export_history_writes_both_files() {
+        let dir = TempDir::new().unwrap();
+        let prefix = dir.path().join("hist").display().to_string();
+        parquet_io::handle_export(vec![
+            prefix.clone(),
+            s("--format"),
+            s("parquet"),
+            s("--mode"),
+            s("history"),
+        ])
+        .expect("history export should succeed");
+        assert!(std::path::Path::new(&format!("{prefix}.node_history.parquet")).exists());
+        assert!(std::path::Path::new(&format!("{prefix}.edge_history.parquet")).exists());
+    }
+
+    #[test]
+    fn export_rejects_unknown_mode() {
+        let dir = TempDir::new().unwrap();
+        let prefix = dir.path().join("out").display().to_string();
+        let err = parquet_io::handle_export(vec![
+            prefix,
+            s("--format"),
+            s("parquet"),
+            s("--mode"),
+            s("bogus"),
+        ])
+        .unwrap_err();
+        assert!(err.contains("mode"), "got: {err}");
     }
 }


### PR DESCRIPTION
## Before / After

**Before:** the only bulk interchange path was CSV/JSONL (#3211). Getting data between AletheiaDB and a Parquet lakehouse meant lossy CSV detours — types degraded to strings, embeddings didn't round-trip, and bi-temporal history had no columnar representation at all.

**After:** a data engineer can move a graph — including embeddings and full bi-temporal history — in and out of AletheiaDB as native Parquet:

```bash
# Import nodes/edges from Parquet (same mapping contract as #3211, columnar-native)
aletheia import people.parquet   --format parquet --label Person --key email \
                                 --property name:string --property age:int --property embedding:embedding
aletheia import knows.parquet    --format parquet --edge-type KNOWS --source-key src --target-key dst

# Export current state, or full bi-temporal history, back to the lake
aletheia export out --format parquet --mode current    # out.nodes.parquet + out.edges.parquet
aletheia export out --format parquet --mode history    # out.node_history.parquet + out.edge_history.parquet
```

Every exported history file is "bi-temporal graph history as a standard lake table" — an analyst can run temporal analytics in DuckDB/pandas/Spark directly over it.

## How

- **Dependency, feature-gated:** `parquet = { version = "59", default-features = false, features = ["arrow","snap"] }` + `arrow` (arrow-rs). New cargo feature `parquet = ["dep:parquet","dep:arrow","import"]`, **out of `default`** — the arrow/parquet dep stays out of default builds. `just check-features` gains a standalone `cargo check --no-default-features --tests --features parquet` line.
- **Import rides the #3211 loop:** `Importer::nodes_from_parquet`/`edges_from_parquet` decode row groups into the same `Row`/`Cell` stream the CSV/JSONL readers yield, then call the existing `import_nodes`/`import_edges` — so all #3211 semantics (abort vs skip-and-report, precise `row N:` errors, null-absence, valid-time backfill, unresolved-endpoint reporting) are inherited unchanged. `ColumnType` gains two additive variants, `Timestamp` and `Embedding`.
- **Greenfield export module** (`src/api/export/`): a two-pass streaming exporter. Pass 1 discovers the property schema; pass 2 emits `batch_size`-row Arrow `RecordBatch`es, each flushed as one Parquet row group (Snappy) before the next is built — bounded peak memory. History mode enumerates entities through the whole-window changefeed so deleted/retracted entities are still exported with their tombstone.
- **Self-describing schema:** file-level key/value metadata (`aletheiadb.schema_version`, `aletheiadb.mode`) lets the importer auto-expand the `properties_json` overflow column of our own exports back into native properties.

## Acceptance-criteria evidence

| # | Acceptance criterion | Status | Evidence |
|---|---|---|---|
| 1 | **Import** API + CLI (`aletheia import --format parquet`), #3211 mapping contract, native numeric/string/bool/**timestamp**/**list-float embedding** columns, optional per-row `valid_time` | **Met** | CLI: `src/bin/aletheia.rs:57,988` (`parquet_io::handle_import`). API: `Importer::nodes_from_parquet`/`edges_from_parquet` (`src/api/import/mod.rs:49`) reuse `import_nodes`/`import_edges`. `ColumnType::{Timestamp,Embedding}` (`src/api/import/mapping.rs`). Tests: `scalar_types_round_trip_natively`, `embedding_list_float32_round_trips_exact_bits`, `native_timestamp_valid_time_round_trips_with_as_of` (`src/api/import/parquet_tests.rs`) |
| 2 | **Export (current state)** typed columns + documented stable schema | **Met** | `Exporter::nodes_to_parquet`/`edges_to_parquet` (`src/api/export/mod.rs`, `parquet.rs`). Stable schema + file metadata documented in `docs/guides/parquet-import-export.md`. Tests: `current_state_round_trip_all_scalar_types_and_embedding`, `current_state_export_stamps_file_metadata` (`src/api/export/tests.rs`) |
| 3 | **Export (history)** one row/version: `valid_from`/`valid_to`(null=open)/`transaction_time`/tombstone/provenance | **Met** | `node_history_to_parquet`/`edge_history_to_parquet`. Tests: `node_history_export_one_row_per_version_with_open_valid_to_null`, `..._marks_tombstone_and_closes_valid_to_on_retract`, `..._carries_provenance_columns`, `..._has_transaction_to_column_null_for_open`, `node_history_tombstone_equals_closed_valid_interval` |
| 4 | **Round-trip fidelity** — export→import reproduces state incl. vectors; history re-import yields identical `AS OF VALID_TIME` answers | **Met** | `current_state_round_trip_all_scalar_types_and_embedding`, `valid_time_column_reimports_and_answers_as_of`, `absent_property_is_null_and_reimports_absent`, `overflow_column_auto_expands_on_reimport_end_to_end`, `deleted_edge_history_recovers_source_and_target_keys` |
| 5 | Files readable by **DuckDB and pandas/pyarrow** without errors, verified | **Partially Met** | Files are standard Snappy Parquet with UTC-zoned `timestamp(µs)` columns, verified readable via the canonical arrow-rs `ParquetRecordBatchReader` in every export test (`read_parquet`, `src/api/export/tests.rs:30`) — the same libparquet family pyarrow/DuckDB use. `docs/guides/parquet-import-export.md` §"Reading the files" carries a worked DuckDB SQL example + a pandas snippet. **Gap:** no CI script literally invokes DuckDB/pandas (see follow-ups) |
| 6 | **Malformed input** matches #3211: `row N:` errors, abort vs skip-and-report, unresolved endpoints reported never dropped | **Met** | `missing_label_column_errors_with_row_number`, `wrong_column_type_abort_reports_row_number`, `wrong_column_type_skip_and_report`, `unresolved_target_endpoint_reported`, `non_parquet_file_is_clean_error_no_writes`, plus overflow/panic-safety edge tests (`date32_overflow_is_clean_row_error_not_panic`, `uint64_above_i64_max_is_clean_error`, `null_element_in_embedding_list_is_clean_error`) in `src/api/import/parquet_tests.rs` |
| 7 | **Streaming** export in row groups, bounded (documented) memory | **Met** | Two-pass streaming, one `RecordBatch`/row group; documented ~1-batch bound ("well under 1 GB" for 1M nodes) in `src/api/export/mod.rs` module docs + `docs/guides/parquet-import-export.md` §"Streaming and memory". Test: `large_export_streams_all_rows_across_row_groups` |
| 8 | **Docs page** both directions + worked DuckDB history example | **Met** | `docs/guides/parquet-import-export.md` (313 lines), linked from `docs/guides/README.md`; §"Reading the files" has the "count facts valid on a date per label" DuckDB SQL over an exported history file |
| — | Feature-flag / default-off | **Met** | `parquet` feature not in `default = ["config-toml","audit-export"]`; `just check-features` standalone line (`justfile`) |
| — | Benchmarks + throughput/memory targets | **Partially Met** | `benches/parquet_throughput.rs` (`required-features=["parquet"]`) benches Parquet-vs-CSV import and current+history export; CI-friendly default row count, `BENCH_PARQUET_ROWS` to scale to the 1M production target. **The 1M-scale numbers (import ≥20% faster than CSV; export <30s/<1GB) are not run in CI** — see Benchmarks + follow-ups |
| — | MCP surface **out of scope** | **Met (correctly excluded)** | No `src/mcp/**` changes in the diff |

## Testing

All gates run with an isolated target dir. Local results:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --no-default-features --features parquet --all-targets -- -D warnings` — clean
- `cargo test --no-default-features --features parquet --lib api::` — **242 passed / 0 failed** (35 Parquet-specific: 18 import in `api::import::parquet_tests`, 17 export in `api::export::tests`)
- `cargo test --no-default-features --features parquet --bin aletheia` — **52 passed / 0 failed** (7 in `parquet_cli_tests`: `export_current_writes_both_files`, `export_history_writes_both_files`, `import_mixed_nodes_and_edges_with_node_property_succeeds`, `import_requires_parquet_format`, `export_rejects_unknown_mode`, + usage-error cases)
- `cargo check --no-default-features --tests` and `--features parquet` — clean (feature compiles standalone, matching the `just check-features` CI job)
- `cargo bench --no-run --no-default-features --features parquet` — `parquet_throughput` bench compiles

Key new test names: `current_state_round_trip_all_scalar_types_and_embedding`, `valid_time_column_reimports_and_answers_as_of`, `node_history_export_one_row_per_version_with_open_valid_to_null`, `node_history_export_marks_tombstone_and_closes_valid_to_on_retract`, `deleted_edge_history_recovers_source_and_target_keys`, `overflow_column_auto_expands_on_reimport_end_to_end`, `embedding_list_float32_round_trips_exact_bits`, `native_timestamp_valid_time_round_trips_with_as_of`.

## Benchmarks

`benches/parquet_throughput.rs` — Parquet-vs-CSV import over identical rows + current/history export throughput. Directional numbers at `BENCH_PARQUET_ROWS=5000` (10 samples, this CI box):

| Bench | median |
|---|---|
| `parquet_import_nodes/parquet` | ~31.3 ms |
| `parquet_import_nodes/csv` | ~30.6 ms |
| `parquet_export/current_nodes` | ~3.43 ms |
| `parquet_export/current_edges` | ~775 µs |
| `parquet_export/history_nodes` | ~11.9 ms |

At 5k rows import is WAL-commit-dominated, so Parquet≈CSV here; the columnar-decode advantage (≥20% target) manifests at the 1M scale where decode, not commit, dominates. **Scale to the production target** with `BENCH_PARQUET_ROWS=1000000 cargo bench --no-default-features --features parquet --bench parquet_throughput` (intentionally not run in CI — slow/heavy).

## Known limitations / follow-ups

- **DuckDB/pandas readability (AC #5)** is verified through the arrow-rs Parquet reader (same libparquet family as pyarrow/DuckDB) plus a worked DuckDB SQL doc example, but there is **no CI step that literally opens an artifact with DuckDB or pandas**. This environment has neither installed and CI workflow files are outside this PR's lane — recommend a follow-up adding a pyarrow/DuckDB smoke step to CI.
- **1M-scale numbers not run in CI** — the `≥20% faster than CSV` and `<30s / <1GB` success metrics are reproducible via `BENCH_PARQUET_ROWS` but are not asserted in CI (would be minutes-long). Follow-up: a gated large-scale perf job.
- **Overflow columns** (`Bytes`, heterogeneous `Array`, `SparseVector`, and any property key whose type conflicts across rows) route to a single reversible `properties_json` column. Round-trip of **our own exports is now lossless** — the importer auto-expands `properties_json` back to native properties (identified by `aletheiadb.schema_version` file metadata; test `overflow_column_auto_expands_on_reimport_end_to_end`). Re-importing that column from a *foreign* Parquet file still needs custom mapping.
- **Tombstone / deleted-edge completeness** rests on the whole-window changefeed enumeration; a deleted edge's endpoints are not carried on a historical version, so `source_key`/`target_key` are written null for a no-longer-live edge (documented; residual completeness caveat is the changefeed's own).
- **HLC logical-counter loss:** only the µs wallclock of `HybridTimestamp` is exported; the sub-microsecond logical tiebreaker is dropped (two events in the same microsecond differ only by logical — documented, acceptable).
- **CI clippy note:** CI clippy runs `--features "config-toml,mcp-server,sharding-rpc,simulation"` (not `--all-features`), so it does not compile the `parquet` code nor the `http-server`-gated `tests/http_run_server_body_limit.rs`; the known pre-existing `collapsible_if` lint there will **not** make this PR's CI red.

Design comment: https://github.com/madmax983/AletheiaDB/issues/3364#issuecomment-4949589868

Closes #3364

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpS7vn3rr6kzksJ8Q2A4qz)_