### PR TITLE
Cypher: EXPLAIN / PROFILE entry points (#562)

### DIFF
--- a/src/cypher/ast.rs
+++ b/src/cypher/ast.rs
@@ -73,6 +73,22 @@ pub enum CypherStatement {
         /// `ORDER BY`, `SKIP`, `LIMIT`).
         return_clause: CypherReturn,
     },
+
+    /// `EXPLAIN <statement>` -- return the query plan for the wrapped statement
+    /// **without executing it** (Issue #562).
+    ///
+    /// The inner statement is any ordinary readable statement (a `MATCH`,
+    /// optionally with a leading temporal clause). A nested/duplicate prefix
+    /// (`EXPLAIN EXPLAIN`, `EXPLAIN PROFILE`) is rejected at parse time, so the
+    /// boxed inner is never itself an `Explain`/`Profile`.
+    Explain(Box<CypherStatement>),
+
+    /// `PROFILE <statement>` -- **execute** the wrapped statement and return its
+    /// plan annotated with per-operator executed statistics (row counts and
+    /// timing) (Issue #562).
+    ///
+    /// Same nesting rules as [`CypherStatement::Explain`].
+    Profile(Box<CypherStatement>),
 }
 
 /// A subsequent `OPTIONAL MATCH` clause within a `MATCH` statement.

--- a/src/cypher/converter.rs
+++ b/src/cypher/converter.rs
@@ -419,6 +419,19 @@ impl CypherConverter {
                  evaluates the list-expansion runtime directly"
                     .to_string(),
             )),
+            // `EXPLAIN`/`PROFILE` are planning/execution *directives*, not
+            // queries: they are unwrapped and dispatched by
+            // [`crate::cypher::plan_cypher`] (which lowers the inner statement
+            // and returns a dedicated `CypherExecution::Explain`/`Profile`), so
+            // the converter never sees them directly. Reject rather than answer
+            // silently wrong if one reaches here.
+            CypherStatement::Explain(_) | CypherStatement::Profile(_) => {
+                Err(CypherError::UnsupportedFeature(
+                    "EXPLAIN/PROFILE are query directives handled by \
+                     cypher::plan_cypher, not lowered by the converter"
+                        .to_string(),
+                ))
+            }
         }
     }
 

--- a/src/cypher/exec.rs
+++ b/src/cypher/exec.rs
@@ -74,6 +74,14 @@ pub enum CypherExecution {
     Query(Query),
     /// Pre-computed result rows (a standalone `UNWIND` expansion).
     Rows(QueryResults),
+    /// `EXPLAIN <query>` (Issue #562): plan the wrapped query and return the
+    /// physical plan as a single `plan` row **without executing it**. The
+    /// caller (`AletheiaDB::execute_cypher`) plans only.
+    Explain(Query),
+    /// `PROFILE <query>` (Issue #562): execute the wrapped query with
+    /// per-operator instrumentation and return the annotated plan as a single
+    /// `plan` row.
+    Profile(Query),
 }
 
 /// Parse and plan a Cypher string with no bound parameters.
@@ -110,10 +118,42 @@ pub fn plan_cypher_with_params(
             let results = execute_unwind(&source, &variable, &return_clause, &params)?;
             Ok(CypherExecution::Rows(results))
         }
+        CypherStatement::Explain(inner) => {
+            let query = lower_for_plan(*inner, params, "EXPLAIN")?;
+            Ok(CypherExecution::Explain(query))
+        }
+        CypherStatement::Profile(inner) => {
+            let query = lower_for_plan(*inner, params, "PROFILE")?;
+            Ok(CypherExecution::Profile(query))
+        }
         other => {
             let query = CypherConverter::with_params(params).convert(other)?;
             Ok(CypherExecution::Query(query))
         }
+    }
+}
+
+/// Lower the statement wrapped by `EXPLAIN`/`PROFILE` into a plannable [`Query`].
+///
+/// Only statements that convert to the graph-query IR are supported. A
+/// standalone `UNWIND` has no `Query` representation (it is evaluated directly
+/// into scalar rows), so `EXPLAIN`/`PROFILE` over it is rejected with an honest
+/// [`CypherError::UnsupportedFeature`] rather than fabricating a plan. A nested
+/// prefix is unreachable (the parser rejects it) but is handled defensively.
+fn lower_for_plan(
+    inner: CypherStatement,
+    params: HashMap<String, CypherParameterValue>,
+    verb: &str,
+) -> Result<Query, CypherError> {
+    match inner {
+        CypherStatement::Unwind { .. } => Err(CypherError::UnsupportedFeature(format!(
+            "{verb} is not supported for a standalone UNWIND statement yet; UNWIND expands a list \
+             into scalar rows and does not lower to a plannable graph query"
+        ))),
+        CypherStatement::Explain(_) | CypherStatement::Profile(_) => Err(
+            CypherError::UnsupportedFeature(format!("{verb} cannot wrap another EXPLAIN/PROFILE")),
+        ),
+        stmt => CypherConverter::with_params(params).convert(stmt),
     }
 }
 

