### PR TITLE
feat(import): Neo4j CSV migration importer (#3356)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -257,8 +257,9 @@ cypher = []
 
 # Bulk graph importer for CSV/JSONL with per-row valid-time backfill (Issue #3211).
 # serde_json (JSONL) and chrono (timestamp parsing) are already non-optional deps,
-# so the only extra dependency is the `csv` reader.
-import = ["dep:csv"]
+# so the only extra dependency is the `csv` reader. `serde` is pulled so the
+# Neo4j importer's fidelity report (Issue #3356) is always machine-serializable.
+import = ["dep:csv", "serde"]
 
 # HTTP server support (Issue #465) — built on autumn-web.
 http-server = [

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -35,6 +35,9 @@ After those four, pick the guides relevant to what you're building.
 - [Sharding Guide](sharding-guide.md) — Domain-based horizontal scaling with 2PC transactions
 - [HTTP State Management](http-state-management.md) — Session and state management for the HTTP API
 
+### Migration & Import
+- [Neo4j Import Guide](neo4j-import.md) — Migrate a Neo4j CSV export (typed headers) with a fidelity report
+
 ---
 
 ## By Role

--- a/docs/guides/neo4j-import.md
+++ b/docs/guides/neo4j-import.md
@@ -61,10 +61,14 @@ aletheia import --format neo4j-csv \
   --valid-from-property joined
 ```
 
-Result: `alice` becomes a `Person` node (label `Person`, with
-`_labels = ["Person","Employee"]`), `skills` becomes a string array, `joined`
-sets each node's `valid_from` (so `AS OF VALID_TIME '2020-03-01'` sees Alice),
-and every version carries `provenance.source = "neo4j-import::people.csv"`.
+Here `--valid-from-property joined` names the **property** `joined` — the part
+before the `:type` in the `joined:datetime` header of `people.csv` above — so
+that column must exist in the node files. Result: `alice` becomes a `Person`
+node (label `Person`, with `_labels = ["Person","Employee"]`), `skills` becomes
+a string array, `joined` sets each node's `valid_from` (so
+`AS OF VALID_TIME '2020-03-01'` sees Alice) and is consumed as valid time rather
+than stored as a property, and every version carries
+`provenance.source = "neo4j-import::people.csv"`.
 
 ## Rust API
 
@@ -118,13 +122,15 @@ endpoints resolve).
 | Neo4j type | Maps to | Notes |
 |---|---|---|
 | `string`, untyped | `String` | |
-| `int`, `long`, `short`, `byte` (scalar) | `Int` (i64) | all fit i64, no loss |
-| `float`, `double` | `Float` (f64) | |
-| `boolean` | `Bool` | |
-| `char` | 1-char `String` | recorded as a `char_to_string` coercion |
-| `date`, `datetime`, `localdatetime` | `Int` (epoch microseconds) | recorded as `temporal_to_micros` |
+| `int`, `long` | `Int` (i64) | |
+| `short` (scalar) | `Int` (i64) | range-checked via `i16`; out-of-range is a clean row error. Recorded as a `short_to_int` coercion |
+| `byte` (scalar) | `Int` (i64) | range-checked via `i8`; out-of-range is a clean row error. Recorded as a `byte_to_int` coercion |
+| `float`, `double` | `Float` (f64) | a non-finite value (e.g. `1e400` overflowing to `inf`) is a clean row error, never stored as `inf` |
+| `boolean` | `Bool` | matches Neo4j's `Boolean.parseBoolean`: `true` **only** when the value case-insensitively equals `"true"`; every other value (`1`, `yes`, `t`, ...) is `false`, never an error |
+| `char` | 1-char `String` | requires **exactly one** character (`"AB"` is a clean row error); recorded as a `char_to_string` coercion |
+| `date`, `datetime`, `localdatetime` | `Int` (epoch microseconds) | recorded as `temporal_to_micros`; a trailing bracketed IANA zone id (`...+01:00[Europe/London]`) is stripped before parsing |
 | `time`, `localtime` | `String` | no epoch anchor; recorded as `time_to_string` |
-| `T[]` (any supported scalar) | `Array` | split on `--array-delimiter` (default `;`) |
+| `T[]` (any supported scalar) | `Array` | split on `--array-delimiter` (default `;`), **quote-aware**: an element quoted with the CSV quote char may itself contain the delimiter (`"a;b";c` → `["a;b","c"]`) |
 | numeric `T[]` **+ `--vector-property`** | `Vector` | explicit opt-in only, **never silent** |
 | **`duration`** | **rejected** | reported under `unsupported` with a count |
 | **`point` / spatial** | **rejected** | reported under `unsupported` with a count |
@@ -165,13 +171,22 @@ reported-and-counted skip.
 The importer honors the #3211 contract:
 
 - `--on-error abort` (default): the first malformed row / unresolved endpoint
-  returns an error with a precise `row N: <message>` location; already-committed
-  chunks persist.
+  returns an error with a precise location; already-committed chunks persist.
 - `--on-error skip`: malformed rows and unresolved endpoints are collected in
   the report (`skipped`, `unresolved_endpoints`) and the import continues.
 - **Header / structural errors** (missing `:ID`, missing `:START_ID`/`:END_ID`/
-  `:TYPE`, missing header row, or a `--strict-types` unsupported type) are hard
-  errors regardless of failure mode — they happen before any transaction opens.
+  `:TYPE`, missing header row, a **duplicate header column**, an **unknown
+  reserved header** like `:FOO`, a **malformed id-space** like `:ID(`, or a
+  `--strict-types` unsupported type) are hard errors regardless of failure mode
+  — they happen before any transaction opens.
+
+**Multi-file error attribution.** Row numbering restarts at 1 for each file, so
+across a multi-file import an error names the **source file** as well as the
+row: `broken.csv row 3: id column ':ID' is empty` /
+`links.csv row 5: unresolved target key 'ghost'`. Both `RowError` and
+`UnresolvedEndpoint` carry an optional `file` field (serialized only when
+present); the single-file generic CSV/JSONL importers leave it unset and render
+as `row N: ...` exactly as before.
 
 ## Fidelity report
 
@@ -185,9 +200,28 @@ The importer honors the #3211 contract:
 | `type_mapping` | neo4j-rel-type → edge-label table with counts |
 | `skipped` | malformed rows (skip mode) with `row N:` messages |
 | `unresolved_endpoints` | edges whose endpoints didn't resolve (skip mode) |
-| `coerced` | value transformations (char, temporal, multi-label) with counts |
+| `coerced` | value transformations (char, byte/short, temporal, multi-label) with counts (one per (row, column)) |
 | `unsupported` | dropped columns (`duration`, `point`, `byte[]`) with counts |
 | `zero_loss` | `true` iff `skipped`, `unresolved_endpoints`, and `unsupported` are all empty |
+
+Counts in `label_mapping`, `type_mapping`, `coerced`, and `unsupported` reflect
+**only rows that were actually imported** — in `--on-error skip` a row that is
+later skipped (bad `:ID`) or has an unresolved endpoint contributes nothing to
+these tables. A `coerced` entry counts **rows affected**, so an array column
+whose every element is coerced still counts once per row.
+
+### What `zero_loss` means (precisely)
+
+`zero_loss` reports whether any **rows or columns were dropped or rejected** —
+it is `true` iff `skipped`, `unresolved_endpoints`, and `unsupported` are all
+empty. It is deliberately **not** affected by lossy *type* coercions: a `char`
+stored as a 1-character string, a `date`/`datetime` stored as epoch
+microseconds (`temporal_to_micros`), a `time` stored as a string
+(`time_to_string`), and a `byte`/`short` widened to a 64-bit `Int`
+(`byte_to_int` / `short_to_int`) are all surfaced in the `coerced` table for
+auditability but do **not** flip `zero_loss` to `false`. Every input row and
+column was imported; only its representation changed. Inspect `coerced` when you
+need to know which type transformations were applied.
 
 ## Unsupported inputs and follow-ups
 

--- a/docs/guides/neo4j-import.md
+++ b/docs/guides/neo4j-import.md
@@ -1,0 +1,218 @@
+# Neo4j Import Guide (Issue #3356)
+
+Migrate a Neo4j graph into AletheiaDB from its **CSV export** — the
+`neo4j-admin database import` / `apoc.export.csv` self-describing typed-header
+convention. The importer reads the header, derives a coercion plan
+automatically (you never hand-write property/type mappings), streams rows
+through the same chunked ACID commit path as the generic bulk importer
+(Issue #3211), and emits a machine-readable **fidelity report** with a
+`zero_loss` boolean.
+
+> **Scope.** CSV only. A binary Neo4j `.dump` archive and the APOC Cypher-script
+> dump (`apoc.export.cypher.all`) are **not** supported — see
+> [Unsupported inputs](#unsupported-inputs-and-follow-ups).
+
+## Quick start (CLI)
+
+```bash
+# Export from Neo4j first, e.g.:
+#   neo4j-admin database import full ... (produces typed-header CSVs)
+#   or CALL apoc.export.csv.all('graph.csv', {})
+
+export ALETHEIADB_DATA_DIR=./mydata
+
+aletheia import --format neo4j-csv \
+  --nodes people.csv --nodes companies.csv \
+  --relationships works_at.csv \
+  --report import-report.json
+```
+
+The command requires building the CLI with `--features import`. It prints the
+fidelity report as JSON to stdout (and to `--report <path>` if given).
+
+### Worked example
+
+`people.csv`:
+
+```csv
+:ID,:LABEL,name,age:int,skills:string[],joined:datetime
+alice,Person;Employee,Alice,30,rust;graphs,2020-03-01T00:00:00Z
+bob,Person,Bob,25,sql,2021-06-15T00:00:00Z
+```
+
+`works_at.csv`:
+
+```csv
+:START_ID,:END_ID,:TYPE,since:int
+alice,acme,WORKS_AT,2020
+```
+
+`companies.csv`:
+
+```csv
+:ID,:LABEL,name
+acme,Company,Acme Inc
+```
+
+```bash
+aletheia import --format neo4j-csv \
+  --nodes people.csv --nodes companies.csv \
+  --relationships works_at.csv \
+  --valid-from-property joined
+```
+
+Result: `alice` becomes a `Person` node (label `Person`, with
+`_labels = ["Person","Employee"]`), `skills` becomes a string array, `joined`
+sets each node's `valid_from` (so `AS OF VALID_TIME '2020-03-01'` sees Alice),
+and every version carries `provenance.source = "neo4j-import::people.csv"`.
+
+## Rust API
+
+```rust
+use aletheiadb::AletheiaDB;
+use aletheiadb::api::import::{Neo4jCsvOptions, LabelStrategy};
+use std::path::PathBuf;
+
+let db = AletheiaDB::new()?;
+let mut importer = db.import();
+
+let opts = Neo4jCsvOptions::new()
+    .array_delimiter(';')
+    .vector_property("embedding")     // numeric[] -> Vector (opt-in, never silent)
+    .valid_from_property("joined")    // date/datetime column -> valid_from
+    .label_strategy(LabelStrategy::First);
+
+let report = importer.neo4j_import_csv(
+    &[PathBuf::from("people.csv"), PathBuf::from("companies.csv")],
+    &[PathBuf::from("works_at.csv")],
+    &opts,
+)?;
+
+assert!(report.zero_loss);
+println!("{} nodes, {} rels", report.nodes_imported, report.relationships_imported);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Single-file entry points also exist:
+`Importer::neo4j_nodes_from_csv(path, &opts)` and
+`Importer::neo4j_edges_from_csv(path, &opts)` (import nodes first so edge
+endpoints resolve).
+
+## Supported vs. rejected header/type matrix
+
+### Reserved headers
+
+| Header | Meaning |
+|---|---|
+| `:ID` | Node business key (used to resolve relationship endpoints). Not stored as a property. |
+| `name:ID` | Named id column — the id is **also** stored as property `name`. |
+| `:ID(group)` | Id-space / group. Keys are namespaced internally (`group\0id`) so the same raw id in two groups never collides. |
+| `:LABEL` | Node label(s); multiple labels separated by the array delimiter (`Person;Employee`). |
+| `:START_ID` / `:START_ID(group)` | Relationship source endpoint. |
+| `:END_ID` / `:END_ID(group)` | Relationship target endpoint. |
+| `:TYPE` | Relationship type -> edge label. |
+| `:IGNORE` | Column dropped entirely. |
+
+### Property types (`name:type`, untyped defaults to `string`)
+
+| Neo4j type | Maps to | Notes |
+|---|---|---|
+| `string`, untyped | `String` | |
+| `int`, `long`, `short`, `byte` (scalar) | `Int` (i64) | all fit i64, no loss |
+| `float`, `double` | `Float` (f64) | |
+| `boolean` | `Bool` | |
+| `char` | 1-char `String` | recorded as a `char_to_string` coercion |
+| `date`, `datetime`, `localdatetime` | `Int` (epoch microseconds) | recorded as `temporal_to_micros` |
+| `time`, `localtime` | `String` | no epoch anchor; recorded as `time_to_string` |
+| `T[]` (any supported scalar) | `Array` | split on `--array-delimiter` (default `;`) |
+| numeric `T[]` **+ `--vector-property`** | `Vector` | explicit opt-in only, **never silent** |
+| **`duration`** | **rejected** | reported under `unsupported` with a count |
+| **`point` / spatial** | **rejected** | reported under `unsupported` with a count |
+| **`byte[]`** | **rejected** | reported under `unsupported` with a count |
+
+With `--strict-types`, an unsupported-type header is a **hard error** at
+header-parse time (before any transaction opens) instead of a
+reported-and-counted skip.
+
+## Mapping decisions
+
+- **Multi-label nodes.** AletheiaDB nodes have exactly one label. By default
+  (`--label-strategy first`) the **first** label wins and the full set is
+  preserved as a `_labels` array property (deterministic and lossless).
+  `--label-strategy concat` produces a single synthetic label
+  (`Person_Employee`, no `_labels`); `--label-strategy property` keeps the first
+  label and **always** stores `_labels`. The retained-labels key defaults to
+  `_labels`.
+- **Id-spaces.** `:ID(group)` / `:START_ID(group)` / `:END_ID(group)` resolve
+  within their group, so the same raw id string in two groups is two distinct
+  nodes.
+- **Arrays.** `name:type[]` splits on the array delimiter into a
+  `PropertyValue::Array`. An empty array cell becomes an *absent* property.
+- **Vectors.** A numeric array becomes a dense `PropertyValue::Vector` **only**
+  when its property name is passed via `--vector-property` (Rust:
+  `Neo4jCsvOptions::vector_property`). Otherwise it stays an `Array`.
+- **Valid time.** By default a fact's `valid_from` is the import (transaction)
+  time. `--valid-from-property <name>` designates a `date`/`datetime` column as
+  each row's `valid_from`; that column is consumed as valid time and not also
+  stored as a property.
+- **Provenance.** Every imported node/edge version carries
+  `provenance.source = "neo4j-import::<file>"` (the basename of the file it came
+  from). Existing (non-Neo4j) importers are unchanged — they record no
+  provenance.
+
+## Failure modes and error reporting
+
+The importer honors the #3211 contract:
+
+- `--on-error abort` (default): the first malformed row / unresolved endpoint
+  returns an error with a precise `row N: <message>` location; already-committed
+  chunks persist.
+- `--on-error skip`: malformed rows and unresolved endpoints are collected in
+  the report (`skipped`, `unresolved_endpoints`) and the import continues.
+- **Header / structural errors** (missing `:ID`, missing `:START_ID`/`:END_ID`/
+  `:TYPE`, missing header row, or a `--strict-types` unsupported type) are hard
+  errors regardless of failure mode — they happen before any transaction opens.
+
+## Fidelity report
+
+`Neo4jFidelityReport` (serde-serializable) is a superset of the generic
+`ImportReport`:
+
+| Field | Meaning |
+|---|---|
+| `rows_read`, `nodes_imported`, `relationships_imported`, `properties_imported` | counts |
+| `label_mapping` | neo4j-label-set → AletheiaDB-label table with counts |
+| `type_mapping` | neo4j-rel-type → edge-label table with counts |
+| `skipped` | malformed rows (skip mode) with `row N:` messages |
+| `unresolved_endpoints` | edges whose endpoints didn't resolve (skip mode) |
+| `coerced` | value transformations (char, temporal, multi-label) with counts |
+| `unsupported` | dropped columns (`duration`, `point`, `byte[]`) with counts |
+| `zero_loss` | `true` iff `skipped`, `unresolved_endpoints`, and `unsupported` are all empty |
+
+## Unsupported inputs and follow-ups
+
+- **Binary Neo4j dump (`.dump`).** A proprietary, versioned page-store archive,
+  not a documented interchange format. The CLI rejects it with a clear message
+  pointing you to CSV export. This is not planned.
+- **APOC Cypher-script dump (`apoc.export.cypher.all`).** A text file of
+  `CREATE (...)` statements. Rejected in v1 with a message pointing you to CSV.
+  A **documented follow-up** would reuse the `cypher` parser to route parsed
+  `CREATE`s through the same prepared-chunk path and report constraint/index/
+  procedure statements as skipped-with-count.
+- **Constraints / indexes / procedures.** Out of scope (report-only in a future
+  Cypher-script path); AletheiaDB does not import Neo4j schema objects.
+
+## Known limitations
+
+- **Array properties and durable index persistence.** AletheiaDB's index
+  persistence (the fast-restart snapshot) does not yet serialize `Array`
+  properties. When you import multi-label nodes (which create a `_labels` array)
+  or array-typed columns into a **durable** data directory, index persistence
+  logs a warning and skips the snapshot for those; the data is still durable via
+  the WAL and reconstructed on restart by WAL replay. This is a pre-existing
+  index-persistence limitation, independent of the importer. Use
+  `--label-strategy concat` if you want to avoid `_labels` arrays entirely.
+- **RFC-4180 quoting only.** Doubled-quote escaping (`""`); the non-RFC
+  `\"`-style (`--legacy-style-quoting=true` in Neo4j) is not supported.
+- **Header is row 1 of each data file.** Standalone header files are not yet
+  supported.

--- a/justfile
+++ b/justfile
@@ -65,6 +65,7 @@ check-features:
     @echo "=== config-toml (standalone) ===" && cargo check --no-default-features --tests --features config-toml
     @echo "=== mcp-server (standalone) ===" && cargo check --no-default-features --tests --features mcp-server
     @echo "=== sharding-rpc (standalone) ===" && cargo check --no-default-features --tests --features sharding-rpc
+    @echo "=== import (standalone) ===" && cargo check --no-default-features --tests --features import
     @echo "=== http-server (standalone) ===" && cargo check --no-default-features --tests --features http-server
     @echo "=== encryption (standalone) ===" && cargo check --no-default-features --tests --features encryption
     @echo "=== encryption-vault (standalone) ===" && cargo check --no-default-features --tests --features encryption-vault

--- a/src/api/import/mod.rs
+++ b/src/api/import/mod.rs
@@ -43,12 +43,20 @@
 //! ```
 
 mod mapping;
+mod neo4j;
 mod parse;
 
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+mod neo4j_tests;
+
 pub use mapping::{ColumnType, EdgeMapping, LabelSource, NodeMapping, PropertyMapping};
+pub use neo4j::{
+    CoercionNote, LabelMapEntry, LabelStrategy, Neo4jCsvOptions, Neo4jFidelityReport, TypeMapEntry,
+    UnsupportedNote,
+};
 
 use std::collections::HashMap;
 use std::fmt;
@@ -59,6 +67,7 @@ use parse::{Row, RowIter};
 use crate::core::error::{Error, Result};
 use crate::core::id::NodeId;
 use crate::core::property::{PropertyMap, PropertyMapBuilder, PropertyValue};
+use crate::core::provenance::Provenance;
 use crate::core::temporal::Timestamp;
 use crate::db::AletheiaDB;
 
@@ -80,6 +89,12 @@ pub struct ImportConfig {
     pub batch_size: usize,
     /// How to react to malformed rows / unresolved endpoints (default [`FailureMode::Abort`]).
     pub failure_mode: FailureMode,
+    /// Optional write-time [`Provenance`] bundle stamped on every imported
+    /// node/edge version (Issue #3224). When `None` (the default) the import
+    /// records no provenance, reproducing the historical behavior of the
+    /// CSV/JSONL importers exactly. The Neo4j importer (Issue #3356) sets this
+    /// to `neo4j-import::<file>`.
+    pub provenance: Option<Provenance>,
 }
 
 impl Default for ImportConfig {
@@ -87,12 +102,13 @@ impl Default for ImportConfig {
         ImportConfig {
             batch_size: 1000,
             failure_mode: FailureMode::Abort,
+            provenance: None,
         }
     }
 }
 
 /// Which end of an edge failed to resolve.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 pub enum Endpoint {
     /// The edge's source endpoint.
     Source,
@@ -110,7 +126,7 @@ impl fmt::Display for Endpoint {
 }
 
 /// A row that could not be imported, with its 1-based row/line number.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct RowError {
     /// The 1-based row (CSV) or line (JSONL) number.
     pub row: usize,
@@ -125,7 +141,7 @@ impl fmt::Display for RowError {
 }
 
 /// An edge whose source or target business key did not resolve to an imported node.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct UnresolvedEndpoint {
     /// The 1-based row number of the offending edge.
     pub row: usize,
@@ -288,6 +304,18 @@ impl<'a> Importer<'a> {
     }
 
     fn import_nodes(&mut self, rows: RowIter, mapping: &NodeMapping) -> Result<ImportReport> {
+        self.import_nodes_with(rows, |row| prepare_node(row, mapping))
+    }
+
+    /// Shared node-import driver: chunked ACID commit + failure-mode handling,
+    /// parameterized by a per-row `prepare` closure that turns a raw [`Row`]
+    /// into a [`PreparedNode`]. Both the CSV/JSONL importers (Issue #3211) and
+    /// the Neo4j importer (Issue #3356) route through this so the commit path,
+    /// batching, provenance, and `row N:` error contract stay identical.
+    fn import_nodes_with<F>(&mut self, rows: RowIter, mut prepare: F) -> Result<ImportReport>
+    where
+        F: FnMut(&Row) -> std::result::Result<PreparedNode, RowError>,
+    {
         let mut report = ImportReport::default();
         let mut chunk: Vec<PreparedNode> = Vec::with_capacity(self.config.batch_size);
 
@@ -301,7 +329,7 @@ impl<'a> Importer<'a> {
                 }
             };
 
-            match prepare_node(&row, mapping) {
+            match prepare(&row) {
                 Ok(prepared) => chunk.push(prepared),
                 Err(row_err) => match self.config.failure_mode {
                     FailureMode::Abort => return Err(ImportError::Row(row_err).into()),
@@ -328,15 +356,22 @@ impl<'a> Importer<'a> {
         }
         let prepared = std::mem::take(chunk);
         let keys: Vec<String> = prepared.iter().map(|p| p.key.clone()).collect();
+        let provenance = self.config.provenance.clone();
 
         // One ACID transaction for the whole chunk: writes flow through the WAL
         // `append_batch` path (see `api::transaction::write::wal`).
         let ids = self.db.write(move |tx| {
-            use crate::api::transaction::WriteOps;
+            use crate::api::transaction::{WriteOps, WriteRequestOptions};
             let mut ids = Vec::with_capacity(prepared.len());
             for node in prepared {
-                let id =
-                    tx.create_node_with_valid_time(&node.label, node.properties, node.valid_from)?;
+                let mut options = WriteRequestOptions::new();
+                if let Some(valid_from) = node.valid_from {
+                    options = options.with_valid_from(valid_from);
+                }
+                if let Some(provenance) = provenance.clone() {
+                    options = options.with_provenance(provenance);
+                }
+                let id = tx.create_node_with_options(&node.label, node.properties, options)?;
                 ids.push(id);
             }
             Ok::<Vec<NodeId>, Error>(ids)
@@ -372,6 +407,19 @@ impl<'a> Importer<'a> {
     }
 
     fn import_edges(&mut self, rows: RowIter, mapping: &EdgeMapping) -> Result<ImportReport> {
+        self.import_edges_with(rows, |key_to_id, row| prepare_edge(key_to_id, row, mapping))
+    }
+
+    /// Shared edge-import driver: the edge counterpart to [`import_nodes_with`].
+    /// The `prepare` closure receives the accumulated business-key → [`NodeId`]
+    /// map so endpoints resolve against nodes imported earlier in the session.
+    fn import_edges_with<F>(&mut self, rows: RowIter, mut prepare: F) -> Result<ImportReport>
+    where
+        F: FnMut(
+            &HashMap<String, NodeId>,
+            &Row,
+        ) -> std::result::Result<PreparedEdge, EdgePrepError>,
+    {
         let mut report = ImportReport::default();
         let mut chunk: Vec<PreparedEdge> = Vec::with_capacity(self.config.batch_size);
 
@@ -385,7 +433,7 @@ impl<'a> Importer<'a> {
                 }
             };
 
-            match prepare_edge(&self.key_to_id, &row, mapping) {
+            match prepare(&self.key_to_id, &row) {
                 Ok(prepared) => chunk.push(prepared),
                 Err(EdgePrepError::Row(row_err)) => match self.config.failure_mode {
                     FailureMode::Abort => return Err(ImportError::Row(row_err).into()),
@@ -418,16 +466,24 @@ impl<'a> Importer<'a> {
         }
         let prepared = std::mem::take(chunk);
         let count = prepared.len();
+        let provenance = self.config.provenance.clone();
 
         self.db.write(move |tx| {
-            use crate::api::transaction::WriteOps;
+            use crate::api::transaction::{WriteOps, WriteRequestOptions};
             for edge in prepared {
-                tx.create_edge_with_valid_time(
+                let mut options = WriteRequestOptions::new();
+                if let Some(valid_from) = edge.valid_from {
+                    options = options.with_valid_from(valid_from);
+                }
+                if let Some(provenance) = provenance.clone() {
+                    options = options.with_provenance(provenance);
+                }
+                tx.create_edge_with_options(
                     edge.source,
                     edge.target,
                     &edge.label,
                     edge.properties,
-                    edge.valid_from,
+                    options,
                 )?;
             }
             Ok::<(), Error>(())

--- a/src/api/import/mod.rs
+++ b/src/api/import/mod.rs
@@ -132,11 +132,31 @@ pub struct RowError {
     pub row: usize,
     /// A precise, human-readable reason.
     pub message: String,
+    /// The source file the row came from, when a multi-file import needs to
+    /// disambiguate per-file row numbering (Issue #3356). `None` for the
+    /// single-file CSV/JSONL importers, which render as `row N: ...`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+}
+
+impl RowError {
+    /// Build a `RowError` with no source-file attribution (the single-file
+    /// importers' behavior).
+    pub(crate) fn new(row: usize, message: String) -> Self {
+        RowError {
+            row,
+            message,
+            file: None,
+        }
+    }
 }
 
 impl fmt::Display for RowError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "row {}: {}", self.row, self.message)
+        match &self.file {
+            Some(file) => write!(f, "{} row {}: {}", file, self.row, self.message),
+            None => write!(f, "row {}: {}", self.row, self.message),
+        }
     }
 }
 
@@ -149,15 +169,27 @@ pub struct UnresolvedEndpoint {
     pub key: String,
     /// Which endpoint failed to resolve.
     pub side: Endpoint,
+    /// The source file the edge row came from, when a multi-file import needs
+    /// to disambiguate per-file row numbering (Issue #3356). `None` for the
+    /// single-file importers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
 }
 
 impl fmt::Display for UnresolvedEndpoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "row {}: unresolved {} key '{}'",
-            self.row, self.side, self.key
-        )
+        match &self.file {
+            Some(file) => write!(
+                f,
+                "{} row {}: unresolved {} key '{}'",
+                file, self.row, self.side, self.key
+            ),
+            None => write!(
+                f,
+                "row {}: unresolved {} key '{}'",
+                self.row, self.side, self.key
+            ),
+        }
     }
 }
 
@@ -517,15 +549,14 @@ fn resolve_label(row: &Row, source: &LabelSource) -> std::result::Result<String,
     match source {
         LabelSource::Fixed(label) => Ok(label.clone()),
         LabelSource::Column(column) => {
-            let value = row.get_str(column).map_err(|message| RowError {
-                row: row.index,
-                message,
-            })?;
+            let value = row
+                .get_str(column)
+                .map_err(|message| RowError::new(row.index, message))?;
             if value.trim().is_empty() {
-                return Err(RowError {
-                    row: row.index,
-                    message: format!("label column '{column}' is empty"),
-                });
+                return Err(RowError::new(
+                    row.index,
+                    format!("label column '{column}' is empty"),
+                ));
             }
             Ok(value)
         }
@@ -539,13 +570,11 @@ fn build_properties(
 ) -> std::result::Result<PropertyMap, RowError> {
     let mut builder = PropertyMapBuilder::new();
     for mapping in properties {
-        let cell = row.cells.get(&mapping.column).ok_or_else(|| RowError {
-            row: row.index,
-            message: format!("missing column '{}'", mapping.column),
+        let cell = row.cells.get(&mapping.column).ok_or_else(|| {
+            RowError::new(row.index, format!("missing column '{}'", mapping.column))
         })?;
-        let value = parse::coerce(cell, mapping.ty).map_err(|message| RowError {
-            row: row.index,
-            message: format!("column '{}': {message}", mapping.column),
+        let value = parse::coerce(cell, mapping.ty).map_err(|message| {
+            RowError::new(row.index, format!("column '{}': {message}", mapping.column))
         })?;
         // Skip nulls so blank cells become absent properties rather than stored nulls.
         if matches!(value, PropertyValue::Null) {
@@ -553,10 +582,7 @@ fn build_properties(
         }
         builder = builder
             .try_insert(&mapping.name, value)
-            .map_err(|e| RowError {
-                row: row.index,
-                message: e.to_string(),
-            })?;
+            .map_err(|e| RowError::new(row.index, e.to_string()))?;
     }
     Ok(builder.build())
 }
@@ -569,17 +595,13 @@ fn extract_valid_time(
     let Some(column) = column else {
         return Ok(None);
     };
-    let raw = row.get_str(column).map_err(|message| RowError {
-        row: row.index,
-        message,
-    })?;
+    let raw = row
+        .get_str(column)
+        .map_err(|message| RowError::new(row.index, message))?;
     if raw.trim().is_empty() {
         return Ok(None);
     }
-    let ts = parse::parse_valid_time(&raw).map_err(|message| RowError {
-        row: row.index,
-        message,
-    })?;
+    let ts = parse::parse_valid_time(&raw).map_err(|message| RowError::new(row.index, message))?;
     Ok(Some(ts))
 }
 
@@ -587,15 +609,12 @@ fn prepare_node(row: &Row, mapping: &NodeMapping) -> std::result::Result<Prepare
     let label = resolve_label(row, &mapping.label)?;
     let key = row
         .get_str(&mapping.key_column)
-        .map_err(|message| RowError {
-            row: row.index,
-            message,
-        })?;
+        .map_err(|message| RowError::new(row.index, message))?;
     if key.trim().is_empty() {
-        return Err(RowError {
-            row: row.index,
-            message: format!("key column '{}' is empty", mapping.key_column),
-        });
+        return Err(RowError::new(
+            row.index,
+            format!("key column '{}' is empty", mapping.key_column),
+        ));
     }
     let properties = build_properties(row, &mapping.properties)?;
     let valid_from = extract_valid_time(row, &mapping.valid_time_column)?;
@@ -614,24 +633,19 @@ fn prepare_edge(
 ) -> std::result::Result<PreparedEdge, EdgePrepError> {
     let label = resolve_label(row, &mapping.label).map_err(EdgePrepError::Row)?;
 
-    let source_key = row.get_str(&mapping.source_key_column).map_err(|message| {
-        EdgePrepError::Row(RowError {
-            row: row.index,
-            message,
-        })
-    })?;
-    let target_key = row.get_str(&mapping.target_key_column).map_err(|message| {
-        EdgePrepError::Row(RowError {
-            row: row.index,
-            message,
-        })
-    })?;
+    let source_key = row
+        .get_str(&mapping.source_key_column)
+        .map_err(|message| EdgePrepError::Row(RowError::new(row.index, message)))?;
+    let target_key = row
+        .get_str(&mapping.target_key_column)
+        .map_err(|message| EdgePrepError::Row(RowError::new(row.index, message)))?;
 
     let source = key_to_id.get(&source_key).copied().ok_or_else(|| {
         EdgePrepError::Unresolved(UnresolvedEndpoint {
             row: row.index,
             key: source_key.clone(),
             side: Endpoint::Source,
+            file: None,
         })
     })?;
     let target = key_to_id.get(&target_key).copied().ok_or_else(|| {
@@ -639,6 +653,7 @@ fn prepare_edge(
             row: row.index,
             key: target_key.clone(),
             side: Endpoint::Target,
+            file: None,
         })
     })?;
 

--- a/src/api/import/neo4j.rs
+++ b/src/api/import/neo4j.rs
@@ -315,6 +315,63 @@ impl Neo4jFidelityReport {
             });
         }
     }
+
+    /// Fold a successfully-imported row's [`RowNotes`] into the report. Called
+    /// only once the row is known to commit, so skipped/unresolved rows never
+    /// inflate the mapping / coercion / unsupported counts (Issue #3356).
+    fn commit_row(&mut self, notes: RowNotes) {
+        if let Some((neo4j_labels, aletheia_label)) = notes.label {
+            self.note_label(&neo4j_labels, &aletheia_label);
+        }
+        if let Some(edge_type) = notes.edge_type {
+            self.note_type(&edge_type);
+        }
+        for (column, kind) in notes.coercions {
+            self.note_coercion(&column, &kind, coercion_detail(&kind));
+        }
+        for (column, neo4j_type) in notes.unsupported {
+            self.note_unsupported(&column, &neo4j_type);
+        }
+        self.properties_imported += notes.properties_imported;
+    }
+}
+
+/// Per-row scratch accumulator for fidelity notes. Notes are recorded here while
+/// a row is being prepared and only folded into the [`Neo4jFidelityReport`] via
+/// [`Neo4jFidelityReport::commit_row`] once the row is known to import — so a row
+/// that is later skipped or has an unresolved endpoint contributes nothing
+/// (Issue #3356, over-count fix). Coercions and unsupported columns are deduped
+/// per (row, column) so an array column counts once per row, not per element.
+#[derive(Default)]
+struct RowNotes {
+    label: Option<(String, String)>,
+    edge_type: Option<String>,
+    coercions: Vec<(String, String)>,
+    unsupported: Vec<(String, String)>,
+    properties_imported: usize,
+}
+
+impl RowNotes {
+    fn note_label(&mut self, neo4j_labels: &str, aletheia_label: &str) {
+        self.label = Some((neo4j_labels.to_string(), aletheia_label.to_string()));
+    }
+
+    fn note_type(&mut self, edge_type: &str) {
+        self.edge_type = Some(edge_type.to_string());
+    }
+
+    fn note_coercion(&mut self, column: &str, kind: &str) {
+        if !self.coercions.iter().any(|(c, k)| c == column && k == kind) {
+            self.coercions.push((column.to_string(), kind.to_string()));
+        }
+    }
+
+    fn note_unsupported(&mut self, column: &str, neo4j_type: &str) {
+        if !self.unsupported.iter().any(|(c, _)| c == column) {
+            self.unsupported
+                .push((column.to_string(), neo4j_type.to_string()));
+        }
+    }
 }
 
 // ---- Header model ----------------------------------------------------------
@@ -324,8 +381,12 @@ impl Neo4jFidelityReport {
 enum NeoScalar {
     /// `string` and untyped columns.
     Str,
-    /// `int`, `long`, `short`, `byte` (scalar).
+    /// `int`, `long`.
     Int,
+    /// `byte` (scalar) — range-checked via `i8`, then widened to `Int`.
+    Byte,
+    /// `short` — range-checked via `i16`, then widened to `Int`.
+    Short,
     /// `float`, `double`.
     Float,
     /// `boolean`.
@@ -392,12 +453,13 @@ fn split_type_token(token: &str) -> (String, Option<String>, bool) {
 fn classify_scalar(base_lower: &str, is_array: bool) -> Option<NeoScalar> {
     match base_lower {
         "string" | "" => Some(NeoScalar::Str),
-        "int" | "long" | "short" => Some(NeoScalar::Int),
+        "int" | "long" => Some(NeoScalar::Int),
+        "short" => Some(NeoScalar::Short),
         "byte" => {
             if is_array {
                 None // byte[] is unsupported (AC8)
             } else {
-                Some(NeoScalar::Int)
+                Some(NeoScalar::Byte)
             }
         }
         "float" | "double" => Some(NeoScalar::Float),
@@ -427,6 +489,15 @@ fn parse_column(header: &str) -> std::result::Result<ColKind, String> {
         }
     };
 
+    // A reserved id-space header (`:ID(space)`, `:START_ID(space)`, ...) with an
+    // unbalanced parenthesis is malformed; report it precisely rather than
+    // letting it fall through to a misleading "missing a name" property error.
+    if type_part.matches('(').count() != type_part.matches(')').count() {
+        return Err(format!(
+            "malformed id-space in '{header}' (unclosed parenthesis)"
+        ));
+    }
+
     let (base, group, is_array) = split_type_token(type_part);
     match base.to_ascii_uppercase().as_str() {
         "ID" => Ok(ColKind::Id {
@@ -445,6 +516,14 @@ fn parse_column(header: &str) -> std::result::Result<ColKind, String> {
         _ => {
             // A property column: name is required.
             if name_part.is_empty() {
+                // An empty-name colon header that looks reserved (`:FOO`, all
+                // upper-case, no lower-case letters) is an unknown reserved
+                // token, not a nameless property.
+                let looks_reserved =
+                    !base.is_empty() && base.chars().all(|c| !c.is_ascii_lowercase());
+                if looks_reserved {
+                    return Err(format!("unknown reserved header '{header}'"));
+                }
                 return Err(format!("property column '{header}' is missing a name"));
             }
             let base_lower = base.to_ascii_lowercase();
@@ -471,7 +550,7 @@ fn parse_columns(headers: &[String]) -> std::result::Result<Vec<Column>, String>
     if headers.is_empty() || (headers.len() == 1 && headers[0].trim().is_empty()) {
         return Err("missing header row".to_string());
     }
-    headers
+    let columns: Vec<Column> = headers
         .iter()
         .map(|h| {
             parse_column(h).map(|kind| Column {
@@ -479,7 +558,27 @@ fn parse_columns(headers: &[String]) -> std::result::Result<Vec<Column>, String>
                 kind,
             })
         })
-        .collect()
+        .collect::<std::result::Result<_, _>>()?;
+    check_duplicate_headers(&columns)?;
+    Ok(columns)
+}
+
+/// Reject duplicate header fields. The CSV reader keys cells by header string,
+/// so two identical data-bearing headers (`:ID` twice, `name:string` twice, a
+/// second `:LABEL`/`:TYPE`) would silently collapse and lose data (Issue #3356).
+/// `:IGNORE` columns are exempt — they read no cell, so duplicates are harmless.
+fn check_duplicate_headers(columns: &[Column]) -> std::result::Result<(), String> {
+    let mut seen = HashSet::new();
+    for col in columns {
+        if matches!(col.kind, ColKind::Ignore) {
+            continue;
+        }
+        let key = col.header.trim();
+        if !seen.insert(key) {
+            return Err(format!("duplicate header column '{key}'"));
+        }
+    }
+    Ok(())
 }
 
 /// If strict types is on, reject the first unsupported column as a hard error.
@@ -503,12 +602,49 @@ fn namespaced_key(group: Option<&str>, id: &str) -> String {
 
 // ---- Value coercion --------------------------------------------------------
 
-fn parse_bool(s: &str) -> Option<bool> {
-    match s.to_ascii_lowercase().as_str() {
-        "true" | "1" | "yes" | "t" => Some(true),
-        "false" | "0" | "no" | "f" => Some(false),
-        _ => None,
+/// Strip a trailing bracketed IANA zone id from a Neo4j `datetime` string
+/// (`2015-06-24T12:50:35.556+01:00[Europe/London]` -> `...+01:00`), which the
+/// shared RFC-3339 parser does not understand. A string without a trailing
+/// `[...]` is returned unchanged.
+fn strip_zone_id(s: &str) -> &str {
+    if s.ends_with(']')
+        && let Some(open) = s.rfind('[')
+    {
+        return s[..open].trim_end();
     }
+    s
+}
+
+/// Split a Neo4j array cell on `delim`, honoring `quote`-quoted elements so an
+/// element that itself contains the delimiter survives (`"a;b";c` -> `a;b`,
+/// `c`). Doubled quotes inside a quoted element escape a literal quote.
+fn split_array_quoted(raw: &str, delim: char, quote: char) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut cur = String::new();
+    let mut in_quotes = false;
+    let mut chars = raw.chars().peekable();
+    while let Some(c) = chars.next() {
+        if in_quotes {
+            if c == quote {
+                if chars.peek() == Some(&quote) {
+                    cur.push(quote);
+                    chars.next();
+                } else {
+                    in_quotes = false;
+                }
+            } else {
+                cur.push(c);
+            }
+        } else if c == quote {
+            in_quotes = true;
+        } else if c == delim {
+            parts.push(std::mem::take(&mut cur));
+        } else {
+            cur.push(c);
+        }
+    }
+    parts.push(cur);
+    parts
 }
 
 /// Coerce one scalar element string per its [`NeoScalar`] type. Returns `Ok(None)`
@@ -536,37 +672,68 @@ fn coerce_scalar<F: FnMut(&str)>(
                 .map(|v| Some(PropertyValue::Int(v)))
                 .map_err(|_| format!("cannot coerce '{raw}' to Int"))
         }
+        NeoScalar::Byte => {
+            if trimmed.is_empty() {
+                return Ok(None);
+            }
+            // Neo4j's ByteExtractor rejects values outside i8 range.
+            on_coerce("byte_to_int");
+            trimmed
+                .parse::<i8>()
+                .map(|v| Some(PropertyValue::Int(v as i64)))
+                .map_err(|_| format!("cannot coerce '{raw}' to byte (expected -128..=127)"))
+        }
+        NeoScalar::Short => {
+            if trimmed.is_empty() {
+                return Ok(None);
+            }
+            // Neo4j's ShortExtractor rejects values outside i16 range.
+            on_coerce("short_to_int");
+            trimmed
+                .parse::<i16>()
+                .map(|v| Some(PropertyValue::Int(v as i64)))
+                .map_err(|_| format!("cannot coerce '{raw}' to short (expected -32768..=32767)"))
+        }
         NeoScalar::Float => {
             if trimmed.is_empty() {
                 return Ok(None);
             }
-            trimmed
+            let v = trimmed
                 .parse::<f64>()
-                .map(|v| Some(PropertyValue::Float(v)))
-                .map_err(|_| format!("cannot coerce '{raw}' to Float"))
+                .map_err(|_| format!("cannot coerce '{raw}' to Float"))?;
+            if !v.is_finite() {
+                return Err(format!("cannot coerce '{raw}' to Float (non-finite)"));
+            }
+            Ok(Some(PropertyValue::Float(v)))
         }
         NeoScalar::Bool => {
+            // Neo4j CSV `boolean` == `Boolean.parseBoolean`: `true` iff the value
+            // case-insensitively equals "true"; every other string is `false`,
+            // and it never errors. Empty stays absent.
             if trimmed.is_empty() {
                 return Ok(None);
             }
-            parse_bool(trimmed)
-                .map(|v| Some(PropertyValue::Bool(v)))
-                .ok_or_else(|| format!("cannot coerce '{raw}' to Bool"))
+            Ok(Some(PropertyValue::Bool(raw.eq_ignore_ascii_case("true"))))
         }
         NeoScalar::Char => {
             if raw.is_empty() {
                 return Ok(None);
             }
+            // Neo4j's `char` requires exactly one character and throws otherwise.
+            if raw.chars().count() != 1 {
+                return Err(format!(
+                    "cannot coerce '{raw}' to char (expected exactly 1 character)"
+                ));
+            }
             on_coerce("char_to_string");
-            let ch = raw.chars().next().expect("non-empty");
-            Ok(Some(PropertyValue::string(ch.to_string())))
+            Ok(Some(PropertyValue::string(raw)))
         }
         NeoScalar::DateTime => {
             if trimmed.is_empty() {
                 return Ok(None);
             }
             on_coerce("temporal_to_micros");
-            let ts = parse::parse_valid_time(trimmed)?;
+            let ts = parse::parse_valid_time(strip_zone_id(trimmed))?;
             Ok(Some(PropertyValue::Int(ts.wallclock())))
         }
         NeoScalar::TimeString => {
@@ -586,6 +753,7 @@ fn coerce_property<F: FnMut(&str)>(
     ty: NeoScalar,
     is_array: bool,
     array_delim: char,
+    quote: char,
     as_vector: bool,
     on_coerce: &mut F,
 ) -> std::result::Result<Option<PropertyValue>, String> {
@@ -595,10 +763,10 @@ fn coerce_property<F: FnMut(&str)>(
     if raw.trim().is_empty() {
         return Ok(None);
     }
-    let parts: Vec<&str> = raw.split(array_delim).collect();
+    let parts = split_array_quoted(raw, array_delim, quote);
     if as_vector && matches!(ty, NeoScalar::Int | NeoScalar::Float) {
         let mut floats = Vec::with_capacity(parts.len());
-        for part in parts {
+        for part in &parts {
             let t = part.trim();
             let v = t
                 .parse::<f32>()
@@ -608,7 +776,7 @@ fn coerce_property<F: FnMut(&str)>(
         return Ok(Some(PropertyValue::vector(&floats)));
     }
     let mut values = Vec::with_capacity(parts.len());
-    for part in parts {
+    for part in &parts {
         if let Some(v) = coerce_scalar(part, ty, on_coerce)? {
             values.push(v);
         }
@@ -618,23 +786,110 @@ fn coerce_property<F: FnMut(&str)>(
 
 // ---- Node / edge preparation -----------------------------------------------
 
+/// A validated node import plan built once per file from the parsed header, so
+/// the required `:ID` / `:LABEL` columns are non-optional by construction and
+/// the per-row hot path needs no `expect`/`unreachable!` (Issue #3356).
+struct NodePlan<'a> {
+    columns: &'a [Column],
+    id_header: &'a str,
+    id_group: Option<String>,
+    id_property_name: Option<String>,
+    label_header: &'a str,
+}
+
+impl<'a> NodePlan<'a> {
+    fn build(columns: &'a [Column]) -> std::result::Result<Self, String> {
+        let mut id: Option<(&str, Option<String>, Option<String>)> = None;
+        let mut label_header: Option<&str> = None;
+        for col in columns {
+            match &col.kind {
+                ColKind::Id {
+                    group,
+                    property_name,
+                } if id.is_none() => {
+                    id = Some((col.header.as_str(), group.clone(), property_name.clone()));
+                }
+                ColKind::Label if label_header.is_none() => {
+                    label_header = Some(col.header.as_str());
+                }
+                _ => {}
+            }
+        }
+        let (id_header, id_group, id_property_name) =
+            id.ok_or_else(|| "node file has no :ID column".to_string())?;
+        let label_header =
+            label_header.ok_or_else(|| "node file has no :LABEL column".to_string())?;
+        Ok(NodePlan {
+            columns,
+            id_header,
+            id_group,
+            id_property_name,
+            label_header,
+        })
+    }
+}
+
+/// A validated relationship import plan (the edge counterpart to [`NodePlan`]).
+struct EdgePlan<'a> {
+    columns: &'a [Column],
+    type_header: &'a str,
+    start_header: &'a str,
+    end_header: &'a str,
+    start_group: Option<String>,
+    end_group: Option<String>,
+}
+
+impl<'a> EdgePlan<'a> {
+    fn build(columns: &'a [Column]) -> std::result::Result<Self, String> {
+        let mut type_header: Option<&str> = None;
+        let mut start: Option<(&str, Option<String>)> = None;
+        let mut end: Option<(&str, Option<String>)> = None;
+        for col in columns {
+            match &col.kind {
+                ColKind::Type if type_header.is_none() => {
+                    type_header = Some(col.header.as_str());
+                }
+                ColKind::StartId { group } if start.is_none() => {
+                    start = Some((col.header.as_str(), group.clone()));
+                }
+                ColKind::EndId { group } if end.is_none() => {
+                    end = Some((col.header.as_str(), group.clone()));
+                }
+                _ => {}
+            }
+        }
+        let (start_header, start_group) =
+            start.ok_or_else(|| "relationship file has no :START_ID column".to_string())?;
+        let (end_header, end_group) =
+            end.ok_or_else(|| "relationship file has no :END_ID column".to_string())?;
+        let type_header =
+            type_header.ok_or_else(|| "relationship file has no :TYPE column".to_string())?;
+        Ok(EdgePlan {
+            columns,
+            type_header,
+            start_header,
+            end_header,
+            start_group,
+            end_group,
+        })
+    }
+}
+
 fn prepare_node(
     row: &Row,
-    columns: &[Column],
+    plan: &NodePlan<'_>,
     opts: &Neo4jCsvOptions,
-    report: &mut Neo4jFidelityReport,
+    notes: &mut RowNotes,
+    file: &str,
 ) -> std::result::Result<PreparedNode, RowError> {
     let row_err = |message: String| RowError {
         row: row.index,
         message,
+        file: Some(file.to_string()),
     };
 
     // --- label ---
-    let label_col = columns
-        .iter()
-        .find(|c| matches!(c.kind, ColKind::Label))
-        .expect("node plan validated to have :LABEL");
-    let raw_label = row.get_str(&label_col.header).map_err(&row_err)?;
+    let raw_label = row.get_str(plan.label_header).map_err(&row_err)?;
     let labels: Vec<String> = raw_label
         .split(opts.array_delimiter)
         .map(|s| s.trim())
@@ -648,16 +903,12 @@ fn prepare_node(
         LabelStrategy::Concat => labels.join("_"),
         LabelStrategy::First | LabelStrategy::Property => labels[0].clone(),
     };
-    report.note_label(
+    notes.note_label(
         &labels.join(&opts.array_delimiter.to_string()),
         &chosen_label,
     );
     if labels.len() > 1 {
-        report.note_coercion(
-            ":LABEL",
-            "multi_label_flattened",
-            "multi-label node flattened; full set kept in _labels",
-        );
+        notes.note_coercion(":LABEL", "multi_label_flattened");
     }
 
     let mut builder = PropertyMapBuilder::new();
@@ -679,23 +930,12 @@ fn prepare_node(
     }
 
     // --- id / key ---
-    let id_col = columns
-        .iter()
-        .find(|c| matches!(c.kind, ColKind::Id { .. }))
-        .expect("node plan validated to have :ID");
-    let (group, property_name) = match &id_col.kind {
-        ColKind::Id {
-            group,
-            property_name,
-        } => (group.clone(), property_name.clone()),
-        _ => unreachable!(),
-    };
-    let raw_id = row.get_str(&id_col.header).map_err(&row_err)?;
+    let raw_id = row.get_str(plan.id_header).map_err(&row_err)?;
     if raw_id.trim().is_empty() {
         return Err(row_err("id column ':ID' is empty".to_string()));
     }
-    let key = namespaced_key(group.as_deref(), raw_id.trim());
-    if let Some(pname) = &property_name {
+    let key = namespaced_key(plan.id_group.as_deref(), raw_id.trim());
+    if let Some(pname) = &plan.id_property_name {
         builder = builder
             .try_insert(pname, PropertyValue::string(raw_id.trim()))
             .map_err(|e| row_err(e.to_string()))?;
@@ -704,7 +944,7 @@ fn prepare_node(
 
     // --- valid_from + properties ---
     let mut valid_from = None;
-    for col in columns {
+    for col in plan.columns {
         match &col.kind {
             ColKind::Property { name, ty, is_array } => {
                 // Consume the valid-from column as valid time, not a property.
@@ -719,14 +959,13 @@ fn prepare_node(
                 }
                 let raw = row.get_str(&col.header).map_err(&row_err)?;
                 let as_vector = opts.vector_properties.contains(name);
-                let mut on_coerce = |kind: &str| {
-                    report.note_coercion(&col.header, kind, coercion_detail(kind));
-                };
+                let mut on_coerce = |kind: &str| notes.note_coercion(&col.header, kind);
                 let value = coerce_property(
                     &raw,
                     *ty,
                     *is_array,
                     opts.array_delimiter,
+                    opts.quote as char,
                     as_vector,
                     &mut on_coerce,
                 )
@@ -741,14 +980,14 @@ fn prepare_node(
             ColKind::Unsupported { type_str, .. } => {
                 let raw = row.get_str(&col.header).map_err(&row_err)?;
                 if !raw.trim().is_empty() {
-                    report.note_unsupported(&col.header, type_str);
+                    notes.note_unsupported(&col.header, type_str);
                 }
             }
             _ => {}
         }
     }
 
-    report.properties_imported += prop_count;
+    notes.properties_imported = prop_count;
     Ok(PreparedNode {
         key,
         label: chosen_label,
@@ -760,49 +999,37 @@ fn prepare_node(
 fn prepare_edge(
     key_to_id: &std::collections::HashMap<String, NodeId>,
     row: &Row,
-    columns: &[Column],
-    start_group: Option<&str>,
-    end_group: Option<&str>,
+    plan: &EdgePlan<'_>,
     opts: &Neo4jCsvOptions,
-    report: &mut Neo4jFidelityReport,
+    notes: &mut RowNotes,
+    file: &str,
 ) -> std::result::Result<PreparedEdge, EdgePrepError> {
     let row_err = |message: String| {
         EdgePrepError::Row(RowError {
             row: row.index,
             message,
+            file: Some(file.to_string()),
         })
     };
 
-    let type_col = columns
-        .iter()
-        .find(|c| matches!(c.kind, ColKind::Type))
-        .expect("edge plan validated to have :TYPE");
-    let raw_type = row.get_str(&type_col.header).map_err(&row_err)?;
+    let raw_type = row.get_str(plan.type_header).map_err(&row_err)?;
     if raw_type.trim().is_empty() {
         return Err(row_err("type column ':TYPE' is empty".to_string()));
     }
     let label = raw_type.trim().to_string();
-    report.note_type(&label);
+    notes.note_type(&label);
 
-    let start_col = columns
-        .iter()
-        .find(|c| matches!(c.kind, ColKind::StartId { .. }))
-        .expect("edge plan validated to have :START_ID");
-    let end_col = columns
-        .iter()
-        .find(|c| matches!(c.kind, ColKind::EndId { .. }))
-        .expect("edge plan validated to have :END_ID");
-
-    let raw_src = row.get_str(&start_col.header).map_err(&row_err)?;
-    let raw_dst = row.get_str(&end_col.header).map_err(&row_err)?;
-    let src_key = namespaced_key(start_group, raw_src.trim());
-    let dst_key = namespaced_key(end_group, raw_dst.trim());
+    let raw_src = row.get_str(plan.start_header).map_err(&row_err)?;
+    let raw_dst = row.get_str(plan.end_header).map_err(&row_err)?;
+    let src_key = namespaced_key(plan.start_group.as_deref(), raw_src.trim());
+    let dst_key = namespaced_key(plan.end_group.as_deref(), raw_dst.trim());
 
     let source = key_to_id.get(&src_key).copied().ok_or_else(|| {
         EdgePrepError::Unresolved(UnresolvedEndpoint {
             row: row.index,
             key: raw_src.trim().to_string(),
             side: Endpoint::Source,
+            file: Some(file.to_string()),
         })
     })?;
     let target = key_to_id.get(&dst_key).copied().ok_or_else(|| {
@@ -810,13 +1037,14 @@ fn prepare_edge(
             row: row.index,
             key: raw_dst.trim().to_string(),
             side: Endpoint::Target,
+            file: Some(file.to_string()),
         })
     })?;
 
     let mut builder = PropertyMapBuilder::new();
     let mut prop_count = 0usize;
     let mut valid_from = None;
-    for col in columns {
+    for col in plan.columns {
         match &col.kind {
             ColKind::Property { name, ty, is_array } => {
                 if opts.valid_from_property.as_deref() == Some(name.as_str()) {
@@ -830,14 +1058,13 @@ fn prepare_edge(
                 }
                 let raw = row.get_str(&col.header).map_err(&row_err)?;
                 let as_vector = opts.vector_properties.contains(name);
-                let mut on_coerce = |kind: &str| {
-                    report.note_coercion(&col.header, kind, coercion_detail(kind));
-                };
+                let mut on_coerce = |kind: &str| notes.note_coercion(&col.header, kind);
                 let value = coerce_property(
                     &raw,
                     *ty,
                     *is_array,
                     opts.array_delimiter,
+                    opts.quote as char,
                     as_vector,
                     &mut on_coerce,
                 )
@@ -852,14 +1079,14 @@ fn prepare_edge(
             ColKind::Unsupported { type_str, .. } => {
                 let raw = row.get_str(&col.header).map_err(&row_err)?;
                 if !raw.trim().is_empty() {
-                    report.note_unsupported(&col.header, type_str);
+                    notes.note_unsupported(&col.header, type_str);
                 }
             }
             _ => {}
         }
     }
 
-    report.properties_imported += prop_count;
+    notes.properties_imported = prop_count;
     Ok(PreparedEdge {
         source,
         target,
@@ -869,9 +1096,19 @@ fn prepare_edge(
     })
 }
 
+/// The source-file label (basename) used to attribute row/endpoint errors in a
+/// multi-file import (Issue #3356), mirroring the provenance basename.
+fn file_label_for(path: &Path) -> String {
+    path.file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.to_string_lossy().to_string())
+}
+
 fn coercion_detail(kind: &str) -> &'static str {
     match kind {
         "char_to_string" => "char coerced to a 1-char string",
+        "byte_to_int" => "byte widened to a 64-bit integer",
+        "short_to_int" => "short widened to a 64-bit integer",
         "temporal_to_micros" => "date/datetime coerced to epoch microseconds",
         "time_to_string" => "time-of-day stored as a string (no epoch anchor)",
         "multi_label_flattened" => "multi-label node flattened; full set kept in _labels",
@@ -897,6 +1134,19 @@ impl<'a> Importer<'a> {
     /// Parses the self-describing header, derives a coercion plan, and streams
     /// rows through the shared chunked-commit path, stamping
     /// `neo4j-import::<file>` provenance. Returns the fidelity report.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be opened/read; the header is
+    /// missing or malformed (no `:ID` or `:LABEL` column, a duplicate header
+    /// column, an unknown reserved header, or a malformed id-space); an
+    /// unsupported type is present and `strict_types` is set; or — in the
+    /// default [`FailureMode::Abort`](super::FailureMode::Abort) — the first
+    /// malformed row/value (a bad `:ID`, an out-of-range `byte`/`short`, a
+    /// multi-character `char`, a non-finite float, an unparseable temporal
+    /// value, ...). In [`SkipAndReport`](super::FailureMode::SkipAndReport)
+    /// mode row-level failures are collected in the report instead. Error
+    /// messages name the offending file and row.
     pub fn neo4j_nodes_from_csv(
         &mut self,
         path: impl AsRef<Path>,
@@ -912,6 +1162,19 @@ impl<'a> Importer<'a> {
     ///
     /// Endpoints resolve against nodes imported earlier in this session (call
     /// [`neo4j_nodes_from_csv`](Self::neo4j_nodes_from_csv) first).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be opened/read; the header is
+    /// missing or malformed (no `:START_ID`, `:END_ID`, or `:TYPE` column, a
+    /// duplicate header column, an unknown reserved header, or a malformed
+    /// id-space); an unsupported type is present and `strict_types` is set;
+    /// or — in the default [`FailureMode::Abort`](super::FailureMode::Abort) —
+    /// the first malformed row, bad value, or unresolved endpoint (a
+    /// `:START_ID`/`:END_ID` key with no matching imported node). In
+    /// [`SkipAndReport`](super::FailureMode::SkipAndReport) mode those
+    /// row-level failures are collected in the report instead. Error messages
+    /// name the offending file and row.
     pub fn neo4j_edges_from_csv(
         &mut self,
         path: impl AsRef<Path>,
@@ -926,6 +1189,18 @@ impl<'a> Importer<'a> {
     /// Import a multi-file Neo4j CSV dataset: all node files first (building the
     /// business-key map), then all relationship files. Returns one merged
     /// fidelity report (Issue #3356).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error under the same conditions as
+    /// [`neo4j_nodes_from_csv`](Self::neo4j_nodes_from_csv) (for each node
+    /// file) and [`neo4j_edges_from_csv`](Self::neo4j_edges_from_csv) (for each
+    /// relationship file): I/O failure, a missing/malformed header, a
+    /// strict-types violation, or — in the default
+    /// [`FailureMode::Abort`](super::FailureMode::Abort) — the first malformed
+    /// row/value or unresolved endpoint. Node files are processed before
+    /// relationship files so endpoints resolve. Error messages name the
+    /// offending file so a failure is locatable across the multi-file input.
     pub fn neo4j_import_csv(
         &mut self,
         nodes: &[std::path::PathBuf],
@@ -951,26 +1226,37 @@ impl<'a> Importer<'a> {
     ) -> Result<()> {
         let headers = parse::read_csv_header(path, opts.delimiter, opts.quote)?;
         let columns = parse_columns(&headers).map_err(Error::other)?;
-        if !columns.iter().any(|c| matches!(c.kind, ColKind::Id { .. })) {
-            return Err(Error::other("node file has no :ID column".to_string()));
-        }
-        if !columns.iter().any(|c| matches!(c.kind, ColKind::Label)) {
-            return Err(Error::other("node file has no :LABEL column".to_string()));
-        }
+        let plan = NodePlan::build(&columns).map_err(Error::other)?;
         if opts.strict_types {
             enforce_strict_types(&columns).map_err(Error::other)?;
         }
 
+        let file_label = file_label_for(path);
         let rows = parse::csv_rows_with(path, opts.delimiter, opts.quote)?;
         let prev_prov = self.config.provenance.take();
         self.config.provenance = Some(provenance_for(path)?);
 
-        let columns_ref = &columns;
-        let result =
-            self.import_nodes_with(rows, |row| prepare_node(row, columns_ref, opts, report));
+        let plan_ref = &plan;
+        let file_ref = file_label.as_str();
+        let result = self.import_nodes_with(rows, |row| {
+            // Notes are folded into the report only on success, so skipped rows
+            // never inflate the mapping/coercion/unsupported counts (Issue #3356).
+            let mut notes = RowNotes::default();
+            let prepared = prepare_node(row, plan_ref, opts, &mut notes, file_ref)?;
+            report.commit_row(notes);
+            Ok(prepared)
+        });
 
         self.config.provenance = prev_prov;
-        let import_report = result?;
+        let mut import_report = result?;
+
+        // Attribute any row/parse errors that weren't already stamped (e.g. a
+        // malformed-CSV error surfaced by the reader) to this file.
+        for e in &mut import_report.skipped {
+            if e.file.is_none() {
+                e.file = Some(file_label.clone());
+            }
+        }
 
         report.rows_read += import_report.rows_read;
         report.nodes_imported += import_report.nodes_imported;
@@ -989,61 +1275,38 @@ impl<'a> Importer<'a> {
     ) -> Result<()> {
         let headers = parse::read_csv_header(path, opts.delimiter, opts.quote)?;
         let columns = parse_columns(&headers).map_err(Error::other)?;
-
-        let start_group = columns.iter().find_map(|c| match &c.kind {
-            ColKind::StartId { group } => Some(group.clone()),
-            _ => None,
-        });
-        let end_group = columns.iter().find_map(|c| match &c.kind {
-            ColKind::EndId { group } => Some(group.clone()),
-            _ => None,
-        });
-        let start_group = match start_group {
-            Some(g) => g,
-            None => {
-                return Err(Error::other(
-                    "relationship file has no :START_ID column".to_string(),
-                ));
-            }
-        };
-        let end_group = match end_group {
-            Some(g) => g,
-            None => {
-                return Err(Error::other(
-                    "relationship file has no :END_ID column".to_string(),
-                ));
-            }
-        };
-        if !columns.iter().any(|c| matches!(c.kind, ColKind::Type)) {
-            return Err(Error::other(
-                "relationship file has no :TYPE column".to_string(),
-            ));
-        }
+        let plan = EdgePlan::build(&columns).map_err(Error::other)?;
         if opts.strict_types {
             enforce_strict_types(&columns).map_err(Error::other)?;
         }
 
+        let file_label = file_label_for(path);
         let rows = parse::csv_rows_with(path, opts.delimiter, opts.quote)?;
         let prev_prov = self.config.provenance.take();
         self.config.provenance = Some(provenance_for(path)?);
 
-        let columns_ref = &columns;
-        let start_group_ref = start_group.as_deref();
-        let end_group_ref = end_group.as_deref();
+        let plan_ref = &plan;
+        let file_ref = file_label.as_str();
         let result = self.import_edges_with(rows, |key_to_id, row| {
-            prepare_edge(
-                key_to_id,
-                row,
-                columns_ref,
-                start_group_ref,
-                end_group_ref,
-                opts,
-                report,
-            )
+            let mut notes = RowNotes::default();
+            let prepared = prepare_edge(key_to_id, row, plan_ref, opts, &mut notes, file_ref)?;
+            report.commit_row(notes);
+            Ok(prepared)
         });
 
         self.config.provenance = prev_prov;
-        let import_report = result?;
+        let mut import_report = result?;
+
+        for e in &mut import_report.skipped {
+            if e.file.is_none() {
+                e.file = Some(file_label.clone());
+            }
+        }
+        for e in &mut import_report.unresolved_endpoints {
+            if e.file.is_none() {
+                e.file = Some(file_label.clone());
+            }
+        }
 
         report.rows_read += import_report.rows_read;
         report.relationships_imported += import_report.edges_imported;

--- a/src/api/import/neo4j.rs
+++ b/src/api/import/neo4j.rs
@@ -1,0 +1,1056 @@
+//! Neo4j CSV migration importer (Issue #3356).
+//!
+//! Loads a Neo4j **CSV** export — the `neo4j-admin database import` /
+//! `apoc.export.csv` self-describing typed-header convention — into AletheiaDB,
+//! reusing the #3211 bulk-import framework wholesale. The Neo4j header is
+//! self-describing, so (unlike the generic CSV importer) the caller does **not**
+//! hand-write property/type mappings: this module parses the header, derives a
+//! per-column coercion plan, and streams rows through the existing chunked ACID
+//! commit loops (`import_nodes_with` / `import_edges_with`).
+//!
+//! # Scope
+//!
+//! CSV only. A binary Neo4j `.dump` archive and the APOC Cypher-script dump
+//! (`apoc.export.cypher.all`) are **rejected** with a clear, actionable error
+//! and tracked as documented follow-ups (see the CLI and
+//! `docs/guides/neo4j-import.md`).
+//!
+//! # Header + type handling
+//!
+//! Reserved headers: `:ID`, `:ID(space)`, `:LABEL`, `:START_ID`/`:START_ID(space)`,
+//! `:END_ID`/`:END_ID(space)`, `:TYPE`, `:IGNORE`. Typed property columns follow
+//! `name:type` (untyped defaults to `string`) and `name:type[]` for arrays.
+//! `duration`, `point`/spatial, and `byte[]` are **rejected** and reported as
+//! `unsupported` with counts; `--strict-types` upgrades that to a hard error.
+//! Multi-label `:LABEL` cells (`Person;Employee`) flatten deterministically
+//! (first label wins by default) while the full set is preserved as a `_labels`
+//! array property. Numeric arrays become vectors **only** via an explicit
+//! `vector_property` opt-in, never silently.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use super::parse::{self, Row};
+use super::{
+    EdgePrepError, Endpoint, Importer, PreparedEdge, PreparedNode, RowError, UnresolvedEndpoint,
+};
+use crate::core::error::{Error, Result};
+use crate::core::id::NodeId;
+use crate::core::property::{PropertyMapBuilder, PropertyValue};
+use crate::core::provenance::Provenance;
+
+/// How a multi-label Neo4j node's label set collapses onto AletheiaDB's
+/// single-label model (Issue #3356).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LabelStrategy {
+    /// The **first** label in the `:LABEL` cell becomes the node label; the full
+    /// set is preserved as a `_labels` array property (default, deterministic,
+    /// lossless).
+    #[default]
+    First,
+    /// The labels are joined with `_` into a single synthetic label
+    /// (`Person;Employee` -> `Person_Employee`).
+    Concat,
+    /// The first label becomes the node label and the full set is **always**
+    /// stored as the `_labels` array property.
+    Property,
+}
+
+/// Options controlling a Neo4j CSV import (Issue #3356).
+///
+/// Constructed via [`Neo4jCsvOptions::new`] / [`Default`] and the fluent
+/// `with_*` methods. The defaults mirror `neo4j-admin database import`
+/// (comma field delimiter, `;` array delimiter, `"` quote, first-label wins).
+#[derive(Debug, Clone)]
+pub struct Neo4jCsvOptions {
+    /// CSV field delimiter (default `b','`).
+    pub delimiter: u8,
+    /// Delimiter separating array elements and multiple labels (default `';'`).
+    pub array_delimiter: char,
+    /// CSV quote character (default `b'"'`, RFC-4180 doubled-quote escaping).
+    pub quote: u8,
+    /// How multi-label nodes collapse onto the single-label model.
+    pub label_strategy: LabelStrategy,
+    /// Property key under which the full label set is preserved (default
+    /// `"_labels"`).
+    pub retained_labels_key: String,
+    /// Property names whose numeric array columns become dense [`PropertyValue::Vector`]s
+    /// instead of [`PropertyValue::Array`]. Explicit opt-in only (AC2).
+    pub vector_properties: HashSet<String>,
+    /// Optional property name of a `date`/`datetime` column designating each
+    /// row's `valid_from` (Issue #3221). The column is consumed as valid time
+    /// and not also stored as a property.
+    pub valid_from_property: Option<String>,
+    /// When `true`, an unsupported type in the header is a hard error at
+    /// header-parse time (before any transaction opens) instead of a
+    /// reported-and-counted skip.
+    pub strict_types: bool,
+}
+
+impl Default for Neo4jCsvOptions {
+    fn default() -> Self {
+        Neo4jCsvOptions {
+            delimiter: b',',
+            array_delimiter: ';',
+            quote: b'"',
+            label_strategy: LabelStrategy::First,
+            retained_labels_key: "_labels".to_string(),
+            vector_properties: HashSet::new(),
+            valid_from_property: None,
+            strict_types: false,
+        }
+    }
+}
+
+impl Neo4jCsvOptions {
+    /// Create default Neo4j CSV import options.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the CSV field delimiter.
+    #[must_use]
+    pub fn delimiter(mut self, delimiter: u8) -> Self {
+        self.delimiter = delimiter;
+        self
+    }
+
+    /// Set the CSV quote character.
+    #[must_use]
+    pub fn quote(mut self, quote: u8) -> Self {
+        self.quote = quote;
+        self
+    }
+
+    /// Set the array / multi-label element delimiter.
+    #[must_use]
+    pub fn array_delimiter(mut self, array_delimiter: char) -> Self {
+        self.array_delimiter = array_delimiter;
+        self
+    }
+
+    /// Set the multi-label collapse strategy.
+    #[must_use]
+    pub fn label_strategy(mut self, strategy: LabelStrategy) -> Self {
+        self.label_strategy = strategy;
+        self
+    }
+
+    /// Set the property key used to preserve the full label set.
+    #[must_use]
+    pub fn retained_labels_key(mut self, key: impl Into<String>) -> Self {
+        self.retained_labels_key = key.into();
+        self
+    }
+
+    /// Mark a numeric-array property to be stored as a dense vector (AC2).
+    #[must_use]
+    pub fn vector_property(mut self, name: impl Into<String>) -> Self {
+        self.vector_properties.insert(name.into());
+        self
+    }
+
+    /// Designate a `date`/`datetime` property as each row's `valid_from`.
+    #[must_use]
+    pub fn valid_from_property(mut self, name: impl Into<String>) -> Self {
+        self.valid_from_property = Some(name.into());
+        self
+    }
+
+    /// Turn unsupported-type headers into a hard error.
+    #[must_use]
+    pub fn strict_types(mut self, strict: bool) -> Self {
+        self.strict_types = strict;
+        self
+    }
+}
+
+/// One entry of the neo4j-label(set) -> AletheiaDB-label mapping table.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct LabelMapEntry {
+    /// The Neo4j label set as written in `:LABEL` (delimiter-joined).
+    pub neo4j_labels: String,
+    /// The AletheiaDB label chosen for those nodes.
+    pub aletheia_label: String,
+    /// Number of nodes mapped this way.
+    pub count: usize,
+}
+
+/// One entry of the neo4j-rel-type -> AletheiaDB-label mapping table.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct TypeMapEntry {
+    /// The Neo4j relationship type.
+    pub neo4j_type: String,
+    /// The AletheiaDB edge label (identical to the type today).
+    pub aletheia_label: String,
+    /// Number of edges mapped this way.
+    pub count: usize,
+}
+
+/// A value that was accepted but transformed on the way in (Issue #3356 AC4).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct CoercionNote {
+    /// The source column header (or a synthetic `:LABEL` marker).
+    pub column: String,
+    /// A stable machine token identifying the coercion kind
+    /// (`char_to_string`, `temporal_to_micros`, `time_to_string`,
+    /// `multi_label_flattened`).
+    pub kind: String,
+    /// A human-readable description of the transformation.
+    pub detail: String,
+    /// Number of rows affected.
+    pub count: usize,
+}
+
+/// A column whose Neo4j type has no AletheiaDB representation and was dropped
+/// (Issue #3356 AC8) — never silently, always counted.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct UnsupportedNote {
+    /// The source column header.
+    pub column: String,
+    /// The unsupported Neo4j type (`duration`, `point`, `byte[]`, ...).
+    pub neo4j_type: String,
+    /// Number of rows that carried a (non-empty) value in this column.
+    pub count: usize,
+}
+
+/// Machine-readable fidelity report for a Neo4j CSV import (Issue #3356 AC4).
+///
+/// A superset of the generic [`ImportReport`](super::ImportReport): it adds the
+/// label/type mapping tables, coercion and unsupported-type notes, and a
+/// `zero_loss` boolean that is `true` iff nothing was skipped, left unresolved,
+/// or dropped as unsupported.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct Neo4jFidelityReport {
+    /// Total input data rows read across all node + relationship files.
+    pub rows_read: usize,
+    /// Number of nodes successfully imported.
+    pub nodes_imported: usize,
+    /// Number of relationships successfully imported.
+    pub relationships_imported: usize,
+    /// Number of property values successfully written.
+    pub properties_imported: usize,
+    /// neo4j-label(set) -> AletheiaDB-label mapping table with counts.
+    pub label_mapping: Vec<LabelMapEntry>,
+    /// neo4j-rel-type -> AletheiaDB-label mapping table with counts.
+    pub type_mapping: Vec<TypeMapEntry>,
+    /// Malformed rows skipped (populated in skip-and-report mode).
+    pub skipped: Vec<RowError>,
+    /// Edges whose endpoints did not resolve (populated in skip-and-report mode).
+    pub unresolved_endpoints: Vec<UnresolvedEndpoint>,
+    /// Values accepted but transformed (char, temporal, multi-label...).
+    pub coerced: Vec<CoercionNote>,
+    /// Columns dropped because their Neo4j type is unsupported.
+    pub unsupported: Vec<UnsupportedNote>,
+    /// `true` iff `skipped`, `unresolved_endpoints`, and `unsupported` are all
+    /// empty — a lossless import.
+    pub zero_loss: bool,
+}
+
+impl Neo4jFidelityReport {
+    /// Recompute [`zero_loss`](Self::zero_loss) from the accumulated notes.
+    fn finalize(&mut self) {
+        self.zero_loss = self.skipped.is_empty()
+            && self.unresolved_endpoints.is_empty()
+            && self.unsupported.is_empty();
+    }
+
+    fn note_label(&mut self, neo4j_labels: &str, aletheia_label: &str) {
+        if let Some(entry) = self
+            .label_mapping
+            .iter_mut()
+            .find(|e| e.neo4j_labels == neo4j_labels && e.aletheia_label == aletheia_label)
+        {
+            entry.count += 1;
+        } else {
+            self.label_mapping.push(LabelMapEntry {
+                neo4j_labels: neo4j_labels.to_string(),
+                aletheia_label: aletheia_label.to_string(),
+                count: 1,
+            });
+        }
+    }
+
+    fn note_type(&mut self, neo4j_type: &str) {
+        if let Some(entry) = self
+            .type_mapping
+            .iter_mut()
+            .find(|e| e.neo4j_type == neo4j_type)
+        {
+            entry.count += 1;
+        } else {
+            self.type_mapping.push(TypeMapEntry {
+                neo4j_type: neo4j_type.to_string(),
+                aletheia_label: neo4j_type.to_string(),
+                count: 1,
+            });
+        }
+    }
+
+    fn note_coercion(&mut self, column: &str, kind: &str, detail: &str) {
+        if let Some(entry) = self
+            .coerced
+            .iter_mut()
+            .find(|e| e.column == column && e.kind == kind)
+        {
+            entry.count += 1;
+        } else {
+            self.coerced.push(CoercionNote {
+                column: column.to_string(),
+                kind: kind.to_string(),
+                detail: detail.to_string(),
+                count: 1,
+            });
+        }
+    }
+
+    fn note_unsupported(&mut self, column: &str, neo4j_type: &str) {
+        if let Some(entry) = self.unsupported.iter_mut().find(|e| e.column == column) {
+            entry.count += 1;
+        } else {
+            self.unsupported.push(UnsupportedNote {
+                column: column.to_string(),
+                neo4j_type: neo4j_type.to_string(),
+                count: 1,
+            });
+        }
+    }
+}
+
+// ---- Header model ----------------------------------------------------------
+
+/// A supported scalar Neo4j type, after header classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NeoScalar {
+    /// `string` and untyped columns.
+    Str,
+    /// `int`, `long`, `short`, `byte` (scalar).
+    Int,
+    /// `float`, `double`.
+    Float,
+    /// `boolean`.
+    Bool,
+    /// `char` -> 1-char string.
+    Char,
+    /// `date`, `datetime`, `localdatetime` -> epoch micros.
+    DateTime,
+    /// `time`, `localtime` -> string (no epoch anchor).
+    TimeString,
+}
+
+/// A parsed header column.
+#[derive(Debug, Clone)]
+enum ColKind {
+    Id {
+        group: Option<String>,
+        property_name: Option<String>,
+    },
+    Label,
+    StartId {
+        group: Option<String>,
+    },
+    EndId {
+        group: Option<String>,
+    },
+    Type,
+    Ignore,
+    Property {
+        name: String,
+        ty: NeoScalar,
+        is_array: bool,
+    },
+    Unsupported {
+        type_str: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+struct Column {
+    header: String,
+    kind: ColKind,
+}
+
+/// Split a header type token into `(base, group, is_array)`.
+///
+/// `ID(Person)` -> `("ID", Some("Person"), false)`; `int[]` -> `("int", None, true)`.
+fn split_type_token(token: &str) -> (String, Option<String>, bool) {
+    let mut base = token.to_string();
+    let mut group = None;
+    let is_array = base.contains("[]");
+    base = base.replace("[]", "");
+    if let (Some(open), Some(close)) = (base.find('('), base.rfind(')'))
+        && close > open
+    {
+        group = Some(base[open + 1..close].to_string());
+        base = base[..open].to_string();
+    }
+    (base.trim().to_string(), group, is_array)
+}
+
+/// Classify a scalar Neo4j type name into a [`NeoScalar`], or `None` if
+/// unsupported (`duration`, `point`, or `byte[]`).
+fn classify_scalar(base_lower: &str, is_array: bool) -> Option<NeoScalar> {
+    match base_lower {
+        "string" | "" => Some(NeoScalar::Str),
+        "int" | "long" | "short" => Some(NeoScalar::Int),
+        "byte" => {
+            if is_array {
+                None // byte[] is unsupported (AC8)
+            } else {
+                Some(NeoScalar::Int)
+            }
+        }
+        "float" | "double" => Some(NeoScalar::Float),
+        "boolean" => Some(NeoScalar::Bool),
+        "char" => Some(NeoScalar::Char),
+        "date" | "datetime" | "localdatetime" => Some(NeoScalar::DateTime),
+        "time" | "localtime" => Some(NeoScalar::TimeString),
+        _ => None, // duration, point, and any unknown type
+    }
+}
+
+/// Parse one CSV header field into a [`ColKind`].
+fn parse_column(header: &str) -> std::result::Result<ColKind, String> {
+    let trimmed = header.trim();
+    let (name_part, type_part) = match trimmed.split_once(':') {
+        Some((name, ty)) => (name.trim(), ty.trim()),
+        None => {
+            if trimmed.is_empty() {
+                return Err("empty header field".to_string());
+            }
+            // Untyped column defaults to a string property.
+            return Ok(ColKind::Property {
+                name: trimmed.to_string(),
+                ty: NeoScalar::Str,
+                is_array: false,
+            });
+        }
+    };
+
+    let (base, group, is_array) = split_type_token(type_part);
+    match base.to_ascii_uppercase().as_str() {
+        "ID" => Ok(ColKind::Id {
+            group,
+            property_name: if name_part.is_empty() {
+                None
+            } else {
+                Some(name_part.to_string())
+            },
+        }),
+        "LABEL" => Ok(ColKind::Label),
+        "START_ID" => Ok(ColKind::StartId { group }),
+        "END_ID" => Ok(ColKind::EndId { group }),
+        "TYPE" => Ok(ColKind::Type),
+        "IGNORE" => Ok(ColKind::Ignore),
+        _ => {
+            // A property column: name is required.
+            if name_part.is_empty() {
+                return Err(format!("property column '{header}' is missing a name"));
+            }
+            let base_lower = base.to_ascii_lowercase();
+            match classify_scalar(&base_lower, is_array) {
+                Some(ty) => Ok(ColKind::Property {
+                    name: name_part.to_string(),
+                    ty,
+                    is_array,
+                }),
+                None => {
+                    let type_str = if is_array {
+                        format!("{base_lower}[]")
+                    } else {
+                        base_lower
+                    };
+                    Ok(ColKind::Unsupported { type_str })
+                }
+            }
+        }
+    }
+}
+
+fn parse_columns(headers: &[String]) -> std::result::Result<Vec<Column>, String> {
+    if headers.is_empty() || (headers.len() == 1 && headers[0].trim().is_empty()) {
+        return Err("missing header row".to_string());
+    }
+    headers
+        .iter()
+        .map(|h| {
+            parse_column(h).map(|kind| Column {
+                header: h.clone(),
+                kind,
+            })
+        })
+        .collect()
+}
+
+/// If strict types is on, reject the first unsupported column as a hard error.
+fn enforce_strict_types(columns: &[Column]) -> std::result::Result<(), String> {
+    for col in columns {
+        if let ColKind::Unsupported { type_str, .. } = &col.kind {
+            return Err(format!(
+                "unsupported Neo4j type '{type_str}' in column '{}'",
+                col.header
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Namespace an id string within its id-space group (`""` = the global group),
+/// so the same raw id in two groups never collides.
+fn namespaced_key(group: Option<&str>, id: &str) -> String {
+    format!("{}\0{}", group.unwrap_or(""), id)
+}
+
+// ---- Value coercion --------------------------------------------------------
+
+fn parse_bool(s: &str) -> Option<bool> {
+    match s.to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "t" => Some(true),
+        "false" | "0" | "no" | "f" => Some(false),
+        _ => None,
+    }
+}
+
+/// Coerce one scalar element string per its [`NeoScalar`] type. Returns `Ok(None)`
+/// for an empty element (which is dropped). Records coercions via `on_coerce`.
+fn coerce_scalar<F: FnMut(&str)>(
+    raw: &str,
+    ty: NeoScalar,
+    on_coerce: &mut F,
+) -> std::result::Result<Option<PropertyValue>, String> {
+    let trimmed = raw.trim();
+    match ty {
+        NeoScalar::Str => {
+            if raw.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(PropertyValue::string(raw)))
+            }
+        }
+        NeoScalar::Int => {
+            if trimmed.is_empty() {
+                return Ok(None);
+            }
+            trimmed
+                .parse::<i64>()
+                .map(|v| Some(PropertyValue::Int(v)))
+                .map_err(|_| format!("cannot coerce '{raw}' to Int"))
+        }
+        NeoScalar::Float => {
+            if trimmed.is_empty() {
+                return Ok(None);
+            }
+            trimmed
+                .parse::<f64>()
+                .map(|v| Some(PropertyValue::Float(v)))
+                .map_err(|_| format!("cannot coerce '{raw}' to Float"))
+        }
+        NeoScalar::Bool => {
+            if trimmed.is_empty() {
+                return Ok(None);
+            }
+            parse_bool(trimmed)
+                .map(|v| Some(PropertyValue::Bool(v)))
+                .ok_or_else(|| format!("cannot coerce '{raw}' to Bool"))
+        }
+        NeoScalar::Char => {
+            if raw.is_empty() {
+                return Ok(None);
+            }
+            on_coerce("char_to_string");
+            let ch = raw.chars().next().expect("non-empty");
+            Ok(Some(PropertyValue::string(ch.to_string())))
+        }
+        NeoScalar::DateTime => {
+            if trimmed.is_empty() {
+                return Ok(None);
+            }
+            on_coerce("temporal_to_micros");
+            let ts = parse::parse_valid_time(trimmed)?;
+            Ok(Some(PropertyValue::Int(ts.wallclock())))
+        }
+        NeoScalar::TimeString => {
+            if trimmed.is_empty() {
+                return Ok(None);
+            }
+            on_coerce("time_to_string");
+            Ok(Some(PropertyValue::string(raw)))
+        }
+    }
+}
+
+/// Coerce a property column's raw cell into a [`PropertyValue`], honoring
+/// arrays / vectors. Returns `Ok(None)` for an absent value.
+fn coerce_property<F: FnMut(&str)>(
+    raw: &str,
+    ty: NeoScalar,
+    is_array: bool,
+    array_delim: char,
+    as_vector: bool,
+    on_coerce: &mut F,
+) -> std::result::Result<Option<PropertyValue>, String> {
+    if !is_array {
+        return coerce_scalar(raw, ty, on_coerce);
+    }
+    if raw.trim().is_empty() {
+        return Ok(None);
+    }
+    let parts: Vec<&str> = raw.split(array_delim).collect();
+    if as_vector && matches!(ty, NeoScalar::Int | NeoScalar::Float) {
+        let mut floats = Vec::with_capacity(parts.len());
+        for part in parts {
+            let t = part.trim();
+            let v = t
+                .parse::<f32>()
+                .map_err(|_| format!("cannot coerce '{part}' to vector element (f32)"))?;
+            floats.push(v);
+        }
+        return Ok(Some(PropertyValue::vector(&floats)));
+    }
+    let mut values = Vec::with_capacity(parts.len());
+    for part in parts {
+        if let Some(v) = coerce_scalar(part, ty, on_coerce)? {
+            values.push(v);
+        }
+    }
+    Ok(Some(PropertyValue::array(values)))
+}
+
+// ---- Node / edge preparation -----------------------------------------------
+
+fn prepare_node(
+    row: &Row,
+    columns: &[Column],
+    opts: &Neo4jCsvOptions,
+    report: &mut Neo4jFidelityReport,
+) -> std::result::Result<PreparedNode, RowError> {
+    let row_err = |message: String| RowError {
+        row: row.index,
+        message,
+    };
+
+    // --- label ---
+    let label_col = columns
+        .iter()
+        .find(|c| matches!(c.kind, ColKind::Label))
+        .expect("node plan validated to have :LABEL");
+    let raw_label = row.get_str(&label_col.header).map_err(&row_err)?;
+    let labels: Vec<String> = raw_label
+        .split(opts.array_delimiter)
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect();
+    if labels.is_empty() {
+        return Err(row_err("node has no label".to_string()));
+    }
+    let chosen_label = match opts.label_strategy {
+        LabelStrategy::Concat => labels.join("_"),
+        LabelStrategy::First | LabelStrategy::Property => labels[0].clone(),
+    };
+    report.note_label(
+        &labels.join(&opts.array_delimiter.to_string()),
+        &chosen_label,
+    );
+    if labels.len() > 1 {
+        report.note_coercion(
+            ":LABEL",
+            "multi_label_flattened",
+            "multi-label node flattened; full set kept in _labels",
+        );
+    }
+
+    let mut builder = PropertyMapBuilder::new();
+    let mut prop_count = 0usize;
+
+    // Preserve the full label set as `_labels` (First: only when multi-label;
+    // Property: always; Concat: never, the concatenated label already holds it).
+    let store_labels = match opts.label_strategy {
+        LabelStrategy::First => labels.len() > 1,
+        LabelStrategy::Property => true,
+        LabelStrategy::Concat => false,
+    };
+    if store_labels {
+        let arr = PropertyValue::array(labels.iter().map(PropertyValue::string).collect());
+        builder = builder
+            .try_insert(&opts.retained_labels_key, arr)
+            .map_err(|e| row_err(e.to_string()))?;
+        prop_count += 1;
+    }
+
+    // --- id / key ---
+    let id_col = columns
+        .iter()
+        .find(|c| matches!(c.kind, ColKind::Id { .. }))
+        .expect("node plan validated to have :ID");
+    let (group, property_name) = match &id_col.kind {
+        ColKind::Id {
+            group,
+            property_name,
+        } => (group.clone(), property_name.clone()),
+        _ => unreachable!(),
+    };
+    let raw_id = row.get_str(&id_col.header).map_err(&row_err)?;
+    if raw_id.trim().is_empty() {
+        return Err(row_err("id column ':ID' is empty".to_string()));
+    }
+    let key = namespaced_key(group.as_deref(), raw_id.trim());
+    if let Some(pname) = &property_name {
+        builder = builder
+            .try_insert(pname, PropertyValue::string(raw_id.trim()))
+            .map_err(|e| row_err(e.to_string()))?;
+        prop_count += 1;
+    }
+
+    // --- valid_from + properties ---
+    let mut valid_from = None;
+    for col in columns {
+        match &col.kind {
+            ColKind::Property { name, ty, is_array } => {
+                // Consume the valid-from column as valid time, not a property.
+                if opts.valid_from_property.as_deref() == Some(name.as_str()) {
+                    let raw = row.get_str(&col.header).map_err(&row_err)?;
+                    if !raw.trim().is_empty() {
+                        let ts = parse::parse_valid_time(raw.trim())
+                            .map_err(|m| row_err(format!("column '{}': {m}", col.header)))?;
+                        valid_from = Some(ts);
+                    }
+                    continue;
+                }
+                let raw = row.get_str(&col.header).map_err(&row_err)?;
+                let as_vector = opts.vector_properties.contains(name);
+                let mut on_coerce = |kind: &str| {
+                    report.note_coercion(&col.header, kind, coercion_detail(kind));
+                };
+                let value = coerce_property(
+                    &raw,
+                    *ty,
+                    *is_array,
+                    opts.array_delimiter,
+                    as_vector,
+                    &mut on_coerce,
+                )
+                .map_err(|m| row_err(format!("column '{}': {m}", col.header)))?;
+                if let Some(value) = value {
+                    builder = builder
+                        .try_insert(name, value)
+                        .map_err(|e| row_err(e.to_string()))?;
+                    prop_count += 1;
+                }
+            }
+            ColKind::Unsupported { type_str, .. } => {
+                let raw = row.get_str(&col.header).map_err(&row_err)?;
+                if !raw.trim().is_empty() {
+                    report.note_unsupported(&col.header, type_str);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    report.properties_imported += prop_count;
+    Ok(PreparedNode {
+        key,
+        label: chosen_label,
+        properties: builder.build(),
+        valid_from,
+    })
+}
+
+fn prepare_edge(
+    key_to_id: &std::collections::HashMap<String, NodeId>,
+    row: &Row,
+    columns: &[Column],
+    start_group: Option<&str>,
+    end_group: Option<&str>,
+    opts: &Neo4jCsvOptions,
+    report: &mut Neo4jFidelityReport,
+) -> std::result::Result<PreparedEdge, EdgePrepError> {
+    let row_err = |message: String| {
+        EdgePrepError::Row(RowError {
+            row: row.index,
+            message,
+        })
+    };
+
+    let type_col = columns
+        .iter()
+        .find(|c| matches!(c.kind, ColKind::Type))
+        .expect("edge plan validated to have :TYPE");
+    let raw_type = row.get_str(&type_col.header).map_err(&row_err)?;
+    if raw_type.trim().is_empty() {
+        return Err(row_err("type column ':TYPE' is empty".to_string()));
+    }
+    let label = raw_type.trim().to_string();
+    report.note_type(&label);
+
+    let start_col = columns
+        .iter()
+        .find(|c| matches!(c.kind, ColKind::StartId { .. }))
+        .expect("edge plan validated to have :START_ID");
+    let end_col = columns
+        .iter()
+        .find(|c| matches!(c.kind, ColKind::EndId { .. }))
+        .expect("edge plan validated to have :END_ID");
+
+    let raw_src = row.get_str(&start_col.header).map_err(&row_err)?;
+    let raw_dst = row.get_str(&end_col.header).map_err(&row_err)?;
+    let src_key = namespaced_key(start_group, raw_src.trim());
+    let dst_key = namespaced_key(end_group, raw_dst.trim());
+
+    let source = key_to_id.get(&src_key).copied().ok_or_else(|| {
+        EdgePrepError::Unresolved(UnresolvedEndpoint {
+            row: row.index,
+            key: raw_src.trim().to_string(),
+            side: Endpoint::Source,
+        })
+    })?;
+    let target = key_to_id.get(&dst_key).copied().ok_or_else(|| {
+        EdgePrepError::Unresolved(UnresolvedEndpoint {
+            row: row.index,
+            key: raw_dst.trim().to_string(),
+            side: Endpoint::Target,
+        })
+    })?;
+
+    let mut builder = PropertyMapBuilder::new();
+    let mut prop_count = 0usize;
+    let mut valid_from = None;
+    for col in columns {
+        match &col.kind {
+            ColKind::Property { name, ty, is_array } => {
+                if opts.valid_from_property.as_deref() == Some(name.as_str()) {
+                    let raw = row.get_str(&col.header).map_err(&row_err)?;
+                    if !raw.trim().is_empty() {
+                        let ts = parse::parse_valid_time(raw.trim())
+                            .map_err(|m| row_err(format!("column '{}': {m}", col.header)))?;
+                        valid_from = Some(ts);
+                    }
+                    continue;
+                }
+                let raw = row.get_str(&col.header).map_err(&row_err)?;
+                let as_vector = opts.vector_properties.contains(name);
+                let mut on_coerce = |kind: &str| {
+                    report.note_coercion(&col.header, kind, coercion_detail(kind));
+                };
+                let value = coerce_property(
+                    &raw,
+                    *ty,
+                    *is_array,
+                    opts.array_delimiter,
+                    as_vector,
+                    &mut on_coerce,
+                )
+                .map_err(|m| row_err(format!("column '{}': {m}", col.header)))?;
+                if let Some(value) = value {
+                    builder = builder
+                        .try_insert(name, value)
+                        .map_err(|e| row_err(e.to_string()))?;
+                    prop_count += 1;
+                }
+            }
+            ColKind::Unsupported { type_str, .. } => {
+                let raw = row.get_str(&col.header).map_err(&row_err)?;
+                if !raw.trim().is_empty() {
+                    report.note_unsupported(&col.header, type_str);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    report.properties_imported += prop_count;
+    Ok(PreparedEdge {
+        source,
+        target,
+        label,
+        properties: builder.build(),
+        valid_from,
+    })
+}
+
+fn coercion_detail(kind: &str) -> &'static str {
+    match kind {
+        "char_to_string" => "char coerced to a 1-char string",
+        "temporal_to_micros" => "date/datetime coerced to epoch microseconds",
+        "time_to_string" => "time-of-day stored as a string (no epoch anchor)",
+        "multi_label_flattened" => "multi-label node flattened; full set kept in _labels",
+        _ => "value coerced",
+    }
+}
+
+/// Derive the `neo4j-import::<basename>` provenance source for a file.
+fn provenance_for(path: &Path) -> Result<Provenance> {
+    let basename = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.to_string_lossy().to_string());
+    Provenance::builder()
+        .source(format!("neo4j-import::{basename}"))
+        .build()
+        .map_err(|e| Error::other(e.to_string()))
+}
+
+impl<'a> Importer<'a> {
+    /// Import Neo4j-CSV nodes from a single file (Issue #3356).
+    ///
+    /// Parses the self-describing header, derives a coercion plan, and streams
+    /// rows through the shared chunked-commit path, stamping
+    /// `neo4j-import::<file>` provenance. Returns the fidelity report.
+    pub fn neo4j_nodes_from_csv(
+        &mut self,
+        path: impl AsRef<Path>,
+        opts: &Neo4jCsvOptions,
+    ) -> Result<Neo4jFidelityReport> {
+        let mut report = Neo4jFidelityReport::default();
+        self.run_nodes(path.as_ref(), opts, &mut report)?;
+        report.finalize();
+        Ok(report)
+    }
+
+    /// Import Neo4j-CSV relationships from a single file (Issue #3356).
+    ///
+    /// Endpoints resolve against nodes imported earlier in this session (call
+    /// [`neo4j_nodes_from_csv`](Self::neo4j_nodes_from_csv) first).
+    pub fn neo4j_edges_from_csv(
+        &mut self,
+        path: impl AsRef<Path>,
+        opts: &Neo4jCsvOptions,
+    ) -> Result<Neo4jFidelityReport> {
+        let mut report = Neo4jFidelityReport::default();
+        self.run_edges(path.as_ref(), opts, &mut report)?;
+        report.finalize();
+        Ok(report)
+    }
+
+    /// Import a multi-file Neo4j CSV dataset: all node files first (building the
+    /// business-key map), then all relationship files. Returns one merged
+    /// fidelity report (Issue #3356).
+    pub fn neo4j_import_csv(
+        &mut self,
+        nodes: &[std::path::PathBuf],
+        rels: &[std::path::PathBuf],
+        opts: &Neo4jCsvOptions,
+    ) -> Result<Neo4jFidelityReport> {
+        let mut report = Neo4jFidelityReport::default();
+        for path in nodes {
+            self.run_nodes(path, opts, &mut report)?;
+        }
+        for path in rels {
+            self.run_edges(path, opts, &mut report)?;
+        }
+        report.finalize();
+        Ok(report)
+    }
+
+    fn run_nodes(
+        &mut self,
+        path: &Path,
+        opts: &Neo4jCsvOptions,
+        report: &mut Neo4jFidelityReport,
+    ) -> Result<()> {
+        let headers = parse::read_csv_header(path, opts.delimiter, opts.quote)?;
+        let columns = parse_columns(&headers).map_err(Error::other)?;
+        if !columns.iter().any(|c| matches!(c.kind, ColKind::Id { .. })) {
+            return Err(Error::other("node file has no :ID column".to_string()));
+        }
+        if !columns.iter().any(|c| matches!(c.kind, ColKind::Label)) {
+            return Err(Error::other("node file has no :LABEL column".to_string()));
+        }
+        if opts.strict_types {
+            enforce_strict_types(&columns).map_err(Error::other)?;
+        }
+
+        let rows = parse::csv_rows_with(path, opts.delimiter, opts.quote)?;
+        let prev_prov = self.config.provenance.take();
+        self.config.provenance = Some(provenance_for(path)?);
+
+        let columns_ref = &columns;
+        let result =
+            self.import_nodes_with(rows, |row| prepare_node(row, columns_ref, opts, report));
+
+        self.config.provenance = prev_prov;
+        let import_report = result?;
+
+        report.rows_read += import_report.rows_read;
+        report.nodes_imported += import_report.nodes_imported;
+        report.skipped.extend(import_report.skipped);
+        report
+            .unresolved_endpoints
+            .extend(import_report.unresolved_endpoints);
+        Ok(())
+    }
+
+    fn run_edges(
+        &mut self,
+        path: &Path,
+        opts: &Neo4jCsvOptions,
+        report: &mut Neo4jFidelityReport,
+    ) -> Result<()> {
+        let headers = parse::read_csv_header(path, opts.delimiter, opts.quote)?;
+        let columns = parse_columns(&headers).map_err(Error::other)?;
+
+        let start_group = columns.iter().find_map(|c| match &c.kind {
+            ColKind::StartId { group } => Some(group.clone()),
+            _ => None,
+        });
+        let end_group = columns.iter().find_map(|c| match &c.kind {
+            ColKind::EndId { group } => Some(group.clone()),
+            _ => None,
+        });
+        let start_group = match start_group {
+            Some(g) => g,
+            None => {
+                return Err(Error::other(
+                    "relationship file has no :START_ID column".to_string(),
+                ));
+            }
+        };
+        let end_group = match end_group {
+            Some(g) => g,
+            None => {
+                return Err(Error::other(
+                    "relationship file has no :END_ID column".to_string(),
+                ));
+            }
+        };
+        if !columns.iter().any(|c| matches!(c.kind, ColKind::Type)) {
+            return Err(Error::other(
+                "relationship file has no :TYPE column".to_string(),
+            ));
+        }
+        if opts.strict_types {
+            enforce_strict_types(&columns).map_err(Error::other)?;
+        }
+
+        let rows = parse::csv_rows_with(path, opts.delimiter, opts.quote)?;
+        let prev_prov = self.config.provenance.take();
+        self.config.provenance = Some(provenance_for(path)?);
+
+        let columns_ref = &columns;
+        let start_group_ref = start_group.as_deref();
+        let end_group_ref = end_group.as_deref();
+        let result = self.import_edges_with(rows, |key_to_id, row| {
+            prepare_edge(
+                key_to_id,
+                row,
+                columns_ref,
+                start_group_ref,
+                end_group_ref,
+                opts,
+                report,
+            )
+        });
+
+        self.config.provenance = prev_prov;
+        let import_report = result?;
+
+        report.rows_read += import_report.rows_read;
+        report.relationships_imported += import_report.edges_imported;
+        report.skipped.extend(import_report.skipped);
+        report
+            .unresolved_endpoints
+            .extend(import_report.unresolved_endpoints);
+        Ok(())
+    }
+}

--- a/src/api/import/neo4j_tests.rs
+++ b/src/api/import/neo4j_tests.rs
@@ -805,6 +805,302 @@ fn valid_from_property_backdates() {
     assert!(db.get_node_at_valid_time(a, ts_2019).is_err());
 }
 
+// ---- Conformance fixes (review) --------------------------------------------
+
+// #1: boolean == Boolean.parseBoolean — `true` iff case-insensitively "true".
+#[test]
+fn boolean_parse_matches_neo4j() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        ":ID,:LABEL,b:boolean\n\
+         one,Person,1\n\
+         yes,Person,yes\n\
+         banana,Person,banana\n\
+         upper,Person,TRUE\n\
+         no,Person,false\n",
+    );
+    let mut importer = db.import();
+    importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("import");
+    let get = |id: &str| {
+        db.get_node(resolve(&importer, "", id))
+            .unwrap()
+            .properties
+            .get("b")
+            .cloned()
+    };
+    assert_eq!(get("one"), Some(PropertyValue::Bool(false))); // "1" is not "true"
+    assert_eq!(get("yes"), Some(PropertyValue::Bool(false))); // "yes" is not "true"
+    assert_eq!(get("banana"), Some(PropertyValue::Bool(false)));
+    assert_eq!(get("upper"), Some(PropertyValue::Bool(true))); // case-insensitive
+    assert_eq!(get("no"), Some(PropertyValue::Bool(false)));
+}
+
+// #2: multi-character `char` is a clean row error; single char is fine.
+#[test]
+fn char_requires_exactly_one_character() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let bad = write_file(&files, "bad.csv", ":ID,:LABEL,c:char\na,Person,AB\n");
+    let mut importer = db.import();
+    let err = importer
+        .neo4j_nodes_from_csv(&bad, &Neo4jCsvOptions::new())
+        .expect_err("multi-char char should error");
+    let msg = err.to_string();
+    assert!(msg.contains("row 1"), "was: {msg}");
+    assert!(
+        msg.contains("char") && msg.contains("exactly 1"),
+        "was: {msg}"
+    );
+
+    let ok = write_file(&files, "ok.csv", ":ID,:LABEL,c:char\na,Person,A\n");
+    let (_tmp2, db2) = create_test_db().unwrap();
+    let mut importer2 = db2.import();
+    importer2
+        .neo4j_nodes_from_csv(&ok, &Neo4jCsvOptions::new())
+        .expect("single char imports");
+    let node = db2
+        .get_node(importer2.resolve_key(&nkey("", "a")).unwrap())
+        .unwrap();
+    assert_eq!(node.properties.get("c"), Some(&PropertyValue::string("A")));
+}
+
+// #3: out-of-range `short` (and `byte`) rejected; in-range become Int.
+#[test]
+fn short_out_of_range_rejected() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        ":ID,:LABEL,tiny:short\na,Person,99999\n",
+    );
+    let mut importer = db.import();
+    let err = importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect_err("out-of-range short should error");
+    let msg = err.to_string();
+    assert!(msg.contains("row 1") && msg.contains("short"), "was: {msg}");
+}
+
+#[test]
+fn byte_out_of_range_rejected() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":ID,:LABEL,b:byte\na,Person,200\n");
+    let mut importer = db.import();
+    let err = importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect_err("out-of-range byte should error");
+    assert!(err.to_string().contains("byte"), "was: {err}");
+}
+
+// #4: quoted array element containing the array delimiter is not mis-split.
+#[test]
+fn quoted_array_element_with_delimiter() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    // CSV cell after unquoting is: "a;b";c  ->  ["a;b", "c"]
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        ":ID,:LABEL,tags:string[]\na,Person,\"\"\"a;b\"\";c\"\n",
+    );
+    let mut importer = db.import();
+    importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("import");
+    let node = db.get_node(resolve(&importer, "", "a")).unwrap();
+    assert_eq!(
+        node.properties.get("tags"),
+        Some(&PropertyValue::array(vec![
+            PropertyValue::string("a;b"),
+            PropertyValue::string("c"),
+        ]))
+    );
+}
+
+// #5: datetime with a trailing bracketed IANA zone id parses.
+#[test]
+fn datetime_named_zone_id_stripped() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        ":ID,:LABEL,born:datetime\n\
+         zoned,Person,2015-06-24T12:50:35.556+01:00[Europe/London]\n\
+         plain,Person,2015-06-24T12:50:35.556+01:00\n",
+    );
+    let mut importer = db.import();
+    importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("import");
+    let zoned = db.get_node(resolve(&importer, "", "zoned")).unwrap();
+    let plain = db.get_node(resolve(&importer, "", "plain")).unwrap();
+    let z = zoned.properties.get("born").cloned();
+    assert!(matches!(z, Some(PropertyValue::Int(_))), "was: {z:?}");
+    // The bracketed zone id names the same instant as the bare offset.
+    assert_eq!(z, plain.properties.get("born").cloned());
+}
+
+// #6: non-finite float (overflow) is rejected, not stored as inf.
+#[test]
+fn non_finite_float_rejected() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":ID,:LABEL,x:double\na,Person,1e400\n");
+    let mut importer = db.import();
+    let err = importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect_err("non-finite float should error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("row 1") && msg.contains("non-finite"),
+        "was: {msg}"
+    );
+}
+
+// #7: multi-file skipped/unresolved errors name the offending file.
+#[test]
+fn multi_file_errors_name_the_file() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let n1 = write_file(&files, "good.csv", ":ID,:LABEL\na,Person\n");
+    // Second node file has a malformed row (empty :ID).
+    let n2 = write_file(&files, "broken.csv", ":ID,:LABEL\n,Person\n");
+    let rels = write_file(
+        &files,
+        "links.csv",
+        ":START_ID,:END_ID,:TYPE\na,ghost,KNOWS\n",
+    );
+
+    let mut importer = db.import().failure_mode(FailureMode::SkipAndReport);
+    let report = importer
+        .neo4j_import_csv(&[n1, n2], &[rels], &Neo4jCsvOptions::new())
+        .expect("import");
+
+    let skipped = report
+        .skipped
+        .iter()
+        .find(|e| e.file.as_deref() == Some("broken.csv"))
+        .expect("skipped row attributed to broken.csv");
+    assert!(skipped.to_string().contains("broken.csv"), "was: {skipped}");
+
+    let unresolved = &report.unresolved_endpoints[0];
+    assert_eq!(unresolved.file.as_deref(), Some("links.csv"));
+    assert!(
+        unresolved.to_string().contains("links.csv"),
+        "was: {unresolved}"
+    );
+}
+
+// #9: duplicate header columns are rejected (would silently collapse).
+#[test]
+fn duplicate_header_rejected() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":ID,:ID,:LABEL\na,b,Person\n");
+    let mut importer = db.import();
+    let err = importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect_err("duplicate header should error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("duplicate header") && msg.contains(":ID"),
+        "was: {msg}"
+    );
+}
+
+// #10: skip mode — mapping counts reflect only imported rows, not skipped ones.
+#[test]
+fn skip_mode_type_mapping_matches_imported() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":ID,:LABEL\na,Person\nb,Person\n");
+    // One resolvable edge + one dangling edge, same :TYPE.
+    let rels = write_file(
+        &files,
+        "rels.csv",
+        ":START_ID,:END_ID,:TYPE\na,b,KNOWS\na,ghost,KNOWS\n",
+    );
+    let mut importer = db.import().failure_mode(FailureMode::SkipAndReport);
+    importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("nodes");
+    let report = importer
+        .neo4j_edges_from_csv(&rels, &Neo4jCsvOptions::new())
+        .expect("edges");
+    assert_eq!(report.relationships_imported, 1);
+    let knows = report
+        .type_mapping
+        .iter()
+        .find(|t| t.neo4j_type == "KNOWS")
+        .expect("KNOWS type mapping");
+    // The dangling row must NOT be counted in the mapping.
+    assert_eq!(knows.count, report.relationships_imported);
+    assert_eq!(knows.count, 1);
+}
+
+// #11: an array column's coercion counts once per row, not per element.
+#[test]
+fn array_coercion_counts_per_row() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        ":ID,:LABEL,grades:char[]\na,Person,A;B;C\n",
+    );
+    let mut importer = db.import();
+    let report = importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("import");
+    let note = report
+        .coerced
+        .iter()
+        .find(|c| c.column == "grades:char[]" && c.kind == "char_to_string")
+        .expect("char coercion recorded");
+    // One row, three elements -> counted once (not three times).
+    assert_eq!(note.count, 1);
+}
+
+// #12: unknown reserved header + malformed id-space report precise errors.
+#[test]
+fn unknown_reserved_header_error() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":ID,:LABEL,:FOO\na,Person,x\n");
+    let mut importer = db.import();
+    let err = importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect_err("unknown reserved header should error");
+    assert!(
+        err.to_string().contains("unknown reserved header"),
+        "was: {err}"
+    );
+}
+
+#[test]
+fn malformed_id_space_error() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":ID(,:LABEL\na,Person\n");
+    let mut importer = db.import();
+    let err = importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect_err("malformed id-space should error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("malformed id-space") && msg.contains("unclosed"),
+        "was: {msg}"
+    );
+}
+
 // ---- Scale (AC7) -----------------------------------------------------------
 
 // 10K-node / ~30K-edge smoke: zero-loss report.

--- a/src/api/import/neo4j_tests.rs
+++ b/src/api/import/neo4j_tests.rs
@@ -1,0 +1,840 @@
+//! Tests for the Neo4j CSV migration importer (Issue #3356).
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+
+use super::neo4j::{LabelStrategy, Neo4jCsvOptions};
+use super::*;
+use crate::core::property::PropertyValue;
+use crate::core::temporal::Timestamp;
+use crate::test_utils::create_test_db;
+
+/// Write `contents` to `name` inside `dir`, returning its path.
+fn write_file(dir: &TempDir, name: &str, contents: &str) -> PathBuf {
+    let path = dir.path().join(name);
+    let mut file = std::fs::File::create(&path).expect("create temp file");
+    file.write_all(contents.as_bytes())
+        .expect("write temp file");
+    path
+}
+
+/// Business key as stored by the Neo4j importer (group-namespaced; `""` = global).
+fn nkey(group: &str, id: &str) -> String {
+    format!("{group}\0{id}")
+}
+
+fn resolve(importer: &Importer<'_>, group: &str, id: &str) -> NodeId {
+    importer
+        .resolve_key(&nkey(group, id))
+        .unwrap_or_else(|| panic!("key '{id}' (group '{group}') should resolve"))
+}
+
+// ---- Header parsing --------------------------------------------------------
+
+// 1 + 8: bare :ID (id not stored as property), untyped column defaults to string.
+#[test]
+fn bare_id_not_stored_untyped_defaults_string() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":ID,:LABEL,name\nalice,Person,Alice\n");
+
+    let mut importer = db.import();
+    let report = importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("nodes import");
+    assert_eq!(report.nodes_imported, 1);
+    assert!(report.zero_loss);
+
+    let alice = resolve(&importer, "", "alice");
+    let node = db.get_node(alice).unwrap();
+    // Untyped `name` stored as string.
+    assert_eq!(
+        node.properties.get("name"),
+        Some(&PropertyValue::string("Alice"))
+    );
+    // Bare :ID is NOT stored as a property (no key by any obvious name).
+    assert_eq!(node.properties.get(":ID"), None);
+    assert_eq!(node.properties.get("id"), None);
+}
+
+// 2: named id column (personId:ID) also stores the id as a property.
+#[test]
+fn named_id_column_stores_id_property() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", "personId:ID,:LABEL\nalice,Person\n");
+
+    let mut importer = db.import();
+    importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("nodes import");
+    let alice = resolve(&importer, "", "alice");
+    let node = db.get_node(alice).unwrap();
+    assert_eq!(
+        node.properties.get("personId"),
+        Some(&PropertyValue::string("alice"))
+    );
+}
+
+// 3: id-spaces — same raw id in two groups does not collide.
+#[test]
+fn id_spaces_do_not_collide() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let people = write_file(&files, "people.csv", ":ID(Person),:LABEL\nx1,Person\n");
+    let places = write_file(&files, "places.csv", ":ID(Place),:LABEL\nx1,Place\n");
+    let rels = write_file(
+        &files,
+        "rels.csv",
+        ":START_ID(Person),:END_ID(Place),:TYPE\nx1,x1,LIVES_IN\n",
+    );
+
+    let mut importer = db.import();
+    let report = importer
+        .neo4j_import_csv(&[people, places], &[rels], &Neo4jCsvOptions::new())
+        .expect("import");
+    assert_eq!(report.nodes_imported, 2);
+    assert_eq!(report.relationships_imported, 1);
+    assert!(report.zero_loss);
+
+    let person = resolve(&importer, "Person", "x1");
+    let place = resolve(&importer, "Place", "x1");
+    assert_ne!(person, place);
+    let out = db.get_outgoing_edges(person);
+    assert_eq!(out.len(), 1);
+    assert_eq!(db.get_edge_target(out[0]).unwrap(), place);
+}
+
+// 4: missing :ID in a node file -> hard error.
+#[test]
+fn node_file_missing_id_errors() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":LABEL,name\nPerson,Alice\n");
+    let mut importer = db.import();
+    let err = importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect_err("should error");
+    assert!(err.to_string().contains(":ID"), "was: {err}");
+}
+
+// 5: rel file missing :START_ID / :END_ID / :TYPE -> hard error naming the field.
+#[test]
+fn rel_file_missing_fields_errors() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let rels = write_file(&files, "rels.csv", ":START_ID,:END_ID\na,b\n");
+    let mut importer = db.import();
+    let err = importer
+        .neo4j_edges_from_csv(&rels, &Neo4jCsvOptions::new())
+        .expect_err("should error");
+    assert!(err.to_string().contains(":TYPE"), "was: {err}");
+}
+
+// 6: :IGNORE column fully dropped.
+#[test]
+fn ignore_column_dropped() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        ":ID,:LABEL,secret:IGNORE,name\na,Person,xxx,Alice\n",
+    );
+    let mut importer = db.import();
+    importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("import");
+    let node = db.get_node(resolve(&importer, "", "a")).unwrap();
+    assert_eq!(node.properties.get("secret"), None);
+    assert_eq!(
+        node.properties.get("name"),
+        Some(&PropertyValue::string("Alice"))
+    );
+}
+
+// 30: truly empty file (no header) -> hard error.
+#[test]
+fn empty_file_no_header_errors() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "empty.csv", "");
+    let mut importer = db.import();
+    let err = importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect_err("should error");
+    let msg = err.to_string();
+    assert!(msg.contains("header") || msg.contains(":ID"), "was: {msg}");
+}
+
+// 29: header-only file (0 data rows) -> rows_read=0, zero_loss=true.
+#[test]
+fn header_only_file_zero_rows() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":ID,:LABEL,name\n");
+    let mut importer = db.import();
+    let report = importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("import");
+    assert_eq!(report.rows_read, 0);
+    assert_eq!(report.nodes_imported, 0);
+    assert!(report.zero_loss);
+}
+
+// ---- Multi-label -----------------------------------------------------------
+
+// 9: default first-label + _labels array property + coercion note.
+#[test]
+fn multi_label_first_plus_labels_property() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":ID,:LABEL\na,Person;Employee\n");
+    let mut importer = db.import();
+    let report = importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("import");
+    let node = db.get_node(resolve(&importer, "", "a")).unwrap();
+    assert_eq!(node.label.to_string(), "Person");
+    assert_eq!(
+        node.properties.get("_labels"),
+        Some(&PropertyValue::array(vec![
+            PropertyValue::string("Person"),
+            PropertyValue::string("Employee"),
+        ]))
+    );
+    assert!(
+        report
+            .coerced
+            .iter()
+            .any(|c| c.kind == "multi_label_flattened" && c.count == 1)
+    );
+    assert!(
+        report
+            .label_mapping
+            .iter()
+            .any(|e| e.neo4j_labels == "Person;Employee"
+                && e.aletheia_label == "Person"
+                && e.count == 1)
+    );
+}
+
+// 10: concat strategy -> single label Person_Employee, no _labels.
+#[test]
+fn multi_label_concat_strategy() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":ID,:LABEL\na,Person;Employee\n");
+    let opts = Neo4jCsvOptions::new().label_strategy(LabelStrategy::Concat);
+    let mut importer = db.import();
+    importer
+        .neo4j_nodes_from_csv(&nodes, &opts)
+        .expect("import");
+    let node = db.get_node(resolve(&importer, "", "a")).unwrap();
+    assert_eq!(node.label.to_string(), "Person_Employee");
+    assert_eq!(node.properties.get("_labels"), None);
+}
+
+// 11: empty :LABEL cell -> row error.
+#[test]
+fn empty_label_cell_row_error() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":ID,:LABEL\na,\n");
+    let mut importer = db.import();
+    let err = importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect_err("should error");
+    let msg = err.to_string();
+    assert!(msg.contains("row 1"), "was: {msg}");
+    assert!(msg.contains("label"), "was: {msg}");
+}
+
+// Property strategy: single-label node still gets _labels.
+#[test]
+fn label_strategy_property_always_stores_labels() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":ID,:LABEL\na,Person\n");
+    let opts = Neo4jCsvOptions::new().label_strategy(LabelStrategy::Property);
+    let mut importer = db.import();
+    importer
+        .neo4j_nodes_from_csv(&nodes, &opts)
+        .expect("import");
+    let node = db.get_node(resolve(&importer, "", "a")).unwrap();
+    assert_eq!(
+        node.properties.get("_labels"),
+        Some(&PropertyValue::array(vec![PropertyValue::string("Person")]))
+    );
+}
+
+// ---- Types / coercion ------------------------------------------------------
+
+// 12: scalar type coercions.
+#[test]
+fn scalar_type_coercions() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        ":ID,:LABEL,age:int,big:long,tiny:short,score:float,ratio:double,active:boolean,grade:char\n\
+         a,Person,30,9000000000,5,1.5,2.25,true,A\n",
+    );
+    let mut importer = db.import();
+    let report = importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("import");
+    let node = db.get_node(resolve(&importer, "", "a")).unwrap();
+    assert_eq!(node.properties.get("age"), Some(&PropertyValue::Int(30)));
+    assert_eq!(
+        node.properties.get("big"),
+        Some(&PropertyValue::Int(9_000_000_000))
+    );
+    assert_eq!(node.properties.get("tiny"), Some(&PropertyValue::Int(5)));
+    assert_eq!(
+        node.properties.get("score"),
+        Some(&PropertyValue::Float(1.5))
+    );
+    assert_eq!(
+        node.properties.get("ratio"),
+        Some(&PropertyValue::Float(2.25))
+    );
+    assert_eq!(
+        node.properties.get("active"),
+        Some(&PropertyValue::Bool(true))
+    );
+    assert_eq!(
+        node.properties.get("grade"),
+        Some(&PropertyValue::string("A"))
+    );
+    assert!(report.coerced.iter().any(|c| c.kind == "char_to_string"));
+}
+
+// 13: date/datetime -> micros Int; time/localtime -> string.
+#[test]
+fn temporal_type_coercions() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        ":ID,:LABEL,born:date,seen:datetime,clock:time\n\
+         a,Person,2020-01-01,2020-01-01T00:00:00Z,13:00:00\n",
+    );
+    let mut importer = db.import();
+    let report = importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("import");
+    let node = db.get_node(resolve(&importer, "", "a")).unwrap();
+    let micros_2020 = 1_577_836_800_000_000i64; // 2020-01-01T00:00:00Z
+    assert_eq!(
+        node.properties.get("born"),
+        Some(&PropertyValue::Int(micros_2020))
+    );
+    assert_eq!(
+        node.properties.get("seen"),
+        Some(&PropertyValue::Int(micros_2020))
+    );
+    assert_eq!(
+        node.properties.get("clock"),
+        Some(&PropertyValue::string("13:00:00"))
+    );
+    assert!(
+        report
+            .coerced
+            .iter()
+            .any(|c| c.kind == "temporal_to_micros")
+    );
+    assert!(report.coerced.iter().any(|c| c.kind == "time_to_string"));
+}
+
+// 14: malformed typed value -> precise row error (abort).
+#[test]
+fn malformed_typed_value_row_error() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":ID,:LABEL,age:int\na,Person,twelve\n");
+    let mut importer = db.import();
+    let err = importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect_err("should error");
+    let msg = err.to_string();
+    assert!(msg.contains("row 1"), "was: {msg}");
+    assert!(msg.contains("Int"), "was: {msg}");
+    assert!(msg.contains("age"), "was: {msg}");
+}
+
+// ---- Unsupported types -----------------------------------------------------
+
+// 7: unsupported type headers reported + counted (values dropped, not silent).
+#[test]
+fn unsupported_types_reported_and_counted() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        ":ID,:LABEL,span:duration,loc:point,blob:byte[]\n\
+         a,Person,P1D,\"POINT(1 2)\",AQID\n",
+    );
+    let mut importer = db.import();
+    let report = importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("import");
+    assert_eq!(report.nodes_imported, 1);
+    assert!(!report.zero_loss);
+    assert!(
+        report
+            .unsupported
+            .iter()
+            .any(|u| u.neo4j_type == "duration")
+    );
+    assert!(report.unsupported.iter().any(|u| u.neo4j_type == "point"));
+    assert!(report.unsupported.iter().any(|u| u.neo4j_type == "byte[]"));
+    // Values were dropped.
+    let node = db.get_node(resolve(&importer, "", "a")).unwrap();
+    assert_eq!(node.properties.get("span"), None);
+    assert_eq!(node.properties.get("blob"), None);
+}
+
+// 7 (strict): --strict-types upgrades unsupported header to a hard error.
+#[test]
+fn strict_types_hard_error() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        ":ID,:LABEL,span:duration\na,Person,P1D\n",
+    );
+    let opts = Neo4jCsvOptions::new().strict_types(true);
+    let mut importer = db.import();
+    let err = importer
+        .neo4j_nodes_from_csv(&nodes, &opts)
+        .expect_err("should hard-error");
+    let msg = err.to_string();
+    assert!(msg.contains("duration"), "was: {msg}");
+    assert!(msg.contains("span:duration"), "was: {msg}");
+    // Nothing was written.
+    assert_eq!(db.node_count(), 0);
+}
+
+// ---- Arrays / vectors ------------------------------------------------------
+
+// 15: int[] -> Array[Int].
+#[test]
+fn int_array_column() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        ":ID,:LABEL,scores:int[]\na,Person,1;2;3\n",
+    );
+    let mut importer = db.import();
+    importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("import");
+    let node = db.get_node(resolve(&importer, "", "a")).unwrap();
+    assert_eq!(
+        node.properties.get("scores"),
+        Some(&PropertyValue::array(vec![
+            PropertyValue::Int(1),
+            PropertyValue::Int(2),
+            PropertyValue::Int(3),
+        ]))
+    );
+}
+
+// 16: custom --array-delimiter honored.
+#[test]
+fn custom_array_delimiter() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        ":ID,:LABEL,tags:string[]\na,Person,x|y|z\n",
+    );
+    let opts = Neo4jCsvOptions::new().array_delimiter('|');
+    let mut importer = db.import();
+    importer
+        .neo4j_nodes_from_csv(&nodes, &opts)
+        .expect("import");
+    let node = db.get_node(resolve(&importer, "", "a")).unwrap();
+    assert_eq!(
+        node.properties.get("tags"),
+        Some(&PropertyValue::array(vec![
+            PropertyValue::string("x"),
+            PropertyValue::string("y"),
+            PropertyValue::string("z"),
+        ]))
+    );
+}
+
+// 17: numeric[] -> Vector only with --vector-property; Array otherwise.
+#[test]
+fn numeric_array_vector_only_with_flag() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        ":ID,:LABEL,emb:float[]\na,Person,0.1;0.2;0.3\n",
+    );
+
+    // Without the flag -> Array of Float.
+    let mut importer = db.import();
+    importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("import");
+    let node = db.get_node(resolve(&importer, "", "a")).unwrap();
+    assert!(matches!(
+        node.properties.get("emb"),
+        Some(PropertyValue::Array(_))
+    ));
+
+    // With the flag -> Vector.
+    let (_tmp2, db2) = create_test_db().unwrap();
+    let opts = Neo4jCsvOptions::new().vector_property("emb");
+    let mut importer2 = db2.import();
+    importer2
+        .neo4j_nodes_from_csv(&nodes, &opts)
+        .expect("import");
+    let node2 = db2
+        .get_node(importer2.resolve_key(&nkey("", "a")).unwrap())
+        .unwrap();
+    match node2.properties.get("emb") {
+        Some(PropertyValue::Vector(v)) => {
+            assert_eq!(v.len(), 3);
+            assert!((v[0] - 0.1).abs() < 1e-6);
+        }
+        other => panic!("expected Vector, got {other:?}"),
+    }
+}
+
+// 18: empty array cell -> absent property.
+#[test]
+fn empty_array_cell_absent() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":ID,:LABEL,scores:int[]\na,Person,\n");
+    let mut importer = db.import();
+    importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("import");
+    let node = db.get_node(resolve(&importer, "", "a")).unwrap();
+    assert_eq!(node.properties.get("scores"), None);
+}
+
+// 19: malformed array element -> row error.
+#[test]
+fn malformed_array_element_row_error() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        ":ID,:LABEL,scores:int[]\na,Person,1;x;3\n",
+    );
+    let mut importer = db.import();
+    let err = importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect_err("should error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("row 1") && msg.contains("scores"),
+        "was: {msg}"
+    );
+}
+
+// ---- Quoting / delimiters (RFC 4180) ---------------------------------------
+
+// 20 + 21: quoted field containing the delimiter + doubled-quote escape.
+#[test]
+fn rfc4180_quoting() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        ":ID,:LABEL,name\na,Person,\"Doe, John\"\nb,Person,\"She said \"\"hi\"\"\"\n",
+    );
+    let mut importer = db.import();
+    importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("import");
+    assert_eq!(
+        db.get_node(resolve(&importer, "", "a"))
+            .unwrap()
+            .properties
+            .get("name"),
+        Some(&PropertyValue::string("Doe, John"))
+    );
+    assert_eq!(
+        db.get_node(resolve(&importer, "", "b"))
+            .unwrap()
+            .properties
+            .get("name"),
+        Some(&PropertyValue::string("She said \"hi\""))
+    );
+}
+
+// ---- Relationships / resolution --------------------------------------------
+
+// 24: dangling :END_ID -> unresolved endpoint (skip mode reports it).
+#[test]
+fn dangling_endpoint_reported() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":ID,:LABEL\na,Person\n");
+    let rels = write_file(
+        &files,
+        "rels.csv",
+        ":START_ID,:END_ID,:TYPE\na,ghost,KNOWS\n",
+    );
+
+    let mut importer = db.import().failure_mode(FailureMode::SkipAndReport);
+    importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("nodes");
+    let report = importer
+        .neo4j_edges_from_csv(&rels, &Neo4jCsvOptions::new())
+        .expect("edges skip mode");
+    assert_eq!(report.relationships_imported, 0);
+    assert_eq!(report.unresolved_endpoints.len(), 1);
+    assert_eq!(report.unresolved_endpoints[0].side, Endpoint::Target);
+    assert!(!report.zero_loss);
+}
+
+// 25: empty :TYPE -> row error.
+#[test]
+fn empty_type_row_error() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":ID,:LABEL\na,Person\nb,Person\n");
+    let rels = write_file(&files, "rels.csv", ":START_ID,:END_ID,:TYPE\na,b,\n");
+    let mut importer = db.import();
+    importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("nodes");
+    let err = importer
+        .neo4j_edges_from_csv(&rels, &Neo4jCsvOptions::new())
+        .expect_err("should error");
+    assert!(err.to_string().contains(":TYPE"), "was: {err}");
+}
+
+// 26: self-loop edge imports fine.
+#[test]
+fn self_loop_edge() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":ID,:LABEL\na,Person\n");
+    let rels = write_file(&files, "rels.csv", ":START_ID,:END_ID,:TYPE\na,a,SELF\n");
+    let mut importer = db.import();
+    importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("nodes");
+    let report = importer
+        .neo4j_edges_from_csv(&rels, &Neo4jCsvOptions::new())
+        .expect("edges");
+    assert_eq!(report.relationships_imported, 1);
+}
+
+// ---- Multi-file & structural -----------------------------------------------
+
+// 27: two node files + one rel file resolve across both.
+#[test]
+fn multi_file_import() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let n1 = write_file(&files, "n1.csv", ":ID,:LABEL,name\na,Person,Alice\n");
+    let n2 = write_file(&files, "n2.csv", ":ID,:LABEL,name\nb,Person,Bob\n");
+    let rels = write_file(&files, "rels.csv", ":START_ID,:END_ID,:TYPE\na,b,KNOWS\n");
+    let mut importer = db.import();
+    let report = importer
+        .neo4j_import_csv(&[n1, n2], &[rels], &Neo4jCsvOptions::new())
+        .expect("import");
+    assert_eq!(report.nodes_imported, 2);
+    assert_eq!(report.relationships_imported, 1);
+    assert_eq!(report.rows_read, 3);
+    assert!(report.zero_loss);
+    assert!(report.type_mapping.iter().any(|t| t.neo4j_type == "KNOWS"));
+}
+
+// 31: malformed CSV (unterminated quote) surfaces (not a silent clean success).
+#[test]
+fn malformed_csv_row_error() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        ":ID,:LABEL,name\na,Person,\"unterminated\nb,Person,ok\n",
+    );
+    let mut importer = db.import().failure_mode(FailureMode::SkipAndReport);
+    let report = importer.neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new());
+    if let Ok(r) = report {
+        assert!(
+            !r.zero_loss || r.nodes_imported < 2,
+            "unexpected clean import: {r:?}"
+        );
+    }
+}
+
+// ---- Fidelity report -------------------------------------------------------
+
+// 32/33: zero_loss true on clean import, false with unsupported column.
+#[test]
+fn zero_loss_flag() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let clean = write_file(&files, "clean.csv", ":ID,:LABEL,age:int\na,Person,1\n");
+    let mut importer = db.import();
+    let r1 = importer
+        .neo4j_nodes_from_csv(&clean, &Neo4jCsvOptions::new())
+        .expect("import");
+    assert!(r1.zero_loss);
+    assert_eq!(r1.properties_imported, 1);
+
+    let dirty = write_file(
+        &files,
+        "dirty.csv",
+        ":ID,:LABEL,span:duration\nb,Person,P1D\n",
+    );
+    let (_tmp2, db2) = create_test_db().unwrap();
+    let mut importer2 = db2.import();
+    let r2 = importer2
+        .neo4j_nodes_from_csv(&dirty, &Neo4jCsvOptions::new())
+        .expect("import");
+    assert!(!r2.zero_loss);
+}
+
+// Report serializes to JSON (superset of ImportReport) with zero_loss field.
+#[test]
+fn report_serializes_to_json() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":ID,:LABEL,name\na,Person,Alice\n");
+    let mut importer = db.import();
+    let report = importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("import");
+    let json = serde_json::to_value(&report).expect("serialize");
+    assert_eq!(json["zero_loss"], serde_json::Value::Bool(true));
+    assert_eq!(json["nodes_imported"], serde_json::json!(1));
+    assert!(json["label_mapping"].is_array());
+}
+
+// ---- Provenance (AC5) ------------------------------------------------------
+
+// 34: every imported node/edge carries neo4j-import::<file> provenance.
+#[test]
+fn provenance_stamped() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", ":ID,:LABEL\na,Person\nb,Person\n");
+    let rels = write_file(&files, "rels.csv", ":START_ID,:END_ID,:TYPE\na,b,KNOWS\n");
+    let mut importer = db.import();
+    importer
+        .neo4j_nodes_from_csv(&nodes, &Neo4jCsvOptions::new())
+        .expect("nodes");
+    importer
+        .neo4j_edges_from_csv(&rels, &Neo4jCsvOptions::new())
+        .expect("edges");
+
+    let a = resolve(&importer, "", "a");
+    let prov = db.get_node_provenance(a).unwrap().expect("node provenance");
+    assert_eq!(prov.source(), Some("neo4j-import::nodes.csv"));
+
+    let edge = db.get_outgoing_edges(a)[0];
+    let eprov = db
+        .get_edge_provenance(edge)
+        .unwrap()
+        .expect("edge provenance");
+    assert_eq!(eprov.source(), Some("neo4j-import::rels.csv"));
+}
+
+// Existing importer behavior unchanged when provenance is None (regression).
+#[test]
+fn generic_import_has_no_provenance() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", "id,name\na,Alice\n");
+    let mapping = NodeMapping::new(LabelSource::fixed("Person"), "id").property(
+        "name",
+        "name",
+        ColumnType::String,
+    );
+    let mut importer = db.import();
+    importer.nodes_from_csv(&nodes, mapping).expect("import");
+    let a = importer.resolve_key("a").unwrap();
+    assert!(db.get_node_provenance(a).unwrap().is_none());
+}
+
+// ---- Valid-time (AC6) ------------------------------------------------------
+
+// 35: --valid-from-property backdates the fact.
+#[test]
+fn valid_from_property_backdates() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        ":ID,:LABEL,since:datetime\na,Person,2020-01-01T00:00:00Z\n",
+    );
+    let opts = Neo4jCsvOptions::new().valid_from_property("since");
+    let mut importer = db.import();
+    importer
+        .neo4j_nodes_from_csv(&nodes, &opts)
+        .expect("import");
+    let a = resolve(&importer, "", "a");
+
+    // Not stored as a regular property (consumed as valid time).
+    let node = db.get_node(a).unwrap();
+    assert_eq!(node.properties.get("since"), None);
+
+    // Visible at 2021 (after valid_from), not at 2019 (before it).
+    let ts_2021 = Timestamp::from(1_609_459_200_000_000i64);
+    let ts_2019 = Timestamp::from(1_546_300_800_000_000i64);
+    assert!(db.get_node_at_valid_time(a, ts_2021).is_ok());
+    assert!(db.get_node_at_valid_time(a, ts_2019).is_err());
+}
+
+// ---- Scale (AC7) -----------------------------------------------------------
+
+// 10K-node / ~30K-edge smoke: zero-loss report.
+#[test]
+fn scale_smoke_10k_nodes() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let mut nbuf = String::from(":ID,:LABEL,name,age:int\n");
+    let n = 10_000usize;
+    for i in 0..n {
+        nbuf.push_str(&format!("n{i},Person,Name{i},{}\n", i % 100));
+    }
+    let nodes = write_file(&files, "nodes.csv", &nbuf);
+
+    let mut ebuf = String::from(":START_ID,:END_ID,:TYPE\n");
+    for i in 0..n {
+        // ~3 edges per node -> ~30K edges, all resolvable.
+        ebuf.push_str(&format!("n{i},n{},KNOWS\n", (i + 1) % n));
+        ebuf.push_str(&format!("n{i},n{},KNOWS\n", (i + 2) % n));
+        ebuf.push_str(&format!("n{i},n{},KNOWS\n", (i + 3) % n));
+    }
+    let rels = write_file(&files, "rels.csv", &ebuf);
+
+    let mut importer = db.import();
+    let report = importer
+        .neo4j_import_csv(&[nodes], &[rels], &Neo4jCsvOptions::new())
+        .expect("import");
+    assert_eq!(report.nodes_imported, n);
+    assert_eq!(report.relationships_imported, n * 3);
+    assert!(report.zero_loss);
+    assert_eq!(db.node_count(), n);
+}

