### PR TITLE
feat: point-in-time restore to a transaction-time coordinate (#3374)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -441,6 +441,13 @@ harness = false
 path = "benches/derivation_lineage.rs"
 required-features = []
 
+# Point-in-time restore (Issue #3374) - end-to-end PITR wall-clock (<30s metric)
+[[bench]]
+name = "pitr"
+harness = false
+path = "benches/pitr.rs"
+required-features = []
+
 [[bench]]
 name = "changefeed"
 harness = false

--- a/benches/pitr.rs
+++ b/benches/pitr.rs
@@ -1,0 +1,145 @@
+//! Benchmark for point-in-time restore (PITR, Issue #3374).
+//!
+//! Times an end-to-end `AletheiaDB::restore_to_data_dir_at` — materialize a base
+//! `.albk`, replay an archived WAL tail, and persist the target state — so the
+//! <30s recovery metric can be checked with a real wall-clock number.
+//!
+//! The fixture aims toward the 10K-node / 50K-edge + WAL-tail AC target. The
+//! synchronous fsync-per-commit source makes the *setup* the dominant cost, so
+//! the sizes below are tunable constants: raise them toward the AC target on a
+//! machine that can absorb the one-time build cost. The measured quantity — one
+//! full PITR — is unchanged by the fixture size choice.
+
+use std::path::Path;
+
+use aletheiadb::config::{AletheiaDBConfig, WalConfigBuilder};
+use aletheiadb::{AletheiaDB, DurabilityMode, PitrTarget, PropertyMapBuilder, Timestamp};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+use tempfile::TempDir;
+
+/// Base graph size captured in the `.albk` (materialized on every restore).
+/// Scale toward the 10K-node / 50K-edge AC target as the host allows.
+const BASE_NODES: usize = 3_000;
+const BASE_EDGES: usize = 6_000;
+/// Post-backup transactions forming the archived WAL tail that PITR replays.
+const POST_TX: usize = 800;
+
+fn source_config(wal_dir: &Path) -> AletheiaDBConfig {
+    AletheiaDBConfig::builder()
+        .wal(
+            WalConfigBuilder::new()
+                .wal_dir(wal_dir.to_path_buf())
+                .durability_mode(DurabilityMode::Synchronous)
+                .build(),
+        )
+        .build()
+}
+
+fn copy_wal_dir(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.is_file() {
+            std::fs::copy(&path, dst.join(entry.file_name())).unwrap();
+        }
+    }
+}
+
+/// A built PITR fixture: a base backup + an archived WAL tail, plus the
+/// mid-stream target timestamp to restore to.
+struct Fixture {
+    _tmp: TempDir,
+    albk: std::path::PathBuf,
+    archive: std::path::PathBuf,
+    target: Timestamp,
+}
+
+fn build_fixture() -> Fixture {
+    let tmp = TempDir::new().unwrap();
+    let wal = tmp.path().join("wal");
+    let db = AletheiaDB::with_unified_config(source_config(&wal)).unwrap();
+
+    // Base graph captured in the `.albk`.
+    let mut node_ids = Vec::with_capacity(BASE_NODES);
+    for i in 0..BASE_NODES {
+        let id = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("name", format!("n{i}"))
+                    .insert("phase", "base")
+                    .build(),
+            )
+            .unwrap();
+        node_ids.push(id);
+    }
+    for i in 0..BASE_EDGES {
+        let a = node_ids[i % BASE_NODES];
+        let b = node_ids[(i * 7 + 1) % BASE_NODES];
+        db.create_edge(a, b, "KNOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+    }
+
+    let albk = tmp.path().join("base.albk");
+    db.backup(&albk).unwrap();
+
+    // Post-backup WAL tail: the transactions PITR replays over the base.
+    let mut target = None;
+    for i in 0..POST_TX {
+        let id = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("name", format!("post{i}"))
+                    .insert("phase", "post")
+                    .build(),
+            )
+            .unwrap();
+        if i == POST_TX / 2 {
+            target = Some(db.get_node(id).unwrap().metadata.commit_timestamp.unwrap());
+        }
+    }
+
+    let archive = tmp.path().join("archive");
+    copy_wal_dir(&wal, &archive);
+    drop(db);
+
+    Fixture {
+        _tmp: tmp,
+        albk,
+        archive,
+        target: target.unwrap(),
+    }
+}
+
+fn bench_pitr_restore(c: &mut Criterion) {
+    let fixture = build_fixture();
+
+    let mut group = c.benchmark_group("pitr_restore");
+    // Restoring a multi-thousand-node base per iteration is expensive; a small
+    // sample keeps the run bounded while still yielding a stable wall-clock.
+    group.sample_size(10);
+
+    group.bench_function(format!("{BASE_NODES}n_{BASE_EDGES}e_{POST_TX}tx"), |b| {
+        b.iter(|| {
+            // Each restore needs a fresh, empty target directory.
+            let dst = TempDir::new().unwrap();
+            let data_dir = dst.path().join("restored");
+            let db = AletheiaDB::restore_to_data_dir_at(
+                &fixture.albk,
+                &fixture.archive,
+                PitrTarget::AsOf(fixture.target),
+                &data_dir,
+            )
+            .unwrap();
+            black_box(db.node_count());
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_pitr_restore);
+criterion_main!(benches);

--- a/docs/adr/0058-point-in-time-restore.md
+++ b/docs/adr/0058-point-in-time-restore.md
@@ -103,9 +103,8 @@ operator can assess blast radius before acting.
 
 The window is bounded **below** by the base backup (PITR cannot reconstruct a
 coordinate before `source_lsn` from base + forward replay) and **above** by the
-archived WAL tail. A target above the tail is not an error — it resolves to a
-full replay ("everything at-or-before the target"). A target **below** the
-window fails with a structured
+archived WAL tail. A target **outside** the window in either direction — below
+the base backup or **above** the archived tail — fails with a structured
 
 ```rust
 BackupError::TargetOutsideWindow { requested, earliest, latest }
@@ -180,6 +179,15 @@ that includes the new vocabulary, or to target a coordinate before the change.
   byte-precise segment truncation/re-encoding is fragile and would touch the
   WAL lane; filtering decoded entries and feeding the existing replay is simpler
   and reuses tested machinery.
-- **Error on targets above the archived tail.** Rejected: the issue's
-  at-or-before tie-break makes "target after all" a well-defined full replay,
-  not an error.
+- **Silently full-replay an explicit target above the archived tail.**
+  Rejected (F2): an explicit above-tail target almost always means the operator
+  misjudged the retained window, and a silent full replay hides that mistake.
+  The at-or-before tie-break's "full replay to the tail" intent is preserved by
+  the **no-target / `--latest`** path instead; an explicit above-tail target is
+  an error naming the window.
+- **Treat a post-backup vocabulary change as a best-effort resolve (id dangles
+  to `None`).** Rejected (F1): the restored interner's `next_id` equals the base
+  string count, so a dangling id does not stay `None` — it collides with the
+  first genuinely-new string a later write interns, silently mislabeling data.
+  A pre-materialize scan that fails cleanly is the only safe option until a
+  durable interner archive lands.

--- a/docs/adr/0058-point-in-time-restore.md
+++ b/docs/adr/0058-point-in-time-restore.md
@@ -115,6 +115,38 @@ mapped at the MCP boundary (`src/mcp/error.rs`) to `FAILED_PRECONDITION`
 (non-retriable), mirroring the #3234 structured-error contract; the message
 names the window.
 
+Above-window rejection is deliberate (F2): an explicit target past the tail
+almost always means the operator misjudged the retained window, and silently
+full-replaying would hide that. The legitimate "restore to the tail" intent is
+expressed by supplying **no target** (the CLI's bare `--wal-archive`, or the
+explicit `--latest` alias), which resolves to the latest reachable coordinate
+(itself in-window) and performs a full replay. In-window target → partial
+restore; no target / `--latest` → full replay to the tail; above-window explicit
+target → error.
+
+### Interner vocabulary-change guard
+
+The WAL stores node/edge labels and property keys as **raw `u32` interner ids**,
+and the base `.albk` only carries the interner as of `source_lsn`. A post-backup
+transaction that introduces a **brand-new label or property key** has an id
+`>= K` (the restored interner's string count). Replaying that id verbatim is
+**silent data corruption**, not a mere failed lookup: it first dangles, then —
+because the restored interner's `next_id` equals `K` — the first genuinely-new
+string a later write interns collides with the dangling id, so a replayed
+node/edge is **mislabeled** or its property dropped.
+
+PITR therefore scans the included band prefix and the constraint-declaration
+slice for any interner id `>= K` **before materializing anything** and, if found,
+fails with a structured
+
+```rust
+BackupError::WindowCrossesVocabularyChange { first_unresolved_id, restored_interner_count }
+```
+
+also mapped to `FAILED_PRECONDITION`. This converts silent mislabeling/dropping
+into a clean, honest failure. The remediation is to take a fresh base backup
+that includes the new vocabulary, or to target a coordinate before the change.
+
 ## Consequences
 
 - **RDBMS-grade DR.** PITR to any coordinate in the retained window with
@@ -126,10 +158,13 @@ names the window.
   (rather than truncating after checkpoint/cold-migration) is an
   operator-managed prerequisite in v1; an integrated retention policy is a
   follow-up.
-- **Interner vocabulary caveat.** The WAL stores labels and property keys as
-  interner ids (property *values* are self-contained). The base backup carries
-  the interner as of `source_lsn`, so a post-backup transaction introducing a
-  brand-new label or property key cannot be resolved after replay. Keeping the
+- **Interner vocabulary caveat (guarded, not silent).** The WAL stores labels
+  and property keys as interner ids (property *values* are self-contained). The
+  base backup carries the interner as of `source_lsn`, so a post-backup
+  transaction introducing a brand-new label or property key cannot be resolved
+  after replay — and replaying it verbatim would **silently mislabel or drop
+  data**, not merely fail to resolve. PITR detects this before materializing and
+  fails cleanly with `WindowCrossesVocabularyChange` (see above). Keeping the
   label/key vocabulary stable across the window is required in v1; a durable
   interner archive is a follow-up.
 - **Cold-tier caveat.** As with `temporal_extent` (#3238), a restored

--- a/docs/adr/0058-point-in-time-restore.md
+++ b/docs/adr/0058-point-in-time-restore.md
@@ -1,0 +1,150 @@
+# ADR-0058: Point-in-Time Restore (PITR) to a Transaction-Time Coordinate
+
+**Status:** Accepted
+**Date:** 2026-07-12
+**Deciders:** AletheiaDB Core Team
+**Categories:** durability, recovery, backup, api, cli
+**Issue:** #3374
+
+## Context
+
+Backup/restore (#3217, `.albk`) recovers a database to the exact moment a
+backup was taken. It does not answer the incident that actually pages
+operators: *"a bad batch job / compromised credential / runaway agent wrote
+garbage for the last 40 minutes — put the database back to 14:05, before it
+started."* Without point-in-time restore (PITR) the only options are restore to
+the last backup (losing every good write since) or hand-edit live data.
+
+AletheiaDB's WAL already records everything needed: a total order over
+transactions, each committed transaction framed as one atomic
+`[BeginTx .. CommitTx]` band carrying an authoritative commit timestamp
+(#3413), and a deterministic crash-recovery replay
+(`replay_entries_into_storage_with_constraints`). PITR is a **product surface
+over guarantees that already exist**: replay the archived WAL over a base
+backup, but *stop* at an operator-chosen transaction-time coordinate.
+
+Note the distinction from bi-temporal reads: `AS OF` *views* the past while
+history is intact; PITR is for when recorded history after a point is
+*unwanted* (bulk corruption, security incident, compliance rollback) and the
+operator needs a running database whose recorded state ends at that point — a
+physically restored instance, not a read-time lens.
+
+## Decision
+
+Add a bounded-replay PITR path in the backup lane
+(`src/db/pitr.rs`), plus a structured out-of-window error and CLI/dry-run
+surfaces.
+
+### Target model
+
+```rust
+pub enum PitrTarget { AsOf(Timestamp), Lsn(u64) }
+```
+
+Transaction time only. Valid-time-targeted restore is a category error
+(valid time is a query dimension) and is out of scope. The target resolves
+**inclusively at-or-before** the coordinate: every transaction committed
+at-or-before the target is present, every one after it is absent. A target
+between two transactions lands on the earlier one.
+
+### Band-boundary filter
+
+`filter_bands` groups the LSN-sorted WAL stream into whole transaction
+**bands** (`[BeginTx .. CommitTx]` frames; legacy unframed entries and
+self-committing control ops are singleton bands) and returns the prefix of
+whole bands whose stop coordinate is at-or-before the target. It **never**
+emits a partial band and **drops an incomplete trailing band** (a torn crash
+tail). It also returns the applied/discarded transaction counts and the
+resolved stop coordinate, which feed the dry-run plan. This function is pure
+and unit-tested against exact-boundary, between-transactions, before-all,
+after-all, torn-tail, and mixed framed/legacy streams.
+
+### Restore mirrors startup differential replay
+
+`restore_to_data_dir_at(albk, wal_archive, target, data_dir)`:
+
+1. `check_target_empty` (same atomicity posture as #3217).
+2. `read_artifact` → `source_lsn`; read the archived WAL; compute the window
+   and validate the target **before** touching the target directory.
+3. `materialize_to_dir` the base snapshot and open the base-state database
+   through `durable_config_for_data_dir` — reusing the tested startup path,
+   which finalizes the base (id generators, temporal index, extent, HLC seed)
+   from the snapshot at `source_lsn`.
+4. Apply the **net constraint declarations** from the full archive up to the
+   target (declarations may predate the backup and are not carried by the base
+   snapshot — mirroring the startup constraint pass over the whole WAL).
+5. Replay the **band prefix** (post-`source_lsn`, at-or-before target) into
+   current + historical storage via
+   `replay_entries_into_storage_with_constraints`, then finalize exactly as
+   startup does: seed id generators and `next_version_id`, rebuild the
+   reservation index, rebuild the temporal index, reseed the HLC.
+6. Record the net constraint declarations in the target WAL (index snapshots do
+   not carry constraints) and `persist_all_indexes` so a subsequent reopen
+   loads the target state.
+
+Choosing `source_lsn` as the replay floor (never below it) means the base
+snapshot's already-captured version is never double-applied, and the idempotent
+re-application guards (#3419) in the replay make the boundary safe regardless.
+
+### Inputs are read-only; the original data dir is untouched
+
+PITR never writes to the `.albk` or the WAL archive, and always produces a
+**fresh** directory (no in-place rollback). The recommended operational flow is
+side-by-side restore-then-switch.
+
+### Dry-run / window inspection
+
+`inspect_pitr(albk, wal_archive, target)` returns a serde-serializable
+`PitrPlan { earliest, latest, resolved_stop, transactions_applied,
+transactions_discarded }` without materializing or opening anything, so an
+operator can assess blast radius before acting.
+
+### Achievable window and out-of-window error
+
+The window is bounded **below** by the base backup (PITR cannot reconstruct a
+coordinate before `source_lsn` from base + forward replay) and **above** by the
+archived WAL tail. A target above the tail is not an error — it resolves to a
+full replay ("everything at-or-before the target"). A target **below** the
+window fails with a structured
+
+```rust
+BackupError::TargetOutsideWindow { requested, earliest, latest }
+```
+
+mapped at the MCP boundary (`src/mcp/error.rs`) to `FAILED_PRECONDITION`
+(non-retriable), mirroring the #3234 structured-error contract; the message
+names the window.
+
+## Consequences
+
+- **RDBMS-grade DR.** PITR to any coordinate in the retained window with
+  bounded, known data loss (only the operator-chosen suffix), matching the
+  operational trust bar of PostgreSQL/MySQL and leapfrogging snapshot-only graph
+  incumbents.
+- **Operator-managed WAL archiving (v1).** PITR reaches only as far as the
+  archived WAL chain + base backup allow. Retaining/archiving WAL segments
+  (rather than truncating after checkpoint/cold-migration) is an
+  operator-managed prerequisite in v1; an integrated retention policy is a
+  follow-up.
+- **Interner vocabulary caveat.** The WAL stores labels and property keys as
+  interner ids (property *values* are self-contained). The base backup carries
+  the interner as of `source_lsn`, so a post-backup transaction introducing a
+  brand-new label or property key cannot be resolved after replay. Keeping the
+  label/key vocabulary stable across the window is required in v1; a durable
+  interner archive is a follow-up.
+- **Cold-tier caveat.** As with `temporal_extent` (#3238), a restored
+  instance's cold-tier coverage depends on the base backup; the window bounds
+  are stated in the same terms.
+- **No new on-disk format.** PITR is pure replay machinery over the existing
+  `.albk` artifact and WAL segment format; no temporal-invariant change (replay
+  determinism is the guarantee being productized) and no feature-flag cohort.
+
+## Alternatives Considered
+
+- **Re-serialize a truncated WAL and let plain startup replay it.** Rejected:
+  byte-precise segment truncation/re-encoding is fragile and would touch the
+  WAL lane; filtering decoded entries and feeding the existing replay is simpler
+  and reuses tested machinery.
+- **Error on targets above the archived tail.** Rejected: the issue's
+  at-or-before tie-break makes "target after all" a well-defined full replay,
+  not an error.

--- a/docs/guides/backup-restore.md
+++ b/docs/guides/backup-restore.md
@@ -260,17 +260,33 @@ Every committed transaction is one atomic `[BeginTx .. CommitTx]` band in the WA
 the prefix of **whole bands** committed **at-or-before** the target and never a partial band. A
 target that falls **between** two transactions lands on the earlier one (inclusive tie-break):
 everything committed at-or-before the coordinate is present, everything after it is absent. An
-incomplete trailing band (a crash-torn tail) is dropped. A target **above** the archived tail
-resolves to a full replay ("everything at-or-before the target"); a target **below** the base
-backup fails (see next).
+incomplete trailing band (a crash-torn tail) is dropped. To replay *everything*, pass **no
+target** / `--latest` (a full replay to the tail); an explicit target **above** the archived tail
+is an error, and a target **below** the base backup fails (see next). Band selection parses whole
+`[BeginTx .. CommitTx]` frames from the full WAL stream, so even if the base backup's `source_lsn`
+lands *inside* a transaction frame, that frame is included or excluded whole — never split into
+mis-timed singleton ops.
 
 ### Target outside the window
 
 The achievable window is bounded **below** by the base backup — PITR cannot reconstruct a
 coordinate before the backup from base + forward replay — and **above** by the archived WAL tail.
-A target below the window fails with a structured `BackupError::TargetOutsideWindow` naming the
-window (`earliest`/`latest`); on the MCP surface this maps to `FAILED_PRECONDITION`. Run
-`--dry-run` first to pick a reachable coordinate.
+A target **outside** the window in either direction (below the base backup, or above the archived
+tail) fails with a structured `BackupError::TargetOutsideWindow` naming the window
+(`earliest`/`latest`); on the MCP surface this maps to `FAILED_PRECONDITION`. An above-tail target
+is a deliberate error (not a silent full replay): to restore to the tail, pass **no target** or
+`--latest`. Run `--dry-run` first to pick a reachable coordinate.
+
+### Window crosses a vocabulary change
+
+The WAL stores labels and property keys as raw interner ids, and the base `.albk` only carries the
+interner as of `source_lsn`. If a transaction at-or-before the target introduced a **brand-new
+label or property key** (an id the base interner does not define), PITR cannot resolve it — and
+replaying it verbatim would **silently mislabel or drop data**, because the restored interner's
+next id collides with the dangling one. PITR detects this before materializing anything and fails
+with a structured `BackupError::WindowCrossesVocabularyChange { first_unresolved_id,
+restored_interner_count }` (MCP `FAILED_PRECONDITION`). Take a fresh base backup that includes the
+new vocabulary, or target a coordinate before the change.
 
 ### Side-by-side restore-then-switch flow
 

--- a/docs/guides/backup-restore.md
+++ b/docs/guides/backup-restore.md
@@ -136,6 +136,10 @@ instance without cold storage (and vice versa) with no version loss.
 ```text
 aletheia backup  <output_path>   # backup → prints JSON summary
 aletheia restore <input_path>    # restore → ALETHEIADB_DATA_DIR must be set and empty
+
+# Point-in-time restore (Issue #3374): replay an archived WAL over the base
+# to a target transaction-time coordinate (see "Point-in-Time Restore" below).
+aletheia restore <input_path> --wal-archive <dir> [--as-of <iso8601|micros> | --lsn <n>] [--dry-run]
 ```
 
 JSON output from `aletheia backup`:
@@ -151,6 +155,134 @@ JSON output from `aletheia backup`:
   "source_lsn": 98765
 }
 ```
+
+## Point-in-Time Restore (PITR)
+
+Plain restore recovers a database to the moment a `.albk` backup was taken. **Point-in-time
+restore** (Issue #3374) reaches *any* transaction-time coordinate between the backup and the
+present, by replaying an **archived WAL chain** over the base backup and **stopping** at an
+operator-chosen target. Use it when recorded history after a point is *unwanted* — a bad batch
+job, a compromised credential, a runaway agent, a compliance-mandated rollback of a bad
+ingestion — and you need a running database whose recorded state ends at the last known-good
+moment, with bounded, known data loss (only the unwanted suffix).
+
+> PITR targets **transaction time only**. Restoring "to a valid time" is a category error:
+> valid time is a query dimension (`AS OF VALID_TIME`), not a physical recovery coordinate.
+> When history itself is intact, use bi-temporal `AS OF` reads instead — PITR is for when the
+> recorded tail is *unwanted*, not merely *old*.
+
+### Prerequisite: an operator-managed WAL archive
+
+PITR reaches only as far as the **base backup + archived WAL chain** allow. The WAL archive is a
+directory of the WAL segment files (`*.log`) covering the window you want to restore into. In
+v1 this archive is **operator-managed**: you must retain/copy WAL segments rather than letting
+them be truncated after checkpoint or cold-tier migration.
+
+Recommended retention runbook:
+
+1. Take periodic base backups: `aletheia backup /backups/base-$(date +%s).albk`.
+2. Continuously archive WAL segments to durable storage (e.g. `rsync`/object-store sync of the
+   `wal/` directory). Keep segments for at least your target RPO window plus one backup interval.
+3. Do **not** delete archived segments that are newer than your oldest retained base backup —
+   they are the replay chain PITR depends on.
+
+RPO statement: with this configuration, the achievable RPO to any coordinate in the retention
+window is **0 discarded good transactions** — the loss is exactly and only the operator-chosen
+suffix.
+
+### Inspecting the window (`--dry-run`)
+
+Before restoring, inspect the achievable window and the blast radius of a target — without
+materializing or opening anything:
+
+```text
+aletheia restore /backups/base.albk --wal-archive /archive/wal --dry-run
+aletheia restore /backups/base.albk --wal-archive /archive/wal --as-of 2026-07-12T14:05:00Z --dry-run
+```
+
+The dry-run prints a `PitrPlan` as JSON:
+
+```json
+{
+  "earliest": { "lsn": 98765, "timestamp_micros": 1783840000000000, "timestamp_rfc3339": "2026-07-12T13:59:00.000000Z" },
+  "latest":   { "lsn": 120400, "timestamp_micros": 1783843200000000, "timestamp_rfc3339": "2026-07-12T14:40:00.000000Z" },
+  "resolved_stop": { "lsn": 110230, "timestamp_micros": 1783840300000000, "timestamp_rfc3339": "2026-07-12T14:05:00.000000Z" },
+  "transactions_applied": 842,
+  "transactions_discarded": 205
+}
+```
+
+`transactions_discarded` is the rollback blast radius: the count of committed transactions after
+the target that this restore would drop.
+
+### Performing the restore
+
+```text
+# Stop at a wall-clock coordinate (ISO 8601 / RFC 3339):
+ALETHEIADB_DATA_DIR=/restore/side-by-side \
+  aletheia restore /backups/base.albk --wal-archive /archive/wal --as-of 2026-07-12T14:05:00Z
+
+# ...or at an exact WAL LSN (or microseconds-since-epoch for --as-of):
+ALETHEIADB_DATA_DIR=/restore/side-by-side \
+  aletheia restore /backups/base.albk --wal-archive /archive/wal --lsn 110230
+```
+
+`--as-of` and `--lsn` are **mutually exclusive**; pass exactly one. The target directory
+(`ALETHEIADB_DATA_DIR`) must be empty, matching plain restore's atomicity posture. The produced
+directory reopens through the canonical `AletheiaDB::open(data_dir)` path with the target state
+intact.
+
+Rust API:
+
+```rust
+use aletheiadb::{AletheiaDB, PitrTarget, Timestamp};
+
+// Dry-run: inspect the window + blast radius.
+let plan = AletheiaDB::inspect_pitr(&albk, &wal_archive, Some(PitrTarget::AsOf(target_ts)))?;
+
+// Restore to a fresh, empty data dir.
+let db = AletheiaDB::restore_to_data_dir_at(
+    &albk, &wal_archive, PitrTarget::AsOf(target_ts), &data_dir,
+)?;
+```
+
+### Band-boundary stop semantics
+
+Every committed transaction is one atomic `[BeginTx .. CommitTx]` band in the WAL. PITR includes
+the prefix of **whole bands** committed **at-or-before** the target and never a partial band. A
+target that falls **between** two transactions lands on the earlier one (inclusive tie-break):
+everything committed at-or-before the coordinate is present, everything after it is absent. An
+incomplete trailing band (a crash-torn tail) is dropped. A target **above** the archived tail
+resolves to a full replay ("everything at-or-before the target"); a target **below** the base
+backup fails (see next).
+
+### Target outside the window
+
+The achievable window is bounded **below** by the base backup — PITR cannot reconstruct a
+coordinate before the backup from base + forward replay — and **above** by the archived WAL tail.
+A target below the window fails with a structured `BackupError::TargetOutsideWindow` naming the
+window (`earliest`/`latest`); on the MCP surface this maps to `FAILED_PRECONDITION`. Run
+`--dry-run` first to pick a reachable coordinate.
+
+### Side-by-side restore-then-switch flow
+
+PITR always produces a **fresh** directory and never mutates the base backup, the WAL archive, or
+your original (pre-incident) data directory. The recommended incident flow:
+
+1. **Assess** — `--dry-run` against candidate targets to bound the blast radius.
+2. **Restore side-by-side** — restore into a *new* empty directory (leave production untouched).
+3. **Verify** — open the restored directory, run integrity/temporal spot checks, confirm the bad
+   writes are gone and good writes are present.
+4. **Switch** — cut traffic over to the restored instance (or promote its data directory).
+5. **Retain** — keep the original directory until the switch is confirmed good.
+
+### Constraints, provenance, and cold tier
+
+- **Constraints (#3218)** declared before the target are re-established and enforced in the
+  restored instance (including declarations that predate the base backup), and survive a reopen.
+- **Provenance (#3224)** on replayed versions is preserved through PITR.
+- **Cold tier (#3238)** coverage of the restored instance depends on what the base backup
+  captured; the window bounds are stated in the same terms as `temporal_extent`.
 
 ## Performance Notes
 
@@ -186,3 +318,19 @@ scan API that avoids this peak is planned as follow-up work.
 Restore enforces a 5 GiB cap on decompressed payload size to guard against
 decompression-bomb denial-of-service attacks. Artifacts larger than 5 GiB
 uncompressed are rejected with `BackupError::Corrupt`.
+
+### Point-in-time restore (v1)
+
+- **WAL archive must be supplied.** PITR reaches only as far as the base backup + archived WAL
+  chain allow; there is no PITR from a `.albk` alone.
+- **Retention is operator-managed.** v1 has no built-in WAL retention/rotation policy — you must
+  archive segments yourself (see the retention runbook above). An integrated policy is a
+  follow-up.
+- **Band-granularity stop.** The stop coordinate resolves to a whole transaction boundary
+  (inclusive at-or-before); PITR never splits a transaction.
+- **Interner vocabulary.** The WAL stores node/edge labels and property keys as interner ids
+  (property *values* are self-contained). The base backup carries the interner as of
+  `source_lsn`, so a post-backup transaction that introduces a **brand-new label or property
+  key** cannot be resolved after replay. Keep the label/key vocabulary stable across the window;
+  a durable interner archive is a follow-up.
+- **Encrypted WAL archives** are not yet supported by the PITR reader (plaintext segments only).

--- a/docs/guides/backup-restore.md
+++ b/docs/guides/backup-restore.md
@@ -328,9 +328,11 @@ uncompressed are rejected with `BackupError::Corrupt`.
   follow-up.
 - **Band-granularity stop.** The stop coordinate resolves to a whole transaction boundary
   (inclusive at-or-before); PITR never splits a transaction.
-- **Interner vocabulary.** The WAL stores node/edge labels and property keys as interner ids
-  (property *values* are self-contained). The base backup carries the interner as of
-  `source_lsn`, so a post-backup transaction that introduces a **brand-new label or property
-  key** cannot be resolved after replay. Keep the label/key vocabulary stable across the window;
-  a durable interner archive is a follow-up.
+- **Interner vocabulary (guarded).** The WAL stores node/edge labels and property keys as interner
+  ids (property *values* are self-contained). The base backup carries the interner as of
+  `source_lsn`, so a post-backup transaction that introduces a **brand-new label or property key**
+  cannot be resolved after replay — and replaying it verbatim would *silently mislabel or drop
+  data*. PITR guards against this: it scans the window before materializing and fails cleanly with
+  `WindowCrossesVocabularyChange` rather than corrupting. Keep the label/key vocabulary stable
+  across the window (or take a fresh base backup); a durable interner archive is a follow-up.
 - **Encrypted WAL archives** are not yet supported by the PITR reader (plaintext segments only).

--- a/docs/guides/backup-restore.md
+++ b/docs/guides/backup-restore.md
@@ -139,7 +139,9 @@ aletheia restore <input_path>    # restore → ALETHEIADB_DATA_DIR must be set a
 
 # Point-in-time restore (Issue #3374): replay an archived WAL over the base
 # to a target transaction-time coordinate (see "Point-in-Time Restore" below).
-aletheia restore <input_path> --wal-archive <dir> [--as-of <iso8601|micros> | --lsn <n>] [--dry-run]
+# In-window target -> partial restore; no target / --latest -> full replay to
+# the tail; an explicit target above the tail is an error.
+aletheia restore <input_path> --wal-archive <dir> [--as-of <iso8601|micros> | --lsn <n> | --latest] [--dry-run]
 ```
 
 JSON output from `aletheia backup`:
@@ -225,12 +227,18 @@ ALETHEIADB_DATA_DIR=/restore/side-by-side \
 # ...or at an exact WAL LSN (or microseconds-since-epoch for --as-of):
 ALETHEIADB_DATA_DIR=/restore/side-by-side \
   aletheia restore /backups/base.albk --wal-archive /archive/wal --lsn 110230
+
+# ...or replay the WHOLE archive to its tail (no target, or the --latest alias):
+ALETHEIADB_DATA_DIR=/restore/side-by-side \
+  aletheia restore /backups/base.albk --wal-archive /archive/wal --latest
 ```
 
-`--as-of` and `--lsn` are **mutually exclusive**; pass exactly one. The target directory
-(`ALETHEIADB_DATA_DIR`) must be empty, matching plain restore's atomicity posture. The produced
-directory reopens through the canonical `AletheiaDB::open(data_dir)` path with the target state
-intact.
+`--as-of` and `--lsn` are **mutually exclusive**; pass exactly one (or neither).
+Passing **no target** — a bare `--wal-archive`, or the explicit `--latest` alias —
+performs a **full replay to the archived tail**; `--latest` is mutually exclusive
+with `--as-of`/`--lsn`. The target directory (`ALETHEIADB_DATA_DIR`) must be empty,
+matching plain restore's atomicity posture. The produced directory reopens through
+the canonical `AletheiaDB::open(data_dir)` path with the target state intact.
 
 Rust API:
 

--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -11,8 +11,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use aletheiadb::{
-    AletheiaDB, Edge, EdgeId, GLOBAL_INTERNER, Node, NodeId, PropertyMap, PropertyMapBuilder,
-    PropertyValue,
+    AletheiaDB, Edge, EdgeId, GLOBAL_INTERNER, Node, NodeId, PitrTarget, PropertyMap,
+    PropertyMapBuilder, PropertyValue, Timestamp,
 };
 
 const DEFAULT_PID_FILE: &str = ".aletheia/daemon.pid";
@@ -85,6 +85,7 @@ Usage:\n\
   aletheia daemon status [--pid-file PATH]\n\
   aletheia backup <output_path>\n\
   aletheia restore <input_path>\n\
+  aletheia restore <input_path> --wal-archive <dir> [--as-of <iso8601|micros> | --lsn <n>] [--dry-run]\n\
   aletheia audit-keygen <key_file>\n\
   aletheia audit-export <node|edge> <id> --key <key_file> --out <path> [--db-id ID] [--redact k1,k2]\n\
   aletheia audit-verify <artifact_path> [--public-key HEX]\n\
@@ -98,6 +99,10 @@ Usage:\n\
   backup  — Write a portable .albk artifact capturing full bi-temporal state.\n\
             Opens the database via ALETHEIADB_CONFIG or ALETHEIADB_DATA_DIR.\n\
   restore — Restore a .albk artifact into ALETHEIADB_DATA_DIR (must be empty).\n\
+            With --wal-archive <dir>, perform a point-in-time restore (PITR):\n\
+            replay the archived WAL over the base to --as-of <ts> or --lsn <n>\n\
+            (inclusive, at-or-before). --dry-run reports the achievable window\n\
+            and the count of transactions discarded, without restoring.\n\
 \nSigned audit export (Issue #3358):\n\
   audit-keygen — Generate an Ed25519 signing key (0600) and print its public key.\n\
   audit-export — Sign an entity's full bi-temporal history into a portable artifact.\n\
@@ -130,20 +135,109 @@ fn handle_backup(args: Vec<String>) -> Result<(), String> {
     Ok(())
 }
 
-/// `aletheia restore <input_path>` — restore a backup artifact into `ALETHEIADB_DATA_DIR`.
+/// `aletheia restore <input_path>` — restore a backup artifact.
+///
+/// Two modes:
+/// * **Plain restore** (no `--wal-archive`): materialize the base `.albk` into
+///   `ALETHEIADB_DATA_DIR` (unchanged #3217 behavior).
+/// * **Point-in-time restore** (`--wal-archive <dir>`, Issue #3374): replay the
+///   archived WAL chain over the base to a target transaction-time coordinate
+///   (`--as-of <iso8601|micros>` XOR `--lsn <n>`). `--dry-run` prints the
+///   achievable window + blast radius as JSON without side effects.
 fn handle_restore(args: Vec<String>) -> Result<(), String> {
     let path = args
         .first()
-        .ok_or_else(|| "usage: aletheia restore <input_path>".to_string())?;
+        .filter(|a| !a.starts_with("--"))
+        .ok_or_else(|| "usage: aletheia restore <input_path> [--wal-archive DIR [--as-of TS | --lsn N] [--dry-run]]".to_string())?;
+    let albk = std::path::Path::new(path);
+
+    let wal_archive = arg_value(&args, "--wal-archive");
+    let as_of = arg_value(&args, "--as-of");
+    let lsn = arg_value(&args, "--lsn");
+    let dry_run = args.iter().any(|a| a == "--dry-run");
+
+    // Plain (#3217) restore: no PITR flags.
+    if wal_archive.is_none() && as_of.is_none() && lsn.is_none() && !dry_run {
+        let data_dir = env::var("ALETHEIADB_DATA_DIR")
+            .map(PathBuf::from)
+            .map_err(|_| {
+                "ALETHEIADB_DATA_DIR must be set to restore into a durable directory".to_string()
+            })?;
+        AletheiaDB::restore_to_data_dir(albk, &data_dir)
+            .map_err(|e| format!("restore failed: {e}"))?;
+        println!("{}", restore_success_json(&data_dir)?);
+        return Ok(());
+    }
+
+    // Point-in-time restore requires the WAL archive.
+    let wal_archive = wal_archive.ok_or_else(|| {
+        "point-in-time restore requires --wal-archive <dir> (the archived WAL chain)".to_string()
+    })?;
+    let wal_archive = PathBuf::from(wal_archive);
+
+    // Resolve the target: --as-of XOR --lsn (both optional for --dry-run).
+    let target = parse_pitr_target(&as_of, &lsn)?;
+
+    if dry_run {
+        let plan = AletheiaDB::inspect_pitr(albk, &wal_archive, target)
+            .map_err(|e| format!("dry-run failed: {e}"))?;
+        let rendered = serde_json::to_string(&plan)
+            .map_err(|e| format!("failed to render JSON output: {e}"))?;
+        println!("{rendered}");
+        return Ok(());
+    }
+
+    let target = target.ok_or_else(|| {
+        "point-in-time restore requires a target: --as-of <iso8601|micros> or --lsn <n>".to_string()
+    })?;
     let data_dir = env::var("ALETHEIADB_DATA_DIR")
         .map(PathBuf::from)
         .map_err(|_| {
             "ALETHEIADB_DATA_DIR must be set to restore into a durable directory".to_string()
         })?;
-    AletheiaDB::restore_to_data_dir(std::path::Path::new(path), &data_dir)
-        .map_err(|e| format!("restore failed: {e}"))?;
+    AletheiaDB::restore_to_data_dir_at(albk, &wal_archive, target, &data_dir)
+        .map_err(|e| format!("point-in-time restore failed: {e}"))?;
     println!("{}", restore_success_json(&data_dir)?);
     Ok(())
+}
+
+/// Resolve the mutually-exclusive `--as-of` / `--lsn` PITR target flags.
+///
+/// Returns `None` when neither is set (a valid state only for `--dry-run`,
+/// which then reports the whole window). Errors if both are set.
+fn parse_pitr_target(
+    as_of: &Option<String>,
+    lsn: &Option<String>,
+) -> Result<Option<PitrTarget>, String> {
+    match (as_of, lsn) {
+        (Some(_), Some(_)) => {
+            Err("--as-of and --lsn are mutually exclusive; pass exactly one".to_string())
+        }
+        (Some(ts), None) => Ok(Some(PitrTarget::AsOf(parse_cli_timestamp(ts)?))),
+        (None, Some(n)) => {
+            let n = n
+                .parse::<u64>()
+                .map_err(|e| format!("invalid --lsn value '{n}': {e}"))?;
+            Ok(Some(PitrTarget::Lsn(n)))
+        }
+        (None, None) => Ok(None),
+    }
+}
+
+/// Parse a CLI timestamp: RFC 3339 / ISO 8601, or microseconds since the epoch.
+fn parse_cli_timestamp(s: &str) -> Result<Timestamp, String> {
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+        return Ok(Timestamp::from(dt.timestamp_micros()));
+    }
+    if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
+        return Ok(Timestamp::from(dt.and_utc().timestamp_micros()));
+    }
+    if let Ok(micros) = s.parse::<i64>() {
+        return Ok(Timestamp::from(micros));
+    }
+    Err(format!(
+        "invalid timestamp '{s}': expected ISO 8601 (e.g. 2024-01-15T10:00:00Z) or microseconds since epoch"
+    ))
 }
 
 /// `aletheia demo` — boot a seeded, ephemeral bi-temporal graph and print a
@@ -1133,6 +1227,47 @@ mod tests {
     fn handle_restore_missing_arg_returns_usage_error() {
         let err = handle_restore(vec![]).unwrap_err();
         assert!(err.contains("usage:"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn parse_pitr_target_rejects_both_flags() {
+        let err = parse_pitr_target(&Some("100".to_string()), &Some("5".to_string())).unwrap_err();
+        assert!(
+            err.contains("mutually exclusive"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_pitr_target_resolves_each_flag() {
+        assert!(matches!(
+            parse_pitr_target(&None, &Some("42".to_string())).unwrap(),
+            Some(PitrTarget::Lsn(42))
+        ));
+        assert!(matches!(
+            parse_pitr_target(&Some("1000".to_string()), &None).unwrap(),
+            Some(PitrTarget::AsOf(_))
+        ));
+        assert!(parse_pitr_target(&None, &None).unwrap().is_none());
+    }
+
+    #[test]
+    fn parse_cli_timestamp_accepts_rfc3339_and_micros() {
+        assert!(parse_cli_timestamp("2024-01-15T10:00:00Z").is_ok());
+        assert!(parse_cli_timestamp("1705312800000000").is_ok());
+        assert!(parse_cli_timestamp("not-a-time").is_err());
+    }
+
+    #[test]
+    fn handle_restore_pitr_without_wal_archive_errors() {
+        // A PITR target flag without --wal-archive is a usage error.
+        let err = handle_restore(vec![
+            "base.albk".to_string(),
+            "--lsn".to_string(),
+            "5".to_string(),
+        ])
+        .unwrap_err();
+        assert!(err.contains("--wal-archive"), "unexpected error: {err}");
     }
 
     #[test]

--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -85,7 +85,7 @@ Usage:\n\
   aletheia daemon status [--pid-file PATH]\n\
   aletheia backup <output_path>\n\
   aletheia restore <input_path>\n\
-  aletheia restore <input_path> --wal-archive <dir> [--as-of <iso8601|micros> | --lsn <n>] [--dry-run]\n\
+  aletheia restore <input_path> --wal-archive <dir> [--as-of <iso8601|micros> | --lsn <n> | --latest] [--dry-run]\n\
   aletheia audit-keygen <key_file>\n\
   aletheia audit-export <node|edge> <id> --key <key_file> --out <path> [--db-id ID] [--redact k1,k2]\n\
   aletheia audit-verify <artifact_path> [--public-key HEX]\n\
@@ -101,8 +101,11 @@ Usage:\n\
   restore — Restore a .albk artifact into ALETHEIADB_DATA_DIR (must be empty).\n\
             With --wal-archive <dir>, perform a point-in-time restore (PITR):\n\
             replay the archived WAL over the base to --as-of <ts> or --lsn <n>\n\
-            (inclusive, at-or-before). --dry-run reports the achievable window\n\
-            and the count of transactions discarded, without restoring.\n\
+            (inclusive, at-or-before). An in-window target does a partial\n\
+            restore; no target (or --latest) replays the full archive to its\n\
+            tail; an explicit target above the tail is an error. --dry-run\n\
+            reports the achievable window and the count of transactions\n\
+            discarded, without restoring.\n\
 \nSigned audit export (Issue #3358):\n\
   audit-keygen — Generate an Ed25519 signing key (0600) and print its public key.\n\
   audit-export — Sign an entity's full bi-temporal history into a portable artifact.\n\
@@ -142,8 +145,10 @@ fn handle_backup(args: Vec<String>) -> Result<(), String> {
 ///   `ALETHEIADB_DATA_DIR` (unchanged #3217 behavior).
 /// * **Point-in-time restore** (`--wal-archive <dir>`, Issue #3374): replay the
 ///   archived WAL chain over the base to a target transaction-time coordinate
-///   (`--as-of <iso8601|micros>` XOR `--lsn <n>`). `--dry-run` prints the
-///   achievable window + blast radius as JSON without side effects.
+///   (`--as-of <iso8601|micros>` XOR `--lsn <n>`). An in-window target does a
+///   partial restore; no target (or `--latest`) replays the whole archive to
+///   its tail; an explicit target above the tail is rejected (F2). `--dry-run`
+///   prints the achievable window + blast radius as JSON without side effects.
 fn handle_restore(args: Vec<String>) -> Result<(), String> {
     let path = args
         .first()
@@ -154,10 +159,11 @@ fn handle_restore(args: Vec<String>) -> Result<(), String> {
     let wal_archive = arg_value(&args, "--wal-archive");
     let as_of = arg_value(&args, "--as-of");
     let lsn = arg_value(&args, "--lsn");
+    let latest = args.iter().any(|a| a == "--latest");
     let dry_run = args.iter().any(|a| a == "--dry-run");
 
-    // Plain (#3217) restore: no PITR flags.
-    if wal_archive.is_none() && as_of.is_none() && lsn.is_none() && !dry_run {
+    // Plain (#3217) restore: no PITR flags at all.
+    if wal_archive.is_none() && as_of.is_none() && lsn.is_none() && !latest && !dry_run {
         let data_dir = env::var("ALETHEIADB_DATA_DIR")
             .map(PathBuf::from)
             .map_err(|_| {
@@ -175,8 +181,18 @@ fn handle_restore(args: Vec<String>) -> Result<(), String> {
     })?;
     let wal_archive = PathBuf::from(wal_archive);
 
-    // Resolve the target: --as-of XOR --lsn (both optional for --dry-run).
+    // Resolve the explicit target: --as-of XOR --lsn (both optional).
     let target = parse_pitr_target(&as_of, &lsn)?;
+
+    // `--latest` is an explicit "restore to the archived tail" alias; a bare
+    // `--wal-archive` with no target means the same thing. Both are mutually
+    // exclusive with an explicit `--as-of`/`--lsn` target.
+    if latest && target.is_some() {
+        return Err(
+            "--latest is mutually exclusive with --as-of/--lsn (it targets the archived tail)"
+                .to_string(),
+        );
+    }
 
     if dry_run {
         let plan = AletheiaDB::inspect_pitr(albk, &wal_archive, target)
@@ -187,16 +203,34 @@ fn handle_restore(args: Vec<String>) -> Result<(), String> {
         return Ok(());
     }
 
-    let target = target.ok_or_else(|| {
-        "point-in-time restore requires a target: --as-of <iso8601|micros> or --lsn <n>".to_string()
-    })?;
     let data_dir = env::var("ALETHEIADB_DATA_DIR")
         .map(PathBuf::from)
         .map_err(|_| {
             "ALETHEIADB_DATA_DIR must be set to restore into a durable directory".to_string()
         })?;
-    AletheiaDB::restore_to_data_dir_at(albk, &wal_archive, target, &data_dir)
-        .map_err(|e| format!("point-in-time restore failed: {e}"))?;
+
+    match target {
+        // In-window target: partial restore, stopping at-or-before the target.
+        Some(t) => {
+            AletheiaDB::restore_to_data_dir_at(albk, &wal_archive, t, &data_dir)
+                .map_err(|e| format!("point-in-time restore failed: {e}"))?;
+        }
+        // No explicit target (or `--latest`): full replay to the archived tail.
+        // Resolve the tail coordinate from the window and restore to it — the
+        // latest coordinate is in-window (an above-tail explicit target would be
+        // rejected, Issue #3374 F2).
+        None => {
+            let plan = AletheiaDB::inspect_pitr(albk, &wal_archive, None)
+                .map_err(|e| format!("failed to resolve archive tail: {e}"))?;
+            AletheiaDB::restore_to_data_dir_at(
+                albk,
+                &wal_archive,
+                PitrTarget::Lsn(plan.latest.lsn),
+                &data_dir,
+            )
+            .map_err(|e| format!("point-in-time restore failed: {e}"))?;
+        }
+    }
     println!("{}", restore_success_json(&data_dir)?);
     Ok(())
 }

--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -191,12 +191,23 @@ fn handle_restore(args: Vec<String>) -> Result<(), String> {
     }
 
     if dry_run {
-        let plan = AletheiaDB::inspect_pitr(albk, &wal_archive, target)
-            .map_err(|e| format!("dry-run failed: {e}"))?;
-        let rendered = serde_json::to_string(&plan)
-            .map_err(|e| format!("failed to render JSON output: {e}"))?;
-        println!("{rendered}");
-        return Ok(());
+        #[cfg(feature = "serde")]
+        {
+            let plan = AletheiaDB::inspect_pitr(albk, &wal_archive, target)
+                .map_err(|e| format!("dry-run failed: {e}"))?;
+            let rendered = serde_json::to_string(&plan)
+                .map_err(|e| format!("failed to render JSON output: {e}"))?;
+            println!("{rendered}");
+            return Ok(());
+        }
+        #[cfg(not(feature = "serde"))]
+        {
+            let _ = (albk, &wal_archive, target);
+            return Err(
+                "`--dry-run` JSON output requires the `serde` feature (rebuild with --features serde)"
+                    .to_string(),
+            );
+        }
     }
 
     let data_dir = required_data_dir()?;

--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -164,11 +164,7 @@ fn handle_restore(args: Vec<String>) -> Result<(), String> {
 
     // Plain (#3217) restore: no PITR flags at all.
     if wal_archive.is_none() && as_of.is_none() && lsn.is_none() && !latest && !dry_run {
-        let data_dir = env::var("ALETHEIADB_DATA_DIR")
-            .map(PathBuf::from)
-            .map_err(|_| {
-                "ALETHEIADB_DATA_DIR must be set to restore into a durable directory".to_string()
-            })?;
+        let data_dir = required_data_dir()?;
         AletheiaDB::restore_to_data_dir(albk, &data_dir)
             .map_err(|e| format!("restore failed: {e}"))?;
         println!("{}", restore_success_json(&data_dir)?);
@@ -203,11 +199,7 @@ fn handle_restore(args: Vec<String>) -> Result<(), String> {
         return Ok(());
     }
 
-    let data_dir = env::var("ALETHEIADB_DATA_DIR")
-        .map(PathBuf::from)
-        .map_err(|_| {
-            "ALETHEIADB_DATA_DIR must be set to restore into a durable directory".to_string()
-        })?;
+    let data_dir = required_data_dir()?;
 
     match target {
         // In-window target: partial restore, stopping at-or-before the target.
@@ -256,6 +248,15 @@ fn parse_pitr_target(
         }
         (None, None) => Ok(None),
     }
+}
+
+/// Resolve the mandatory `ALETHEIADB_DATA_DIR` target directory for a restore.
+fn required_data_dir() -> Result<PathBuf, String> {
+    env::var("ALETHEIADB_DATA_DIR")
+        .map(PathBuf::from)
+        .map_err(|_| {
+            "ALETHEIADB_DATA_DIR must be set to restore into a durable directory".to_string()
+        })
 }
 
 /// Parse a CLI timestamp: RFC 3339 / ISO 8601, or microseconds since the epoch.

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -28,7 +28,7 @@ fn bootstrap_timestamp(
 ) -> crate::core::temporal::Timestamp {
     let mut max_timestamp = time::now();
 
-    for node in current.all_nodes() {
+    for node in current.iter_nodes() {
         if let Some(commit_ts) = node.metadata.commit_timestamp
             && commit_ts > max_timestamp
         {
@@ -36,7 +36,7 @@ fn bootstrap_timestamp(
         }
     }
 
-    for edge in current.all_edges() {
+    for edge in current.iter_edges() {
         if let Some(commit_ts) = edge.metadata.commit_timestamp
             && commit_ts > max_timestamp
         {

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -72,7 +72,7 @@ fn bootstrap_timestamp(
     max_timestamp
 }
 
-fn seed_startup_current_timestamp(db: &AletheiaDB) -> Result<()> {
+pub(crate) fn seed_startup_current_timestamp(db: &AletheiaDB) -> Result<()> {
     let startup_timestamp = bootstrap_timestamp(&db.current, &db.historical);
     let mut current_timestamp = db.current_timestamp.lock().map_err(|_| {
         crate::core::error::Error::Storage(StorageError::LockPoisoned {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -33,6 +33,8 @@ pub mod graph_view;
 pub mod lineage;
 /// Basic graph operations (CRUD).
 pub mod ops;
+/// Point-in-time restore (PITR) to a transaction-time coordinate (Issue #3374).
+pub mod pitr;
 /// Query builder and executor hooks.
 pub mod query;
 /// Graph schema discovery (labels, edge types, property keys).
@@ -58,6 +60,7 @@ pub use constraint_builder::UniqueConstraintBuilder;
 pub use extent::{LabelExtent, TemporalExtent, TimeBounds};
 pub use lineage::{FactStatus, LineageView, LineageViewEntry};
 pub use ops::NodesAtTime;
+pub use pitr::{PitrCoord, PitrPlan, PitrTarget};
 pub use schema::{EdgeTypeSchema, GraphSchema, LabelSchema, SchemaInstant};
 pub use similarity_query::{SimilarityQuery, SimilaritySource};
 pub use stats::{

--- a/src/db/pitr.rs
+++ b/src/db/pitr.rs
@@ -26,14 +26,29 @@
 //! the coordinate: every transaction committed at-or-before the target is
 //! present, every transaction after it is absent.
 //!
-//! # Interner caveat (v1)
+//! # Interner vocabulary guard (v1)
 //!
-//! The WAL stores node/edge **labels** and **property keys** as interner ids
-//! (not strings); property *values* are self-contained. The base backup carries
-//! the interner as of `source_lsn`, so a post-backup transaction that
-//! introduces a **brand-new label or property key** cannot be resolved after a
-//! PITR replay. Keep the label/key vocabulary stable across the window (a
-//! durable interner archive is a follow-up).
+//! The WAL stores node/edge **labels** and **property keys** as raw `u32`
+//! interner ids (not strings); property *values* are self-contained. The base
+//! backup carries the interner as of `source_lsn`, so a post-backup transaction
+//! that introduces a **brand-new label or property key** has an id `>= K`, where
+//! `K` is the restored interner's string count. Replaying such an id verbatim is
+//! **silent data corruption**, not a mere failed lookup: the id first dangles,
+//! then — because the restored interner's `next_id` equals `K` — the first
+//! genuinely-new string a later write interns collides with the dangling id, so
+//! a replayed node/edge is **mislabeled** (e.g. "Manager" becomes the user's new
+//! "Department") or its property silently dropped.
+//!
+//! PITR therefore **refuses** such a window: before materializing anything, it
+//! scans the included band prefix and constraint-declaration slice for any
+//! interner id that references a string the base snapshot does not contain and,
+//! if found, fails with
+//! [`BackupError::WindowCrossesVocabularyChange`](crate::storage::backup::BackupError::WindowCrossesVocabularyChange)
+//! (mapped to `FAILED_PRECONDITION` at the MCP boundary). This converts silent
+//! mislabeling/dropping into a clean, honest error. Keep the label/key
+//! vocabulary stable across the window, take a fresh base backup that includes
+//! the new vocabulary, or target a coordinate before the change (a durable
+//! interner archive is a follow-up).
 
 use std::path::Path;
 
@@ -121,6 +136,63 @@ struct FilteredBands {
     discarded: u64,
     /// The coordinate of the last included transaction band, if any.
     resolved_stop: Option<PitrCoord>,
+}
+
+/// Scan a WAL operation's **label / property-key** positions for the first
+/// interner id that is `>= restored_count` — i.e. references a string the base
+/// backup's interner (ids `0..restored_count`) does not contain. Property
+/// *values* are self-contained (never interned) and are deliberately excluded.
+///
+/// A `Some` result means this operation would replay a dangling id and silently
+/// mislabel/drop data (see the module-level vocabulary guard); `None` means every
+/// id it references resolves against the base interner.
+fn first_out_of_range_id(op: &WalOperation, restored_count: u32) -> Option<u32> {
+    let check = |id: crate::core::interning::InternedString| -> Option<u32> {
+        let raw = id.as_u32();
+        (raw >= restored_count).then_some(raw)
+    };
+    let check_keys = |properties: &crate::core::property::PropertyMap| -> Option<u32> {
+        properties
+            .keys()
+            .map(|k| k.as_u32())
+            .find(|&raw| raw >= restored_count)
+    };
+    match op {
+        // Create/update of nodes and edges all carry a `label` and a
+        // `properties` map whose KEYS are interned (values are inline).
+        WalOperation::CreateNode {
+            label, properties, ..
+        }
+        | WalOperation::UpdateNode {
+            label, properties, ..
+        }
+        | WalOperation::CreateEdge {
+            label, properties, ..
+        }
+        | WalOperation::UpdateEdge {
+            label, properties, ..
+        } => check(*label).or_else(|| check_keys(properties)),
+        // Constraint declarations reference an interned label + property key.
+        WalOperation::DeclareUniqueConstraint { label, property }
+        | WalOperation::DropUniqueConstraint { label, property } => {
+            check(*label).or_else(|| check(*property))
+        }
+        // Deletes/retracts carry only ids/timestamps; control/framing markers
+        // carry no vocabulary.
+        _ => None,
+    }
+}
+
+/// Return the first interner id, across all `entries`, that references a string
+/// the base backup's interner does not define (`>= restored_count`), or `None`
+/// if the whole stream resolves against the base vocabulary.
+fn first_unresolved_interned_id<'a>(
+    entries: impl IntoIterator<Item = &'a WalEntry>,
+    restored_count: u32,
+) -> Option<u32> {
+    entries
+        .into_iter()
+        .find_map(|e| first_out_of_range_id(&e.operation, restored_count))
 }
 
 /// Is this a data-bearing operation (as opposed to a control/framing marker)?

--- a/src/db/pitr.rs
+++ b/src/db/pitr.rs
@@ -605,8 +605,17 @@ impl AletheiaDB {
     /// # Errors
     ///
     /// - [`BackupError::TargetNotEmpty`] — `data_dir` already holds data.
-    /// - [`BackupError::TargetOutsideWindow`] — `target` is below the base
-    ///   backup (unreachable); the error names the achievable window.
+    /// - [`BackupError::TargetOutsideWindow`] — `target` is outside the
+    ///   achievable window: below the base backup (unreachable) **or** above the
+    ///   archived WAL tail (Issue #3374, F2 — an above-tail target is an error,
+    ///   not a silent full replay). The error names the achievable window. For a
+    ///   deliberate "restore to the tail" pass the latest coordinate (the CLI's
+    ///   no-target / `--latest` path resolves this from
+    ///   [`AletheiaDB::inspect_pitr`]).
+    /// - [`BackupError::WindowCrossesVocabularyChange`] — a transaction
+    ///   at-or-before `target` introduced a label/property key absent from the
+    ///   base backup's interner; replaying it would silently mislabel/drop data,
+    ///   so PITR refuses (Issue #3374, F1).
     /// - Artifact/WAL read or replay failures propagate as [`Error`].
     pub fn restore_to_data_dir_at(
         albk: &Path,
@@ -619,36 +628,89 @@ impl AletheiaDB {
         check_target_empty(&index_root).map_err(Error::Backup)?;
 
         // Read the artifact header and the archive BEFORE materializing, so an
-        // out-of-window target fails without touching the target directory.
+        // out-of-window target (or a vocabulary-change crossing) fails without
+        // touching the target directory.
         let payload = read_artifact(albk).map_err(Error::Backup)?;
         let source_lsn = payload.source_lsn;
+        // The base interner defines ids `0..restored_interner_count`; any WAL id
+        // at or above this references a string introduced after the backup.
+        let restored_interner_count = payload.interner.strings.len() as u32;
 
         let all = read_entries_from_dir_with_options(wal_archive, LSN::initial(), None, true)?;
         let window = compute_window(&all, source_lsn);
         window.validate(&target)?;
 
-        // Post-backup entries drive the bounded data replay; the base snapshot
-        // already covers everything below `source_lsn`.
-        let post = read_entries_from_dir_with_options(wal_archive, LSN(source_lsn), None, true)?;
-        let filtered = filter_bands(post, &target);
+        // Net constraint state at the target from the FULL archive (including
+        // declarations that predate the backup, which the base snapshot does not
+        // carry — the differential replay would otherwise miss them). Only the
+        // constraint ops matter to `apply_constraint_declarations`; filtering to
+        // them keeps this slice small even for large archives.
+        let constraint_slice: Vec<WalEntry> = all
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e.operation,
+                    WalOperation::DeclareUniqueConstraint { .. }
+                        | WalOperation::DropUniqueConstraint { .. }
+                ) && entry_at_or_before(e, &target)
+            })
+            .cloned()
+            .collect();
+
+        // The band prefix (whole bands, differential floor at `source_lsn`).
+        // Parsing from the FULL stream eliminates band-straddle (F5).
+        let filtered = filter_bands(all, &target, source_lsn);
+
+        // Vocabulary-change guard (F1): if any included op — data band or
+        // constraint declaration — references an interner id the base backup
+        // does not define, replaying it verbatim would silently mislabel/drop
+        // data. Refuse cleanly BEFORE materializing anything.
+        if let Some(first_unresolved_id) = first_unresolved_interned_id(
+            filtered.entries.iter().chain(constraint_slice.iter()),
+            restored_interner_count,
+        ) {
+            return Err(Error::Backup(BackupError::WindowCrossesVocabularyChange {
+                first_unresolved_id,
+                restored_interner_count,
+            }));
+        }
 
         // Materialize the base snapshot and open the base-state database. The
         // open path fully finalizes the base (id generators, temporal index,
         // extent, HLC seed) from the snapshot at `source_lsn`.
         materialize_to_dir(&payload, &index_root).map_err(Error::Backup)?;
         drop(payload);
+
+        // Everything past this point mutates the (now committed) base manifest.
+        // If any step fails, the target `indexes/` would otherwise be left
+        // looking like a complete base-only restore (no in-progress sentinel),
+        // blocking a clean retry. Wrap the replay + persistence so any error
+        // removes the target `indexes/` before returning, matching #3217's
+        // "a failed restore leaves a clean target" posture (Issue #3374, F4).
+        let outcome = Self::finish_pitr_replay(data_dir, filtered, &constraint_slice);
+        match outcome {
+            Ok(db) => Ok(db),
+            Err(e) => {
+                let _ = std::fs::remove_dir_all(&index_root);
+                Err(e)
+            }
+        }
+    }
+
+    /// Post-materialize half of [`AletheiaDB::restore_to_data_dir_at`]: open the
+    /// base-state DB, apply the net constraints, replay the band prefix, and
+    /// persist the target state. Extracted so the caller can clean up the target
+    /// directory if any step here fails (Issue #3374, F4).
+    fn finish_pitr_replay(
+        data_dir: &Path,
+        filtered: FilteredBands,
+        constraint_slice: &[WalEntry],
+    ) -> Result<AletheiaDB> {
         let config = crate::config::durable_config_for_data_dir(data_dir.to_path_buf());
         let db = AletheiaDB::with_unified_config(config)?;
 
-        // Net constraint state at the target from the FULL archive (including
-        // declarations that predate the backup, which the base snapshot does
-        // not carry — the differential replay would otherwise miss them).
-        let constraint_slice: Vec<WalEntry> = all
-            .into_iter()
-            .filter(|e| entry_at_or_before(e, &target))
-            .collect();
         crate::storage::recovery::apply_constraint_declarations(
-            &constraint_slice,
+            constraint_slice,
             &db.constraint_registry,
         );
 

--- a/src/db/pitr.rs
+++ b/src/db/pitr.rs
@@ -344,18 +344,35 @@ fn band_within(band: &Band, target: &PitrTarget) -> bool {
     }
 }
 
-/// Filter an LSN-sorted WAL entry stream to the prefix of whole transaction
-/// bands committed at-or-before `target` (inclusive tie-break).
+/// Filter an LSN-sorted **full** WAL entry stream (from `LSN::initial()`, not a
+/// floor-cut read) to the prefix of whole transaction bands committed
+/// at-or-before `target` (inclusive tie-break), restricted to bands at or above
+/// the base backup's replay floor `source_lsn`.
+///
+/// Parsing whole bands from the full stream, rather than from a read that starts
+/// at `LSN(source_lsn)`, structurally eliminates **band-straddle** (Issue #3374,
+/// F5): if `source_lsn` ever lands INSIDE a `[BeginTx .. CommitTx]` frame, that
+/// frame is still parsed as one whole band — stamped with its authoritative
+/// `CommitTx` coordinate — and is either wholly included or wholly excluded,
+/// never split into mis-timed singleton data ops. A band whose commit LSN is
+/// below `source_lsn` is already captured by the base snapshot and is skipped
+/// (differential replay). The straddling band's sub-`source_lsn` data ops are
+/// re-touched on replay, which is safe under the #3419 idempotent
+/// re-application guards.
 ///
 /// Never includes a partial band; drops an incomplete trailing band (torn
 /// tail); returns the flattened prefix (markers preserved for replay), the
-/// applied/discarded transaction counts, and the resolved stop coordinate.
-fn filter_bands(entries: Vec<WalEntry>, target: &PitrTarget) -> FilteredBands {
+/// applied/discarded transaction counts (relative to post-`source_lsn`
+/// transactions), and the resolved stop coordinate.
+fn filter_bands(entries: Vec<WalEntry>, target: &PitrTarget, source_lsn: u64) -> FilteredBands {
     let bands = parse_bands(entries);
 
+    // Post-backup transaction bands are those whose commit LSN is at or above
+    // the replay floor; bands fully below `source_lsn` live in the base snapshot
+    // and are neither replayed nor counted.
     let total_transactions = bands
         .iter()
-        .filter(|b| b.complete && b.is_transaction)
+        .filter(|b| b.complete && b.is_transaction && b.stop_lsn.0 >= source_lsn)
         .count() as u64;
 
     let mut out: Vec<WalEntry> = Vec::new();
@@ -366,6 +383,9 @@ fn filter_bands(entries: Vec<WalEntry>, target: &PitrTarget) -> FilteredBands {
     for band in bands {
         if !band.complete {
             continue; // torn tail: excluded, never counted
+        }
+        if band.stop_lsn.0 < source_lsn {
+            continue; // already in the base snapshot (differential replay floor)
         }
         if stopped {
             continue; // prefix already closed; remaining bands are discarded
@@ -378,6 +398,16 @@ fn filter_bands(entries: Vec<WalEntry>, target: &PitrTarget) -> FilteredBands {
             }
             out.extend(band.entries);
         } else {
+            // Monotonicity assumption (F6): the stream is LSN-sorted, and the
+            // WAL's HLC <-> LSN contract makes commit timestamps monotonic with
+            // commit LSN — a later-committing transaction has BOTH a strictly
+            // greater `CommitTx` LSN and a strictly greater commit timestamp.
+            // So once a band's stop coordinate exceeds the target, every later
+            // band's does too: closing the prefix at the first out-of-range band
+            // is correct for an `AsOf` (timestamp) target exactly as it is for an
+            // `Lsn` target. If that contract were ever violated, a later band
+            // committing at a smaller timestamp could be wrongly included; the
+            // WAL write path upholds it.
             stopped = true;
         }
     }
@@ -488,11 +518,13 @@ fn compute_window(all: &[WalEntry], source_lsn: u64) -> PitrWindow {
     }
 }
 
-/// Count complete transaction bands in a stream (for the no-target dry-run).
-fn count_transactions(entries: &[WalEntry]) -> u64 {
+/// Count complete post-backup transaction bands in a full stream (for the
+/// no-target dry-run / to-latest full replay). Bands whose commit LSN is below
+/// `source_lsn` live in the base snapshot and are not counted.
+fn count_transactions(entries: &[WalEntry], source_lsn: u64) -> u64 {
     parse_bands(entries.to_vec())
         .iter()
-        .filter(|b| b.complete && b.is_transaction)
+        .filter(|b| b.complete && b.is_transaction && b.stop_lsn.0 >= source_lsn)
         .count() as u64
 }
 
@@ -698,7 +730,8 @@ impl AletheiaDB {
     ///
     /// # Errors
     ///
-    /// - [`BackupError::TargetOutsideWindow`] — `target` is below the window.
+    /// - [`BackupError::TargetOutsideWindow`] — `target` is outside the window
+    ///   (below the base backup or above the archived WAL tail).
     /// - Artifact/WAL read failures propagate as [`Error`].
     pub fn inspect_pitr(
         albk: &Path,
@@ -708,18 +741,20 @@ impl AletheiaDB {
         let source_lsn = read_artifact(albk).map_err(Error::Backup)?.source_lsn;
         let all = read_entries_from_dir_with_options(wal_archive, LSN::initial(), None, true)?;
         let window = compute_window(&all, source_lsn);
-        let post = read_entries_from_dir_with_options(wal_archive, LSN(source_lsn), None, true)?;
 
         let (resolved_stop, applied, discarded) = match &target {
             Some(t) => {
                 window.validate(t)?;
-                let f = filter_bands(post, t);
+                // Band selection is over the full stream with a `source_lsn`
+                // differential floor (F5); parsing whole bands is straddle-safe.
+                let f = filter_bands(all, t, source_lsn);
                 (f.resolved_stop, f.applied, f.discarded)
             }
             None => {
-                // No target: report the full window; a full replay applies
-                // every reachable post-backup transaction, discarding none.
-                let total = count_transactions(&post);
+                // No target: report the full window; a full replay to the tail
+                // applies every reachable post-backup transaction, discarding
+                // none.
+                let total = count_transactions(&all, source_lsn);
                 (Some(window.latest_coord()), total, 0)
             }
         };
@@ -805,7 +840,7 @@ mod band_filter_tests {
         // Two transactions committing at t=100 and t=200; target exactly 100
         // keeps the first, drops the second.
         let entries = all_of(vec![tx(1, 1, 1, ts(100)), tx(4, 2, 1, ts(200))]);
-        let f = filter_bands(entries, &PitrTarget::AsOf(ts(100)));
+        let f = filter_bands(entries, &PitrTarget::AsOf(ts(100)), 0);
         assert_eq!(f.applied, 1);
         assert_eq!(f.discarded, 1);
         assert_eq!(f.resolved_stop.as_ref().unwrap().timestamp_micros, 100);
@@ -817,7 +852,7 @@ mod band_filter_tests {
     fn asof_between_transactions_takes_at_or_before() {
         // Commits at 100 and 200; target 150 keeps only the first.
         let entries = all_of(vec![tx(1, 1, 1, ts(100)), tx(4, 2, 1, ts(200))]);
-        let f = filter_bands(entries, &PitrTarget::AsOf(ts(150)));
+        let f = filter_bands(entries, &PitrTarget::AsOf(ts(150)), 0);
         assert_eq!(f.applied, 1);
         assert_eq!(f.discarded, 1);
         assert_eq!(f.resolved_stop.unwrap().timestamp_micros, 100);
@@ -826,7 +861,7 @@ mod band_filter_tests {
     #[test]
     fn target_before_all_yields_empty_prefix() {
         let entries = all_of(vec![tx(1, 1, 1, ts(100)), tx(4, 2, 1, ts(200))]);
-        let f = filter_bands(entries, &PitrTarget::AsOf(ts(50)));
+        let f = filter_bands(entries, &PitrTarget::AsOf(ts(50)), 0);
         assert_eq!(f.applied, 0);
         assert_eq!(f.discarded, 2);
         assert!(f.resolved_stop.is_none());
@@ -836,7 +871,7 @@ mod band_filter_tests {
     #[test]
     fn target_after_all_yields_full_prefix() {
         let entries = all_of(vec![tx(1, 1, 1, ts(100)), tx(4, 2, 1, ts(200))]);
-        let f = filter_bands(entries, &PitrTarget::AsOf(ts(9999)));
+        let f = filter_bands(entries, &PitrTarget::AsOf(ts(9999)), 0);
         assert_eq!(f.applied, 2);
         assert_eq!(f.discarded, 0);
         assert_eq!(f.resolved_stop.unwrap().timestamp_micros, 200);
@@ -847,7 +882,7 @@ mod band_filter_tests {
     fn lsn_target_stops_at_commit_lsn() {
         // First band commits at LSN 3, second at LSN 6.
         let entries = all_of(vec![tx(1, 1, 1, ts(100)), tx(4, 2, 1, ts(200))]);
-        let f = filter_bands(entries, &PitrTarget::Lsn(3));
+        let f = filter_bands(entries, &PitrTarget::Lsn(3), 0);
         assert_eq!(f.applied, 1);
         assert_eq!(f.discarded, 1);
         assert_eq!(f.resolved_stop.unwrap().lsn, 3);
@@ -855,7 +890,7 @@ mod band_filter_tests {
         // A target between the two commit LSNs (4 or 5) still keeps only the
         // first whole band — never a partial second band.
         let entries = all_of(vec![tx(1, 1, 1, ts(100)), tx(4, 2, 1, ts(200))]);
-        let f = filter_bands(entries, &PitrTarget::Lsn(5));
+        let f = filter_bands(entries, &PitrTarget::Lsn(5), 0);
         assert_eq!(f.applied, 1);
         assert_eq!(f.entries.len(), 3);
     }
@@ -866,7 +901,7 @@ mod band_filter_tests {
         let mut entries = tx(1, 1, 1, ts(100));
         entries.push(framed(4, WalOperation::BeginTx { tx_id: 2 }, ts(0)));
         entries.push(framed(5, create_node_op(5), ts(0)));
-        let f = filter_bands(entries, &PitrTarget::AsOf(ts(9999)));
+        let f = filter_bands(entries, &PitrTarget::AsOf(ts(9999)), 0);
         assert_eq!(f.applied, 1, "only the complete band is applied");
         assert_eq!(
             f.discarded, 0,
@@ -880,12 +915,12 @@ mod band_filter_tests {
         // A legacy (pre-v7) data op at t=50, then a framed tx at t=150.
         let mut entries = vec![legacy(1, create_node_op(1), ts(50))];
         entries.extend(tx(2, 1, 1, ts(150)));
-        let f = filter_bands(entries.clone(), &PitrTarget::AsOf(ts(100)));
+        let f = filter_bands(entries.clone(), &PitrTarget::AsOf(ts(100)), 0);
         assert_eq!(f.applied, 1, "only the legacy op is at-or-before 100");
         assert_eq!(f.discarded, 1);
         assert_eq!(f.resolved_stop.unwrap().timestamp_micros, 50);
 
-        let f = filter_bands(entries, &PitrTarget::AsOf(ts(200)));
+        let f = filter_bands(entries, &PitrTarget::AsOf(ts(200)), 0);
         assert_eq!(f.applied, 2);
         assert_eq!(f.discarded, 0);
     }
@@ -905,7 +940,7 @@ mod band_filter_tests {
         let mut entries = tx(1, 1, 1, ts(100));
         entries.push(decl);
         entries.extend(tx(5, 2, 1, ts(200)));
-        let f = filter_bands(entries, &PitrTarget::AsOf(ts(150)));
+        let f = filter_bands(entries, &PitrTarget::AsOf(ts(150)), 0);
         assert_eq!(f.applied, 1, "one transaction band before 150");
         assert_eq!(f.discarded, 1);
         // Begin+data+Commit (3) + the declaration (1) = 4 entries carried.
@@ -913,19 +948,54 @@ mod band_filter_tests {
     }
 
     #[test]
-    fn window_lower_bound_rejects_target_below_base() {
-        // Base at source_lsn=10 with a pre-backup commit at t=500 (lsn 3).
+    fn window_rejects_targets_outside_bounds() {
+        // Base at source_lsn=10 with a pre-backup commit at t=500 (lsn 3) and a
+        // post-backup commit at t=800 (begin 10, data 11, commit lsn 12).
         let all = all_of(vec![tx(1, 1, 1, ts(500)), tx(10, 2, 1, ts(800))]);
         let window = compute_window(&all, 10);
-        // A timestamp before the base's latest commit is unreachable.
+        // A timestamp before the base's latest commit is unreachable (below).
         assert!(window.validate(&PitrTarget::AsOf(ts(400))).is_err());
         // At-or-after the base is fine.
         assert!(window.validate(&PitrTarget::AsOf(ts(500))).is_ok());
-        // An LSN below source_lsn is unreachable.
+        // An LSN below source_lsn is unreachable (below).
         assert!(window.validate(&PitrTarget::Lsn(3)).is_err());
         assert!(window.validate(&PitrTarget::Lsn(10)).is_ok());
+        // The latest coordinate itself is in-window (a to-tail full replay).
+        assert!(window.validate(&PitrTarget::AsOf(ts(800))).is_ok());
+        assert!(window.validate(&PitrTarget::Lsn(12)).is_ok());
+        // F2: an explicit target ABOVE the archived tail is an error, not a
+        // silent full replay.
+        assert!(window.validate(&PitrTarget::AsOf(ts(801))).is_err());
+        assert!(window.validate(&PitrTarget::Lsn(13)).is_err());
         // The window bounds are reported.
         assert_eq!(window.earliest_coord().lsn, 10);
+        assert_eq!(window.latest_coord().lsn, 12);
         assert_eq!(window.latest_coord().timestamp_micros, 800);
+    }
+
+    #[test]
+    fn source_lsn_inside_a_band_selects_whole_band() {
+        // F5 regression: `source_lsn` lands INSIDE the second band
+        // (begin lsn 4 < source_lsn 5 <= commit lsn 6). Parsing whole bands from
+        // the full stream must select that band ENTIRE — with its authoritative
+        // CommitTx timestamp — never split it into mis-timed singletons, and must
+        // skip the first band, which lives fully below the floor (in the base).
+        let entries = all_of(vec![tx(1, 1, 1, ts(100)), tx(4, 2, 1, ts(200))]);
+        let f = filter_bands(entries, &PitrTarget::AsOf(ts(9999)), 5);
+
+        assert_eq!(f.applied, 1, "only the straddling band is post-backup");
+        assert_eq!(f.discarded, 0);
+        // Begin(lsn4) + data(lsn5) + Commit(lsn6) = 3 whole-band entries.
+        assert_eq!(f.entries.len(), 3, "whole band, not split singletons");
+        assert!(
+            matches!(f.entries[0].operation, WalOperation::BeginTx { .. }),
+            "band prefix begins with its BeginTx marker"
+        );
+        let stop = f.resolved_stop.expect("a band was applied");
+        assert_eq!(
+            stop.timestamp_micros, 200,
+            "band carries its CommitTx timestamp, not a data op's"
+        );
+        assert_eq!(stop.lsn, 6, "stop is the CommitTx LSN");
     }
 }

--- a/src/db/pitr.rs
+++ b/src/db/pitr.rs
@@ -224,6 +224,16 @@ struct Band {
     complete: bool,
 }
 
+impl Band {
+    /// Whether this band is a complete, post-backup transaction counted in the
+    /// applied/discarded stats: a durable data transaction whose commit LSN is
+    /// at or above the base backup's replay floor (bands fully below
+    /// `source_lsn` already live in the base snapshot).
+    fn is_post_backup_transaction(&self, source_lsn: u64) -> bool {
+        self.complete && self.is_transaction && self.stop_lsn.0 >= source_lsn
+    }
+}
+
 /// Group an LSN-sorted WAL entry stream into whole transaction bands.
 ///
 /// A framed `[BeginTx .. CommitTx]` frame is one band stamped with the
@@ -372,7 +382,7 @@ fn filter_bands(entries: Vec<WalEntry>, target: &PitrTarget, source_lsn: u64) ->
     // and are neither replayed nor counted.
     let total_transactions = bands
         .iter()
-        .filter(|b| b.complete && b.is_transaction && b.stop_lsn.0 >= source_lsn)
+        .filter(|b| b.is_post_backup_transaction(source_lsn))
         .count() as u64;
 
     let mut out: Vec<WalEntry> = Vec::new();
@@ -524,7 +534,7 @@ fn compute_window(all: &[WalEntry], source_lsn: u64) -> PitrWindow {
 fn count_transactions(entries: &[WalEntry], source_lsn: u64) -> u64 {
     parse_bands(entries.to_vec())
         .iter()
-        .filter(|b| b.complete && b.is_transaction && b.stop_lsn.0 >= source_lsn)
+        .filter(|b| b.is_post_backup_transaction(source_lsn))
         .count() as u64
 }
 
@@ -535,59 +545,6 @@ fn entry_at_or_before(entry: &WalEntry, target: &PitrTarget) -> bool {
         PitrTarget::AsOf(t) => entry.timestamp <= *t,
         PitrTarget::Lsn(n) => entry.lsn.0 <= *n,
     }
-}
-
-/// Recompute the HLC seed from restored state (mirrors the startup bootstrap),
-/// so writes to the returned database stay monotonic above every replayed
-/// transaction time.
-fn reseed_current_timestamp(db: &AletheiaDB) -> Result<()> {
-    let mut max_ts = crate::core::temporal::time::now();
-
-    for node in db.current.all_nodes() {
-        if let Some(ts) = node.metadata.commit_timestamp
-            && ts > max_ts
-        {
-            max_ts = ts;
-        }
-    }
-    for edge in db.current.all_edges() {
-        if let Some(ts) = edge.metadata.commit_timestamp
-            && ts > max_ts
-        {
-            max_ts = ts;
-        }
-    }
-    {
-        let hist = db.historical.read();
-        for v in hist.get_node_versions().values() {
-            let tt = v.temporal.transaction_time();
-            if tt.start() > max_ts {
-                max_ts = tt.start();
-            }
-            if !tt.is_current() && tt.end() > max_ts {
-                max_ts = tt.end();
-            }
-        }
-        for v in hist.get_edge_versions().values() {
-            let tt = v.temporal.transaction_time();
-            if tt.start() > max_ts {
-                max_ts = tt.start();
-            }
-            if !tt.is_current() && tt.end() > max_ts {
-                max_ts = tt.end();
-            }
-        }
-    }
-
-    let mut ct = db.current_timestamp.lock().map_err(|_| {
-        Error::Storage(crate::core::error::StorageError::LockPoisoned {
-            resource: "current_timestamp".to_string(),
-        })
-    })?;
-    if max_ts > *ct {
-        *ct = max_ts;
-    }
-    Ok(())
 }
 
 impl AletheiaDB {
@@ -753,8 +710,13 @@ impl AletheiaDB {
         }
 
         // Wire the replayed versions into the temporal index and reseed the HLC.
+        // Reuse the startup seed helper (Issue #3387 closed-tx-end folding lives
+        // there): on a freshly-opened restored DB the recomputed bootstrap value
+        // is always >= the value `open()` already seeded (same `now()` floor over
+        // a superset of versions), so the helper's unconditional set is identical
+        // to the previous `if max_ts > *ct` guard.
         db.historical.write().rebuild_temporal_index_from_versions();
-        reseed_current_timestamp(&db)?;
+        crate::db::config::seed_startup_current_timestamp(&db)?;
 
         // Record the net constraint declarations in the target WAL so a later
         // reopen recovers them (index snapshots do not carry constraints), then

--- a/src/db/pitr.rs
+++ b/src/db/pitr.rs
@@ -1,0 +1,852 @@
+//! Point-in-time restore (PITR) to a transaction-time coordinate (Issue #3374).
+//!
+//! Backup/restore (#3217) recovers a database to the exact moment a `.albk`
+//! backup was taken. PITR extends that to *any* transaction-time coordinate in
+//! between: given a base `.albk` backup **plus an archived WAL chain**, it
+//! materializes a fresh database whose recorded history ends exactly at an
+//! operator-chosen target (a timestamp or an LSN).
+//!
+//! The mechanism is a bounded, deterministic replay over the same
+//! crash-recovery machinery used at startup:
+//!
+//! 1. materialize the base snapshot (state at `source_lsn`);
+//! 2. read the archived WAL from `source_lsn` (inclusive);
+//! 3. keep only the prefix of **whole transaction bands** committed
+//!    at-or-before the target (never a partial band — see [`filter_bands`]);
+//! 4. replay that prefix into the restored storage, mirroring the startup
+//!    differential-replay start-LSN and finalization semantics;
+//! 5. persist the target state so a subsequent reopen loads it.
+//!
+//! Inputs (the `.albk` and the WAL archive) are **read-only**: PITR never
+//! mutates them.
+//!
+//! # Tie-breaking
+//!
+//! A target falling between two transactions resolves **inclusively at-or-before**
+//! the coordinate: every transaction committed at-or-before the target is
+//! present, every transaction after it is absent.
+//!
+//! # Interner caveat (v1)
+//!
+//! The WAL stores node/edge **labels** and **property keys** as interner ids
+//! (not strings); property *values* are self-contained. The base backup carries
+//! the interner as of `source_lsn`, so a post-backup transaction that
+//! introduces a **brand-new label or property key** cannot be resolved after a
+//! PITR replay. Keep the label/key vocabulary stable across the window (a
+//! durable interner archive is a follow-up).
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::core::error::{Error, Result};
+use crate::core::interning::GLOBAL_INTERNER;
+use crate::core::temporal::Timestamp;
+use crate::db::AletheiaDB;
+use crate::storage::backup::{BackupError, check_target_empty, materialize_to_dir, read_artifact};
+use crate::storage::wal::segment_reader::read_entries_from_dir_with_options;
+use crate::storage::wal::{LSN, WalEntry, WalOperation};
+
+/// A PITR stop target: an absolute transaction-time coordinate.
+///
+/// Valid time is deliberately **not** a PITR target — physical restore targets
+/// transaction time only (valid time is a query dimension; see the issue's
+/// out-of-scope note).
+#[derive(Debug, Clone, Copy)]
+pub enum PitrTarget {
+    /// Stop at-or-before a transaction-time commit timestamp.
+    AsOf(Timestamp),
+    /// Stop at-or-before a WAL LSN.
+    Lsn(u64),
+}
+
+/// A bi-coordinate (LSN + transaction time) describing a PITR stop point or a
+/// window bound. Serde-serializable for `--dry-run` JSON output.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PitrCoord {
+    /// The WAL LSN of the coordinate.
+    pub lsn: u64,
+    /// The transaction-time coordinate, microseconds since the Unix epoch.
+    pub timestamp_micros: i64,
+    /// The transaction-time coordinate as an RFC 3339 string (UTC, `Z`).
+    pub timestamp_rfc3339: String,
+}
+
+impl PitrCoord {
+    fn new(lsn: u64, ts: Timestamp) -> Self {
+        let micros = ts.wallclock();
+        let rfc = chrono::DateTime::<chrono::Utc>::from_timestamp_micros(micros)
+            .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Micros, true))
+            .unwrap_or_else(|| micros.to_string());
+        Self {
+            lsn,
+            timestamp_micros: micros,
+            timestamp_rfc3339: rfc,
+        }
+    }
+
+    fn describe(&self) -> String {
+        format!("lsn={} / {}", self.lsn, self.timestamp_rfc3339)
+    }
+}
+
+/// The plan a `--dry-run` PITR inspection produces without materializing or
+/// opening anything: the achievable window plus, for a given target, the
+/// resolved stop coordinate and applied/discarded transaction counts.
+#[derive(Debug, Clone, Serialize)]
+pub struct PitrPlan {
+    /// The earliest reachable coordinate (the base backup). PITR cannot stop
+    /// before this.
+    pub earliest: PitrCoord,
+    /// The latest reachable coordinate (the archived WAL tail).
+    pub latest: PitrCoord,
+    /// The coordinate replay would stop at for the given target, or `None`
+    /// when no target was supplied or the target resolves to base-only.
+    pub resolved_stop: Option<PitrCoord>,
+    /// Number of post-backup transactions that would be applied.
+    pub transactions_applied: u64,
+    /// Number of post-backup transactions that would be discarded (the blast
+    /// radius of the rollback).
+    pub transactions_discarded: u64,
+}
+
+/// Result of [`filter_bands`]: the flattened band prefix plus stats.
+struct FilteredBands {
+    /// The LSN-ordered WAL entries of every included whole band (data ops with
+    /// their `BeginTx`/`CommitTx` markers preserved, plus control ops).
+    entries: Vec<WalEntry>,
+    /// Number of included transaction bands.
+    applied: u64,
+    /// Number of complete transaction bands excluded (after the target).
+    discarded: u64,
+    /// The coordinate of the last included transaction band, if any.
+    resolved_stop: Option<PitrCoord>,
+}
+
+/// Is this a data-bearing operation (as opposed to a control/framing marker)?
+fn is_data_op(op: &WalOperation) -> bool {
+    matches!(
+        op,
+        WalOperation::CreateNode { .. }
+            | WalOperation::CreateEdge { .. }
+            | WalOperation::UpdateNode { .. }
+            | WalOperation::UpdateEdge { .. }
+            | WalOperation::DeleteNode { .. }
+            | WalOperation::DeleteEdge { .. }
+            | WalOperation::RetractNode { .. }
+            | WalOperation::RetractEdge { .. }
+    )
+}
+
+/// A parsed transaction band: the atomic unit PITR includes or excludes.
+struct Band {
+    entries: Vec<WalEntry>,
+    /// The band's stop coordinate (its `CommitTx`, or a legacy/raw op's own).
+    stop_lsn: LSN,
+    stop_ts: Timestamp,
+    /// Whether the band represents a data transaction (counted in stats) as
+    /// opposed to a self-committing control op (constraint/checkpoint).
+    is_transaction: bool,
+    /// Whether the band is a complete, durable transaction. Incomplete
+    /// (torn-tail) bands are excluded from replay and never counted.
+    complete: bool,
+}
+
+/// Group an LSN-sorted WAL entry stream into whole transaction bands.
+///
+/// A framed `[BeginTx .. CommitTx]` frame is one band stamped with the
+/// `CommitTx` coordinate; a legacy (`!framed`) entry or a framed raw/control op
+/// is a singleton band stamped with its own coordinate. A `BeginTx` with no
+/// matching `CommitTx` (crash tail) yields a single `complete = false` band.
+fn parse_bands(entries: Vec<WalEntry>) -> Vec<Band> {
+    /// Flush a still-open frame as an INCOMPLETE (torn) band, draining `open`.
+    fn flush_incomplete(open: &mut Vec<WalEntry>, bands: &mut Vec<Band>) {
+        if let Some(last) = open.last() {
+            let (stop_lsn, stop_ts) = (last.lsn, last.timestamp);
+            bands.push(Band {
+                stop_lsn,
+                stop_ts,
+                is_transaction: true,
+                complete: false,
+                entries: std::mem::take(open),
+            });
+        }
+    }
+
+    let mut bands: Vec<Band> = Vec::new();
+    let mut open: Vec<WalEntry> = Vec::new();
+    let mut open_active = false;
+
+    for entry in entries {
+        if !entry.framed {
+            // Legacy / non-transactional entry: apply as a singleton band.
+            if open_active {
+                flush_incomplete(&mut open, &mut bands);
+                open_active = false;
+            }
+            let is_tx = is_data_op(&entry.operation);
+            bands.push(Band {
+                stop_lsn: entry.lsn,
+                stop_ts: entry.timestamp,
+                is_transaction: is_tx,
+                complete: true,
+                entries: vec![entry],
+            });
+            continue;
+        }
+
+        match &entry.operation {
+            WalOperation::BeginTx { .. } => {
+                if open_active {
+                    flush_incomplete(&mut open, &mut bands);
+                }
+                open_active = true;
+                open.push(entry);
+            }
+            WalOperation::CommitTx {
+                commit_timestamp, ..
+            } => {
+                if open_active {
+                    let stop_lsn = entry.lsn;
+                    let stop_ts = *commit_timestamp;
+                    open.push(entry);
+                    bands.push(Band {
+                        stop_lsn,
+                        stop_ts,
+                        is_transaction: true,
+                        complete: true,
+                        entries: std::mem::take(&mut open),
+                    });
+                    open_active = false;
+                }
+                // A stray CommitTx with no open frame is a benign skip (its
+                // BeginTx lies below the read floor) — drop it.
+            }
+            WalOperation::Checkpoint { .. }
+            | WalOperation::DeclareUniqueConstraint { .. }
+            | WalOperation::DropUniqueConstraint { .. } => {
+                if open_active {
+                    flush_incomplete(&mut open, &mut bands);
+                    open_active = false;
+                }
+                bands.push(Band {
+                    stop_lsn: entry.lsn,
+                    stop_ts: entry.timestamp,
+                    is_transaction: false,
+                    complete: true,
+                    entries: vec![entry],
+                });
+            }
+            _ => {
+                // A framed data op.
+                if open_active {
+                    open.push(entry);
+                } else {
+                    // Raw framed append with no open frame (test/tooling path):
+                    // treat as a singleton transaction band.
+                    bands.push(Band {
+                        stop_lsn: entry.lsn,
+                        stop_ts: entry.timestamp,
+                        is_transaction: true,
+                        complete: true,
+                        entries: vec![entry],
+                    });
+                }
+            }
+        }
+    }
+
+    // Any still-open frame at end-of-stream is an uncommitted crash tail.
+    if open_active {
+        flush_incomplete(&mut open, &mut bands);
+    }
+
+    bands
+}
+
+/// Whether a band's stop coordinate is at-or-before the target.
+fn band_within(band: &Band, target: &PitrTarget) -> bool {
+    match target {
+        PitrTarget::AsOf(t) => band.stop_ts <= *t,
+        PitrTarget::Lsn(n) => band.stop_lsn.0 <= *n,
+    }
+}
+
+/// Filter an LSN-sorted WAL entry stream to the prefix of whole transaction
+/// bands committed at-or-before `target` (inclusive tie-break).
+///
+/// Never includes a partial band; drops an incomplete trailing band (torn
+/// tail); returns the flattened prefix (markers preserved for replay), the
+/// applied/discarded transaction counts, and the resolved stop coordinate.
+fn filter_bands(entries: Vec<WalEntry>, target: &PitrTarget) -> FilteredBands {
+    let bands = parse_bands(entries);
+
+    let total_transactions = bands
+        .iter()
+        .filter(|b| b.complete && b.is_transaction)
+        .count() as u64;
+
+    let mut out: Vec<WalEntry> = Vec::new();
+    let mut applied: u64 = 0;
+    let mut resolved_stop: Option<PitrCoord> = None;
+    let mut stopped = false;
+
+    for band in bands {
+        if !band.complete {
+            continue; // torn tail: excluded, never counted
+        }
+        if stopped {
+            continue; // prefix already closed; remaining bands are discarded
+        }
+        if band_within(&band, target) {
+            let coord = PitrCoord::new(band.stop_lsn.0, band.stop_ts);
+            if band.is_transaction {
+                applied += 1;
+                resolved_stop = Some(coord);
+            }
+            out.extend(band.entries);
+        } else {
+            stopped = true;
+        }
+    }
+
+    FilteredBands {
+        entries: out,
+        applied,
+        discarded: total_transactions.saturating_sub(applied),
+        resolved_stop,
+    }
+}
+
+/// The achievable PITR window derived from the base backup + archived WAL.
+struct PitrWindow {
+    /// The base backup coordinate (the earliest reachable LSN).
+    source_lsn: u64,
+    /// Max commit timestamp of any transaction already in the base
+    /// (`lsn < source_lsn`); `None` if the base is empty.
+    base_ts: Option<Timestamp>,
+    /// The latest reachable transaction's LSN.
+    latest_lsn: u64,
+    /// The latest reachable transaction's commit timestamp.
+    latest_ts: Timestamp,
+}
+
+impl PitrWindow {
+    fn earliest_coord(&self) -> PitrCoord {
+        PitrCoord::new(
+            self.source_lsn,
+            self.base_ts.unwrap_or_else(|| Timestamp::from(0)),
+        )
+    }
+
+    fn latest_coord(&self) -> PitrCoord {
+        PitrCoord::new(self.latest_lsn, self.latest_ts)
+    }
+
+    /// Reject a target that lies below the achievable window (before the base
+    /// backup). Targets above the latest reachable coordinate are permitted:
+    /// they resolve to a full replay ("everything at-or-before the target").
+    fn validate(&self, target: &PitrTarget) -> Result<()> {
+        let outside = match target {
+            PitrTarget::Lsn(n) => *n < self.source_lsn,
+            PitrTarget::AsOf(t) => self.base_ts.is_some_and(|bt| *t < bt),
+        };
+        if outside {
+            let requested = match target {
+                PitrTarget::Lsn(n) => format!("lsn={n}"),
+                PitrTarget::AsOf(t) => PitrCoord::new(0, *t).timestamp_rfc3339,
+            };
+            return Err(Error::Backup(BackupError::TargetOutsideWindow {
+                requested,
+                earliest: self.earliest_coord().describe(),
+                latest: self.latest_coord().describe(),
+            }));
+        }
+        Ok(())
+    }
+}
+
+/// Compute the achievable window by scanning the full archive once.
+fn compute_window(all: &[WalEntry], source_lsn: u64) -> PitrWindow {
+    let mut base_ts: Option<Timestamp> = None;
+    let mut latest_lsn = source_lsn;
+    let mut latest_ts = Timestamp::from(0);
+    let mut have_latest = false;
+
+    for e in all {
+        // A transaction's commit coordinate: the framed `CommitTx`, or a legacy
+        // (unframed) data op's own coordinate. Control ops and framed data ops
+        // (accounted by their `CommitTx`) are skipped to avoid double counting.
+        let coord = match &e.operation {
+            WalOperation::CommitTx {
+                commit_timestamp, ..
+            } => Some((e.lsn.0, *commit_timestamp)),
+            op if is_data_op(op) && !e.framed => Some((e.lsn.0, e.timestamp)),
+            _ => None,
+        };
+        if let Some((lsn, ts)) = coord {
+            if lsn < source_lsn {
+                base_ts = Some(base_ts.map_or(ts, |b| b.max(ts)));
+            }
+            if !have_latest || lsn > latest_lsn {
+                latest_lsn = lsn;
+                latest_ts = ts;
+                have_latest = true;
+            }
+        }
+    }
+
+    if !have_latest {
+        latest_lsn = source_lsn;
+        latest_ts = base_ts.unwrap_or_else(|| Timestamp::from(0));
+    }
+
+    PitrWindow {
+        source_lsn,
+        base_ts,
+        latest_lsn,
+        latest_ts,
+    }
+}
+
+/// Count complete transaction bands in a stream (for the no-target dry-run).
+fn count_transactions(entries: &[WalEntry]) -> u64 {
+    parse_bands(entries.to_vec())
+        .iter()
+        .filter(|b| b.complete && b.is_transaction)
+        .count() as u64
+}
+
+/// Whether a raw entry's own coordinate is at-or-before the target (used to
+/// scope constraint declarations, which are self-committing control ops).
+fn entry_at_or_before(entry: &WalEntry, target: &PitrTarget) -> bool {
+    match target {
+        PitrTarget::AsOf(t) => entry.timestamp <= *t,
+        PitrTarget::Lsn(n) => entry.lsn.0 <= *n,
+    }
+}
+
+/// Recompute the HLC seed from restored state (mirrors the startup bootstrap),
+/// so writes to the returned database stay monotonic above every replayed
+/// transaction time.
+fn reseed_current_timestamp(db: &AletheiaDB) -> Result<()> {
+    let mut max_ts = crate::core::temporal::time::now();
+
+    for node in db.current.all_nodes() {
+        if let Some(ts) = node.metadata.commit_timestamp
+            && ts > max_ts
+        {
+            max_ts = ts;
+        }
+    }
+    for edge in db.current.all_edges() {
+        if let Some(ts) = edge.metadata.commit_timestamp
+            && ts > max_ts
+        {
+            max_ts = ts;
+        }
+    }
+    {
+        let hist = db.historical.read();
+        for v in hist.get_node_versions().values() {
+            let tt = v.temporal.transaction_time();
+            if tt.start() > max_ts {
+                max_ts = tt.start();
+            }
+            if !tt.is_current() && tt.end() > max_ts {
+                max_ts = tt.end();
+            }
+        }
+        for v in hist.get_edge_versions().values() {
+            let tt = v.temporal.transaction_time();
+            if tt.start() > max_ts {
+                max_ts = tt.start();
+            }
+            if !tt.is_current() && tt.end() > max_ts {
+                max_ts = tt.end();
+            }
+        }
+    }
+
+    let mut ct = db.current_timestamp.lock().map_err(|_| {
+        Error::Storage(crate::core::error::StorageError::LockPoisoned {
+            resource: "current_timestamp".to_string(),
+        })
+    })?;
+    if max_ts > *ct {
+        *ct = max_ts;
+    }
+    Ok(())
+}
+
+impl AletheiaDB {
+    /// Restore a base `.albk` backup plus its archived WAL chain to an exact
+    /// transaction-time coordinate, producing a fresh durable database at
+    /// `data_dir` whose recorded history ends at `target` (Issue #3374).
+    ///
+    /// Every transaction committed at-or-before `target` is present with full
+    /// bi-temporal fidelity; every transaction after it is absent. Constraints
+    /// (#3218) and provenance (#3224) are re-established at the target.
+    ///
+    /// Inputs are **read-only**: neither `albk` nor `wal_archive` is mutated.
+    /// The target directory must be empty.
+    ///
+    /// # Errors
+    ///
+    /// - [`BackupError::TargetNotEmpty`] — `data_dir` already holds data.
+    /// - [`BackupError::TargetOutsideWindow`] — `target` is below the base
+    ///   backup (unreachable); the error names the achievable window.
+    /// - Artifact/WAL read or replay failures propagate as [`Error`].
+    pub fn restore_to_data_dir_at(
+        albk: &Path,
+        wal_archive: &Path,
+        target: PitrTarget,
+        data_dir: &Path,
+    ) -> Result<AletheiaDB> {
+        // Canonical index-persistence root (mirrors `restore_to_data_dir`).
+        let index_root = data_dir.join("indexes");
+        check_target_empty(&index_root).map_err(Error::Backup)?;
+
+        // Read the artifact header and the archive BEFORE materializing, so an
+        // out-of-window target fails without touching the target directory.
+        let payload = read_artifact(albk).map_err(Error::Backup)?;
+        let source_lsn = payload.source_lsn;
+
+        let all = read_entries_from_dir_with_options(wal_archive, LSN::initial(), None, true)?;
+        let window = compute_window(&all, source_lsn);
+        window.validate(&target)?;
+
+        // Post-backup entries drive the bounded data replay; the base snapshot
+        // already covers everything below `source_lsn`.
+        let post = read_entries_from_dir_with_options(wal_archive, LSN(source_lsn), None, true)?;
+        let filtered = filter_bands(post, &target);
+
+        // Materialize the base snapshot and open the base-state database. The
+        // open path fully finalizes the base (id generators, temporal index,
+        // extent, HLC seed) from the snapshot at `source_lsn`.
+        materialize_to_dir(&payload, &index_root).map_err(Error::Backup)?;
+        drop(payload);
+        let config = crate::config::durable_config_for_data_dir(data_dir.to_path_buf());
+        let db = AletheiaDB::with_unified_config(config)?;
+
+        // Net constraint state at the target from the FULL archive (including
+        // declarations that predate the backup, which the base snapshot does
+        // not carry — the differential replay would otherwise miss them).
+        let constraint_slice: Vec<WalEntry> = all
+            .into_iter()
+            .filter(|e| entry_at_or_before(e, &target))
+            .collect();
+        crate::storage::recovery::apply_constraint_declarations(
+            &constraint_slice,
+            &db.constraint_registry,
+        );
+
+        // Bounded differential replay of the band prefix into current +
+        // historical storage.
+        {
+            let initial_version_id = db.version_id_gen.current();
+            let mut hist = db.historical.write();
+            let (_final_lsn, max_node_id, max_edge_id, next_version_id) =
+                crate::storage::recovery::replay_entries_into_storage_with_constraints(
+                    &db.wal,
+                    filtered.entries,
+                    &db.current,
+                    &mut hist,
+                    initial_version_id,
+                    Some(&db.constraint_registry),
+                )?;
+            drop(hist);
+
+            if let Some(m) = max_node_id {
+                db.node_id_gen.ensure_at_least(m + 1);
+            }
+            if let Some(m) = max_edge_id {
+                db.edge_id_gen.ensure_at_least(m + 1);
+            }
+            db.version_id_gen.ensure_at_least(next_version_id);
+        }
+
+        // Rebuild the reservation index for declared constraints from the
+        // restored current-state nodes.
+        for (label_str, property_str) in db.constraint_registry.list() {
+            if let (Some(label_id), Some(property_id)) = (
+                GLOBAL_INTERNER.get_id(&label_str),
+                GLOBAL_INTERNER.get_id(&property_str),
+            ) {
+                let nodes = db.current.get_nodes_by_label(&label_str);
+                db.constraint_registry
+                    .rebuild_from_nodes(&nodes, label_id, property_id);
+            }
+        }
+
+        // Wire the replayed versions into the temporal index and reseed the HLC.
+        db.historical.write().rebuild_temporal_index_from_versions();
+        reseed_current_timestamp(&db)?;
+
+        // Record the net constraint declarations in the target WAL so a later
+        // reopen recovers them (index snapshots do not carry constraints), then
+        // persist the target state so a reopen loads it.
+        for (label_str, property_str) in db.constraint_registry.list() {
+            if let (Some(label_id), Some(property_id)) = (
+                GLOBAL_INTERNER.get_id(&label_str),
+                GLOBAL_INTERNER.get_id(&property_str),
+            ) {
+                db.wal.append(WalOperation::DeclareUniqueConstraint {
+                    label: label_id,
+                    property: property_id,
+                })?;
+            }
+        }
+        db.wal.flush()?;
+
+        if let (Some(manager), Some(tracker)) = (&db.persistence_manager, &db.persistence_tracker) {
+            crate::storage::index_persistence::operations::persist_all_indexes(
+                &db.current,
+                &db.historical,
+                &db.temporal_indexes,
+                &db.wal,
+                manager,
+                tracker,
+            )?;
+        }
+
+        Ok(db)
+    }
+
+    /// Inspect the achievable PITR window and, for a given `target`, the
+    /// resolved stop and the count of transactions that would be discarded —
+    /// without materializing or opening anything (the `--dry-run` path).
+    ///
+    /// # Errors
+    ///
+    /// - [`BackupError::TargetOutsideWindow`] — `target` is below the window.
+    /// - Artifact/WAL read failures propagate as [`Error`].
+    pub fn inspect_pitr(
+        albk: &Path,
+        wal_archive: &Path,
+        target: Option<PitrTarget>,
+    ) -> Result<PitrPlan> {
+        let source_lsn = read_artifact(albk).map_err(Error::Backup)?.source_lsn;
+        let all = read_entries_from_dir_with_options(wal_archive, LSN::initial(), None, true)?;
+        let window = compute_window(&all, source_lsn);
+        let post = read_entries_from_dir_with_options(wal_archive, LSN(source_lsn), None, true)?;
+
+        let (resolved_stop, applied, discarded) = match &target {
+            Some(t) => {
+                window.validate(t)?;
+                let f = filter_bands(post, t);
+                (f.resolved_stop, f.applied, f.discarded)
+            }
+            None => {
+                // No target: report the full window; a full replay applies
+                // every reachable post-backup transaction, discarding none.
+                let total = count_transactions(&post);
+                (Some(window.latest_coord()), total, 0)
+            }
+        };
+
+        Ok(PitrPlan {
+            earliest: window.earliest_coord(),
+            latest: window.latest_coord(),
+            resolved_stop,
+            transactions_applied: applied,
+            transactions_discarded: discarded,
+        })
+    }
+}
+
+#[cfg(test)]
+mod band_filter_tests {
+    use super::*;
+    use crate::core::hlc::HybridTimestamp;
+    use crate::core::interning::GLOBAL_INTERNER;
+    use crate::core::property::PropertyMap;
+
+    fn ts(v: i64) -> Timestamp {
+        HybridTimestamp::new_unchecked(v, 0)
+    }
+
+    fn create_node_op(id: u64) -> WalOperation {
+        WalOperation::CreateNode {
+            node_id: crate::core::NodeId::new(id).unwrap(),
+            label: GLOBAL_INTERNER.intern("PitrBand").unwrap(),
+            properties: PropertyMap::new(),
+            valid_from: ts(1),
+            provenance: None,
+        }
+    }
+
+    fn framed(lsn: u64, op: WalOperation, timestamp: Timestamp) -> WalEntry {
+        WalEntry {
+            lsn: LSN(lsn),
+            timestamp,
+            operation: op,
+            checksum: 0,
+            framed: true,
+        }
+    }
+
+    fn legacy(lsn: u64, op: WalOperation, timestamp: Timestamp) -> WalEntry {
+        WalEntry {
+            lsn: LSN(lsn),
+            timestamp,
+            operation: op,
+            checksum: 0,
+            framed: false,
+        }
+    }
+
+    /// Build a framed transaction band `[BeginTx, data.., CommitTx]` occupying
+    /// contiguous LSNs starting at `begin_lsn`, committing at `commit_ts`.
+    fn tx(begin_lsn: u64, tx_id: u64, data: usize, commit_ts: Timestamp) -> Vec<WalEntry> {
+        let mut v = vec![framed(begin_lsn, WalOperation::BeginTx { tx_id }, ts(0))];
+        for i in 0..data {
+            let lsn = begin_lsn + 1 + i as u64;
+            v.push(framed(lsn, create_node_op(lsn), ts(0)));
+        }
+        let commit_lsn = begin_lsn + 1 + data as u64;
+        v.push(framed(
+            commit_lsn,
+            WalOperation::CommitTx {
+                tx_id,
+                entry_count: data as u32,
+                commit_timestamp: commit_ts,
+            },
+            ts(0),
+        ));
+        v
+    }
+
+    fn all_of(bands: Vec<Vec<WalEntry>>) -> Vec<WalEntry> {
+        bands.into_iter().flatten().collect()
+    }
+
+    #[test]
+    fn asof_exact_boundary_is_inclusive() {
+        // Two transactions committing at t=100 and t=200; target exactly 100
+        // keeps the first, drops the second.
+        let entries = all_of(vec![tx(1, 1, 1, ts(100)), tx(4, 2, 1, ts(200))]);
+        let f = filter_bands(entries, &PitrTarget::AsOf(ts(100)));
+        assert_eq!(f.applied, 1);
+        assert_eq!(f.discarded, 1);
+        assert_eq!(f.resolved_stop.as_ref().unwrap().timestamp_micros, 100);
+        // Prefix is exactly the first band (Begin + 1 data + Commit = 3).
+        assert_eq!(f.entries.len(), 3);
+    }
+
+    #[test]
+    fn asof_between_transactions_takes_at_or_before() {
+        // Commits at 100 and 200; target 150 keeps only the first.
+        let entries = all_of(vec![tx(1, 1, 1, ts(100)), tx(4, 2, 1, ts(200))]);
+        let f = filter_bands(entries, &PitrTarget::AsOf(ts(150)));
+        assert_eq!(f.applied, 1);
+        assert_eq!(f.discarded, 1);
+        assert_eq!(f.resolved_stop.unwrap().timestamp_micros, 100);
+    }
+
+    #[test]
+    fn target_before_all_yields_empty_prefix() {
+        let entries = all_of(vec![tx(1, 1, 1, ts(100)), tx(4, 2, 1, ts(200))]);
+        let f = filter_bands(entries, &PitrTarget::AsOf(ts(50)));
+        assert_eq!(f.applied, 0);
+        assert_eq!(f.discarded, 2);
+        assert!(f.resolved_stop.is_none());
+        assert!(f.entries.is_empty());
+    }
+
+    #[test]
+    fn target_after_all_yields_full_prefix() {
+        let entries = all_of(vec![tx(1, 1, 1, ts(100)), tx(4, 2, 1, ts(200))]);
+        let f = filter_bands(entries, &PitrTarget::AsOf(ts(9999)));
+        assert_eq!(f.applied, 2);
+        assert_eq!(f.discarded, 0);
+        assert_eq!(f.resolved_stop.unwrap().timestamp_micros, 200);
+        assert_eq!(f.entries.len(), 6);
+    }
+
+    #[test]
+    fn lsn_target_stops_at_commit_lsn() {
+        // First band commits at LSN 3, second at LSN 6.
+        let entries = all_of(vec![tx(1, 1, 1, ts(100)), tx(4, 2, 1, ts(200))]);
+        let f = filter_bands(entries, &PitrTarget::Lsn(3));
+        assert_eq!(f.applied, 1);
+        assert_eq!(f.discarded, 1);
+        assert_eq!(f.resolved_stop.unwrap().lsn, 3);
+
+        // A target between the two commit LSNs (4 or 5) still keeps only the
+        // first whole band — never a partial second band.
+        let entries = all_of(vec![tx(1, 1, 1, ts(100)), tx(4, 2, 1, ts(200))]);
+        let f = filter_bands(entries, &PitrTarget::Lsn(5));
+        assert_eq!(f.applied, 1);
+        assert_eq!(f.entries.len(), 3);
+    }
+
+    #[test]
+    fn torn_trailing_band_is_excluded() {
+        // A complete band, then a BeginTx with no CommitTx (crash tail).
+        let mut entries = tx(1, 1, 1, ts(100));
+        entries.push(framed(4, WalOperation::BeginTx { tx_id: 2 }, ts(0)));
+        entries.push(framed(5, create_node_op(5), ts(0)));
+        let f = filter_bands(entries, &PitrTarget::AsOf(ts(9999)));
+        assert_eq!(f.applied, 1, "only the complete band is applied");
+        assert_eq!(
+            f.discarded, 0,
+            "the torn tail is not a committed transaction"
+        );
+        assert_eq!(f.entries.len(), 3);
+    }
+
+    #[test]
+    fn mixed_framed_and_legacy_entries() {
+        // A legacy (pre-v7) data op at t=50, then a framed tx at t=150.
+        let mut entries = vec![legacy(1, create_node_op(1), ts(50))];
+        entries.extend(tx(2, 1, 1, ts(150)));
+        let f = filter_bands(entries.clone(), &PitrTarget::AsOf(ts(100)));
+        assert_eq!(f.applied, 1, "only the legacy op is at-or-before 100");
+        assert_eq!(f.discarded, 1);
+        assert_eq!(f.resolved_stop.unwrap().timestamp_micros, 50);
+
+        let f = filter_bands(entries, &PitrTarget::AsOf(ts(200)));
+        assert_eq!(f.applied, 2);
+        assert_eq!(f.discarded, 0);
+    }
+
+    #[test]
+    fn control_ops_are_included_but_not_counted() {
+        // A constraint declaration between two transactions is carried in the
+        // prefix (so replay re-establishes it) but is not a counted transaction.
+        let decl = framed(
+            4,
+            WalOperation::DeclareUniqueConstraint {
+                label: GLOBAL_INTERNER.intern("PitrBand").unwrap(),
+                property: GLOBAL_INTERNER.intern("k").unwrap(),
+            },
+            ts(120),
+        );
+        let mut entries = tx(1, 1, 1, ts(100));
+        entries.push(decl);
+        entries.extend(tx(5, 2, 1, ts(200)));
+        let f = filter_bands(entries, &PitrTarget::AsOf(ts(150)));
+        assert_eq!(f.applied, 1, "one transaction band before 150");
+        assert_eq!(f.discarded, 1);
+        // Begin+data+Commit (3) + the declaration (1) = 4 entries carried.
+        assert_eq!(f.entries.len(), 4);
+    }
+
+    #[test]
+    fn window_lower_bound_rejects_target_below_base() {
+        // Base at source_lsn=10 with a pre-backup commit at t=500 (lsn 3).
+        let all = all_of(vec![tx(1, 1, 1, ts(500)), tx(10, 2, 1, ts(800))]);
+        let window = compute_window(&all, 10);
+        // A timestamp before the base's latest commit is unreachable.
+        assert!(window.validate(&PitrTarget::AsOf(ts(400))).is_err());
+        // At-or-after the base is fine.
+        assert!(window.validate(&PitrTarget::AsOf(ts(500))).is_ok());
+        // An LSN below source_lsn is unreachable.
+        assert!(window.validate(&PitrTarget::Lsn(3)).is_err());
+        assert!(window.validate(&PitrTarget::Lsn(10)).is_ok());
+        // The window bounds are reported.
+        assert_eq!(window.earliest_coord().lsn, 10);
+        assert_eq!(window.latest_coord().timestamp_micros, 800);
+    }
+}

--- a/src/db/pitr.rs
+++ b/src/db/pitr.rs
@@ -52,6 +52,7 @@
 
 use std::path::Path;
 
+#[cfg(feature = "serde")]
 use serde::Serialize;
 
 use crate::core::error::{Error, Result};
@@ -77,7 +78,8 @@ pub enum PitrTarget {
 
 /// A bi-coordinate (LSN + transaction time) describing a PITR stop point or a
 /// window bound. Serde-serializable for `--dry-run` JSON output.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct PitrCoord {
     /// The WAL LSN of the coordinate.
     pub lsn: u64,
@@ -108,7 +110,8 @@ impl PitrCoord {
 /// The plan a `--dry-run` PITR inspection produces without materializing or
 /// opening anything: the achievable window plus, for a given target, the
 /// resolved stop coordinate and applied/discarded transaction counts.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct PitrPlan {
     /// The earliest reachable coordinate (the base backup). PITR cannot stop
     /// before this.

--- a/src/db/pitr.rs
+++ b/src/db/pitr.rs
@@ -415,15 +415,22 @@ impl PitrWindow {
         PitrCoord::new(self.latest_lsn, self.latest_ts)
     }
 
-    /// Reject a target that lies below the achievable window (before the base
-    /// backup). Targets above the latest reachable coordinate are permitted:
-    /// they resolve to a full replay ("everything at-or-before the target").
+    /// Reject a target that lies **outside** the achievable window — below the
+    /// base backup (unreachable from base + forward replay) or above the archived
+    /// WAL tail (Issue #3374, F2). An explicit target above the tail is an error,
+    /// not a silent full replay; a caller who wants "restore to the tail" passes
+    /// no target (`--latest`), which resolves to the latest coordinate — see
+    /// [`AletheiaDB::restore_to_data_dir_at`].
     fn validate(&self, target: &PitrTarget) -> Result<()> {
-        let outside = match target {
+        let below = match target {
             PitrTarget::Lsn(n) => *n < self.source_lsn,
             PitrTarget::AsOf(t) => self.base_ts.is_some_and(|bt| *t < bt),
         };
-        if outside {
+        let above = match target {
+            PitrTarget::Lsn(n) => *n > self.latest_lsn,
+            PitrTarget::AsOf(t) => *t > self.latest_ts,
+        };
+        if below || above {
             let requested = match target {
                 PitrTarget::Lsn(n) => format!("lsn={n}"),
                 PitrTarget::AsOf(t) => PitrCoord::new(0, *t).timestamp_rfc3339,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,9 +134,9 @@ pub use core::error::{
 pub use db::{
     AletheiaDB, BackupSummary, ColdStorageDetails, ColdStorageTierStats, CurrentStateStats,
     DatabaseStats, EdgeTypeSchema, FactStatus, GraphSchema, HistoricalDepthStats, LabelExtent,
-    LabelSchema, LineageView, LineageViewEntry, SchemaInstant, SimilarityQuery, SimilaritySource,
-    TemporalExtent, TierAccessStats, TimeBounds, UniqueConstraintBuilder, VectorIndexBuilder,
-    WalStateStats,
+    LabelSchema, LineageView, LineageViewEntry, PitrCoord, PitrPlan, PitrTarget, SchemaInstant,
+    SimilarityQuery, SimilaritySource, TemporalExtent, TierAccessStats, TimeBounds,
+    UniqueConstraintBuilder, VectorIndexBuilder, WalStateStats,
 };
 pub use index::{
     AdjacencyIndex, CurrentIndexes, TemporalIndexes,

--- a/src/mcp/error.rs
+++ b/src/mcp/error.rs
@@ -211,12 +211,14 @@ fn classify_db_error(e: &Error) -> (McpErrorCode, bool) {
         // A provenance bundle failing validation is a caller fault.
         Error::Provenance(_) => (McpErrorCode::InvalidArgument, false),
         Error::Lineage(le) => classify_lineage_error(le),
-        // A PITR (#3374) target below the achievable window is a caller-fault
-        // precondition failure; its Display names the window. All other backup
-        // errors remain Internal.
-        Error::Backup(crate::storage::backup::BackupError::TargetOutsideWindow { .. }) => {
-            (McpErrorCode::FailedPrecondition, false)
-        }
+        // A PITR (#3374) target outside the achievable window, or a window that
+        // crosses a post-backup vocabulary change, is a caller-fault precondition
+        // failure; each error's Display explains the remediation. All other
+        // backup errors remain Internal.
+        Error::Backup(
+            crate::storage::backup::BackupError::TargetOutsideWindow { .. }
+            | crate::storage::backup::BackupError::WindowCrossesVocabularyChange { .. },
+        ) => (McpErrorCode::FailedPrecondition, false),
         Error::Io(_) | Error::Backup(_) => (McpErrorCode::Internal, false),
         // The feature exists but this build/deployment doesn't provide it.
         Error::NotImplemented { .. } => (McpErrorCode::FailedPrecondition, false),

--- a/src/mcp/error.rs
+++ b/src/mcp/error.rs
@@ -211,6 +211,12 @@ fn classify_db_error(e: &Error) -> (McpErrorCode, bool) {
         // A provenance bundle failing validation is a caller fault.
         Error::Provenance(_) => (McpErrorCode::InvalidArgument, false),
         Error::Lineage(le) => classify_lineage_error(le),
+        // A PITR (#3374) target below the achievable window is a caller-fault
+        // precondition failure; its Display names the window. All other backup
+        // errors remain Internal.
+        Error::Backup(crate::storage::backup::BackupError::TargetOutsideWindow { .. }) => {
+            (McpErrorCode::FailedPrecondition, false)
+        }
         Error::Io(_) | Error::Backup(_) => (McpErrorCode::Internal, false),
         // The feature exists but this build/deployment doesn't provide it.
         Error::NotImplemented { .. } => (McpErrorCode::FailedPrecondition, false),

--- a/src/storage/backup/mod.rs
+++ b/src/storage/backup/mod.rs
@@ -119,6 +119,36 @@ pub enum BackupError {
         /// The latest reachable coordinate (the archived WAL tail).
         latest: String,
     },
+    /// A point-in-time restore (PITR, Issue #3374) window crosses a **vocabulary
+    /// change**: a transaction at-or-before the target references an interner id
+    /// (a node/edge label or a property key) that the base backup's interner
+    /// does not define, because that label/key was introduced *after* the base
+    /// backup was taken.
+    ///
+    /// The WAL stores labels and property keys as raw `u32` interner ids, not
+    /// strings, and the base `.albk` only carries the interner as of
+    /// `source_lsn`. Replaying an out-of-range id would first dangle (resolve to
+    /// nothing) and then, because the restored interner's `next_id` equals the
+    /// base string count, silently **collide** with the first genuinely-new
+    /// string a later write interns — mislabeling or dropping data. PITR refuses
+    /// instead of corrupting: take a fresh base backup that includes the new
+    /// vocabulary, or target a coordinate before the vocabulary change.
+    #[error(
+        "point-in-time restore window crosses a vocabulary change: a transaction \
+         at-or-before the target references interner id {first_unresolved_id}, but \
+         the base backup's interner only defines ids 0..{restored_interner_count} \
+         (a label or property key introduced after the base backup). Replaying it \
+         would silently mislabel or drop data. Take a fresh base backup that \
+         includes the new vocabulary, or choose a target before the change."
+    )]
+    WindowCrossesVocabularyChange {
+        /// The first out-of-range interner id encountered (references a string
+        /// the base snapshot's interner does not contain).
+        first_unresolved_id: u32,
+        /// The number of strings the base backup's interner defines; valid ids
+        /// are `0..restored_interner_count`.
+        restored_interner_count: u32,
+    },
 }
 
 // ============================================================================

--- a/src/storage/backup/mod.rs
+++ b/src/storage/backup/mod.rs
@@ -100,6 +100,25 @@ pub enum BackupError {
     /// The backup artifact is corrupt (bad checksum, truncated, or invalid data).
     #[error("Corrupt backup data: {0}")]
     Corrupt(String),
+    /// A point-in-time restore (PITR, Issue #3374) target lies outside the
+    /// achievable recovery window (base backup + archived WAL chain).
+    ///
+    /// The window is bounded below by the base backup's coordinate — PITR can
+    /// only stop at-or-after the backup, never before it — and reported so the
+    /// operator can pick a reachable target.
+    #[error(
+        "point-in-time restore target {requested} is outside the achievable window \
+         [earliest={earliest}, latest={latest}]. PITR can only reach a coordinate \
+         at-or-after the base backup and at-or-before the archived WAL tail."
+    )]
+    TargetOutsideWindow {
+        /// The requested target coordinate, as a human-readable string.
+        requested: String,
+        /// The earliest reachable coordinate (the base backup).
+        earliest: String,
+        /// The latest reachable coordinate (the archived WAL tail).
+        latest: String,
+    },
 }
 
 // ============================================================================

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -2362,6 +2362,32 @@ impl CurrentStorage {
         self.indexes.iter_edges().map(|e| e.clone())
     }
 
+    /// Iterate over all nodes by borrow (no per-element clone).
+    ///
+    /// Yields DashMap guard references (`Deref<Target = Node>`) delegated to
+    /// [`CurrentIndexes::iter_nodes`], for read-only scans (e.g. the HLC
+    /// startup seed) that only need to read fields off each node. Prefer this
+    /// over [`Self::all_nodes`], which clones every `Node`, when owned values
+    /// are not required.
+    pub(crate) fn iter_nodes(
+        &self,
+    ) -> impl Iterator<Item = impl std::ops::Deref<Target = Node> + '_> + '_ {
+        self.indexes.iter_nodes()
+    }
+
+    /// Iterate over all edges by borrow (no per-element clone).
+    ///
+    /// Yields DashMap guard references (`Deref<Target = Edge>`) delegated to
+    /// [`CurrentIndexes::iter_edges`], for read-only scans (e.g. the HLC
+    /// startup seed) that only need to read fields off each edge. Prefer this
+    /// over [`Self::all_edges`], which clones every `Edge`, when owned values
+    /// are not required.
+    pub(crate) fn iter_edges(
+        &self,
+    ) -> impl Iterator<Item = impl std::ops::Deref<Target = Edge> + '_> + '_ {
+        self.indexes.iter_edges()
+    }
+
     /// Scan nodes by label, returning an iterator over matching node IDs.
     ///
     /// This method efficiently filters the node collection to find all nodes

--- a/tests/pitr.rs
+++ b/tests/pitr.rs
@@ -944,3 +944,89 @@ fn pitr_large_stream_restores_exact_prefix() {
         }
     }
 }
+
+// ============================================================================
+// #3387: PITR HLC seed folds restored CLOSED transaction-time ends
+// ============================================================================
+
+#[test]
+#[serial]
+fn pitr_hlc_seed_stays_monotonic_over_restored_closed_tx_end() {
+    // Guards the Issue #3387 invariant through the PITR path: when a post-backup
+    // transaction SUPERSEDES an earlier version, that earlier version's
+    // transaction-time interval is CLOSED at the superseding transaction's commit
+    // timestamp. The restored database's HLC seed must fold that closed tx end in
+    // (via the shared startup seed helper), so the first write on the restored DB
+    // is stamped strictly ABOVE it — never regressing to a stale timestamp that
+    // would break transaction-time monotonicity.
+    let tmp = TempDir::new().unwrap();
+    let wal = tmp.path().join("wal");
+    let db = AletheiaDB::with_unified_config(source_config(&wal)).unwrap();
+
+    // Pre-backup: create node A (v1) using the base vocabulary, then back up.
+    let a = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "alice")
+                .insert("phase", "v1")
+                .build(),
+        )
+        .unwrap();
+    db.backup(&tmp.path().join("base.albk")).unwrap();
+
+    // Post-backup: UPDATE A (v2). This supersedes v1, closing v1's
+    // transaction-time interval at v2's commit timestamp — the closed tx end.
+    db.update_node_with_valid_time(
+        a,
+        PropertyMapBuilder::new()
+            .insert("name", "alice")
+            .insert("phase", "v2")
+            .build(),
+        None,
+    )
+    .unwrap();
+    // v2's commit timestamp equals the restored closed tx end of v1 (replay
+    // reproduces the update op verbatim), so it is the coordinate the HLC seed
+    // must clear.
+    let closed_tx_end = db.get_node(a).unwrap().metadata.commit_timestamp.unwrap();
+
+    let archive = tmp.path().join("archive");
+    copy_wal_dir(&wal, &archive);
+    drop(db);
+
+    // Restore to a target that INCLUDES the superseding update, so the restored
+    // history carries v1's closed transaction-time interval.
+    let dst = TempDir::new().unwrap();
+    let data_dir = dst.path().join("db");
+    let restored = AletheiaDB::restore_to_data_dir_at(
+        &tmp.path().join("base.albk"),
+        &archive,
+        PitrTarget::AsOf(closed_tx_end),
+        &data_dir,
+    )
+    .unwrap();
+
+    // A fresh write on the restored DB must be stamped strictly above the closed
+    // tx end (HLC seed stayed monotonic — no regression to a stale timestamp).
+    let fresh = restored
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "bob")
+                .insert("phase", "post-restore")
+                .build(),
+        )
+        .unwrap();
+    let fresh_ts = restored
+        .get_node(fresh)
+        .unwrap()
+        .metadata
+        .commit_timestamp
+        .unwrap();
+    assert!(
+        fresh_ts > closed_tx_end,
+        "restored HLC seed must clear the restored closed tx end \
+         (fresh {fresh_ts:?} must exceed closed end {closed_tx_end:?})"
+    );
+}

--- a/tests/pitr.rs
+++ b/tests/pitr.rs
@@ -688,6 +688,7 @@ fn cli_pitr_restore_reopens_with_target_state() {
 
 #[test]
 #[serial]
+#[cfg(feature = "serde")]
 fn cli_pitr_dry_run_prints_plan_json() {
     let s = build_scenario(1, 4);
     let bin = env!("CARGO_BIN_EXE_aletheia");

--- a/tests/pitr.rs
+++ b/tests/pitr.rs
@@ -296,15 +296,17 @@ fn pitr_target_equal_source_lsn_is_base_only() {
 
 #[test]
 #[serial]
-fn pitr_target_after_all_is_full_replay() {
+fn pitr_target_at_latest_is_full_replay() {
+    // A target AT the latest archived commit is in-window and replays every
+    // post-backup transaction (the "restore to the tail" coordinate).
     let s = build_scenario(1, 5);
     let dst = TempDir::new().unwrap();
     let data_dir = dst.path().join("db");
-    let far_future = Timestamp::from(i64::MAX / 2);
+    let latest_ts = s.post.last().unwrap().1;
     let restored = AletheiaDB::restore_to_data_dir_at(
         &s.albk,
         &s.archive,
-        PitrTarget::AsOf(far_future),
+        PitrTarget::AsOf(latest_ts),
         &data_dir,
     )
     .unwrap();
@@ -312,9 +314,41 @@ fn pitr_target_after_all_is_full_replay() {
     for (id, _) in &s.post {
         assert!(
             restored.get_node(*id).is_ok(),
-            "every post node present in full replay"
+            "every post node present in full replay to the tail"
         );
     }
+}
+
+#[test]
+#[serial]
+fn pitr_target_above_window_errors() {
+    // F2: an explicit target strictly ABOVE the archived WAL tail is an error
+    // (not a silent full replay). The window is named in the structured error.
+    let s = build_scenario(2, 3);
+    let dst = TempDir::new().unwrap();
+    let data_dir = dst.path().join("db");
+    let far_future = Timestamp::from(i64::MAX / 2);
+    let err = AletheiaDB::restore_to_data_dir_at(
+        &s.albk,
+        &s.archive,
+        PitrTarget::AsOf(far_future),
+        &data_dir,
+    )
+    .unwrap_err();
+    match err {
+        Error::Backup(BackupError::TargetOutsideWindow {
+            requested, latest, ..
+        }) => {
+            assert!(!requested.is_empty());
+            assert!(!latest.is_empty(), "the achievable tail must be named");
+        }
+        other => panic!("expected TargetOutsideWindow, got {other:?}"),
+    }
+    // The failed restore must not have materialized the target directory.
+    assert!(
+        !data_dir.join("indexes").exists(),
+        "an above-window target must not materialize the data dir"
+    );
 }
 
 // ============================================================================
@@ -678,4 +712,235 @@ fn cli_pitr_dry_run_prints_plan_json() {
     );
     assert_eq!(json["transactions_discarded"], s.post.len());
     assert!(json["earliest"]["lsn"].as_u64().unwrap() == s.source_lsn);
+}
+
+#[test]
+#[serial]
+fn cli_pitr_restore_latest_replays_full_tail() {
+    // F2: `restore --wal-archive <dir>` with no target flag (equivalently
+    // `--latest`) performs a FULL replay to the archived tail.
+    let s = build_scenario(2, 4);
+    let dst = TempDir::new().unwrap();
+    let data_dir = dst.path().join("db");
+
+    let bin = env!("CARGO_BIN_EXE_aletheia");
+    let output = std::process::Command::new(bin)
+        .args([
+            "restore",
+            s.albk.to_str().unwrap(),
+            "--wal-archive",
+            s.archive.to_str().unwrap(),
+            "--latest",
+        ])
+        .env("ALETHEIADB_DATA_DIR", &data_dir)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "CLI --latest restore failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let reopened = AletheiaDB::open(&data_dir).unwrap();
+    assert_eq!(
+        reopened.node_count(),
+        s.pre_ids.len() + s.post.len(),
+        "full replay to the tail includes every post-backup node"
+    );
+    for (id, _) in &s.post {
+        assert!(reopened.get_node(*id).is_ok());
+    }
+}
+
+// ============================================================================
+// F1: interner vocabulary-change guard
+// ============================================================================
+
+#[test]
+#[serial]
+fn pitr_window_crossing_vocabulary_change_errors() {
+    // A PITR whose window crosses a post-backup vocabulary change (a brand-new
+    // label whose interner id is absent from the base backup) must FAIL with a
+    // structured error rather than silently mislabel/drop the replayed node.
+    // A PITR to a target BEFORE the vocabulary change still succeeds.
+    let tmp = TempDir::new().unwrap();
+    let wal = tmp.path().join("wal");
+    let db = AletheiaDB::with_unified_config(source_config(&wal)).unwrap();
+
+    // Base vocabulary: Person / name. Take the base backup.
+    let pre = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "alice").build(),
+        )
+        .unwrap();
+    db.backup(&tmp.path().join("base.albk")).unwrap();
+
+    // Post-backup, still using the base vocabulary: a target before any change.
+    let bob = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "bob").build(),
+        )
+        .unwrap();
+    let ts_before_change = db.get_node(bob).unwrap().metadata.commit_timestamp.unwrap();
+
+    // Post-backup vocabulary change: a BRAND-NEW label not present in the base
+    // interner (a unique string never interned before this write).
+    let mgr = db
+        .create_node(
+            "MgrNovelLabel3374",
+            PropertyMapBuilder::new().insert("name", "boss").build(),
+        )
+        .unwrap();
+    let ts_after_change = db.get_node(mgr).unwrap().metadata.commit_timestamp.unwrap();
+
+    let archive = tmp.path().join("archive");
+    copy_wal_dir(&wal, &archive);
+    drop(db);
+
+    // (a) Target at/after the vocabulary change → structured refusal.
+    let dst_fail = TempDir::new().unwrap();
+    let data_dir_fail = dst_fail.path().join("db");
+    let err = AletheiaDB::restore_to_data_dir_at(
+        &tmp.path().join("base.albk"),
+        &archive,
+        PitrTarget::AsOf(ts_after_change),
+        &data_dir_fail,
+    )
+    .unwrap_err();
+    match err {
+        Error::Backup(BackupError::WindowCrossesVocabularyChange {
+            first_unresolved_id,
+            restored_interner_count,
+        }) => {
+            assert!(
+                first_unresolved_id >= restored_interner_count,
+                "the unresolved id must be outside the base interner"
+            );
+        }
+        other => panic!("expected WindowCrossesVocabularyChange, got {other:?}"),
+    }
+    assert!(
+        !data_dir_fail.join("indexes").exists(),
+        "a vocabulary-crossing restore must not materialize the data dir"
+    );
+
+    // (b) Target BEFORE the vocabulary change → clean success (Manager absent).
+    let dst_ok = TempDir::new().unwrap();
+    let data_dir_ok = dst_ok.path().join("db");
+    let restored = AletheiaDB::restore_to_data_dir_at(
+        &tmp.path().join("base.albk"),
+        &archive,
+        PitrTarget::AsOf(ts_before_change),
+        &data_dir_ok,
+    )
+    .unwrap();
+    assert_eq!(
+        restored.node_count(),
+        2,
+        "pre (alice) + bob, before the vocabulary change"
+    );
+    assert!(restored.get_node(pre).is_ok());
+    assert!(restored.get_node(bob).is_ok());
+    assert!(
+        restored.get_node(mgr).is_err(),
+        "the new-label node is after the target and must be absent"
+    );
+}
+
+// ============================================================================
+// F4: failed restore after materialize leaves a clean target
+// ============================================================================
+
+#[test]
+#[serial]
+fn pitr_post_materialize_failure_leaves_clean_target() {
+    // If a step AFTER the base manifest is committed fails, the target
+    // `indexes/` must be cleaned up so a retry is not blocked by a half-restored
+    // directory. We inject a deterministic post-materialize failure by planting
+    // a regular FILE where the WAL directory must be created, so opening the
+    // base-state database fails only after `materialize_to_dir` has run.
+    let s = build_scenario(1, 3);
+    let dst = TempDir::new().unwrap();
+    let data_dir = dst.path().join("db");
+
+    // Plant a file at data_dir/wal so the durable open cannot create the WAL dir.
+    std::fs::create_dir_all(&data_dir).unwrap();
+    std::fs::write(data_dir.join("wal"), b"not a directory").unwrap();
+
+    let result = AletheiaDB::restore_to_data_dir_at(
+        &s.albk,
+        &s.archive,
+        PitrTarget::AsOf(s.post[1].1),
+        &data_dir,
+    );
+    assert!(
+        result.is_err(),
+        "restore must fail when the WAL dir cannot be created"
+    );
+
+    // The target index root must be cleaned up (no half-restored base left
+    // behind), so a subsequent restore into a fresh dir would not be blocked.
+    assert!(
+        !data_dir.join("indexes").exists(),
+        "a failed post-materialize restore must leave the target indexes/ clean"
+    );
+}
+
+// ============================================================================
+// F3: large exact-prefix fidelity (AC success metric)
+// ============================================================================
+
+#[test]
+#[serial]
+fn pitr_large_stream_restores_exact_prefix() {
+    // AC success metric names a 10,000-transaction fixture; the synchronous WAL
+    // fsync-per-commit source makes 10K writes heavy for this disk/time ceiling,
+    // so the fixture is SCALED to a few thousand transactions. The property under
+    // test is unchanged: PITR to a mid-stream target restores EXACTLY the prefix
+    // committed at-or-before the target — 0 missing, 0 extra — versus the
+    // transactions that were written.
+    const SCALED_POST_TX: usize = 3_000; // scaled from the 10K AC metric (see above)
+    let s = build_scenario(4, SCALED_POST_TX);
+
+    // Target the midpoint transaction: post[0..=k] must be present, the rest
+    // absent.
+    let k = SCALED_POST_TX / 2;
+    let target_ts = s.post[k].1;
+
+    let dst = TempDir::new().unwrap();
+    let data_dir = dst.path().join("db");
+    let restored = AletheiaDB::restore_to_data_dir_at(
+        &s.albk,
+        &s.archive,
+        PitrTarget::AsOf(target_ts),
+        &data_dir,
+    )
+    .unwrap();
+
+    // Exact size: pre + the kept prefix, no more, no less.
+    assert_eq!(
+        restored.node_count(),
+        s.pre_ids.len() + (k + 1),
+        "restored size must equal pre + kept prefix exactly"
+    );
+    // Every pre node survives.
+    for id in &s.pre_ids {
+        assert!(restored.get_node(*id).is_ok(), "pre node must survive");
+    }
+    // Exact membership: present iff committed at-or-before the target.
+    for (i, (id, _)) in s.post.iter().enumerate() {
+        if i <= k {
+            assert!(
+                restored.get_node(*id).is_ok(),
+                "post-{i} at-or-before target must be present (0 missing)"
+            );
+        } else {
+            assert!(
+                restored.get_node(*id).is_err(),
+                "post-{i} after target must be absent (0 extra)"
+            );
+        }
+    }
 }

--- a/tests/pitr.rs
+++ b/tests/pitr.rs
@@ -1,0 +1,681 @@
+#![cfg(test)]
+
+//! Integration tests for point-in-time restore (PITR, Issue #3374).
+//!
+//! PITR replays an archived WAL chain over a base `.albk` backup to an exact
+//! transaction-time coordinate. These tests exercise the headline round-trip
+//! equivalence property plus the boundary, error, read-only-input, provenance,
+//! constraint, dry-run, and CLI-reopen behaviors.
+//!
+//! All tests are `#[serial]` because `restore` clears and repopulates the
+//! process-global string interner (`materialize_to_dir`), so no two restores —
+//! and no live source DB — may share the interner concurrently.
+
+use std::path::{Path, PathBuf};
+
+use aletheiadb::config::{AletheiaDBConfig, WalConfigBuilder};
+use aletheiadb::core::error::Error;
+use aletheiadb::core::id::NodeId;
+use aletheiadb::core::provenance::Provenance;
+use aletheiadb::storage::backup::BackupError;
+use aletheiadb::{AletheiaDB, DurabilityMode, PitrTarget, PropertyMapBuilder, Timestamp};
+use serial_test::serial;
+use tempfile::TempDir;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// A WAL-only (no index persistence) source config with an isolated, durable
+/// WAL directory we can archive and read back.
+fn source_config(wal_dir: &Path) -> AletheiaDBConfig {
+    AletheiaDBConfig::builder()
+        .wal(
+            WalConfigBuilder::new()
+                .wal_dir(wal_dir.to_path_buf())
+                .durability_mode(DurabilityMode::Synchronous)
+                .build(),
+        )
+        .build()
+}
+
+/// Copy the flat set of `*.log` WAL segment files from `src` to a fresh `dst`.
+fn copy_wal_dir(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.is_file() {
+            std::fs::copy(&path, dst.join(entry.file_name())).unwrap();
+        }
+    }
+}
+
+/// A built PITR scenario: a base backup plus an archived WAL tail, with the
+/// coordinates needed to target mid-stream transactions.
+struct Scenario {
+    _tmp: TempDir,
+    albk: PathBuf,
+    archive: PathBuf,
+    source_lsn: u64,
+    /// Pre-backup node ids (always present in the base).
+    pre_ids: Vec<NodeId>,
+    /// Post-backup `(id, commit_ts)` in commit order.
+    post: Vec<(NodeId, Timestamp)>,
+}
+
+/// Build a scenario with `num_pre` pre-backup and `num_post` post-backup nodes,
+/// all using a fixed `Person`/`name`/`phase` vocabulary interned before the
+/// backup (so the WAL's interner ids resolve after restore).
+fn build_scenario(num_pre: usize, num_post: usize) -> Scenario {
+    let tmp = TempDir::new().unwrap();
+    let wal = tmp.path().join("wal");
+    let db = AletheiaDB::with_unified_config(source_config(&wal)).unwrap();
+
+    let mut pre_ids = Vec::new();
+    for i in 0..num_pre {
+        let id = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("name", format!("pre-{i}"))
+                    .insert("phase", "pre")
+                    .build(),
+            )
+            .unwrap();
+        pre_ids.push(id);
+    }
+
+    let albk = tmp.path().join("base.albk");
+    let source_lsn = db.backup(&albk).unwrap().source_lsn;
+
+    let mut post = Vec::new();
+    for i in 0..num_post {
+        let id = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("name", format!("post-{i}"))
+                    .insert("phase", "post")
+                    .build(),
+            )
+            .unwrap();
+        let ts = db.get_node(id).unwrap().metadata.commit_timestamp.unwrap();
+        post.push((id, ts));
+    }
+
+    let archive = tmp.path().join("archive");
+    copy_wal_dir(&wal, &archive);
+
+    // Drop the source DB before any restore: materialize_to_dir clears the
+    // process-global interner, which no live DB may share.
+    drop(db);
+
+    Scenario {
+        _tmp: tmp,
+        albk,
+        archive,
+        source_lsn,
+        pre_ids,
+        post,
+    }
+}
+
+fn name_of(db: &AletheiaDB, id: NodeId) -> Option<String> {
+    db.get_node(id).ok().and_then(|n| {
+        n.get_property("name")
+            .and_then(|v| v.as_str().map(String::from))
+    })
+}
+
+// ============================================================================
+// Headline: round-trip observational equivalence
+// ============================================================================
+
+#[test]
+#[serial]
+fn pitr_roundtrip_observational_equivalence() {
+    let s = build_scenario(2, 6);
+    // Target the commit of post index 2 → post 0,1,2 kept; 3,4,5 dropped.
+    let k = 2usize;
+    let target_ts = s.post[k].1;
+
+    let dst = TempDir::new().unwrap();
+    let data_dir = dst.path().join("restored");
+    let restored = AletheiaDB::restore_to_data_dir_at(
+        &s.albk,
+        &s.archive,
+        PitrTarget::AsOf(target_ts),
+        &data_dir,
+    )
+    .unwrap();
+
+    // 0 missing, 0 extra: exactly pre + post[0..=k].
+    assert_eq!(restored.node_count(), s.pre_ids.len() + (k + 1));
+    for id in &s.pre_ids {
+        assert!(restored.get_node(*id).is_ok(), "pre node must survive");
+    }
+    for (i, (id, _)) in s.post.iter().enumerate() {
+        if i <= k {
+            assert!(
+                restored.get_node(*id).is_ok(),
+                "post-{i} committed at-or-before target must be present"
+            );
+        } else {
+            assert!(
+                restored.get_node(*id).is_err(),
+                "post-{i} committed after target must be absent"
+            );
+        }
+    }
+
+    // Reference DB: an independent database that simply stopped writing at the
+    // target coordinate. Build it AFTER restore (shares the repopulated
+    // interner vocabulary) and compare observationally.
+    let ref_tmp = TempDir::new().unwrap();
+    let reference =
+        AletheiaDB::with_unified_config(source_config(&ref_tmp.path().join("wal"))).unwrap();
+    let mut ref_pre = Vec::new();
+    for i in 0..s.pre_ids.len() {
+        ref_pre.push(
+            reference
+                .create_node(
+                    "Person",
+                    PropertyMapBuilder::new()
+                        .insert("name", format!("pre-{i}"))
+                        .insert("phase", "pre")
+                        .build(),
+                )
+                .unwrap(),
+        );
+    }
+    let mut ref_post = Vec::new();
+    for i in 0..=k {
+        ref_post.push(
+            reference
+                .create_node(
+                    "Person",
+                    PropertyMapBuilder::new()
+                        .insert("name", format!("post-{i}"))
+                        .insert("phase", "post")
+                        .build(),
+                )
+                .unwrap(),
+        );
+    }
+
+    assert_eq!(
+        restored.node_count(),
+        reference.node_count(),
+        "restored and reference must have identical current-state size"
+    );
+
+    // Current-state name sets must match (0 missing / 0 extra by content).
+    let names = |db: &AletheiaDB, ids: &[NodeId]| -> Vec<String> {
+        let mut v: Vec<String> = ids.iter().filter_map(|id| name_of(db, *id)).collect();
+        v.sort();
+        v
+    };
+    let mut restored_ids: Vec<NodeId> = s.pre_ids.clone();
+    restored_ids.extend(s.post[..=k].iter().map(|(id, _)| *id));
+    let mut reference_ids = ref_pre.clone();
+    reference_ids.extend(ref_post.iter().copied());
+    assert_eq!(
+        names(&restored, &restored_ids),
+        names(&reference, &reference_ids),
+        "current-state node names must be observationally equivalent"
+    );
+
+    // Randomized-ish AS OF (transaction-time) probes: at every kept post
+    // commit coordinate, the restored DB must resolve each kept node exactly as
+    // its current state (the versions are unchanged after that commit).
+    for probe in 0..=k {
+        let probe_ts = s.post[probe].1;
+        for (i, (id, _)) in s.post.iter().enumerate().take(probe + 1) {
+            let at = restored.get_node_at_transaction_time(*id, probe_ts);
+            assert!(
+                at.is_ok(),
+                "post-{i} must be visible AS OF the probe commit {probe}"
+            );
+        }
+    }
+}
+
+// ============================================================================
+// Boundary cases
+// ============================================================================
+
+#[test]
+#[serial]
+fn pitr_exact_target_at_a_commit() {
+    let s = build_scenario(1, 4);
+    let k = 1usize;
+    let dst = TempDir::new().unwrap();
+    let data_dir = dst.path().join("db");
+    let restored = AletheiaDB::restore_to_data_dir_at(
+        &s.albk,
+        &s.archive,
+        PitrTarget::AsOf(s.post[k].1),
+        &data_dir,
+    )
+    .unwrap();
+    assert!(
+        restored.get_node(s.post[k].0).is_ok(),
+        "node at exact target present"
+    );
+    assert!(
+        restored.get_node(s.post[k + 1].0).is_err(),
+        "next node absent"
+    );
+    assert_eq!(restored.node_count(), s.pre_ids.len() + (k + 1));
+}
+
+#[test]
+#[serial]
+fn pitr_target_equal_source_lsn_is_base_only() {
+    let s = build_scenario(2, 3);
+    let dst = TempDir::new().unwrap();
+    let data_dir = dst.path().join("db");
+    // source_lsn is the next-to-allocate LSN at backup; no post-backup band
+    // has a CommitTx LSN <= source_lsn, so the prefix is empty (base only).
+    let restored = AletheiaDB::restore_to_data_dir_at(
+        &s.albk,
+        &s.archive,
+        PitrTarget::Lsn(s.source_lsn),
+        &data_dir,
+    )
+    .unwrap();
+    assert_eq!(restored.node_count(), s.pre_ids.len(), "base-only restore");
+    for (id, _) in &s.post {
+        assert!(
+            restored.get_node(*id).is_err(),
+            "no post node in base-only restore"
+        );
+    }
+}
+
+#[test]
+#[serial]
+fn pitr_target_after_all_is_full_replay() {
+    let s = build_scenario(1, 5);
+    let dst = TempDir::new().unwrap();
+    let data_dir = dst.path().join("db");
+    let far_future = Timestamp::from(i64::MAX / 2);
+    let restored = AletheiaDB::restore_to_data_dir_at(
+        &s.albk,
+        &s.archive,
+        PitrTarget::AsOf(far_future),
+        &data_dir,
+    )
+    .unwrap();
+    assert_eq!(restored.node_count(), s.pre_ids.len() + s.post.len());
+    for (id, _) in &s.post {
+        assert!(
+            restored.get_node(*id).is_ok(),
+            "every post node present in full replay"
+        );
+    }
+}
+
+// ============================================================================
+// Errors and read-only-input guarantees
+// ============================================================================
+
+#[test]
+#[serial]
+fn pitr_target_outside_window_errors() {
+    let s = build_scenario(2, 3);
+    let dst = TempDir::new().unwrap();
+    let data_dir = dst.path().join("db");
+    // An LSN below source_lsn cannot be reconstructed from base + forward WAL.
+    let err = AletheiaDB::restore_to_data_dir_at(
+        &s.albk,
+        &s.archive,
+        PitrTarget::Lsn(s.source_lsn - 1),
+        &data_dir,
+    )
+    .unwrap_err();
+    match err {
+        Error::Backup(BackupError::TargetOutsideWindow {
+            requested,
+            earliest,
+            latest,
+        }) => {
+            assert!(requested.contains(&(s.source_lsn - 1).to_string()));
+            assert!(earliest.contains(&format!("lsn={}", s.source_lsn)));
+            assert!(!latest.is_empty());
+        }
+        other => panic!("expected TargetOutsideWindow, got {other:?}"),
+    }
+    // The failed restore must not have created the target directory.
+    assert!(
+        !data_dir.join("indexes").exists(),
+        "an out-of-window target must not materialize the data dir"
+    );
+}
+
+#[test]
+#[serial]
+fn pitr_non_empty_target_dir_fails_cleanly() {
+    let s = build_scenario(1, 2);
+    let dst = TempDir::new().unwrap();
+    let data_dir = dst.path().join("db");
+    // Pre-populate the index root so check_target_empty refuses. The manager
+    // appends its own `indexes/`, so the manifest it checks for lives at
+    // `data_dir/indexes/indexes/manifest.idx`.
+    let manifest_dir = data_dir.join("indexes").join("indexes");
+    std::fs::create_dir_all(&manifest_dir).unwrap();
+    std::fs::write(manifest_dir.join("manifest.idx"), b"fake").unwrap();
+    let err = AletheiaDB::restore_to_data_dir_at(
+        &s.albk,
+        &s.archive,
+        PitrTarget::AsOf(s.post[0].1),
+        &data_dir,
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::Backup(BackupError::TargetNotEmpty)));
+}
+
+#[test]
+#[serial]
+fn pitr_inputs_are_read_only() {
+    let s = build_scenario(1, 3);
+    // Snapshot input bytes + mtimes before the restore.
+    let albk_before = std::fs::read(&s.albk).unwrap();
+    let archive_before: Vec<(PathBuf, Vec<u8>)> = std::fs::read_dir(&s.archive)
+        .unwrap()
+        .map(|e| {
+            let p = e.unwrap().path();
+            let bytes = std::fs::read(&p).unwrap();
+            (p, bytes)
+        })
+        .collect();
+
+    let dst = TempDir::new().unwrap();
+    let data_dir = dst.path().join("db");
+    AletheiaDB::restore_to_data_dir_at(
+        &s.albk,
+        &s.archive,
+        PitrTarget::AsOf(s.post[1].1),
+        &data_dir,
+    )
+    .unwrap();
+
+    assert_eq!(
+        std::fs::read(&s.albk).unwrap(),
+        albk_before,
+        "albk unchanged"
+    );
+    for (p, before) in &archive_before {
+        assert_eq!(
+            &std::fs::read(p).unwrap(),
+            before,
+            "archive segment unchanged"
+        );
+    }
+}
+
+// ============================================================================
+// Subsystems: provenance, constraints, reopen
+// ============================================================================
+
+#[test]
+#[serial]
+fn pitr_preserves_provenance() {
+    let tmp = TempDir::new().unwrap();
+    let wal = tmp.path().join("wal");
+    let db = AletheiaDB::with_unified_config(source_config(&wal)).unwrap();
+    // Establish vocabulary + take a base backup with one node.
+    let _seed = db
+        .create_node(
+            "Doc",
+            PropertyMapBuilder::new().insert("title", "seed").build(),
+        )
+        .unwrap();
+    let source_lsn = db.backup(&tmp.path().join("base.albk")).unwrap().source_lsn;
+    let _ = source_lsn;
+
+    // Post-backup: a node carrying provenance.
+    let prov = Provenance::builder()
+        .source("hr-system")
+        .confidence(0.95)
+        .build()
+        .unwrap();
+    let provd = db
+        .create_node_with_options(
+            "Doc",
+            PropertyMapBuilder::new().insert("title", "provd").build(),
+            aletheiadb::api::transaction::WriteRequestOptions::new().with_provenance(prov),
+        )
+        .unwrap();
+    let target_ts = db
+        .get_node(provd)
+        .unwrap()
+        .metadata
+        .commit_timestamp
+        .unwrap();
+
+    let archive = tmp.path().join("archive");
+    copy_wal_dir(&wal, &archive);
+    drop(db);
+
+    let dst = TempDir::new().unwrap();
+    let data_dir = dst.path().join("db");
+    let restored = AletheiaDB::restore_to_data_dir_at(
+        &tmp.path().join("base.albk"),
+        &archive,
+        PitrTarget::AsOf(target_ts),
+        &data_dir,
+    )
+    .unwrap();
+
+    let recovered = restored.get_node_provenance(provd).unwrap();
+    let recovered = recovered.expect("provenance must survive PITR");
+    assert_eq!(recovered.source(), Some("hr-system"));
+}
+
+#[test]
+#[serial]
+fn pitr_enforces_constraint_declared_before_target() {
+    let tmp = TempDir::new().unwrap();
+    let wal = tmp.path().join("wal");
+    let db = AletheiaDB::with_unified_config(source_config(&wal)).unwrap();
+    // Declare a unique constraint, then back up (declaration is below source_lsn).
+    db.unique_constraint("User", "email").enable().unwrap();
+    let seed = db
+        .create_node(
+            "User",
+            PropertyMapBuilder::new().insert("email", "a@x.com").build(),
+        )
+        .unwrap();
+    let source_lsn = db.backup(&tmp.path().join("base.albk")).unwrap().source_lsn;
+    let _ = (seed, source_lsn);
+
+    // Post-backup node under the same constraint.
+    let post = db
+        .create_node(
+            "User",
+            PropertyMapBuilder::new().insert("email", "b@x.com").build(),
+        )
+        .unwrap();
+    let target_ts = db
+        .get_node(post)
+        .unwrap()
+        .metadata
+        .commit_timestamp
+        .unwrap();
+
+    let archive = tmp.path().join("archive");
+    copy_wal_dir(&wal, &archive);
+    drop(db);
+
+    let dst = TempDir::new().unwrap();
+    let data_dir = dst.path().join("db");
+    let restored = AletheiaDB::restore_to_data_dir_at(
+        &tmp.path().join("base.albk"),
+        &archive,
+        PitrTarget::AsOf(target_ts),
+        &data_dir,
+    )
+    .unwrap();
+
+    // The constraint declared before the target must be enforced in the
+    // restored DB (a duplicate email is rejected).
+    let dup = restored.create_node(
+        "User",
+        PropertyMapBuilder::new().insert("email", "a@x.com").build(),
+    );
+    assert!(
+        dup.is_err(),
+        "unique constraint must be enforced after PITR"
+    );
+
+    // And it must survive a reopen through the canonical durable path.
+    drop(restored);
+    let reopened = AletheiaDB::open(&data_dir).unwrap();
+    let dup2 = reopened.create_node(
+        "User",
+        PropertyMapBuilder::new().insert("email", "b@x.com").build(),
+    );
+    assert!(
+        dup2.is_err(),
+        "unique constraint must survive reopen after PITR"
+    );
+}
+
+#[test]
+#[serial]
+fn pitr_restored_dir_reopens_with_target_state() {
+    let s = build_scenario(2, 5);
+    let k = 1usize;
+    let target_ts = s.post[k].1;
+    let dst = TempDir::new().unwrap();
+    let data_dir = dst.path().join("db");
+    {
+        let restored = AletheiaDB::restore_to_data_dir_at(
+            &s.albk,
+            &s.archive,
+            PitrTarget::AsOf(target_ts),
+            &data_dir,
+        )
+        .unwrap();
+        assert_eq!(restored.node_count(), s.pre_ids.len() + (k + 1));
+    }
+    // Reopen must load exactly the persisted target state.
+    let reopened = AletheiaDB::open(&data_dir).unwrap();
+    assert_eq!(
+        reopened.node_count(),
+        s.pre_ids.len() + (k + 1),
+        "reopen must reflect the persisted target state"
+    );
+    assert!(reopened.get_node(s.post[k].0).is_ok());
+    assert!(reopened.get_node(s.post[k + 1].0).is_err());
+}
+
+// ============================================================================
+// Dry-run / inspection
+// ============================================================================
+
+#[test]
+#[serial]
+fn pitr_inspect_reports_counts_and_window_without_side_effects() {
+    let s = build_scenario(2, 6);
+    let k = 2usize;
+    let plan =
+        AletheiaDB::inspect_pitr(&s.albk, &s.archive, Some(PitrTarget::AsOf(s.post[k].1))).unwrap();
+    assert_eq!(
+        plan.transactions_applied,
+        (k + 1) as u64,
+        "applied = kept post txns"
+    );
+    assert_eq!(
+        plan.transactions_discarded,
+        (s.post.len() - (k + 1)) as u64,
+        "discarded = post txns after target"
+    );
+    assert_eq!(plan.earliest.lsn, s.source_lsn);
+    assert_eq!(
+        plan.resolved_stop.as_ref().unwrap().timestamp_micros,
+        s.post[k].1.wallclock()
+    );
+
+    // No target: reports the full window, discards nothing.
+    let full = AletheiaDB::inspect_pitr(&s.albk, &s.archive, None).unwrap();
+    assert_eq!(full.transactions_applied, s.post.len() as u64);
+    assert_eq!(full.transactions_discarded, 0);
+
+    // Inspection must not create anything on disk.
+    let ghost = TempDir::new().unwrap();
+    let ghost_dir = ghost.path().join("never");
+    let _ =
+        AletheiaDB::inspect_pitr(&s.albk, &s.archive, Some(PitrTarget::Lsn(s.source_lsn))).unwrap();
+    assert!(!ghost_dir.exists(), "inspect must not create a target dir");
+}
+
+// ============================================================================
+// CLI reopen
+// ============================================================================
+
+#[test]
+#[serial]
+fn cli_pitr_restore_reopens_with_target_state() {
+    let s = build_scenario(2, 5);
+    let k = 2usize;
+    let target_micros = s.post[k].1.wallclock();
+
+    let dst = TempDir::new().unwrap();
+    let data_dir = dst.path().join("db");
+
+    let bin = env!("CARGO_BIN_EXE_aletheia");
+    let output = std::process::Command::new(bin)
+        .args([
+            "restore",
+            s.albk.to_str().unwrap(),
+            "--wal-archive",
+            s.archive.to_str().unwrap(),
+            "--as-of",
+            &target_micros.to_string(),
+        ])
+        .env("ALETHEIADB_DATA_DIR", &data_dir)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "CLI PITR restore failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The produced dir reopens and reflects the target state.
+    let reopened = AletheiaDB::open(&data_dir).unwrap();
+    assert_eq!(reopened.node_count(), s.pre_ids.len() + (k + 1));
+    assert!(reopened.get_node(s.post[k].0).is_ok());
+    assert!(reopened.get_node(s.post[k + 1].0).is_err());
+}
+
+#[test]
+#[serial]
+fn cli_pitr_dry_run_prints_plan_json() {
+    let s = build_scenario(1, 4);
+    let bin = env!("CARGO_BIN_EXE_aletheia");
+    let output = std::process::Command::new(bin)
+        .args([
+            "restore",
+            s.albk.to_str().unwrap(),
+            "--wal-archive",
+            s.archive.to_str().unwrap(),
+            "--lsn",
+            &s.source_lsn.to_string(),
+            "--dry-run",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(
+        json["transactions_applied"], 0,
+        "base-only target applies nothing"
+    );
+    assert_eq!(json["transactions_discarded"], s.post.len());
+    assert!(json["earliest"]["lsn"].as_u64().unwrap() == s.source_lsn);
+}


### PR DESCRIPTION
## Summary
Before — the `.albk` backup/restore (#3217) only recovers to the exact moment a backup was taken. After — restore a base `.albk` + an archived WAL chain forward to an exact **transaction-time** coordinate (timestamp or LSN), producing a FRESH data dir whose recorded history ends exactly at the target: every transaction at-or-before the target is present with full bi-temporal fidelity, every transaction after it is absent. Rust API `AletheiaDB::restore_to_data_dir_at` + `inspect_pitr` (dry-run); CLI `aletheia restore --wal-archive <dir> [--as-of <ts> | --lsn <n> | --latest] [--dry-run]`.

## How
Reuses existing machinery with **zero changes to WAL/recovery/transaction internals**: materialize the base snapshot (existing path), read the archived WAL with the DB-less segment reader, select WHOLE transaction bands whose commit coordinate is at-or-before the target (inclusive tie-break; straddle-safe by parsing whole bands from the full stream), and feed that bounded prefix to the existing `replay_entries_into_storage_with_constraints`. Design comment: https://github.com/madmax983/AletheiaDB/issues/3374#issuecomment-4950267916

## Acceptance criteria — evidence
Pull the exact AC list from issue #3374 and present a table mapping each AC to code + test. Evidence to cite (verify each test name exists in `tests/pitr.rs` / `src/db/pitr.rs` before citing):
- Base + WAL-archive + target → fresh dir ending exactly at target, full bi-temporal fidelity: `restore_to_data_dir_at` (`src/db/pitr.rs`); `pitr_roundtrip_observational_equivalence`, `pitr_exact_target_at_a_commit`.
- Round-trip observational equivalence vs a reference DB stopped at target: `pitr_roundtrip_observational_equivalence`; large exact-prefix `pitr_large_stream_restores_exact_prefix` (3,000-tx prefix, 0 missing/0 extra — in-code comment names the 10K AC metric, scaled for the sandbox disk ceiling).
- `--dry-run`/inspection reports achievable window + discarded-tx count, no side effects: `inspect_pitr`; `pitr_inspect_reports_counts_and_window_without_side_effects`.
- Target outside window → structured error naming the window, BOTH below-base and above-latest: `pitr_target_outside_window_errors`, `pitr_target_above_window_errors`; explicit "to latest"/no-target full-replay path: `pitr_target_at_latest_is_full_replay`, `cli_pitr_restore_latest_replays_full_tail`.
- Between-transactions tie-break inclusive at-or-before: `asof_between_transactions_takes_at_or_before`.
- Read-only inputs: `pitr_inputs_are_read_only`. Non-empty target fails cleanly + clean target on post-materialize failure: `pitr_non_empty_target_dir_fails_cleanly`, `pitr_post_materialize_failure_leaves_clean_target`.
- Works with provenance + constraints: `pitr_preserves_provenance`, `pitr_enforces_constraint_declared_before_target`.
- PITR runbook: `docs/guides/backup-restore.md` PITR section; ADR `docs/adr/0058-point-in-time-restore.md`.
- Success metrics: exact-prefix test above; Criterion bench `benches/pitr.rs` ≈1.4s (debug) for a 3,000-node/6,000-edge base + 800-tx tail — well under the 30s target.

## Review & fixes
A correctness/AC review found and fixed: a HIGH **interner vocabulary-change landmine** — a label/property-key created after the base backup could silently mislabel replayed data via interner-id collision; now **guarded** with a clean structured error `WindowCrossesVocabularyChange` (FAILED_PRECONDITION) instead of silent corruption. Also: above-window targets now error naming the window (were silently full-replaying); whole-band straddle-safe selection; clean target dir on post-materialize failure; documented the HLC↔LSN monotonicity assumption.

## v1 limitations (honest)
- WAL archiving is **operator-managed** (the only truncation lever + the `segments_to_retain` knob are WAL-lane-owned/unenforced; automatic retention wiring is a cross-lane follow-up). PITR reaches only as far as archived WAL + base backup allow.
- Band-granularity stop (whole transactions; inclusive at-or-before tie-break).
- A window crossing a post-backup vocabulary change **fails cleanly** rather than mislabeling.
- Transaction-time targets only (valid-time-targeted restore is a documented category error, per the issue).
- Cold-tier versions are folded into the base at backup time (replay is hot-only).
- Follow-ups noted from review: reuse the shared startup HLC-seed helper; extract shared replay-finalization + timestamp-format/parse helpers.

## CI note
The clippy CI lane uses `--features "config-toml,mcp-server,sharding-rpc,simulation"` (not `--all-features`).

## Files
New `src/db/pitr.rs`, `benches/pitr.rs`, `tests/pitr.rs`, `docs/adr/0058-point-in-time-restore.md`; extended `src/db/backup.rs`, `src/storage/backup/mod.rs` (new `BackupError` variants), `src/bin/aletheia.rs` (CLI), one arm in `src/mcp/error.rs`, `docs/guides/backup-restore.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQCy2i5JEZ1MmgxNumhhuN)_