### PR TITLE
fix(lint): pre-existing --all-features clippy errors

### DIFF
--- a/src/api/import/tests.rs
+++ b/src/api/import/tests.rs
@@ -373,7 +373,7 @@ fn handle_row_failure_io_is_fatal_in_skip_mode() {
     let importer = db.import().failure_mode(FailureMode::SkipAndReport);
 
     // Build a synthetic Io error by wrapping a std::io::Error (the variant holds its string).
-    let io_err = std::io::Error::new(std::io::ErrorKind::Other, "synthetic mid-stream I/O");
+    let io_err = std::io::Error::other("synthetic mid-stream I/O");
     let mut report = ImportReport::default();
     let result = importer.handle_row_failure(ImportError::Io(io_err.to_string()), &mut report);
 

--- a/tests/http_run_server_body_limit.rs
+++ b/tests/http_run_server_body_limit.rs
@@ -63,13 +63,13 @@ fn post_status(addr: &str, path: &str, body: &[u8]) -> Option<u16> {
     // with BrokenPipe/ConnectionReset even though a valid `413` status line is
     // already waiting to be read. Tolerate those write errors and still attempt
     // the read — the status line, not a clean write, is the real assertion.
-    if let Err(e) = stream.write_all(body) {
-        if !matches!(
+    if let Err(e) = stream.write_all(body)
+        && !matches!(
             e.kind(),
             std::io::ErrorKind::BrokenPipe | std::io::ErrorKind::ConnectionReset
-        ) {
-            return None;
-        }
+        )
+    {
+        return None;
     }
     let _ = stream.flush();
 


### PR DESCRIPTION
## Summary

Fixes two pre-existing clippy errors that are red on the developer `--all-features` gate but invisible to CI's feature subset (`config-toml,mcp-server,sharding-rpc,simulation`), so they slipped onto trunk. Surgical, two-spot lint fix — no behavior change.

## Fixes

1. **`clippy::io_other_error`** — `src/api/import/tests.rs:376`
   - Before: `std::io::Error::new(std::io::ErrorKind::Other, "synthetic mid-stream I/O")`
   - After: `std::io::Error::other("synthetic mid-stream I/O")`

2. **`clippy::collapsible_if`** — `tests/http_run_server_body_limit.rs:66` (gated `#[cfg(feature = "http-server")]`)
   - Collapsed a nested `if let Err(e) = ... { if !matches!(...) { ... } }` into a single let-chain (`if let ... && !matches!(...)`), matching the edition-2024 let-chain idiom already used in the codebase (e.g. `src/api/transaction/write/mod.rs:561`).

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` → **exit 0** (the previously-red gate; no other pre-existing errors surfaced)
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` → exit 0 (CI subset still clean)
- `cargo fmt --all -- --check` → clean
- `cargo test --features import --lib import` → 25 passed, 0 failed (incl. touched `handle_row_failure_io_is_fatal_in_skip_mode`)
- `cargo test --features http-server --test http_run_server_body_limit` → 1 passed, 0 failed

No issue to close — developer `--all-features` gate hygiene.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpS7vn3rr6kzksJ8Q2A4qz)_