--- a/src/api/import/parse.rs
+++ b/src/api/import/parse.rs
@@ -166,11 +166,24 @@ pub(crate) fn parse_valid_time(s: &str) -> Result<Timestamp, String> {
 
 /// Build a streaming row reader over a CSV file (first record is the header).
 pub(crate) fn csv_rows(path: &Path) -> Result<RowIter, ImportError> {
+    csv_rows_with(path, b',', b'"')
+}
+
+/// Build a streaming row reader over a CSV file with a configurable field
+/// delimiter and quote character (Issue #3356).
+///
+/// The Neo4j importer supplies the delimiter/quote from
+/// [`Neo4jCsvOptions`](super::Neo4jCsvOptions). Quoting/escaping follows
+/// RFC 4180 (doubled quotes escape a literal quote); the array delimiter is
+/// applied later, in the Neo4j coercion layer, not here.
+pub(crate) fn csv_rows_with(path: &Path, delimiter: u8, quote: u8) -> Result<RowIter, ImportError> {
     let file = File::open(path)
         .map_err(|e| ImportError::Io(format!("opening {}: {e}", path.display())))?;
     let mut reader = csv::ReaderBuilder::new()
         .has_headers(true)
         .flexible(true)
+        .delimiter(delimiter)
+        .quote(quote)
         .from_reader(file);
 
     let headers = reader
@@ -199,6 +212,30 @@ pub(crate) fn csv_rows(path: &Path) -> Result<RowIter, ImportError> {
     });
 
     Ok(Box::new(iter))
+}
+
+/// Read only the header row of a CSV file (Issue #3356).
+///
+/// The Neo4j importer builds its per-column coercion plan from the
+/// self-describing header before streaming data rows via [`csv_rows_with`]
+/// (whose reader skips the same header). Returns the ordered header fields.
+pub(crate) fn read_csv_header(
+    path: &Path,
+    delimiter: u8,
+    quote: u8,
+) -> Result<Vec<String>, ImportError> {
+    let file = File::open(path)
+        .map_err(|e| ImportError::Io(format!("opening {}: {e}", path.display())))?;
+    let mut reader = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .flexible(true)
+        .delimiter(delimiter)
+        .quote(quote)
+        .from_reader(file);
+    let headers = reader
+        .headers()
+        .map_err(|e| ImportError::Io(format!("reading header of {}: {e}", path.display())))?;
+    Ok(headers.iter().map(|h| h.to_string()).collect())
 }
 
 /// Build a streaming row reader over a JSONL file (one JSON object per line).

