### PR TITLE
feat: tamper-evident provenance hash chain (#3351)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1212,6 +1212,7 @@ unless `detach: true` / `retract_node_detach` co-retracts the connected edges.
 - **[docs/EMBEDDINGS.md](docs/EMBEDDINGS.md)** - Embedding generation guide
 - **[docs/query-language-design.md](docs/query-language-design.md)** - Query language grammar and semantics
 - **[docs/guides/derivation-lineage.md](docs/guides/derivation-lineage.md)** - Derivation lineage between facts (Issue #3371)
+- **[docs/guides/provenance-hash-chain.md](docs/guides/provenance-hash-chain.md)** - Tamper-evident provenance hash chain: `aletheia verify`, `verify_chain`/`export_chain_head` MCP tools, external anchoring (Issue #3351)
 
 ### User Guides
 - **[docs/guides/vector-search-integration.md](docs/guides/vector-search-integration.md)** - Complete vector search API

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,7 @@ dependencies = [
  "embed_anything",
  "hkdf",
  "lazy_static",
+ "libc",
  "loom",
  "memmap2",
  "metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -407,6 +407,12 @@ name = "durability_modes"
 harness = false
 path = "benches/durability_modes.rs"
 
+# Provenance hash chain write-throughput overhead (Issue #3351)
+[[bench]]
+name = "provenance_chain"
+harness = false
+path = "benches/provenance_chain.rs"
+
 [[bench]]
 name = "checkpoints"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,11 @@ aws-sdk-kms = { version = "1.106.0", optional = true }
 # Constant-time equality for API-key digest comparison (Issue #3350).
 subtle = "2.6"
 
+# Per-platform O_NOFOLLOW for hardened key-file writes (Issue #3351). Already
+# present transitively; pinned as a direct dep so the audit signing path can name
+# the correct constant instead of hardcoding a platform-specific integer.
+libc = "0.2"
+
 # Ed25519 asymmetric signatures for signed audit-export artifacts (Issue #3358).
 # Chosen over HMAC so third parties verify offline with ONLY the signer's public
 # key. Pure-Rust, RFC 8032 deterministic signatures → reproducible artifacts.

--- a/benches/provenance_chain.rs
+++ b/benches/provenance_chain.rs
@@ -14,16 +14,27 @@
 //! deliberately cheap to sample so CI/local runs stay fast; the ratio is
 //! reported, not hard-gated here (headless CI hardware is noisy — gate the
 //! metric on the performance rig).
+//!
+//! Two workloads are covered: the original single-thread **create-only** path
+//! (a best case for the sealer — one leaf per transaction, no property
+//! reconstruction churn) and, added under Issue #3351 task #7, a
+//! **multi-threaded update-heavy** path. Updates supersede prior versions (the
+//! seal path reconstructs full property state and the timeline shifts), and
+//! concurrent writers contend on the bounded seal channel — so the update
+//! variant stresses inline-seal backpressure that the create-only best case
+//! never hits.
 
 mod common;
 
+use aletheiadb::api::transaction::WriteOps;
 use aletheiadb::config::WalConfigBuilder;
 use aletheiadb::provenance_chain::{ChainConfig, ChainFsyncMode};
 use aletheiadb::storage::index_persistence::PersistenceConfig;
 use aletheiadb::storage::wal::DurabilityMode;
-use aletheiadb::{AletheiaDB, AletheiaDBConfig, PropertyMapBuilder};
+use aletheiadb::{AletheiaDB, AletheiaDBConfig, NodeId, PropertyMapBuilder};
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use std::hint::black_box;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 use tempfile::TempDir;
@@ -141,9 +152,76 @@ fn bench_chain_write_throughput(c: &mut Criterion) {
     );
 }
 
+/// Number of writer threads for the concurrent update variant.
+const UPDATE_THREADS: u64 = 4;
+/// Updates each thread performs per benchmark iteration.
+const UPDATES_PER_THREAD: u64 = 250;
+
+/// Drive `UPDATE_THREADS` threads, each issuing `UPDATES_PER_THREAD`
+/// `update_node` writes cycling over the pre-created `nodes`. Updates supersede
+/// prior versions, so the seal path reconstructs full property state and the
+/// per-entity timeline grows — and concurrent writers contend on the bounded
+/// seal channel (inline-seal backpressure) that create-only never exercises.
+fn drive_concurrent_updates(db: &Arc<AletheiaDB>, nodes: &Arc<Vec<NodeId>>, counter: &AtomicU64) {
+    let mut handles = Vec::with_capacity(UPDATE_THREADS as usize);
+    for _ in 0..UPDATE_THREADS {
+        let db = Arc::clone(db);
+        let nodes = Arc::clone(nodes);
+        let base = counter.fetch_add(UPDATES_PER_THREAD, Ordering::Relaxed);
+        handles.push(std::thread::spawn(move || {
+            for i in 0..UPDATES_PER_THREAD {
+                let node = nodes[(base + i) as usize % nodes.len()];
+                let n = base + i;
+                db.write(|tx| {
+                    tx.update_node(
+                        node,
+                        PropertyMapBuilder::new()
+                            .insert("counter", black_box(n) as i64)
+                            .build(),
+                    )?;
+                    Ok::<_, aletheiadb::Error>(())
+                })
+                .expect("update_node");
+            }
+        }));
+    }
+    for h in handles {
+        h.join().expect("writer thread");
+    }
+}
+
+/// Benchmark multi-threaded, update-heavy write throughput with the chain
+/// enabled (Issue #3351 task #7). This is the worst-case complement to the
+/// single-thread create-only best case above.
+fn bench_chain_concurrent_updates(c: &mut Criterion) {
+    let total = UPDATE_THREADS * UPDATES_PER_THREAD;
+    let mut group = c.benchmark_group("provenance_chain_concurrent_updates");
+    group.throughput(Throughput::Elements(total));
+
+    group.bench_function("chain_enabled_updates", |b| {
+        let dir = TempDir::new().expect("temp dir");
+        let db = Arc::new(build_db(dir.path(), true));
+        // Pre-create a pool of nodes the update threads cycle over.
+        let nodes: Vec<NodeId> = (0..64)
+            .map(|i| {
+                db.create_node(
+                    "Bench",
+                    PropertyMapBuilder::new().insert("seed", i as i64).build(),
+                )
+                .expect("seed node")
+            })
+            .collect();
+        let nodes = Arc::new(nodes);
+        let counter = AtomicU64::new(0);
+        b.iter(|| drive_concurrent_updates(&db, &nodes, &counter));
+    });
+
+    group.finish();
+}
+
 criterion_group!(
     name = benches;
     config = common::configure_criterion();
-    targets = bench_chain_write_throughput,
+    targets = bench_chain_write_throughput, bench_chain_concurrent_updates,
 );
 criterion_main!(benches);

--- a/benches/provenance_chain.rs
+++ b/benches/provenance_chain.rs
@@ -1,0 +1,149 @@
+//! Throughput benchmarks for the tamper-evident provenance hash chain
+//! (Issue #3351).
+//!
+//! The chain is an opt-in, async sidecar: on the commit hot path it only
+//! *captures* the version refs a transaction produced and enqueues them to a
+//! background sealer (the SHA-256 folding happens off the critical path). The
+//! acceptance metric (#3383 concern) is that enabling the chain keeps write
+//! throughput at **≥ 90% of the chain-disabled baseline** under GroupCommit
+//! durability.
+//!
+//! This bench measures GroupCommit `create_node` throughput with the chain
+//! DISABLED (baseline) vs ENABLED, on otherwise-identical durable databases,
+//! and prints the enabled/baseline ratio so the comparison is explicit. It is
+//! deliberately cheap to sample so CI/local runs stay fast; the ratio is
+//! reported, not hard-gated here (headless CI hardware is noisy — gate the
+//! metric on the performance rig).
+
+mod common;
+
+use aletheiadb::config::WalConfigBuilder;
+use aletheiadb::provenance_chain::{ChainConfig, ChainFsyncMode};
+use aletheiadb::storage::index_persistence::PersistenceConfig;
+use aletheiadb::storage::wal::DurabilityMode;
+use aletheiadb::{AletheiaDB, AletheiaDBConfig, PropertyMapBuilder};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+use tempfile::TempDir;
+
+/// Number of `create_node` writes measured per benchmark iteration.
+const WRITES_PER_ITER: u64 = 1000;
+
+/// Build a durable, GroupCommit database rooted at `data_dir`, optionally
+/// enabling the provenance hash chain. Both variants share identical WAL and
+/// persistence settings so the only measured difference is the chain.
+fn build_db(data_dir: &std::path::Path, chain_enabled: bool) -> AletheiaDB {
+    let mut builder = AletheiaDBConfig::builder()
+        .wal(
+            WalConfigBuilder::new()
+                .wal_dir(data_dir.join("wal"))
+                .durability_mode(DurabilityMode::GroupCommit {
+                    max_delay_ms: 10,
+                    max_batch_size: 200,
+                })
+                .build(),
+        )
+        .persistence(PersistenceConfig {
+            enabled: true,
+            data_dir: data_dir.join("indexes"),
+            load_on_startup: true,
+            ..Default::default()
+        });
+
+    if chain_enabled {
+        builder = builder.chain(ChainConfig {
+            enabled: true,
+            // Batched flush keeps the sealer off the commit critical path —
+            // the durability model this metric targets.
+            fsync: ChainFsyncMode::Batched,
+            dir: None,
+        });
+    }
+
+    AletheiaDB::with_unified_config(builder.build()).expect("db init")
+}
+
+/// Drive `WRITES_PER_ITER` `create_node` writes against `db`, returning nothing
+/// but forcing the work via `black_box`.
+fn drive_writes(db: &AletheiaDB, counter: &AtomicU64) {
+    for _ in 0..WRITES_PER_ITER {
+        let n = counter.fetch_add(1, Ordering::Relaxed);
+        let id = db
+            .create_node(
+                "Bench",
+                PropertyMapBuilder::new()
+                    .insert("counter", black_box(n) as i64)
+                    .build(),
+            )
+            .expect("create_node");
+        black_box(id);
+    }
+}
+
+/// Measured wall-clock throughput (writes/sec) of `WRITES_PER_ITER` writes,
+/// used to compute and print the enabled/baseline ratio outside Criterion's
+/// statistical harness.
+fn measure_throughput(chain_enabled: bool) -> f64 {
+    let dir = TempDir::new().expect("temp dir");
+    let db = build_db(dir.path(), chain_enabled);
+    let counter = AtomicU64::new(0);
+    // Warm up so index/WAL structures are populated before timing.
+    drive_writes(&db, &counter);
+    let start = Instant::now();
+    let iters = 5u64;
+    for _ in 0..iters {
+        drive_writes(&db, &counter);
+    }
+    let elapsed = start.elapsed().as_secs_f64();
+    (WRITES_PER_ITER * iters) as f64 / elapsed
+}
+
+/// Benchmark GroupCommit write throughput: chain disabled vs enabled.
+fn bench_chain_write_throughput(c: &mut Criterion) {
+    let mut group = c.benchmark_group("provenance_chain_write_throughput");
+    group.throughput(Throughput::Elements(WRITES_PER_ITER));
+
+    group.bench_function("chain_disabled", |b| {
+        let dir = TempDir::new().expect("temp dir");
+        let db = build_db(dir.path(), false);
+        let counter = AtomicU64::new(0);
+        b.iter(|| drive_writes(&db, &counter));
+    });
+
+    group.bench_function("chain_enabled", |b| {
+        let dir = TempDir::new().expect("temp dir");
+        let db = build_db(dir.path(), true);
+        let counter = AtomicU64::new(0);
+        b.iter(|| drive_writes(&db, &counter));
+    });
+
+    group.finish();
+
+    // Report the enabled/baseline ratio explicitly (the AC success metric).
+    // This is an out-of-band coarse wall-clock comparison, not a Criterion
+    // statistical result; it makes the ≥90% target visible in the bench output
+    // without hard-failing on noisy CI hardware.
+    let baseline = measure_throughput(false);
+    let enabled = measure_throughput(true);
+    let ratio = if baseline > 0.0 {
+        enabled / baseline
+    } else {
+        f64::NAN
+    };
+    println!(
+        "\n[provenance-chain] GroupCommit write throughput\n\
+         [provenance-chain]   chain DISABLED: {baseline:>10.0} writes/sec (baseline)\n\
+         [provenance-chain]   chain ENABLED:  {enabled:>10.0} writes/sec\n\
+         [provenance-chain]   ratio enabled/baseline: {ratio:.3} \
+         (target >= 0.90 on the perf rig)\n"
+    );
+}
+
+criterion_group!(
+    name = benches;
+    config = common::configure_criterion();
+    targets = bench_chain_write_throughput,
+);
+criterion_main!(benches);

--- a/docs/adr/0057-provenance-hash-chain.md
+++ b/docs/adr/0057-provenance-hash-chain.md
@@ -44,8 +44,18 @@ transaction share one commit timestamp, which is the grouping and ordering key.
 The fold is three levels of domain-separated SHA-256:
 
 1. **Leaf** — each version is normalized to a canonical, injective
-   `VersionHashInput` (entity kind/id, version id, bi-temporal bounds,
-   provenance, sorted properties) and hashed to a `version_leaf`.
+   `VersionHashInput` and hashed to a `version_leaf`. Exact leaf coverage (what
+   a byte-edit of the stored version must not change to pass verify): entity
+   id + kind, version id and `prev_version_id`, node **label**, edge
+   **source/target**, `valid_from` and `transaction_from`, provenance, the
+   **sorted** property set, the `is_tombstone` flag, and — for a *born-closed
+   terminal* version (a delete tombstone or a retraction) — its `valid_to`. The
+   interval **ends** of a still-live (superseded-later) version are deliberately
+   **not** hashed directly (a later supersession mutates them, so they cannot be
+   bound into an append-only leaf); they are instead protected by the per-entity
+   timeline-consistency check in `verify_full` (monotonic transaction starts +
+   per-version interval well-formedness). See the "born-closed" limitation
+   below.
 2. **Transaction digest** — the leaves of one transaction fold, with the commit
    timestamp and tx id, into a `tx_digest`.
 3. **Chain step** — each transaction digest chains onto the previous record's
@@ -76,13 +86,53 @@ without the WAL carrying any chain-specific payload.
 ### Per-WAL-mode durability semantics (AC6)
 
 The chain's sidecar-flush policy (`ChainFsyncMode`: `PerTransaction`,
-`Batched` (default), `Never`) composes with, but is independent of, the WAL
-durability mode. The invariant that makes this safe: **the WAL is the source of
-truth; the chain is derived.** If the process crashes with sealed WAL
-transactions whose chain records were not yet flushed, recovery re-derives them
-from replayed history. A chain record can never be *more* durable than the WAL
-transaction it describes, and never needs to be — so no durability mode can
-produce a chain that disagrees with recovered history.
+`Batched` (default), `Never`) composes with, but is **independent of**, the WAL
+durability mode (`Synchronous`, `GroupCommit`, `Async`). The invariant that
+makes every combination safe: **the WAL is the source of truth; the chain is
+derived.** A chain record can never be *more* durable than the WAL transaction
+it describes, and never needs to be, because on recovery the unsealed tail is
+re-derived from replayed history (`rebuild_chain_tail`).
+
+What "durable" means therefore splits along two axes:
+
+1. **Is the transaction itself durable?** Governed entirely by the WAL mode.
+   - `Synchronous` — the commit fsyncs the WAL before returning; the transaction
+     survives a crash.
+   - `GroupCommit` — the commit returns after its batch's fsync completes; the
+     transaction survives a crash (ACID, just batched).
+   - `Async` — the commit returns before the WAL fsync; a crash can lose the
+     most recent transactions (eventual durability). Anything the WAL loses was
+     never committed, so the chain correctly never sealed it either.
+
+2. **Is the chain record durable, or re-derived on recovery?** Governed by
+   `ChainFsyncMode`, but the answer never affects *correctness* — only whether a
+   given record is read back from `chain.log` or re-folded from history:
+
+| WAL mode | `ChainFsyncMode` | Guaranteed sealed-and-durable on the sidecar | Re-derived on recovery |
+|----------|------------------|----------------------------------------------|------------------------|
+| `Synchronous` / `GroupCommit` | `PerTransaction` | Every transaction whose seal `append` returned before the crash (sealing is async, so the newest *sealed* records are `fsync`-durable, but transactions committed-yet-not-yet-sealed are not on the sidecar). | Any committed transaction the async sealer had not yet processed + fsynced. |
+| `Synchronous` / `GroupCommit` | `Batched` (default) | Only records flushed by an explicit `flush()` / shutdown checkpoint or OS writeback. | Everything since the last sidecar flush. |
+| `Synchronous` / `GroupCommit` | `Never` | Nothing is guaranteed by the chain layer (OS decides). | Potentially the entire unsealed/unflushed tail. |
+| `Async` | any | Same as above, **bounded by** what the WAL retained: a transaction the WAL lost on an async crash is (correctly) neither in history nor in the chain. | The tail the WAL *did* retain but the sealer had not durably sealed. |
+
+The recovery contract is identical in every cell: after WAL replay restores
+history, `rebuild_chain_tail` groups every restored version by its exact commit
+timestamp and seals each transaction beyond the loaded head, in canonical
+commit order. Because the fold is a deterministic function of the
+commit-timestamp-ordered record set (finding 4), the re-derived tail reproduces
+the exact digests a live seal would have produced — so a pre-crash exported
+anchor still verifies as an append-only extension regardless of which
+combination above was in effect (test:
+`finding4_partial_tail_rebuild_matches_precrash_anchor`).
+
+**Backpressure / tail-latency tradeoff.** Sealing is off the commit critical
+path via a bounded channel (`SEAL_CHANNEL_CAPACITY`). When that channel is full
+the committing thread **inline-seals** the transaction itself
+(`enqueue_commit` → `seal_one`) rather than blocking or dropping it. This
+guarantees every committed transaction is sealed exactly once, at the cost of a
+tail-latency spike on the commit path under sustained bursts that outrun the
+sealer. It is a deliberate drop-to-sync-seal choice: correctness over smooth
+latency under overload.
 
 ## Alternatives Considered
 
@@ -128,6 +178,17 @@ is exactly the point at which an anchor was last externalized: anything after
 the last exported head is only tamper-*evident* within the log, not
 tamper-*proof* against a full-log rewrite.
 
+**The unsealed-tail / offline-tamper boundary (security boundary).**
+Tamper-evidence covers the **sealed prefix** only. A version's content is bound
+into the chain by its *first seal*. Content altered **before** that first seal —
+or altered while the process is offline, before the startup rebuild re-folds the
+tail — is re-blessed on rebuild: `rebuild_chain_tail` reads whatever bytes are
+in history and seals *those*, so a mutation that lands before sealing becomes
+the sealed truth and is not flagged. In practice sealing is near-immediate after
+commit (async sealer + inline-seal fallback), so the exposure window is small,
+but it is a real boundary: the guarantee is "no post-seal mutation goes
+undetected," not "no mutation is ever possible."
+
 **Out of scope (v1 limitations):**
 
 - The exported anchor is **unsigned**. Establishing cryptographic authorship of
@@ -138,6 +199,28 @@ tamper-*proof* against a full-log rewrite.
 - The chain is **not woven into the WAL format**; chain state is lineage-style,
   re-derived on recovery rather than loaded from a durable chain-specific WAL
   payload.
+- **Born-closed `valid_to` predicate false-positive.** The leaf binds a
+  terminal `valid_to` only when it looks born-closed (`valid_to <=
+  transaction_from`, or the tombstone flag). A *heavily backdated* supersession
+  can make a legitimately superseded (open-at-seal) version match that predicate
+  at verify and produce a **false positive** — a spurious failure, never a
+  missed tamper. A stored born-closed discriminator is a follow-up.
+- **Cold-tier rebuild.** Verification `fetch` is cold-aware (it reads through
+  the tiered hot+cold path, so verify does not false-fail after a sealed version
+  migrates to the Redb cold tier). But the startup **crash-rebuild scan**
+  (`rebuild_chain_tail`) enumerates **hot-tier history only**; a version
+  migrated to cold *before its transaction was ever sealed* would be omitted
+  from a from-scratch rebuild. Migration normally happens well after sealing, so
+  this is a narrow edge and a tracked follow-up.
+- **Unbounded in-memory growth (scaling).** The engine keeps the full
+  `records: Vec<ChainTxRecord>` and the derived `EntityIndex` **resident in
+  RAM**, growing linearly with total transaction count — there is no spill or
+  eviction in v1. Additionally, `verify_full` / `verify_against_anchor` /
+  `export` snapshot-**clone** the records vector under the `inner` lock (entity
+  verify, post task #1, borrows in place and does not clone). Resident memory
+  therefore grows with history and each full snapshot transiently doubles the
+  records footprint. Bounding/spilling the in-memory chain (and a
+  clone-free/streaming verify) is a tracked follow-up.
 
 ## Two In-Scope Audit Security Fixes
 

--- a/docs/adr/0057-provenance-hash-chain.md
+++ b/docs/adr/0057-provenance-hash-chain.md
@@ -1,0 +1,195 @@
+# ADR-0057: Tamper-Evident Provenance Hash Chain
+
+**Status:** Accepted
+**Date:** 2026-07-12
+**Deciders:** AletheiaDB Core Team
+**Categories:** storage, transaction, security, audit
+
+## Context
+
+AletheiaDB's value proposition is that recorded history is *trustworthy*: an LLM
+(or auditor, or regulator) can ask "what did the system know about X, and when?"
+and rely on the answer. Bi-temporal versioning already makes history
+*queryable* and append-only *by convention*, and the signed audit export
+(Issue #3358) lets a third party verify a single entity's history offline. What
+was missing is a **database-wide, tamper-evident** guarantee: a way to detect
+that stored history was altered after the fact — a version's bytes edited, a
+transaction deleted or reordered or inserted, the tail truncated — and, against
+an externally held anchor, to *prove* rollback and fork.
+
+The constraints that shaped the design:
+
+- **Zero behavior/format change when disabled.** The overwhelming majority of
+  deployments will not enable this. A disabled build must be byte-identical on
+  disk and on the hot path.
+- **Negligible write-throughput cost when enabled.** The acceptance metric
+  (#3383 concern) is ≥ 90% of the chain-disabled GroupCommit baseline.
+- **Recoverable.** The guarantee must survive crash recovery: after WAL replay
+  the chain must cover the full recovered history.
+- **Do not touch the WAL format.** The WAL, recovery, transaction, and
+  historical-storage layers are load-bearing and out of scope for churn
+  (durable rehydration of chain state is a tracked follow-up, mirroring the
+  lineage index in Issue #3371).
+
+## Decision
+
+Introduce an **opt-in, self-contained sidecar** (`src/provenance_chain/`) that
+binds every committed transaction into a domain-separated SHA-256 hash chain
+over the database's recorded history.
+
+### Chain construction
+
+The chain unit is a **committed transaction**. The versions produced by one
+transaction share one commit timestamp, which is the grouping and ordering key.
+The fold is three levels of domain-separated SHA-256:
+
+1. **Leaf** — each version is normalized to a canonical, injective
+   `VersionHashInput` (entity kind/id, version id, bi-temporal bounds,
+   provenance, sorted properties) and hashed to a `version_leaf`.
+2. **Transaction digest** — the leaves of one transaction fold, with the commit
+   timestamp and tx id, into a `tx_digest`.
+3. **Chain step** — each transaction digest chains onto the previous record's
+   digest (`chain_step(prev, tx_digest)`), seeded by an explicit **genesis**
+   record (enable LSN + timestamp).
+
+Records are persisted to an append-only log (header + length-framed records +
+a head checkpoint), tolerant of a torn trailing record. Verification is
+database-independent: it re-fetches each referenced version through a
+`VersionSource`, recomputes leaves and the fold, and compares against the sealed
+digests — localizing the **earliest** broken sequence number on tamper.
+
+### Durability model: async sealer, re-derivable on recovery
+
+Sealing is **off the commit critical path**. On commit the hot path only
+*captures* the version refs the transaction produced (from the write buffer)
+and enqueues a `PendingTx` to a background sealer thread that does the hashing
+and log append. This is what keeps the enabled path within the throughput
+budget.
+
+Because the chain is a pure function of recorded history, it is
+**re-derivable on recovery**: at startup, after WAL replay restores history and
+before the sealer starts, `rebuild_chain_tail` groups every restored version by
+its exact commit timestamp and synchronously seals every transaction beyond the
+loaded head. The chain therefore always covers the full recovered prefix
+without the WAL carrying any chain-specific payload.
+
+### Per-WAL-mode durability semantics (AC6)
+
+The chain's sidecar-flush policy (`ChainFsyncMode`: `PerTransaction`,
+`Batched` (default), `Never`) composes with, but is independent of, the WAL
+durability mode. The invariant that makes this safe: **the WAL is the source of
+truth; the chain is derived.** If the process crashes with sealed WAL
+transactions whose chain records were not yet flushed, recovery re-derives them
+from replayed history. A chain record can never be *more* durable than the WAL
+transaction it describes, and never needs to be — so no durability mode can
+produce a chain that disagrees with recovered history.
+
+## Alternatives Considered
+
+- **WAL-embedded chain (per-entry digest in the WAL record).** Strongest
+  binding, but requires a WAL format change and touches recovery — explicitly
+  out of scope, and it would couple the tamper-evidence guarantee to WAL
+  framing forever. Rejected in favor of the derivable sidecar.
+- **Merkle tree over versions (inclusion proofs).** A Merkle accumulator would
+  give O(log n) inclusion proofs and true per-entity Merkle membership. But the
+  natural, cheap-to-maintain unit here is the *transaction* (its versions
+  already share a commit stamp), and a linear per-transaction chain gives
+  precise earliest-tamper localization for free. Entity-scoped verification is
+  implemented as a **layered** recomputation over the records that touch the
+  entity, not a Merkle-inclusion proof — a deliberate v1 simplification
+  (Merkle accumulation is a possible follow-up).
+- **Sidecar over historical storage (chosen).** Derives cleanly from recorded
+  history, needs no WAL/recovery change, and is fully opt-in. The cost is that
+  chain state is currently in the sidecar log only (durable rehydration across
+  restart is re-derived from history rather than loaded, as above).
+
+### Commit-timestamp grouping / ordering
+
+Transactions are ordered by their full commit `Timestamp` (`(wallclock,
+logical)`), so two transactions sharing a wallclock but differing in the HLC
+logical component stay distinct and deterministically ordered. Rebuilt records
+use a synthetic, deterministic tx id (the WAL does not preserve the original tx
+id for replayed history); verification recomputes purely from stored record
+fields, so internal consistency holds regardless.
+
+## Threat Model and the External-Anchor Boundary
+
+**In scope (detectable):** post-hoc mutation of any stored version's content;
+deletion, reordering, or insertion of a transaction; truncation of the tail.
+Full verification localizes the earliest affected sequence number.
+
+**Requires an external anchor (provable):** an adversary who can rewrite the
+*entire* sidecar log can produce a self-consistent alternate chain. Detecting
+**rollback** (truncation to an earlier state) and **fork** (divergence)
+therefore requires periodically exporting the chain head
+(`export_chain_head`) and storing it **offsite**; `verify_chain_against` then
+proves the current chain append-only-extends that anchor. The security boundary
+is exactly the point at which an anchor was last externalized: anything after
+the last exported head is only tamper-*evident* within the log, not
+tamper-*proof* against a full-log rewrite.
+
+**Out of scope (v1 limitations):**
+
+- The exported anchor is **unsigned**. Establishing cryptographic authorship of
+  an anchor is left to the operator (e.g. store it in an append-only external
+  system, or sign it with the audit key). Signing the anchor is a follow-up.
+- Entity-scoped verification is **layered, not a Merkle-inclusion proof** (see
+  Alternatives).
+- The chain is **not woven into the WAL format**; chain state is lineage-style,
+  re-derived on recovery rather than loaded from a durable chain-specific WAL
+  payload.
+
+## Two In-Scope Audit Security Fixes
+
+Landed with the core (commit `7aaec98`) as part of hardening the verification
+path:
+
+1. **Bounded framing on decode.** The append-only store's length-prefixed
+   counts are validated against the remaining buffer before allocation, so a
+   corrupt/hostile length field cannot drive an unbounded pre-allocation
+   (decompression-bomb-style DoS) — a decode returns a structured
+   `BadFraming` error instead.
+2. **Injective canonical encoding.** The version canonicalization is length-
+   prefixed and domain-separated at every level (genesis/leaf/tx/node domains),
+   so distinct logical inputs cannot collide by field-boundary ambiguity — the
+   precondition for the whole chain's soundness.
+
+## Consequences
+
+### Positive
+
+- Database-wide tamper-evidence over recorded history, opt-in, with precise
+  earliest-tamper localization.
+- Offsite anchor workflow gives provable rollback/fork detection.
+- Disabled by default → byte-identical behavior and on-disk layout for existing
+  deployments; enabled path stays within the write-throughput budget (async
+  sealer).
+- Surfaced on every user-facing surface: Rust API, `aletheia verify` CLI, MCP
+  `verify_chain` / `export_chain_head` tools, and the `database_stats` chain
+  block.
+
+### Negative
+
+- Enabling the chain adds a background sealer thread and a sidecar log to
+  manage.
+- Full verification is O(history): it re-fetches and re-folds every version.
+  Entity-scoped verification avoids the full scan but is layered, not a
+  succinct inclusion proof.
+
+### Neutral
+
+- Chain state is re-derived on recovery rather than loaded from a durable
+  chain-specific format; durable rehydration is a tracked follow-up that will
+  not change the verification contract.
+- `aletheia verify` requires the chain to have been enabled for the opened data
+  directory (via an `ALETHEIADB_CONFIG` TOML `[chain]` section); opening a data
+  dir alone does not enable it.
+
+## References
+
+- Issue #3351 — Tamper-evident provenance hash chain
+- Issue #3383 — Write-throughput budget concern
+- ADR-0028 — Encryption at rest (adjacent durability/security surface)
+- [docs/guides/provenance-hash-chain.md](../guides/provenance-hash-chain.md) —
+  user guide
+- Issue #3358 — Signed audit export (single-entity, offline-verifiable)

--- a/docs/guides/access-control-matrix.md
+++ b/docs/guides/access-control-matrix.md
@@ -99,6 +99,8 @@ is served by the HTTP admin endpoints over the shared persisted store
 | `lineage_upstream` | read |
 | `lineage_downstream` | read |
 | `audit_export` | read |
+| `verify_chain` | read |
+| `export_chain_head` | read |
 | `database_stats` | metrics |
 | `create_node` | write |
 | `update_node` | write |

--- a/docs/guides/provenance-hash-chain.md
+++ b/docs/guides/provenance-hash-chain.md
@@ -226,6 +226,42 @@ to be: if a crash loses chain records for already-committed WAL transactions,
 recovery re-derives them. No WAL durability mode can produce a chain that
 disagrees with recovered history.
 
+### What is guaranteed per WAL mode × flush mode
+
+Two independent questions:
+
+1. **Did the transaction survive the crash?** — the WAL mode decides.
+   `Synchronous` and `GroupCommit` are ACID (the transaction is durable before,
+   or as, commit returns). `Async` is eventual: a crash may lose the most recent
+   commits — but anything the WAL loses was never committed, so the chain
+   correctly never sealed it.
+2. **Was its chain record on disk, or re-derived on recovery?** — the
+   `ChainFsyncMode` decides, and the answer never changes correctness, only
+   whether the record is read from `chain.log` or re-folded from history:
+
+| WAL mode | `ChainFsyncMode` | Sealed-and-durable on the sidecar | Re-derived on recovery |
+|----------|------------------|-----------------------------------|------------------------|
+| `Synchronous` / `GroupCommit` | `PerTransaction` | Every record whose async-sealer `append` fsynced before the crash. | Committed transactions the sealer had not yet processed. |
+| `Synchronous` / `GroupCommit` | `Batched` (default) | Records flushed by an explicit `flush()`, the shutdown checkpoint, or OS writeback. | Everything since the last sidecar flush. |
+| `Synchronous` / `GroupCommit` | `Never` | Nothing guaranteed by the chain layer. | The whole unflushed tail. |
+| `Async` | any | As above, **bounded by** what the WAL retained. | The tail the WAL kept but the sealer had not durably sealed. |
+
+In every cell the re-derived tail reproduces the exact digests a live seal
+would have produced (the fold is deterministic over commit-ordered records), so
+a **pre-crash exported anchor still verifies** after recovery — proven by the
+`finding4_partial_tail_rebuild_matches_precrash_anchor` integration test (a
+genuine mid-workload crash: a sealed prefix on disk plus an unsealed tail
+rebuilt from history).
+
+### Backpressure (tail-latency tradeoff)
+
+Sealing runs off the commit path through a bounded channel. When that channel is
+**full**, the committing thread **inline-seals** the transaction itself rather
+than blocking or dropping it (drop-to-sync-seal). This keeps the "every
+committed transaction is sealed exactly once" guarantee, at the cost of a
+tail-latency spike on commits during sustained bursts that outrun the sealer —
+a deliberate correctness-over-latency choice.
+
 ## External anchoring workflow
 
 Tamper-*evidence* within the log detects mutation, deletion, reordering, and
@@ -265,11 +301,39 @@ transaction id. The chain digest is a deterministic function of the record set
 crash reproduces the exact pre-crash head digest (a pre-crash anchor still
 verifies), regardless of the order in which commits were originally enqueued.
 
+### Exact leaf coverage
+
+A byte-edit of a stored version is caught if it changes any of: entity id +
+kind, version id / `prev_version_id`, node **label**, edge **source/target**,
+`valid_from`, `transaction_from`, provenance, the **sorted** property set, the
+`is_tombstone` flag, and — for a *born-closed terminal* version (delete
+tombstone or retraction) — its `valid_to`. Interior (still-live, later
+superseded) versions' interval **ends** are **not** hashed directly (a later
+write mutates them); they are instead protected by the per-entity
+timeline-consistency check that `verify_full` runs (monotonic transaction
+starts + per-version interval well-formedness). See the born-closed
+false-positive note below.
+
+### The unsealed-tail / offline-tamper boundary
+
+Tamper-evidence covers the **sealed prefix**. A version is bound into the chain
+by its *first seal*; content altered **before** that seal (or altered offline,
+before the startup rebuild re-folds the tail) is re-blessed on rebuild — the
+rebuild seals whatever bytes history holds. Sealing is near-immediate after
+commit, so the window is small, but the guarantee is precisely "no **post-seal**
+mutation goes undetected," not "no mutation is ever possible."
+
 ### v1 limitations
 
 - The exported anchor is **unsigned** (authorship is the operator's
   responsibility; signing is a follow-up).
 - Entity-scoped verification is **layered**, not a Merkle-inclusion proof.
+- **Unbounded in-memory growth.** The chain keeps its full record vector and
+  entity index resident in RAM (linear in transaction count — no spill/eviction
+  in v1), and full/anchor verification and export snapshot-**clone** that vector
+  under lock (entity verify borrows in place and does not clone). Resident
+  memory grows with history and a full-verify transiently doubles the record
+  footprint; bounding/spilling and a clone-free verify are tracked follow-ups.
 - The chain is **lineage-style**: it is not woven into the WAL format; chain
   state is re-derived on recovery rather than loaded from a durable
   chain-specific WAL payload (durable rehydration is a tracked follow-up that

--- a/docs/guides/provenance-hash-chain.md
+++ b/docs/guides/provenance-hash-chain.md
@@ -1,0 +1,274 @@
+# Tamper-Evident Provenance Hash Chain (Issue #3351)
+
+AletheiaDB records bi-temporal history that is append-only *by convention*. The
+**provenance hash chain** upgrades that to a **cryptographic, tamper-evident**
+guarantee: an opt-in sidecar that binds every committed transaction into a
+domain-separated SHA-256 hash chain over recorded history, so that any post-hoc
+alteration — editing a byte of a stored version, deleting/reordering/inserting a
+transaction, truncating the tail — is **detectable**, and (against an
+externally held anchor) rollback and fork are **provable**.
+
+It is **disabled by default**. A database that does not enable it keeps
+byte-identical behavior and on-disk layout, and pays nothing on the write path.
+
+> **Scope.** This complements — it does not replace — the single-entity
+> [signed audit export](../guides/mcp-query-tool.md) (Issue #3358). The audit
+> export proves *one entity's* history offline with a signature; the hash chain
+> gives a *database-wide* tamper-evidence guarantee over all recorded history.
+> See [ADR-0057](../adr/0057-provenance-hash-chain.md) for the design rationale.
+
+## Enabling the chain
+
+### Programmatically
+
+```rust
+use aletheiadb::{AletheiaDB, AletheiaDBConfig};
+use aletheiadb::config::WalConfigBuilder;
+use aletheiadb::provenance_chain::{ChainConfig, ChainFsyncMode};
+
+let config = AletheiaDBConfig::builder()
+    .wal(WalConfigBuilder::new().wal_dir("data/wal").build())
+    .chain(ChainConfig {
+        enabled: true,
+        fsync: ChainFsyncMode::Batched, // default; see durability below
+        dir: None,                       // default: <data_dir>/chain
+    })
+    .build();
+
+let db = AletheiaDB::with_unified_config(config)?;
+```
+
+The chain lives under `<data_dir>/chain` by default (the parent of the WAL
+directory), or an explicit `dir` override.
+
+### Via TOML (`config-toml`)
+
+The chain round-trips through the unified config file, so the same database can
+be opened with the chain enabled by every binary (CLI, MCP server, HTTP server)
+that honours `ALETHEIADB_CONFIG`:
+
+```toml
+[wal]
+wal_dir = "data/wal"
+
+[chain]
+enabled = true
+fsync = "per_transaction"   # per_transaction | batched | never
+# dir = "data/chain"        # optional; defaults to <data_dir>/chain
+```
+
+Omitting the `[chain]` section keeps the chain disabled (byte-identical to a
+config that predates this feature).
+
+## `aletheia verify` (CLI)
+
+The CLI opens the database via `ALETHEIADB_CONFIG` (TOML) or
+`ALETHEIADB_DATA_DIR`, then verifies the chain.
+
+> **The chain must be enabled for the opened data dir.** Opening a data dir
+> alone (`ALETHEIADB_DATA_DIR`) does **not** enable the chain. Point
+> `ALETHEIADB_CONFIG` at a TOML config whose `[chain]` section has
+> `enabled = true`. If the chain is disabled, `aletheia verify` prints a clear
+> message and exits non-zero.
+
+```
+aletheia verify [--entity <node|edge>:<id>] [--export-head PATH] [--against PATH] [--json]
+```
+
+### Full-chain verify (default)
+
+```console
+$ ALETHEIADB_CONFIG=aletheia.toml aletheia verify
+Provenance chain verification: PASS (scope: full)
+  head seq:             128
+  head digest:          9f2c…a1
+  transactions checked: 128
+```
+
+On tamper the earliest broken position is reported and the process exits
+non-zero:
+
+```console
+$ aletheia verify
+Provenance chain verification: FAIL (scope: full)
+  head seq:             128
+  head digest:          9f2c…a1
+  transactions checked: 63
+  earliest broken seq:  64
+  reason:               recomputed leaf(s) differ from sealed leaves
+error: provenance chain verification FAILED (full) at seq 64
+```
+
+### Entity-scoped verify
+
+Recompute only one entity's contribution (no full scan):
+
+```console
+$ aletheia verify --entity node:42
+Provenance chain verification: PASS (scope: entity)
+  ...
+```
+
+### Export the head anchor
+
+Write the current chain head to a JSON file for offsite storage:
+
+```console
+$ aletheia verify --export-head head-2026-07-12.json
+Exported chain head anchor to head-2026-07-12.json
+  seq:    128
+  digest: 9f2c…a1
+```
+
+### Verify against a stored anchor (fork/rollback detection)
+
+Prove the current chain append-only-extends a previously exported head:
+
+```console
+$ aletheia verify --against head-2026-07-12.json
+Provenance chain verification: PASS (scope: anchor)
+  ...
+```
+
+A missing record at the anchor's sequence is reported as a **rollback**
+(truncation); a mismatching digest as a **fork** (divergence). Both exit
+non-zero.
+
+Add `--json` to any mode for machine-readable output:
+
+```console
+$ aletheia verify --json
+{
+  "scope": "full",
+  "passed": true,
+  "head_seq": 128,
+  "head_digest": "9f2c...a1",
+  "earliest_broken_seq": null,
+  "reason": null,
+  "transactions_checked": 128
+}
+```
+
+## MCP tools
+
+Two read-class (`reader` role) tools expose the chain to an LLM/agent:
+
+### `verify_chain`
+
+Three modes, resolved in precedence order:
+
+| Arguments | Mode |
+|-----------|------|
+| `against` (an exported head object) | **Anchor extension** — prove append-only extension; detect rollback/fork. |
+| `entity_kind` (`"node"`/`"edge"`) + `id` | **Entity-scoped** — recompute only that entity's contribution. |
+| *(none)* | **Full** — walk the whole chain from genesis; localize `earliest_broken_seq` on tamper. |
+
+Returns `{scope, passed, head_seq, head_digest, earliest_broken_seq, reason,
+transactions_checked}`.
+
+### `export_chain_head`
+
+No arguments. Returns the current chain head checkpoint
+`{seq, digest, commit_ts, anchor_lsn, genesis_digest}` (digests as lowercase
+hex) — store it offsite and pass it back as `verify_chain`'s `against`.
+
+### Errors
+
+Both tools use the [structured error codes](../guides/mcp-query-tool.md)
+(Issue #3234). When the chain is not enabled for the database the response is a
+non-retriable `FAILED_PRECONDITION` — never a silent empty "pass". A malformed
+`against` anchor or a bad `entity_kind` is `INVALID_ARGUMENT`.
+
+## `database_stats` chain block
+
+The `database_stats` tool (and the Rust `AletheiaDB::stats()` snapshot) carries
+a `chain` block — an O(1) read of the in-memory head, safe to call frequently:
+
+```json
+{
+  "chain": {
+    "enabled": true,
+    "head_seq": 128,
+    "head_digest": "9f2c...a1",
+    "genesis_digest": "0000...",
+    "last_verified": { "passed": true, "at_micros": 1752307200000000 }
+  }
+}
+```
+
+When the chain is disabled, every optional field is `null` and `enabled` is
+`false` — never a misleading zero.
+
+## Durability semantics per WAL mode
+
+Sealing runs on a **background sealer thread**, off the commit critical path:
+the hot path only captures the version refs a transaction produced and enqueues
+them. This keeps enabled-path write throughput within budget (the acceptance
+target is ≥ 90% of the chain-disabled GroupCommit baseline; see the
+`provenance_chain` benchmark).
+
+The `ChainFsyncMode` flush policy controls how the sidecar log reaches disk,
+independently of the WAL durability mode:
+
+| `ChainFsyncMode` | Behavior |
+|------------------|----------|
+| `PerTransaction` | fsync after every appended chain record (strongest). |
+| `Batched` (default) | rely on explicit flush / OS writeback (keeps hashing off the commit path). |
+| `Never` | durability is entirely the OS's decision (fastest, weakest). |
+
+The key invariant: **the WAL is the source of truth; the chain is derived.**
+The chain is a pure function of recorded history, so it is **re-derivable on
+recovery**. At startup, after WAL replay restores history, the unsealed tail is
+rebuilt by grouping every restored version by its exact commit timestamp and
+sealing each transaction beyond the loaded head. A chain record therefore can
+never be *more* durable than the WAL transaction it describes, and never needs
+to be: if a crash loses chain records for already-committed WAL transactions,
+recovery re-derives them. No WAL durability mode can produce a chain that
+disagrees with recovered history.
+
+## External anchoring workflow
+
+Tamper-*evidence* within the log detects mutation, deletion, reordering, and
+truncation. Detecting **rollback** and **fork** against an adversary who can
+rewrite the *entire* sidecar log requires an external anchor:
+
+1. **Export** the head periodically: `aletheia verify --export-head head.json`
+   (or the `export_chain_head` MCP tool).
+2. **Store it offsite** — an append-only external system, a signed commit, a
+   witness service, etc. (The v1 anchor is unsigned; establishing authorship is
+   the operator's responsibility.)
+3. **Verify-against** later: `aletheia verify --against head.json` (or
+   `verify_chain` with `against`). A truncated chain (rollback) or a diverged
+   digest (fork) is reported and exits non-zero.
+
+The security boundary is exactly the last externalized anchor: everything after
+it is tamper-evident within the log, but only tamper-*proof* against a full-log
+rewrite up to the anchor point.
+
+## Threat boundary (summary)
+
+| Threat | Guarantee |
+|--------|-----------|
+| Edit a stored version's bytes | Detected by full/entity verify (earliest seq localized). |
+| Delete / reorder / insert a transaction | Detected by full verify. |
+| Truncate the tail | Detected by verify-against an exported anchor (rollback). |
+| Fork to an alternate history | Detected by verify-against an exported anchor (fork). |
+| Rewrite the entire sidecar log | Detectable only against an externally held anchor. |
+
+### v1 limitations
+
+- The exported anchor is **unsigned** (authorship is the operator's
+  responsibility; signing is a follow-up).
+- Entity-scoped verification is **layered**, not a Merkle-inclusion proof.
+- The chain is **lineage-style**: it is not woven into the WAL format; chain
+  state is re-derived on recovery rather than loaded from a durable
+  chain-specific WAL payload (durable rehydration is a tracked follow-up that
+  will not change the verification contract).
+
+## See also
+
+- [ADR-0057](../adr/0057-provenance-hash-chain.md) — design rationale and
+  alternatives.
+- [Access control matrix](../guides/access-control-matrix.md) — `verify_chain`
+  / `export_chain_head` are `reader`-class.
+- Issue #3358 signed audit export — single-entity, offline-verifiable evidence.

--- a/docs/guides/provenance-hash-chain.md
+++ b/docs/guides/provenance-hash-chain.md
@@ -249,11 +249,21 @@ rewrite up to the anchor point.
 
 | Threat | Guarantee |
 |--------|-----------|
-| Edit a stored version's bytes | Detected by full/entity verify (earliest seq localized). |
+| Edit a stored version's properties, **label**, **edge source/target**, provenance, or creation coordinates | Detected by full/entity verify (earliest seq localized). The per-version leaf binds all of these. |
+| Un-delete a version (re-open a delete tombstone) or re-validate a retraction (extend its `valid_to`) | Detected: the leaf binds the tombstone flag and the born-closed terminal `valid_to`; a per-entity timeline-consistency check backs this up. |
 | Delete / reorder / insert a transaction | Detected by full verify. |
 | Truncate the tail | Detected by verify-against an exported anchor (rollback). |
-| Fork to an alternate history | Detected by verify-against an exported anchor (fork). |
-| Rewrite the entire sidecar log | Detectable only against an externally held anchor. |
+| Fork to an alternate history | Detected by verify-against an exported anchor (fork). The anchor check **re-folds the log from genesis** up to the anchor sequence and requires the chain's genesis digest to match the anchor's, so a fabricated log that merely parrots the anchor digest at that sequence is rejected. |
+| Rewrite the entire sidecar log | Detectable only against an externally held anchor (re-folded, per above). |
+
+### What the digest binds (determinism)
+
+The per-transaction digest binds the **full HLC commit timestamp** (wallclock
+micros + logical counter) and the transaction's sorted leaves — **not** the
+transaction id. The chain digest is a deterministic function of the record set
+**sorted by commit timestamp**, so a chain rebuilt from replayed history after a
+crash reproduces the exact pre-crash head digest (a pre-crash anchor still
+verifies), regardless of the order in which commits were originally enqueued.
 
 ### v1 limitations
 
@@ -264,6 +274,19 @@ rewrite up to the anchor point.
   state is re-derived on recovery rather than loaded from a durable
   chain-specific WAL payload (durable rehydration is a tracked follow-up that
   will not change the verification contract).
+- The born-closed-terminal `valid_to` binding uses the stable predicate
+  `valid_to <= transaction_from` (plus the tombstone flag). A *heavily backdated*
+  supersession — two backdated writes to one entity where the successor's valid
+  start lands at or before the prior version's own transaction start — can make a
+  legitimately superseded (open-at-seal) version look born-closed at verify and
+  produce a **false positive**, not a missed tamper. This is a rare edge; a
+  stored born-closed discriminator is a follow-up.
+- Cold tier: verification reads versions through the tiered (hot **and** cold)
+  path, so it does not false-fail after a sealed version migrates to the Redb
+  cold tier. The startup **tail rebuild** scans hot history only; a version
+  migrated to cold before its transaction was ever sealed would be omitted from a
+  from-scratch rebuild (migration normally happens well after sealing, so this is
+  a narrow edge and a tracked follow-up).
 
 ## See also
 

--- a/src/audit/canonical.rs
+++ b/src/audit/canonical.rs
@@ -124,9 +124,22 @@ impl Canon {
                 self.tag(5);
                 // Encode the decoded bytes so an equivalent-but-recased hex still
                 // canonicalizes identically; fall back to raw string on garbage.
+                //
+                // A 1-byte discriminator immediately after the tag keeps the two
+                // sub-domains injective: without it, a valid-hex value decoding to
+                // some byte string B and a garbage-hex value whose raw UTF-8 equals
+                // B both emitted `tag(5) || len-prefixed(B)` and therefore collided
+                // (Issue #3351 security fix). `0` = decoded bytes, `1` = raw-string
+                // fallback; they can never share an encoding.
                 match hex::decode(hex) {
-                    Some(bytes) => self.bytes(&bytes),
-                    None => self.str(hex),
+                    Some(bytes) => {
+                        self.buf.push(0);
+                        self.bytes(&bytes);
+                    }
+                    None => {
+                        self.buf.push(1);
+                        self.str(hex);
+                    }
                 }
             }
             ExportedValue::Array { values } => {
@@ -349,4 +362,35 @@ pub(crate) fn hex_to_32(s: &str) -> Option<[u8; 32]> {
     let mut out = [0u8; 32];
     out.copy_from_slice(&v);
     Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn canon_value(v: &ExportedValue) -> Vec<u8> {
+        let mut c = Canon::default();
+        c.value(v);
+        c.buf
+    }
+
+    #[test]
+    fn bytes_decoded_and_raw_string_fallback_do_not_collide() {
+        // "68656c6c6f" is valid hex that decodes to the bytes of "hello", so it
+        // takes the decoded-bytes path. "hello" is NOT valid hex, so it takes the
+        // raw-string fallback. Before the Issue #3351 discriminator fix both
+        // produced identical canonical bytes (`tag(5) || len-prefixed "hello"`);
+        // they must now differ.
+        let decoded = ExportedValue::Bytes {
+            hex: "68656c6c6f".to_string(),
+        };
+        let raw_fallback = ExportedValue::Bytes {
+            hex: "hello".to_string(),
+        };
+        assert_ne!(
+            canon_value(&decoded),
+            canon_value(&raw_fallback),
+            "decoded-bytes and raw-string-fallback Bytes must not share a canonical encoding"
+        );
+    }
 }

--- a/src/audit/model.rs
+++ b/src/audit/model.rs
@@ -13,7 +13,12 @@
 use serde::{Deserialize, Serialize};
 
 /// Format version of the artifact. Bumped only on breaking format changes.
-pub const AUDIT_FORMAT_VERSION: u32 = 1;
+///
+/// Bumped to `2` in Issue #3351: the canonical `Bytes` encoding gained a 1-byte
+/// discriminator (decoded-bytes vs raw-string fallback), so leaf/root hashes for
+/// any export containing byte-valued properties changed. Older `v1` artifacts are
+/// rejected by the verifier (their signatures cover the old canonical bytes).
+pub const AUDIT_FORMAT_VERSION: u32 = 2;
 
 /// Hash-chain algorithm identifier embedded in the artifact.
 pub const HASH_ALGORITHM: &str = "sha256-linked-v1";

--- a/src/audit/signing.rs
+++ b/src/audit/signing.rs
@@ -103,8 +103,17 @@ impl AuditSigningKey {
     /// The file is created with restrictive permissions from the start so the
     /// secret is never briefly world-readable.
     ///
+    /// # Security (Issue #3351)
+    /// The file is created with `create_new(true)` (`O_CREAT | O_EXCL`), so the
+    /// call **fails if the path already exists** — an attacker cannot pre-plant a
+    /// symlink or a sensitive file for us to follow and truncate. On unix we also
+    /// add `O_NOFOLLOW` as defense-in-depth so the final path component is never a
+    /// followed symlink. The previous `create(true).truncate(true)` behavior
+    /// silently followed symlinks and truncated whatever it found.
+    ///
     /// # Errors
-    /// Returns [`AuditError::Io`] on write failure.
+    /// Returns [`AuditError::Io`] on write failure, including when the target path
+    /// already exists (write over refused) or is a symlink.
     pub fn write_to_file(&self, path: impl AsRef<Path>) -> AuditResult<()> {
         let path = path.as_ref();
         let seed = Zeroizing::new(self.inner.to_bytes());
@@ -112,15 +121,23 @@ impl AuditSigningKey {
 
         use std::io::Write as _;
         let mut options = std::fs::OpenOptions::new();
-        options.write(true).create(true).truncate(true);
+        // create_new => O_CREAT | O_EXCL: refuse to open a pre-existing path
+        // (regular file OR symlink), so we never follow/truncate attacker-planted
+        // content. No truncate flag: we only ever create fresh.
+        options.write(true).create_new(true);
         #[cfg(unix)]
         {
             use std::os::unix::fs::OpenOptionsExt as _;
             options.mode(0o600);
+            // Belt-and-suspenders: also refuse to follow a symlink at the final
+            // component. libc supplies the correct per-platform O_NOFOLLOW value.
+            options.custom_flags(libc::O_NOFOLLOW);
         }
-        let mut file = options
-            .open(path)
-            .map_err(|e| AuditError::Io(format!("creating signing key file: {e}")))?;
+        let mut file = options.open(path).map_err(|e| {
+            AuditError::Io(format!(
+                "creating signing key file (refused: path must not already exist and must not be a symlink): {e}"
+            ))
+        })?;
         file.write_all(hex_seed.as_bytes())
             .map_err(|e| AuditError::Io(format!("writing signing key file: {e}")))?;
         file.write_all(b"\n")

--- a/src/audit/tests.rs
+++ b/src/audit/tests.rs
@@ -35,6 +35,40 @@ fn signing_key_debug_hides_secret() {
 }
 
 #[test]
+fn write_to_file_refuses_existing_path() {
+    // Issue #3351: create_new(true) refuses to write over a pre-existing file,
+    // so an attacker-planted file is never followed/truncated.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("key.hex");
+    let k = key();
+    k.write_to_file(&path).unwrap();
+    let err = k.write_to_file(&path).unwrap_err();
+    assert!(
+        matches!(err, AuditError::Io(_)),
+        "second write over an existing path must be refused"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn write_to_file_refuses_symlink_target() {
+    // A symlink planted at the target must not be followed/truncated.
+    let dir = tempfile::tempdir().unwrap();
+    let real = dir.path().join("real.txt");
+    std::fs::write(&real, b"planted-secret").unwrap();
+    let link = dir.path().join("link.hex");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+
+    let err = key().write_to_file(&link).unwrap_err();
+    assert!(
+        matches!(err, AuditError::Io(_)),
+        "writing through a symlink must be refused"
+    );
+    // The pre-existing real file must be untouched.
+    assert_eq!(std::fs::read(&real).unwrap(), b"planted-secret");
+}
+
+#[test]
 fn export_is_deterministic_for_same_content_ordering() {
     // Two exports of the same entity produce identical chains (only the export
     // timestamp/anchor differ, which live in metadata) — the per-version leaves

--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -10,7 +10,9 @@ use std::io::{self, ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use aletheiadb::provenance_chain::{ChainHead, ChainVerification, EntityKind};
+#[cfg(feature = "serde")]
+use aletheiadb::provenance_chain::ChainHead;
+use aletheiadb::provenance_chain::{ChainVerification, EntityKind};
 use aletheiadb::{
     AletheiaDB, Edge, EdgeId, GLOBAL_INTERNER, Node, NodeId, PropertyMap, PropertyMapBuilder,
     PropertyValue,
@@ -182,6 +184,10 @@ fn handle_verify(args: Vec<String>) -> Result<(), String> {
     let db = open_db()?;
 
     // Export-head mode takes precedence: it is an explicit export action.
+    // Exporting/importing a chain head anchor serializes `ChainHead` via
+    // `serde_json`, so it is only available when the `serde` feature is
+    // compiled in.
+    #[cfg(feature = "serde")]
     if let Some(path) = arg_value(&args, "--export-head") {
         let head = db.export_chain_head().map_err(chain_error_hint)?;
         write_chain_head(&head, &path)?;
@@ -190,10 +196,24 @@ fn handle_verify(args: Vec<String>) -> Result<(), String> {
     }
 
     // Against-anchor mode: prove append-only extension of a stored head.
+    #[cfg(feature = "serde")]
     if let Some(path) = arg_value(&args, "--against") {
         let anchor = read_chain_head(&path)?;
         let result = db.verify_chain_against(&anchor).map_err(chain_error_hint)?;
         return finish_verification(&result, "anchor", json);
+    }
+
+    // Without `serde`, the chain-head export/compare CLI is unavailable. Report
+    // a clean error (non-zero exit via `Err`) instead of silently ignoring the
+    // flags or leaving a compile error, mirroring how other feature-gated CLI
+    // paths surface unavailability. The plain `verify` path below still works.
+    #[cfg(not(feature = "serde"))]
+    if arg_value(&args, "--export-head").is_some() || arg_value(&args, "--against").is_some() {
+        return Err(
+            "chain head export/compare requires the `serde` feature (rebuild with \
+             --features serde)"
+                .to_string(),
+        );
     }
 
     // Entity-scoped mode.
@@ -306,6 +326,7 @@ fn render_verification(
 }
 
 /// Render the confirmation for an `--export-head` action.
+#[cfg(feature = "serde")]
 fn render_head_export(head: &ChainHead, path: &str, json: bool) -> Result<String, String> {
     if json {
         let value = serde_json::json!({
@@ -325,6 +346,7 @@ fn render_head_export(head: &ChainHead, path: &str, json: bool) -> Result<String
 }
 
 /// Serialize a [`ChainHead`] to a JSON file (pretty, digests as hex).
+#[cfg(feature = "serde")]
 fn write_chain_head(head: &ChainHead, path: &str) -> Result<(), String> {
     let bytes = serde_json::to_vec_pretty(head)
         .map_err(|e| format!("failed to serialize chain head: {e}"))?;
@@ -332,6 +354,7 @@ fn write_chain_head(head: &ChainHead, path: &str) -> Result<(), String> {
 }
 
 /// Load a [`ChainHead`] previously exported to a JSON file.
+#[cfg(feature = "serde")]
 fn read_chain_head(path: &str) -> Result<ChainHead, String> {
     let bytes =
         fs::read(path).map_err(|e| format!("failed to read chain head from '{path}': {e}"))?;
@@ -1438,6 +1461,7 @@ mod tests {
         assert!(finish_verification(&sample_verification(true), "full", true).is_ok());
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn chain_head_round_trips_through_file() {
         let head = ChainHead::genesis(5, 1234);
@@ -1449,6 +1473,7 @@ mod tests {
         assert_eq!(head, loaded);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn read_chain_head_rejects_garbage() {
         let dir = tempfile::tempdir().unwrap();
@@ -1461,6 +1486,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn render_head_export_human_and_json() {
         let head = ChainHead::genesis(9, 42);

--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -10,6 +10,7 @@ use std::io::{self, ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+use aletheiadb::provenance_chain::{ChainHead, ChainVerification, EntityKind};
 use aletheiadb::{
     AletheiaDB, Edge, EdgeId, GLOBAL_INTERNER, Node, NodeId, PropertyMap, PropertyMapBuilder,
     PropertyValue,
@@ -53,6 +54,7 @@ fn run() -> Result<(), String> {
         Some("daemon") => handle_daemon(args.collect()),
         Some("backup") => handle_backup(args.collect()),
         Some("restore") => handle_restore(args.collect()),
+        Some("verify") => handle_verify(args.collect()),
         #[cfg(feature = "audit-export")]
         Some("audit-keygen") => audit::handle_keygen(args.collect()),
         #[cfg(feature = "audit-export")]
@@ -85,6 +87,7 @@ Usage:\n\
   aletheia daemon status [--pid-file PATH]\n\
   aletheia backup <output_path>\n\
   aletheia restore <input_path>\n\
+  aletheia verify [--entity <node|edge>:<id>] [--export-head PATH] [--against PATH] [--json]\n\
   aletheia audit-keygen <key_file>\n\
   aletheia audit-export <node|edge> <id> --key <key_file> --out <path> [--db-id ID] [--redact k1,k2]\n\
   aletheia audit-verify <artifact_path> [--public-key HEX]\n\
@@ -98,6 +101,15 @@ Usage:\n\
   backup  — Write a portable .albk artifact capturing full bi-temporal state.\n\
             Opens the database via ALETHEIADB_CONFIG or ALETHEIADB_DATA_DIR.\n\
   restore — Restore a .albk artifact into ALETHEIADB_DATA_DIR (must be empty).\n\
+\nProvenance hash chain (Issue #3351):\n\
+  verify  — Verify the tamper-evident provenance hash chain over recorded history.\n\
+            Default: full-chain verify. --entity <node|edge>:<id> scopes to one entity.\n\
+            --export-head PATH writes the current head anchor (JSON) for offsite storage.\n\
+            --against PATH verifies the chain append-only-extends a previously exported\n\
+            head (fork/rollback detection). --json emits machine-readable output.\n\
+            Requires the chain to be enabled for the opened data dir (via an\n\
+            ALETHEIADB_CONFIG TOML carrying `[chain] enabled = true`); exits non-zero\n\
+            if the chain is disabled or verification fails.\n\
 \nSigned audit export (Issue #3358):\n\
   audit-keygen — Generate an Ed25519 signing key (0600) and print its public key.\n\
   audit-export — Sign an entity's full bi-temporal history into a portable artifact.\n\
@@ -144,6 +156,187 @@ fn handle_restore(args: Vec<String>) -> Result<(), String> {
         .map_err(|e| format!("restore failed: {e}"))?;
     println!("{}", restore_success_json(&data_dir)?);
     Ok(())
+}
+
+/// `aletheia verify` — verify the tamper-evident provenance hash chain
+/// (Issue #3351).
+///
+/// Modes, resolved in precedence order:
+/// - `--export-head PATH`: export the current chain head anchor as JSON to
+///   `PATH` (for offsite storage; feed it back later via `--against`).
+/// - `--against PATH`: load a previously exported head and prove the current
+///   chain append-only-extends it (rollback/fork detection).
+/// - `--entity <node|edge>:<id>`: verify only one entity's contribution.
+/// - (default): full-chain verify from genesis.
+///
+/// `--json` emits machine-readable output. Verification failure (or a
+/// disabled chain) exits non-zero.
+///
+/// The database is opened via [`open_db`], which honours `ALETHEIADB_CONFIG`
+/// (a TOML file that can enable the chain with `[chain] enabled = true`) or
+/// `ALETHEIADB_DATA_DIR`. Note that opening by data dir alone does NOT enable
+/// the chain — a chain-enabled TOML config is required for `verify` to have a
+/// chain to check.
+fn handle_verify(args: Vec<String>) -> Result<(), String> {
+    let json = args.iter().any(|a| a == "--json");
+    let db = open_db()?;
+
+    // Export-head mode takes precedence: it is an explicit export action.
+    if let Some(path) = arg_value(&args, "--export-head") {
+        let head = db.export_chain_head().map_err(chain_error_hint)?;
+        write_chain_head(&head, &path)?;
+        println!("{}", render_head_export(&head, &path, json)?);
+        return Ok(());
+    }
+
+    // Against-anchor mode: prove append-only extension of a stored head.
+    if let Some(path) = arg_value(&args, "--against") {
+        let anchor = read_chain_head(&path)?;
+        let result = db.verify_chain_against(&anchor).map_err(chain_error_hint)?;
+        return finish_verification(&result, "anchor", json);
+    }
+
+    // Entity-scoped mode.
+    if let Some(spec) = arg_value(&args, "--entity") {
+        let (kind, id) = parse_entity_arg(&spec)?;
+        let result = db.verify_entity_chain(kind, id).map_err(chain_error_hint)?;
+        return finish_verification(&result, "entity", json);
+    }
+
+    // Default: full-chain verify.
+    let result = db.verify_chain().map_err(chain_error_hint)?;
+    finish_verification(&result, "full", json)
+}
+
+/// Turn a chain API error (notably "chain not enabled") into a CLI-friendly
+/// message with remediation guidance.
+fn chain_error_hint(e: impl std::fmt::Display) -> String {
+    format!(
+        "{e}\n\
+         hint: `aletheia verify` requires the provenance hash chain to be enabled for the \
+         opened database. Open it via ALETHEIADB_CONFIG pointing at a TOML config that \
+         carries a `[chain]` section with `enabled = true`."
+    )
+}
+
+/// Parse an `--entity <node|edge>:<id>` argument into its kind and id.
+fn parse_entity_arg(spec: &str) -> Result<(EntityKind, u64), String> {
+    let (kind_str, id_str) = spec.split_once(':').ok_or_else(|| {
+        format!("invalid --entity '{spec}': expected '<node|edge>:<id>' (e.g. node:42)")
+    })?;
+    let kind = match kind_str.trim().to_ascii_lowercase().as_str() {
+        "node" => EntityKind::Node,
+        "edge" => EntityKind::Edge,
+        other => {
+            return Err(format!(
+                "invalid --entity kind '{other}': expected 'node' or 'edge'"
+            ));
+        }
+    };
+    let id = id_str
+        .trim()
+        .parse::<u64>()
+        .map_err(|e| format!("invalid --entity id '{id_str}': {e}"))?;
+    Ok((kind, id))
+}
+
+/// Render a verification result and return non-zero (via `Err`) on failure.
+///
+/// The full result is printed to stdout in both success and failure cases so a
+/// caller always sees the details; on failure a terse `Err` drives the
+/// process exit code to non-zero (main prints it to stderr).
+fn finish_verification(result: &ChainVerification, scope: &str, json: bool) -> Result<(), String> {
+    println!("{}", render_verification(result, scope, json)?);
+    if result.passed {
+        Ok(())
+    } else {
+        Err(format!(
+            "provenance chain verification FAILED ({scope}){}",
+            result
+                .earliest_broken_seq
+                .map(|s| format!(" at seq {s}"))
+                .unwrap_or_default()
+        ))
+    }
+}
+
+/// Render a [`ChainVerification`] as human-readable text or JSON.
+fn render_verification(
+    result: &ChainVerification,
+    scope: &str,
+    json: bool,
+) -> Result<String, String> {
+    if json {
+        let value = serde_json::json!({
+            "scope": scope,
+            "passed": result.passed,
+            "head_seq": result.head_seq,
+            "head_digest": result.head_digest_hex,
+            "earliest_broken_seq": result.earliest_broken_seq,
+            "reason": result.reason,
+            "transactions_checked": result.transactions_checked,
+        });
+        return serde_json::to_string_pretty(&value)
+            .map_err(|e| format!("failed to render JSON output: {e}"));
+    }
+
+    let status = if result.passed { "PASS" } else { "FAIL" };
+    let mut out = String::new();
+    out.push_str(&format!(
+        "Provenance chain verification: {status} (scope: {scope})\n"
+    ));
+    out.push_str(&format!("  head seq:             {}\n", result.head_seq));
+    out.push_str(&format!(
+        "  head digest:          {}\n",
+        result.head_digest_hex
+    ));
+    out.push_str(&format!(
+        "  transactions checked: {}",
+        result.transactions_checked
+    ));
+    if !result.passed {
+        if let Some(seq) = result.earliest_broken_seq {
+            out.push_str(&format!("\n  earliest broken seq:  {seq}"));
+        }
+        if let Some(reason) = &result.reason {
+            out.push_str(&format!("\n  reason:               {reason}"));
+        }
+    }
+    Ok(out)
+}
+
+/// Render the confirmation for an `--export-head` action.
+fn render_head_export(head: &ChainHead, path: &str, json: bool) -> Result<String, String> {
+    if json {
+        let value = serde_json::json!({
+            "ok": true,
+            "path": path,
+            "seq": head.seq,
+            "digest": aletheiadb::provenance_chain::to_hex(&head.digest),
+        });
+        return serde_json::to_string(&value)
+            .map_err(|e| format!("failed to render JSON output: {e}"));
+    }
+    Ok(format!(
+        "Exported chain head anchor to {path}\n  seq:    {}\n  digest: {}",
+        head.seq,
+        aletheiadb::provenance_chain::to_hex(&head.digest)
+    ))
+}
+
+/// Serialize a [`ChainHead`] to a JSON file (pretty, digests as hex).
+fn write_chain_head(head: &ChainHead, path: &str) -> Result<(), String> {
+    let bytes = serde_json::to_vec_pretty(head)
+        .map_err(|e| format!("failed to serialize chain head: {e}"))?;
+    fs::write(path, bytes).map_err(|e| format!("failed to write chain head to '{path}': {e}"))
+}
+
+/// Load a [`ChainHead`] previously exported to a JSON file.
+fn read_chain_head(path: &str) -> Result<ChainHead, String> {
+    let bytes =
+        fs::read(path).map_err(|e| format!("failed to read chain head from '{path}': {e}"))?;
+    serde_json::from_slice(&bytes)
+        .map_err(|e| format!("'{path}' is not a valid exported chain head: {e}"))
 }
 
 /// `aletheia demo` — boot a seeded, ephemeral bi-temporal graph and print a
@@ -1161,6 +1354,123 @@ mod tests {
             serde_json::json!(win_path.display().to_string()),
             "data_dir must round-trip exactly through JSON escaping"
         );
+    }
+
+    // ========================================================================
+    // Issue #3351 — `aletheia verify` helper unit tests.
+    // ========================================================================
+
+    fn sample_verification(passed: bool) -> ChainVerification {
+        ChainVerification {
+            passed,
+            head_seq: 7,
+            head_digest_hex: "abcd".to_string(),
+            earliest_broken_seq: if passed { None } else { Some(3) },
+            reason: if passed {
+                None
+            } else {
+                Some("recomputed chain digest differs from sealed digest".to_string())
+            },
+            transactions_checked: 7,
+        }
+    }
+
+    #[test]
+    fn parse_entity_arg_accepts_node_and_edge() {
+        let (kind, id) = parse_entity_arg("node:42").unwrap();
+        assert!(matches!(kind, EntityKind::Node));
+        assert_eq!(id, 42);
+        let (kind, id) = parse_entity_arg("EDGE:7").unwrap();
+        assert!(matches!(kind, EntityKind::Edge));
+        assert_eq!(id, 7);
+    }
+
+    #[test]
+    fn parse_entity_arg_rejects_missing_colon() {
+        let err = parse_entity_arg("node42").unwrap_err();
+        assert!(err.contains("expected"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn parse_entity_arg_rejects_unknown_kind() {
+        let err = parse_entity_arg("vertex:1").unwrap_err();
+        assert!(err.contains("expected 'node' or 'edge'"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_entity_arg_rejects_non_numeric_id() {
+        let err = parse_entity_arg("node:abc").unwrap_err();
+        assert!(err.contains("invalid --entity id"), "got: {err}");
+    }
+
+    #[test]
+    fn render_verification_human_pass_reports_status_and_head() {
+        let out = render_verification(&sample_verification(true), "full", false).unwrap();
+        assert!(out.contains("PASS"), "got: {out}");
+        assert!(out.contains("scope: full"), "got: {out}");
+        assert!(out.contains("head seq:             7"), "got: {out}");
+        // A clean pass must NOT print a broken seq / reason line.
+        assert!(!out.contains("earliest broken seq"), "got: {out}");
+    }
+
+    #[test]
+    fn render_verification_human_fail_reports_broken_seq_and_reason() {
+        let out = render_verification(&sample_verification(false), "entity", false).unwrap();
+        assert!(out.contains("FAIL"), "got: {out}");
+        assert!(out.contains("earliest broken seq:  3"), "got: {out}");
+        assert!(out.contains("differs from sealed digest"), "got: {out}");
+    }
+
+    #[test]
+    fn render_verification_json_is_machine_readable() {
+        let out = render_verification(&sample_verification(false), "anchor", true).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&out).expect("valid JSON");
+        assert_eq!(value["scope"], serde_json::json!("anchor"));
+        assert_eq!(value["passed"], serde_json::json!(false));
+        assert_eq!(value["earliest_broken_seq"], serde_json::json!(3));
+        assert_eq!(value["head_seq"], serde_json::json!(7));
+    }
+
+    #[test]
+    fn finish_verification_returns_err_on_failure() {
+        // Failure must map to a non-zero exit (Err), success to Ok.
+        assert!(finish_verification(&sample_verification(false), "full", true).is_err());
+        assert!(finish_verification(&sample_verification(true), "full", true).is_ok());
+    }
+
+    #[test]
+    fn chain_head_round_trips_through_file() {
+        let head = ChainHead::genesis(5, 1234);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("head.json");
+        let path_str = path.to_str().unwrap();
+        write_chain_head(&head, path_str).unwrap();
+        let loaded = read_chain_head(path_str).unwrap();
+        assert_eq!(head, loaded);
+    }
+
+    #[test]
+    fn read_chain_head_rejects_garbage() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.json");
+        fs::write(&path, b"not a chain head").unwrap();
+        let err = read_chain_head(path.to_str().unwrap()).unwrap_err();
+        assert!(
+            err.contains("not a valid exported chain head"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn render_head_export_human_and_json() {
+        let head = ChainHead::genesis(9, 42);
+        let human = render_head_export(&head, "/tmp/x.json", false).unwrap();
+        assert!(human.contains("Exported chain head anchor to /tmp/x.json"));
+        assert!(human.contains("seq:    0"));
+        let json = render_head_export(&head, "/tmp/x.json", true).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["ok"], serde_json::json!(true));
+        assert_eq!(value["seq"], serde_json::json!(0));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -825,6 +825,10 @@ pub struct AletheiaDBConfig {
     pub persistence: PersistenceConfig,
     /// Encryption at rest configuration
     pub encryption: crate::encryption::config::EncryptionConfig,
+    /// Opt-in tamper-evident provenance hash chain (Issue #3351). Disabled by
+    /// default, so a database keeps byte-identical behavior and on-disk layout
+    /// unless the chain is explicitly enabled.
+    pub chain: crate::provenance_chain::ChainConfig,
 }
 
 /// Builder for unified database configuration.
@@ -874,6 +878,16 @@ impl AletheiaDBConfigBuilder {
         encryption_config: crate::encryption::config::EncryptionConfig,
     ) -> Self {
         self.config.encryption = encryption_config;
+        self
+    }
+
+    /// Set the provenance hash chain configuration (Issue #3351).
+    ///
+    /// The default is disabled; passing a [`ChainConfig`](crate::provenance_chain::ChainConfig)
+    /// with `enabled: true` opts the database into the tamper-evident sidecar
+    /// chain over its recorded history.
+    pub fn chain(mut self, chain_config: crate::provenance_chain::ChainConfig) -> Self {
+        self.config.chain = chain_config;
         self
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1338,6 +1338,45 @@ mod tests {
 
     #[test]
     #[cfg(feature = "config-toml")]
+    fn test_toml_chain_section_round_trips() {
+        // The opt-in provenance hash chain (Issue #3351) must round-trip
+        // through TOML via the `[chain]` section so `aletheia verify` can be
+        // driven by an on-disk config that enables the chain.
+        use crate::provenance_chain::ChainFsyncMode;
+
+        let toml_str = r#"
+[chain]
+enabled = true
+fsync = "per_transaction"
+dir = "/var/lib/aletheia/chain"
+        "#;
+
+        let config = AletheiaDBConfig::from_toml_str(toml_str).unwrap();
+        assert!(config.chain.enabled, "[chain] enabled must deserialize");
+        assert_eq!(config.chain.fsync, ChainFsyncMode::PerTransaction);
+        assert_eq!(
+            config.chain.dir,
+            Some(std::path::PathBuf::from("/var/lib/aletheia/chain"))
+        );
+
+        // Serialize back out and confirm the section is present and re-parses
+        // to an identical config (full round-trip, no field loss).
+        let rendered = config.to_toml_string().unwrap();
+        assert!(rendered.contains("[chain]"), "rendered TOML: {rendered}");
+        assert!(rendered.contains("enabled = true"));
+        let reparsed = AletheiaDBConfig::from_toml_str(&rendered).unwrap();
+        assert_eq!(reparsed.chain, config.chain);
+
+        // Omitting the section keeps the chain disabled by default (byte-
+        // identical behavior for existing configs).
+        let no_chain = AletheiaDBConfig::from_toml_str("[wal]\nnum_stripes = 16\n").unwrap();
+        assert!(!no_chain.chain.enabled);
+        assert_eq!(no_chain.chain.fsync, ChainFsyncMode::Batched);
+        assert!(no_chain.chain.dir.is_none());
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
     fn test_toml_deserialization_partial() {
         // Test partial config - only override WAL settings
         let toml_str = r#"

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -68,6 +68,12 @@ pub enum Error {
         /// Why it's not implemented (e.g., "Phase 4 feature")
         reason: String,
     },
+    /// A precondition for the requested operation is not met — e.g. an opt-in
+    /// feature is disabled (the provenance hash chain, Issue #3351). Distinct
+    /// from [`Error::Other`] so callers can match on it programmatically; maps to
+    /// the MCP `FAILED_PRECONDITION` structured code.
+    #[error("{0}")]
+    FailedPrecondition(String),
     /// Other errors.
     #[error("{0}")]
     Other(String),
@@ -93,7 +99,7 @@ impl Error {
                 Error::Constraint(_) => crate::observability::ErrorCategory::Other,
                 Error::Io(_) => crate::observability::ErrorCategory::Io,
                 Error::Backup(_) => crate::observability::ErrorCategory::Other,
-                Error::NotImplemented { .. } | Error::Other(_) => {
+                Error::NotImplemented { .. } | Error::FailedPrecondition(_) | Error::Other(_) => {
                     crate::observability::ErrorCategory::Other
                 }
             };

--- a/src/db/chain.rs
+++ b/src/db/chain.rs
@@ -203,7 +203,7 @@ impl AletheiaDB {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Other`] when the provenance hash chain is not enabled on
+    /// Returns [`Error::FailedPrecondition`] when the provenance hash chain is not enabled on
     /// this database (see [`ChainConfig`](crate::provenance_chain::ChainConfig)).
     pub fn verify_chain(&self) -> Result<ChainVerification> {
         Ok(self.require_chain()?.verify_full())
@@ -214,7 +214,7 @@ impl AletheiaDB {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Other`] when the chain is not enabled.
+    /// Returns [`Error::FailedPrecondition`] when the chain is not enabled.
     pub fn verify_entity_chain(&self, kind: EntityKind, id: u64) -> Result<ChainVerification> {
         Ok(self.require_chain()?.verify_entity(kind, id))
     }
@@ -223,7 +223,7 @@ impl AletheiaDB {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Other`] when the chain is not enabled.
+    /// Returns [`Error::FailedPrecondition`] when the chain is not enabled.
     pub fn export_chain_head(&self) -> Result<ChainHead> {
         Ok(self.require_chain()?.export_head())
     }
@@ -233,14 +233,14 @@ impl AletheiaDB {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Other`] when the chain is not enabled.
+    /// Returns [`Error::FailedPrecondition`] when the chain is not enabled.
     pub fn verify_chain_against(&self, anchor: &ChainHead) -> Result<ChainVerification> {
         Ok(self.require_chain()?.verify_against_anchor(anchor))
     }
 
     fn require_chain(&self) -> Result<&Arc<ProvenanceChain>> {
         self.chain.as_ref().ok_or_else(|| {
-            Error::Other(
+            Error::FailedPrecondition(
                 "provenance hash chain is not enabled (set ChainConfig::enabled = true)"
                     .to_string(),
             )

--- a/src/db/chain.rs
+++ b/src/db/chain.rs
@@ -1,0 +1,245 @@
+//! Provenance hash chain integration on [`AletheiaDB`] (Issue #3351).
+//!
+//! This module wires the opt-in tamper-evident chain into the database:
+//! - capturing the version refs a committed transaction produced (hot path),
+//! - rebuilding the unsealed tail from replayed history at startup, and
+//! - the public verification / anchor-export API.
+//!
+//! When the chain is disabled (the default), none of this runs and the verify
+//! API returns a clear "not enabled" error, so behavior is byte-identical to a
+//! database without the feature.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use crate::api::transaction::{BufferedWrite, WriteTransaction};
+use crate::core::error::{Error, Result};
+use crate::core::id::{EdgeId, NodeId};
+use crate::core::temporal::Timestamp;
+use crate::db::AletheiaDB;
+use crate::provenance_chain::{
+    ChainHead, ChainVerification, EntityKind, PendingTx, ProvenanceChain,
+};
+
+/// A single version reference: `(kind, entity_id, version_id)`.
+type VersionRef = (EntityKind, u64, u64);
+
+/// Restored versions grouped by their exact commit timestamp `(wallclock,
+/// logical)` — one group per recovered transaction, keyed for ascending order.
+type CommitGroups = BTreeMap<(i64, u32), Vec<VersionRef>>;
+
+/// Version refs captured from a transaction's write buffer *before* commit
+/// consumes it. Create/update refs are exact (their version ids live in the
+/// buffer); delete/retract entity ids are resolved to their closing version id
+/// after commit via [`AletheiaDB::finalize_chain_capture`].
+pub(crate) struct ChainCapture {
+    tx_id: u64,
+    refs: Vec<(EntityKind, u64, u64)>,
+    closing_nodes: Vec<u64>,
+    closing_edges: Vec<u64>,
+}
+
+impl AletheiaDB {
+    /// Capture the version refs a transaction will commit, from its write
+    /// buffer. Called on the hot path only when the chain is enabled.
+    pub(crate) fn precapture_chain(&self, tx: &WriteTransaction) -> ChainCapture {
+        let mut refs = Vec::new();
+        let mut closing_nodes = Vec::new();
+        let mut closing_edges = Vec::new();
+        for op in tx.buffer.operations() {
+            match op {
+                BufferedWrite::CreateNode {
+                    node_id,
+                    version_id,
+                    ..
+                }
+                | BufferedWrite::UpdateNode {
+                    node_id,
+                    version_id,
+                    ..
+                } => refs.push((EntityKind::Node, node_id.as_u64(), version_id.as_u64())),
+                BufferedWrite::CreateEdge {
+                    edge_id,
+                    version_id,
+                    ..
+                }
+                | BufferedWrite::UpdateEdge {
+                    edge_id,
+                    version_id,
+                    ..
+                } => refs.push((EntityKind::Edge, edge_id.as_u64(), version_id.as_u64())),
+                BufferedWrite::DeleteNode { node_id, .. }
+                | BufferedWrite::RetractNode { node_id, .. } => {
+                    closing_nodes.push(node_id.as_u64())
+                }
+                BufferedWrite::DeleteEdge { edge_id, .. }
+                | BufferedWrite::RetractEdge { edge_id, .. } => {
+                    closing_edges.push(edge_id.as_u64())
+                }
+            }
+        }
+        ChainCapture {
+            tx_id: tx.tx_id.as_u64(),
+            refs,
+            closing_nodes,
+            closing_edges,
+        }
+    }
+
+    /// Resolve any delete/retract closing versions (their ids are allocated at
+    /// apply time, not in the buffer) and produce the [`PendingTx`] to enqueue.
+    ///
+    /// v1 caveat: the closing version id is read as the entity's *current* head
+    /// right after commit. Under a concurrent supersession of the same entity
+    /// between this commit and the head read, a later immutable version could be
+    /// attributed to this transaction — a fidelity edge case that never breaks
+    /// verification (seal and verify both fetch the same version id).
+    pub(crate) fn finalize_chain_capture(
+        &self,
+        mut cap: ChainCapture,
+        commit_ts: Timestamp,
+        anchor_lsn: u64,
+    ) -> PendingTx {
+        if !cap.closing_nodes.is_empty() || !cap.closing_edges.is_empty() {
+            let historical = self.historical.read();
+            for nid in cap.closing_nodes.drain(..) {
+                if let Ok(node_id) = NodeId::new(nid)
+                    && let Some(vid) = historical.get_current_node_version(node_id)
+                {
+                    cap.refs.push((EntityKind::Node, nid, vid.as_u64()));
+                }
+            }
+            for eid in cap.closing_edges.drain(..) {
+                if let Ok(edge_id) = EdgeId::new(eid)
+                    && let Some(vid) = historical.get_current_edge_version(edge_id)
+                {
+                    cap.refs.push((EntityKind::Edge, eid, vid.as_u64()));
+                }
+            }
+        }
+        PendingTx {
+            commit_ts_micros: commit_ts.wallclock(),
+            tx_id: cap.tx_id,
+            anchor_lsn,
+            entity_refs: cap.refs,
+        }
+    }
+
+    /// Finalize a pre-commit capture and enqueue it to the sealer. A no-op when
+    /// the chain is disabled or no capture was taken (the hot path calls this
+    /// unconditionally; the `Option`s collapse to nothing when disabled).
+    pub(crate) fn enqueue_chain_commit(&self, capture: Option<ChainCapture>, commit_ts: Timestamp) {
+        if let (Some(chain), Some(cap)) = (self.chain.as_ref(), capture) {
+            let anchor_lsn = self.wal.current_lsn().0;
+            let pending = self.finalize_chain_capture(cap, commit_ts, anchor_lsn);
+            chain.enqueue_commit(pending);
+        }
+    }
+
+    /// Rebuild the unsealed tail of the chain from replayed history (Issue #3351
+    /// AC6). Groups every restored node/edge version by its exact commit
+    /// timestamp (a transaction's versions share one HLC stamp) and, for each
+    /// group beyond the loaded chain head, seals it synchronously in ascending
+    /// commit order so the chain covers the full recovered prefix.
+    ///
+    /// Called once at startup after WAL replay and before the sealer thread
+    /// starts. Idempotent against an already-sealed prefix: only transactions
+    /// with a commit timestamp strictly beyond the head are folded in.
+    pub(crate) fn rebuild_chain_tail(&self, chain: &Arc<ProvenanceChain>) {
+        let head = chain.head();
+        let head_ts = head.commit_ts;
+
+        // Group version refs by their full commit Timestamp so two transactions
+        // sharing a wallclock (different logical) stay distinct.
+        let mut groups: CommitGroups = BTreeMap::new();
+        {
+            let historical = self.historical.read();
+            for (vid, v) in historical.get_node_versions() {
+                let ts = v.temporal.transaction_time().start();
+                groups
+                    .entry((ts.wallclock(), ts.logical()))
+                    .or_default()
+                    .push((EntityKind::Node, v.node_id.as_u64(), vid.as_u64()));
+            }
+            for (vid, v) in historical.get_edge_versions() {
+                let ts = v.temporal.transaction_time().start();
+                groups
+                    .entry((ts.wallclock(), ts.logical()))
+                    .or_default()
+                    .push((EntityKind::Edge, v.edge_id.as_u64(), vid.as_u64()));
+            }
+        }
+
+        for ((wallclock, _logical), refs) in groups {
+            // Only seal transactions beyond the loaded head. When the head is
+            // genesis (seq 0) every restored transaction is unsealed; otherwise
+            // skip anything at or before the head's commit timestamp (already
+            // sealed). v1 limitation: two transactions sharing a wallclock where
+            // one is the head are not distinguished (rare HLC collision).
+            if head.seq != 0 && wallclock <= head_ts {
+                continue;
+            }
+            let pending = PendingTx {
+                commit_ts_micros: wallclock,
+                // Synthetic, deterministic tx id for rebuilt records: the WAL
+                // does not carry the original tx id, and these transactions were
+                // never live-sealed, so any stable value keeps the record
+                // internally consistent (verify recomputes from stored fields).
+                tx_id: wallclock as u64,
+                anchor_lsn: head.anchor_lsn,
+                entity_refs: refs,
+            };
+            let _ = chain.seal_pending_sync(pending);
+        }
+        let _ = chain.checkpoint();
+    }
+
+    /// Verify the entire provenance hash chain against stored history
+    /// (Issue #3351 AC2). Returns the earliest broken sequence number on tamper.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Other`] when the provenance hash chain is not enabled on
+    /// this database (see [`ChainConfig`](crate::provenance_chain::ChainConfig)).
+    pub fn verify_chain(&self) -> Result<ChainVerification> {
+        Ok(self.require_chain()?.verify_full())
+    }
+
+    /// Verify only one entity's contribution to the chain (Issue #3351 AC2),
+    /// recomputing just that entity's leaves.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Other`] when the chain is not enabled.
+    pub fn verify_entity_chain(&self, kind: EntityKind, id: u64) -> Result<ChainVerification> {
+        Ok(self.require_chain()?.verify_entity(kind, id))
+    }
+
+    /// Export the current chain head as an external anchor (Issue #3351 AC4).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Other`] when the chain is not enabled.
+    pub fn export_chain_head(&self) -> Result<ChainHead> {
+        Ok(self.require_chain()?.export_head())
+    }
+
+    /// Prove the current chain append-only-extends a previously exported anchor
+    /// (Issue #3351 AC4); detects rollback (truncation) and fork (divergence).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Other`] when the chain is not enabled.
+    pub fn verify_chain_against(&self, anchor: &ChainHead) -> Result<ChainVerification> {
+        Ok(self.require_chain()?.verify_against_anchor(anchor))
+    }
+
+    fn require_chain(&self) -> Result<&Arc<ProvenanceChain>> {
+        self.chain.as_ref().ok_or_else(|| {
+            Error::Other(
+                "provenance hash chain is not enabled (set ChainConfig::enabled = true)"
+                    .to_string(),
+            )
+        })
+    }
+}

--- a/src/db/chain.rs
+++ b/src/db/chain.rs
@@ -119,6 +119,7 @@ impl AletheiaDB {
         }
         PendingTx {
             commit_ts_micros: commit_ts.wallclock(),
+            commit_ts_logical: commit_ts.logical(),
             tx_id: cap.tx_id,
             anchor_lsn,
             entity_refs: cap.refs,
@@ -170,7 +171,7 @@ impl AletheiaDB {
             }
         }
 
-        for ((wallclock, _logical), refs) in groups {
+        for ((wallclock, logical), refs) in groups {
             // Only seal transactions beyond the loaded head. When the head is
             // genesis (seq 0) every restored transaction is unsealed; otherwise
             // skip anything at or before the head's commit timestamp (already
@@ -181,10 +182,13 @@ impl AletheiaDB {
             }
             let pending = PendingTx {
                 commit_ts_micros: wallclock,
-                // Synthetic, deterministic tx id for rebuilt records: the WAL
-                // does not carry the original tx id, and these transactions were
-                // never live-sealed, so any stable value keeps the record
-                // internally consistent (verify recomputes from stored fields).
+                // The full HLC commit timestamp (wallclock + logical) is what the
+                // digest binds — identical in the live-seal and rebuild paths, so
+                // a rebuilt chain reproduces the live head (Issue #3351 finding 4).
+                commit_ts_logical: logical,
+                // Synthetic tx id for rebuilt records: the WAL does not carry the
+                // original tx id, and it is NOT folded into the digest — it is
+                // record metadata only, so any stable value is fine.
                 tx_id: wallclock as u64,
                 anchor_lsn: head.anchor_lsn,
                 entity_refs: refs,
@@ -241,5 +245,181 @@ impl AletheiaDB {
                     .to_string(),
             )
         })
+    }
+}
+
+#[cfg(test)]
+mod tamper_tests {
+    //! Real historical-version tamper tests (Issue #3351 finding 6, exercising
+    //! findings 1 & 2). Unlike the AC3 integration test (which tampers the sealed
+    //! `chain.log`), these mutate a **stored data version**'s content in place via
+    //! the `pub(crate)` `insert_restored_*_version` storage API — the same path
+    //! index-persistence restore uses — then assert `verify_chain` recomputes the
+    //! leaf from the tampered version, finds it disagrees with the sealed leaf,
+    //! and localizes the break. This is the dual of AC3 and the only in-crate way
+    //! to reach the stored version without touching off-limits storage internals.
+
+    use std::time::Duration;
+
+    use crate::PropertyMapBuilder;
+    use crate::config::{AletheiaDBConfig, WalConfigBuilder};
+    use crate::core::interning::GLOBAL_INTERNER;
+    use crate::core::temporal::{BiTemporalInterval, time};
+    use crate::db::AletheiaDB;
+    use crate::provenance_chain::{ChainConfig, ChainFsyncMode};
+    use crate::storage::index_persistence::PersistenceConfig;
+    use crate::storage::wal::DurabilityMode;
+
+    fn enabled_db(dir: &std::path::Path) -> AletheiaDB {
+        let config = AletheiaDBConfig::builder()
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(dir.join("wal"))
+                    .durability_mode(DurabilityMode::Synchronous)
+                    .build(),
+            )
+            .persistence(PersistenceConfig {
+                enabled: true,
+                data_dir: dir.join("indexes"),
+                load_on_startup: true,
+                ..Default::default()
+            })
+            .chain(ChainConfig {
+                enabled: true,
+                fsync: ChainFsyncMode::PerTransaction,
+                dir: None,
+            })
+            .build();
+        AletheiaDB::with_unified_config(config).unwrap()
+    }
+
+    fn props(name: &str) -> crate::PropertyMap {
+        PropertyMapBuilder::new().insert("name", name).build()
+    }
+
+    fn wait_seq(db: &AletheiaDB, expected: u64) {
+        for _ in 0..300 {
+            if db.export_chain_head().unwrap().seq >= expected {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!(
+            "chain head stuck at {}",
+            db.export_chain_head().unwrap().seq
+        );
+    }
+
+    /// Finding 1: relabeling a stored node version is caught (label is now bound
+    /// into the leaf).
+    #[test]
+    fn tampering_stored_node_label_is_detected() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = enabled_db(dir.path());
+        let alice = db.create_node("Person", props("Alice")).unwrap();
+        wait_seq(&db, 1);
+        assert!(db.verify_chain().unwrap().passed);
+
+        // Relabel the stored version in place.
+        {
+            let mut hist = db.historical.write();
+            let vid = hist.get_current_node_version(alice).unwrap();
+            let mut v = hist.get_node_version(vid).unwrap().clone();
+            v.label = GLOBAL_INTERNER.intern("Robot").unwrap();
+            hist.insert_restored_node_version(v).unwrap();
+        }
+
+        let v = db.verify_chain().unwrap();
+        assert!(!v.passed, "a relabel must be detected");
+        assert!(v.earliest_broken_seq.is_some(), "tamper is localized");
+    }
+
+    /// Finding 1: rewiring a stored edge version's target is caught (endpoints are
+    /// now bound into the leaf).
+    #[test]
+    fn tampering_stored_edge_endpoint_is_detected() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = enabled_db(dir.path());
+        let a = db.create_node("Person", props("Alice")).unwrap();
+        let b = db.create_node("Person", props("Bob")).unwrap();
+        let c = db.create_node("Person", props("Carol")).unwrap();
+        let edge = db.create_edge(a, b, "KNOWS", props("")).unwrap();
+        wait_seq(&db, 4);
+        assert!(db.verify_chain().unwrap().passed);
+
+        // Rewire the stored edge's target from b to c.
+        {
+            let mut hist = db.historical.write();
+            let vid = hist.get_current_edge_version(edge).unwrap();
+            let mut v = hist.get_edge_version(vid).unwrap().clone();
+            v.target = c;
+            hist.insert_restored_edge_version(v).unwrap();
+        }
+
+        let v = db.verify_chain().unwrap();
+        assert!(!v.passed, "an edge endpoint rewire must be detected");
+        assert!(v.earliest_broken_seq.is_some());
+    }
+
+    /// Finding 2: extending a retraction version's `valid_to` (re-validating an
+    /// ended fact) is caught — the born-closed terminal `valid_to` is bound.
+    #[test]
+    fn tampering_retraction_valid_to_is_detected() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = enabled_db(dir.path());
+        let alice = db.create_node("Person", props("Alice")).unwrap();
+        // Retract at "now": closes valid time. Seals as a second transaction.
+        db.retract_node(alice, time::now()).unwrap();
+        wait_seq(&db, 2);
+        assert!(db.verify_chain().unwrap().passed);
+
+        // Extend the stored retraction's valid_to far into the future.
+        {
+            let mut hist = db.historical.write();
+            let vid = hist.get_current_node_version(alice).unwrap();
+            let mut v = hist.get_node_version(vid).unwrap().clone();
+            let vf = v.temporal.valid_time().start();
+            let extended = crate::core::hlc::HybridTimestamp::new_unchecked(
+                vf.wallclock() + 10_000_000_000,
+                0,
+            );
+            v.temporal = v.temporal.close_valid_time(extended).unwrap();
+            hist.insert_restored_node_version(v).unwrap();
+        }
+
+        let v = db.verify_chain().unwrap();
+        assert!(
+            !v.passed,
+            "extending a retraction valid_to must be detected"
+        );
+        assert!(v.earliest_broken_seq.is_some());
+    }
+
+    /// Finding 2: re-opening a delete tombstone's interval (un-deleting) is caught
+    /// — the tombstone flag is bound into the leaf.
+    #[test]
+    fn tampering_tombstone_reopen_is_detected() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = enabled_db(dir.path());
+        let alice = db.create_node("Person", props("Alice")).unwrap();
+        // Delete (no connected edges): creates a tombstone, sealed as tx 2.
+        db.delete_node_with_valid_time(alice, None).unwrap();
+        wait_seq(&db, 2);
+        assert!(db.verify_chain().unwrap().passed);
+
+        // Re-open the tombstone's empty valid interval into an open one.
+        {
+            let mut hist = db.historical.write();
+            let vid = hist.get_current_node_version(alice).unwrap();
+            let mut v = hist.get_node_version(vid).unwrap().clone();
+            let vf = v.temporal.valid_time().start();
+            let tx_from = v.temporal.transaction_time().start();
+            v.temporal = BiTemporalInterval::with_valid_time(vf, tx_from); // open valid
+            hist.insert_restored_node_version(v).unwrap();
+        }
+
+        let v = db.verify_chain().unwrap();
+        assert!(!v.passed, "re-opening a tombstone must be detected");
+        assert!(v.earliest_broken_seq.is_some());
     }
 }

--- a/src/db/chain_source.rs
+++ b/src/db/chain_source.rs
@@ -1,0 +1,100 @@
+//! A [`VersionSource`] over the live historical store (Issue #3351).
+//!
+//! The provenance-chain sealer and verifier both resolve authoritative version
+//! content through this source, so a sealed leaf and a recomputed leaf hash
+//! identical bytes unless the stored version was tampered with. Reading the
+//! *stored* version (including superseded/tombstone versions) is exactly what
+//! makes on-disk tamper detectable: a byte changed in a persisted version
+//! changes the recomputed leaf and breaks the fold at that transaction.
+//!
+//! # Hashing the immutable logical version, not its storage encoding
+//!
+//! Several facets of a stored version are mutated by *later* writes and
+//! therefore cannot be bound into an append-only leaf:
+//! - its transaction-time END, its **valid-time END**, and its `is_current`
+//!   flag are all closed/flipped when a newer version supersedes it (an update
+//!   closes the prior version's open intervals at the successor's start — see
+//!   `close_previous_version_intervals`), and
+//! - its anchor/delta **encoding** changes: AletheiaDB re-encodes a prior
+//!   anchor as a reverse delta when a new version arrives, so the raw
+//!   `VersionData` for a fixed version id is not stable over time.
+//!
+//! So this source hashes the version's **reconstructed full property state**
+//! (stable regardless of anchor/delta re-encoding) plus its immutable identity
+//! and creation coordinates (`valid_from`/`transaction_from`, `prev_version`,
+//! provenance), with the interval **ends** and `is_current` normalized out. The
+//! same normalization runs on the seal and verify paths (both route through
+//! this source), so their leaves match by construction — while a tampered
+//! property value, valid-from/transaction-from, provenance, or identity still
+//! diverges and is caught.
+
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use crate::core::id::VersionId;
+use crate::core::interning::GLOBAL_INTERNER;
+use crate::provenance_chain::{EntityKind, VersionHashInput, VersionSource};
+use crate::storage::historical::HistoricalStorage;
+
+/// A [`VersionSource`] backed by the database's historical storage.
+pub(crate) struct DbVersionSource {
+    historical: Arc<RwLock<HistoricalStorage>>,
+}
+
+impl DbVersionSource {
+    /// Wrap a shared historical store as a version source.
+    pub(crate) fn new(historical: Arc<RwLock<HistoricalStorage>>) -> Self {
+        DbVersionSource { historical }
+    }
+}
+
+impl VersionSource for DbVersionSource {
+    fn fetch(&self, kind: EntityKind, _id: u64, version_id: u64) -> Option<VersionHashInput> {
+        let vid = VersionId::new(version_id).ok()?;
+        let historical = self.historical.read();
+        let mut input = match kind {
+            EntityKind::Node => {
+                let v = historical.get_node_version(vid)?;
+                let mut input = VersionHashInput::from(v);
+                let full = historical.reconstruct_node_properties(vid).ok()?;
+                input.properties = resolve_properties(&full);
+                input
+            }
+            EntityKind::Edge => {
+                let v = historical.get_edge_version(vid)?;
+                let mut input = VersionHashInput::from(v);
+                let full = historical.reconstruct_edge_properties(vid).ok()?;
+                input.properties = resolve_properties(&full);
+                input
+            }
+        };
+        normalize_immutable(&mut input);
+        Some(input)
+    }
+}
+
+/// Resolve an interned-keyed property map into `(String, value)` pairs. Key
+/// ordering is irrelevant — the canonical encoder sorts by key.
+fn resolve_properties(
+    map: &crate::core::property::PropertyMap,
+) -> Vec<(String, crate::core::property::PropertyValue)> {
+    map.iter()
+        .filter_map(|(key, value)| {
+            GLOBAL_INTERNER
+                .resolve_with(*key, |s| s.to_string())
+                .map(|name| (name, value.clone()))
+        })
+        .collect()
+}
+
+/// Normalize the fields a later supersession mutates to their as-written state,
+/// so a version's leaf is stable after sealing. The interval **ends** are
+/// closed and `is_current` flips when a successor version arrives, so all three
+/// are excluded from the bound content; the interval **starts**
+/// (`valid_from`/`transaction_from`), which are fixed at creation, remain bound.
+fn normalize_immutable(input: &mut VersionHashInput) {
+    input.valid_to = None;
+    input.transaction_to = None;
+    input.is_current = true;
+}

--- a/src/db/chain_source.rs
+++ b/src/db/chain_source.rs
@@ -53,17 +53,21 @@ impl VersionSource for DbVersionSource {
     fn fetch(&self, kind: EntityKind, _id: u64, version_id: u64) -> Option<VersionHashInput> {
         let vid = VersionId::new(version_id).ok()?;
         let historical = self.historical.read();
+        // Cold-tier aware (Issue #3351 finding 5): read the version metadata via
+        // the tiered getter so verify does not FALSE-FAIL ("version not found")
+        // once a sealed version has migrated to the Redb cold tier. Property
+        // reconstruction (`reconstruct_*_properties`) is already tier-aware.
         let mut input = match kind {
             EntityKind::Node => {
-                let v = historical.get_node_version(vid)?;
-                let mut input = VersionHashInput::from(v);
+                let v = historical.get_node_version_tiered(vid).ok().flatten()?;
+                let mut input = VersionHashInput::from(v.as_ref());
                 let full = historical.reconstruct_node_properties(vid).ok()?;
                 input.properties = resolve_properties(&full);
                 input
             }
             EntityKind::Edge => {
-                let v = historical.get_edge_version(vid)?;
-                let mut input = VersionHashInput::from(v);
+                let v = historical.get_edge_version_tiered(vid).ok().flatten()?;
+                let mut input = VersionHashInput::from(v.as_ref());
                 let full = historical.reconstruct_edge_properties(vid).ok()?;
                 input.properties = resolve_properties(&full);
                 input
@@ -89,12 +93,47 @@ fn resolve_properties(
 }
 
 /// Normalize the fields a later supersession mutates to their as-written state,
-/// so a version's leaf is stable after sealing. The interval **ends** are
-/// closed and `is_current` flips when a successor version arrives, so all three
-/// are excluded from the bound content; the interval **starts**
-/// (`valid_from`/`transaction_from`), which are fixed at creation, remain bound.
+/// so a version's leaf is stable after sealing.
+///
+/// `transaction_to` and `is_current` are ALWAYS normalized out: a successor
+/// version closes the prior version's open transaction interval and flips
+/// `is_current`, so neither can be bound into an append-only leaf.
+///
+/// The valid-time **end** (`valid_to`) is handled per finding 2c:
+/// - For a *live* version it starts open and is closed by a later supersession
+///   (`close_previous_version_intervals` only closes **open** valid intervals),
+///   so it is mutable and MUST be normalized out — otherwise a legitimately
+///   superseded version would fail verification.
+/// - For a **born-closed terminal** version (a delete tombstone, or a
+///   retraction) the valid end is immutable: it is closed at creation and never
+///   re-closed (an already-closed valid interval fails the
+///   `is_currently_valid()` guard in supersession). Binding it directly makes a
+///   re-validation tamper (extending a retraction's `valid_to`, or re-opening a
+///   tombstone) change the leaf and break verification.
+///
+/// We detect "born-closed / historical closure" as `valid_to <= transaction_from`
+/// (the fact stopped being true at or before it was recorded — a tombstone has
+/// `valid_to == valid_from <= tx_from`, a default retraction has
+/// `valid_to == now == tx_from`) plus the explicit tombstone flag. This is a
+/// stable seal==verify predicate for the common case.
+///
+/// # Known limitation (documented v1)
+///
+/// A *backdated* supersession — two heavily backdated writes to the same entity
+/// where the successor's `valid_start` lands at or before the prior version's
+/// own `transaction_from` — closes the prior (live) version's `valid_to` to a
+/// point `<= tx_from`, which this predicate would then treat as born-closed and
+/// bind, while it was open at seal time. That is a rare false-positive class, not
+/// a missed tamper; the timeline-consistency check does not add false negatives.
 fn normalize_immutable(input: &mut VersionHashInput) {
-    input.valid_to = None;
+    let born_closed = input.is_tombstone
+        || matches!(
+            (input.valid_to, input.transaction_from),
+            (Some(vt), Some(tf)) if vt <= tf
+        );
+    if !born_closed {
+        input.valid_to = None;
+    }
     input.transaction_to = None;
     input.is_current = true;
 }

--- a/src/db/chain_source.rs
+++ b/src/db/chain_source.rs
@@ -51,31 +51,70 @@ impl DbVersionSource {
 
 impl VersionSource for DbVersionSource {
     fn fetch(&self, kind: EntityKind, _id: u64, version_id: u64) -> Option<VersionHashInput> {
-        let vid = VersionId::new(version_id).ok()?;
         let historical = self.historical.read();
-        // Cold-tier aware (Issue #3351 finding 5): read the version metadata via
-        // the tiered getter so verify does not FALSE-FAIL ("version not found")
-        // once a sealed version has migrated to the Redb cold tier. Property
-        // reconstruction (`reconstruct_*_properties`) is already tier-aware.
-        let mut input = match kind {
-            EntityKind::Node => {
-                let v = historical.get_node_version_tiered(vid).ok().flatten()?;
-                let mut input = VersionHashInput::from(v.as_ref());
-                let full = historical.reconstruct_node_properties(vid).ok()?;
-                input.properties = resolve_properties(&full);
-                input
-            }
-            EntityKind::Edge => {
-                let v = historical.get_edge_version_tiered(vid).ok().flatten()?;
-                let mut input = VersionHashInput::from(v.as_ref());
-                let full = historical.reconstruct_edge_properties(vid).ok()?;
-                input.properties = resolve_properties(&full);
-                input
-            }
-        };
-        normalize_immutable(&mut input);
-        Some(input)
+        fetch_locked(&historical, kind, version_id)
     }
+
+    /// Hold the historical **read lock once** for the whole verification pass
+    /// (Issue #3351 task #2). `verify_full`/`verify_entity` route every leaf
+    /// re-fetch through the borrowed [`LockedDbVersionSource`], so the pass
+    /// acquires the lock a single time instead of once per version — turning an
+    /// O(versions) lock churn into O(1).
+    fn scoped(&self, f: &mut dyn FnMut(&dyn VersionSource)) {
+        let historical = self.historical.read();
+        let locked = LockedDbVersionSource {
+            historical: &historical,
+        };
+        f(&locked);
+    }
+}
+
+/// A [`VersionSource`] view over an **already-locked** historical store,
+/// borrowed for the duration of one `scoped` verification pass. Its `fetch`
+/// never re-locks (Issue #3351 task #2).
+struct LockedDbVersionSource<'a> {
+    historical: &'a HistoricalStorage,
+}
+
+impl VersionSource for LockedDbVersionSource<'_> {
+    fn fetch(&self, kind: EntityKind, _id: u64, version_id: u64) -> Option<VersionHashInput> {
+        fetch_locked(self.historical, kind, version_id)
+    }
+    // `scoped` default (call `f(self)`): the read lock is already held.
+}
+
+/// Reconstruct the authoritative, normalized [`VersionHashInput`] for a version
+/// from an already-locked historical store. Shared by the per-call
+/// [`DbVersionSource::fetch`] and the single-lock
+/// [`LockedDbVersionSource::fetch`] so both produce byte-identical leaves.
+fn fetch_locked(
+    historical: &HistoricalStorage,
+    kind: EntityKind,
+    version_id: u64,
+) -> Option<VersionHashInput> {
+    let vid = VersionId::new(version_id).ok()?;
+    // Cold-tier aware (Issue #3351 finding 5): read the version metadata via
+    // the tiered getter so verify does not FALSE-FAIL ("version not found")
+    // once a sealed version has migrated to the Redb cold tier. Property
+    // reconstruction (`reconstruct_*_properties`) is already tier-aware.
+    let mut input = match kind {
+        EntityKind::Node => {
+            let v = historical.get_node_version_tiered(vid).ok().flatten()?;
+            let mut input = VersionHashInput::from(v.as_ref());
+            let full = historical.reconstruct_node_properties(vid).ok()?;
+            input.properties = resolve_properties(&full);
+            input
+        }
+        EntityKind::Edge => {
+            let v = historical.get_edge_version_tiered(vid).ok().flatten()?;
+            let mut input = VersionHashInput::from(v.as_ref());
+            let full = historical.reconstruct_edge_properties(vid).ok()?;
+            input.properties = resolve_properties(&full);
+            input
+        }
+    };
+    normalize_immutable(&mut input);
+    Some(input)
 }
 
 /// Resolve an interned-keyed property map into `(String, value)` pairs. Key

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -355,6 +355,17 @@ impl AletheiaDB {
         let result = (|| {
             let durability_mode = config.wal.durability_mode;
 
+            // Capture provenance-chain settings before `config.wal.wal_dir` is
+            // moved into the WAL system config. The chain lives under the data
+            // dir (the parent of the WAL dir) unless an explicit override is set.
+            let chain_config = config.chain.clone();
+            let chain_data_dir: std::path::PathBuf = config
+                .wal
+                .wal_dir
+                .parent()
+                .map(std::path::Path::to_path_buf)
+                .unwrap_or_else(|| std::path::PathBuf::from("."));
+
             // Create encryption manager if encryption is enabled
             let encryption_manager = if config.encryption.enabled {
                 let manager = crate::encryption::EncryptionManager::from_config(&config.encryption)
@@ -474,6 +485,7 @@ impl AletheiaDB {
                 encryption_manager: encryption_manager.clone(),
                 constraint_registry: Arc::new(crate::core::constraint::ConstraintRegistry::new()),
                 lineage: Arc::new(crate::core::lineage::LineageStore::new()),
+                chain: None,
                 _tempdir: None,
             };
 
@@ -736,6 +748,38 @@ impl AletheiaDB {
 
             seed_startup_current_timestamp(&db)?;
 
+            // Wire the opt-in provenance hash chain (Issue #3351). Constructed
+            // after WAL replay + state restore so the genesis anchors the
+            // post-recovery LSN and the tail rebuild can fold every restored
+            // transaction. Nothing here runs (and no chain dir is created) when
+            // the chain is disabled — the default — preserving byte-identical
+            // behavior.
+            if chain_config.enabled {
+                let source: Arc<dyn crate::provenance_chain::VersionSource + Send + Sync> =
+                    Arc::new(crate::db::chain_source::DbVersionSource::new(Arc::clone(
+                        &db.historical,
+                    )));
+                let genesis_lsn = db.wal.current_lsn().0;
+                let genesis_ts = time::now().wallclock();
+                let chain = crate::provenance_chain::ProvenanceChain::open(
+                    &chain_config,
+                    &chain_data_dir,
+                    genesis_lsn,
+                    genesis_ts,
+                    source,
+                )
+                .map_err(|e| {
+                    crate::core::error::Error::Other(format!(
+                        "provenance hash chain open failed: {e}"
+                    ))
+                })?;
+                // Rebuild the unsealed tail from replayed history, then start the
+                // background sealer for live commits.
+                db.rebuild_chain_tail(&chain);
+                chain.start();
+                db.chain = Some(chain);
+            }
+
             Ok(db)
         })();
         result.record_error_metric()
@@ -803,6 +847,7 @@ impl AletheiaDB {
                 encryption_manager: None,
                 constraint_registry: Arc::new(crate::core::constraint::ConstraintRegistry::new()),
                 lineage: Arc::new(crate::core::lineage::LineageStore::new()),
+                chain: None,
                 _tempdir: None,
             };
             seed_startup_current_timestamp(&db)?;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -21,6 +21,11 @@ use std::time::Instant;
 pub mod admin;
 /// Backup and restore operations.
 pub mod backup;
+/// Provenance hash chain integration: capture, rebuild, and verification API
+/// (Issue #3351).
+pub mod chain;
+/// A `VersionSource` over historical storage for the provenance chain.
+pub(crate) mod chain_source;
 /// Configuration and initialization.
 pub mod config;
 /// Uniqueness constraint builder.
@@ -192,6 +197,14 @@ pub struct AletheiaDB {
     /// in-memory (does not survive restart) to keep the WAL format untouched
     /// (Issue #3413); see [`crate::core::lineage`].
     pub(crate) lineage: Arc<crate::core::lineage::LineageStore>,
+    /// Opt-in tamper-evident provenance hash chain (Issue #3351).
+    ///
+    /// `None` unless `config.chain.enabled`. When present, each committed
+    /// transaction's version refs are enqueued to a background sealer that
+    /// folds them into a domain-separated SHA-256 hash chain over recorded
+    /// history. Declared before `_tempdir` so it is dropped (flushing the
+    /// sealer) before the tempdir is removed.
+    pub(crate) chain: Option<Arc<crate::provenance_chain::ProvenanceChain>>,
     /// Backing tempdir for ephemeral databases created via [`AletheiaDB::new`].
     /// Declared last so it is dropped last (Rust drops struct fields in
     /// declaration order); this guarantees the WAL/persistence file handles
@@ -219,6 +232,13 @@ impl std::fmt::Debug for AletheiaDB {
 
 impl Drop for AletheiaDB {
     fn drop(&mut self) {
+        // Flush and stop the provenance-chain sealer first so its final records
+        // and head checkpoint are durable before storage handles are torn down
+        // (Issue #3351). Idempotent with the chain's own Drop.
+        if let Some(ref chain) = self.chain {
+            chain.shutdown();
+        }
+
         // Signal shutdown to background persistence thread
         if let Some(ref tracker) = self.persistence_tracker {
             tracker.signal_shutdown();

--- a/src/db/stats.rs
+++ b/src/db/stats.rs
@@ -68,6 +68,42 @@ pub struct DatabaseStats {
     pub cold_storage: ColdStorageTierStats,
     /// Write-ahead-log durability state.
     pub wal: WalStateStats,
+    /// Tamper-evident provenance hash chain status (Issue #3351). `enabled:
+    /// false` with all-`None` fields when the chain is not configured.
+    pub chain: ProvenanceChainStats,
+}
+
+/// Status of the opt-in provenance hash chain (Issue #3351).
+///
+/// All fields are O(1) reads of the in-memory chain head (no scans), so this
+/// is safe to include in the frequently-called `stats()` snapshot. When the
+/// chain is disabled every optional field is `None`.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[non_exhaustive]
+pub struct ProvenanceChainStats {
+    /// Whether the provenance hash chain is active on this database.
+    pub enabled: bool,
+    /// Sequence number of the current chain head (`0` = genesis, no sealed
+    /// transactions yet). `None` when disabled.
+    pub head_seq: Option<u64>,
+    /// Lowercase-hex digest of the current chain head. `None` when disabled.
+    pub head_digest: Option<String>,
+    /// Lowercase-hex digest of the genesis seed. `None` when disabled.
+    pub genesis_digest: Option<String>,
+    /// The most recent verification result, if a verify has run this session.
+    pub last_verified: Option<LastVerifiedStats>,
+}
+
+/// Outcome of the most recent chain verification (Issue #3351).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[non_exhaustive]
+pub struct LastVerifiedStats {
+    /// Whether the pass verified cleanly.
+    pub passed: bool,
+    /// Wallclock micros when the pass completed.
+    pub at_micros: i64,
 }
 
 /// Current-state (hot tier) graph size.
@@ -314,6 +350,32 @@ impl AletheiaDB {
             },
         };
 
+        // Provenance hash chain (Issue #3351): O(1) reads of the in-memory head.
+        let chain = match self.chain.as_ref() {
+            Some(chain) => {
+                let head = chain.head();
+                ProvenanceChainStats {
+                    enabled: true,
+                    head_seq: Some(head.seq),
+                    head_digest: Some(crate::provenance_chain::to_hex(&head.digest)),
+                    genesis_digest: Some(crate::provenance_chain::to_hex(
+                        &chain.genesis().genesis_digest,
+                    )),
+                    last_verified: chain.last_verified().map(|lv| LastVerifiedStats {
+                        passed: lv.passed,
+                        at_micros: lv.at_micros,
+                    }),
+                }
+            }
+            None => ProvenanceChainStats {
+                enabled: false,
+                head_seq: None,
+                head_digest: None,
+                genesis_digest: None,
+                last_verified: None,
+            },
+        };
+
         DatabaseStats {
             current: CurrentStateStats {
                 node_count: current_stats.node_count,
@@ -322,6 +384,7 @@ impl AletheiaDB {
             historical,
             cold_storage,
             wal,
+            chain,
         }
     }
 }

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -314,8 +314,12 @@ impl AletheiaDB {
     {
         let mut tx = self.write_transaction().map_err(E::from)?;
         let result = f(&mut tx)?;
+        // Provenance-chain capture (Issue #3351): only when the chain is
+        // enabled; a disabled chain adds nothing beyond this Option check.
+        let chain_capture = self.chain.as_ref().map(|_| self.precapture_chain(&tx));
         record_tx_mutations(self.persistence_tracker.as_ref(), &tx);
-        tx.commit().map_err(E::from)?;
+        let commit_ts = tx.commit_with_timestamp().map_err(E::from)?;
+        self.enqueue_chain_commit(chain_capture, commit_ts);
         Ok(result)
     }
 
@@ -369,8 +373,10 @@ impl AletheiaDB {
     {
         let mut tx = self.write_transaction().map_err(E::from)?;
         let result = f(&mut tx)?;
+        let chain_capture = self.chain.as_ref().map(|_| self.precapture_chain(&tx));
         record_tx_mutations(self.persistence_tracker.as_ref(), &tx);
         let commit_ts = tx.commit_with_timestamp().map_err(E::from)?;
+        self.enqueue_chain_commit(chain_capture, commit_ts);
         Ok((result, commit_ts))
     }
 
@@ -435,8 +441,10 @@ impl AletheiaDB {
             .write_transaction_with_options(options)
             .map_err(E::from)?;
         let result = f(&mut tx)?;
+        let chain_capture = self.chain.as_ref().map(|_| self.precapture_chain(&tx));
         record_tx_mutations(self.persistence_tracker.as_ref(), &tx);
-        tx.commit().map_err(E::from)?;
+        let commit_ts = tx.commit_with_timestamp().map_err(E::from)?;
+        self.enqueue_chain_commit(chain_capture, commit_ts);
         Ok(result)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,9 @@ pub mod db;
 /// Encryption at rest (ADR-0028).
 pub mod encryption;
 pub mod index;
+/// Tamper-evident provenance hash chain (Issue #3351): canonical version
+/// encoder, append-only sidecar store, and offline verification.
+pub mod provenance_chain;
 pub mod query;
 pub mod storage;
 // Semantic search cohort (graduated from "Nova" in 0.1).

--- a/src/mcp/auth.rs
+++ b/src/mcp/auth.rs
@@ -101,6 +101,9 @@ pub(crate) const TOOL_ACCESS_CLASSES: &[(&str, AccessClass)] = &[
     ("lineage_downstream", AccessClass::Read),
     // Signed audit export reads history and signs it — no mutation (Issue #3358).
     ("audit_export", AccessClass::Read),
+    // Provenance hash chain verification / anchor export — read-only (Issue #3351).
+    ("verify_chain", AccessClass::Read),
+    ("export_chain_head", AccessClass::Read),
     // ---- Metrics: operational health/stats.
     ("database_stats", AccessClass::Metrics),
     // ---- Write: graph mutations plus index/constraint state changes.

--- a/src/mcp/auth_tests.rs
+++ b/src/mcp/auth_tests.rs
@@ -829,8 +829,8 @@ fn write_and_metrics_sets_match_hardcoded_snapshot() {
     // Everything else must be Read (no fourth class sneaking in).
     assert_eq!(
         TOOL_ACCESS_CLASSES.len(),
-        actual_write.len() + actual_metrics.len() + 31,
-        "Read tool count changed (expected 31); if a tool was added or \
+        actual_write.len() + actual_metrics.len() + 33,
+        "Read tool count changed (expected 33); if a tool was added or \
          removed, re-verify its classification and update this count"
     );
 }

--- a/src/mcp/error.rs
+++ b/src/mcp/error.rs
@@ -214,6 +214,8 @@ fn classify_db_error(e: &Error) -> (McpErrorCode, bool) {
         Error::Io(_) | Error::Backup(_) => (McpErrorCode::Internal, false),
         // The feature exists but this build/deployment doesn't provide it.
         Error::NotImplemented { .. } => (McpErrorCode::FailedPrecondition, false),
+        // An opt-in feature is disabled (e.g. the provenance hash chain).
+        Error::FailedPrecondition(_) => (McpErrorCode::FailedPrecondition, false),
         Error::Other(_) => (McpErrorCode::Internal, false),
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -4640,6 +4640,114 @@ impl AletheiaMcpServer {
         }
     }
 
+    /// Handle the `verify_chain` tool (Issue #3351): verify the tamper-evident
+    /// provenance hash chain — full, entity-scoped, or against an exported
+    /// anchor. Read-only; when the chain is not enabled the request is a
+    /// structured `FAILED_PRECONDITION` (never a silent empty pass).
+    fn handle_verify_chain(&self, args: serde_json::Value) -> CallToolResult {
+        let args = if args.is_null() {
+            serde_json::Value::Object(serde_json::Map::new())
+        } else {
+            args
+        };
+        let req: VerifyChainRequest = match serde_json::from_value(args) {
+            Ok(r) => r,
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
+        };
+
+        // Precedence: anchor extension > entity-scoped > full.
+        let (verification, scope) = if let Some(anchor_value) = req.against {
+            let anchor: crate::provenance_chain::ChainHead =
+                match serde_json::from_value(anchor_value) {
+                    Ok(a) => a,
+                    Err(e) => {
+                        return self.invalid_argument(&format!(
+                            "`against` is not a valid exported chain head (as returned by \
+                             export_chain_head): {e}"
+                        ));
+                    }
+                };
+            match self.db.verify_chain_against(&anchor) {
+                Ok(v) => (v, "anchor"),
+                Err(e) => return self.chain_not_enabled(e),
+            }
+        } else if req.entity_kind.is_some() || req.id.is_some() {
+            let kind = match req.entity_kind.as_deref() {
+                Some(k) => match k.trim().to_ascii_lowercase().as_str() {
+                    "node" => crate::provenance_chain::EntityKind::Node,
+                    "edge" => crate::provenance_chain::EntityKind::Edge,
+                    other => {
+                        return self.invalid_argument(&format!(
+                            "entity_kind must be 'node' or 'edge', got '{other}'"
+                        ));
+                    }
+                },
+                None => {
+                    return self.invalid_argument("entity_kind is required when `id` is supplied");
+                }
+            };
+            let id = match req.id {
+                Some(id) => id,
+                None => {
+                    return self
+                        .invalid_argument("`id` is required when `entity_kind` is supplied");
+                }
+            };
+            match self.db.verify_entity_chain(kind, id) {
+                Ok(v) => (v, "entity"),
+                Err(e) => return self.chain_not_enabled(e),
+            }
+        } else {
+            match self.db.verify_chain() {
+                Ok(v) => (v, "full"),
+                Err(e) => return self.chain_not_enabled(e),
+            }
+        };
+
+        self.success_json(json!({
+            "scope": scope,
+            "passed": verification.passed,
+            "head_seq": verification.head_seq,
+            "head_digest": verification.head_digest_hex,
+            "earliest_broken_seq": verification.earliest_broken_seq,
+            "reason": verification.reason,
+            "transactions_checked": verification.transactions_checked,
+        }))
+    }
+
+    /// Handle the `export_chain_head` tool (Issue #3351): export the current
+    /// chain head as an external anchor for offline storage and later
+    /// fork/rollback detection via `verify_chain`'s `against` argument.
+    fn handle_export_chain_head(&self, args: serde_json::Value) -> CallToolResult {
+        let args = if args.is_null() {
+            serde_json::Value::Object(serde_json::Map::new())
+        } else {
+            args
+        };
+        let _req: ExportChainHeadRequest = match serde_json::from_value(args) {
+            Ok(r) => r,
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
+        };
+
+        match self.db.export_chain_head() {
+            Ok(head) => match serde_json::to_value(&head) {
+                Ok(value) => self.success_json(value),
+                Err(e) => self.error_result(McpError::new(
+                    McpErrorCode::Internal,
+                    format!("Failed to serialize chain head: {}", e),
+                )),
+            },
+            Err(e) => self.chain_not_enabled(e),
+        }
+    }
+
+    /// Map the "chain not enabled" database error (Issue #3351) to a structured
+    /// `FAILED_PRECONDITION` so a caller learns the chain must be enabled for
+    /// this data dir rather than misreading a bare failure.
+    fn chain_not_enabled(&self, e: crate::core::error::Error) -> CallToolResult {
+        self.failed_precondition(&e.to_string())
+    }
+
     fn handle_hybrid_query(&self, args: serde_json::Value) -> CallToolResult {
         let req: HybridQueryRequest = match serde_json::from_value(args) {
             Ok(r) => r,
@@ -5382,6 +5490,8 @@ impl AletheiaMcpServer {
             "lineage_downstream" => self.handle_lineage_downstream(args),
             "audit_export" => self.handle_audit_export(args),
             "database_stats" => self.handle_database_stats(args),
+            "verify_chain" => self.handle_verify_chain(args),
+            "export_chain_head" => self.handle_export_chain_head(args),
             _ => self.error_result(
                 McpError::new(McpErrorCode::NotFound, format!("Unknown tool: {}", name))
                     .details(json!({ "tool": name })),
@@ -6003,6 +6113,31 @@ fn tool_definitions() -> Vec<Tool> {
              of stored history (earliest/latest timestamps) use temporal_extent; \
              for per-label breakdowns use get_schema.",
             make_input_schema::<DatabaseStatsRequest>(),
+        ),
+        Tool::new(
+            "verify_chain",
+            "Verify the tamper-evident provenance hash chain (Issue #3351) — proof that the \
+             recorded bi-temporal history has not been altered. Three modes: (1) FULL (no \
+             arguments) walks the whole chain from genesis and, on tamper, reports the \
+             `earliest_broken_seq`; (2) ENTITY-SCOPED (pass `entity_kind` 'node'|'edge' and \
+             `id`) recomputes only that entity's contribution; (3) ANCHOR EXTENSION (pass \
+             `against`, a previously exported chain head from export_chain_head) proves the \
+             current chain append-only-extends that anchor, detecting rollback (truncation) \
+             and fork (divergence). Read-only. Returns {scope, passed, head_seq, head_digest, \
+             earliest_broken_seq, reason, transactions_checked}. Requires the chain to be \
+             enabled for this database; if it is not, returns a FAILED_PRECONDITION error \
+             (never a silent empty pass).",
+            make_input_schema::<VerifyChainRequest>(),
+        ),
+        Tool::new(
+            "export_chain_head",
+            "Export the current provenance hash chain head as an external anchor (Issue \
+             #3351). Store the returned checkpoint offsite; later pass it back as \
+             verify_chain's `against` argument to prove the chain has only been appended to \
+             (detecting rollback and fork). No arguments. Returns the chain head {seq, digest, \
+             commit_ts, anchor_lsn, genesis_digest} with digests as lowercase hex. Requires \
+             the chain to be enabled; otherwise returns a FAILED_PRECONDITION error.",
+            make_input_schema::<ExportChainHeadRequest>(),
         ),
     ];
 

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -9271,11 +9271,17 @@ mod structured_error_tests {
                     !message.contains("Unknown tool"),
                     "[{tool}] advertised but not dispatched: {message}"
                 );
-                // Null args can only fail argument deserialization, so the
-                // code must be exactly INVALID_ARGUMENT.
-                assert_eq!(
-                    code, "INVALID_ARGUMENT",
-                    "[{tool}] null args must classify as INVALID_ARGUMENT: {value}"
+                // Null args normalize to the empty request for no-required-arg
+                // tools, so a tool either (a) fails argument deserialization ->
+                // INVALID_ARGUMENT, or (b) deserializes cleanly but hits an
+                // unmet precondition -> FAILED_PRECONDITION (e.g. the Issue
+                // #3351 chain tools when the provenance chain is not enabled on
+                // this server). Both are structured, non-retriable, and
+                // caller-actionable; anything else is a bug.
+                assert!(
+                    code == "INVALID_ARGUMENT" || code == "FAILED_PRECONDITION",
+                    "[{tool}] null args must classify as INVALID_ARGUMENT or \
+                     FAILED_PRECONDITION: {value}"
                 );
             }
         }
@@ -10627,7 +10633,20 @@ mod database_stats_tests {
         let value = stats_response(&server);
         assert_eq!(
             keys(&value),
-            vec!["cold_storage", "current", "historical", "wal"]
+            vec!["chain", "cold_storage", "current", "historical", "wal"]
+        );
+        // Provenance hash chain block (Issue #3351 AC7): present on every
+        // stats response; disabled here, so all optional fields are null but
+        // their keys are always emitted.
+        assert_eq!(
+            keys(&value["chain"]),
+            vec![
+                "enabled",
+                "genesis_digest",
+                "head_digest",
+                "head_seq",
+                "last_verified",
+            ]
         );
         assert_eq!(keys(&value["current"]), vec!["edge_count", "node_count"]);
         assert_eq!(
@@ -15609,5 +15628,169 @@ mod lineage_tool_tests {
                 .and_then(|c| c.as_str()),
             Some("PERMISSION_DENIED")
         );
+    }
+}
+
+// ============================================================================
+// Provenance hash chain tools (Issue #3351): verify_chain, export_chain_head
+// ============================================================================
+
+#[cfg(test)]
+mod provenance_chain_tests {
+    use super::*;
+    use crate::config::WalConfigBuilder;
+    use crate::provenance_chain::{ChainConfig, ChainFsyncMode};
+    use serde_json::json;
+
+    /// Dispatch a tool and return `(parsed_json, is_error)`.
+    fn dispatch(
+        server: &AletheiaMcpServer,
+        tool: &str,
+        args: serde_json::Value,
+    ) -> (serde_json::Value, bool) {
+        let result = server.dispatch_tool(tool, args);
+        let is_error = result.is_error.unwrap_or(false);
+        let text = result
+            .content
+            .first()
+            .and_then(|c| c.as_text().map(|t| t.text.clone()))
+            .expect("tool result must carry text content");
+        (
+            serde_json::from_str(&text).expect("tool response must be valid JSON"),
+            is_error,
+        )
+    }
+
+    /// Build an MCP server over a durable, chain-enabled database rooted at a
+    /// tempdir. Returns the guard so the data dir outlives the server.
+    fn chain_enabled_server() -> (tempfile::TempDir, AletheiaMcpServer) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let config = crate::config::AletheiaDBConfig::builder()
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(dir.path().join("wal"))
+                    .build(),
+            )
+            .chain(ChainConfig {
+                enabled: true,
+                fsync: ChainFsyncMode::Batched,
+                dir: None,
+            })
+            .build();
+        let db = AletheiaDB::with_unified_config(config).expect("chain-enabled db");
+        (dir, AletheiaMcpServer::new(Arc::new(db)))
+    }
+
+    #[test]
+    fn both_tools_are_advertised() {
+        let server = create_test_server();
+        let advertised = server.list_tools_for_test();
+        assert!(advertised.iter().any(|t| t == "verify_chain"));
+        assert!(advertised.iter().any(|t| t == "export_chain_head"));
+    }
+
+    #[test]
+    fn verify_chain_disabled_is_failed_precondition() {
+        // The default test server has no chain enabled.
+        let server = create_test_server();
+        let (value, is_error) = dispatch(&server, "verify_chain", json!({}));
+        assert!(
+            is_error,
+            "verify on a disabled chain must be an error: {value}"
+        );
+        assert_eq!(value["error"]["code"].as_str(), Some("FAILED_PRECONDITION"));
+        assert_eq!(value["error"]["retriable"].as_bool(), Some(false));
+    }
+
+    #[test]
+    fn export_chain_head_disabled_is_failed_precondition() {
+        let server = create_test_server();
+        let (value, is_error) = dispatch(&server, "export_chain_head", json!({}));
+        assert!(
+            is_error,
+            "export on a disabled chain must be an error: {value}"
+        );
+        assert_eq!(value["error"]["code"].as_str(), Some("FAILED_PRECONDITION"));
+    }
+
+    #[test]
+    fn verify_chain_rejects_bad_entity_kind() {
+        let (_guard, server) = chain_enabled_server();
+        let (value, is_error) = dispatch(
+            &server,
+            "verify_chain",
+            json!({"entity_kind": "vertex", "id": 1}),
+        );
+        assert!(is_error, "bad entity_kind must error: {value}");
+        assert_eq!(value["error"]["code"].as_str(), Some("INVALID_ARGUMENT"));
+    }
+
+    #[test]
+    fn verify_chain_rejects_malformed_against_anchor() {
+        let (_guard, server) = chain_enabled_server();
+        let (value, is_error) = dispatch(
+            &server,
+            "verify_chain",
+            json!({"against": {"not": "a head"}}),
+        );
+        assert!(is_error, "malformed anchor must error: {value}");
+        assert_eq!(value["error"]["code"].as_str(), Some("INVALID_ARGUMENT"));
+    }
+
+    #[test]
+    fn full_verify_export_and_anchor_extension_flow() {
+        let (_guard, server) = chain_enabled_server();
+
+        // Seed some writes so the chain seals real transactions.
+        for _ in 0..5 {
+            let (_v, err) = dispatch(
+                &server,
+                "create_node",
+                json!({"label": "Person", "properties": {}}),
+            );
+            assert!(!err);
+        }
+
+        // Full verify must pass.
+        let (full, err) = dispatch(&server, "verify_chain", json!({}));
+        assert!(!err, "full verify must succeed: {full}");
+        assert_eq!(full["passed"].as_bool(), Some(true), "{full}");
+        assert_eq!(full["scope"].as_str(), Some("full"));
+        assert!(full["head_digest"].as_str().is_some());
+
+        // Export the head anchor.
+        let (head, err) = dispatch(&server, "export_chain_head", json!({}));
+        assert!(!err, "export must succeed: {head}");
+        assert!(
+            head["digest"].as_str().is_some(),
+            "head has a hex digest: {head}"
+        );
+
+        // Anchor-extension verify against the exported head must pass.
+        let (against, err) = dispatch(&server, "verify_chain", json!({ "against": head.clone() }));
+        assert!(!err, "anchor verify must succeed: {against}");
+        assert_eq!(against["passed"].as_bool(), Some(true), "{against}");
+        assert_eq!(against["scope"].as_str(), Some("anchor"));
+    }
+
+    #[test]
+    fn entity_scoped_verify_passes_on_a_created_node() {
+        let (_guard, server) = chain_enabled_server();
+        let (created, err) = dispatch(
+            &server,
+            "create_node",
+            json!({"label": "Person", "properties": {}}),
+        );
+        assert!(!err, "create must succeed: {created}");
+        let node_id = created["id"].as_u64().expect("created node id");
+
+        let (scoped, err) = dispatch(
+            &server,
+            "verify_chain",
+            json!({"entity_kind": "node", "id": node_id}),
+        );
+        assert!(!err, "entity verify must succeed: {scoped}");
+        assert_eq!(scoped["passed"].as_bool(), Some(true), "{scoped}");
+        assert_eq!(scoped["scope"].as_str(), Some("entity"));
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1190,6 +1190,56 @@ pub struct TemporalExtentRequest {
 pub struct DatabaseStatsRequest {}
 
 // ============================================================================
+// Provenance hash chain (Issue #3351)
+// ============================================================================
+
+/// Request to verify the tamper-evident provenance hash chain.
+///
+/// Three independent modes, resolved in this precedence order:
+///
+/// 1. **Anchor extension** — pass `against` (a previously exported chain head,
+///    the object `export_chain_head` returns) to prove the current chain is an
+///    append-only extension of that anchor, detecting rollback (truncation)
+///    and fork (divergence).
+/// 2. **Entity-scoped** — pass `entity_kind` (`"node"`/`"edge"`) and `id` to
+///    recompute only that entity's contribution to the chain.
+/// 3. **Full** — pass nothing to walk the whole chain from genesis and
+///    localize the earliest broken sequence number on tamper.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+pub struct VerifyChainRequest {
+    /// Entity kind for an entity-scoped verify: `node` or `edge`.
+    #[serde(default)]
+    #[schemars(
+        description = "For an entity-scoped verify, the entity kind: 'node' or 'edge' \
+                       (requires `id`). Omit for a full-chain verify."
+    )]
+    pub entity_kind: Option<String>,
+
+    /// Entity id for an entity-scoped verify.
+    #[serde(default)]
+    #[schemars(
+        description = "For an entity-scoped verify, the entity id (requires `entity_kind`)."
+    )]
+    pub id: Option<u64>,
+
+    /// A previously exported chain head to verify append-only extension
+    /// against (as returned by `export_chain_head`).
+    #[serde(default)]
+    #[schemars(
+        description = "Optional previously-exported chain head object (as returned by \
+                       export_chain_head) to verify the current chain append-only-extends it, \
+                       detecting rollback (truncation) and fork (divergence)."
+    )]
+    pub against: Option<serde_json::Value>,
+}
+
+/// Request to export the current chain head as an external anchor.
+///
+/// Takes no arguments — the tool always returns the current head checkpoint.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+pub struct ExportChainHeadRequest {}
+
+// ============================================================================
 // Response Types (for serialization)
 // ============================================================================
 

--- a/src/provenance_chain/canonical.rs
+++ b/src/provenance_chain/canonical.rs
@@ -1,0 +1,636 @@
+//! Injective, deterministic, domain-separated SHA-256 canonical encoder for a
+//! version, plus the folding primitives that build a transaction digest and
+//! chain step (Issue #3351).
+//!
+//! # Why a normalized [`VersionHashInput`]
+//!
+//! Both the seal path and the verify path hash the **same** normalized form so a
+//! digest is reproducible from reconstructed history alone. [`From`] conversions
+//! turn a live [`NodeVersion`]/[`EdgeVersion`] into a [`VersionHashInput`], and a
+//! [`VersionSource`](super::verify::VersionSource) reconstructs one at verify
+//! time; the encoder never sees the storage structs directly.
+//!
+//! # Injectivity
+//!
+//! The encoder is designed so that two *distinct logical values* can never
+//! produce identical bytes:
+//! - every value carries a 1-byte **type tag**,
+//! - every variable-length field is **length-prefixed** with a big-endian `u64`,
+//! - `Option`s emit a `0`/`1` presence byte,
+//! - properties are **sorted by key** before encoding so map iteration order does
+//!   not change the digest,
+//! - `Bytes` (tag 5) and `String` (tag 4) differ by tag, so the same underlying
+//!   bytes as a byte string vs. a UTF-8 string hash **differently** (the boundary
+//!   the audit encoder's `Bytes` fallback previously violated — see the sibling
+//!   fix in `src/audit/canonical.rs`).
+
+use crate::core::hex;
+use crate::core::property::PropertyValue;
+use crate::core::version::{EdgeVersion, NodeVersion, VersionData};
+use sha2::{Digest, Sha256};
+
+/// Domain tag for a per-version leaf hash.
+pub const CHAIN_LEAF_DOMAIN: &[u8] = b"aletheiadb.chain.v1.leaf\0";
+/// Domain tag for a per-transaction digest.
+pub const CHAIN_TX_DOMAIN: &[u8] = b"aletheiadb.chain.v1.tx\0";
+/// Domain tag for a chain step (fold of previous digest + tx digest).
+pub const CHAIN_NODE_DOMAIN: &[u8] = b"aletheiadb.chain.v1.node\0";
+/// Domain tag for the genesis digest.
+pub const CHAIN_GENESIS_DOMAIN: &[u8] = b"aletheiadb.chain.v1.genesis\0";
+
+/// Whether a version belongs to a node or an edge. The tag byte is part of the
+/// canonical encoding so a node and an edge that happen to share an id and
+/// content still hash differently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
+)]
+pub enum EntityKind {
+    /// A graph node.
+    Node,
+    /// A graph edge.
+    Edge,
+}
+
+impl EntityKind {
+    /// The 1-byte discriminator used in the canonical encoding and on disk.
+    #[must_use]
+    pub const fn tag(self) -> u8 {
+        match self {
+            EntityKind::Node => 0,
+            EntityKind::Edge => 1,
+        }
+    }
+
+    /// Reconstruct an [`EntityKind`] from its on-disk tag byte.
+    #[must_use]
+    pub const fn from_tag(tag: u8) -> Option<Self> {
+        match tag {
+            0 => Some(EntityKind::Node),
+            1 => Some(EntityKind::Edge),
+            _ => None,
+        }
+    }
+}
+
+/// Normalized, hashable form of a version's write-time provenance bundle.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct ProvenanceHashInput {
+    /// Source system/identifier that produced the write.
+    pub source: Option<String>,
+    /// Writer confidence in `[0.0, 1.0]`.
+    pub confidence: Option<f64>,
+    /// Free-text note.
+    pub note: Option<String>,
+    /// Correlation id grouping writes of one logical operation.
+    pub correlation_id: Option<String>,
+    /// Authenticated principal that made the write.
+    pub principal: Option<String>,
+}
+
+impl From<&crate::core::provenance::Provenance> for ProvenanceHashInput {
+    fn from(p: &crate::core::provenance::Provenance) -> Self {
+        ProvenanceHashInput {
+            source: p.source().map(str::to_owned),
+            confidence: p.confidence(),
+            note: p.note().map(str::to_owned),
+            correlation_id: p.correlation_id().map(str::to_owned),
+            principal: p.principal().map(str::to_owned),
+        }
+    }
+}
+
+/// Normalized, hashable form of a single version.
+///
+/// This is the ONLY structure the canonical encoder reads, so seal-time and
+/// verify-time necessarily hash identical bytes. Timestamps are microseconds
+/// since the Unix epoch; a `None` end means an open (still-current) interval.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VersionHashInput {
+    /// Whether this is a node or edge version.
+    pub entity_kind: EntityKind,
+    /// The owning entity's numeric id.
+    pub entity_id: u64,
+    /// This version's id.
+    pub version_id: u64,
+    /// The previous version's id in the chain, if any.
+    pub prev_version_id: Option<u64>,
+    /// Valid-time start (micros); `None` only for a degenerate open start.
+    pub valid_from: Option<i64>,
+    /// Valid-time end (micros); `None` == open.
+    pub valid_to: Option<i64>,
+    /// Transaction-time start (micros).
+    pub transaction_from: Option<i64>,
+    /// Transaction-time end (micros); `None` == open.
+    pub transaction_to: Option<i64>,
+    /// Whether this version is current in both temporal dimensions.
+    pub is_current: bool,
+    /// Write-time provenance, if any.
+    pub provenance: Option<ProvenanceHashInput>,
+    /// Materialized properties `(key, value)`. Encoding sorts by key, so the
+    /// caller may supply them in any order.
+    pub properties: Vec<(String, PropertyValue)>,
+}
+
+/// Extract `(key, value)` property pairs from a version's [`VersionData`].
+///
+/// For an anchor this is the full property snapshot. For a delta only the
+/// changed (non-removed) properties are available from the version in isolation;
+/// callers that need full-state leaves (the seal path) should reconstruct the
+/// state first and build the [`VersionHashInput`] from that. This helper keeps
+/// the [`From`] conversions total and lossless for anchors.
+fn properties_from_data(data: &VersionData) -> Vec<(String, PropertyValue)> {
+    use crate::core::interning::GLOBAL_INTERNER;
+    let mut out: Vec<(String, PropertyValue)> = Vec::new();
+    match data {
+        VersionData::Anchor { properties, .. } => {
+            for (key, value) in properties.iter() {
+                if let Some(name) = GLOBAL_INTERNER.resolve_with(*key, |s| s.to_string()) {
+                    out.push((name, value.clone()));
+                }
+            }
+        }
+        VersionData::Delta { delta } => {
+            for (key, value) in &delta.changed {
+                if let Some(name) = GLOBAL_INTERNER.resolve_with(*key, |s| s.to_string()) {
+                    out.push((name, value.clone()));
+                }
+            }
+        }
+    }
+    out
+}
+
+impl From<&NodeVersion> for VersionHashInput {
+    fn from(v: &NodeVersion) -> Self {
+        let (vf, vt, tf, tt) = temporal_micros(&v.temporal);
+        VersionHashInput {
+            entity_kind: EntityKind::Node,
+            entity_id: v.node_id.as_u64(),
+            version_id: v.id.as_u64(),
+            prev_version_id: v.prev_version.map(|p| p.as_u64()),
+            valid_from: vf,
+            valid_to: vt,
+            transaction_from: tf,
+            transaction_to: tt,
+            is_current: v.temporal.is_current(),
+            provenance: v.provenance.as_deref().map(ProvenanceHashInput::from),
+            properties: properties_from_data(&v.data),
+        }
+    }
+}
+
+impl From<&EdgeVersion> for VersionHashInput {
+    fn from(v: &EdgeVersion) -> Self {
+        let (vf, vt, tf, tt) = temporal_micros(&v.temporal);
+        VersionHashInput {
+            entity_kind: EntityKind::Edge,
+            entity_id: v.edge_id.as_u64(),
+            version_id: v.id.as_u64(),
+            prev_version_id: v.prev_version.map(|p| p.as_u64()),
+            valid_from: vf,
+            valid_to: vt,
+            transaction_from: tf,
+            transaction_to: tt,
+            is_current: v.temporal.is_current(),
+            provenance: v.provenance.as_deref().map(ProvenanceHashInput::from),
+            properties: properties_from_data(&v.data),
+        }
+    }
+}
+
+/// Decompose a bi-temporal interval into `(valid_from, valid_to, tx_from,
+/// tx_to)` micros, mapping the open-interval sentinel (`TIMESTAMP_MAX`) to
+/// `None`.
+fn temporal_micros(
+    interval: &crate::core::temporal::BiTemporalInterval,
+) -> (Option<i64>, Option<i64>, Option<i64>, Option<i64>) {
+    use crate::core::temporal::TIMESTAMP_MAX;
+    let end_micros = |ts: crate::core::temporal::Timestamp| -> Option<i64> {
+        if ts == TIMESTAMP_MAX {
+            None
+        } else {
+            Some(ts.wallclock())
+        }
+    };
+    let vt = interval.valid_time();
+    let tt = interval.transaction_time();
+    (
+        Some(vt.start().wallclock()),
+        end_micros(vt.end()),
+        Some(tt.start().wallclock()),
+        end_micros(tt.end()),
+    )
+}
+
+/// A tiny append-only canonical byte writer (mirrors `audit::canonical::Canon`).
+#[derive(Default)]
+struct Canon {
+    buf: Vec<u8>,
+}
+
+impl Canon {
+    fn tag(&mut self, t: u8) {
+        self.buf.push(t);
+    }
+    fn u32(&mut self, v: u32) {
+        self.buf.extend_from_slice(&v.to_be_bytes());
+    }
+    fn u64(&mut self, v: u64) {
+        self.buf.extend_from_slice(&v.to_be_bytes());
+    }
+    fn i64(&mut self, v: i64) {
+        self.buf.extend_from_slice(&v.to_be_bytes());
+    }
+    fn f32bits(&mut self, v: f32) {
+        self.buf.extend_from_slice(&v.to_bits().to_be_bytes());
+    }
+    fn f64bits(&mut self, v: f64) {
+        self.buf.extend_from_slice(&v.to_bits().to_be_bytes());
+    }
+    fn bool(&mut self, v: bool) {
+        self.buf.push(u8::from(v));
+    }
+    fn bytes(&mut self, b: &[u8]) {
+        self.u64(b.len() as u64);
+        self.buf.extend_from_slice(b);
+    }
+    fn str(&mut self, s: &str) {
+        self.bytes(s.as_bytes());
+    }
+    fn opt_u64(&mut self, v: Option<u64>) {
+        match v {
+            None => self.buf.push(0),
+            Some(x) => {
+                self.buf.push(1);
+                self.u64(x);
+            }
+        }
+    }
+    fn opt_i64(&mut self, v: Option<i64>) {
+        match v {
+            None => self.buf.push(0),
+            Some(x) => {
+                self.buf.push(1);
+                self.i64(x);
+            }
+        }
+    }
+    fn opt_str(&mut self, v: Option<&str>) {
+        match v {
+            None => self.buf.push(0),
+            Some(s) => {
+                self.buf.push(1);
+                self.str(s);
+            }
+        }
+    }
+    fn opt_f64(&mut self, v: Option<f64>) {
+        match v {
+            None => self.buf.push(0),
+            Some(x) => {
+                self.buf.push(1);
+                self.f64bits(x);
+            }
+        }
+    }
+
+    /// Encode a property value with a per-variant type tag. Every variable-length
+    /// payload is length-prefixed, so the encoding is injective across variants.
+    fn value(&mut self, v: &PropertyValue) {
+        match v {
+            PropertyValue::Null => self.tag(0),
+            PropertyValue::Bool(b) => {
+                self.tag(1);
+                self.bool(*b);
+            }
+            PropertyValue::Int(i) => {
+                self.tag(2);
+                self.i64(*i);
+            }
+            PropertyValue::Float(f) => {
+                self.tag(3);
+                self.f64bits(*f);
+            }
+            PropertyValue::String(s) => {
+                self.tag(4);
+                self.str(s);
+            }
+            PropertyValue::Bytes(b) => {
+                // Distinct tag from String: identical underlying bytes as a byte
+                // string vs. a UTF-8 string hash differently.
+                self.tag(5);
+                self.bytes(b);
+            }
+            PropertyValue::Array(items) => {
+                self.tag(6);
+                self.u64(items.len() as u64);
+                for item in items.iter() {
+                    self.value(item);
+                }
+            }
+            PropertyValue::Vector(vec) => {
+                self.tag(7);
+                self.u64(vec.len() as u64);
+                for f in vec.iter() {
+                    self.f32bits(*f);
+                }
+            }
+            PropertyValue::SparseVector(sparse) => {
+                self.tag(8);
+                self.u64(sparse.dimension() as u64);
+                let indices = sparse.indices();
+                self.u64(indices.len() as u64);
+                for i in indices {
+                    self.u32(*i);
+                }
+                let values = sparse.values();
+                self.u64(values.len() as u64);
+                for f in values {
+                    self.f32bits(*f);
+                }
+            }
+        }
+    }
+
+    fn provenance(&mut self, p: &Option<ProvenanceHashInput>) {
+        match p {
+            None => self.buf.push(0),
+            Some(pr) => {
+                self.buf.push(1);
+                self.opt_str(pr.source.as_deref());
+                self.opt_f64(pr.confidence);
+                self.opt_str(pr.note.as_deref());
+                self.opt_str(pr.correlation_id.as_deref());
+                self.opt_str(pr.principal.as_deref());
+            }
+        }
+    }
+}
+
+/// Deterministic canonical bytes for a version (independent of property order).
+fn version_canonical(input: &VersionHashInput) -> Vec<u8> {
+    let mut c = Canon::default();
+    c.tag(input.entity_kind.tag());
+    c.u64(input.entity_id);
+    c.u64(input.version_id);
+    c.opt_u64(input.prev_version_id);
+    c.opt_i64(input.valid_from);
+    c.opt_i64(input.valid_to);
+    c.opt_i64(input.transaction_from);
+    c.opt_i64(input.transaction_to);
+    c.bool(input.is_current);
+    c.provenance(&input.provenance);
+
+    // Sort properties by key so map iteration order is not signed content.
+    let mut props: Vec<&(String, PropertyValue)> = input.properties.iter().collect();
+    props.sort_by(|a, b| a.0.cmp(&b.0));
+    c.u64(props.len() as u64);
+    for (key, value) in props {
+        c.str(key);
+        c.value(value);
+    }
+    c.buf
+}
+
+/// SHA-256 of `domain || payload`.
+fn hash_domain(domain: &[u8], payload: &[u8]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(domain);
+    h.update(payload);
+    h.finalize().into()
+}
+
+/// The per-version leaf hash: `SHA256(LEAF_DOMAIN || canon(version))`.
+#[must_use]
+pub fn version_leaf(input: &VersionHashInput) -> [u8; 32] {
+    hash_domain(CHAIN_LEAF_DOMAIN, &version_canonical(input))
+}
+
+/// The per-transaction digest, order- and count-dependent over its leaves:
+/// `SHA256(TX_DOMAIN || commit_ts || tx_id || len || leaf_0 || .. || leaf_n)`.
+#[must_use]
+pub fn tx_digest(commit_ts_micros: i64, tx_id: u64, leaves: &[[u8; 32]]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(CHAIN_TX_DOMAIN);
+    h.update(commit_ts_micros.to_be_bytes());
+    h.update(tx_id.to_be_bytes());
+    h.update((leaves.len() as u64).to_be_bytes());
+    for leaf in leaves {
+        h.update(leaf);
+    }
+    h.finalize().into()
+}
+
+/// One chain step: `SHA256(NODE_DOMAIN || prev || tx_digest)`.
+#[must_use]
+pub fn chain_step(prev: &[u8; 32], tx_digest: &[u8; 32]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(CHAIN_NODE_DOMAIN);
+    h.update(prev);
+    h.update(tx_digest);
+    h.finalize().into()
+}
+
+/// The genesis digest seeding a chain: `SHA256(GENESIS_DOMAIN || enable_lsn ||
+/// enable_ts)`.
+#[must_use]
+pub fn genesis_digest(enable_lsn: u64, enable_ts: i64) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(CHAIN_GENESIS_DOMAIN);
+    h.update(enable_lsn.to_be_bytes());
+    h.update(enable_ts.to_be_bytes());
+    h.finalize().into()
+}
+
+/// Lowercase-hex encode a 32-byte digest.
+#[must_use]
+pub fn to_hex(bytes: &[u8; 32]) -> String {
+    hex::encode(bytes)
+}
+
+/// Decode a 64-char lowercase-hex string into a 32-byte digest.
+#[must_use]
+pub fn from_hex_32(s: &str) -> Option<[u8; 32]> {
+    let v = hex::decode(s)?;
+    if v.len() != 32 {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&v);
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn base() -> VersionHashInput {
+        VersionHashInput {
+            entity_kind: EntityKind::Node,
+            entity_id: 1,
+            version_id: 1,
+            prev_version_id: None,
+            valid_from: Some(100),
+            valid_to: None,
+            transaction_from: Some(100),
+            transaction_to: None,
+            is_current: true,
+            provenance: None,
+            properties: vec![("name".to_string(), PropertyValue::string("Alice"))],
+        }
+    }
+
+    #[test]
+    fn distinct_property_values_produce_distinct_leaves() {
+        let a = base();
+        let mut b = base();
+        b.properties = vec![("name".to_string(), PropertyValue::string("Bob"))];
+        assert_ne!(version_leaf(&a), version_leaf(&b));
+    }
+
+    #[test]
+    fn distinct_provenance_produces_distinct_leaves() {
+        let a = base();
+        let mut b = base();
+        b.provenance = Some(ProvenanceHashInput {
+            source: Some("csv".to_string()),
+            ..Default::default()
+        });
+        assert_ne!(version_leaf(&a), version_leaf(&b));
+    }
+
+    #[test]
+    fn distinct_bitemporal_coords_produce_distinct_leaves() {
+        let a = base();
+        let mut b = base();
+        b.valid_to = Some(999); // was open (None)
+        assert_ne!(version_leaf(&a), version_leaf(&b));
+
+        let mut c = base();
+        c.transaction_from = Some(101);
+        assert_ne!(version_leaf(&a), version_leaf(&c));
+    }
+
+    #[test]
+    fn property_order_independence() {
+        let mut a = base();
+        a.properties = vec![
+            ("name".to_string(), PropertyValue::string("Alice")),
+            ("age".to_string(), PropertyValue::Int(30)),
+            ("city".to_string(), PropertyValue::string("NYC")),
+        ];
+        let mut b = base();
+        b.properties = vec![
+            ("city".to_string(), PropertyValue::string("NYC")),
+            ("name".to_string(), PropertyValue::string("Alice")),
+            ("age".to_string(), PropertyValue::Int(30)),
+        ];
+        assert_eq!(
+            version_leaf(&a),
+            version_leaf(&b),
+            "reordering the same property map must not change the leaf"
+        );
+    }
+
+    #[test]
+    fn bytes_and_string_with_same_underlying_bytes_differ() {
+        // The exact boundary the audit Bytes fallback violated: a byte string and
+        // a UTF-8 string over identical bytes must hash differently.
+        let mut a = base();
+        a.properties = vec![(
+            "x".to_string(),
+            PropertyValue::Bytes(Arc::from(&b"hello"[..])),
+        )];
+        let mut b = base();
+        b.properties = vec![("x".to_string(), PropertyValue::string("hello"))];
+        assert_ne!(version_leaf(&a), version_leaf(&b));
+    }
+
+    #[test]
+    fn tx_digest_is_order_and_count_dependent() {
+        let l1 = version_leaf(&base());
+        let mut other = base();
+        other.version_id = 2;
+        let l2 = version_leaf(&other);
+
+        let d_12 = tx_digest(500, 7, &[l1, l2]);
+        let d_21 = tx_digest(500, 7, &[l2, l1]);
+        let d_1 = tx_digest(500, 7, &[l1]);
+        assert_ne!(d_12, d_21, "leaf order must matter");
+        assert_ne!(d_12, d_1, "leaf count must matter");
+
+        // commit_ts and tx_id are bound into the digest.
+        assert_ne!(d_12, tx_digest(501, 7, &[l1, l2]));
+        assert_ne!(d_12, tx_digest(500, 8, &[l1, l2]));
+    }
+
+    #[test]
+    fn genesis_digest_is_deterministic_and_input_sensitive() {
+        assert_eq!(genesis_digest(10, 1000), genesis_digest(10, 1000));
+        assert_ne!(genesis_digest(10, 1000), genesis_digest(11, 1000));
+        assert_ne!(genesis_digest(10, 1000), genesis_digest(10, 1001));
+    }
+
+    #[test]
+    fn hex_round_trip() {
+        let d = version_leaf(&base());
+        let s = to_hex(&d);
+        assert_eq!(s.len(), 64);
+        assert_eq!(from_hex_32(&s), Some(d));
+        assert_eq!(from_hex_32("nothex"), None);
+        assert_eq!(from_hex_32("ab"), None); // too short
+    }
+
+    #[test]
+    fn entity_kind_tag_round_trip() {
+        assert_eq!(
+            EntityKind::from_tag(EntityKind::Node.tag()),
+            Some(EntityKind::Node)
+        );
+        assert_eq!(
+            EntityKind::from_tag(EntityKind::Edge.tag()),
+            Some(EntityKind::Edge)
+        );
+        assert_eq!(EntityKind::from_tag(9), None);
+    }
+
+    #[test]
+    fn node_and_edge_with_same_ids_hash_differently() {
+        let mut node = base();
+        node.entity_kind = EntityKind::Node;
+        let mut edge = base();
+        edge.entity_kind = EntityKind::Edge;
+        assert_ne!(version_leaf(&node), version_leaf(&edge));
+    }
+
+    #[test]
+    fn from_node_version_hashes() {
+        use crate::core::id::{NodeId, VersionId};
+        use crate::core::interning::GLOBAL_INTERNER;
+        use crate::core::property::PropertyMapBuilder;
+        use crate::core::temporal::BiTemporalInterval;
+
+        let props = PropertyMapBuilder::new().insert("name", "Alice").build();
+        let temporal = BiTemporalInterval::current(1000.into());
+        let v = NodeVersion::new_anchor(
+            VersionId::new(1).unwrap(),
+            NodeId::new(10).unwrap(),
+            temporal,
+            GLOBAL_INTERNER.intern("Person").unwrap(),
+            props,
+        );
+        let input = VersionHashInput::from(&v);
+        assert_eq!(input.entity_kind, EntityKind::Node);
+        assert_eq!(input.entity_id, 10);
+        assert_eq!(input.properties.len(), 1);
+        // Leaf is stable across repeated conversions.
+        assert_eq!(
+            version_leaf(&input),
+            version_leaf(&VersionHashInput::from(&v))
+        );
+    }
+}

--- a/src/provenance_chain/canonical.rs
+++ b/src/provenance_chain/canonical.rs
@@ -117,16 +117,42 @@ pub struct VersionHashInput {
     pub version_id: u64,
     /// The previous version's id in the chain, if any.
     pub prev_version_id: Option<u64>,
+    /// The entity's label at this version (node label / edge type), resolved to
+    /// a string. Bound into the leaf so a relabel is tamper-evident (Issue
+    /// #3351: leaf previously omitted the label).
+    pub label: String,
+    /// For an edge, the source node id; `None` for a node. Bound so an edge
+    /// endpoint rewire is tamper-evident (Issue #3351).
+    pub source: Option<u64>,
+    /// For an edge, the target node id; `None` for a node. Bound so an edge
+    /// endpoint rewire is tamper-evident (Issue #3351).
+    pub target: Option<u64>,
     /// Valid-time start (micros); `None` only for a degenerate open start.
     pub valid_from: Option<i64>,
     /// Valid-time end (micros); `None` == open.
+    ///
+    /// A *live* version's valid end is closed by a later supersession, so it is
+    /// normalized out of the leaf (see `db::chain_source::normalize_immutable`).
+    /// A **born-closed terminal** version (delete tombstone or retraction) has an
+    /// immutable valid end (never re-closed by supersession because
+    /// `close_previous_version_intervals` only closes *open* valid intervals), so
+    /// for those it is retained and bound — closing the un-retract / re-validate
+    /// tamper hole (Issue #3351 finding 2).
     pub valid_to: Option<i64>,
     /// Transaction-time start (micros).
     pub transaction_from: Option<i64>,
-    /// Transaction-time end (micros); `None` == open.
+    /// Transaction-time end (micros); `None` == open. Always normalized out of
+    /// the leaf (a supersession closes it), retained here only for structural
+    /// consistency checks.
     pub transaction_to: Option<i64>,
-    /// Whether this version is current in both temporal dimensions.
+    /// Whether this version is current in both temporal dimensions. Normalized
+    /// out of the leaf (flips on supersession).
     pub is_current: bool,
+    /// Whether this version is a delete tombstone (its valid-time interval is
+    /// empty — `start == end`). Immutable after creation and bound into the leaf
+    /// so an un-delete (re-opening the tombstone interval) is tamper-evident
+    /// (Issue #3351 finding 2).
+    pub is_tombstone: bool,
     /// Write-time provenance, if any.
     pub provenance: Option<ProvenanceHashInput>,
     /// Materialized properties `(key, value)`. Encoding sorts by key, so the
@@ -163,6 +189,24 @@ fn properties_from_data(data: &VersionData) -> Vec<(String, PropertyValue)> {
     out
 }
 
+/// Resolve an [`InternedString`](crate::core::interning::InternedString) label to
+/// an owned string, defaulting to empty when the intern table cannot resolve it
+/// (a resolvable label always round-trips; the empty default keeps the leaf total).
+fn resolve_label(label: crate::core::interning::InternedString) -> String {
+    use crate::core::interning::GLOBAL_INTERNER;
+    GLOBAL_INTERNER
+        .resolve_with(label, |s| s.to_string())
+        .unwrap_or_default()
+}
+
+/// Whether a bi-temporal interval's valid-time dimension is empty
+/// (`start == end`), which is exactly how a delete tombstone is encoded (see
+/// `apply::create_temporal_interval` / `HistoricalStorage::add_node_version`).
+fn is_tombstone_interval(interval: &crate::core::temporal::BiTemporalInterval) -> bool {
+    let vt = interval.valid_time();
+    vt.start() == vt.end()
+}
+
 impl From<&NodeVersion> for VersionHashInput {
     fn from(v: &NodeVersion) -> Self {
         let (vf, vt, tf, tt) = temporal_micros(&v.temporal);
@@ -171,11 +215,15 @@ impl From<&NodeVersion> for VersionHashInput {
             entity_id: v.node_id.as_u64(),
             version_id: v.id.as_u64(),
             prev_version_id: v.prev_version.map(|p| p.as_u64()),
+            label: resolve_label(v.label),
+            source: None,
+            target: None,
             valid_from: vf,
             valid_to: vt,
             transaction_from: tf,
             transaction_to: tt,
             is_current: v.temporal.is_current(),
+            is_tombstone: is_tombstone_interval(&v.temporal),
             provenance: v.provenance.as_deref().map(ProvenanceHashInput::from),
             properties: properties_from_data(&v.data),
         }
@@ -190,11 +238,15 @@ impl From<&EdgeVersion> for VersionHashInput {
             entity_id: v.edge_id.as_u64(),
             version_id: v.id.as_u64(),
             prev_version_id: v.prev_version.map(|p| p.as_u64()),
+            label: resolve_label(v.label),
+            source: Some(v.source.as_u64()),
+            target: Some(v.target.as_u64()),
             valid_from: vf,
             valid_to: vt,
             transaction_from: tf,
             transaction_to: tt,
             is_current: v.temporal.is_current(),
+            is_tombstone: is_tombstone_interval(&v.temporal),
             provenance: v.provenance.as_deref().map(ProvenanceHashInput::from),
             properties: properties_from_data(&v.data),
         }
@@ -377,11 +429,22 @@ fn version_canonical(input: &VersionHashInput) -> Vec<u8> {
     c.u64(input.entity_id);
     c.u64(input.version_id);
     c.opt_u64(input.prev_version_id);
+    // Label (length-prefixed str) — binds node label / edge type so a relabel
+    // changes the leaf (Issue #3351 finding 1).
+    c.str(&input.label);
+    // Edge endpoints (presence-gated u64) — bind source/target so an endpoint
+    // rewire changes the leaf; a node emits two `0` presence bytes (Issue #3351
+    // finding 1).
+    c.opt_u64(input.source);
+    c.opt_u64(input.target);
     c.opt_i64(input.valid_from);
     c.opt_i64(input.valid_to);
     c.opt_i64(input.transaction_from);
     c.opt_i64(input.transaction_to);
     c.bool(input.is_current);
+    // Tombstone discriminator — binds the delete flag so re-opening a tombstone
+    // interval (un-delete) changes the leaf (Issue #3351 finding 2).
+    c.bool(input.is_tombstone);
     c.provenance(&input.provenance);
 
     // Sort properties by key so map iteration order is not signed content.
@@ -410,13 +473,27 @@ pub fn version_leaf(input: &VersionHashInput) -> [u8; 32] {
 }
 
 /// The per-transaction digest, order- and count-dependent over its leaves:
-/// `SHA256(TX_DOMAIN || commit_ts || tx_id || len || leaf_0 || .. || leaf_n)`.
+/// `SHA256(TX_DOMAIN || commit_ts_micros || commit_ts_logical || len || leaf_0
+/// || .. || leaf_n)`.
+///
+/// # Determinism across live-seal and post-crash rebuild (Issue #3351 finding 4)
+///
+/// The digest binds the **full HLC commit timestamp** (`commit_ts_micros` *and*
+/// the logical counter), NOT the transaction id. The transaction id survives as
+/// record metadata only. This is deliberate:
+/// - the live seal path knows the real `tx_id`, but a post-crash rebuild folds
+///   from replayed history where the original `tx_id` is not recoverable — so
+///   binding `tx_id` made a rebuilt chain diverge from a pre-crash anchor;
+/// - the commit timestamp plus the (sorted) leaves uniquely identify a
+///   committed transaction, and the logical counter keeps two commits that
+///   share a wallclock microsecond distinct in *both* the live and rebuild
+///   paths.
 #[must_use]
-pub fn tx_digest(commit_ts_micros: i64, tx_id: u64, leaves: &[[u8; 32]]) -> [u8; 32] {
+pub fn tx_digest(commit_ts_micros: i64, commit_ts_logical: u32, leaves: &[[u8; 32]]) -> [u8; 32] {
     let mut h = Sha256::new();
     h.update(CHAIN_TX_DOMAIN);
     h.update(commit_ts_micros.to_be_bytes());
-    h.update(tx_id.to_be_bytes());
+    h.update(commit_ts_logical.to_be_bytes());
     h.update((leaves.len() as u64).to_be_bytes());
     for leaf in leaves {
         h.update(leaf);
@@ -474,14 +551,60 @@ mod tests {
             entity_id: 1,
             version_id: 1,
             prev_version_id: None,
+            label: "Person".to_string(),
+            source: None,
+            target: None,
             valid_from: Some(100),
             valid_to: None,
             transaction_from: Some(100),
             transaction_to: None,
             is_current: true,
+            is_tombstone: false,
             provenance: None,
             properties: vec![("name".to_string(), PropertyValue::string("Alice"))],
         }
+    }
+
+    #[test]
+    fn distinct_label_produces_distinct_leaves() {
+        let a = base();
+        let mut b = base();
+        b.label = "Company".to_string();
+        assert_ne!(
+            version_leaf(&a),
+            version_leaf(&b),
+            "a relabel must change the leaf (Issue #3351 finding 1)"
+        );
+    }
+
+    #[test]
+    fn distinct_edge_endpoints_produce_distinct_leaves() {
+        let mut a = base();
+        a.entity_kind = EntityKind::Edge;
+        a.source = Some(10);
+        a.target = Some(20);
+        let mut b = a.clone();
+        b.target = Some(99); // rewire target
+        assert_ne!(
+            version_leaf(&a),
+            version_leaf(&b),
+            "an edge endpoint rewire must change the leaf (Issue #3351 finding 1)"
+        );
+        let mut c = a.clone();
+        c.source = Some(99); // rewire source
+        assert_ne!(version_leaf(&a), version_leaf(&c));
+    }
+
+    #[test]
+    fn tombstone_flag_produces_distinct_leaves() {
+        let a = base();
+        let mut b = base();
+        b.is_tombstone = true;
+        assert_ne!(
+            version_leaf(&a),
+            version_leaf(&b),
+            "the tombstone flag must change the leaf (Issue #3351 finding 2)"
+        );
     }
 
     #[test]
@@ -563,7 +686,8 @@ mod tests {
         assert_ne!(d_12, d_21, "leaf order must matter");
         assert_ne!(d_12, d_1, "leaf count must matter");
 
-        // commit_ts and tx_id are bound into the digest.
+        // The full HLC commit timestamp (wallclock micros AND logical counter)
+        // is bound into the digest; the tx id is not (Issue #3351 finding 4).
         assert_ne!(d_12, tx_digest(501, 7, &[l1, l2]));
         assert_ne!(d_12, tx_digest(500, 8, &[l1, l2]));
     }

--- a/src/provenance_chain/config.rs
+++ b/src/provenance_chain/config.rs
@@ -1,0 +1,100 @@
+//! Configuration for the opt-in provenance hash chain (Issue #3351).
+//!
+//! Mirrors the shape of the other unified-config structs: `#[derive(Default)]`
+//! with the feature **disabled** by default so enabling the chain is an explicit
+//! opt-in and a disabled database keeps byte-identical behavior.
+
+use std::path::PathBuf;
+
+/// When the sidecar chain log is flushed to durable storage.
+///
+/// The default (`Batched`) keeps hashing/fsync off the commit critical path;
+/// `PerTransaction` fsyncs every appended transaction record for the strongest
+/// durability, and `Never` leaves flushing to the OS (fastest, weakest).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
+)]
+pub enum ChainFsyncMode {
+    /// fsync after every appended transaction record.
+    PerTransaction,
+    /// Do not fsync per append; rely on an explicit `flush()` / OS writeback.
+    #[default]
+    Batched,
+    /// Never fsync from the store; durability is entirely the OS's decision.
+    Never,
+}
+
+/// Opt-in configuration for the tamper-evident provenance hash chain.
+///
+/// Disabled by default. When `enabled` is `false`, no chain directory is touched
+/// and no hashing work is performed, so behavior and on-disk formats are
+/// byte-identical to a build without the feature.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(default)
+)]
+pub struct ChainConfig {
+    /// Whether the provenance hash chain is active.
+    pub enabled: bool,
+    /// Flush policy for the sidecar log.
+    pub fsync: ChainFsyncMode,
+    /// Override for the chain directory. When `None`, the default
+    /// `<data_dir>/chain` is used.
+    pub dir: Option<PathBuf>,
+}
+
+impl ChainConfig {
+    /// Construct an enabled config with the default flush policy and directory.
+    #[must_use]
+    pub fn enabled() -> Self {
+        ChainConfig {
+            enabled: true,
+            ..Default::default()
+        }
+    }
+
+    /// Resolve the chain directory against a data directory: the explicit `dir`
+    /// override if set, otherwise `<data_dir>/chain`.
+    #[must_use]
+    pub fn resolve_dir(&self, data_dir: &std::path::Path) -> PathBuf {
+        self.dir.clone().unwrap_or_else(|| data_dir.join("chain"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_disabled_and_batched() {
+        let c = ChainConfig::default();
+        assert!(!c.enabled);
+        assert_eq!(c.fsync, ChainFsyncMode::Batched);
+        assert!(c.dir.is_none());
+    }
+
+    #[test]
+    fn resolve_dir_defaults_under_data_dir() {
+        let c = ChainConfig::default();
+        let resolved = c.resolve_dir(std::path::Path::new("/data"));
+        assert_eq!(resolved, PathBuf::from("/data/chain"));
+    }
+
+    #[test]
+    fn resolve_dir_honors_override() {
+        let c = ChainConfig {
+            enabled: true,
+            fsync: ChainFsyncMode::PerTransaction,
+            dir: Some(PathBuf::from("/custom/place")),
+        };
+        assert_eq!(
+            c.resolve_dir(std::path::Path::new("/data")),
+            PathBuf::from("/custom/place")
+        );
+    }
+}

--- a/src/provenance_chain/engine.rs
+++ b/src/provenance_chain/engine.rs
@@ -1,0 +1,490 @@
+//! Runtime engine wiring the provenance hash chain into a live database
+//! (Issue #3351).
+//!
+//! The [`ProvenanceChain`] owns the [`ChainStore`], an in-memory head and
+//! running [`EntityIndex`], and a background **sealer** thread. The hot write
+//! path only *enqueues* the version refs a committed transaction produced; the
+//! sealer reads their authoritative content back from historical storage (via a
+//! [`VersionSource`]), folds the per-transaction digest onto the running head,
+//! and appends a [`ChainTxRecord`]. Because the seal path and the verify path
+//! read the SAME [`VersionSource`], a sealed leaf always reproduces exactly
+//! unless the stored version content was tampered with.
+//!
+//! # Ordering
+//!
+//! The sealer keeps a small reorder buffer keyed by `(commit_ts, tx_id)` so
+//! records are appended in commit order even when two racing writers enqueue out
+//! of order. Correctness never depends on the channel capacity: an enqueue that
+//! finds the channel full seals **inline** (drop-to-sync-seal) rather than
+//! blocking or dropping the transaction, so every committed transaction is
+//! always sealed exactly once.
+//!
+//! # Recovery
+//!
+//! The sealed prefix lives in the append-only log; the unsealed tail is always
+//! re-derivable from durable history. After WAL replay the caller folds any
+//! transactions whose commit timestamp is beyond the loaded head back into the
+//! chain via [`ProvenanceChain::seal_pending_sync`] before starting the sealer.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, SyncSender, TrySendError, sync_channel};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+
+use super::canonical::{EntityKind, chain_step, tx_digest, version_leaf};
+use super::config::{ChainConfig, ChainFsyncMode};
+use super::error::{ChainError, ChainResult};
+use super::record::{ChainHead, ChainTxRecord};
+use super::store::ChainStore;
+use super::verify::{
+    ChainVerification, EntityIndex, VersionSource, verify_against_anchor, verify_entity,
+    verify_full,
+};
+
+/// Bounded capacity of the hot-path -> sealer channel. Chosen generously; when
+/// it fills the enqueue path seals inline, so this only trades a little memory
+/// for a lower inline-seal rate under bursty load. Correctness is independent of
+/// this value.
+const SEAL_CHANNEL_CAPACITY: usize = 4096;
+
+/// A committed transaction handed from the hot path to the sealer.
+///
+/// Carries only the version refs the transaction produced (not their content):
+/// the sealer resolves authoritative content from the [`VersionSource`], so a
+/// leaf is always recomputed from stored history, never from a possibly-stale
+/// in-flight buffer.
+#[derive(Debug, Clone)]
+pub struct PendingTx {
+    /// Commit timestamp (micros since epoch) — the grouping and ordering key.
+    pub commit_ts_micros: i64,
+    /// The committing transaction's id.
+    pub tx_id: u64,
+    /// WAL LSN this transaction is anchored at.
+    pub anchor_lsn: u64,
+    /// `(kind, entity_id, version_id)` for each version the transaction wrote.
+    pub entity_refs: Vec<(EntityKind, u64, u64)>,
+}
+
+/// The result of the most recent verification pass, cached for O(1) stats.
+#[derive(Debug, Clone, Copy)]
+pub struct LastVerified {
+    /// Whether the pass verified cleanly.
+    pub passed: bool,
+    /// Wallclock micros when the pass completed.
+    pub at_micros: i64,
+}
+
+/// Messages sent to the background sealer thread.
+enum SealMsg {
+    Seal(PendingTx),
+    Stop,
+}
+
+/// Shared sealing state: the append-only store, the version source, and the
+/// mutable in-memory chain (records + head + running index). Cloned as an
+/// `Arc` into the sealer thread and shared with the owning [`ProvenanceChain`].
+struct Sealer {
+    store: Arc<ChainStore>,
+    source: Arc<dyn VersionSource + Send + Sync>,
+    genesis: ChainHead,
+    inner: Mutex<ChainInner>,
+}
+
+/// The mutable in-memory chain state, guarded by a single mutex.
+struct ChainInner {
+    records: Vec<ChainTxRecord>,
+    head: ChainHead,
+    index: EntityIndex,
+}
+
+impl Sealer {
+    /// Seal one transaction: recompute its leaves from the source, fold onto the
+    /// running head, append the record, and advance the head + entity index.
+    ///
+    /// A transaction whose versions cannot be resolved at all (every ref missing
+    /// from the source) produces no record — there is nothing to bind.
+    fn seal_one(&self, pending: PendingTx) -> ChainResult<()> {
+        // Deterministic leaf order, independent of enqueue/buffer order.
+        let mut refs = pending.entity_refs;
+        refs.sort_by(|a, b| (a.0.tag(), a.1, a.2).cmp(&(b.0.tag(), b.1, b.2)));
+
+        let mut kept_refs: Vec<(EntityKind, u64, u64)> = Vec::with_capacity(refs.len());
+        let mut leaves: Vec<[u8; 32]> = Vec::with_capacity(refs.len());
+        for (kind, id, vid) in refs {
+            if let Some(input) = self.source.fetch(kind, id, vid) {
+                leaves.push(version_leaf(&input));
+                kept_refs.push((kind, id, vid));
+            }
+        }
+        if leaves.is_empty() {
+            return Ok(());
+        }
+
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|_| ChainError::Io("provenance chain inner lock poisoned".into()))?;
+
+        let seq = inner.head.seq + 1;
+        let prev = inner.head.digest;
+        let txd = tx_digest(pending.commit_ts_micros, pending.tx_id, &leaves);
+        let digest = chain_step(&prev, &txd);
+        let record = ChainTxRecord {
+            seq,
+            commit_ts: pending.commit_ts_micros,
+            tx_id: pending.tx_id,
+            anchor_lsn: pending.anchor_lsn,
+            leaves,
+            entity_refs: kept_refs,
+            digest,
+        };
+
+        self.store.append(&record)?;
+
+        let record_idx = inner.records.len();
+        inner.index.push_record(record_idx, &record);
+        inner.head = ChainHead {
+            seq,
+            digest,
+            commit_ts: pending.commit_ts_micros,
+            anchor_lsn: pending.anchor_lsn,
+            genesis_digest: self.genesis.genesis_digest,
+        };
+        inner.records.push(record);
+        Ok(())
+    }
+
+    /// Persist the current head as an atomic checkpoint (carries the genesis
+    /// digest, enabling a fast, genesis-stable reopen).
+    fn checkpoint(&self) -> ChainResult<()> {
+        let head = {
+            let inner = self
+                .inner
+                .lock()
+                .map_err(|_| ChainError::Io("provenance chain inner lock poisoned".into()))?;
+            inner.head.clone()
+        };
+        self.store.write_head_checkpoint(&head)
+    }
+}
+
+/// The database-facing runtime handle for the provenance hash chain.
+pub struct ProvenanceChain {
+    sealer: Arc<Sealer>,
+    genesis: ChainHead,
+    sender: SyncSender<SealMsg>,
+    /// Receiver held until [`start`](Self::start) spawns the sealer thread.
+    pending_rx: Mutex<Option<Receiver<SealMsg>>>,
+    /// Set once the chain has been shut down; further enqueues seal inline.
+    stopped: AtomicBool,
+    handle: Mutex<Option<JoinHandle<()>>>,
+    last_verified: Mutex<Option<LastVerified>>,
+    fsync: ChainFsyncMode,
+}
+
+impl ProvenanceChain {
+    /// Open (or create) the chain under `data_dir`, loading any persisted
+    /// records and head checkpoint. The sealer thread is NOT started yet — the
+    /// caller rebuilds the unsealed tail (via [`seal_pending_sync`]) and then
+    /// calls [`start`].
+    ///
+    /// `genesis_lsn`/`genesis_ts_micros` seed a fresh genesis and are used ONLY
+    /// when the store has no prior head checkpoint; an existing chain preserves
+    /// its original genesis digest across restarts.
+    ///
+    /// [`seal_pending_sync`]: Self::seal_pending_sync
+    /// [`start`]: Self::start
+    pub fn open(
+        config: &ChainConfig,
+        data_dir: &Path,
+        genesis_lsn: u64,
+        genesis_ts_micros: i64,
+        source: Arc<dyn VersionSource + Send + Sync>,
+    ) -> ChainResult<Arc<Self>> {
+        let dir = config.resolve_dir(data_dir);
+        let store = Arc::new(ChainStore::open(&dir, config.fsync)?);
+        let records = store.load()?;
+
+        // Reconstruct the genesis. An existing head checkpoint carries the
+        // original genesis digest, so the genesis stays stable across restarts;
+        // a fresh store gets a genesis seeded from (lsn, ts) and persisted
+        // synchronously so a crash before the first periodic checkpoint still
+        // reopens against the same genesis.
+        let genesis = match store.read_head_checkpoint()? {
+            Some(cp) => ChainHead {
+                seq: 0,
+                digest: cp.genesis_digest,
+                commit_ts: genesis_ts_micros,
+                anchor_lsn: genesis_lsn,
+                genesis_digest: cp.genesis_digest,
+            },
+            None => {
+                let g = ChainHead::genesis(genesis_lsn, genesis_ts_micros);
+                store.write_head_checkpoint(&g)?;
+                g
+            }
+        };
+
+        // The append-only log is the source of truth for the sealed prefix; the
+        // in-memory head is the last logged record (or genesis when empty).
+        let head = records
+            .last()
+            .map(|r| ChainHead {
+                seq: r.seq,
+                digest: r.digest,
+                commit_ts: r.commit_ts,
+                anchor_lsn: r.anchor_lsn,
+                genesis_digest: genesis.genesis_digest,
+            })
+            .unwrap_or_else(|| genesis.clone());
+        let index = EntityIndex::build(&records);
+
+        let sealer = Arc::new(Sealer {
+            store,
+            source,
+            genesis: genesis.clone(),
+            inner: Mutex::new(ChainInner {
+                records,
+                head,
+                index,
+            }),
+        });
+
+        let (sender, rx) = sync_channel(SEAL_CHANNEL_CAPACITY);
+        Ok(Arc::new(ProvenanceChain {
+            sealer,
+            genesis,
+            sender,
+            pending_rx: Mutex::new(Some(rx)),
+            stopped: AtomicBool::new(false),
+            handle: Mutex::new(None),
+            last_verified: Mutex::new(None),
+            fsync: config.fsync,
+        }))
+    }
+
+    /// Spawn the background sealer thread. Idempotent: a second call is a no-op.
+    pub fn start(self: &Arc<Self>) {
+        let Some(rx) = self
+            .pending_rx
+            .lock()
+            .ok()
+            .and_then(|mut guard| guard.take())
+        else {
+            return;
+        };
+        let sealer = Arc::clone(&self.sealer);
+        let handle = std::thread::Builder::new()
+            .name("aletheia-provenance-sealer".into())
+            .spawn(move || run_sealer(sealer, rx))
+            .expect("failed to spawn provenance sealer thread");
+        if let Ok(mut guard) = self.handle.lock() {
+            *guard = Some(handle);
+        }
+    }
+
+    /// Enqueue a committed transaction for sealing. Non-blocking: when the
+    /// channel is full (or the sealer has stopped) the transaction is sealed
+    /// inline so it is never lost.
+    pub fn enqueue_commit(&self, pending: PendingTx) {
+        if self.stopped.load(Ordering::Acquire) {
+            let _ = self.sealer.seal_one(pending);
+            return;
+        }
+        match self.sender.try_send(SealMsg::Seal(pending)) {
+            Ok(()) => {}
+            Err(TrySendError::Full(SealMsg::Seal(p)))
+            | Err(TrySendError::Disconnected(SealMsg::Seal(p))) => {
+                let _ = self.sealer.seal_one(p);
+            }
+            Err(_) => {}
+        }
+    }
+
+    /// Seal one transaction synchronously (used to rebuild the unsealed tail at
+    /// startup, before the sealer thread is running).
+    pub fn seal_pending_sync(&self, pending: PendingTx) -> ChainResult<()> {
+        self.sealer.seal_one(pending)
+    }
+
+    /// Persist the current head checkpoint.
+    pub fn checkpoint(&self) -> ChainResult<()> {
+        self.sealer.checkpoint()
+    }
+
+    /// The current in-memory chain head.
+    #[must_use]
+    pub fn head(&self) -> ChainHead {
+        self.sealer
+            .inner
+            .lock()
+            .map(|inner| inner.head.clone())
+            .unwrap_or_else(|_| self.genesis.clone())
+    }
+
+    /// Export the current head as an external anchor (rollback/fork proof).
+    #[must_use]
+    pub fn export_head(&self) -> ChainHead {
+        self.head()
+    }
+
+    /// The genesis head this chain was seeded with.
+    #[must_use]
+    pub fn genesis(&self) -> ChainHead {
+        self.genesis.clone()
+    }
+
+    /// The most recent verification result, if any (O(1), for stats).
+    #[must_use]
+    pub fn last_verified(&self) -> Option<LastVerified> {
+        self.last_verified.lock().ok().and_then(|g| *g)
+    }
+
+    fn record_verification(&self, result: &ChainVerification) {
+        if let Ok(mut g) = self.last_verified.lock() {
+            *g = Some(LastVerified {
+                passed: result.passed,
+                at_micros: crate::core::temporal::time::now().wallclock(),
+            });
+        }
+    }
+
+    /// Full-chain verification: recompute every leaf from stored history and
+    /// re-fold from genesis, localizing the earliest broken sequence on tamper.
+    #[must_use]
+    pub fn verify_full(&self) -> ChainVerification {
+        let records = self.snapshot_records();
+        let result = verify_full(&records, &*self.sealer.source, &self.genesis);
+        self.record_verification(&result);
+        result
+    }
+
+    /// Entity-scoped verification: recompute only `(kind, id)`'s leaves.
+    #[must_use]
+    pub fn verify_entity(&self, kind: EntityKind, id: u64) -> ChainVerification {
+        let records = self.snapshot_records();
+        let index = EntityIndex::build(&records);
+        let result = verify_entity(
+            &records,
+            &index,
+            (kind, id),
+            &self.genesis,
+            &*self.sealer.source,
+        );
+        self.record_verification(&result);
+        result
+    }
+
+    /// Prove the current chain extends a previously exported anchor.
+    #[must_use]
+    pub fn verify_against_anchor(&self, anchor: &ChainHead) -> ChainVerification {
+        let records = self.snapshot_records();
+        let result = verify_against_anchor(&records, anchor);
+        self.record_verification(&result);
+        result
+    }
+
+    fn snapshot_records(&self) -> Vec<ChainTxRecord> {
+        self.sealer
+            .inner
+            .lock()
+            .map(|inner| inner.records.clone())
+            .unwrap_or_default()
+    }
+
+    /// Flush and stop the sealer thread. Idempotent.
+    pub fn shutdown(&self) {
+        if self.stopped.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        // With `stopped` set, concurrent enqueues seal inline, so the channel
+        // drains and this Stop is guaranteed to be delivered.
+        let _ = self.sender.send(SealMsg::Stop);
+        if let Ok(mut guard) = self.handle.lock()
+            && let Some(handle) = guard.take()
+        {
+            let _ = handle.join();
+        }
+        // Final durability: flush the log and checkpoint the head.
+        if self.fsync != ChainFsyncMode::Never {
+            let _ = self.sealer.store.flush();
+        }
+        let _ = self.sealer.checkpoint();
+    }
+}
+
+impl Drop for ProvenanceChain {
+    fn drop(&mut self) {
+        // `stopped`/`handle` guard against a double shutdown if one already ran.
+        if self.stopped.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let _ = self.sender.send(SealMsg::Stop);
+        if let Ok(mut guard) = self.handle.lock()
+            && let Some(handle) = guard.take()
+        {
+            let _ = handle.join();
+        }
+        if self.fsync != ChainFsyncMode::Never {
+            let _ = self.sealer.store.flush();
+        }
+        let _ = self.sealer.checkpoint();
+    }
+}
+
+/// The background sealer loop: drain the channel into a commit-ordered reorder
+/// buffer, then flush the buffer to the log in `(commit_ts, tx_id)` order.
+fn run_sealer(sealer: Arc<Sealer>, rx: Receiver<SealMsg>) {
+    let mut buffer: BTreeMap<(i64, u64), PendingTx> = BTreeMap::new();
+    loop {
+        match rx.recv() {
+            Ok(SealMsg::Seal(p)) => {
+                buffer.insert((p.commit_ts_micros, p.tx_id), p);
+                // Absorb everything already queued so a burst flushes in order.
+                let mut stop = false;
+                loop {
+                    match rx.try_recv() {
+                        Ok(SealMsg::Seal(p2)) => {
+                            buffer.insert((p2.commit_ts_micros, p2.tx_id), p2);
+                        }
+                        Ok(SealMsg::Stop) => {
+                            stop = true;
+                            break;
+                        }
+                        Err(std::sync::mpsc::TryRecvError::Empty) => break,
+                        Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                            stop = true;
+                            break;
+                        }
+                    }
+                }
+                flush_buffer(&sealer, &mut buffer);
+                if stop {
+                    let _ = sealer.checkpoint();
+                    return;
+                }
+            }
+            Ok(SealMsg::Stop) | Err(_) => {
+                flush_buffer(&sealer, &mut buffer);
+                let _ = sealer.checkpoint();
+                return;
+            }
+        }
+    }
+}
+
+/// Drain the reorder buffer in ascending `(commit_ts, tx_id)` order, sealing
+/// each transaction, then checkpoint the advanced head.
+fn flush_buffer(sealer: &Sealer, buffer: &mut BTreeMap<(i64, u64), PendingTx>) {
+    if buffer.is_empty() {
+        return;
+    }
+    while let Some((&key, _)) = buffer.iter().next() {
+        if let Some(pending) = buffer.remove(&key) {
+            let _ = sealer.seal_one(pending);
+        }
+    }
+    let _ = sealer.checkpoint();
+}

--- a/src/provenance_chain/engine.rs
+++ b/src/provenance_chain/engine.rs
@@ -10,13 +10,23 @@
 //! read the SAME [`VersionSource`], a sealed leaf always reproduces exactly
 //! unless the stored version content was tampered with.
 //!
-//! # Ordering
+//! # Ordering (Issue #3351 finding 4)
 //!
-//! The sealer keeps a small reorder buffer keyed by `(commit_ts, tx_id)` so
-//! records are appended in commit order even when two racing writers enqueue out
-//! of order. Correctness never depends on the channel capacity: an enqueue that
-//! finds the channel full seals **inline** (drop-to-sync-seal) rather than
-//! blocking or dropping the transaction, so every committed transaction is
+//! The chain digest is a deterministic function of the record set **sorted by
+//! the full HLC commit timestamp** `(commit_ts, commit_ts_logical)` (tie-broken
+//! by the sorted leaves), NOT of enqueue/arrival order. [`Sealer::seal_one`]
+//! inserts each new record at its canonical sorted position: the common case is
+//! an append at the tail (`O(1)` fold), and a rare out-of-order arrival re-folds
+//! only the bounded suffix after the insertion point and rewrites the log so the
+//! persisted order stays canonical. Consequently a live-sealed chain and a
+//! post-crash rebuilt chain (which folds replayed history in the same sorted
+//! order) yield the identical head digest — enqueue order cannot fork them. The
+//! sealer's reorder buffer is now only a batching convenience.
+//!
+//! Correctness never depends on the channel capacity: an enqueue that finds the
+//! channel full seals **inline** (drop-to-sync-seal) — which still routes through
+//! the same sorted-insert `seal_one`, so it cannot fold out of order — rather
+//! than blocking or dropping the transaction, so every committed transaction is
 //! always sealed exactly once.
 //!
 //! # Recovery
@@ -57,9 +67,14 @@ const SEAL_CHANNEL_CAPACITY: usize = 4096;
 /// in-flight buffer.
 #[derive(Debug, Clone)]
 pub struct PendingTx {
-    /// Commit timestamp (micros since epoch) — the grouping and ordering key.
+    /// Commit timestamp (micros since epoch) — the primary grouping/ordering key.
     pub commit_ts_micros: i64,
-    /// The committing transaction's id.
+    /// Logical counter of the HLC commit timestamp — the ordering tie-breaker so
+    /// two transactions in the same microsecond stay distinct (Issue #3351
+    /// finding 4).
+    pub commit_ts_logical: u32,
+    /// The committing transaction's id. Carried as record metadata only; NOT
+    /// folded into the digest (a rebuild cannot recover it).
     pub tx_id: u64,
     /// WAL LSN this transaction is anchored at.
     pub anchor_lsn: u64,
@@ -100,8 +115,20 @@ struct ChainInner {
 }
 
 impl Sealer {
-    /// Seal one transaction: recompute its leaves from the source, fold onto the
-    /// running head, append the record, and advance the head + entity index.
+    /// Seal one transaction: recompute its leaves from the source, insert the
+    /// record at its **commit-timestamp-sorted** position, (re-)fold the affected
+    /// suffix, persist, and advance the head + entity index.
+    ///
+    /// # Deterministic, commit-ordered digest (Issue #3351 finding 4)
+    ///
+    /// The chain digest is a function of the record set **sorted by the full HLC
+    /// commit timestamp** `(commit_ts, commit_ts_logical)`, tie-broken by the
+    /// (already sorted) leaves — never of arrival order. The common case is a
+    /// tail append (`O(1)` fold + one `append`); a rare out-of-order arrival
+    /// re-folds the bounded suffix after the insertion point and rewrites the log
+    /// so the persisted order stays canonical. This makes a live-sealed chain and
+    /// a post-crash rebuilt chain (which folds replayed history in the same
+    /// sorted order) produce the identical head digest, eliminating false forks.
     ///
     /// A transaction whose versions cannot be resolved at all (every ref missing
     /// from the source) produces no record — there is nothing to bind.
@@ -127,33 +154,76 @@ impl Sealer {
             .lock()
             .map_err(|_| ChainError::Io("provenance chain inner lock poisoned".into()))?;
 
-        let seq = inner.head.seq + 1;
-        let prev = inner.head.digest;
-        let txd = tx_digest(pending.commit_ts_micros, pending.tx_id, &leaves);
-        let digest = chain_step(&prev, &txd);
-        let record = ChainTxRecord {
-            seq,
-            commit_ts: pending.commit_ts_micros,
-            tx_id: pending.tx_id,
-            anchor_lsn: pending.anchor_lsn,
-            leaves,
-            entity_refs: kept_refs,
-            digest,
-        };
+        // Find the sorted insertion position by the canonical commit-order key.
+        let idx = inner.records.partition_point(|r| {
+            (r.commit_ts, r.commit_ts_logical, &r.leaves)
+                < (pending.commit_ts_micros, pending.commit_ts_logical, &leaves)
+        });
 
-        self.store.append(&record)?;
+        // Insert an un-folded shell; `refold_suffix` fills seq + digest.
+        inner.records.insert(
+            idx,
+            ChainTxRecord {
+                seq: 0,
+                commit_ts: pending.commit_ts_micros,
+                commit_ts_logical: pending.commit_ts_logical,
+                tx_id: pending.tx_id,
+                anchor_lsn: pending.anchor_lsn,
+                leaves,
+                entity_refs: kept_refs,
+                digest: [0u8; 32],
+            },
+        );
 
-        let record_idx = inner.records.len();
-        inner.index.push_record(record_idx, &record);
+        let is_tail = idx + 1 == inner.records.len();
+        self.refold_suffix(&mut inner, idx);
+
+        if is_tail {
+            // Common case: append the single new record to the log.
+            let rec = inner.records[idx].clone();
+            self.store.append(&rec)?;
+            inner.index.push_record(idx, &rec);
+        } else {
+            // Rare out-of-order arrival: the suffix digests/seqs shifted, so
+            // rewrite the log in canonical order and rebuild the entity index.
+            let snapshot = inner.records.clone();
+            self.store.rewrite(&snapshot)?;
+            inner.index = EntityIndex::build(&inner.records);
+        }
+
+        let last = inner
+            .records
+            .last()
+            .expect("records is non-empty after insert");
         inner.head = ChainHead {
-            seq,
-            digest,
-            commit_ts: pending.commit_ts_micros,
-            anchor_lsn: pending.anchor_lsn,
+            seq: last.seq,
+            digest: last.digest,
+            commit_ts: last.commit_ts,
+            anchor_lsn: last.anchor_lsn,
             genesis_digest: self.genesis.genesis_digest,
         };
-        inner.records.push(record);
         Ok(())
+    }
+
+    /// Recompute `seq` and `digest` for every record from `start` to the tail,
+    /// folding each onto its predecessor (genesis for index 0). `records[start]`
+    /// and everything after it must already be in canonical order.
+    fn refold_suffix(&self, inner: &mut ChainInner, start: usize) {
+        for i in start..inner.records.len() {
+            let prev = if i == 0 {
+                self.genesis.digest
+            } else {
+                inner.records[i - 1].digest
+            };
+            let txd = {
+                let rec = &inner.records[i];
+                tx_digest(rec.commit_ts, rec.commit_ts_logical, &rec.leaves)
+            };
+            let digest = chain_step(&prev, &txd);
+            let rec = &mut inner.records[i];
+            rec.seq = (i as u64) + 1;
+            rec.digest = digest;
+        }
     }
 
     /// Persist the current head as an atomic checkpoint (carries the genesis
@@ -205,7 +275,17 @@ impl ProvenanceChain {
     ) -> ChainResult<Arc<Self>> {
         let dir = config.resolve_dir(data_dir);
         let store = Arc::new(ChainStore::open(&dir, config.fsync)?);
-        let records = store.load()?;
+        let mut records = store.load()?;
+        // The digest chain is defined over records in canonical commit-timestamp
+        // order (Issue #3351 finding 4). The store persists them so, but sort
+        // defensively so the loaded head/fold are canonical regardless.
+        records.sort_by(|a, b| {
+            (a.commit_ts, a.commit_ts_logical, &a.leaves).cmp(&(
+                b.commit_ts,
+                b.commit_ts_logical,
+                &b.leaves,
+            ))
+        });
 
         // Reconstruct the genesis. An existing head checkpoint carries the
         // original genesis digest, so the genesis stays stable across restarts;
@@ -381,7 +461,7 @@ impl ProvenanceChain {
     #[must_use]
     pub fn verify_against_anchor(&self, anchor: &ChainHead) -> ChainVerification {
         let records = self.snapshot_records();
-        let result = verify_against_anchor(&records, anchor);
+        let result = verify_against_anchor(&records, &self.genesis, anchor);
         self.record_verification(&result);
         result
     }
@@ -435,19 +515,22 @@ impl Drop for ProvenanceChain {
 }
 
 /// The background sealer loop: drain the channel into a commit-ordered reorder
-/// buffer, then flush the buffer to the log in `(commit_ts, tx_id)` order.
+/// buffer, then flush the buffer to the log in `(commit_ts, commit_ts_logical,
+/// tx_id)` order. Final canonical ordering is enforced by
+/// [`Sealer::seal_one`]'s sorted insert regardless.
 fn run_sealer(sealer: Arc<Sealer>, rx: Receiver<SealMsg>) {
-    let mut buffer: BTreeMap<(i64, u64), PendingTx> = BTreeMap::new();
+    let mut buffer: BTreeMap<(i64, u32, u64), PendingTx> = BTreeMap::new();
     loop {
         match rx.recv() {
             Ok(SealMsg::Seal(p)) => {
-                buffer.insert((p.commit_ts_micros, p.tx_id), p);
+                buffer.insert((p.commit_ts_micros, p.commit_ts_logical, p.tx_id), p);
                 // Absorb everything already queued so a burst flushes in order.
                 let mut stop = false;
                 loop {
                     match rx.try_recv() {
                         Ok(SealMsg::Seal(p2)) => {
-                            buffer.insert((p2.commit_ts_micros, p2.tx_id), p2);
+                            buffer
+                                .insert((p2.commit_ts_micros, p2.commit_ts_logical, p2.tx_id), p2);
                         }
                         Ok(SealMsg::Stop) => {
                             stop = true;
@@ -475,9 +558,9 @@ fn run_sealer(sealer: Arc<Sealer>, rx: Receiver<SealMsg>) {
     }
 }
 
-/// Drain the reorder buffer in ascending `(commit_ts, tx_id)` order, sealing
-/// each transaction, then checkpoint the advanced head.
-fn flush_buffer(sealer: &Sealer, buffer: &mut BTreeMap<(i64, u64), PendingTx>) {
+/// Drain the reorder buffer in ascending `(commit_ts, commit_ts_logical, tx_id)`
+/// order, sealing each transaction, then checkpoint the advanced head.
+fn flush_buffer(sealer: &Sealer, buffer: &mut BTreeMap<(i64, u32, u64), PendingTx>) {
     if buffer.is_empty() {
         return;
     }
@@ -487,4 +570,98 @@ fn flush_buffer(sealer: &Sealer, buffer: &mut BTreeMap<(i64, u64), PendingTx>) {
         }
     }
     let _ = sealer.checkpoint();
+}
+
+#[cfg(test)]
+mod ordering_tests {
+    //! Issue #3351 finding 4b: the head digest is a deterministic function of the
+    //! commit-timestamp-ordered record set, independent of enqueue arrival order.
+
+    use super::*;
+    use crate::core::property::PropertyValue;
+    use crate::provenance_chain::canonical::VersionHashInput;
+    use std::collections::HashMap;
+
+    struct MapSource(HashMap<(EntityKind, u64, u64), VersionHashInput>);
+    impl VersionSource for MapSource {
+        fn fetch(&self, kind: EntityKind, id: u64, version_id: u64) -> Option<VersionHashInput> {
+            self.0.get(&(kind, id, version_id)).cloned()
+        }
+    }
+
+    fn vinput(id: u64, vid: u64) -> VersionHashInput {
+        VersionHashInput {
+            entity_kind: EntityKind::Node,
+            entity_id: id,
+            version_id: vid,
+            prev_version_id: None,
+            label: "Person".to_string(),
+            source: None,
+            target: None,
+            valid_from: Some(100),
+            valid_to: None,
+            transaction_from: Some(100),
+            transaction_to: None,
+            is_current: true,
+            is_tombstone: false,
+            provenance: None,
+            properties: vec![("name".to_string(), PropertyValue::string("n"))],
+        }
+    }
+
+    /// Seal `specs` (each `(commit_ts, logical, entity_id, version_id)`) into a
+    /// fresh chain via the synchronous path and return the resulting head digest.
+    fn head_after(specs: &[(i64, u32, u64, u64)]) -> [u8; 32] {
+        let dir = tempfile::tempdir().unwrap();
+        let mut map = HashMap::new();
+        for (_, _, id, vid) in specs {
+            let vi = vinput(*id, *vid);
+            map.insert((vi.entity_kind, vi.entity_id, vi.version_id), vi);
+        }
+        let source: Arc<dyn VersionSource + Send + Sync> = Arc::new(MapSource(map));
+        let config = ChainConfig {
+            enabled: true,
+            fsync: ChainFsyncMode::Never,
+            dir: None,
+        };
+        let chain = ProvenanceChain::open(&config, dir.path(), 1, 0, source).unwrap();
+        for (commit_ts, logical, id, vid) in specs {
+            chain
+                .seal_pending_sync(PendingTx {
+                    commit_ts_micros: *commit_ts,
+                    commit_ts_logical: *logical,
+                    tx_id: *vid, // arbitrary metadata; not folded
+                    anchor_lsn: 1,
+                    entity_refs: vec![(EntityKind::Node, *id, *vid)],
+                })
+                .unwrap();
+        }
+        chain.head().digest
+    }
+
+    #[test]
+    fn out_of_order_enqueue_yields_same_head_as_in_order() {
+        // Three transactions with distinct commit timestamps.
+        let in_order = [(100, 0, 1, 1), (200, 0, 2, 2), (300, 0, 3, 3)];
+        let reversed = [(300, 0, 3, 3), (100, 0, 1, 1), (200, 0, 2, 2)];
+        let shuffled = [(200, 0, 2, 2), (300, 0, 3, 3), (100, 0, 1, 1)];
+
+        let h_in = head_after(&in_order);
+        let h_rev = head_after(&reversed);
+        let h_shuf = head_after(&shuffled);
+
+        assert_eq!(
+            h_in, h_rev,
+            "reverse-order enqueue must match in-order head"
+        );
+        assert_eq!(h_in, h_shuf, "shuffled enqueue must match in-order head");
+    }
+
+    #[test]
+    fn same_wallclock_distinct_logical_stays_ordered() {
+        // Two transactions in the same microsecond, distinguished by logical.
+        let a = [(100, 1, 1, 1), (100, 2, 2, 2)];
+        let b = [(100, 2, 2, 2), (100, 1, 1, 1)];
+        assert_eq!(head_after(&a), head_after(&b));
+    }
 }

--- a/src/provenance_chain/engine.rs
+++ b/src/provenance_chain/engine.rs
@@ -494,11 +494,19 @@ impl ProvenanceChain {
 
     /// Flush and stop the sealer thread. Idempotent.
     pub fn shutdown(&self) {
+        self.stop_and_flush();
+    }
+
+    /// Signal the sealer to stop, join it, and flush the log + checkpoint the
+    /// head. Idempotent: the `stopped` swap guards against a double stop, so a
+    /// `Drop` after an explicit [`shutdown`](Self::shutdown) is a no-op.
+    ///
+    /// With `stopped` set, concurrent enqueues seal inline, so the channel
+    /// drains and the `Stop` is guaranteed to be delivered.
+    fn stop_and_flush(&self) {
         if self.stopped.swap(true, Ordering::AcqRel) {
             return;
         }
-        // With `stopped` set, concurrent enqueues seal inline, so the channel
-        // drains and this Stop is guaranteed to be delivered.
         let _ = self.sender.send(SealMsg::Stop);
         if let Ok(mut guard) = self.handle.lock()
             && let Some(handle) = guard.take()
@@ -515,20 +523,7 @@ impl ProvenanceChain {
 
 impl Drop for ProvenanceChain {
     fn drop(&mut self) {
-        // `stopped`/`handle` guard against a double shutdown if one already ran.
-        if self.stopped.swap(true, Ordering::AcqRel) {
-            return;
-        }
-        let _ = self.sender.send(SealMsg::Stop);
-        if let Ok(mut guard) = self.handle.lock()
-            && let Some(handle) = guard.take()
-        {
-            let _ = handle.join();
-        }
-        if self.fsync != ChainFsyncMode::Never {
-            let _ = self.sealer.store.flush();
-        }
-        let _ = self.sealer.checkpoint();
+        self.stop_and_flush();
     }
 }
 

--- a/src/provenance_chain/engine.rs
+++ b/src/provenance_chain/engine.rs
@@ -135,7 +135,7 @@ impl Sealer {
     fn seal_one(&self, pending: PendingTx) -> ChainResult<()> {
         // Deterministic leaf order, independent of enqueue/buffer order.
         let mut refs = pending.entity_refs;
-        refs.sort_by(|a, b| (a.0.tag(), a.1, a.2).cmp(&(b.0.tag(), b.1, b.2)));
+        refs.sort_by_key(|a| (a.0.tag(), a.1, a.2));
 
         let mut kept_refs: Vec<(EntityKind, u64, u64)> = Vec::with_capacity(refs.len());
         let mut leaves: Vec<[u8; 32]> = Vec::with_capacity(refs.len());

--- a/src/provenance_chain/engine.rs
+++ b/src/provenance_chain/engine.rs
@@ -442,17 +442,35 @@ impl ProvenanceChain {
     }
 
     /// Entity-scoped verification: recompute only `(kind, id)`'s leaves.
+    ///
+    /// Truly scan-free (Issue #3351 task #1): instead of cloning every record
+    /// and rebuilding the whole [`EntityIndex`] on each call — O(total tx) — this
+    /// locks `inner` and hands the core verifier the sealer's **running**
+    /// `records` + `index` directly. The core then touches only the records that
+    /// reference the entity (leaf recompute is already entity-scoped), so the
+    /// whole call is O(entity versions), independent of database size. The
+    /// running index is kept correct by [`Sealer::seal_one`] on both the common
+    /// tail-append path (`push_record`) and the rare out-of-order re-fold path
+    /// (full `EntityIndex::build`), so it always matches `inner.records`.
     #[must_use]
     pub fn verify_entity(&self, kind: EntityKind, id: u64) -> ChainVerification {
-        let records = self.snapshot_records();
-        let index = EntityIndex::build(&records);
-        let result = verify_entity(
-            &records,
-            &index,
-            (kind, id),
-            &self.genesis,
-            &*self.sealer.source,
-        );
+        let result = match self.sealer.inner.lock() {
+            Ok(inner) => verify_entity(
+                &inner.records,
+                &inner.index,
+                (kind, id),
+                &self.genesis,
+                &*self.sealer.source,
+            ),
+            Err(_) => ChainVerification {
+                passed: false,
+                head_seq: self.genesis.seq,
+                head_digest_hex: String::new(),
+                earliest_broken_seq: None,
+                reason: Some("provenance chain inner lock poisoned".to_string()),
+                transactions_checked: 0,
+            },
+        };
         self.record_verification(&result);
         result
     }
@@ -663,5 +681,110 @@ mod ordering_tests {
         let a = [(100, 1, 1, 1), (100, 2, 2, 2)];
         let b = [(100, 2, 2, 2), (100, 1, 1, 1)];
         assert_eq!(head_after(&a), head_after(&b));
+    }
+}
+
+#[cfg(test)]
+mod scan_free_tests {
+    //! Issue #3351 task #1: entity-scoped verify must touch only the target
+    //! entity's records — O(entity versions), not O(database size). Proven by
+    //! counting `VersionSource::fetch` calls: a `verify_entity` fetches exactly
+    //! the entity's version count, regardless of how many other transactions the
+    //! chain holds.
+
+    use super::*;
+    use crate::core::property::PropertyValue;
+    use crate::provenance_chain::canonical::VersionHashInput;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+    /// A version source that counts every `fetch` so a test can assert an
+    /// entity-scoped verify does not re-fetch the whole database.
+    struct CountingSource {
+        map: HashMap<(EntityKind, u64, u64), VersionHashInput>,
+        fetches: AtomicUsize,
+    }
+    impl VersionSource for CountingSource {
+        fn fetch(&self, kind: EntityKind, id: u64, version_id: u64) -> Option<VersionHashInput> {
+            self.fetches.fetch_add(1, AtomicOrdering::Relaxed);
+            self.map.get(&(kind, id, version_id)).cloned()
+        }
+    }
+
+    fn vinput(id: u64, vid: u64) -> VersionHashInput {
+        VersionHashInput {
+            entity_kind: EntityKind::Node,
+            entity_id: id,
+            version_id: vid,
+            prev_version_id: None,
+            label: "Person".to_string(),
+            source: None,
+            target: None,
+            valid_from: Some(100),
+            valid_to: None,
+            transaction_from: Some(100),
+            transaction_to: None,
+            is_current: true,
+            is_tombstone: false,
+            provenance: None,
+            properties: vec![("name".to_string(), PropertyValue::string("n"))],
+        }
+    }
+
+    #[test]
+    fn entity_verify_fetches_only_the_entity_versions() {
+        // Five transactions; entity 1 appears in exactly two of them.
+        let specs: [(i64, u32, u64, u64); 5] = [
+            (100, 0, 1, 1), // entity 1, v1
+            (200, 0, 2, 2), // entity 2
+            (300, 0, 3, 3), // entity 3
+            (400, 0, 1, 4), // entity 1, v4 (second occurrence)
+            (500, 0, 4, 5), // entity 4
+        ];
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut map = HashMap::new();
+        for (_, _, id, vid) in specs {
+            let vi = vinput(id, vid);
+            map.insert((vi.entity_kind, vi.entity_id, vi.version_id), vi);
+        }
+        let source = Arc::new(CountingSource {
+            map,
+            fetches: AtomicUsize::new(0),
+        });
+        let config = ChainConfig {
+            enabled: true,
+            fsync: ChainFsyncMode::Never,
+            dir: None,
+        };
+        let chain =
+            ProvenanceChain::open(&config, dir.path(), 1, 0, source.clone() as Arc<_>).unwrap();
+        for (commit_ts, logical, id, vid) in specs {
+            chain
+                .seal_pending_sync(PendingTx {
+                    commit_ts_micros: commit_ts,
+                    commit_ts_logical: logical,
+                    tx_id: vid,
+                    anchor_lsn: 1,
+                    entity_refs: vec![(EntityKind::Node, id, vid)],
+                })
+                .unwrap();
+        }
+
+        // Reset the counter: sealing itself fetches (once per version). We only
+        // want to measure the *verify* pass.
+        source.fetches.store(0, AtomicOrdering::Relaxed);
+
+        let v = chain.verify_entity(EntityKind::Node, 1);
+        assert!(v.passed, "clean entity verify: {:?}", v.reason);
+        assert_eq!(
+            v.transactions_checked, 2,
+            "entity 1 is present in exactly two transactions"
+        );
+        assert_eq!(
+            source.fetches.load(AtomicOrdering::Relaxed),
+            2,
+            "entity verify must fetch only entity 1's two versions, not all five"
+        );
     }
 }

--- a/src/provenance_chain/error.rs
+++ b/src/provenance_chain/error.rs
@@ -1,0 +1,35 @@
+//! Error types for the provenance hash chain (Issue #3351).
+
+use thiserror::Error;
+
+/// Result alias for provenance-chain operations.
+pub type ChainResult<T> = Result<T, ChainError>;
+
+/// Errors produced by the provenance hash chain store and codecs.
+#[derive(Debug, Error)]
+pub enum ChainError {
+    /// An underlying I/O operation failed.
+    #[error("provenance chain I/O error: {0}")]
+    Io(String),
+
+    /// The on-disk data is structurally invalid (bad magic, unexpected EOF in a
+    /// framed field, impossible length, etc.).
+    #[error("provenance chain corruption: {0}")]
+    Corrupt(String),
+
+    /// The file header magic or format version did not match what this build
+    /// understands.
+    #[error("provenance chain header mismatch: {0}")]
+    HeaderMismatch(String),
+
+    /// A length-prefixed record could not be decoded because its framing was
+    /// inconsistent (declared length disagrees with available bytes).
+    #[error("provenance chain framing error: {0}")]
+    BadFraming(String),
+}
+
+impl From<std::io::Error> for ChainError {
+    fn from(e: std::io::Error) -> Self {
+        ChainError::Io(e.to_string())
+    }
+}

--- a/src/provenance_chain/mod.rs
+++ b/src/provenance_chain/mod.rs
@@ -68,11 +68,15 @@ mod integration_tests {
             entity_id: id,
             version_id: vid,
             prev_version_id: None,
+            label: "Person".to_string(),
+            source: None,
+            target: None,
             valid_from: Some(10),
             valid_to: None,
             transaction_from: Some(10),
             transaction_to: None,
             is_current: true,
+            is_tombstone: false,
             provenance: None,
             properties: vec![("name".to_string(), PropertyValue::string(name))],
         }
@@ -92,11 +96,12 @@ mod integration_tests {
             src.0
                 .insert((v.entity_kind, v.entity_id, v.version_id), v.clone());
             let leaf = version_leaf(&v);
-            let txd = tx_digest(1000 + seq as i64, seq, &[leaf]);
+            let txd = tx_digest(1000 + seq as i64, 0, &[leaf]);
             let digest = chain_step(&prev, &txd);
             let rec = ChainTxRecord {
                 seq,
                 commit_ts: 1000 + seq as i64,
+                commit_ts_logical: 0,
                 tx_id: seq,
                 anchor_lsn: seq,
                 leaves: vec![leaf],
@@ -129,6 +134,6 @@ mod integration_tests {
         assert_eq!(result.head_digest_hex, to_hex(&head.digest));
 
         // The reloaded head extends the exported anchor.
-        assert!(verify_against_anchor(&records, &checkpoint).passed);
+        assert!(verify_against_anchor(&records, &genesis, &checkpoint).passed);
     }
 }

--- a/src/provenance_chain/mod.rs
+++ b/src/provenance_chain/mod.rs
@@ -1,0 +1,132 @@
+//! Tamper-evident provenance hash chain (Issue #3351).
+//!
+//! An opt-in, self-contained sidecar that binds every committed transaction into
+//! a domain-separated SHA-256 hash chain over the database's recorded history, so
+//! that any post-hoc alteration of stored versions — editing a byte of a version,
+//! deleting/reordering/inserting a transaction, truncating the tail — is
+//! detectable, and (against an exported anchor) rollback and fork are provable.
+//!
+//! # Layers (this module is the pure core; no database wiring)
+//!
+//! - [`config`] — [`ChainConfig`] / [`ChainFsyncMode`], opt-in and disabled by
+//!   default.
+//! - [`canonical`] — the injective, deterministic canonical encoder over a
+//!   normalized [`VersionHashInput`], plus the folding primitives
+//!   ([`version_leaf`], [`tx_digest`], [`chain_step`], [`genesis_digest`]).
+//! - [`record`] — [`ChainTxRecord`] and [`ChainHead`] with binary + serde codecs.
+//! - [`store`] — the append-only [`ChainStore`] (header + length-framed records +
+//!   head checkpoint), tolerant of a torn trailing record.
+//! - [`verify`] — DB-independent verification: [`verify_full`],
+//!   [`verify_entity`], and [`verify_against_anchor`] over a [`VersionSource`].
+//!
+//! The chain unit is a committed transaction. Versions of one transaction share
+//! one commit timestamp, which is the grouping and ordering key. Each version is
+//! reduced to a leaf hash; the leaves fold into a per-transaction digest; each
+//! transaction digest chains onto the previous, seeded by an explicit genesis
+//! record (enable LSN + timestamp).
+
+pub mod canonical;
+pub mod config;
+pub mod error;
+pub mod record;
+pub mod store;
+pub mod verify;
+
+pub use canonical::{
+    CHAIN_GENESIS_DOMAIN, CHAIN_LEAF_DOMAIN, CHAIN_NODE_DOMAIN, CHAIN_TX_DOMAIN, EntityKind,
+    ProvenanceHashInput, VersionHashInput, chain_step, from_hex_32, genesis_digest, to_hex,
+    tx_digest, version_leaf,
+};
+pub use config::{ChainConfig, ChainFsyncMode};
+pub use error::{ChainError, ChainResult};
+pub use record::{ChainHead, ChainTxRecord};
+pub use store::ChainStore;
+pub use verify::{
+    ChainVerification, EntityIndex, VersionSource, verify_against_anchor, verify_entity,
+    verify_full,
+};
+
+#[cfg(test)]
+mod integration_tests {
+    //! End-to-end core flow: build a chain, persist it, reload, verify.
+    use super::*;
+    use crate::core::property::PropertyValue;
+    use std::collections::HashMap;
+
+    struct MapSource(HashMap<(EntityKind, u64, u64), VersionHashInput>);
+    impl VersionSource for MapSource {
+        fn fetch(&self, kind: EntityKind, id: u64, version_id: u64) -> Option<VersionHashInput> {
+            self.0.get(&(kind, id, version_id)).cloned()
+        }
+    }
+
+    fn version(id: u64, vid: u64, name: &str) -> VersionHashInput {
+        VersionHashInput {
+            entity_kind: EntityKind::Node,
+            entity_id: id,
+            version_id: vid,
+            prev_version_id: None,
+            valid_from: Some(10),
+            valid_to: None,
+            transaction_from: Some(10),
+            transaction_to: None,
+            is_current: true,
+            provenance: None,
+            properties: vec![("name".to_string(), PropertyValue::string(name))],
+        }
+    }
+
+    #[test]
+    fn persist_reload_and_verify_full_chain() {
+        let dir = tempfile::tempdir().unwrap();
+        let genesis = ChainHead::genesis(1, 0);
+        let mut src = MapSource(HashMap::new());
+
+        // Seal three transactions.
+        let store = ChainStore::open(dir.path(), ChainFsyncMode::PerTransaction).unwrap();
+        let mut prev = genesis.digest;
+        for seq in 1..=3u64 {
+            let v = version(seq, 1, &format!("n{seq}"));
+            src.0
+                .insert((v.entity_kind, v.entity_id, v.version_id), v.clone());
+            let leaf = version_leaf(&v);
+            let txd = tx_digest(1000 + seq as i64, seq, &[leaf]);
+            let digest = chain_step(&prev, &txd);
+            let rec = ChainTxRecord {
+                seq,
+                commit_ts: 1000 + seq as i64,
+                tx_id: seq,
+                anchor_lsn: seq,
+                leaves: vec![leaf],
+                entity_refs: vec![(EntityKind::Node, seq, 1)],
+                digest,
+            };
+            store.append(&rec).unwrap();
+            prev = digest;
+        }
+        // Checkpoint the head.
+        let head = ChainHead {
+            seq: 3,
+            digest: prev,
+            commit_ts: 1003,
+            anchor_lsn: 3,
+            genesis_digest: genesis.genesis_digest,
+        };
+        store.write_head_checkpoint(&head).unwrap();
+
+        // Reopen, reload, verify.
+        let store2 = ChainStore::open(dir.path(), ChainFsyncMode::PerTransaction).unwrap();
+        let records = store2.load().unwrap();
+        assert_eq!(records.len(), 3);
+        let checkpoint = store2.read_head_checkpoint().unwrap().unwrap();
+        assert_eq!(checkpoint, head);
+
+        let result = verify_full(&records, &src, &genesis);
+        assert!(result.passed, "reason: {:?}", result.reason);
+        assert_eq!(result.head_seq, 3);
+        assert_eq!(result.head_digest_hex, to_hex(&head.digest));
+
+        // The reloaded head extends the exported anchor.
+        assert!(verify_against_anchor(&records, &checkpoint).passed);
+    }
+}

--- a/src/provenance_chain/mod.rs
+++ b/src/provenance_chain/mod.rs
@@ -27,6 +27,7 @@
 
 pub mod canonical;
 pub mod config;
+pub mod engine;
 pub mod error;
 pub mod record;
 pub mod store;
@@ -38,6 +39,7 @@ pub use canonical::{
     tx_digest, version_leaf,
 };
 pub use config::{ChainConfig, ChainFsyncMode};
+pub use engine::{LastVerified, PendingTx, ProvenanceChain};
 pub use error::{ChainError, ChainResult};
 pub use record::{ChainHead, ChainTxRecord};
 pub use store::ChainStore;

--- a/src/provenance_chain/record.rs
+++ b/src/provenance_chain/record.rs
@@ -18,9 +18,15 @@ use super::error::{ChainError, ChainResult};
 pub struct ChainTxRecord {
     /// Monotonic sequence number (genesis is `0`; first real tx is `1`).
     pub seq: u64,
-    /// Commit timestamp (micros since epoch) — the ordering key for the tx.
+    /// Commit timestamp (micros since epoch) — the primary ordering key.
     pub commit_ts: i64,
-    /// The committing transaction's id.
+    /// Logical counter of the HLC commit timestamp — the tie-breaker so two
+    /// transactions sharing a wallclock microsecond stay distinct and ordered
+    /// (Issue #3351 finding 4). Bound into `tx_digest` alongside `commit_ts`.
+    pub commit_ts_logical: u32,
+    /// The committing transaction's id. Record metadata only — NOT bound into
+    /// `tx_digest` (a post-crash rebuild cannot recover it; see
+    /// [`tx_digest`](super::canonical::tx_digest)).
     pub tx_id: u64,
     /// The WAL LSN this record is anchored at (for truncation/recovery).
     pub anchor_lsn: u64,
@@ -108,6 +114,13 @@ impl<'a> Reader<'a> {
         Ok(u64::from_be_bytes(arr))
     }
 
+    fn u32(&mut self) -> ChainResult<u32> {
+        let b = self.take(4)?;
+        let mut arr = [0u8; 4];
+        arr.copy_from_slice(b);
+        Ok(u32::from_be_bytes(arr))
+    }
+
     fn i64(&mut self) -> ChainResult<i64> {
         Ok(self.u64()? as i64)
     }
@@ -143,12 +156,17 @@ fn put_u64(out: &mut Vec<u8>, v: u64) {
     out.extend_from_slice(&v.to_be_bytes());
 }
 
+fn put_u32(out: &mut Vec<u8>, v: u32) {
+    out.extend_from_slice(&v.to_be_bytes());
+}
+
 impl ChainTxRecord {
     /// Encode the record to its self-contained binary payload (no outer frame).
     pub(super) fn encode(&self) -> Vec<u8> {
         let mut out = Vec::with_capacity(64 + self.leaves.len() * 32 + self.entity_refs.len() * 17);
         put_u64(&mut out, self.seq);
         put_u64(&mut out, self.commit_ts as u64);
+        put_u32(&mut out, self.commit_ts_logical);
         put_u64(&mut out, self.tx_id);
         put_u64(&mut out, self.anchor_lsn);
         put_u64(&mut out, self.leaves.len() as u64);
@@ -181,6 +199,7 @@ impl ChainTxRecord {
     fn read_from(r: &mut Reader<'_>) -> ChainResult<Self> {
         let seq = r.u64()?;
         let commit_ts = r.i64()?;
+        let commit_ts_logical = r.u32()?;
         let tx_id = r.u64()?;
         let anchor_lsn = r.u64()?;
         let n_leaves = r.count(32)?;
@@ -202,6 +221,7 @@ impl ChainTxRecord {
         Ok(ChainTxRecord {
             seq,
             commit_ts,
+            commit_ts_logical,
             tx_id,
             anchor_lsn,
             leaves,
@@ -289,6 +309,7 @@ mod tests {
         ChainTxRecord {
             seq,
             commit_ts: 1_000 + seq as i64,
+            commit_ts_logical: seq as u32,
             tx_id: 42 + seq,
             anchor_lsn: 7 + seq,
             leaves: vec![[seq as u8; 32], [(seq + 1) as u8; 32]],

--- a/src/provenance_chain/record.rs
+++ b/src/provenance_chain/record.rs
@@ -1,0 +1,342 @@
+//! On-chain records: a per-transaction record and a head checkpoint (Issue #3351).
+//!
+//! Each type has a self-describing, length-framed binary codec used by
+//! [`super::store`], and (behind the `serde` feature) a JSON representation with
+//! digests rendered as lowercase hex for external export / anchoring.
+
+use super::canonical::EntityKind;
+use super::error::{ChainError, ChainResult};
+
+/// A sealed record for one committed transaction.
+///
+/// `digest` is `chain_step(prev_digest, tx_digest(commit_ts, tx_id, leaves))`,
+/// where `prev_digest` is the previous record's digest (or the genesis digest
+/// for `seq == 1`). The record is self-contained: it carries the leaves and the
+/// entity refs that produced them so a verifier can recompute everything.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ChainTxRecord {
+    /// Monotonic sequence number (genesis is `0`; first real tx is `1`).
+    pub seq: u64,
+    /// Commit timestamp (micros since epoch) — the ordering key for the tx.
+    pub commit_ts: i64,
+    /// The committing transaction's id.
+    pub tx_id: u64,
+    /// The WAL LSN this record is anchored at (for truncation/recovery).
+    pub anchor_lsn: u64,
+    /// Per-version leaf hashes, in the same order as `entity_refs`.
+    #[cfg_attr(feature = "serde", serde(with = "hex_vec"))]
+    pub leaves: Vec<[u8; 32]>,
+    /// `(kind, entity_id, version_id)` for each leaf, in leaf order.
+    pub entity_refs: Vec<(EntityKind, u64, u64)>,
+    /// This record's chained digest.
+    #[cfg_attr(feature = "serde", serde(with = "hex_digest"))]
+    pub digest: [u8; 32],
+}
+
+/// An exported/checkpointed head of the chain — the external anchor used to
+/// prove append-only extension (rollback/fork detection).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ChainHead {
+    /// Sequence number of the head record (`0` for a bare genesis).
+    pub seq: u64,
+    /// The head record's chained digest.
+    #[cfg_attr(feature = "serde", serde(with = "hex_digest"))]
+    pub digest: [u8; 32],
+    /// Commit timestamp of the head record (micros).
+    pub commit_ts: i64,
+    /// WAL LSN the head is anchored at.
+    pub anchor_lsn: u64,
+    /// The genesis digest this chain was seeded with.
+    #[cfg_attr(feature = "serde", serde(with = "hex_digest"))]
+    pub genesis_digest: [u8; 32],
+}
+
+impl ChainHead {
+    /// Construct the genesis head (seq 0) for a chain enabled at
+    /// `(enable_lsn, enable_ts)`. Its `digest` equals its `genesis_digest`, so it
+    /// seeds `chain_step` for the first real transaction.
+    #[must_use]
+    pub fn genesis(enable_lsn: u64, enable_ts: i64) -> Self {
+        let g = super::canonical::genesis_digest(enable_lsn, enable_ts);
+        ChainHead {
+            seq: 0,
+            digest: g,
+            commit_ts: enable_ts,
+            anchor_lsn: enable_lsn,
+            genesis_digest: g,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Binary codecs (used by the append-only store; independent of serde).
+// ---------------------------------------------------------------------------
+
+/// A minimal big-endian byte reader with bounds checks.
+pub(super) struct Reader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    pub(super) fn new(buf: &'a [u8]) -> Self {
+        Reader { buf, pos: 0 }
+    }
+
+    fn take(&mut self, n: usize) -> ChainResult<&'a [u8]> {
+        let end = self
+            .pos
+            .checked_add(n)
+            .ok_or_else(|| ChainError::BadFraming("length overflow".into()))?;
+        if end > self.buf.len() {
+            return Err(ChainError::BadFraming(format!(
+                "unexpected end of buffer: need {n} bytes at offset {}",
+                self.pos
+            )));
+        }
+        let out = &self.buf[self.pos..end];
+        self.pos = end;
+        Ok(out)
+    }
+
+    fn u64(&mut self) -> ChainResult<u64> {
+        let b = self.take(8)?;
+        let mut arr = [0u8; 8];
+        arr.copy_from_slice(b);
+        Ok(u64::from_be_bytes(arr))
+    }
+
+    fn i64(&mut self) -> ChainResult<i64> {
+        Ok(self.u64()? as i64)
+    }
+
+    fn u8(&mut self) -> ChainResult<u8> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn digest(&mut self) -> ChainResult<[u8; 32]> {
+        let b = self.take(32)?;
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(b);
+        Ok(arr)
+    }
+
+    /// A `u64`-prefixed count, guarded against absurd values so a corrupt length
+    /// cannot trigger a huge pre-allocation.
+    fn count(&mut self, remaining_min_per_item: usize) -> ChainResult<usize> {
+        let n = self.u64()? as usize;
+        // Each item consumes at least `remaining_min_per_item` bytes; reject a
+        // count that cannot possibly fit in the remaining buffer.
+        let remaining = self.buf.len().saturating_sub(self.pos);
+        if remaining_min_per_item > 0 && n > remaining / remaining_min_per_item + 1 {
+            return Err(ChainError::BadFraming(format!(
+                "declared count {n} exceeds buffer capacity"
+            )));
+        }
+        Ok(n)
+    }
+}
+
+fn put_u64(out: &mut Vec<u8>, v: u64) {
+    out.extend_from_slice(&v.to_be_bytes());
+}
+
+impl ChainTxRecord {
+    /// Encode the record to its self-contained binary payload (no outer frame).
+    pub(super) fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(64 + self.leaves.len() * 32 + self.entity_refs.len() * 17);
+        put_u64(&mut out, self.seq);
+        put_u64(&mut out, self.commit_ts as u64);
+        put_u64(&mut out, self.tx_id);
+        put_u64(&mut out, self.anchor_lsn);
+        put_u64(&mut out, self.leaves.len() as u64);
+        for leaf in &self.leaves {
+            out.extend_from_slice(leaf);
+        }
+        put_u64(&mut out, self.entity_refs.len() as u64);
+        for (kind, id, vid) in &self.entity_refs {
+            out.push(kind.tag());
+            put_u64(&mut out, *id);
+            put_u64(&mut out, *vid);
+        }
+        out.extend_from_slice(&self.digest);
+        out
+    }
+
+    /// Decode a record from a binary payload (exactly one record; trailing bytes
+    /// are an error).
+    pub(super) fn decode(bytes: &[u8]) -> ChainResult<Self> {
+        let mut r = Reader::new(bytes);
+        let rec = Self::read_from(&mut r)?;
+        if r.pos != bytes.len() {
+            return Err(ChainError::BadFraming(
+                "trailing bytes after record payload".into(),
+            ));
+        }
+        Ok(rec)
+    }
+
+    fn read_from(r: &mut Reader<'_>) -> ChainResult<Self> {
+        let seq = r.u64()?;
+        let commit_ts = r.i64()?;
+        let tx_id = r.u64()?;
+        let anchor_lsn = r.u64()?;
+        let n_leaves = r.count(32)?;
+        let mut leaves = Vec::with_capacity(n_leaves);
+        for _ in 0..n_leaves {
+            leaves.push(r.digest()?);
+        }
+        let n_refs = r.count(17)?;
+        let mut entity_refs = Vec::with_capacity(n_refs);
+        for _ in 0..n_refs {
+            let tag = r.u8()?;
+            let kind = EntityKind::from_tag(tag)
+                .ok_or_else(|| ChainError::Corrupt(format!("invalid entity-kind tag {tag}")))?;
+            let id = r.u64()?;
+            let vid = r.u64()?;
+            entity_refs.push((kind, id, vid));
+        }
+        let digest = r.digest()?;
+        Ok(ChainTxRecord {
+            seq,
+            commit_ts,
+            tx_id,
+            anchor_lsn,
+            leaves,
+            entity_refs,
+            digest,
+        })
+    }
+}
+
+impl ChainHead {
+    /// Encode the head to its self-contained binary payload (no outer frame).
+    pub(super) fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(8 + 32 + 8 + 8 + 32);
+        put_u64(&mut out, self.seq);
+        out.extend_from_slice(&self.digest);
+        put_u64(&mut out, self.commit_ts as u64);
+        put_u64(&mut out, self.anchor_lsn);
+        out.extend_from_slice(&self.genesis_digest);
+        out
+    }
+
+    /// Decode a head from a binary payload.
+    pub(super) fn decode(bytes: &[u8]) -> ChainResult<Self> {
+        let mut r = Reader::new(bytes);
+        let seq = r.u64()?;
+        let digest = r.digest()?;
+        let commit_ts = r.i64()?;
+        let anchor_lsn = r.u64()?;
+        let genesis_digest = r.digest()?;
+        Ok(ChainHead {
+            seq,
+            digest,
+            commit_ts,
+            anchor_lsn,
+            genesis_digest,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// serde hex helpers.
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "serde")]
+mod hex_digest {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(d: &[u8; 32], s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&super::super::canonical::to_hex(d))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<[u8; 32], D::Error> {
+        let s = String::deserialize(d)?;
+        super::super::canonical::from_hex_32(&s)
+            .ok_or_else(|| serde::de::Error::custom("invalid 32-byte hex digest"))
+    }
+}
+
+#[cfg(feature = "serde")]
+mod hex_vec {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(v: &[[u8; 32]], s: S) -> Result<S::Ok, S::Error> {
+        let hexed: Vec<String> = v.iter().map(super::super::canonical::to_hex).collect();
+        hexed.serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<[u8; 32]>, D::Error> {
+        let hexed = Vec::<String>::deserialize(d)?;
+        hexed
+            .iter()
+            .map(|s| {
+                super::super::canonical::from_hex_32(s)
+                    .ok_or_else(|| serde::de::Error::custom("invalid 32-byte hex digest"))
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_record(seq: u64) -> ChainTxRecord {
+        ChainTxRecord {
+            seq,
+            commit_ts: 1_000 + seq as i64,
+            tx_id: 42 + seq,
+            anchor_lsn: 7 + seq,
+            leaves: vec![[seq as u8; 32], [(seq + 1) as u8; 32]],
+            entity_refs: vec![(EntityKind::Node, 10, 1), (EntityKind::Edge, 20, 2)],
+            digest: [(seq + 3) as u8; 32],
+        }
+    }
+
+    #[test]
+    fn record_binary_round_trip() {
+        let rec = sample_record(5);
+        let encoded = rec.encode();
+        let decoded = ChainTxRecord::decode(&encoded).unwrap();
+        assert_eq!(rec, decoded);
+    }
+
+    #[test]
+    fn record_decode_rejects_trailing_bytes() {
+        let mut encoded = sample_record(1).encode();
+        encoded.push(0xAB);
+        assert!(matches!(
+            ChainTxRecord::decode(&encoded),
+            Err(ChainError::BadFraming(_))
+        ));
+    }
+
+    #[test]
+    fn record_decode_rejects_truncation() {
+        let encoded = sample_record(1).encode();
+        assert!(ChainTxRecord::decode(&encoded[..encoded.len() - 4]).is_err());
+    }
+
+    #[test]
+    fn head_binary_round_trip() {
+        let head = ChainHead::genesis(99, 12345);
+        let decoded = ChainHead::decode(&head.encode()).unwrap();
+        assert_eq!(head, decoded);
+        assert_eq!(head.seq, 0);
+        assert_eq!(head.digest, head.genesis_digest);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn record_serde_uses_hex_digests() {
+        let rec = sample_record(2);
+        let json = serde_json::to_string(&rec).unwrap();
+        assert!(json.contains(&super::super::canonical::to_hex(&rec.digest)));
+        let back: ChainTxRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(rec, back);
+    }
+}

--- a/src/provenance_chain/store.rs
+++ b/src/provenance_chain/store.rs
@@ -96,6 +96,51 @@ impl ChainStore {
         Ok(())
     }
 
+    /// Atomically rewrite the entire log to `records` (header + framed records),
+    /// replacing the append handle with one positioned at the new tail.
+    ///
+    /// Used by the sealer's rare out-of-order path (Issue #3351 finding 4): when
+    /// a transaction arrives with a commit timestamp that sorts *before* an
+    /// already-sealed record, the in-memory suffix is re-folded and the log is
+    /// rewritten so the persisted order stays the canonical commit-timestamp
+    /// order. The common in-order case still uses [`append`](Self::append).
+    pub fn rewrite(&self, records: &[ChainTxRecord]) -> ChainResult<()> {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(LOG_MAGIC);
+        payload.extend_from_slice(&FORMAT_VERSION.to_be_bytes());
+        for record in records {
+            let body = record.encode();
+            let len = u32::try_from(body.len())
+                .map_err(|_| ChainError::BadFraming("record too large to frame".into()))?;
+            payload.extend_from_slice(&len.to_be_bytes());
+            payload.extend_from_slice(&body);
+        }
+
+        let tmp_path = self.log_path.with_extension("log.tmp");
+        {
+            let mut f = OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .open(&tmp_path)?;
+            f.write_all(&payload)?;
+            f.sync_all()?;
+        }
+        std::fs::rename(&tmp_path, &self.log_path)?;
+
+        // Re-point the append handle at the rewritten log.
+        let new_append = OpenOptions::new().append(true).open(&self.log_path)?;
+        let mut guard = self
+            .append
+            .lock()
+            .map_err(|_| ChainError::Io("chain append lock poisoned".into()))?;
+        *guard = new_append;
+        if self.fsync == ChainFsyncMode::PerTransaction {
+            guard.sync_all()?;
+        }
+        Ok(())
+    }
+
     /// Force any buffered/os-cached writes to durable storage. Useful for
     /// [`ChainFsyncMode::Batched`] callers that batch appends and flush
     /// explicitly.
@@ -219,6 +264,7 @@ mod tests {
         ChainTxRecord {
             seq,
             commit_ts: 1000 + seq as i64,
+            commit_ts_logical: 0,
             tx_id: seq,
             anchor_lsn: seq,
             leaves: vec![[seq as u8; 32]],

--- a/src/provenance_chain/store.rs
+++ b/src/provenance_chain/store.rs
@@ -183,11 +183,9 @@ impl ChainStore {
                 // Torn record body at the tail — drop it and keep the prefix.
                 break;
             }
-            match ChainTxRecord::decode(&bytes[body_start..body_end]) {
-                Ok(rec) => records.push(rec),
-                // A corrupt (non-tail) record is a hard error, not a torn tail.
-                Err(e) => return Err(e),
-            }
+            // A corrupt (non-tail) record is a hard error, not a torn tail.
+            let rec = ChainTxRecord::decode(&bytes[body_start..body_end])?;
+            records.push(rec);
             pos = body_end;
         }
         Ok(records)

--- a/src/provenance_chain/store.rs
+++ b/src/provenance_chain/store.rs
@@ -1,0 +1,316 @@
+//! Append-only persistence for the provenance hash chain (Issue #3351).
+//!
+//! Layout under the chain directory:
+//! - `chain.log` — a header (`ALCHAIN1` magic + format-version `u32`) followed by
+//!   length-prefixed [`ChainTxRecord`]s (`u32` big-endian frame length, then the
+//!   record's binary payload).
+//! - `head` — an atomically-rewritten [`ChainHead`] checkpoint (`ALCHEAD1` magic +
+//!   version + payload), enabling fast startup without replaying the whole log.
+//!
+//! Torn-tail tolerance: [`ChainStore::load`] returns the longest valid prefix of
+//! records. A partially-written trailing frame (crash mid-append) is dropped
+//! rather than failing the load, mirroring WAL recovery.
+
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use super::config::ChainFsyncMode;
+use super::error::{ChainError, ChainResult};
+use super::record::{ChainHead, ChainTxRecord};
+
+const LOG_MAGIC: &[u8; 8] = b"ALCHAIN1";
+const HEAD_MAGIC: &[u8; 8] = b"ALCHEAD1";
+const FORMAT_VERSION: u32 = 1;
+const HEADER_LEN: usize = 12; // magic(8) + version(4)
+
+/// Append-only store for the sealed portion of a provenance hash chain.
+pub struct ChainStore {
+    log_path: PathBuf,
+    head_path: PathBuf,
+    fsync: ChainFsyncMode,
+    /// Append handle guarded for cross-thread appends.
+    append: Mutex<File>,
+}
+
+impl ChainStore {
+    /// Open (creating if necessary) the chain store under `dir`.
+    ///
+    /// Creates the directory and writes a fresh log header if the log does not
+    /// yet exist. If the log exists, its header is validated.
+    pub fn open(dir: impl AsRef<Path>, fsync: ChainFsyncMode) -> ChainResult<Self> {
+        let dir = dir.as_ref();
+        std::fs::create_dir_all(dir)?;
+        let log_path = dir.join("chain.log");
+        let head_path = dir.join("head");
+
+        if !log_path.exists() {
+            // Create with header.
+            let mut f = OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .open(&log_path)?;
+            let mut header = Vec::with_capacity(HEADER_LEN);
+            header.extend_from_slice(LOG_MAGIC);
+            header.extend_from_slice(&FORMAT_VERSION.to_be_bytes());
+            f.write_all(&header)?;
+            f.sync_all()?;
+        } else {
+            // Validate the existing header eagerly.
+            let mut f = File::open(&log_path)?;
+            let mut header = [0u8; HEADER_LEN];
+            f.read_exact(&mut header)
+                .map_err(|_| ChainError::HeaderMismatch("chain log too short for header".into()))?;
+            validate_header(&header)?;
+        }
+
+        let append = OpenOptions::new().append(true).open(&log_path)?;
+        Ok(ChainStore {
+            log_path,
+            head_path,
+            fsync,
+            append: Mutex::new(append),
+        })
+    }
+
+    /// Append one sealed transaction record, flushing per the configured mode.
+    pub fn append(&self, record: &ChainTxRecord) -> ChainResult<()> {
+        let payload = record.encode();
+        let len = u32::try_from(payload.len())
+            .map_err(|_| ChainError::BadFraming("record too large to frame".into()))?;
+
+        let mut framed = Vec::with_capacity(4 + payload.len());
+        framed.extend_from_slice(&len.to_be_bytes());
+        framed.extend_from_slice(&payload);
+
+        let mut guard = self
+            .append
+            .lock()
+            .map_err(|_| ChainError::Io("chain append lock poisoned".into()))?;
+        guard.write_all(&framed)?;
+        match self.fsync {
+            ChainFsyncMode::PerTransaction => guard.sync_all()?,
+            ChainFsyncMode::Batched | ChainFsyncMode::Never => {}
+        }
+        Ok(())
+    }
+
+    /// Force any buffered/os-cached writes to durable storage. Useful for
+    /// [`ChainFsyncMode::Batched`] callers that batch appends and flush
+    /// explicitly.
+    pub fn flush(&self) -> ChainResult<()> {
+        let guard = self
+            .append
+            .lock()
+            .map_err(|_| ChainError::Io("chain append lock poisoned".into()))?;
+        guard.sync_all()?;
+        Ok(())
+    }
+
+    /// Load all valid records from the log, tolerating a torn trailing frame.
+    pub fn load(&self) -> ChainResult<Vec<ChainTxRecord>> {
+        let bytes = std::fs::read(&self.log_path)?;
+        if bytes.len() < HEADER_LEN {
+            return Err(ChainError::HeaderMismatch(
+                "chain log too short for header".into(),
+            ));
+        }
+        validate_header(&bytes[..HEADER_LEN])?;
+
+        let mut records = Vec::new();
+        let mut pos = HEADER_LEN;
+        while pos < bytes.len() {
+            // Need at least 4 bytes for the frame length.
+            if pos + 4 > bytes.len() {
+                // Torn length prefix at the tail — drop it.
+                break;
+            }
+            let len =
+                u32::from_be_bytes([bytes[pos], bytes[pos + 1], bytes[pos + 2], bytes[pos + 3]])
+                    as usize;
+            let body_start = pos + 4;
+            let body_end = match body_start.checked_add(len) {
+                Some(e) => e,
+                None => break, // absurd length; stop
+            };
+            if body_end > bytes.len() {
+                // Torn record body at the tail — drop it and keep the prefix.
+                break;
+            }
+            match ChainTxRecord::decode(&bytes[body_start..body_end]) {
+                Ok(rec) => records.push(rec),
+                // A corrupt (non-tail) record is a hard error, not a torn tail.
+                Err(e) => return Err(e),
+            }
+            pos = body_end;
+        }
+        Ok(records)
+    }
+
+    /// Atomically write the head checkpoint (temp file + rename), fsyncing the
+    /// temp file first.
+    pub fn write_head_checkpoint(&self, head: &ChainHead) -> ChainResult<()> {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(HEAD_MAGIC);
+        payload.extend_from_slice(&FORMAT_VERSION.to_be_bytes());
+        payload.extend_from_slice(&head.encode());
+
+        let tmp_path = self.head_path.with_extension("tmp");
+        {
+            let mut f = OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .open(&tmp_path)?;
+            f.write_all(&payload)?;
+            f.sync_all()?;
+        }
+        std::fs::rename(&tmp_path, &self.head_path)?;
+        Ok(())
+    }
+
+    /// Read the head checkpoint, returning `None` if none has been written.
+    pub fn read_head_checkpoint(&self) -> ChainResult<Option<ChainHead>> {
+        let bytes = match std::fs::read(&self.head_path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(e.into()),
+        };
+        if bytes.len() < HEADER_LEN {
+            return Err(ChainError::Corrupt("head checkpoint too short".into()));
+        }
+        if &bytes[..8] != HEAD_MAGIC {
+            return Err(ChainError::HeaderMismatch("bad head magic".into()));
+        }
+        let version = u32::from_be_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]);
+        if version != FORMAT_VERSION {
+            return Err(ChainError::HeaderMismatch(format!(
+                "unsupported head version {version}"
+            )));
+        }
+        let head = ChainHead::decode(&bytes[HEADER_LEN..])?;
+        Ok(Some(head))
+    }
+}
+
+fn validate_header(header: &[u8]) -> ChainResult<()> {
+    if header.len() < HEADER_LEN {
+        return Err(ChainError::HeaderMismatch("header too short".into()));
+    }
+    if &header[..8] != LOG_MAGIC {
+        return Err(ChainError::HeaderMismatch("bad chain log magic".into()));
+    }
+    let version = u32::from_be_bytes([header[8], header[9], header[10], header[11]]);
+    if version != FORMAT_VERSION {
+        return Err(ChainError::HeaderMismatch(format!(
+            "unsupported chain log version {version}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provenance_chain::canonical::EntityKind;
+
+    fn rec(seq: u64) -> ChainTxRecord {
+        ChainTxRecord {
+            seq,
+            commit_ts: 1000 + seq as i64,
+            tx_id: seq,
+            anchor_lsn: seq,
+            leaves: vec![[seq as u8; 32]],
+            entity_refs: vec![(EntityKind::Node, seq, seq)],
+            digest: [(seq + 100) as u8; 32],
+        }
+    }
+
+    #[test]
+    fn append_and_load_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ChainStore::open(dir.path(), ChainFsyncMode::PerTransaction).unwrap();
+        let records: Vec<_> = (1..=5).map(rec).collect();
+        for r in &records {
+            store.append(r).unwrap();
+        }
+        let loaded = store.load().unwrap();
+        assert_eq!(loaded, records);
+    }
+
+    #[test]
+    fn reopen_appends_after_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let store = ChainStore::open(dir.path(), ChainFsyncMode::Batched).unwrap();
+            store.append(&rec(1)).unwrap();
+            store.flush().unwrap();
+        }
+        let store = ChainStore::open(dir.path(), ChainFsyncMode::Batched).unwrap();
+        store.append(&rec(2)).unwrap();
+        let loaded = store.load().unwrap();
+        assert_eq!(loaded, vec![rec(1), rec(2)]);
+    }
+
+    #[test]
+    fn torn_trailing_record_yields_valid_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ChainStore::open(dir.path(), ChainFsyncMode::Never).unwrap();
+        store.append(&rec(1)).unwrap();
+        store.append(&rec(2)).unwrap();
+        store.flush().unwrap();
+
+        // Corrupt the tail: append a partial frame (a length prefix promising more
+        // bytes than are present).
+        let log_path = dir.path().join("chain.log");
+        let mut f = OpenOptions::new().append(true).open(&log_path).unwrap();
+        f.write_all(&999u32.to_be_bytes()).unwrap(); // frame len = 999
+        f.write_all(&[0xAB, 0xCD]).unwrap(); // only 2 bytes of body
+        f.sync_all().unwrap();
+
+        let loaded = store.load().unwrap();
+        assert_eq!(loaded, vec![rec(1), rec(2)], "torn tail must be dropped");
+    }
+
+    #[test]
+    fn head_checkpoint_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ChainStore::open(dir.path(), ChainFsyncMode::Batched).unwrap();
+        assert!(store.read_head_checkpoint().unwrap().is_none());
+
+        let head = ChainHead::genesis(3, 4242);
+        store.write_head_checkpoint(&head).unwrap();
+        let read = store.read_head_checkpoint().unwrap().unwrap();
+        assert_eq!(read, head);
+
+        // Overwrite is atomic and readable.
+        let head2 = ChainHead {
+            seq: 9,
+            digest: [7u8; 32],
+            commit_ts: 5000,
+            anchor_lsn: 88,
+            genesis_digest: head.genesis_digest,
+        };
+        store.write_head_checkpoint(&head2).unwrap();
+        assert_eq!(store.read_head_checkpoint().unwrap().unwrap(), head2);
+    }
+
+    #[test]
+    fn open_rejects_bad_magic() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("chain.log");
+        std::fs::write(&log_path, b"XXXXXXXX\x00\x00\x00\x01").unwrap();
+        assert!(matches!(
+            ChainStore::open(dir.path(), ChainFsyncMode::Batched),
+            Err(ChainError::HeaderMismatch(_))
+        ));
+    }
+
+    #[test]
+    fn empty_chain_loads_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ChainStore::open(dir.path(), ChainFsyncMode::Batched).unwrap();
+        assert!(store.load().unwrap().is_empty());
+    }
+}

--- a/src/provenance_chain/verify.rs
+++ b/src/provenance_chain/verify.rs
@@ -72,10 +72,22 @@ pub fn verify_full(
     src: &dyn VersionSource,
     genesis: &ChainHead,
 ) -> ChainVerification {
+    // Fold in canonical commit-timestamp order (Issue #3351 finding 4); records
+    // reach here already sorted, but sort a local copy defensively so the fold is
+    // order-independent.
+    let mut ordered: Vec<&ChainTxRecord> = records.iter().collect();
+    ordered.sort_by(|a, b| {
+        (a.commit_ts, a.commit_ts_logical, &a.leaves).cmp(&(
+            b.commit_ts,
+            b.commit_ts_logical,
+            &b.leaves,
+        ))
+    });
+
     let mut prev = genesis.digest;
     let mut checked: u64 = 0;
 
-    for rec in records {
+    for rec in &ordered {
         // Recompute each leaf from the authoritative source.
         let mut recomputed_leaves = Vec::with_capacity(rec.entity_refs.len());
         for (kind, id, vid) in &rec.entity_refs {
@@ -106,7 +118,7 @@ pub fn verify_full(
         }
 
         // Recompute the tx digest and fold; compare to the sealed digest.
-        let txd = tx_digest(rec.commit_ts, rec.tx_id, &recomputed_leaves);
+        let txd = tx_digest(rec.commit_ts, rec.commit_ts_logical, &recomputed_leaves);
         let step = chain_step(&prev, &txd);
         if step != rec.digest {
             return ChainVerification::broken(
@@ -122,7 +134,13 @@ pub fn verify_full(
         checked += 1;
     }
 
-    let head_seq = records.last().map(|r| r.seq).unwrap_or(genesis.seq);
+    // Structural timeline-consistency check (Issue #3351 finding 2b). Runs after
+    // the fold so a leaf/digest tamper is reported first.
+    if let Some(broken) = check_timeline_consistency(&ordered, src) {
+        return broken;
+    }
+
+    let head_seq = ordered.last().map(|r| r.seq).unwrap_or(genesis.seq);
     ChainVerification {
         passed: true,
         head_seq,
@@ -131,6 +149,100 @@ pub fn verify_full(
         reason: None,
         transactions_checked: checked,
     }
+}
+
+/// Per-entity bi-temporal timeline-consistency check (Issue #3351 finding 2b).
+///
+/// The leaf hash binds the interval **starts**, the tombstone flag, and — for
+/// born-closed terminal versions — the valid-time **end** (see
+/// `db::chain_source::normalize_immutable`), but a *live* version's ends are
+/// mutated by later supersession and so are not directly hashable. This check
+/// catches structural interval-END tampering that the leaf hash cannot:
+///
+/// **What it catches:** per entity, the versions ordered by transaction-time
+/// start must have non-decreasing transaction starts and each version's own
+/// interval must be well-formed (`valid_from <= valid_to`, `tx_from <= tx_to`).
+/// A tombstone/retraction whose end was widened past a well-formedness bound, or
+/// a version whose recorded transaction start was moved before an earlier one,
+/// is flagged.
+///
+/// **What it does NOT catch:** it cannot, on its own, detect an interval-end
+/// edit that keeps every per-version interval individually well-formed and does
+/// not reorder transaction starts (e.g. extending a *terminal* retraction's
+/// `valid_to` to a still-valid future point when nothing follows it) — that case
+/// is covered instead by the leaf hash binding the born-closed terminal
+/// `valid_to` (finding 2c). The two mechanisms are complementary.
+fn check_timeline_consistency(
+    ordered: &[&ChainTxRecord],
+    src: &dyn VersionSource,
+) -> Option<ChainVerification> {
+    use std::collections::BTreeMap;
+
+    // Collect (tx_from, valid_from, valid_to, tx_to) per entity from the source.
+    struct Iv {
+        seq: u64,
+        valid_from: Option<i64>,
+        valid_to: Option<i64>,
+        tx_from: Option<i64>,
+        tx_to: Option<i64>,
+    }
+    let mut by_entity: BTreeMap<(u8, u64), Vec<Iv>> = BTreeMap::new();
+    for rec in ordered {
+        for (kind, id, vid) in &rec.entity_refs {
+            if let Some(input) = src.fetch(*kind, *id, *vid) {
+                by_entity.entry((kind.tag(), *id)).or_default().push(Iv {
+                    seq: rec.seq,
+                    valid_from: input.valid_from,
+                    valid_to: input.valid_to,
+                    tx_from: input.transaction_from,
+                    tx_to: input.transaction_to,
+                });
+            }
+        }
+    }
+
+    for ivs in by_entity.values() {
+        let mut prev_tx_from: Option<i64> = None;
+        for iv in ivs {
+            // Each version's own interval must be well-formed.
+            if let (Some(vf), Some(vt)) = (iv.valid_from, iv.valid_to)
+                && vt < vf
+            {
+                return Some(ChainVerification::broken(
+                    iv.seq.saturating_sub(1),
+                    String::new(),
+                    iv.seq,
+                    "timeline inconsistency: valid_to precedes valid_from".to_string(),
+                    0,
+                ));
+            }
+            if let (Some(tf), Some(tt)) = (iv.tx_from, iv.tx_to)
+                && tt < tf
+            {
+                return Some(ChainVerification::broken(
+                    iv.seq.saturating_sub(1),
+                    String::new(),
+                    iv.seq,
+                    "timeline inconsistency: transaction_to precedes transaction_from".to_string(),
+                    0,
+                ));
+            }
+            // Transaction starts are monotonic in fold order for one entity.
+            if let (Some(prev), Some(cur)) = (prev_tx_from, iv.tx_from)
+                && cur < prev
+            {
+                return Some(ChainVerification::broken(
+                    iv.seq.saturating_sub(1),
+                    String::new(),
+                    iv.seq,
+                    "timeline inconsistency: transaction start regressed for entity".to_string(),
+                    0,
+                ));
+            }
+            prev_tx_from = iv.tx_from.or(prev_tx_from);
+        }
+    }
+    None
 }
 
 /// Maps an entity identity to every `(record index, leaf position, version id)`
@@ -250,7 +362,7 @@ pub fn verify_entity(
         } else {
             records[occ.record_idx - 1].digest
         };
-        let txd = tx_digest(rec.commit_ts, rec.tx_id, &rec.leaves);
+        let txd = tx_digest(rec.commit_ts, rec.commit_ts_logical, &rec.leaves);
         if chain_step(&prev, &txd) != rec.digest {
             return ChainVerification::broken(
                 rec.seq.saturating_sub(1),
@@ -276,17 +388,92 @@ pub fn verify_entity(
     }
 }
 
-/// Prove the current chain extends a previously exported anchor: the record at
-/// `anchor.seq` must exist and match `anchor.digest`. A missing seq means the
-/// chain was truncated (rollback); a mismatching digest means it diverged (fork).
+/// Prove the current chain append-only-extends a previously exported anchor
+/// (Issue #3351 finding 3).
+///
+/// # Why this RE-FOLDS instead of trusting the stored digest
+///
+/// A prior version merely looked up the record at `anchor.seq` and compared its
+/// stored `digest` field to `anchor.digest`. That is forgeable: an attacker who
+/// knows the (offsite) anchor digest can fabricate a `chain.log` that simply
+/// carries `anchor.digest` in the `digest` field of the record at `anchor.seq`
+/// while every leaf/fold underneath is bogus — and it would pass. Instead this
+/// **recomputes the chain from genesis** up to `anchor.seq`: it re-folds each
+/// record's `tx_digest`/`chain_step` from the sealed leaves, requires the
+/// recomputed digest at `anchor.seq` to equal `anchor.digest`, and requires the
+/// chain's own genesis digest to equal the anchor's `genesis_digest`. Only then
+/// is the equality trustworthy. It then confirms the current chain extends that
+/// verified prefix (no fork past the anchor).
+///
+/// Note this re-folds the log's own leaves (proving the log is internally sound
+/// and genuinely descends from the anchored genesis); it does not re-fetch
+/// version content — pair with [`verify_full`] for on-disk version tamper.
 #[must_use]
-pub fn verify_against_anchor(records: &[ChainTxRecord], anchor: &ChainHead) -> ChainVerification {
-    let head_seq = records.last().map(|r| r.seq).unwrap_or(0);
-    let head_digest_hex =
-        super::canonical::to_hex(&records.last().map(|r| r.digest).unwrap_or(anchor.digest));
+pub fn verify_against_anchor(
+    records: &[ChainTxRecord],
+    genesis: &ChainHead,
+    anchor: &ChainHead,
+) -> ChainVerification {
+    // Fold in canonical order (defensive; records arrive sorted).
+    let mut ordered: Vec<&ChainTxRecord> = records.iter().collect();
+    ordered.sort_by(|a, b| {
+        (a.commit_ts, a.commit_ts_logical, &a.leaves).cmp(&(
+            b.commit_ts,
+            b.commit_ts_logical,
+            &b.leaves,
+        ))
+    });
 
-    // A genesis anchor (seq 0) is extended by any chain; the digest can only be
-    // checked once real records exist, which they always do here.
+    let head_seq = ordered.last().map(|r| r.seq).unwrap_or(0);
+    let head_digest_hex =
+        super::canonical::to_hex(&ordered.last().map(|r| r.digest).unwrap_or(anchor.digest));
+
+    // The anchor must descend from the same genesis this chain was seeded with;
+    // otherwise the comparison below would be against an unrelated chain.
+    if anchor.genesis_digest != genesis.genesis_digest {
+        return ChainVerification::broken(
+            head_seq,
+            head_digest_hex,
+            anchor.seq,
+            "anchor genesis digest does not match this chain's genesis (unrelated chain)"
+                .to_string(),
+            0,
+        );
+    }
+
+    // Re-fold from genesis, checking each record's stored digest against the
+    // recomputed fold, and capture the recomputed digest at `anchor.seq`.
+    let mut prev = genesis.digest;
+    let mut recomputed_at_anchor: Option<[u8; 32]> = None;
+    let mut checked: u64 = 0;
+    for rec in &ordered {
+        let txd = tx_digest(rec.commit_ts, rec.commit_ts_logical, &rec.leaves);
+        let step = chain_step(&prev, &txd);
+        if step != rec.digest {
+            // The log is internally inconsistent — a forged/tampered record.
+            return ChainVerification::broken(
+                rec.seq.saturating_sub(1),
+                super::canonical::to_hex(&prev),
+                rec.seq,
+                "recomputed chain digest differs from stored digest (forged/tampered log)"
+                    .to_string(),
+                checked,
+            );
+        }
+        if rec.seq == anchor.seq {
+            recomputed_at_anchor = Some(step);
+        }
+        prev = rec.digest;
+        checked += 1;
+        if rec.seq == anchor.seq {
+            // We have re-folded the whole prefix up to the anchor; stop verifying
+            // the prefix (records beyond it are the extension).
+            break;
+        }
+    }
+
+    // A genesis anchor (seq 0) is extended by any chain that shares its genesis
+    // (already checked above).
     if anchor.seq == 0 {
         return ChainVerification {
             passed: true,
@@ -294,11 +481,11 @@ pub fn verify_against_anchor(records: &[ChainTxRecord], anchor: &ChainHead) -> C
             head_digest_hex,
             earliest_broken_seq: None,
             reason: None,
-            transactions_checked: 0,
+            transactions_checked: checked,
         };
     }
 
-    match records.iter().find(|r| r.seq == anchor.seq) {
+    match recomputed_at_anchor {
         None => ChainVerification::broken(
             head_seq,
             head_digest_hex,
@@ -307,25 +494,25 @@ pub fn verify_against_anchor(records: &[ChainTxRecord], anchor: &ChainHead) -> C
                 "chain truncated: no record at anchor seq {} (rollback)",
                 anchor.seq
             ),
-            0,
+            checked,
         ),
-        Some(rec) if rec.digest == anchor.digest => ChainVerification {
+        Some(d) if d == anchor.digest => ChainVerification {
             passed: true,
             head_seq,
             head_digest_hex,
             earliest_broken_seq: None,
             reason: None,
-            transactions_checked: 1,
+            transactions_checked: checked,
         },
         Some(_) => ChainVerification::broken(
             head_seq,
             head_digest_hex,
             anchor.seq,
             format!(
-                "chain diverged: digest at seq {} differs from anchor (fork)",
+                "chain diverged: recomputed digest at seq {} differs from anchor (fork)",
                 anchor.seq
             ),
-            0,
+            checked,
         ),
     }
 }
@@ -363,11 +550,15 @@ mod tests {
             entity_id: id,
             version_id: vid,
             prev_version_id: None,
+            label: "Person".to_string(),
+            source: None,
+            target: None,
             valid_from: Some(100),
             valid_to: None,
             transaction_from: Some(100),
             transaction_to: None,
             is_current: true,
+            is_tombstone: false,
             provenance: None,
             properties: vec![("name".to_string(), PropertyValue::string(name))],
         }
@@ -385,12 +576,14 @@ mod tests {
             let leaf = version_leaf(&vi);
             let seq = (i + 1) as u64;
             let commit_ts = 1000 + seq as i64;
+            let commit_ts_logical = 0u32;
             let tx_id = seq;
-            let txd = tx_digest(commit_ts, tx_id, &[leaf]);
+            let txd = tx_digest(commit_ts, commit_ts_logical, &[leaf]);
             let digest = chain_step(&prev, &txd);
             records.push(ChainTxRecord {
                 seq,
                 commit_ts,
+                commit_ts_logical,
                 tx_id,
                 anchor_lsn: seq,
                 leaves: vec![leaf],
@@ -465,31 +658,31 @@ mod tests {
 
     #[test]
     fn verify_against_anchor_passes_on_extension() {
-        let (records, _src, _genesis) = build_chain(&[(1, 1, "a"), (2, 1, "b"), (3, 1, "c")]);
+        let (records, _src, genesis) = build_chain(&[(1, 1, "a"), (2, 1, "b"), (3, 1, "c")]);
         let anchor = ChainHead {
             seq: 2,
             digest: records[1].digest,
             commit_ts: records[1].commit_ts,
             anchor_lsn: records[1].anchor_lsn,
-            genesis_digest: [0u8; 32],
+            genesis_digest: genesis.genesis_digest,
         };
-        let v = verify_against_anchor(&records, &anchor);
+        let v = verify_against_anchor(&records, &genesis, &anchor);
         assert!(v.passed, "reason: {:?}", v.reason);
     }
 
     #[test]
     fn verify_against_anchor_detects_truncation() {
-        let (records, _src, _genesis) = build_chain(&[(1, 1, "a"), (2, 1, "b"), (3, 1, "c")]);
+        let (records, _src, genesis) = build_chain(&[(1, 1, "a"), (2, 1, "b"), (3, 1, "c")]);
         let anchor = ChainHead {
             seq: 3,
             digest: records[2].digest,
             commit_ts: records[2].commit_ts,
             anchor_lsn: records[2].anchor_lsn,
-            genesis_digest: [0u8; 32],
+            genesis_digest: genesis.genesis_digest,
         };
         // Roll back to only 2 records.
         let truncated = &records[..2];
-        let v = verify_against_anchor(truncated, &anchor);
+        let v = verify_against_anchor(truncated, &genesis, &anchor);
         assert!(!v.passed);
         assert_eq!(v.earliest_broken_seq, Some(3));
         assert!(v.reason.unwrap().contains("rollback"));
@@ -497,18 +690,43 @@ mod tests {
 
     #[test]
     fn verify_against_anchor_detects_fork() {
-        let (records, _src, _genesis) = build_chain(&[(1, 1, "a"), (2, 1, "b"), (3, 1, "c")]);
+        let (records, _src, genesis) = build_chain(&[(1, 1, "a"), (2, 1, "b"), (3, 1, "c")]);
         let anchor = ChainHead {
             seq: 2,
             // A digest that does not match the real record at seq 2.
             digest: [0x11u8; 32],
             commit_ts: records[1].commit_ts,
             anchor_lsn: records[1].anchor_lsn,
-            genesis_digest: [0u8; 32],
+            genesis_digest: genesis.genesis_digest,
         };
-        let v = verify_against_anchor(&records, &anchor);
+        let v = verify_against_anchor(&records, &genesis, &anchor);
         assert!(!v.passed);
         assert_eq!(v.earliest_broken_seq, Some(2));
         assert!(v.reason.unwrap().contains("fork"));
+    }
+
+    /// Issue #3351 finding 3: a forged log whose record at `anchor.seq` carries
+    /// the known anchor digest but whose fold is broken must be REJECTED (the
+    /// old compare-stored-digest path accepted it).
+    #[test]
+    fn verify_against_anchor_rejects_forged_digest_with_broken_fold() {
+        let (records, _src, genesis) = build_chain(&[(1, 1, "a"), (2, 1, "b"), (3, 1, "c")]);
+        let anchor = ChainHead {
+            seq: 2,
+            digest: records[1].digest,
+            commit_ts: records[1].commit_ts,
+            anchor_lsn: records[1].anchor_lsn,
+            genesis_digest: genesis.genesis_digest,
+        };
+        // Forge a log: keep the anchor digest at seq 2, but corrupt the leaves so
+        // the fold no longer produces that digest.
+        let mut forged = records.clone();
+        forged[1].leaves[0][0] ^= 0xFF; // break the fold under the anchored digest
+        let v = verify_against_anchor(&forged, &genesis, &anchor);
+        assert!(!v.passed, "forged log must be rejected");
+        assert!(
+            v.reason.as_deref().unwrap().contains("forged")
+                || v.reason.as_deref().unwrap().contains("tampered")
+        );
     }
 }

--- a/src/provenance_chain/verify.rs
+++ b/src/provenance_chain/verify.rs
@@ -1,0 +1,497 @@
+//! Verification of a provenance hash chain, independent of the database (Issue #3351).
+//!
+//! Verification recomputes leaves and the folded chain from a
+//! [`VersionSource`] (which reconstructs the authoritative version content) plus
+//! the genesis, and compares against the sealed digests:
+//! - [`verify_full`] walks the whole chain from genesis and localizes the
+//!   **earliest** broken sequence number.
+//! - [`verify_entity`] recomputes only one entity's leaves using a per-entity
+//!   index, with no full scan.
+//! - [`verify_against_anchor`] proves the current chain extends a previously
+//!   exported [`ChainHead`], detecting rollback (truncation) and fork
+//!   (divergence).
+
+use std::collections::HashMap;
+
+use super::canonical::{EntityKind, VersionHashInput, chain_step, tx_digest, version_leaf};
+use super::record::{ChainHead, ChainTxRecord};
+
+/// Reconstructs the authoritative, hashable form of a specific version.
+///
+/// Implemented against whatever holds the real version content (the historical
+/// store at runtime, or a synthetic map in tests). Returning `None` means the
+/// referenced version cannot be found, which fails verification.
+pub trait VersionSource {
+    /// Fetch the normalized hash input for `(kind, id, version_id)`.
+    fn fetch(&self, kind: EntityKind, id: u64, version_id: u64) -> Option<VersionHashInput>;
+}
+
+/// Outcome of a chain verification pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ChainVerification {
+    /// Whether the chain verified cleanly.
+    pub passed: bool,
+    /// Sequence number of the verified head (last checked record, or the
+    /// genesis/anchor seq when nothing was checked).
+    pub head_seq: u64,
+    /// Hex digest of the verified head.
+    pub head_digest_hex: String,
+    /// The earliest sequence number that failed, if any (localizes tamper).
+    pub earliest_broken_seq: Option<u64>,
+    /// Human-readable reason for a failure.
+    pub reason: Option<String>,
+    /// Number of transactions actually checked.
+    pub transactions_checked: u64,
+}
+
+impl ChainVerification {
+    fn broken(
+        head_seq: u64,
+        head_digest_hex: String,
+        seq: u64,
+        reason: impl Into<String>,
+        checked: u64,
+    ) -> Self {
+        ChainVerification {
+            passed: false,
+            head_seq,
+            head_digest_hex,
+            earliest_broken_seq: Some(seq),
+            reason: Some(reason.into()),
+            transactions_checked: checked,
+        }
+    }
+}
+
+/// Full-chain verification: recompute every leaf from `src` and re-fold from
+/// `genesis`, returning the earliest broken sequence number on tamper.
+#[must_use]
+pub fn verify_full(
+    records: &[ChainTxRecord],
+    src: &dyn VersionSource,
+    genesis: &ChainHead,
+) -> ChainVerification {
+    let mut prev = genesis.digest;
+    let mut checked: u64 = 0;
+
+    for rec in records {
+        // Recompute each leaf from the authoritative source.
+        let mut recomputed_leaves = Vec::with_capacity(rec.entity_refs.len());
+        for (kind, id, vid) in &rec.entity_refs {
+            match src.fetch(*kind, *id, *vid) {
+                Some(input) => recomputed_leaves.push(version_leaf(&input)),
+                None => {
+                    return ChainVerification::broken(
+                        rec.seq.saturating_sub(1),
+                        super::canonical::to_hex(&prev),
+                        rec.seq,
+                        format!("version {vid} for entity {id} not found in source"),
+                        checked,
+                    );
+                }
+            }
+        }
+
+        // The stored leaves must match what the source produces (localizes a
+        // single-version tamper precisely).
+        if recomputed_leaves != rec.leaves {
+            return ChainVerification::broken(
+                rec.seq.saturating_sub(1),
+                super::canonical::to_hex(&prev),
+                rec.seq,
+                "recomputed leaf(s) differ from sealed leaves".to_string(),
+                checked,
+            );
+        }
+
+        // Recompute the tx digest and fold; compare to the sealed digest.
+        let txd = tx_digest(rec.commit_ts, rec.tx_id, &recomputed_leaves);
+        let step = chain_step(&prev, &txd);
+        if step != rec.digest {
+            return ChainVerification::broken(
+                rec.seq.saturating_sub(1),
+                super::canonical::to_hex(&prev),
+                rec.seq,
+                "recomputed chain digest differs from sealed digest".to_string(),
+                checked,
+            );
+        }
+
+        prev = rec.digest;
+        checked += 1;
+    }
+
+    let head_seq = records.last().map(|r| r.seq).unwrap_or(genesis.seq);
+    ChainVerification {
+        passed: true,
+        head_seq,
+        head_digest_hex: super::canonical::to_hex(&prev),
+        earliest_broken_seq: None,
+        reason: None,
+        transactions_checked: checked,
+    }
+}
+
+/// Maps an entity identity to every `(record index, leaf position, version id)`
+/// where it appears — enabling entity-scoped verification without a full scan.
+#[derive(Debug, Default)]
+pub struct EntityIndex {
+    inner: HashMap<(EntityKind, u64), Vec<EntityOccurrence>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct EntityOccurrence {
+    record_idx: usize,
+    leaf_pos: usize,
+    version_id: u64,
+}
+
+impl EntityIndex {
+    /// Build the index by scanning the records once (the only full pass; later
+    /// entity verifications reuse it).
+    #[must_use]
+    pub fn build(records: &[ChainTxRecord]) -> Self {
+        let mut inner: HashMap<(EntityKind, u64), Vec<EntityOccurrence>> = HashMap::new();
+        for (record_idx, rec) in records.iter().enumerate() {
+            for (leaf_pos, (kind, id, version_id)) in rec.entity_refs.iter().enumerate() {
+                inner
+                    .entry((*kind, *id))
+                    .or_default()
+                    .push(EntityOccurrence {
+                        record_idx,
+                        leaf_pos,
+                        version_id: *version_id,
+                    });
+            }
+        }
+        EntityIndex { inner }
+    }
+}
+
+/// Entity-scoped verification: recompute only `entity`'s leaves via `src` and
+/// confirm, for each touching record, that the sealed leaf matches and the
+/// record's own digest folds consistently from its (stored) predecessor.
+///
+/// No full scan of the chain — only the records that reference `entity`.
+#[must_use]
+pub fn verify_entity(
+    records: &[ChainTxRecord],
+    index: &EntityIndex,
+    entity: (EntityKind, u64),
+    genesis: &ChainHead,
+    src: &dyn VersionSource,
+) -> ChainVerification {
+    let occurrences = match index.inner.get(&entity) {
+        Some(o) => o,
+        None => {
+            // Entity absent from the chain: trivially consistent (nothing to check).
+            let head_seq = records.last().map(|r| r.seq).unwrap_or(genesis.seq);
+            return ChainVerification {
+                passed: true,
+                head_seq,
+                head_digest_hex: String::new(),
+                earliest_broken_seq: None,
+                reason: Some("entity not present in chain".to_string()),
+                transactions_checked: 0,
+            };
+        }
+    };
+
+    let mut checked: u64 = 0;
+    for occ in occurrences {
+        let rec = &records[occ.record_idx];
+
+        // Recompute just this entity's leaf.
+        let input = match src.fetch(entity.0, entity.1, occ.version_id) {
+            Some(i) => i,
+            None => {
+                return ChainVerification::broken(
+                    rec.seq.saturating_sub(1),
+                    String::new(),
+                    rec.seq,
+                    format!("version {} not found in source", occ.version_id),
+                    checked,
+                );
+            }
+        };
+        let recomputed_leaf = version_leaf(&input);
+        if recomputed_leaf != rec.leaves[occ.leaf_pos] {
+            return ChainVerification::broken(
+                rec.seq.saturating_sub(1),
+                String::new(),
+                rec.seq,
+                "entity leaf differs from sealed leaf".to_string(),
+                checked,
+            );
+        }
+
+        // Confirm the record's digest folds from its stored predecessor. This is
+        // a local check using neighbor digests, not a full re-fold.
+        let prev = if occ.record_idx == 0 {
+            genesis.digest
+        } else {
+            records[occ.record_idx - 1].digest
+        };
+        let txd = tx_digest(rec.commit_ts, rec.tx_id, &rec.leaves);
+        if chain_step(&prev, &txd) != rec.digest {
+            return ChainVerification::broken(
+                rec.seq.saturating_sub(1),
+                String::new(),
+                rec.seq,
+                "record digest inconsistent with stored predecessor".to_string(),
+                checked,
+            );
+        }
+        checked += 1;
+    }
+
+    let head_seq = records.last().map(|r| r.seq).unwrap_or(genesis.seq);
+    ChainVerification {
+        passed: true,
+        head_seq,
+        head_digest_hex: super::canonical::to_hex(
+            &records.last().map(|r| r.digest).unwrap_or(genesis.digest),
+        ),
+        earliest_broken_seq: None,
+        reason: None,
+        transactions_checked: checked,
+    }
+}
+
+/// Prove the current chain extends a previously exported anchor: the record at
+/// `anchor.seq` must exist and match `anchor.digest`. A missing seq means the
+/// chain was truncated (rollback); a mismatching digest means it diverged (fork).
+#[must_use]
+pub fn verify_against_anchor(records: &[ChainTxRecord], anchor: &ChainHead) -> ChainVerification {
+    let head_seq = records.last().map(|r| r.seq).unwrap_or(0);
+    let head_digest_hex =
+        super::canonical::to_hex(&records.last().map(|r| r.digest).unwrap_or(anchor.digest));
+
+    // A genesis anchor (seq 0) is extended by any chain; the digest can only be
+    // checked once real records exist, which they always do here.
+    if anchor.seq == 0 {
+        return ChainVerification {
+            passed: true,
+            head_seq,
+            head_digest_hex,
+            earliest_broken_seq: None,
+            reason: None,
+            transactions_checked: 0,
+        };
+    }
+
+    match records.iter().find(|r| r.seq == anchor.seq) {
+        None => ChainVerification::broken(
+            head_seq,
+            head_digest_hex,
+            anchor.seq,
+            format!(
+                "chain truncated: no record at anchor seq {} (rollback)",
+                anchor.seq
+            ),
+            0,
+        ),
+        Some(rec) if rec.digest == anchor.digest => ChainVerification {
+            passed: true,
+            head_seq,
+            head_digest_hex,
+            earliest_broken_seq: None,
+            reason: None,
+            transactions_checked: 1,
+        },
+        Some(_) => ChainVerification::broken(
+            head_seq,
+            head_digest_hex,
+            anchor.seq,
+            format!(
+                "chain diverged: digest at seq {} differs from anchor (fork)",
+                anchor.seq
+            ),
+            0,
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::property::PropertyValue;
+    use std::collections::HashMap;
+
+    /// A synthetic in-memory version source keyed by (kind, id, version_id).
+    #[derive(Default)]
+    struct MapSource {
+        map: HashMap<(EntityKind, u64, u64), VersionHashInput>,
+    }
+
+    impl MapSource {
+        fn insert(&mut self, input: VersionHashInput) {
+            self.map.insert(
+                (input.entity_kind, input.entity_id, input.version_id),
+                input,
+            );
+        }
+    }
+
+    impl VersionSource for MapSource {
+        fn fetch(&self, kind: EntityKind, id: u64, version_id: u64) -> Option<VersionHashInput> {
+            self.map.get(&(kind, id, version_id)).cloned()
+        }
+    }
+
+    fn input(id: u64, vid: u64, name: &str) -> VersionHashInput {
+        VersionHashInput {
+            entity_kind: EntityKind::Node,
+            entity_id: id,
+            version_id: vid,
+            prev_version_id: None,
+            valid_from: Some(100),
+            valid_to: None,
+            transaction_from: Some(100),
+            transaction_to: None,
+            is_current: true,
+            provenance: None,
+            properties: vec![("name".to_string(), PropertyValue::string(name))],
+        }
+    }
+
+    /// Build a clean chain of N single-version transactions plus a source and genesis.
+    fn build_chain(specs: &[(u64, u64, &str)]) -> (Vec<ChainTxRecord>, MapSource, ChainHead) {
+        let genesis = ChainHead::genesis(1, 0);
+        let mut src = MapSource::default();
+        let mut records = Vec::new();
+        let mut prev = genesis.digest;
+        for (i, (id, vid, name)) in specs.iter().enumerate() {
+            let vi = input(*id, *vid, name);
+            src.insert(vi.clone());
+            let leaf = version_leaf(&vi);
+            let seq = (i + 1) as u64;
+            let commit_ts = 1000 + seq as i64;
+            let tx_id = seq;
+            let txd = tx_digest(commit_ts, tx_id, &[leaf]);
+            let digest = chain_step(&prev, &txd);
+            records.push(ChainTxRecord {
+                seq,
+                commit_ts,
+                tx_id,
+                anchor_lsn: seq,
+                leaves: vec![leaf],
+                entity_refs: vec![(EntityKind::Node, *id, *vid)],
+                digest,
+            });
+            prev = digest;
+        }
+        (records, src, genesis)
+    }
+
+    #[test]
+    fn verify_full_passes_on_clean_chain() {
+        let (records, src, genesis) = build_chain(&[(1, 1, "a"), (2, 1, "b"), (3, 1, "c")]);
+        let v = verify_full(&records, &src, &genesis);
+        assert!(v.passed, "reason: {:?}", v.reason);
+        assert_eq!(v.transactions_checked, 3);
+        assert_eq!(v.head_seq, 3);
+        assert!(v.earliest_broken_seq.is_none());
+    }
+
+    #[test]
+    fn verify_full_localizes_a_mutated_version() {
+        let (records, mut src, genesis) = build_chain(&[(1, 1, "a"), (2, 1, "b"), (3, 1, "c")]);
+        // Tamper the stored version content of the entity in tx 2.
+        src.insert(input(2, 1, "TAMPERED"));
+        let v = verify_full(&records, &src, &genesis);
+        assert!(!v.passed);
+        assert_eq!(v.earliest_broken_seq, Some(2));
+    }
+
+    #[test]
+    fn verify_full_detects_deleted_transaction() {
+        let (mut records, src, genesis) = build_chain(&[(1, 1, "a"), (2, 1, "b"), (3, 1, "c")]);
+        // Delete the middle transaction; the fold breaks at what is now seq 3.
+        records.remove(1);
+        let v = verify_full(&records, &src, &genesis);
+        assert!(!v.passed);
+        // seq 1 still folds from genesis; the break is at the record after it.
+        assert_eq!(v.earliest_broken_seq, Some(3));
+    }
+
+    #[test]
+    fn verify_full_detects_single_mutated_leaf() {
+        let (mut records, src, genesis) = build_chain(&[(1, 1, "a"), (2, 1, "b")]);
+        // Flip a byte of a sealed leaf.
+        records[0].leaves[0][0] ^= 0xFF;
+        let v = verify_full(&records, &src, &genesis);
+        assert!(!v.passed);
+        assert_eq!(v.earliest_broken_seq, Some(1));
+    }
+
+    #[test]
+    fn verify_entity_passes_clean_without_full_scan() {
+        let (records, src, genesis) = build_chain(&[(1, 1, "a"), (2, 1, "b"), (1, 2, "a2")]);
+        let index = EntityIndex::build(&records);
+        let v = verify_entity(&records, &index, (EntityKind::Node, 1), &genesis, &src);
+        assert!(v.passed, "reason: {:?}", v.reason);
+        // Entity 1 appears in tx 1 and tx 3 only.
+        assert_eq!(v.transactions_checked, 2);
+    }
+
+    #[test]
+    fn verify_entity_catches_mutation() {
+        let (records, mut src, genesis) = build_chain(&[(1, 1, "a"), (2, 1, "b"), (1, 2, "a2")]);
+        let index = EntityIndex::build(&records);
+        src.insert(input(1, 2, "HACKED"));
+        let v = verify_entity(&records, &index, (EntityKind::Node, 1), &genesis, &src);
+        assert!(!v.passed);
+        assert_eq!(v.earliest_broken_seq, Some(3));
+    }
+
+    #[test]
+    fn verify_against_anchor_passes_on_extension() {
+        let (records, _src, _genesis) = build_chain(&[(1, 1, "a"), (2, 1, "b"), (3, 1, "c")]);
+        let anchor = ChainHead {
+            seq: 2,
+            digest: records[1].digest,
+            commit_ts: records[1].commit_ts,
+            anchor_lsn: records[1].anchor_lsn,
+            genesis_digest: [0u8; 32],
+        };
+        let v = verify_against_anchor(&records, &anchor);
+        assert!(v.passed, "reason: {:?}", v.reason);
+    }
+
+    #[test]
+    fn verify_against_anchor_detects_truncation() {
+        let (records, _src, _genesis) = build_chain(&[(1, 1, "a"), (2, 1, "b"), (3, 1, "c")]);
+        let anchor = ChainHead {
+            seq: 3,
+            digest: records[2].digest,
+            commit_ts: records[2].commit_ts,
+            anchor_lsn: records[2].anchor_lsn,
+            genesis_digest: [0u8; 32],
+        };
+        // Roll back to only 2 records.
+        let truncated = &records[..2];
+        let v = verify_against_anchor(truncated, &anchor);
+        assert!(!v.passed);
+        assert_eq!(v.earliest_broken_seq, Some(3));
+        assert!(v.reason.unwrap().contains("rollback"));
+    }
+
+    #[test]
+    fn verify_against_anchor_detects_fork() {
+        let (records, _src, _genesis) = build_chain(&[(1, 1, "a"), (2, 1, "b"), (3, 1, "c")]);
+        let anchor = ChainHead {
+            seq: 2,
+            // A digest that does not match the real record at seq 2.
+            digest: [0x11u8; 32],
+            commit_ts: records[1].commit_ts,
+            anchor_lsn: records[1].anchor_lsn,
+            genesis_digest: [0u8; 32],
+        };
+        let v = verify_against_anchor(&records, &anchor);
+        assert!(!v.passed);
+        assert_eq!(v.earliest_broken_seq, Some(2));
+        assert!(v.reason.unwrap().contains("fork"));
+    }
+}

--- a/src/provenance_chain/verify.rs
+++ b/src/provenance_chain/verify.rs
@@ -24,6 +24,38 @@ use super::record::{ChainHead, ChainTxRecord};
 pub trait VersionSource {
     /// Fetch the normalized hash input for `(kind, id, version_id)`.
     fn fetch(&self, kind: EntityKind, id: u64, version_id: u64) -> Option<VersionHashInput>;
+
+    /// Run `f` against a fetch view for the duration of one verification pass,
+    /// giving a lock-backed source the chance to acquire its underlying shared
+    /// lock **once** for the whole pass instead of re-locking on every
+    /// [`fetch`](Self::fetch) (Issue #3351 AC4 / task #2).
+    ///
+    /// The default implementation simply runs `f` against `self` — correct for
+    /// any source whose `fetch` is already cheap/lock-free (e.g. an in-memory
+    /// test map). A source that guards real storage behind a `RwLock` overrides
+    /// this to hold its read guard across `f`, so a full/entity verify takes the
+    /// read lock a single time rather than once per version.
+    fn scoped(&self, f: &mut dyn FnMut(&dyn VersionSource)) {
+        // Object-safe self-reborrow: `&Self` cannot coerce to `&dyn` for an
+        // unsized `Self`, so wrap it in a `Sized` adapter that delegates `fetch`.
+        struct Reborrow<'a, S: ?Sized>(&'a S);
+        impl<S: VersionSource + ?Sized> VersionSource for Reborrow<'_, S> {
+            fn fetch(
+                &self,
+                kind: EntityKind,
+                id: u64,
+                version_id: u64,
+            ) -> Option<VersionHashInput> {
+                self.0.fetch(kind, id, version_id)
+            }
+            // `Reborrow` is `Sized`, so `&self` coerces to `&dyn` directly here —
+            // overriding avoids the default rebuilding `Reborrow<Reborrow<..>>`.
+            fn scoped(&self, f: &mut dyn FnMut(&dyn VersionSource)) {
+                f(self);
+            }
+        }
+        f(&Reborrow(self));
+    }
 }
 
 /// Outcome of a chain verification pass.
@@ -66,8 +98,22 @@ impl ChainVerification {
 
 /// Full-chain verification: recompute every leaf from `src` and re-fold from
 /// `genesis`, returning the earliest broken sequence number on tamper.
+///
+/// Routes through [`VersionSource::scoped`] so a lock-backed source (the live
+/// historical store) holds its read lock **once** for the whole pass rather than
+/// re-acquiring it per version (Issue #3351 task #2).
 #[must_use]
 pub fn verify_full(
+    records: &[ChainTxRecord],
+    src: &dyn VersionSource,
+    genesis: &ChainHead,
+) -> ChainVerification {
+    let mut out: Option<ChainVerification> = None;
+    src.scoped(&mut |s| out = Some(verify_full_inner(records, s, genesis)));
+    out.expect("VersionSource::scoped must invoke its callback exactly once")
+}
+
+fn verify_full_inner(
     records: &[ChainTxRecord],
     src: &dyn VersionSource,
     genesis: &ChainHead,
@@ -303,8 +349,23 @@ impl EntityIndex {
 /// record's own digest folds consistently from its (stored) predecessor.
 ///
 /// No full scan of the chain — only the records that reference `entity`.
+///
+/// Like [`verify_full`], routes through [`VersionSource::scoped`] so the live
+/// historical store is locked once for the (already entity-scoped) pass.
 #[must_use]
 pub fn verify_entity(
+    records: &[ChainTxRecord],
+    index: &EntityIndex,
+    entity: (EntityKind, u64),
+    genesis: &ChainHead,
+    src: &dyn VersionSource,
+) -> ChainVerification {
+    let mut out: Option<ChainVerification> = None;
+    src.scoped(&mut |s| out = Some(verify_entity_inner(records, index, entity, genesis, s)));
+    out.expect("VersionSource::scoped must invoke its callback exactly once")
+}
+
+fn verify_entity_inner(
     records: &[ChainTxRecord],
     index: &EntityIndex,
     entity: (EntityKind, u64),
@@ -634,6 +695,67 @@ mod tests {
         let v = verify_full(&records, &src, &genesis);
         assert!(!v.passed);
         assert_eq!(v.earliest_broken_seq, Some(1));
+    }
+
+    /// AC1 (reorder): moving a transaction to a different point in the timeline
+    /// changes the head digest and is caught + localized. We swap two records'
+    /// commit timestamps (their timeline position) while leaving the sealed
+    /// digests untouched: the fold re-orders by commit timestamp, recomputes each
+    /// `tx_digest` (which binds the commit timestamp), and no longer reproduces
+    /// the sealed digests.
+    #[test]
+    fn verify_full_detects_reordered_transactions() {
+        let (mut records, src, genesis) = build_chain(&[(1, 1, "a"), (2, 1, "b"), (3, 1, "c")]);
+        let clean_head = records.last().unwrap().digest;
+
+        // Swap the commit timestamps of tx 1 and tx 2 — a timeline reorder.
+        let ts0 = records[0].commit_ts;
+        records[0].commit_ts = records[1].commit_ts;
+        records[1].commit_ts = ts0;
+
+        let v = verify_full(&records, &src, &genesis);
+        assert!(!v.passed, "a transaction reorder must be detected");
+        assert!(
+            v.earliest_broken_seq.is_some(),
+            "reorder tamper is localized"
+        );
+        // The reorder necessarily changes the canonical head digest.
+        assert_ne!(
+            v.head_digest_hex,
+            crate::provenance_chain::canonical::to_hex(&clean_head),
+            "reorder must change the folded head digest"
+        );
+    }
+
+    /// AC1 (insert): a forged transaction spliced into the chain is caught +
+    /// localized. The forged record references a version that stored history does
+    /// not contain, so its leaf cannot be reproduced — the fold breaks exactly at
+    /// the forged sequence.
+    #[test]
+    fn verify_full_detects_forged_inserted_transaction() {
+        let (mut records, src, genesis) = build_chain(&[(1, 1, "a"), (2, 1, "b"), (3, 1, "c")]);
+
+        // Fabricate a record that sorts between tx 1 and tx 2 but references a
+        // version (entity 999) absent from the source.
+        let forged = ChainTxRecord {
+            seq: 99,
+            commit_ts: records[0].commit_ts + 1,
+            commit_ts_logical: 0,
+            tx_id: 12345,
+            anchor_lsn: 42,
+            leaves: vec![[0xAAu8; 32]],
+            entity_refs: vec![(EntityKind::Node, 999, 999)],
+            digest: [0xBBu8; 32],
+        };
+        records.insert(1, forged);
+
+        let v = verify_full(&records, &src, &genesis);
+        assert!(!v.passed, "a forged inserted transaction must be detected");
+        assert_eq!(
+            v.earliest_broken_seq,
+            Some(99),
+            "the forged record's sequence is localized"
+        );
     }
 
     #[test]

--- a/src/provenance_chain/verify.rs
+++ b/src/provenance_chain/verify.rs
@@ -167,6 +167,23 @@ impl EntityIndex {
         }
         EntityIndex { inner }
     }
+
+    /// Extend the index with one newly-appended record at `record_idx`, keeping
+    /// a running index in lockstep with the sealed log (Issue #3351 engine).
+    /// `record_idx` must be the record's position in the `records` slice a later
+    /// [`verify_entity`] will be called against.
+    pub fn push_record(&mut self, record_idx: usize, record: &ChainTxRecord) {
+        for (leaf_pos, (kind, id, version_id)) in record.entity_refs.iter().enumerate() {
+            self.inner
+                .entry((*kind, *id))
+                .or_default()
+                .push(EntityOccurrence {
+                    record_idx,
+                    leaf_pos,
+                    version_id: *version_id,
+                });
+        }
+    }
 }
 
 /// Entity-scoped verification: recompute only `entity`'s leaves via `src` and

--- a/tests/provenance_chain_integration.rs
+++ b/tests/provenance_chain_integration.rs
@@ -173,12 +173,13 @@ fn ac3_tamper_is_detected_and_localized() {
 
     // Flip one byte inside the first sealed record's first leaf. Layout of
     // chain.log: header(12) + [frame_len(4) + payload]; payload =
-    // seq(8) commit_ts(8) tx_id(8) anchor_lsn(8) n_leaves(8) leaves(32*n)...,
-    // so the first leaf begins at offset 12 + 4 + 40 = 56.
+    // seq(8) commit_ts(8) commit_ts_logical(4) tx_id(8) anchor_lsn(8)
+    // n_leaves(8) leaves(32*n)..., so the first leaf begins at offset
+    // 12 + 4 + (8+8+4+8+8+8) = 60.
     let log_path = dir.path().join("chain").join("chain.log");
     let mut bytes = std::fs::read(&log_path).unwrap();
-    assert!(bytes.len() > 56, "chain log unexpectedly small");
-    bytes[56] ^= 0xFF;
+    assert!(bytes.len() > 60, "chain log unexpectedly small");
+    bytes[60] ^= 0xFF;
     std::fs::write(&log_path, &bytes).unwrap();
 
     // Reopen and verify: the tampered sealed leaf no longer matches history.
@@ -339,6 +340,65 @@ fn ac6_crash_recovery_rebuilds_tail() {
     let v = db.verify_chain().unwrap();
     assert!(v.passed, "rebuilt chain must verify: {:?}", v.reason);
     assert_eq!(v.transactions_checked, 3);
+}
+
+// ---------------------------------------------------------------------------
+// Finding 4 (Issue #3351): the rebuilt-from-history chain must reproduce the
+// EXACT pre-crash head digest, so an anchor exported before the crash still
+// verifies as an append-only extension after rebuild. This fails without the
+// deterministic commit-ordered digest (tx_id removed from the fold; full HLC
+// bound; records folded in commit-timestamp order in both live and rebuild
+// paths).
+//
+// Crash model: the head checkpoint (which carries the immutable genesis digest)
+// survives, but the sealed log tail is lost — forcing a full tail rebuild on
+// reopen. The genesis cannot be reproduced from scratch (it is seeded from the
+// open-time LSN, which differs after replay), so preserving the checkpoint's
+// genesis is exactly what a real durable chain does.
+// ---------------------------------------------------------------------------
+#[test]
+fn finding4_rebuilt_chain_matches_precrash_anchor() {
+    let dir = tempfile::tempdir().unwrap();
+    let anchor;
+    {
+        let db = AletheiaDB::with_unified_config(enabled_config(dir.path())).unwrap();
+        let a = db.create_node("Person", props("Alice")).unwrap();
+        let b = db.create_node("Person", props("Bob")).unwrap();
+        db.create_edge(a, b, "KNOWS", props("")).unwrap();
+        db.create_node("Person", props("Carol")).unwrap();
+        wait_for_head_seq(&db, 4);
+        anchor = db.export_chain_head().unwrap();
+        assert_eq!(anchor.seq, 4);
+        // db drops here: log + head checkpoint flushed.
+    }
+
+    // Simulate the lost sealed tail: truncate chain.log back to just its 12-byte
+    // header (dropping every sealed record) while KEEPING the head checkpoint so
+    // the genesis digest survives. On reopen the chain loads zero records
+    // (head == genesis) and rebuilds all four transactions from replayed history.
+    let log_path = dir.path().join("chain").join("chain.log");
+    let bytes = std::fs::read(&log_path).unwrap();
+    std::fs::write(&log_path, &bytes[..12]).unwrap();
+
+    let db = AletheiaDB::with_unified_config(enabled_config(dir.path())).unwrap();
+    let head = db.export_chain_head().unwrap();
+    assert_eq!(head.seq, 4, "tail rebuilt one record per recovered tx");
+
+    // The rebuilt chain reproduces the pre-crash digest exactly: the pre-crash
+    // anchor verifies as an append-only extension (no false fork).
+    assert_eq!(
+        head.digest, anchor.digest,
+        "rebuilt head digest must equal the pre-crash head digest"
+    );
+    let v = db.verify_chain_against(&anchor).unwrap();
+    assert!(
+        v.passed,
+        "pre-crash anchor must verify against the rebuilt chain: {:?}",
+        v.reason
+    );
+
+    // And full verification still passes over the rebuilt records.
+    assert!(db.verify_chain().unwrap().passed);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/provenance_chain_integration.rs
+++ b/tests/provenance_chain_integration.rs
@@ -1,0 +1,369 @@
+//! Integration tests for the tamper-evident provenance hash chain database
+//! layer (Issue #3351). Each test maps to an acceptance criterion (AC1..AC7).
+
+use std::path::Path;
+use std::time::Duration;
+
+use aletheiadb::config::{AletheiaDBConfig, WalConfigBuilder};
+use aletheiadb::provenance_chain::{ChainConfig, ChainFsyncMode, ChainHead, EntityKind};
+use aletheiadb::{AletheiaDB, DurabilityMode, PersistenceConfig, PropertyMapBuilder};
+
+/// Build a config with the provenance chain enabled, WAL + index persistence
+/// durable, rooted at `data_dir`. The chain lives at `<data_dir>/chain`.
+fn enabled_config(data_dir: &Path) -> AletheiaDBConfig {
+    AletheiaDBConfig::builder()
+        .wal(
+            WalConfigBuilder::new()
+                .wal_dir(data_dir.join("wal"))
+                .durability_mode(DurabilityMode::Synchronous)
+                .build(),
+        )
+        .persistence(PersistenceConfig {
+            enabled: true,
+            data_dir: data_dir.join("indexes"),
+            load_on_startup: true,
+            ..Default::default()
+        })
+        .chain(ChainConfig {
+            enabled: true,
+            fsync: ChainFsyncMode::PerTransaction,
+            dir: None,
+        })
+        .build()
+}
+
+fn props(name: &str) -> aletheiadb::PropertyMap {
+    PropertyMapBuilder::new().insert("name", name).build()
+}
+
+/// Wait for the async sealer to reach at least `expected` sealed transactions.
+fn wait_for_head_seq(db: &AletheiaDB, expected: u64) {
+    for _ in 0..300 {
+        if db.export_chain_head().expect("chain enabled").seq >= expected {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    panic!(
+        "chain head did not reach seq {expected} (stuck at {})",
+        db.export_chain_head().unwrap().seq
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC1: every committed transaction advances the chain head by exactly one seq
+// and changes the head digest; a no-op/read-only transaction adds no record.
+// ---------------------------------------------------------------------------
+#[test]
+fn ac1_head_advances_one_seq_per_transaction() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = AletheiaDB::with_unified_config(enabled_config(dir.path())).unwrap();
+
+    assert_eq!(db.export_chain_head().unwrap().seq, 0, "starts at genesis");
+    let genesis_digest = db.export_chain_head().unwrap().digest;
+
+    // Tx 1: a node.
+    let alice = db.create_node("Person", props("Alice")).unwrap();
+    wait_for_head_seq(&db, 1);
+    let h1 = db.export_chain_head().unwrap();
+    assert_eq!(h1.seq, 1);
+    assert_ne!(h1.digest, genesis_digest, "head digest advances");
+
+    // Tx 2: another node.
+    let bob = db.create_node("Person", props("Bob")).unwrap();
+    wait_for_head_seq(&db, 2);
+    let h2 = db.export_chain_head().unwrap();
+    assert_eq!(h2.seq, 2);
+    assert_ne!(h2.digest, h1.digest, "each tx changes the head digest");
+
+    // Tx 3: an edge.
+    db.create_edge(alice, bob, "KNOWS", props("")).unwrap();
+    wait_for_head_seq(&db, 3);
+    assert_eq!(db.export_chain_head().unwrap().seq, 3);
+
+    // Tx 4: a multi-op batch (two nodes + an edge) — still ONE record.
+    db.write(|tx| {
+        use aletheiadb::api::transaction::WriteOps;
+        let c = tx.create_node("Person", props("Carol"))?;
+        let d = tx.create_node("Person", props("Dave"))?;
+        tx.create_edge(c, d, "KNOWS", props(""))?;
+        Ok::<_, aletheiadb::Error>(())
+    })
+    .unwrap();
+    wait_for_head_seq(&db, 4);
+    assert_eq!(
+        db.export_chain_head().unwrap().seq,
+        4,
+        "a multi-op batch seals as a single transaction record"
+    );
+
+    // A read-only op and an empty write add NO record.
+    let _ = db.get_node(alice).unwrap();
+    db.write(|_tx| Ok::<_, aletheiadb::Error>(())).unwrap();
+    std::thread::sleep(Duration::from_millis(50));
+    assert_eq!(
+        db.export_chain_head().unwrap().seq,
+        4,
+        "read-only / empty transactions do not add chain records"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC2: full-chain and entity-scoped verification pass on a clean database.
+// ---------------------------------------------------------------------------
+#[test]
+fn ac2_full_and_entity_verification_pass_clean() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = AletheiaDB::with_unified_config(enabled_config(dir.path())).unwrap();
+
+    let alice = db.create_node("Person", props("Alice")).unwrap();
+    let _bob = db.create_node("Person", props("Bob")).unwrap();
+    // A second write to `alice` so it appears in two transactions.
+    db.write(|tx| {
+        use aletheiadb::api::transaction::WriteOps;
+        tx.update_node(alice, props("Alice2"))?;
+        Ok::<_, aletheiadb::Error>(())
+    })
+    .unwrap();
+    wait_for_head_seq(&db, 3);
+
+    let full = db.verify_chain().unwrap();
+    assert!(full.passed, "clean full verify: {:?}", full.reason);
+    assert_eq!(full.transactions_checked, 3);
+
+    // Entity-scoped: alice appears in tx 1 and tx 3 only — verification touches
+    // exactly those two records, not all three.
+    let ev = db
+        .verify_entity_chain(EntityKind::Node, alice.as_u64())
+        .unwrap();
+    assert!(ev.passed, "clean entity verify: {:?}", ev.reason);
+    assert_eq!(
+        ev.transactions_checked, 2,
+        "entity verify is scoped to the entity's records"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC3 (headline): a persisted sealed record no longer matching stored history
+// is caught and localized.
+//
+// Tamper mechanism: after sealing, we flip one byte of a persisted sealed leaf
+// in `chain.log`, then reopen. Verify recomputes that leaf from stored history
+// and finds it disagrees with the persisted sealed leaf — passed = false, with
+// `earliest_broken_seq` localizing the exact transaction. This exercises the
+// identical recompute-vs-sealed comparison that catches a tampered *data*
+// version (the dual): AletheiaDB's WAL/index stores checksum a raw data-byte
+// flip, and storage internals are out of this lane's scope (no in-process API
+// to mutate a stored historical version), so per the design's documented
+// fallback we tamper the persisted verifiable state and assert the chain both
+// detects and localizes the divergence.
+// ---------------------------------------------------------------------------
+#[test]
+fn ac3_tamper_is_detected_and_localized() {
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let db = AletheiaDB::with_unified_config(enabled_config(dir.path())).unwrap();
+        db.create_node("Person", props("Alice")).unwrap();
+        db.create_node("Person", props("Bob")).unwrap();
+        db.create_node("Person", props("Carol")).unwrap();
+        wait_for_head_seq(&db, 3);
+        assert!(db.verify_chain().unwrap().passed);
+        // db drops here: sealer flushes + head checkpoint persisted.
+    }
+
+    // Flip one byte inside the first sealed record's first leaf. Layout of
+    // chain.log: header(12) + [frame_len(4) + payload]; payload =
+    // seq(8) commit_ts(8) tx_id(8) anchor_lsn(8) n_leaves(8) leaves(32*n)...,
+    // so the first leaf begins at offset 12 + 4 + 40 = 56.
+    let log_path = dir.path().join("chain").join("chain.log");
+    let mut bytes = std::fs::read(&log_path).unwrap();
+    assert!(bytes.len() > 56, "chain log unexpectedly small");
+    bytes[56] ^= 0xFF;
+    std::fs::write(&log_path, &bytes).unwrap();
+
+    // Reopen and verify: the tampered sealed leaf no longer matches history.
+    let db = AletheiaDB::with_unified_config(enabled_config(dir.path())).unwrap();
+    let v = db.verify_chain().unwrap();
+    assert!(!v.passed, "tamper must be detected");
+    assert_eq!(
+        v.earliest_broken_seq,
+        Some(1),
+        "tamper is localized to the affected transaction"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC4: an exported head anchors append-only extension; a truncated/divergent
+// anchor is rejected.
+// ---------------------------------------------------------------------------
+#[test]
+fn ac4_anchor_proves_extension_and_detects_rollback_fork() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = AletheiaDB::with_unified_config(enabled_config(dir.path())).unwrap();
+
+    db.create_node("Person", props("Alice")).unwrap();
+    db.create_node("Person", props("Bob")).unwrap();
+    wait_for_head_seq(&db, 2);
+    let anchor = db.export_chain_head().unwrap();
+    assert_eq!(anchor.seq, 2);
+
+    // Extend the chain, then prove it append-only-extends the earlier anchor.
+    db.create_node("Person", props("Carol")).unwrap();
+    wait_for_head_seq(&db, 3);
+    let ext = db.verify_chain_against(&anchor).unwrap();
+    assert!(
+        ext.passed,
+        "extension of an anchor must verify: {:?}",
+        ext.reason
+    );
+
+    // Rollback: an anchor at a seq the (truncated) chain no longer has.
+    let rollback_anchor = ChainHead {
+        seq: 99,
+        digest: [0x11u8; 32],
+        commit_ts: anchor.commit_ts,
+        anchor_lsn: anchor.anchor_lsn,
+        genesis_digest: anchor.genesis_digest,
+    };
+    let rb = db.verify_chain_against(&rollback_anchor).unwrap();
+    assert!(!rb.passed, "a rollback anchor must fail");
+    assert!(rb.reason.unwrap().contains("rollback"));
+
+    // Fork: an anchor at an existing seq but with a divergent digest.
+    let fork_anchor = ChainHead {
+        seq: 2,
+        digest: [0xABu8; 32],
+        commit_ts: anchor.commit_ts,
+        anchor_lsn: anchor.anchor_lsn,
+        genesis_digest: anchor.genesis_digest,
+    };
+    let fk = db.verify_chain_against(&fork_anchor).unwrap();
+    assert!(!fk.passed, "a divergent anchor must fail");
+    assert!(fk.reason.unwrap().contains("fork"));
+}
+
+// ---------------------------------------------------------------------------
+// AC5: with the chain DISABLED (the default), no chain files are created, the
+// verify API reports "not enabled", stats.chain.enabled is false, and writes
+// behave identically.
+// ---------------------------------------------------------------------------
+#[test]
+fn ac5_disabled_is_zero_behavior_change() {
+    let dir = tempfile::tempdir().unwrap();
+    // Durable config WITHOUT enabling the chain (chain defaults to disabled).
+    let config = AletheiaDBConfig::builder()
+        .wal(
+            WalConfigBuilder::new()
+                .wal_dir(dir.path().join("wal"))
+                .durability_mode(DurabilityMode::Synchronous)
+                .build(),
+        )
+        .persistence(PersistenceConfig {
+            enabled: true,
+            data_dir: dir.path().join("indexes"),
+            load_on_startup: true,
+            ..Default::default()
+        })
+        .build();
+    assert!(!config.chain.enabled, "chain disabled by default");
+
+    let db = AletheiaDB::with_unified_config(config).unwrap();
+
+    // Writes succeed identically.
+    let alice = db.create_node("Person", props("Alice")).unwrap();
+    let node = db.get_node(alice).unwrap();
+    assert_eq!(
+        node.properties.get("name").and_then(|v| v.as_str()),
+        Some("Alice")
+    );
+
+    // No chain directory or files were created.
+    assert!(
+        !dir.path().join("chain").exists(),
+        "no chain dir when disabled"
+    );
+
+    // stats reports the chain disabled.
+    let stats = db.stats();
+    assert!(!stats.chain.enabled);
+    assert!(stats.chain.head_seq.is_none());
+    assert!(stats.chain.head_digest.is_none());
+
+    // The verify API returns a clear "not enabled" error (proving the field is
+    // None).
+    assert!(db.verify_chain().is_err());
+    assert!(db.export_chain_head().is_err());
+}
+
+// ---------------------------------------------------------------------------
+// AC6: after an unclean stop (the chain sidecar lost while durable history
+// survives), reopening rebuilds the tail from replayed history and verifies.
+// ---------------------------------------------------------------------------
+#[test]
+fn ac6_crash_recovery_rebuilds_tail() {
+    let dir = tempfile::tempdir().unwrap();
+    let node_ids;
+    {
+        let db = AletheiaDB::with_unified_config(enabled_config(dir.path())).unwrap();
+        let a = db.create_node("Person", props("Alice")).unwrap();
+        let b = db.create_node("Person", props("Bob")).unwrap();
+        db.create_edge(a, b, "KNOWS", props("")).unwrap();
+        node_ids = (a, b);
+        wait_for_head_seq(&db, 3);
+        assert!(db.verify_chain().unwrap().passed);
+        // db drops here.
+    }
+
+    // Simulate an unclean stop: the durable WAL/index survive, but the chain
+    // sidecar never made it to disk (delete it entirely). On reopen the chain
+    // must re-derive its records from replayed history.
+    std::fs::remove_dir_all(dir.path().join("chain")).unwrap();
+    assert!(!dir.path().join("chain").exists());
+
+    let db = AletheiaDB::with_unified_config(enabled_config(dir.path())).unwrap();
+
+    // Data survived recovery.
+    assert_eq!(
+        db.get_node(node_ids.0)
+            .unwrap()
+            .properties
+            .get("name")
+            .and_then(|v| v.as_str()),
+        Some("Alice")
+    );
+
+    // The chain was rebuilt from history and verifies over the recovered
+    // prefix (3 transactions -> 3 records).
+    let head = db.export_chain_head().unwrap();
+    assert_eq!(head.seq, 3, "chain rebuilt one record per recovered tx");
+    let v = db.verify_chain().unwrap();
+    assert!(v.passed, "rebuilt chain must verify: {:?}", v.reason);
+    assert_eq!(v.transactions_checked, 3);
+}
+
+// ---------------------------------------------------------------------------
+// AC7: database_stats surfaces chain status (enabled, head, genesis, and the
+// last verification result once a verify has run).
+// ---------------------------------------------------------------------------
+#[test]
+fn ac7_stats_reports_chain_status() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = AletheiaDB::with_unified_config(enabled_config(dir.path())).unwrap();
+
+    db.create_node("Person", props("Alice")).unwrap();
+    wait_for_head_seq(&db, 1);
+
+    let stats = db.stats();
+    assert!(stats.chain.enabled);
+    assert_eq!(stats.chain.head_seq, Some(1));
+    assert!(stats.chain.head_digest.is_some());
+    assert!(stats.chain.genesis_digest.is_some());
+    assert!(stats.chain.last_verified.is_none(), "no verify has run yet");
+
+    // After a verify, stats carries the cached result.
+    assert!(db.verify_chain().unwrap().passed);
+    let stats = db.stats();
+    let lv = stats.chain.last_verified.expect("verify recorded");
+    assert!(lv.passed);
+    assert!(lv.at_micros > 0);
+}

--- a/tests/provenance_chain_integration.rs
+++ b/tests/provenance_chain_integration.rs
@@ -402,6 +402,91 @@ fn finding4_rebuilt_chain_matches_precrash_anchor() {
 }
 
 // ---------------------------------------------------------------------------
+// Finding 4 / AC6 (mid-workload crash): a *genuine* mid-workload crash leaves a
+// SEALED PREFIX on disk plus an UNSEALED TAIL (transactions committed to the WAL
+// but not yet sealed). On reopen the chain loads the durable prefix and rebuilds
+// only the tail from replayed history — and the recombined chain must reproduce
+// the exact pre-crash head digest, so a pre-crash anchor still verifies and full
+// verify passes over the whole recovered prefix.
+//
+// This is stronger than `finding4_rebuilt_chain_matches_precrash_anchor` (which
+// drops the ENTIRE log — an empty prefix). Here we keep the first two sealed
+// records and drop the rest, exercising the load-prefix + rebuild-tail merge.
+// ---------------------------------------------------------------------------
+
+/// Return the byte offset in a `chain.log` just past the first `keep` sealed
+/// record frames. Layout: 12-byte header, then repeated `[u32 BE len][len bytes]`.
+fn offset_after_records(bytes: &[u8], keep: usize) -> usize {
+    let mut pos = 12usize; // header
+    for _ in 0..keep {
+        assert!(pos + 4 <= bytes.len(), "log shorter than requested prefix");
+        let len = u32::from_be_bytes([bytes[pos], bytes[pos + 1], bytes[pos + 2], bytes[pos + 3]])
+            as usize;
+        pos += 4 + len;
+        assert!(pos <= bytes.len(), "frame runs past end of log");
+    }
+    pos
+}
+
+#[test]
+fn finding4_partial_tail_rebuild_matches_precrash_anchor() {
+    let dir = tempfile::tempdir().unwrap();
+    let anchor;
+    {
+        let db = AletheiaDB::with_unified_config(enabled_config(dir.path())).unwrap();
+        let a = db.create_node("Person", props("Alice")).unwrap();
+        let b = db.create_node("Person", props("Bob")).unwrap();
+        db.create_edge(a, b, "KNOWS", props("")).unwrap();
+        db.create_node("Person", props("Carol")).unwrap();
+        wait_for_head_seq(&db, 4);
+        anchor = db.export_chain_head().unwrap();
+        assert_eq!(anchor.seq, 4);
+        // db drops here: all four records + head checkpoint flushed.
+    }
+
+    // Simulate a mid-workload crash: the sealer had durably sealed the first TWO
+    // transactions, but the last two records never reached the sidecar (their
+    // commits are in the WAL/index and will be replayed). Keep the head
+    // checkpoint so the genesis digest survives, matching a real durable chain.
+    let log_path = dir.path().join("chain").join("chain.log");
+    let bytes = std::fs::read(&log_path).unwrap();
+    let cut = offset_after_records(&bytes, 2);
+    assert!(cut < bytes.len(), "expected an unsealed tail to drop");
+    std::fs::write(&log_path, &bytes[..cut]).unwrap();
+
+    // Reopen: loads the 2-record prefix (head at seq 2) and rebuilds txns 3..4
+    // from replayed history.
+    let db = AletheiaDB::with_unified_config(enabled_config(dir.path())).unwrap();
+    let head = db.export_chain_head().unwrap();
+    assert_eq!(
+        head.seq, 4,
+        "prefix loaded + tail rebuilt to the full 4 txns"
+    );
+
+    // The merged (loaded prefix + rebuilt tail) chain reproduces the pre-crash
+    // head digest exactly — no false fork.
+    assert_eq!(
+        head.digest, anchor.digest,
+        "recovered head digest must equal the pre-crash head digest"
+    );
+    let v = db.verify_chain_against(&anchor).unwrap();
+    assert!(
+        v.passed,
+        "pre-crash anchor must verify against the recovered chain: {:?}",
+        v.reason
+    );
+
+    // Full verify passes over the whole recovered prefix.
+    let full = db.verify_chain().unwrap();
+    assert!(
+        full.passed,
+        "full verify over recovered chain: {:?}",
+        full.reason
+    );
+    assert_eq!(full.transactions_checked, 4);
+}
+
+// ---------------------------------------------------------------------------
 // AC7: database_stats surfaces chain status (enabled, head, genesis, and the
 // last verification result once a verify has run).
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #3351.

**Before.** AletheiaDB's pitch is *trustworthy* history — a bi-temporal record of what was known, when, and from which source. But that trust was purely operational: nothing proved the recorded history had not been altered after the fact. For compliance, legal discovery, and AI-governance audits, "the database says so" is an assertion, not evidence.

**After.** An **opt-in, per-database cryptographic hash chain** links every committed transaction to its predecessor over the transaction's content — writes, temporal coordinates, and provenance. Any post-hoc alteration (editing a byte of a stored version, deleting/reordering/inserting a transaction, truncating the tail) breaks the fold at that point and is localized to the earliest affected transaction. Operators get:

- `aletheia verify` (CLI) — full-chain and entity-scoped verification;
- `verify_chain` / `export_chain_head` MCP tools + matching Rust API;
- **external-anchor** fork/rollback detection (export a compact head, later prove the DB is an append-only extension of it);
- chain status surfaced in `database_stats`.

**Disabled by default**, so write paths and on-disk formats are byte-identical to today unless a database explicitly opts in.

## How

A **sidecar chain derived from the historical version store** — it touches no WAL or transaction internals. Transactions are grouped and ordered by their unique HLC commit-timestamp; each version is reduced to a domain-separated SHA-256 **leaf**, leaves fold into a per-transaction **tx-digest**, and each tx-digest chains onto its predecessor (seeded by an explicit genesis record). Sealing runs **off the commit critical path** on a background sealer, and the unsealed tail is **re-derivable from durable history** on recovery, so a rebuilt chain reproduces the pre-crash head exactly. Domain separation is applied at every stage (leaf / tx-digest / fold / genesis).

Design write-up: https://github.com/madmax983/AletheiaDB/issues/3351#issuecomment-4949601376

## Acceptance-criteria evidence

| AC | What it requires | Code | Test |
|----|------------------|------|------|
| **AC1** | Each committed tx gets a digest that chains to its predecessor; modify/reorder/delete/insert changes all subsequent digests | `src/provenance_chain/engine.rs` (`seal_one`, `refold_suffix`), `canonical.rs` (`version_leaf`/`tx_digest`/`chain_step`) | `tests/provenance_chain_integration.rs::ac1_head_advances_one_seq_per_transaction`; `verify.rs::{verify_full_detects_single_mutated_leaf, verify_full_detects_reordered_transactions, verify_full_detects_deleted_transaction, verify_full_detects_forged_inserted_transaction}` |
| **AC2** | Full-chain verify → pass/fail + earliest broken position; **entity-scoped** verify with no full scan; on CLI + MCP + Rust | `src/provenance_chain/verify.rs` (`verify_full`, `verify_entity`), `src/db/chain.rs` (`verify_chain`, `verify_entity_chain`), CLI `src/bin/aletheia.rs`, MCP `src/mcp/server.rs` | `verify.rs::{verify_full_passes_on_clean_chain, verify_full_localizes_a_mutated_version, verify_entity_passes_clean_without_full_scan}`; `engine.rs::scan_free_tests::entity_verify_fetches_only_the_entity_versions` (O(entity), scan-free); `ac2_full_and_entity_verification_pass_clean` |
| **AC3** | Automated test alters one byte of a **persisted historical version** → verify fails and localizes it | `src/db/chain_source.rs` (leaf reconstructed from stored version) | `src/db/chain.rs::tamper_tests` (mutating stored versions via `insert_restored_*_version`: label, edge endpoint, retraction `valid_to`, tombstone reopen); `tests/provenance_chain_integration.rs::ac3_tamper_is_detected_and_localized` |
| **AC4** | Head exportable as a compact anchor; verify **against** a prior head → fork/rollback detection | `src/db/chain.rs` (`export_chain_head`, `verify_chain_against`), `verify.rs::verify_against_anchor`, CLI + MCP `export`/`verify --against` | `verify.rs::{verify_against_anchor_passes_on_extension, verify_against_anchor_detects_truncation, verify_against_anchor_detects_fork, verify_against_anchor_rejects_forged_digest_with_broken_fold}`; `ac4_anchor_proves_extension_and_detects_rollback_fork` |
| **AC5** | Opt-in; zero behavior change when disabled; enabling records an explicit genesis | `src/provenance_chain/config.rs`, `src/db/config.rs`, `engine.rs` (`ChainHead::genesis`) | `ac5_disabled_is_zero_behavior_change` |
| **AC6** | Durability documented per WAL mode; crash mid-workload → recover → verify passes over recovered prefix | `src/db/chain.rs::rebuild_chain_tail`, `docs/guides/provenance-hash-chain.md` (per-mode guarantees) | `ac6_crash_recovery_rebuilds_tail`, `finding4_rebuilt_chain_matches_precrash_anchor`, `finding4_partial_tail_rebuild_matches_precrash_anchor` |
| **AC7** | `database_stats` reports chain status (enabled, head position, last verification result/time) | `src/db/stats.rs` (chain block), `engine.rs::LastVerified` | `ac7_stats_reports_chain_status`; `mcp::tests::provenance_chain_tests::*` |

**Test totals:** 51 provenance_chain unit tests + 9 integration tests + 7 MCP tests + `tamper_tests`, all green. Throughput benchmark (`benches/provenance_chain.rs`) enabled/baseline ≈ **1.005** (target ≥ 0.90).

## Security review & fixes

Three adversarial review passes ran — (1) security / tamper-evidence, (2) correctness / concurrency, (3) performance / API — and each found merge-blockers that are **fixed** in this PR:

- **Graph-rewire hole (leaf coverage).** The leaf now binds the **node label**, **edge source/target**, and the **tombstone flag** (previously omitted), so relabeling a node, rewiring an edge, or reopening a delete tombstone changes the leaf and is caught.
- **Terminal interval binding.** Born-closed `valid_to` (retraction / tombstone) is now bound, with a **timeline-consistency check**, so extending a retraction's valid-time end is detected.
- **Forgeable anchor comparison.** `verify_against_anchor` now **re-folds from genesis** instead of comparing a raw stored digest — a forged head with a broken internal fold is rejected.
- **Crash-rebuild false-fork.** The digest is now a **deterministic function of durable history**: the synthetic `tx_id` was dropped from the fold, the full HLC commit timestamp is bound, and records fold in commit-timestamp-sorted order — so a post-crash rebuild reproduces the pre-crash anchor rather than false-forking it.
- **Cold-tier-aware fetch.** Verification reads version metadata through the tiered getter so a sealed version that migrated to the Redb cold tier does not false-fail as "version not found".

Plus the two mandated in-scope **audit-hardening** fixes (partially discharging the parked audit follow-up):

- **Injective canonical encoding** — `src/audit/canonical.rs` `Bytes` encoding was non-injective (previously at :123–131); made injective and bumped `AUDIT_FORMAT_VERSION`.
- **Hardened key-file write** — `src/audit/signing.rs` now writes with `create_new` + `O_NOFOLLOW`.

## v1 limitations (stated honestly)

- **Unsigned anchor.** The exported head is not yet digitally signed; Ed25519 signing is a follow-up reusing `src/audit/signing.rs`.
- **Unsealed-tail / offline-tamper boundary.** Tamper-evidence covers the **sealed prefix**; the in-flight unsealed tail is re-derived from durable history, not yet itself attested.
- **Cold-tier crash-rebuild scan is hot-tier-only** (the *fetch* path is cold-aware; the rebuild scan is not).
- **In-memory chain index grows unbounded** — a bound/spill-to-disk is a follow-up.
- **Entity-scoped inclusion is layered, not Merkle** (a per-entity index over the linear chain, not a Merkle inclusion proof).
- **Rare born-closed-`valid_to` false-positive** on heavily-backdated supersession (a false *positive*, never a missed tamper).
- **Lineage-style in-memory chain state** — not woven into the WAL format, consistent with #3413.

## CI note

The clippy CI lane uses `--features "config-toml,mcp-server,sharding-rpc,simulation"` (not `--all-features`). This PR is clippy-clean under that feature set. Two pre-existing clippy-1.94.0 lints exist only under `--all-features` in files outside this PR's scope and CI's feature set (`tests/http_run_server_body_limit.rs`, `src/api/import/tests.rs`).

## Files

- New module `src/provenance_chain/` (`canonical`, `config`, `engine`, `error`, `record`, `store`, `verify`).
- DB integration: `src/db/chain.rs`, `src/db/chain_source.rs`.
- CLI: `verify` subcommand in `src/bin/aletheia.rs`.
- MCP tools: `src/mcp/server.rs`, `src/mcp/tools.rs`.
- Docs: `docs/adr/0057-provenance-hash-chain.md`, `docs/guides/provenance-hash-chain.md`.
- Benchmark: `benches/provenance_chain.rs`.
- Audit fixes: `src/audit/canonical.rs`, `src/audit/signing.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQCy2i5JEZ1MmgxNumhhuN

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQCy2i5JEZ1MmgxNumhhuN)_