### PR TITLE
Cypher: fix IS NULL / IS NOT NULL on absent properties (#561 follow-up)

### DIFF
--- a/src/cypher/converter.rs
+++ b/src/cypher/converter.rs
@@ -1013,18 +1013,58 @@ impl CypherConverter {
                 Ok(Predicate::Not(Box::new(inner_pred)))
             }
             CypherExpr::IsNull(inner) => {
-                let key = self.extract_property_key(inner)?;
-                Ok(Predicate::Eq {
-                    key,
-                    value: PredicateValue::Null,
-                })
+                match inner.as_ref() {
+                    // Property access (`n.email IS NULL`): openCypher treats a
+                    // property as null when it is ABSENT *or* present with an
+                    // explicit null value. The data model represents both (a
+                    // missing key and a stored `PropertyValue::Null`), so lower to
+                    // `NotExists(key) OR Eq(key, Null)`. The old `Eq(key, Null)`-only
+                    // lowering matched present-null but silently missed absence.
+                    CypherExpr::Property { property, .. } => Ok(Predicate::Or(vec![
+                        Predicate::NotExists(property.clone()),
+                        Predicate::Eq {
+                            key: property.clone(),
+                            value: PredicateValue::Null,
+                        },
+                    ])),
+                    // Bare variable (`x IS NULL`): a node/edge-level null check
+                    // (only an OPTIONAL MATCH unmatched binding is ever null). Keep
+                    // the `Eq(var, Null)` lowering: a matched entity has no property
+                    // literally named after the variable (so it is not-null), and a
+                    // null binding is handled by the executor's null-row path.
+                    _ => {
+                        let key = self.extract_property_key(inner)?;
+                        Ok(Predicate::Eq {
+                            key,
+                            value: PredicateValue::Null,
+                        })
+                    }
+                }
             }
             CypherExpr::IsNotNull(inner) => {
-                let key = self.extract_property_key(inner)?;
-                Ok(Predicate::Ne {
-                    key,
-                    value: PredicateValue::Null,
-                })
+                match inner.as_ref() {
+                    // Property access (`n.email IS NOT NULL`): openCypher requires
+                    // the property to be PRESENT with a non-null value. Lower to
+                    // `Exists(key) AND Ne(key, Null)`; the old `Ne(key, Null)`-only
+                    // lowering wrongly matched absent properties (the executor treats
+                    // a missing property as `!= null`).
+                    CypherExpr::Property { property, .. } => Ok(Predicate::And(vec![
+                        Predicate::Exists(property.clone()),
+                        Predicate::Ne {
+                            key: property.clone(),
+                            value: PredicateValue::Null,
+                        },
+                    ])),
+                    // Bare variable (`x IS NOT NULL`): node/edge-level null check
+                    // (see IsNull above). Keep the `Ne(var, Null)` lowering.
+                    _ => {
+                        let key = self.extract_property_key(inner)?;
+                        Ok(Predicate::Ne {
+                            key,
+                            value: PredicateValue::Null,
+                        })
+                    }
+                }
             }
             CypherExpr::In { expr, values } => {
                 let key = self.extract_property_key(expr)?;

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -2299,6 +2299,174 @@ fn test_e2e_optional_match_matched() {
     assert_eq!(row_name(&rows[0]).as_deref(), Some("Bob"));
 }
 
+// -----------------------------------------------------------------------------
+// IS NULL / IS NOT NULL on absent / present-null / present-non-null properties
+// (openCypher: a missing property IS null).
+// -----------------------------------------------------------------------------
+
+/// Nodes with a mix of: present-non-null `email`, absent `email`, and an
+/// explicitly present-null `email` value (the data model stores
+/// `PropertyValue::Null` as a real present value, so all three cases exist).
+fn is_null_test_db() -> AletheiaDB {
+    let db = AletheiaDB::new().unwrap();
+    // Present, non-null email.
+    db.create_node(
+        "Person",
+        PropertyMapBuilder::new()
+            .insert("name", "Alice")
+            .insert("email", "alice@example.com")
+            .build(),
+    )
+    .unwrap();
+    db.create_node(
+        "Person",
+        PropertyMapBuilder::new()
+            .insert("name", "Bob")
+            .insert("email", "bob@example.com")
+            .build(),
+    )
+    .unwrap();
+    // Absent email (missing property).
+    db.create_node(
+        "Person",
+        PropertyMapBuilder::new().insert("name", "Carol").build(),
+    )
+    .unwrap();
+    db.create_node(
+        "Person",
+        PropertyMapBuilder::new().insert("name", "Dave").build(),
+    )
+    .unwrap();
+    // Present, explicitly-null email.
+    db.create_node(
+        "Person",
+        PropertyMapBuilder::new()
+            .insert("name", "Eve")
+            .insert("email", crate::core::property::PropertyValue::Null)
+            .build(),
+    )
+    .unwrap();
+    db
+}
+
+fn row_names_sorted(rows: &[crate::query::executor::QueryRow]) -> Vec<String> {
+    let mut names: Vec<String> = rows.iter().filter_map(row_name).collect();
+    names.sort();
+    names
+}
+
+#[test]
+fn is_null_absent_property_matches() {
+    // openCypher: a missing property IS null, so `IS NULL` must match every node
+    // that lacks `email` (Carol, Dave) as well as the present-null one (Eve),
+    // and exclude the present-non-null ones (Alice, Bob).
+    let db = is_null_test_db();
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) WHERE n.email IS NULL RETURN n")
+            .unwrap(),
+    );
+    assert_eq!(
+        row_names_sorted(&rows),
+        vec!["Carol".to_string(), "Dave".to_string(), "Eve".to_string()],
+        "IS NULL must match absent (Carol/Dave) and present-null (Eve) properties"
+    );
+}
+
+#[test]
+fn is_not_null_absent_property_excludes() {
+    // `IS NOT NULL` must return only nodes with a present, non-null `email`
+    // (Alice, Bob) -- excluding the absent (Carol, Dave) and present-null (Eve).
+    let db = is_null_test_db();
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) WHERE n.email IS NOT NULL RETURN n")
+            .unwrap(),
+    );
+    assert_eq!(
+        row_names_sorted(&rows),
+        vec!["Alice".to_string(), "Bob".to_string()],
+        "IS NOT NULL must match only present non-null properties"
+    );
+}
+
+#[test]
+fn is_null_present_nonnull_property() {
+    // Control (correct both before and after the fix): a node WITH a non-null
+    // email is excluded by IS NULL and included by IS NOT NULL.
+    let db = is_null_test_db();
+    let is_null = collect_rows(
+        db.execute_cypher("MATCH (n:Person {name: 'Alice'}) WHERE n.email IS NULL RETURN n")
+            .unwrap(),
+    );
+    assert_eq!(is_null.len(), 0, "present non-null property is not IS NULL");
+
+    let is_not_null = collect_rows(
+        db.execute_cypher("MATCH (n:Person {name: 'Alice'}) WHERE n.email IS NOT NULL RETURN n")
+            .unwrap(),
+    );
+    assert_eq!(
+        row_names_sorted(&is_not_null),
+        vec!["Alice".to_string()],
+        "present non-null property is IS NOT NULL"
+    );
+}
+
+#[test]
+fn is_null_present_null_value() {
+    // A property present with an explicit null value IS null (and is NOT
+    // IS NOT NULL): the composed lowering must handle present-null, not just
+    // absence.
+    let db = is_null_test_db();
+    let is_null = collect_rows(
+        db.execute_cypher("MATCH (n:Person {name: 'Eve'}) WHERE n.email IS NULL RETURN n")
+            .unwrap(),
+    );
+    assert_eq!(
+        row_names_sorted(&is_null),
+        vec!["Eve".to_string()],
+        "present-null property IS NULL"
+    );
+
+    let is_not_null = collect_rows(
+        db.execute_cypher("MATCH (n:Person {name: 'Eve'}) WHERE n.email IS NOT NULL RETURN n")
+            .unwrap(),
+    );
+    assert_eq!(
+        is_not_null.len(),
+        0,
+        "present-null property is NOT IS NOT NULL"
+    );
+}
+
+#[test]
+fn is_null_composed_with_and() {
+    // The composed lowering (Or(NotExists, Eq{Null}) / And(Exists, Ne{Null}))
+    // must still compose correctly under a surrounding AND/OR.
+    let db = is_null_test_db();
+    // IS NULL AND another predicate -> only the absent-email node named Carol.
+    let rows = collect_rows(
+        db.execute_cypher("MATCH (n:Person) WHERE n.email IS NULL AND n.name = 'Carol' RETURN n")
+            .unwrap(),
+    );
+    assert_eq!(
+        row_names_sorted(&rows),
+        vec!["Carol".to_string()],
+        "IS NULL composes under AND"
+    );
+
+    // IS NOT NULL OR name = 'Carol' -> Alice, Bob (non-null email) plus Carol.
+    let rows = collect_rows(
+        db.execute_cypher(
+            "MATCH (n:Person) WHERE n.email IS NOT NULL OR n.name = 'Carol' RETURN n",
+        )
+        .unwrap(),
+    );
+    assert_eq!(
+        row_names_sorted(&rows),
+        vec!["Alice".to_string(), "Bob".to_string(), "Carol".to_string()],
+        "IS NOT NULL composes under OR"
+    );
+}
+
 #[test]
 fn test_e2e_optional_match_unmatched_returns_null_row() {
     let db = optional_match_test_db();

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -1805,9 +1805,14 @@ impl FilterIterator {
     ///
     /// Approximates openCypher three-valued logic at the "not true" level:
     /// any comparison, string predicate, or membership test involving the
-    /// null binding is not-true (row filtered), `IS NULL` (encoded as
-    /// `Eq { value: Null }`) is true, and `IS NOT NULL` (encoded as
-    /// `Ne { value: Null }`) is false.
+    /// null binding is not-true (row filtered). A node/edge-level `x IS NULL`
+    /// (bare variable) is lowered by the Cypher converter to
+    /// `Eq { value: Null }` (true here) and `x IS NOT NULL` to
+    /// `Ne { value: Null }` (false here). A property-level `x.p IS NULL` is
+    /// instead lowered to `Or(NotExists, Eq { value: Null })` (true for a null
+    /// binding via its `NotExists` arm) and `x.p IS NOT NULL` to
+    /// `And(Exists, Ne { value: Null })` (false via its `Exists` arm); the bare
+    /// `Eq`/`Ne { value: Null }` arms below also serve that composed form.
     ///
     /// Known deviation: `NOT` uses two-valued negation (`NOT (null.p = 1)`
     /// keeps the row where openCypher's `NOT null` would drop it). This


### PR DESCRIPTION
## Before / After
**Before:** `WHERE n.email IS NULL` returned 0 rows when `email` was absent (openCypher: a missing property IS null, so all such rows should match); `IS NOT NULL` was inverted (returned the absent-property rows). Present-property behavior was already correct.
**After:** `IS NULL` matches absent (and present-null) properties; `IS NOT NULL` matches only present non-null properties — openCypher-correct for absent, present-non-null, and present-null.

## How
The converter lowered `n.p IS NULL`→`Eq{key,Null}` and `n.p IS NOT NULL`→`Ne{key,Null}`, and the executor treats a missing property as non-matching for `Eq` / matching for `Ne`, inverting the intended meaning. Re-lowered the **property-access** forms to the executor's existing presence predicates:

- `n.p IS NULL` → `Or(NotExists(p), Eq(p, Null))`
- `n.p IS NOT NULL` → `And(Exists(p), Ne(p, Null))`

Present-null is real in this data model (`PropertyMapBuilder` stores a `PropertyValue::Null` without dropping it, and `compare_eq` matches `Null == Null`), so the composed form is used to stay correct across absent / present-null / present-non-null. **Bare-variable** node/edge-level checks (`x IS NULL` from an unmatched `OPTIONAL MATCH` binding) deliberately keep the `Eq/Ne{Null}` lowering — a matched entity has no property literally named after the variable, and the executor's null-row path (`evaluate_null`) already handles the null binding; the converter branches on `CypherExpr::Property` vs bare variable to keep the two semantics separate. `evaluate_eq`/`evaluate_ne` general semantics are untouched.

## Tests (in `src/cypher/tests.rs`)
New (TDD, red→green over a db mixing present-non-null, absent, and present-null `email`):
- `is_null_absent_property_matches` — `IS NULL` returns absent (Carol, Dave) + present-null (Eve). (Failed before: returned only present-null.)
- `is_not_null_absent_property_excludes` — `IS NOT NULL` returns only present-non-null (Alice, Bob).
- `is_null_present_nonnull_property` — control: present-non-null excluded by `IS NULL`, included by `IS NOT NULL`.
- `is_null_present_null_value` — present-null included by `IS NULL`, excluded by `IS NOT NULL`.
- `is_null_composed_with_and` — `IS NULL AND …` / `IS NOT NULL OR …` compose correctly under the composed lowering.

No existing test encoded the wrong behavior; all `OPTIONAL MATCH` bare-variable `IS NULL`/`IS NOT NULL` tests still pass (verified — the bare-variable branch preserves their lowering).

## Note — coordination with #561 (PR forthcoming/open)
This bug was discovered by the #561 compatibility suite, which pins the (pre-fix) behavior in a `compat_known_deviations` change-detector test and documents it under Known Limitations. When both land, that test must be flipped to the corrected expectation and the doc's Known-Limitations entry moved to Supported. (Merge order doesn't matter as long as the second one updates `src/cypher/compat.rs` + `docs/guides/cypher-compatibility.md`.)

## Gates (isolated target dir)
- `cargo test --features cypher --lib`: **3933 passed; 0 failed; 2 ignored**
- `cargo clippy --all-targets --features cypher -- -D warnings`: clean
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings`: clean
- `cargo fmt --all`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDxuBsxZU6SLfsTr7jtBbX

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDxuBsxZU6SLfsTr7jtBbX)_