--- a/src/api/import/parse.rs
+++ b/src/api/import/parse.rs
@@ -204,10 +204,10 @@ pub(crate) fn csv_rows_with(path: &Path, delimiter: u8, quote: u8) -> Result<Row
                     cells,
                 })
             }
-            Err(e) => Err(ImportError::Row(RowError {
-                row: row_num,
-                message: format!("CSV parse error: {e}"),
-            })),
+            Err(e) => Err(ImportError::Row(RowError::new(
+                row_num,
+                format!("CSV parse error: {e}"),
+            ))),
         }
     });
 
@@ -265,20 +265,20 @@ pub(crate) fn jsonl_rows(path: &Path) -> Result<RowIter, ImportError> {
                             cells,
                         }))
                     }
-                    Ok(_) => Some(Err(ImportError::Row(RowError {
-                        row: line_num,
-                        message: "JSONL line is not a JSON object".to_string(),
-                    }))),
-                    Err(e) => Some(Err(ImportError::Row(RowError {
-                        row: line_num,
-                        message: format!("invalid JSON: {e}"),
-                    }))),
+                    Ok(_) => Some(Err(ImportError::Row(RowError::new(
+                        line_num,
+                        "JSONL line is not a JSON object".to_string(),
+                    )))),
+                    Err(e) => Some(Err(ImportError::Row(RowError::new(
+                        line_num,
+                        format!("invalid JSON: {e}"),
+                    )))),
                 }
             }