--- a/src/cypher/lexer.rs
+++ b/src/cypher/lexer.rs
@@ -37,10 +37,6 @@ pub enum TokenKind {
     With,
     /// `UNWIND`
     Unwind,
-    /// `EXPLAIN` (query-plan inspection prefix, Issue #562)
-    Explain,
-    /// `PROFILE` (executed-plan statistics prefix, Issue #562)
-    Profile,
 
     // -- Keywords: ordering / projection ------------------------------------
     /// `ORDER`
@@ -641,8 +637,6 @@ impl<'a> CypherLexer<'a> {
             "RETURN" => TokenKind::Return,
             "WITH" => TokenKind::With,
             "UNWIND" => TokenKind::Unwind,
-            "EXPLAIN" => TokenKind::Explain,
-            "PROFILE" => TokenKind::Profile,
 
             // Ordering / projection
             "ORDER" => TokenKind::Order,
@@ -711,8 +705,6 @@ mod unit_tests {
             "RETURN",
             "WITH",
             "UNWIND",
-            "EXPLAIN",
-            "PROFILE",
             "ORDER",
             "BY",
             "LIMIT",

--- a/src/cypher/lexer.rs
+++ b/src/cypher/lexer.rs
@@ -37,6 +37,10 @@ pub enum TokenKind {
     With,
     /// `UNWIND`
     Unwind,
+    /// `EXPLAIN` (query-plan inspection prefix, Issue #562)
+    Explain,
+    /// `PROFILE` (executed-plan statistics prefix, Issue #562)
+    Profile,
 
     // -- Keywords: ordering / projection ------------------------------------
     /// `ORDER`
@@ -637,6 +641,8 @@ impl<'a> CypherLexer<'a> {
             "RETURN" => TokenKind::Return,
             "WITH" => TokenKind::With,
             "UNWIND" => TokenKind::Unwind,
+            "EXPLAIN" => TokenKind::Explain,
+            "PROFILE" => TokenKind::Profile,
 
             // Ordering / projection
             "ORDER" => TokenKind::Order,
@@ -705,6 +711,8 @@ mod unit_tests {
             "RETURN",
             "WITH",
             "UNWIND",
+            "EXPLAIN",
+            "PROFILE",
             "ORDER",
             "BY",
             "LIMIT",

--- a/src/cypher/parser.rs
+++ b/src/cypher/parser.rs
@@ -148,6 +148,26 @@ impl CypherParser {
         }
     }
 
+    /// If the current token is a bare identifier whose text (case-insensitively)
+    /// is `EXPLAIN` or `PROFILE`, return `Some(true)` for `EXPLAIN` /
+    /// `Some(false)` for `PROFILE`; otherwise `None`.
+    ///
+    /// `EXPLAIN` / `PROFILE` are pre-parser prefix keywords (Issue #562): they
+    /// are only meaningful at statement start and remain ordinary identifiers
+    /// everywhere else, so they are lexed as [`TokenKind::Identifier`] and
+    /// distinguished here by inspecting the token text.
+    fn leading_explain_profile_prefix(&self) -> Option<bool> {
+        let tok = self.peek();
+        if tok.kind != TokenKind::Identifier {
+            return None;
+        }
+        match tok.text.to_ascii_uppercase().as_str() {
+            "EXPLAIN" => Some(true),
+            "PROFILE" => Some(false),
+            _ => None,
+        }
+    }
+
     /// Build a [`CypherError::ParseError`] at the current token position.
     fn error(&self, message: &str) -> CypherError {
         CypherError::ParseError {
@@ -171,10 +191,18 @@ impl CypherParser {
         // nested/duplicate prefix (`EXPLAIN EXPLAIN`, `EXPLAIN PROFILE`,
         // `PROFILE EXPLAIN`, `PROFILE PROFILE`) is rejected rather than silently
         // collapsed.
-        if self.at(TokenKind::Explain) || self.at(TokenKind::Profile) {
-            let is_explain = self.at(TokenKind::Explain);
-            self.advance(); // consume the prefix keyword
-            if self.at(TokenKind::Explain) || self.at(TokenKind::Profile) {
+        //
+        // These are PRE-PARSER keywords: openCypher treats them as special only
+        // at statement start, so they lex as ordinary identifiers and must stay
+        // usable as variables/labels/rel-types/property keys everywhere else.
+        // We therefore detect the prefix by inspecting the leading token's
+        // *text* (see `leading_explain_profile_prefix`) rather than a dedicated
+        // token kind. This is unambiguous: no valid statement begins with a bare
+        // identifier (statements start with MATCH / OPTIONAL / UNWIND / a
+        // temporal keyword), so a leading identifier is only ever the prefix.
+        if let Some(is_explain) = self.leading_explain_profile_prefix() {
+            self.advance(); // consume the prefix identifier
+            if self.leading_explain_profile_prefix().is_some() {
                 return Err(self.error(
                     "EXPLAIN/PROFILE cannot be nested; use a single EXPLAIN or PROFILE prefix",
                 ));

--- a/src/cypher/parser.rs
+++ b/src/cypher/parser.rs
@@ -164,6 +164,29 @@ impl CypherParser {
     /// statement := [temporal] match_stmt
     /// ```
     fn parse_statement(&mut self) -> Result<CypherStatement, CypherError> {
+        // A leading `EXPLAIN` / `PROFILE` prefix (Issue #562) wraps the rest of
+        // the statement. It is handled *before* the expression grammar (it adds
+        // no expression recursion, so the depth caps are untouched) and before
+        // the temporal clause, so `EXPLAIN AS OF ... MATCH ...` works. A
+        // nested/duplicate prefix (`EXPLAIN EXPLAIN`, `EXPLAIN PROFILE`,
+        // `PROFILE EXPLAIN`, `PROFILE PROFILE`) is rejected rather than silently
+        // collapsed.
+        if self.at(TokenKind::Explain) || self.at(TokenKind::Profile) {
+            let is_explain = self.at(TokenKind::Explain);
+            self.advance(); // consume the prefix keyword
+            if self.at(TokenKind::Explain) || self.at(TokenKind::Profile) {
+                return Err(self.error(
+                    "EXPLAIN/PROFILE cannot be nested; use a single EXPLAIN or PROFILE prefix",
+                ));
+            }
+            let inner = self.parse_statement()?;
+            return Ok(if is_explain {
+                CypherStatement::Explain(Box::new(inner))
+            } else {
+                CypherStatement::Profile(Box::new(inner))
+            });
+        }
+
         // Check for leading temporal clause (AS OF / FOR / BETWEEN).
         let temporal = self.try_parse_temporal()?;
 

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -5262,6 +5262,38 @@ mod explain_profile_parse {
     }
 
     #[test]
+    fn identifier_named_explain_still_parses() {
+        // `explain` used as a variable name must still parse (pre-parser
+        // keyword semantics: EXPLAIN is only special at statement start).
+        let ast = CypherParser::parse("MATCH (explain:Thing) RETURN explain").unwrap();
+        assert!(matches!(ast, CypherStatement::Match { .. }));
+    }
+
+    #[test]
+    fn property_key_profile_still_parses() {
+        let ast = CypherParser::parse("MATCH (n) WHERE n.profile = 1 RETURN n").unwrap();
+        assert!(matches!(ast, CypherStatement::Match { .. }));
+    }
+
+    #[test]
+    fn label_named_profile_still_parses() {
+        let ast = CypherParser::parse("MATCH (n:Profile) RETURN n").unwrap();
+        assert!(matches!(ast, CypherStatement::Match { .. }));
+    }
+
+    #[test]
+    fn rel_type_named_explain_still_parses() {
+        let ast = CypherParser::parse("MATCH (a)-[:EXPLAIN]->(b) RETURN b").unwrap();
+        assert!(matches!(ast, CypherStatement::Match { .. }));
+    }
+
+    #[test]
+    fn inline_property_explain_still_parses() {
+        let ast = CypherParser::parse("MATCH (n {explain: 1}) RETURN n").unwrap();
+        assert!(matches!(ast, CypherStatement::Match { .. }));
+    }
+
+    #[test]
     fn deep_inner_expression_hits_the_depth_cap_cleanly() {
         // A pathologically deep expression under EXPLAIN must surface the
         // expression depth cap as a ParseError (no stack overflow / SIGABRT):

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -4840,14 +4840,20 @@ mod unwind {
 
     #[test]
     fn plan_cypher_routes_unwind_to_rows() {
-        match plan_cypher("UNWIND [1, 2] AS x RETURN x").unwrap() {
-            CypherExecution::Rows(_) => {}
-            CypherExecution::Query(_) => panic!("UNWIND must plan to Rows, not a Query"),
-        }
-        match plan_cypher("MATCH (n:Person) RETURN n").unwrap() {
-            CypherExecution::Query(_) => {}
-            CypherExecution::Rows(_) => panic!("MATCH must plan to a Query"),
-        }
+        assert!(
+            matches!(
+                plan_cypher("UNWIND [1, 2] AS x RETURN x").unwrap(),
+                CypherExecution::Rows(_)
+            ),
+            "UNWIND must plan to Rows, not a Query"
+        );
+        assert!(
+            matches!(
+                plan_cypher("MATCH (n:Person) RETURN n").unwrap(),
+                CypherExecution::Query(_)
+            ),
+            "MATCH must plan to a Query"
+        );
     }
 
     // ---- depth / robustness (issue #3404) ----------------------------------
@@ -4994,6 +5000,281 @@ mod unwind {
         assert!(
             matches!(err, Err(CypherError::ParseError { .. })),
             "an over-cap list literal must yield a ParseError, got {err:?}"
+        );
+    }
+}
+
+// ============================================================================
+// EXPLAIN / PROFILE entry points (Issue #562)
+// ============================================================================
+
+#[cfg(test)]
+mod explain_profile {
+    use crate::AletheiaDB;
+    use crate::core::property::{
+        PropertyMap as CorePropertyMap, PropertyMapBuilder, PropertyValue,
+    };
+
+    /// Run a Cypher statement expected to return exactly one computed row with a
+    /// single `plan` string column, and return that plan text.
+    fn plan_text(db: &AletheiaDB, query: &str) -> String {
+        let results = db
+            .execute_cypher(query)
+            .unwrap_or_else(|e| panic!("`{query}` should execute, got error: {e:?}"));
+        let rows: Vec<_> = results.collect::<Result<Vec<_>, _>>().unwrap();
+        assert_eq!(rows.len(), 1, "EXPLAIN/PROFILE must return exactly one row");
+        let cols = rows[0]
+            .columns
+            .as_ref()
+            .expect("plan row must carry computed columns");
+        assert_eq!(cols.len(), 1, "plan row has a single column");
+        assert_eq!(cols[0].0, "plan", "the column is named `plan`");
+        match &cols[0].1 {
+            PropertyValue::String(s) => s.to_string(),
+            other => panic!("plan column must be a string, got {other:?}"),
+        }
+    }
+
+    fn seed_people(db: &AletheiaDB) {
+        for name in ["Alice", "Bob", "Carol"] {
+            let props = PropertyMapBuilder::new().insert("name", name).build();
+            db.create_node("Person", props).unwrap();
+        }
+    }
+
+    #[test]
+    fn explain_returns_a_plan_with_estimates() {
+        let db = AletheiaDB::new().unwrap();
+        seed_people(&db);
+        let text = plan_text(&db, "EXPLAIN MATCH (n:Person) RETURN n");
+        assert!(
+            text.contains("Physical Plan"),
+            "EXPLAIN output should carry the plan header: {text}"
+        );
+        assert!(
+            text.contains("NodeScan"),
+            "EXPLAIN of a label scan should name the NodeScan operator: {text}"
+        );
+        assert!(
+            text.contains("rows:"),
+            "EXPLAIN output should include a `rows:` estimate: {text}"
+        );
+        // EXPLAIN must not annotate with executed stats.
+        assert!(
+            !text.contains("actual rows:"),
+            "EXPLAIN must not include executed `actual rows:` stats: {text}"
+        );
+    }
+
+    #[test]
+    fn explain_does_not_execute() {
+        // An empty database still yields a plan (planning, not execution).
+        let db = AletheiaDB::new().unwrap();
+        let text = plan_text(&db, "EXPLAIN MATCH (n:Person) RETURN n");
+        assert!(
+            text.contains("NodeScan"),
+            "plan present even with no data: {text}"
+        );
+    }
+
+    #[test]
+    fn profile_reports_actual_rows_and_timing() {
+        let db = AletheiaDB::new().unwrap();
+        seed_people(&db);
+        let text = plan_text(&db, "PROFILE MATCH (n:Person) RETURN n");
+        assert!(
+            text.contains("actual rows: 3"),
+            "PROFILE scan should report 3 actual rows: {text}"
+        );
+        assert!(
+            text.contains("time:"),
+            "PROFILE output should include a per-operator timing field: {text}"
+        );
+        assert!(
+            text.contains("NodeScan"),
+            "PROFILE output names the executed operator: {text}"
+        );
+    }
+
+    #[test]
+    fn profile_filter_reflects_selectivity() {
+        let db = AletheiaDB::new().unwrap();
+        for age in [10i64, 20, 30] {
+            let props = PropertyMapBuilder::new()
+                .insert("name", "P")
+                .insert("age", age)
+                .build();
+            db.create_node("Person", props).unwrap();
+        }
+        let text = plan_text(&db, "PROFILE MATCH (n:Person) WHERE n.age > 18 RETURN n");
+        assert!(
+            text.contains("Filter"),
+            "PROFILE should show the Filter operator: {text}"
+        );
+        // 2 of 3 satisfy age > 18.
+        assert!(
+            text.contains("actual rows: 2"),
+            "Filter should emit 2 rows for age > 18: {text}"
+        );
+    }
+
+    #[test]
+    fn explain_shows_property_scan_optimization() {
+        // AC-5: a property-filtered label match lowers to a PropertyScan; the
+        // EXPLAIN output must surface that optimized operator.
+        let db = AletheiaDB::new().unwrap();
+        seed_people(&db);
+        let text = plan_text(&db, "EXPLAIN MATCH (n:Person {name: 'Alice'}) RETURN n");
+        assert!(
+            text.contains("PropertyScan"),
+            "EXPLAIN of a property-filtered scan should name PropertyScan: {text}"
+        );
+    }
+
+    #[test]
+    fn explain_unwind_is_rejected_honestly() {
+        let db = AletheiaDB::new().unwrap();
+        let err = db.execute_cypher("EXPLAIN UNWIND [1, 2, 3] AS x RETURN x");
+        assert!(
+            err.is_err(),
+            "EXPLAIN of a standalone UNWIND should be a structured error, not a fake plan"
+        );
+    }
+
+    #[test]
+    fn profile_traversal_shows_operators() {
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Alice").build(),
+            )
+            .unwrap();
+        let b = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Bob").build(),
+            )
+            .unwrap();
+        db.create_edge(a, b, "KNOWS", CorePropertyMap::new())
+            .unwrap();
+        let text = plan_text(
+            &db,
+            "PROFILE MATCH (a:Person {name: 'Alice'})-[:KNOWS]->(b) RETURN b",
+        );
+        assert!(
+            text.contains("IndexedTraversal"),
+            "PROFILE of a traversal should show the traversal operator: {text}"
+        );
+        assert!(text.contains("actual rows:"), "traversal annotated: {text}");
+    }
+}
+
+// ============================================================================
+// EXPLAIN / PROFILE parsing (Issue #562)
+// ============================================================================
+
+#[cfg(test)]
+mod explain_profile_parse {
+    use super::super::ast::CypherStatement;
+    use super::super::error::CypherError;
+    use super::super::parser::CypherParser;
+
+    #[test]
+    fn explain_wraps_the_inner_match() {
+        let ast = CypherParser::parse("EXPLAIN MATCH (n) RETURN n").unwrap();
+        match ast {
+            CypherStatement::Explain(inner) => {
+                assert!(matches!(*inner, CypherStatement::Match { .. }));
+            }
+            other => panic!("expected Explain(Match), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn profile_wraps_the_inner_match() {
+        let ast = CypherParser::parse("PROFILE MATCH (n:Person) RETURN n").unwrap();
+        match ast {
+            CypherStatement::Profile(inner) => {
+                assert!(matches!(*inner, CypherStatement::Match { .. }));
+            }
+            other => panic!("expected Profile(Match), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn keywords_are_case_insensitive() {
+        assert!(matches!(
+            CypherParser::parse("explain MATCH (n) RETURN n").unwrap(),
+            CypherStatement::Explain(_)
+        ));
+        assert!(matches!(
+            CypherParser::parse("Profile Match (n) Return n").unwrap(),
+            CypherStatement::Profile(_)
+        ));
+    }
+
+    #[test]
+    fn explain_wraps_a_standalone_unwind_at_parse_level() {
+        // The parser accepts EXPLAIN over any statement; the execution layer is
+        // where UNWIND is rejected (it has no plannable Query). Parsing must
+        // still produce Explain(Unwind).
+        let ast = CypherParser::parse("EXPLAIN UNWIND [1, 2] AS x RETURN x").unwrap();
+        match ast {
+            CypherStatement::Explain(inner) => {
+                assert!(matches!(*inner, CypherStatement::Unwind { .. }));
+            }
+            other => panic!("expected Explain(Unwind), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn explain_allows_a_leading_temporal_clause() {
+        let ast = CypherParser::parse(
+            "EXPLAIN AS OF TIMESTAMP '2024-01-01T00:00:00Z' MATCH (n) RETURN n",
+        )
+        .unwrap();
+        match ast {
+            CypherStatement::Explain(inner) => match *inner {
+                CypherStatement::Match { temporal, .. } => {
+                    assert!(temporal.is_some(), "temporal clause should be captured");
+                }
+                other => panic!("expected inner Match, got {other:?}"),
+            },
+            other => panic!("expected Explain(Match), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_and_duplicate_prefixes_are_rejected() {
+        for q in [
+            "EXPLAIN EXPLAIN MATCH (n) RETURN n",
+            "EXPLAIN PROFILE MATCH (n) RETURN n",
+            "PROFILE EXPLAIN MATCH (n) RETURN n",
+            "PROFILE PROFILE MATCH (n) RETURN n",
+        ] {
+            let result = CypherParser::parse(q);
+            assert!(
+                matches!(result, Err(CypherError::ParseError { .. })),
+                "`{q}` must be a ParseError, got {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn deep_inner_expression_hits_the_depth_cap_cleanly() {
+        // A pathologically deep expression under EXPLAIN must surface the
+        // expression depth cap as a ParseError (no stack overflow / SIGABRT):
+        // the prefix adds no expression recursion and must not defeat the cap.
+        let query = format!(
+            "EXPLAIN MATCH (n) WHERE {}n.a = 1{} RETURN n",
+            "(".repeat(5000),
+            ")".repeat(5000)
+        );
+        let result = CypherParser::parse(&query);
+        assert!(
+            matches!(result, Err(CypherError::ParseError { .. })),
+            "deep nested expression under EXPLAIN must be a ParseError, got {result:?}"
         );
     }
 }

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -339,6 +339,8 @@ impl AletheiaDB {
         match crate::cypher::plan_cypher(query_string)? {
             crate::cypher::CypherExecution::Query(query) => self.execute_query(query),
             crate::cypher::CypherExecution::Rows(results) => Ok(results),
+            crate::cypher::CypherExecution::Explain(query) => self.explain_cypher_query(query),
+            crate::cypher::CypherExecution::Profile(query) => self.profile_cypher_query(query),
         }
     }
 
@@ -383,7 +385,54 @@ impl AletheiaDB {
         match crate::cypher::plan_cypher_with_params(query_string, params)? {
             crate::cypher::CypherExecution::Query(query) => self.execute_query(query),
             crate::cypher::CypherExecution::Rows(results) => Ok(results),
+            crate::cypher::CypherExecution::Explain(query) => self.explain_cypher_query(query),
+            crate::cypher::CypherExecution::Profile(query) => self.profile_cypher_query(query),
         }
+    }
+
+    /// Plan (but do not execute) a Cypher `EXPLAIN` query, returning the
+    /// physical plan as a single `plan` text row (Issue #562).
+    ///
+    /// This mirrors [`Self::execute_query`]'s planner construction but stops
+    /// after planning -- no executor is run, so there are no side effects and
+    /// the plan is returned even against an empty database.
+    fn explain_cypher_query(&self, query: Query) -> Result<QueryResults> {
+        let planner = QueryPlanner::new(Arc::clone(&self.stats), Arc::clone(&self.current));
+        let physical_plan = planner.plan(query)?;
+        Ok(Self::plan_text_result("plan", physical_plan.explain()))
+    }
+
+    /// Execute a Cypher `PROFILE` query with per-operator instrumentation,
+    /// returning the plan annotated with executed row counts and timing as a
+    /// single `plan` text row (Issue #562).
+    ///
+    /// The instrumented stream is drained (its data rows discarded -- `PROFILE`
+    /// reports statistics, not the query's data, in v1) so the per-operator
+    /// counters are fully populated before the annotated plan is rendered.
+    fn profile_cypher_query(&self, query: Query) -> Result<QueryResults> {
+        let planner = QueryPlanner::new(Arc::clone(&self.stats), Arc::clone(&self.current));
+        let physical_plan = planner.plan(query)?;
+
+        let executor = QueryExecutor::new(Arc::clone(&self.current), Arc::clone(&self.historical));
+        let (results, registry) = executor.execute_profiled(&physical_plan)?;
+
+        // Fully drain so every operator's counters are populated before render.
+        let _ = results.collect_all()?;
+
+        let annotations: Vec<String> = registry.iter().map(|op| op.annotation()).collect();
+        Ok(Self::plan_text_result(
+            "plan",
+            physical_plan.explain_annotated(&annotations),
+        ))
+    }
+
+    /// Wrap a rendered plan string in a single computed-column result row.
+    fn plan_text_result(column: &str, text: String) -> QueryResults {
+        let row = crate::query::executor::QueryRow::from_columns(vec![(
+            column.to_string(),
+            crate::core::property::PropertyValue::String(std::sync::Arc::from(text.as_str())),
+        )]);
+        QueryResults::from_rows(vec![row])
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6151,6 +6151,44 @@ mod server_unit_tests {
         val["error"].clone()
     }
 
+    /// EXPLAIN (Issue #562) flows through the MCP `query` tool's
+    /// computed-columns path unchanged: it is not a mutating clause, and its
+    /// single `plan`-column row renders like any aggregate/computed row.
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn handle_query_explain_returns_plan_column() {
+        let db = Arc::new(AletheiaDB::new().expect("db init"));
+        db.create_node("Person", crate::core::property::PropertyMap::new())
+            .unwrap();
+        let server = AletheiaMcpServer::new(db);
+
+        let result = server.handle_query(serde_json::json!({
+            "language": "cypher",
+            "query": "EXPLAIN MATCH (n:Person) RETURN n",
+        }));
+        let text = AletheiaMcpServer::extract_text(result);
+        let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+
+        assert!(
+            val.get("error").is_none(),
+            "EXPLAIN of a read query must not be rejected: {val}"
+        );
+        assert_eq!(val["row_count"], 1, "EXPLAIN yields one row: {val}");
+        let rows = val["rows"].as_array().expect("rows array");
+        let plan = rows[0]["plan"]
+            .as_str()
+            .expect("the row carries a `plan` string column");
+        assert!(
+            plan.contains("NodeScan"),
+            "the plan text is surfaced through MCP: {plan}"
+        );
+        let columns = val["columns"].as_array().expect("columns array");
+        assert!(
+            columns.iter().any(|c| c["name"] == "plan"),
+            "column metadata names the `plan` column: {val}"
+        );
+    }
+
     #[test]
     fn map_query_error_unsupported_feature_yields_unsupported_construct() {
         let server = make_server();

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -5,6 +5,7 @@
 //! lazily produce results.
 
 mod iterators;
+mod profiling;
 mod results;
 
 use parking_lot::RwLock;
@@ -27,6 +28,7 @@ pub use iterators::{
     LimitIterator, ProjectIterator, ProvenanceFilterIterator, SortIterator, TemporalNodeIterator,
     TemporalNodeRangeScanIterator, VectorRerankIterator, VectorResultIterator,
 };
+pub use profiling::{OpProfile, ProfileRegistry, ProfilingIterator};
 pub use results::{EntityId, EntityResult, QueryResults, QueryRow};
 
 /// Configuration for query execution.
@@ -192,13 +194,40 @@ impl QueryExecutor {
     /// }
     /// ```
     pub fn execute(&self, plan: PhysicalPlan) -> Result<QueryResults> {
-        let iterator = self.execute_op(&plan.root)?;
+        let iterator = self.build_op(&plan.root, &mut None, 0)?;
         // Wrap with provenance filter to conditionally strip metadata
         let filtered = Box::new(iterators::ProvenanceFilterIterator::new(
             iterator,
             plan.include_provenance,
         ));
         Ok(QueryResults::new(filtered))
+    }
+
+    /// Execute a physical plan with per-operator profiling instrumentation
+    /// (Issue #562, the `PROFILE` entry point).
+    ///
+    /// Builds the same iterator pipeline as [`Self::execute`], but wraps every
+    /// operator in a [`ProfilingIterator`] that records the rows it emits and
+    /// the cumulative wall-clock time spent in its `next()`. The returned
+    /// [`ProfileRegistry`] is ordered in plan-tree **pre-order**, aligning by
+    /// index with `PhysicalPlan::explain`'s traversal so the caller can annotate
+    /// each plan line with its executed stats.
+    ///
+    /// Stats are only meaningful **after** the returned [`QueryResults`] stream
+    /// is fully drained (an iterator is lazy). The caller
+    /// (`AletheiaDB::execute_cypher` for `PROFILE`) drains the stream, then reads
+    /// the registry.
+    pub fn execute_profiled(&self, plan: &PhysicalPlan) -> Result<(QueryResults, ProfileRegistry)> {
+        let mut registry: Option<ProfileRegistry> = Some(Vec::new());
+        let iterator = self.build_op(&plan.root, &mut registry, 0)?;
+        let filtered = Box::new(iterators::ProvenanceFilterIterator::new(
+            iterator,
+            plan.include_provenance,
+        ));
+        // `registry` was seeded `Some` above and is never taken, so the unwrap
+        // is infallible.
+        let registry = registry.unwrap_or_default();
+        Ok((QueryResults::new(filtered), registry))
     }
 
     /// Candidate node ids for a temporal label scan (`AS OF` / `BETWEEN`).
@@ -244,17 +273,41 @@ impl QueryExecutor {
         ids
     }
 
-    /// Execute a physical operator, returning an iterator
-    fn execute_op(&self, op: &PhysicalOp) -> Result<Box<dyn ResultIterator>> {
-        match op {
-            PhysicalOp::NodeLookup { node_ids } => Ok(Box::new(
-                iterators::NodeLookupIterator::new(node_ids.clone(), Arc::clone(&self.current)),
+    /// Execute a physical operator, returning an iterator.
+    ///
+    /// Builds the iterator pipeline for `op`. When `profile` is `Some`, every
+    /// operator is instrumented: a shared [`OpProfile`] handle is registered
+    /// (in plan-tree **pre-order** -- parent before children, so the registry
+    /// index aligns with `PhysicalPlan::explain`'s pre-order render) and this
+    /// operator's iterator is wrapped in a [`ProfilingIterator`]. When `profile`
+    /// is `None` (the ordinary [`Self::execute`] path) no wrapping occurs and
+    /// there is no measurable overhead.
+    fn build_op(
+        &self,
+        op: &PhysicalOp,
+        profile: &mut Option<ProfileRegistry>,
+        depth: usize,
+    ) -> Result<Box<dyn ResultIterator>> {
+        // Reserve this operator's profile slot *before* building its children so
+        // the registry is in pre-order (the closure's mutable borrow of the
+        // registry ends before the match reborrows `profile` for recursion).
+        let handle = profile.as_mut().map(|registry| {
+            let h = Arc::new(OpProfile::new(op.name(), depth));
+            registry.push(Arc::clone(&h));
+            h
+        });
+
+        let child_depth = depth + 1;
+        let iter: Box<dyn ResultIterator> = match op {
+            PhysicalOp::NodeLookup { node_ids } => Box::new(iterators::NodeLookupIterator::new(
+                node_ids.clone(),
+                Arc::clone(&self.current),
             )),
 
-            PhysicalOp::NodeScan { label, .. } => Ok(Box::new(iterators::NodeScanIterator::new(
+            PhysicalOp::NodeScan { label, .. } => Box::new(iterators::NodeScanIterator::new(
                 label.clone(),
                 Arc::clone(&self.current),
-            ))),
+            )),
 
             PhysicalOp::HnswSearch {
                 embedding,
@@ -266,7 +319,7 @@ impl QueryExecutor {
                 *k,
                 label_filter.as_deref(),
                 property_key.as_deref(),
-            ),
+            )?,
 
             PhysicalOp::TemporalNodeLookup {
                 node_ids,
@@ -276,20 +329,20 @@ impl QueryExecutor {
             } => {
                 if *use_batch {
                     // Use batch iterator for large queries (holds lock across all iterations)
-                    Ok(Box::new(iterators::BatchTemporalNodeIterator::new(
+                    Box::new(iterators::BatchTemporalNodeIterator::new(
                         node_ids.clone(),
                         *valid_time,
                         *transaction_time,
                         Arc::clone(&self.historical),
-                    )?))
+                    )?)
                 } else {
                     // Use per-node iterator for small queries (lock per node)
-                    Ok(Box::new(iterators::TemporalNodeIterator::new(
+                    Box::new(iterators::TemporalNodeIterator::new(
                         node_ids.clone(),
                         *valid_time,
                         *transaction_time,
                         Arc::clone(&self.historical),
-                    )))
+                    ))
                 }
             }
 
@@ -304,7 +357,7 @@ impl QueryExecutor {
                 // requested bi-temporal point, filtering by label; candidates that
                 // did not exist at that instant are skipped, not errors.
                 let node_ids = self.temporal_scan_candidates();
-                Ok(Box::new(
+                Box::new(
                     iterators::TemporalNodeScanIterator::new(
                         node_ids,
                         *valid_time,
@@ -313,7 +366,7 @@ impl QueryExecutor {
                         label.clone(),
                     )
                     .skipping_missing(),
-                ))
+                )
             }
 
             PhysicalOp::TemporalNodeRangeScan {
@@ -328,14 +381,14 @@ impl QueryExecutor {
                 // overlaps the range (at most one row per node -- multiple rows
                 // only across distinct nodes).
                 let node_ids = self.temporal_scan_candidates();
-                Ok(Box::new(iterators::TemporalNodeRangeScanIterator::new(
+                Box::new(iterators::TemporalNodeRangeScanIterator::new(
                     node_ids,
                     *valid_from,
                     *valid_to,
                     *transaction_time,
                     Arc::clone(&self.historical),
                     label.clone(),
-                )))
+                ))
             }
 
             PhysicalOp::TemporalVectorSearch {
@@ -352,10 +405,10 @@ impl QueryExecutor {
                     .current
                     .find_similar_as_of_in(prop, embedding, *k, *timestamp)?;
 
-                Ok(Box::new(iterators::VectorResultIterator::new(
+                Box::new(iterators::VectorResultIterator::new(
                     results,
                     Arc::clone(&self.current),
-                )))
+                ))
             }
 
             PhysicalOp::IndexedTraversal {
@@ -363,37 +416,37 @@ impl QueryExecutor {
                 direction,
                 label,
                 min_depth,
-                depth,
+                depth: traversal_depth,
                 temporal_context,
             } => {
-                let input_iter = self.execute_op(input)?;
-                Ok(Box::new(iterators::TraversalIterator::new(
+                let input_iter = self.build_op(input, profile, child_depth)?;
+                Box::new(iterators::TraversalIterator::new(
                     input_iter,
                     *direction,
                     label.clone(),
                     *min_depth,
-                    *depth,
+                    *traversal_depth,
                     Arc::clone(&self.current),
                     Arc::clone(&self.historical),
                     *temporal_context,
-                )))
+                ))
             }
 
             PhysicalOp::PropertyScan {
                 label, key, value, ..
-            } => Ok(Box::new(iterators::PropertyScanIterator::new(
+            } => Box::new(iterators::PropertyScanIterator::new(
                 label.clone(),
                 key.clone(),
                 value,
                 Arc::clone(&self.current),
-            ))),
+            )),
 
             PhysicalOp::Filter { input, predicate } => {
-                let input_iter = self.execute_op(input)?;
-                Ok(Box::new(iterators::FilterIterator::new(
+                let input_iter = self.build_op(input, profile, child_depth)?;
+                Box::new(iterators::FilterIterator::new(
                     input_iter,
                     predicate.clone(),
-                )))
+                ))
             }
 
             PhysicalOp::VectorRerank {
@@ -402,14 +455,14 @@ impl QueryExecutor {
                 k,
                 property_key,
             } => {
-                let input_iter = self.execute_op(input)?;
-                Ok(Box::new(iterators::VectorRerankIterator::new(
+                let input_iter = self.build_op(input, profile, child_depth)?;
+                Box::new(iterators::VectorRerankIterator::new(
                     input_iter,
                     embedding.clone(),
                     *k,
                     Arc::clone(&self.current),
                     property_key.clone(),
-                )))
+                ))
             }
 
             PhysicalOp::Limit {
@@ -417,28 +470,26 @@ impl QueryExecutor {
                 count,
                 offset,
             } => {
-                let input_iter = self.execute_op(input)?;
-                Ok(Box::new(iterators::LimitIterator::new(
-                    input_iter, *offset, *count,
-                )))
+                let input_iter = self.build_op(input, profile, child_depth)?;
+                Box::new(iterators::LimitIterator::new(input_iter, *offset, *count))
             }
 
             PhysicalOp::Project { input, properties } => {
-                let input_iter = self.execute_op(input)?;
-                Ok(Box::new(iterators::ProjectIterator::new(
+                let input_iter = self.build_op(input, profile, child_depth)?;
+                Box::new(iterators::ProjectIterator::new(
                     input_iter,
                     properties.clone(),
-                )))
+                ))
             }
 
             PhysicalOp::OptionalApply { input, steps } => {
-                let input_iter = self.execute_op(input)?;
-                Ok(Box::new(iterators::OptionalApplyIterator::new(
+                let input_iter = self.build_op(input, profile, child_depth)?;
+                Box::new(iterators::OptionalApplyIterator::new(
                     input_iter,
                     steps.clone(),
                     Arc::clone(&self.current),
                     Arc::clone(&self.historical),
-                )))
+                ))
             }
 
             PhysicalOp::Aggregate {
@@ -446,33 +497,30 @@ impl QueryExecutor {
                 group_keys,
                 aggregates,
             } => {
-                let input_iter = self.execute_op(input)?;
-                Ok(Box::new(iterators::AggregateIterator::new(
+                let input_iter = self.build_op(input, profile, child_depth)?;
+                Box::new(iterators::AggregateIterator::new(
                     input_iter,
                     group_keys.clone(),
                     aggregates.clone(),
-                )))
+                ))
             }
 
             PhysicalOp::Distinct { input } => {
-                let input_iter = self.execute_op(input)?;
-                Ok(Box::new(iterators::DistinctIterator::new(input_iter)))
+                let input_iter = self.build_op(input, profile, child_depth)?;
+                Box::new(iterators::DistinctIterator::new(input_iter))
             }
 
             PhysicalOp::Sort { input, keys } => {
-                let input_iter = self.execute_op(input)?;
-                Ok(Box::new(iterators::SortIterator::new(
-                    input_iter,
-                    keys.clone(),
-                )))
+                let input_iter = self.build_op(input, profile, child_depth)?;
+                Box::new(iterators::SortIterator::new(input_iter, keys.clone()))
             }
 
             PhysicalOp::Count { input } => {
-                let input_iter = self.execute_op(input)?;
-                Ok(Box::new(iterators::CountIterator::new(input_iter)))
+                let input_iter = self.build_op(input, profile, child_depth)?;
+                Box::new(iterators::CountIterator::new(input_iter))
             }
 
-            PhysicalOp::Empty => Ok(Box::new(iterators::EmptyIterator)),
+            PhysicalOp::Empty => Box::new(iterators::EmptyIterator),
             PhysicalOp::SimilarToNode {
                 source_node,
                 property_key,
@@ -483,15 +531,23 @@ impl QueryExecutor {
                 property_key,
                 *k,
                 label_filter.as_deref(),
-            ),
+            )?,
 
             // For unsupported operations, return error
-            _ => Err(crate::core::error::Error::Query(
-                crate::core::error::QueryError::SyntaxError {
-                    message: format!("Unsupported physical operator: {:?}", op.name()),
-                },
-            )),
-        }
+            _ => {
+                return Err(crate::core::error::Error::Query(
+                    crate::core::error::QueryError::SyntaxError {
+                        message: format!("Unsupported physical operator: {:?}", op.name()),
+                    },
+                ));
+            }
+        };
+
+        // Instrument this operator when profiling.
+        Ok(match handle {
+            Some(h) => Box::new(ProfilingIterator::new(iter, h)),
+            None => iter,
+        })
     }
 
     fn execute_hnsw_search(

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -1097,6 +1097,92 @@ mod tests {
         assert_eq!(rows[0].entity.node_id(), Some(bob));
     }
 
+    // ==================== Profiling (PROFILE) Tests ====================
+
+    #[test]
+    fn test_execute_profiled_records_per_operator_rows() {
+        let (current, historical, alice, bob) = create_test_storage_with_data();
+        let executor = QueryExecutor::new(current, historical);
+
+        // Limit (count well above input) over a NodeLookup of two ids, so both
+        // operators forward both rows.
+        let plan = PhysicalPlan {
+            root: PhysicalOp::Limit {
+                input: Box::new(PhysicalOp::NodeLookup {
+                    node_ids: vec![alice, bob],
+                }),
+                count: 100,
+                offset: 0,
+            },
+            estimated_cost: Default::default(),
+            temporal_context: None,
+            parallel: false,
+            include_provenance: false,
+        };
+
+        let (results, registry) = executor
+            .execute_profiled(&plan)
+            .expect("Profiled execution failed");
+
+        // The registry is seeded in plan-tree pre-order: [Limit, NodeLookup].
+        assert_eq!(registry.len(), 2);
+        assert_eq!(registry[0].op_name(), "Limit");
+        assert_eq!(registry[0].depth(), 0);
+        assert_eq!(registry[1].op_name(), "NodeLookup");
+        assert_eq!(registry[1].depth(), 1);
+
+        // Stats are only meaningful after the (lazy) stream is drained.
+        assert_eq!(
+            registry[0].actual_rows(),
+            0,
+            "no rows counted before draining"
+        );
+
+        let rows: Vec<_> = results.collect_all().expect("Collection failed");
+        assert_eq!(rows.len(), 2);
+
+        // Both operators emitted the two rows.
+        assert_eq!(registry[1].actual_rows(), 2, "NodeLookup emitted 2 rows");
+        assert_eq!(registry[0].actual_rows(), 2, "Limit forwarded 2 rows");
+    }
+
+    #[test]
+    fn test_execute_profiled_annotations_align_with_explain() {
+        let (current, historical, alice, _bob) = create_test_storage_with_data();
+        let executor = QueryExecutor::new(current, historical);
+
+        let plan = PhysicalPlan {
+            root: PhysicalOp::Limit {
+                input: Box::new(PhysicalOp::NodeLookup {
+                    node_ids: vec![alice],
+                }),
+                count: 10,
+                offset: 0,
+            },
+            estimated_cost: Default::default(),
+            temporal_context: None,
+            parallel: false,
+            include_provenance: false,
+        };
+
+        let (results, registry) = executor
+            .execute_profiled(&plan)
+            .expect("Profiled execution failed");
+        let _ = results.collect_all().expect("Collection failed");
+
+        // Feed the per-operator annotations back into the plan renderer and
+        // confirm each operator line carries its own stats, in order.
+        let annotations: Vec<String> = registry.iter().map(|p| p.annotation()).collect();
+        let explained = plan.explain_annotated(&annotations);
+        let lines: Vec<&str> = explained.lines().collect();
+        // Header + 2 operator lines.
+        assert_eq!(lines.len(), 3);
+        assert!(lines[1].contains("Limit"));
+        assert!(lines[1].contains("actual rows: 1"));
+        assert!(lines[2].contains("NodeLookup"));
+        assert!(lines[2].contains("actual rows: 1"));
+    }
+
     // ==================== SimilarTo Tests ====================
 
     #[test]

--- a/src/query/executor/profiling.rs
+++ b/src/query/executor/profiling.rs
@@ -78,10 +78,13 @@ impl OpProfile {
     /// The suffix appended to this operator's `explain` line in `PROFILE`
     /// output. Uses a stable, fixed-label format (`actual rows:` / `time:`) so
     /// substring assertions in tests are robust against timing non-determinism.
+    /// The `(incl. children)` qualifier discloses that the reported time is
+    /// cumulative over child operators (the Volcano `next()` recurses), so the
+    /// number is not this operator's self-time.
     #[must_use]
     pub fn annotation(&self) -> String {
         format!(
-            " | actual rows: {}, time: {}µs",
+            " | actual rows: {}, time: {}µs (incl. children)",
             self.actual_rows(),
             self.elapsed_micros()
         )

--- a/src/query/executor/profiling.rs
+++ b/src/query/executor/profiling.rs
@@ -1,0 +1,135 @@
+//! Per-operator execution profiling for the Cypher `PROFILE` entry point
+//! (Issue #562).
+//!
+//! [`ProfilingIterator`] wraps another [`ResultIterator`] and records, for the
+//! operator it fronts, (a) the number of rows it emits and (b) the cumulative
+//! wall-clock time spent in its `next()` calls. Each wrapper shares an
+//! [`OpProfile`] handle (interior-mutable via atomics, so the wrapper stays
+//! `Send`); the executor collects those handles into an ordered
+//! [`ProfileRegistry`] in plan-tree **pre-order** so the recorded stats line up
+//! one-to-one with the operators rendered by `PhysicalPlan::explain`.
+//!
+//! Timing is inclusive of child operators (an operator's `next()` drives its
+//! input's `next()`), which mirrors how engines report cumulative operator
+//! time. Because timings are wall-clock and therefore non-deterministic, tests
+//! assert on structure and row counts, never absolute times.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use crate::core::error::Result;
+
+use super::iterators::ResultIterator;
+use super::results::QueryRow;
+
+/// Recorded execution statistics for a single physical operator.
+///
+/// Counters are atomic so the shared handle stays `Send` (the pull-based
+/// executor drives one thread, but the wrapper must satisfy the
+/// [`ResultIterator`] `Send` bound). All updates use `Relaxed` ordering:
+/// there is no cross-thread happens-before requirement, only monotonic
+/// accumulation read back after the stream is fully drained.
+#[derive(Debug)]
+pub struct OpProfile {
+    op_name: &'static str,
+    depth: usize,
+    actual_rows: AtomicU64,
+    elapsed_nanos: AtomicU64,
+}
+
+impl OpProfile {
+    /// Create a zeroed profile for an operator at the given tree `depth`.
+    #[must_use]
+    pub fn new(op_name: &'static str, depth: usize) -> Self {
+        Self {
+            op_name,
+            depth,
+            actual_rows: AtomicU64::new(0),
+            elapsed_nanos: AtomicU64::new(0),
+        }
+    }
+
+    /// The operator's name (matches `PhysicalOp::name`).
+    #[must_use]
+    pub fn op_name(&self) -> &'static str {
+        self.op_name
+    }
+
+    /// The operator's depth in the plan tree (root is 0).
+    #[must_use]
+    pub fn depth(&self) -> usize {
+        self.depth
+    }
+
+    /// Number of rows this operator emitted over the whole scan.
+    #[must_use]
+    pub fn actual_rows(&self) -> u64 {
+        self.actual_rows.load(Ordering::Relaxed)
+    }
+
+    /// Cumulative wall-clock time spent in this operator's `next()`, in
+    /// microseconds (inclusive of children).
+    #[must_use]
+    pub fn elapsed_micros(&self) -> u64 {
+        self.elapsed_nanos.load(Ordering::Relaxed) / 1_000
+    }
+
+    /// The suffix appended to this operator's `explain` line in `PROFILE`
+    /// output. Uses a stable, fixed-label format (`actual rows:` / `time:`) so
+    /// substring assertions in tests are robust against timing non-determinism.
+    #[must_use]
+    pub fn annotation(&self) -> String {
+        format!(
+            " | actual rows: {}, time: {}µs",
+            self.actual_rows(),
+            self.elapsed_micros()
+        )
+    }
+
+    fn record_row(&self) {
+        self.actual_rows.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_time(&self, nanos: u64) {
+        self.elapsed_nanos.fetch_add(nanos, Ordering::Relaxed);
+    }
+}
+
+/// Ordered collection of per-operator profiles, in plan-tree pre-order.
+///
+/// The i-th entry corresponds to the i-th operator visited by
+/// `PhysicalPlan::explain`'s pre-order walk, so the executor's registration
+/// order and the renderer's traversal order stay aligned by index.
+pub type ProfileRegistry = Vec<Arc<OpProfile>>;
+
+/// A [`ResultIterator`] that records row-count and timing for the operator it
+/// wraps, delegating all row production to `inner`.
+pub struct ProfilingIterator {
+    inner: Box<dyn ResultIterator>,
+    profile: Arc<OpProfile>,
+}
+
+impl ProfilingIterator {
+    /// Wrap `inner`, recording stats into the shared `profile` handle.
+    #[must_use]
+    pub fn new(inner: Box<dyn ResultIterator>, profile: Arc<OpProfile>) -> Self {
+        Self { inner, profile }
+    }
+}
+
+impl ResultIterator for ProfilingIterator {
+    fn next(&mut self) -> Option<Result<QueryRow>> {
+        let start = Instant::now();
+        let item = self.inner.next();
+        self.profile.record_time(start.elapsed().as_nanos() as u64);
+        if matches!(item, Some(Ok(_))) {
+            self.profile.record_row();
+        }
+        item
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}

--- a/src/query/executor/profiling.rs
+++ b/src/query/executor/profiling.rs
@@ -136,3 +136,170 @@ impl ResultIterator for ProfilingIterator {
         self.inner.size_hint()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::error::{Error, QueryError};
+    use crate::core::property::PropertyValue;
+    use std::collections::VecDeque;
+    use std::time::Duration;
+
+    /// Minimal in-memory [`ResultIterator`] for exercising the profiling
+    /// wrapper without any storage. Each `next()` optionally sleeps (so the
+    /// wrapper records a non-zero elapsed) and returns the next preloaded
+    /// response; once the queue is empty it yields `None` like any exhausted
+    /// iterator.
+    struct StubIterator {
+        responses: VecDeque<Option<Result<QueryRow>>>,
+        sleep_per_call: Duration,
+    }
+
+    impl StubIterator {
+        fn new(responses: Vec<Option<Result<QueryRow>>>, sleep_per_call: Duration) -> Self {
+            Self {
+                responses: responses.into_iter().collect(),
+                sleep_per_call,
+            }
+        }
+    }
+
+    impl ResultIterator for StubIterator {
+        fn next(&mut self) -> Option<Result<QueryRow>> {
+            if !self.sleep_per_call.is_zero() {
+                std::thread::sleep(self.sleep_per_call);
+            }
+            self.responses.pop_front().flatten()
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (0, Some(self.responses.len()))
+        }
+    }
+
+    /// Build a row tagged with an integer id so forwarding order is observable.
+    fn row_with_id(id: i64) -> QueryRow {
+        QueryRow::from_columns(vec![("id".to_string(), PropertyValue::Int(id))])
+    }
+
+    fn row_id(row: &QueryRow) -> Option<i64> {
+        match row.columns.as_ref()?.first()? {
+            (_, PropertyValue::Int(n)) => Some(*n),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn profiling_iterator_forwards_rows_and_counts_only_ok() {
+        let profile = Arc::new(OpProfile::new("TestOp", 0));
+        let inner = StubIterator::new(
+            vec![
+                Some(Ok(row_with_id(1))),
+                Some(Err(Error::Query(QueryError::ExecutionError {
+                    message: "boom".to_string(),
+                }))),
+                Some(Ok(row_with_id(2))),
+            ],
+            Duration::from_millis(1),
+        );
+        let mut wrapper = ProfilingIterator::new(Box::new(inner), Arc::clone(&profile));
+
+        // Drain the stream, recording what came through the wrapper.
+        let mut ok_ids = Vec::new();
+        let mut saw_err = false;
+        while let Some(item) = wrapper.next() {
+            match item {
+                Ok(row) => ok_ids.push(row_id(&row).expect("row carries an id column")),
+                Err(_) => saw_err = true,
+            }
+        }
+
+        // Rows are forwarded verbatim, in order.
+        assert_eq!(ok_ids, vec![1, 2]);
+        assert!(saw_err, "the Err item must be forwarded to the caller");
+
+        // Only the two Ok rows count; the Err and the terminating None do not.
+        assert_eq!(profile.actual_rows(), 2);
+
+        // Every next() (incl. the Err and the terminating None) was timed with a
+        // 1ms sleep, so the accumulated elapsed must be non-zero.
+        assert!(
+            profile.elapsed_micros() > 0,
+            "wrapper must accumulate non-zero elapsed time"
+        );
+    }
+
+    #[test]
+    fn profiling_iterator_surfaces_and_does_not_count_none() {
+        let profile = Arc::new(OpProfile::new("TestOp", 0));
+        // An inner `None` in the middle terminates the stream (Volcano
+        // contract) and must not be counted as a row.
+        let inner = StubIterator::new(
+            vec![Some(Ok(row_with_id(7))), None, Some(Ok(row_with_id(8)))],
+            Duration::ZERO,
+        );
+        let mut wrapper = ProfilingIterator::new(Box::new(inner), Arc::clone(&profile));
+
+        assert!(matches!(wrapper.next(), Some(Ok(_))));
+        assert!(wrapper.next().is_none(), "inner None surfaces as None");
+        // The None was not counted; only the single Ok row was.
+        assert_eq!(profile.actual_rows(), 1);
+    }
+
+    #[test]
+    fn profiling_iterator_forwards_size_hint() {
+        let profile = Arc::new(OpProfile::new("TestOp", 0));
+        let inner = StubIterator::new(
+            vec![Some(Ok(row_with_id(1))), Some(Ok(row_with_id(2)))],
+            Duration::ZERO,
+        );
+        let wrapper = ProfilingIterator::new(Box::new(inner), profile);
+        assert_eq!(wrapper.size_hint(), (0, Some(2)));
+    }
+
+    #[test]
+    fn op_profile_annotation_format() {
+        let profile = OpProfile::new("NodeScan", 2);
+        assert_eq!(profile.op_name(), "NodeScan");
+        assert_eq!(profile.depth(), 2);
+        // A freshly created profile is zeroed.
+        assert_eq!(profile.actual_rows(), 0);
+        assert_eq!(profile.elapsed_micros(), 0);
+        assert_eq!(
+            profile.annotation(),
+            " | actual rows: 0, time: 0µs (incl. children)"
+        );
+
+        // Record some rows and time, then re-check the rendered annotation.
+        profile.record_row();
+        profile.record_row();
+        profile.record_row();
+        profile.record_time(5_000); // 5µs expressed in nanos
+        assert_eq!(profile.actual_rows(), 3);
+        assert_eq!(profile.elapsed_micros(), 5); // nanos / 1000
+        assert_eq!(
+            profile.annotation(),
+            " | actual rows: 3, time: 5µs (incl. children)"
+        );
+
+        // Sub-microsecond time floors to 0µs (integer division).
+        let sub = OpProfile::new("Empty", 0);
+        sub.record_time(999);
+        assert_eq!(sub.elapsed_micros(), 0);
+    }
+
+    #[test]
+    fn profile_registry_preserves_push_order() {
+        // The registry is a plain Vec seeded in plan-tree pre-order; assert the
+        // per-operator handles keep their insertion order and identity.
+        let mut registry: ProfileRegistry = Vec::new();
+        for (name, depth) in [("Limit", 0usize), ("Filter", 1), ("NodeLookup", 2)] {
+            registry.push(Arc::new(OpProfile::new(name, depth)));
+        }
+
+        let names: Vec<_> = registry.iter().map(|p| p.op_name()).collect();
+        assert_eq!(names, vec!["Limit", "Filter", "NodeLookup"]);
+        let depths: Vec<_> = registry.iter().map(|p| p.depth()).collect();
+        assert_eq!(depths, vec![0, 1, 2]);
+    }
+}

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -292,6 +292,18 @@ impl QueryResults {
         QueryResults { iterator }
     }
 
+    /// Build a result stream from an in-memory vector of rows.
+    ///
+    /// Used by the Cypher `EXPLAIN`/`PROFILE` entry points (Issue #562), which
+    /// synthesize a single computed `plan` row rather than streaming stored
+    /// entities.
+    #[cfg(feature = "cypher")]
+    pub(crate) fn from_rows(rows: Vec<QueryRow>) -> Self {
+        QueryResults::new(Box::new(MaterializedRows {
+            rows: rows.into_iter(),
+        }))
+    }
+
     /// Eagerly collect every row in the result stream into a memory-backed vector.
     ///
     /// **Why?** Use this when the expected result set is small and you need random access.
@@ -843,6 +855,27 @@ impl QueryResults {
             versions,
             columns,
         })
+    }
+}
+
+/// A [`ResultIterator`] backed by a pre-computed vector of rows.
+///
+/// Backs [`QueryResults::from_rows`] -- the one-row `plan` stream returned by
+/// the Cypher `EXPLAIN`/`PROFILE` entry points (Issue #562).
+#[cfg(feature = "cypher")]
+struct MaterializedRows {
+    rows: std::vec::IntoIter<QueryRow>,
+}
+
+#[cfg(feature = "cypher")]
+impl ResultIterator for MaterializedRows {
+    fn next(&mut self) -> Option<Result<QueryRow>> {
+        self.rows.next().map(Ok)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let n = self.rows.len();
+        (n, Some(n))
     }
 }
 

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -113,6 +113,24 @@ impl PhysicalPlan {
     /// ```
     #[must_use]
     pub fn explain(&self) -> String {
+        self.explain_with(None)
+    }
+
+    /// Generate the plan explanation, appending a per-operator annotation to
+    /// each operator's line (Issue #562, the `PROFILE` entry point).
+    ///
+    /// `annotations` is indexed by the plan tree's **pre-order** operator
+    /// position -- the same order this renderer walks the tree and the same
+    /// order [`crate::query::executor::QueryExecutor::execute_profiled`]
+    /// registers its per-operator profiles -- so `annotations[i]` decorates the
+    /// i-th operator. A shorter slice leaves later operators unannotated rather
+    /// than panicking.
+    #[must_use]
+    pub fn explain_annotated(&self, annotations: &[String]) -> String {
+        self.explain_with(Some(annotations))
+    }
+
+    fn explain_with(&self, annotations: Option<&[String]>) -> String {
         let mut output = String::new();
 
         // Header with overall plan info
@@ -150,14 +168,31 @@ impl PhysicalPlan {
             output.push_str("  Parallel execution enabled\n");
         }
 
-        // Explain the operator tree
-        self.explain_op(&self.root, &mut output, 0, "");
+        // Explain the operator tree. `idx` tracks the pre-order operator
+        // position so PROFILE annotations line up with the executor's registry.
+        let mut idx = 0usize;
+        self.explain_op(&self.root, &mut output, 0, "", annotations, &mut idx);
 
         output
     }
 
     /// Recursively explain an operator with indentation.
-    fn explain_op(&self, op: &PhysicalOp, output: &mut String, indent: usize, prefix: &str) {
+    ///
+    /// `annotations`/`idx` support the `PROFILE` path: when present, the
+    /// annotation for this operator's pre-order position is appended to its
+    /// line. `idx` is advanced once per operator, matching the executor's
+    /// pre-order profile registration.
+    fn explain_op(
+        &self,
+        op: &PhysicalOp,
+        output: &mut String,
+        indent: usize,
+        prefix: &str,
+        annotations: Option<&[String]>,
+        idx: &mut usize,
+    ) {
+        let my_idx = *idx;
+        *idx += 1;
         let indent_str = "  ".repeat(indent);
         let op_name = op.name();
 
@@ -302,6 +337,13 @@ impl PhysicalPlan {
             _ => {} // Other operators don't need extra details
         }
 
+        // Append this operator's PROFILE annotation (executed stats), if any.
+        if let Some(anns) = annotations
+            && let Some(annotation) = anns.get(my_idx)
+        {
+            line.push_str(annotation);
+        }
+
         output.push_str(&line);
         output.push('\n');
 
@@ -320,7 +362,7 @@ impl PhysicalPlan {
             | PhysicalOp::TemporalTrack { input, .. }
             | PhysicalOp::IndexedTraversal { input, .. }
             | PhysicalOp::OptionalApply { input, .. } => {
-                self.explain_op(input, output, indent + 1, "└─ ");
+                self.explain_op(input, output, indent + 1, "└─ ", annotations, idx);
             }
 
             // Binary operators
@@ -328,8 +370,8 @@ impl PhysicalPlan {
             | PhysicalOp::Union { left, right }
             | PhysicalOp::Intersect { left, right }
             | PhysicalOp::Except { left, right } => {
-                self.explain_op(left, output, indent + 1, "├─ ");
-                self.explain_op(right, output, indent + 1, "└─ ");
+                self.explain_op(left, output, indent + 1, "├─ ", annotations, idx);
+                self.explain_op(right, output, indent + 1, "└─ ", annotations, idx);
             }
 
             // Leaf operators (no children)

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -2026,6 +2026,117 @@ mod tests {
         assert!(lines[3].starts_with("    └─ NodeLookup"));
     }
 
+    // ==================== explain_annotated (PROFILE) Tests ====================
+
+    fn nested_unary_plan() -> PhysicalPlan {
+        PhysicalPlan {
+            root: PhysicalOp::Limit {
+                input: Box::new(PhysicalOp::Filter {
+                    input: Box::new(PhysicalOp::NodeLookup {
+                        node_ids: vec![NodeId::new(1).unwrap()],
+                    }),
+                    predicate: Predicate::True,
+                }),
+                count: 10,
+                offset: 0,
+            },
+            estimated_cost: Cost::default(),
+            temporal_context: None,
+            parallel: false,
+            include_provenance: false,
+        }
+    }
+
+    #[test]
+    fn test_explain_annotated_appends_in_preorder() {
+        let plan = nested_unary_plan();
+        // Pre-order operator positions: [Limit, Filter, NodeLookup].
+        let annotations = vec![
+            " | actual rows: 10, time: 5µs (incl. children)".to_string(),
+            " | actual rows: 20, time: 3µs (incl. children)".to_string(),
+            " | actual rows: 1, time: 1µs (incl. children)".to_string(),
+        ];
+
+        let explained = plan.explain_annotated(&annotations);
+        let lines: Vec<&str> = explained.lines().collect();
+        // Header + 3 operator lines.
+        assert_eq!(lines.len(), 4);
+        assert!(lines[1].contains("Limit"));
+        assert!(lines[1].ends_with("actual rows: 10, time: 5µs (incl. children)"));
+        assert!(lines[2].contains("Filter"));
+        assert!(lines[2].ends_with("actual rows: 20, time: 3µs (incl. children)"));
+        assert!(lines[3].contains("NodeLookup"));
+        assert!(lines[3].ends_with("actual rows: 1, time: 1µs (incl. children)"));
+
+        // The plain (unannotated) render carries none of the stats.
+        let plain = plan.explain();
+        assert!(!plain.contains("actual rows"));
+    }
+
+    #[test]
+    fn test_explain_annotated_short_slice_leaves_later_ops_unannotated() {
+        let plan = nested_unary_plan();
+        // Only the root operator has an annotation; the shorter slice must not
+        // panic and must leave later operators bare.
+        let annotations = vec![" | actual rows: 10, time: 5µs (incl. children)".to_string()];
+
+        let explained = plan.explain_annotated(&annotations);
+        let lines: Vec<&str> = explained.lines().collect();
+        assert_eq!(lines.len(), 4);
+        assert!(lines[1].contains("Limit"));
+        assert!(lines[1].contains("actual rows: 10"));
+        // Filter and NodeLookup had no annotation slot.
+        assert!(!lines[2].contains("actual rows"));
+        assert!(!lines[3].contains("actual rows"));
+
+        // An empty slice annotates nothing but still renders every operator.
+        let none = plan.explain_annotated(&[]);
+        assert!(!none.contains("actual rows"));
+        assert!(none.contains("Limit"));
+        assert!(none.contains("Filter"));
+        assert!(none.contains("NodeLookup"));
+    }
+
+    #[test]
+    fn test_explain_annotated_binary_preorder() {
+        // Binary operator: pre-order visits parent, then left, then right, so
+        // the annotation indices must follow that order.
+        let plan = PhysicalPlan {
+            root: PhysicalOp::HashJoin {
+                left: Box::new(PhysicalOp::NodeScan {
+                    label: Some("Person".to_string()),
+                    estimated_rows: 100,
+                }),
+                right: Box::new(PhysicalOp::NodeScan {
+                    label: Some("Company".to_string()),
+                    estimated_rows: 50,
+                }),
+                left_key: "id".to_string(),
+                right_key: "person_id".to_string(),
+            },
+            estimated_cost: Cost::default(),
+            temporal_context: None,
+            parallel: false,
+            include_provenance: false,
+        };
+        let annotations = vec![
+            " | actual rows: 7, time: 9µs (incl. children)".to_string(),
+            " | actual rows: 100, time: 4µs (incl. children)".to_string(),
+            " | actual rows: 50, time: 2µs (incl. children)".to_string(),
+        ];
+
+        let explained = plan.explain_annotated(&annotations);
+        let lines: Vec<&str> = explained.lines().collect();
+        assert_eq!(lines.len(), 4);
+        assert!(lines[1].contains("HashJoin"));
+        assert!(lines[1].contains("actual rows: 7"));
+        // Left child (Person) is visited before the right child (Company).
+        assert!(lines[2].contains("Person"));
+        assert!(lines[2].contains("actual rows: 100"));
+        assert!(lines[3].contains("Company"));
+        assert!(lines[3].contains("actual rows: 50"));
+    }
+
     #[test]
     fn test_explain_with_temporal_context() {
         let plan = PhysicalPlan {


### PR DESCRIPTION
## Before / After
**Before:** Cypher had no way to inspect a query's plan or execution stats; there was no `EXPLAIN`/`PROFILE`.
**After:** `EXPLAIN <query>` returns the physical plan (operators + estimated rows) without executing; `PROFILE <query>` executes the query and returns the plan annotated with per-operator actual row counts and timing. Both are read-only and flow through the MCP `query` tool. Closes #562.

## How
- Lexer/parser recognize `EXPLAIN`/`PROFILE` as **statement-start prefix keywords** (pre-parser semantics — still usable as ordinary identifiers/labels/property keys elsewhere); the prefix wraps the inner statement in `CypherStatement::Explain`/`Profile`; nested/duplicate prefixes are rejected with a structured error; expression depth caps (#3404) untouched.
- `EXPLAIN` plans only (no execution) and returns the existing `PhysicalPlan::explain()` render as a one-row `plan` column.
- `PROFILE` executes via an instrumented path: a `ProfilingIterator` wraps each physical operator (pre-order registration matching the plan-tree render) recording actual rows and wall-time, fully drains the read query, discards data rows, and returns the plan annotated with `actual rows: N, time: Nµs (incl. children)` per operator. Timing is inclusive of children (disclosed in the label).
- Unsupported inner shapes (e.g. `UNWIND`) return a structured `UnsupportedFeature` rather than a fabricated plan.

## Acceptance Criteria evidence
| # | Criterion | Evidence |
|---|-----------|----------|
| 1 | EXPLAIN parses and returns a plan | `explain_returns_a_plan_with_estimates`, `explain_does_not_execute` |
| 2 | PROFILE parses and returns executed plan stats | `profile_reports_actual_rows_and_timing` |
| 3 | Output includes row counts and timing per major operation | `profile_reports_actual_rows_and_timing`, `profile_filter_reflects_selectivity` (Filter selectivity) |
| 4 | Output is stable enough to test | tests assert operator names + exact row counts; only timing is non-deterministic |
| 5 | Demonstrates index/optimization visibility | `explain_shows_property_scan_optimization` (property-filtered scan lowers to `PropertyScan`) |

## Notes / v1 limitations
- `EXPLAIN`/`PROFILE` supported for statements that lower to the physical planner; `UNWIND` (and any non-plannable shape) is rejected with a structured error.
- PROFILE timing is inclusive of child operators (labeled `(incl. children)`); self-time is a follow-up.
- MCP `query` tool renders the `plan` column via its existing computed-columns path.

## Gates
- `cargo test --features cypher --lib`: 3947 passed; 0 failed; 2 ignored
- `cargo clippy --all-targets --features cypher -- -D warnings`: clean
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings`: clean
- `cargo fmt --all`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDxuBsxZU6SLfsTr7jtBbX

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDxuBsxZU6SLfsTr7jtBbX)_