### PR TITLE
test: fix wrong-path manifest assertion in restore E2E test (#3516)

### DIFF
--- a/tests/cli_aletheia.rs
+++ b/tests/cli_aletheia.rs
@@ -55,6 +55,38 @@ fn stdout_json(out: &str) -> serde_json::Value {
     serde_json::from_str(out.trim()).unwrap_or_else(|e| panic!("stdout not JSON ({e}): {out:?}"))
 }
 
+/// Bounded poll: wait up to `timeout` (100ms cadence) for `path` to exist AND be
+/// non-empty, then return; panic with a descriptive message if the deadline
+/// elapses first.
+///
+/// `restore` materialises its index manifest synchronously (via
+/// `materialize_to_dir`'s atomic write + fsync) before the CLI returns, so this
+/// normally succeeds on the first probe. The poll is belt-and-suspenders against
+/// residual filesystem-visibility latency and keeps the assertion STRICT (the
+/// manifest must be present and non-empty) without a bare, racy `.exists()`.
+fn wait_for_nonempty_file(path: &Path, timeout: std::time::Duration) {
+    let start = std::time::Instant::now();
+    loop {
+        if let Ok(meta) = std::fs::metadata(path)
+            && meta.is_file()
+            && meta.len() > 0
+        {
+            return;
+        }
+        if start.elapsed() >= timeout {
+            let observed = std::fs::metadata(path)
+                .map(|m| format!("exists, len={}", m.len()))
+                .unwrap_or_else(|e| format!("absent ({e})"));
+            panic!(
+                "timed out after {:?} waiting for a non-empty file at {} ({observed})",
+                timeout,
+                path.display(),
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
 // ============================================================================
 // help / usage / unknown command
 // ============================================================================
@@ -613,11 +645,19 @@ fn restore_into_fresh_dir_succeeds_and_materializes() {
         j.get("data_dir").and_then(|v| v.as_str()),
         Some(target.path().to_str().unwrap())
     );
-    // Restore must have materialized index files on disk.
-    assert!(
-        target.path().join("indexes").join("manifest.idx").exists(),
-        "restore must materialize a manifest.idx under the target"
-    );
+    // Restore must have materialized index files on disk. The canonical durable
+    // layout (#3497) writes the manifest under `indexes/indexes/manifest.idx` —
+    // the exact depth `AletheiaDB::open`/`open_from_env` reads on reopen (the
+    // `IndexPersistenceManager` appends its own `indexes/` beneath the
+    // `data_dir/indexes` persistence root). `materialize_to_dir` writes it
+    // synchronously before `restore` returns; the bounded poll guards against
+    // filesystem-visibility latency and asserts the manifest is non-empty.
+    let manifest = target
+        .path()
+        .join("indexes")
+        .join("indexes")
+        .join("manifest.idx");
+    wait_for_nonempty_file(&manifest, std::time::Duration::from_secs(15));
 }
 
 #[test]

--- a/tests/cli_aletheia.rs
+++ b/tests/cli_aletheia.rs
@@ -67,9 +67,9 @@ fn stdout_json(out: &str) -> serde_json::Value {
 fn wait_for_nonempty_file(path: &Path, timeout: std::time::Duration) {
     let start = std::time::Instant::now();
     loop {
-        if let Ok(meta) = std::fs::metadata(path)
-            && meta.is_file()
-            && meta.len() > 0
+        if std::fs::metadata(path)
+            .map(|meta| meta.is_file() && meta.len() > 0)
+            .unwrap_or(false)
         {
             return;
         }


### PR DESCRIPTION
Closes #3516

## Before
`restore_into_fresh_dir_succeeds_and_materializes` (`tests/cli_aletheia.rs`) asserted `data_dir/indexes/manifest.idx` with a bare `.exists()`. That path is never written on current trunk, so the test **fails deterministically** (reproduced locally on Linux at the assertion line).

## After
The test now asserts the **canonical** `data_dir/indexes/indexes/manifest.idx` — the exact depth `open`/`open_from_env` reads, and where `restore_to_data_dir` synchronously materializes the manifest. The bare `.exists()` is replaced with a shared bounded-poll helper (`wait_for_nonempty_file`) that keeps the assertion **strict**: the manifest must exist AND be non-empty, polling every 100ms up to 15s. Because the manifest is written synchronously, the poll normally passes on the first probe; it is belt-and-suspenders against filesystem-visibility latency.

## Root cause (not a race)
- **#3495** (`e284e91`) added the test asserting the old, shallow path `indexes/manifest.idx`.
- **#3497** (`e687b16`, *"restore writes index at canonical layout so open_from_env can reopen"*) intentionally moved the restored manifest to `indexes/indexes/manifest.idx` (the durable layout `durable_config_for_data_dir`/`open` reads — `PersistenceConfig::data_dir = data_dir/indexes`, then `IndexPersistenceManager` appends its own `indexes/`). #3497 updated its own tests but not the #3495 test.
- Both commits are ancestors of trunk (`d7573c1`), so the test checks a path the manifest is no longer written to → deterministic wrong-path failure.
- The manifest is written **synchronously** by `materialize_to_dir` → `atomic_write` (temp + `sync_all` + rename) *before* `restore_to_data_dir` reopens the DB. There is no async worker involved; a flush would not fix it.
- This also explains the mixed CI pass/fail: PRs branched **before** #3497 pass, **after** fail. It is not a timing race.

Ground truth from a real `aletheia restore`:
```
<TGT>/indexes/indexes/manifest.idx        <- EXISTS, non-empty (synchronous materialize)
<TGT>/indexes/manifest.idx                <- absent (what the test previously checked)
```

## Sibling audit
None. Other `.exists()` sites in the file assert **backup artifact** files, which the `backup` command writes synchronously (atomic temp→rename) before returning — not the async/wrong-path pattern. `restore_into_non_empty_dir_errors` relies on `check_target_empty` reading the synchronously-materialized manifest and passes unchanged.

## Verification
- **50/50 green**: `cargo test --test cli_aletheia --features "config-toml,mcp-server,sharding-rpc" restore_into_fresh_dir_succeeds_and_materializes -- --exact`, isolated `CARGO_TARGET_DIR`.
- **40 under-load runs green**: 10 parallel bursts of the `restore` group at `--test-threads=8` (4 tests each), zero failures.
- **Full `cli_aletheia` suite**: 25 passed; 0 failed.
- **clippy gate-1** (`--all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings`): clean.
- **`cargo fmt --all`**: clean.
- **clippy gate-2** (`--all-targets --all-features -- -D warnings`): 4 pre-existing errors in **untouched** files (`src/api/import/tests.rs` io_other_error, `http_run_server_body_limit`), reproduced on the pristine base — independent of this change (noted as out-of-lane in #3497 / #3371).

Test-only change; no product behavior modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg943CeLPVnAWSUJiZGVYt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fg943CeLPVnAWSUJiZGVYt)_