-            Err(e) => Some(Err(ImportError::Row(RowError {
-                row: line_num,
-                message: format!("IO error reading line: {e}"),
-            }))),
+            Err(e) => Some(Err(ImportError::Row(RowError::new(
+                line_num,
+                format!("IO error reading line: {e}"),
+            )))),
         }
     });
 

--- a/src/api/import/tests.rs
+++ b/src/api/import/tests.rs
@@ -373,7 +373,7 @@ fn handle_row_failure_io_is_fatal_in_skip_mode() {
     let importer = db.import().failure_mode(FailureMode::SkipAndReport);
 
     // Build a synthetic Io error by wrapping a std::io::Error (the variant holds its string).
-    let io_err = std::io::Error::new(std::io::ErrorKind::Other, "synthetic mid-stream I/O");
+    let io_err = std::io::Error::other("synthetic mid-stream I/O");
     let mut report = ImportReport::default();
     let result = importer.handle_row_failure(ImportError::Io(io_err.to_string()), &mut report);
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -100,6 +100,8 @@ pub use transaction::{ReadOps, ReadTransaction, TxId, TxState, WriteOps, WriteTr
 
 #[cfg(feature = "import")]
 pub use import::{
-    ColumnType, EdgeMapping, Endpoint, FailureMode, ImportConfig, ImportError, ImportReport,
-    Importer, LabelSource, NodeMapping, PropertyMapping, RowError, UnresolvedEndpoint,
+    CoercionNote, ColumnType, EdgeMapping, Endpoint, FailureMode, ImportConfig, ImportError,
+    ImportReport, Importer, LabelMapEntry, LabelSource, LabelStrategy, Neo4jCsvOptions,
+    Neo4jFidelityReport, NodeMapping, PropertyMapping, RowError, TypeMapEntry, UnresolvedEndpoint,
+    UnsupportedNote,
 };

--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -53,6 +53,7 @@ fn run() -> Result<(), String> {
         Some("daemon") => handle_daemon(args.collect()),
         Some("backup") => handle_backup(args.collect()),
         Some("restore") => handle_restore(args.collect()),
+        Some("import") => handle_import(args.collect()),
         #[cfg(feature = "audit-export")]
         Some("audit-keygen") => audit::handle_keygen(args.collect()),
         #[cfg(feature = "audit-export")]
@@ -85,6 +86,7 @@ Usage:\n\
   aletheia daemon status [--pid-file PATH]\n\
   aletheia backup <output_path>\n\
   aletheia restore <input_path>\n\
+  aletheia import --format neo4j-csv --nodes <f>... --relationships <f>... [options]\n\
   aletheia audit-keygen <key_file>\n\
   aletheia audit-export <node|edge> <id> --key <key_file> --out <path> [--db-id ID] [--redact k1,k2]\n\
   aletheia audit-verify <artifact_path> [--public-key HEX]\n\
@@ -98,6 +100,22 @@ Usage:\n\
   backup  — Write a portable .albk artifact capturing full bi-temporal state.\n\
             Opens the database via ALETHEIADB_CONFIG or ALETHEIADB_DATA_DIR.\n\
   restore — Restore a .albk artifact into ALETHEIADB_DATA_DIR (must be empty).\n\
+\nImport (Issue #3356):\n\
+  import  — Load a Neo4j CSV export (neo4j-admin / apoc.export.csv typed headers)\n\
+            into the database, emitting a machine-readable fidelity report.\n\
+            Requires --features import. Options:\n\
+              --format neo4j-csv         (required; binary .dump is unsupported)\n\
+              --nodes <file>             node CSV file (repeatable)\n\
+              --relationships <file>     relationship CSV file (repeatable)\n\
+              --array-delimiter <char>   array/multi-label delimiter (default ;)\n\
+              --delimiter <char>         field delimiter (default ,)\n\
+              --quote <char>             quote char (default \")\n\
+              --vector-property <name>   numeric[] -> vector (repeatable, opt-in)\n\
+              --valid-from-property <n>  date/datetime column -> valid_from\n\
+              --label-strategy <s>       first|concat|property (default first)\n\
+              --on-error <mode>          abort|skip (default abort)\n\
+              --strict-types             reject unsupported type headers\n\
+              --report <path>            also write the fidelity report JSON here\n\
 \nSigned audit export (Issue #3358):\n\
   audit-keygen — Generate an Ed25519 signing key (0600) and print its public key.\n\
   audit-export — Sign an entity's full bi-temporal history into a portable artifact.\n\
@@ -144,6 +162,165 @@ fn handle_restore(args: Vec<String>) -> Result<(), String> {
         .map_err(|e| format!("restore failed: {e}"))?;
     println!("{}", restore_success_json(&data_dir)?);
     Ok(())
+}
+
+/// `aletheia import` — load an external graph export (Issue #3356).
+///
+/// v1 supports the Neo4j CSV export convention (`--format neo4j-csv`). A binary
+/// Neo4j `.dump` archive and the APOC Cypher-script dump are unsupported and
+/// rejected with an actionable message (documented follow-ups).
+#[cfg(feature = "import")]
+fn handle_import(args: Vec<String>) -> Result<(), String> {
+    use aletheiadb::api::import::{FailureMode, LabelStrategy, Neo4jCsvOptions};
+
+    let format = arg_value(&args, "--format").unwrap_or_else(|| "neo4j-csv".to_string());
+    let nodes = arg_values(&args, "--nodes");
+    let rels = arg_values(&args, "--relationships");
+
+    // Reject binary dump / Cypher-script inputs with a clear pointer to CSV.
+    for path in nodes.iter().chain(rels.iter()) {
+        let lower = path.to_ascii_lowercase();
+        if lower.ends_with(".dump") {
+            return Err(
+                "neo4j binary dump import is not supported; export to CSV with \
+                'neo4j-admin database import' headers or apoc.export.csv"
+                    .to_string(),
+            );
+        }
+        if lower.ends_with(".cypher") {
+            return Err(
+                "neo4j Cypher-script dump import is a documented follow-up; \
+                use CSV export (neo4j-admin database import / apoc.export.csv)"
+                    .to_string(),
+            );
+        }
+    }
+
+    match format.as_str() {
+        "neo4j-csv" | "neo4j" => {}
+        "neo4j-dump" | "dump" => {
+            return Err(
+                "neo4j binary dump import is not supported; export to CSV with \
+                'neo4j-admin database import' headers or apoc.export.csv"
+                    .to_string(),
+            );
+        }
+        other => {
+            return Err(format!(
+                "unsupported import format '{other}'; supported: neo4j-csv"
+            ));
+        }
+    }
+
+    if nodes.is_empty() && rels.is_empty() {
+        return Err(
+            "usage: aletheia import --format neo4j-csv --nodes <file>... \
+            [--relationships <file>...] [options]"
+                .to_string(),
+        );
+    }
+
+    let mut opts = Neo4jCsvOptions::new();
+    if let Some(d) = arg_value(&args, "--array-delimiter") {
+        opts.array_delimiter = single_char(&d, "--array-delimiter")?;
+    }
+    if let Some(d) = arg_value(&args, "--delimiter") {
+        opts.delimiter = single_byte(&d, "--delimiter")?;
+    }
+    if let Some(q) = arg_value(&args, "--quote") {
+        opts.quote = single_byte(&q, "--quote")?;
+    }
+    for name in arg_values(&args, "--vector-property") {
+        opts.vector_properties.insert(name);
+    }
+    if let Some(name) = arg_value(&args, "--valid-from-property") {
+        opts.valid_from_property = Some(name);
+    }
+    if let Some(strategy) = arg_value(&args, "--label-strategy") {
+        opts.label_strategy = match strategy.as_str() {
+            "first" => LabelStrategy::First,
+            "concat" => LabelStrategy::Concat,
+            "property" => LabelStrategy::Property,
+            other => {
+                return Err(format!(
+                    "invalid --label-strategy '{other}', expected first|concat|property"
+                ));
+            }
+        };
+    }
+    if args.iter().any(|a| a == "--strict-types") {
+        opts.strict_types = true;
+    }
+    let failure_mode = match arg_value(&args, "--on-error").as_deref() {
+        None | Some("abort") => FailureMode::Abort,
+        Some("skip") => FailureMode::SkipAndReport,
+        Some(other) => {
+            return Err(format!("invalid --on-error '{other}', expected abort|skip"));
+        }
+    };
+
+    let node_paths: Vec<PathBuf> = nodes.iter().map(PathBuf::from).collect();
+    let rel_paths: Vec<PathBuf> = rels.iter().map(PathBuf::from).collect();
+
+    let db = open_db()?;
+    let mut importer = db.import().failure_mode(failure_mode);
+    let report = importer
+        .neo4j_import_csv(&node_paths, &rel_paths, &opts)
+        .map_err(|e| format!("import failed: {e}"))?;
+
+    let value =
+        serde_json::to_value(&report).map_err(|e| format!("failed to render report JSON: {e}"))?;
+    if let Some(report_path) = arg_value(&args, "--report") {
+        let rendered = serde_json::to_string_pretty(&value)
+            .map_err(|e| format!("failed to render report JSON: {e}"))?;
+        fs::write(&report_path, rendered)
+            .map_err(|e| format!("failed to write report to '{report_path}': {e}"))?;
+    }
+    print_json_pretty(&value)
+}
+
+/// Stub `import` handler when the `import` feature is not compiled in.
+#[cfg(not(feature = "import"))]
+fn handle_import(_args: Vec<String>) -> Result<(), String> {
+    Err("the 'import' subcommand requires building with --features import".to_string())
+}
+
+/// Collect every value following each occurrence of `flag` (repeatable flags).
+#[cfg(feature = "import")]
+fn arg_values(args: &[String], flag: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut iter = args.iter();
+    while let Some(token) = iter.next() {
+        if token == flag
+            && let Some(value) = iter.next()
+        {
+            out.push(value.clone());
+        }
+    }
+    out
+}
+
+/// Parse a single-character CLI argument into a `char`.
+#[cfg(feature = "import")]
+fn single_char(value: &str, flag: &str) -> Result<char, String> {
+    let mut chars = value.chars();
+    match (chars.next(), chars.next()) {
+        (Some(c), None) => Ok(c),
+        _ => Err(format!("{flag} must be a single character, got '{value}'")),
+    }
+}
+
+/// Parse a single-ASCII-byte CLI argument (field delimiter / quote).
+#[cfg(feature = "import")]
+fn single_byte(value: &str, flag: &str) -> Result<u8, String> {
+    let bytes = value.as_bytes();
+    if bytes.len() == 1 {
+        Ok(bytes[0])
+    } else {
+        Err(format!(
+            "{flag} must be a single ASCII character, got '{value}'"
+        ))
+    }
 }
 
 /// `aletheia demo` — boot a seeded, ephemeral bi-temporal graph and print a


### PR DESCRIPTION
## Summary

Adds a first-class **Neo4j CSV migration importer** so a data engineer can move a Neo4j export into AletheiaDB with one command and get a machine-readable fidelity report. Implements the **CSV-first** slice of #3356 (design comment: https://github.com/madmax983/AletheiaDB/issues/3356#issuecomment-4950032387). Binary `.dump` and the APOC Cypher-script dump are rejected with clear, actionable errors and tracked as documented follow-ups (so AC1(a) is never silently dropped).

### Before / After (plain language)

**Before:** A Neo4j user evaluating AletheiaDB had to hand-write an ETL to reshape their export into #3211's generic CSV/JSONL mapping format, guess whether labels/types/arrays survived, and verify by eyeball. Evaluations died at "get my data in."

**After:** The user runs one command against the self-describing Neo4j export they already know how to produce:

```
aletheia import --format neo4j-csv \
  --nodes people.csv --relationships knows.csv \
  [--vector-property embedding] [--valid-from-property since] \
  [--label-strategy first|concat|property] [--array-delimiter ';'] \
  [--on-error abort|skip] [--strict-types] [--report report.json]
```

The importer reads the typed header (`:ID`, `:LABEL`, `:START_ID`/`:END_ID`, `:TYPE`, `:IGNORE`, `age:int`, `scores:int[]`, id-spaces `:ID(Person)`) and does the rest — multi-label flattening, id-space resolution, typed/array columns, numeric-array→vector opt-in, valid-time backdating, provenance stamping — then emits a fidelity report with a `zero_loss` boolean. The user never writes `--property`/`--type` mappings.

## How

- **Reuses the #3211 `Importer` loop wholesale.** A new header-driven `src/api/import/neo4j.rs` submodule parses the self-describing Neo4j CSV header into a per-column coercion plan, auto-builds a `NodeMapping`/`EdgeMapping` + `RowIter`, and calls the existing chunked ACID `import_nodes`/`import_edges` commit path. Neo4j type knowledge stays local (a `ColKind`/`NeoScalar` descriptor) — the shared `Copy` `ColumnType` is untouched.
- **Additive provenance seam:** `ImportConfig.provenance: Option<Provenance>` (default `None` → byte-identical prior behavior); `commit_node_chunk`/`commit_edge_chunk` switch from `create_*_with_valid_time` to `create_*_with_options` and stamp `source="neo4j-import::<file>"`. Benefits all importers.
- **Validated plans:** header/structural errors are pre-transaction hard errors; id-spaces namespace business keys internally (`group\0id`) so the same raw id in two groups never collides; `parse::csv_rows_with(path, delimiter, quote)` adds configurable delimiters.
- **CLI:** new `aletheia import` verb (`handle_import`, `arg_values`, `single_char`, `single_byte`) gated `#[cfg(feature = "import")]` with a helpful rebuild stub otherwise.

## Acceptance-criteria evidence

| # | AC (abridged) | Status | Evidence |
|---|---|---|---|
| 1a | Cypher-script dump (`apoc.export.cypher.all`) import | **Not met (documented follow-up)** | Rejected with actionable error, `src/bin/aletheia.rs:191-194`; tracked in `docs/guides/neo4j-import.md` §"Unsupported inputs and follow-ups". Deliberately deferred per design comment. |
| 1b | CSV header convention (`:ID`/`:LABEL`/`:START_ID`/`:END_ID`/`:TYPE`, typed headers) | **Met** | `neo4j.rs` header parser (`parse_columns`/`ColKind`); tests `bare_id_not_stored_untyped_defaults_string`, `named_id_column_stores_id_property`, `ignore_column_dropped`, `node_file_missing_id_errors`, `rel_file_missing_fields_errors`, `unknown_reserved_header_error` (`neo4j_tests.rs`). |
| 2 | Types (str/int/float/bool/temporal/arrays); multi-label deterministic rule; numeric-array→vector via explicit flag | **Met** | `scalar_type_coercions`, `temporal_type_coercions`, `int_array_column`, `custom_array_delimiter`; multi-label: `multi_label_first_plus_labels_property`, `multi_label_concat_strategy`, `label_strategy_property_always_stores_labels`; vector opt-in: `numeric_array_vector_only_with_flag` (Vector only with `--vector-property`, else `Array` — never silent). |
| 3 | Route through #3211; abort vs skip-and-report with per-row locations | **Met** | `import_nodes_with`/`import_edges_with` drivers in `mod.rs`; `FailureMode{Abort,SkipAndReport}`; tests `malformed_typed_value_row_error`, `malformed_array_element_row_error`, `malformed_csv_row_error`, `skip_mode_type_mapping_matches_imported`, `dangling_endpoint_reported` (`row N:` / `UnresolvedEndpoint` contract). |
| 4 | Machine-readable fidelity report: counts + label/type table + skipped/coerced w/ reason + `zero_loss` bool | **Met** | `Neo4jFidelityReport` (serde `Serialize`), `neo4j.rs`; tests `zero_loss_flag`, `report_serializes_to_json`, `unsupported_types_reported_and_counted`, `array_coercion_counts_per_row`. |
| 5 | Every version carries provenance `neo4j-import::<file>` (#3224) | **Met** | `ImportConfig.provenance` + `create_*_with_options` (`mod.rs:391-404`); tests `provenance_stamped`, `generic_import_has_no_provenance`. |
| 6 | Valid-time: default import-time; optional datetime property → `valid_from` (#3221) | **Met** | `Neo4jCsvOptions.valid_from_property` → `valid_time_column`; test `valid_from_property_backdates` (queryable `AS OF VALID_TIME`); documented `docs/guides/neo4j-import.md`. |
| 7 | CI round-trip: ≥10K nodes / 50K rels fixture, zero-loss + equivalence queries | **Partially met** | Lib smoke test `scale_smoke_10k_nodes` imports 10K nodes / 30K edges with `zero_loss` + count assertions. **Caveats:** it is a unit test (not a CI-wired fixture), exercises 30K (not 50K) edges, and does not run in CI because the CI feature set excludes `import` (see Testing). A full 50K-rel equivalence-query fixture is a follow-up. |
| 8 | Unsupported constructs (duration, spatial/point, byte[]) enumerated in docs, reported skipped with counts | **Met** | `UnsupportedNote` w/ counts; tests `unsupported_types_reported_and_counted`, `strict_types_hard_error`; matrix in `docs/guides/neo4j-import.md` §"Supported vs. rejected". |

## Neo4j type / header support matrix

**Reserved headers (all supported):** `:ID`, `:ID(<space>)`, `:LABEL`, `:START_ID`/`:START_ID(<space>)`, `:END_ID`/`:END_ID(<space>)`, `:TYPE`, `:IGNORE`. A named id column (`personId:ID`) also stores the id as a property; bare `:ID` does not. Unknown `:RESERVED` headers → hard error.

| Neo4j type | Maps to | Status |
|---|---|---|
| `string` / untyped | `String` | Supported |
| `int`, `long`, `short`, `byte` (scalar) | `Int` (i64) | Supported (range-checked: `short_out_of_range_rejected`, `byte_out_of_range_rejected`) |
| `float`, `double` | `Float` (f64) | Supported (non-finite rejected: `non_finite_float_rejected`) |
| `boolean` | `Bool` | Supported (`boolean_parse_matches_neo4j`) |
| `char` | 1-char `String` | Supported, **coerced** (exactly one char: `char_requires_exactly_one_character`) |
| `date`, `datetime`, `localdatetime` | `Int` (micros via `parse_valid_time`) | Supported, **coerced** (named-zone id stripped: `datetime_named_zone_id_stripped`) |
| `time`, `localtime` | `String` | Supported, **coerced** (no epoch anchor) |
| `T[]` (string/numeric/bool/temporal) | `Array` | Supported (split on `--array-delimiter`; quoted elements ok) |
| numeric `[]` **+ `--vector-property`** | `Vector` (`Arc<[f32]>`) | Supported, **opt-in only — never silent** |
| `duration` | — | **Rejected** → `unsupported` w/ count (`--strict-types` → hard error) |
| `point` / spatial | — | **Rejected** → `unsupported` w/ count |
| `byte[]` (byte array) | — | **Rejected** → `unsupported` w/ count |

## Testing

- **68 unit tests in `src/api/import/`** — 47 Neo4j-specific (`neo4j_tests.rs`, including the 13 review-fix tests: range checks, non-finite floats, named-zone stripping, quoted array elements, multi-file error filenames, duplicate-header rejection, per-row coercion counts, malformed id-space, unknown reserved header, char arity, skip-mode mapping parity) + 21 generic import tests (`tests.rs`) — plus the `aletheia import` CLI-handler tests in the bin. All green under `cargo test --features import`.
- `cargo clippy --all-targets` (with `import`) exit 0; `cargo fmt --all --check` clean; the `just check-features` `import (standalone)` line (`justfile:68`) exit 0.
- **Expected CI note (not a defect):** CI's clippy/test job uses `--features "config-toml,mcp-server,sharding-rpc,simulation"`, which **does not include `import`** — so the Neo4j import tests do not *run* in CI; the `import` feature is **compile-checked** via the `just check-features` line this PR adds. This is expected for a feature-gated module. CI will not be red from the pre-existing `http-server`-gated `collapsible_if` lint in `tests/http_run_server_body_limit.rs` either — that file is outside CI's feature set.
- One pre-existing, unrelated failure (`cli_aletheia::restore_into_fresh_dir_succeeds_and_materializes`, backup/restore index persistence) reproduces identically on the untouched base tree — not caused by this PR.

## Known limitations / follow-ups

- **APOC Cypher-script dump (AC1a):** deferred; would reuse the `cypher` parser and route parsed `CREATE`s through the same prepared-chunk path. Rejected with a clear error today.
- **Binary `.dump` format:** proprietary versioned page-store archive, not a documented interchange format — rejected, not tractable; error directs the user to CSV export.
- **`--id-type` integer id-spaces:** only string business keys in v1 (Neo4j's default `--id-type=string`).
- **`zero_loss` excludes lossy coercions by design:** `zero_loss` is `true` iff `skipped` + `unresolved_endpoints` + `unsupported` are all empty. Reported **coercions** (char→1-char string, datetime→micros, multi-label flatten) are tracked in `coerced` for auditability but do **not** flip `zero_loss` to `false` — they are treated as faithful, queryable mappings. Documented in `docs/guides/neo4j-import.md` §"What `zero_loss` means (precisely)".
- **Array/multi-label durable-snapshot caveat:** AletheiaDB index persistence does not yet serialize `Array` properties, so importing multi-label nodes (which create a `_labels` array) or array columns into a durable data dir logs an index-persistence warning and skips that snapshot; data is still durable via WAL and reconstructed on restart. Pre-existing, independent of this importer; documented.

## ⚠️ Merge coordination (for merge planning)

This PR and the **parquet importer PR #3508** both add an `aletheia import` CLI verb **and** an `arg_values` helper in `src/bin/aletheia.rs`, both branched off trunk independently. When both merge they will **collide as `E0428` (duplicate definition)** under `--all-features`. **Resolution:** rebase whichever merges **second** and unify into a single `handle_import` that dispatches on `--format` (`neo4j-csv` vs the parquet format), keeping one shared `arg_values`. No data-model or storage conflict — purely the CLI dispatch + one helper.

## Design decision: `Refs` not `Closes`

Using `Refs #3356` rather than `Closes` — the issue's AC1 explicitly lists **both** the APOC Cypher-script dump (AC1a, deferred here) and the CSV convention, and AC7's full CI round-trip fixture is only partially delivered (import isn't in the CI feature set). Leaving the issue open lets it track those documented follow-ups. The CSV core (AC1b, 2–6, 8) is complete.

Refs #3356

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpS7vn3rr6kzksJ8Q2A4qz)_