### PR TITLE
test: fix false-positive in lock-order doc validation (either order ⊂ neither ordering)

### DIFF
--- a/tests/cli_aletheia.rs
+++ b/tests/cli_aletheia.rs
@@ -55,6 +55,38 @@ fn stdout_json(out: &str) -> serde_json::Value {
     serde_json::from_str(out.trim()).unwrap_or_else(|e| panic!("stdout not JSON ({e}): {out:?}"))
 }
 
+/// Bounded poll: wait up to `timeout` (100ms cadence) for `path` to exist AND be
+/// non-empty, then return; panic with a descriptive message if the deadline
+/// elapses first.
+///
+/// `restore` materialises its index manifest synchronously (via
+/// `materialize_to_dir`'s atomic write + fsync) before the CLI returns, so this
+/// normally succeeds on the first probe. The poll is belt-and-suspenders against
+/// residual filesystem-visibility latency and keeps the assertion STRICT (the
+/// manifest must be present and non-empty) without a bare, racy `.exists()`.
+fn wait_for_nonempty_file(path: &Path, timeout: std::time::Duration) {
+    let start = std::time::Instant::now();
+    loop {
+        if let Ok(meta) = std::fs::metadata(path)
+            && meta.is_file()
+            && meta.len() > 0
+        {
+            return;
+        }
+        if start.elapsed() >= timeout {
+            let observed = std::fs::metadata(path)
+                .map(|m| format!("exists, len={}", m.len()))
+                .unwrap_or_else(|e| format!("absent ({e})"));
+            panic!(
+                "timed out after {:?} waiting for a non-empty file at {} ({observed})",
+                timeout,
+                path.display(),
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
 // ============================================================================
 // help / usage / unknown command
 // ============================================================================
@@ -613,11 +645,19 @@ fn restore_into_fresh_dir_succeeds_and_materializes() {
         j.get("data_dir").and_then(|v| v.as_str()),
         Some(target.path().to_str().unwrap())
     );
-    // Restore must have materialized index files on disk.
-    assert!(
-        target.path().join("indexes").join("manifest.idx").exists(),
-        "restore must materialize a manifest.idx under the target"
-    );
+    // Restore must have materialized index files on disk. The canonical durable
+    // layout (#3497) writes the manifest under `indexes/indexes/manifest.idx` —
+    // the exact depth `AletheiaDB::open`/`open_from_env` reads on reopen (the
+    // `IndexPersistenceManager` appends its own `indexes/` beneath the
+    // `data_dir/indexes` persistence root). `materialize_to_dir` writes it
+    // synchronously before `restore` returns; the bounded poll guards against
+    // filesystem-visibility latency and asserts the manifest is non-empty.
+    let manifest = target
+        .path()
+        .join("indexes")
+        .join("indexes")
+        .join("manifest.idx");
+    wait_for_nonempty_file(&manifest, std::time::Duration::from_secs(15));
 }
 
 #[test]

--- a/tests/cli_aletheia.rs
+++ b/tests/cli_aletheia.rs
@@ -67,9 +67,9 @@ fn stdout_json(out: &str) -> serde_json::Value {
 fn wait_for_nonempty_file(path: &Path, timeout: std::time::Duration) {
     let start = std::time::Instant::now();
     loop {
-        if let Ok(meta) = std::fs::metadata(path)
-            && meta.is_file()
-            && meta.len() > 0
+        if std::fs::metadata(path)
+            .map(|meta| meta.is_file() && meta.len() > 0)
+            .unwrap_or(false)
         {
             return;
         }

--- a/tests/documentation_validation.rs
+++ b/tests/documentation_validation.rs
@@ -162,6 +162,31 @@ fn extract_numbered_lock_order(section: &str) -> Vec<String> {
     entries
 }
 
+/// Returns `true` only if `needle` occurs in `haystack` as a standalone phrase
+/// -- i.e. not embedded inside a longer word. The character immediately before
+/// the match must not be alphabetic and the character immediately after must
+/// not be alphabetic.
+///
+/// This exists so the lock-order assertion below does not false-positive on
+/// unrelated prose: the naive `haystack.contains("either order")` also matches
+/// the substring inside "neither ordering" (`n[either order]ing`), which
+/// appears elsewhere in CLAUDE.md. A whole-phrase check still catches a genuine
+/// "... in either order" statement while ignoring "neither ordering".
+fn contains_whole_phrase(haystack: &str, needle: &str) -> bool {
+    haystack.match_indices(needle).any(|(start, matched)| {
+        let end = start + matched.len();
+        let prev_is_alpha = haystack[..start]
+            .chars()
+            .next_back()
+            .is_some_and(|c| c.is_alphabetic());
+        let next_is_alpha = haystack[end..]
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_alphabetic());
+        !prev_is_alpha && !next_is_alpha
+    })
+}
+
 /// Test that the lock acquisition order is documented for future write-path changes.
 #[test]
 fn test_lock_acquisition_order_documented() {
@@ -183,10 +208,22 @@ fn test_lock_acquisition_order_documented() {
     .map(String::from)
     .collect();
 
-    let claude_section = claude
+    // Scope the CLAUDE.md slice to just the "Lock Acquisition Order" subsection
+    // (heading -> next markdown heading) so unrelated later prose is not
+    // scanned. Without this bound, distant sections such as the Known
+    // Limitations wording "so neither ordering can commit a new dangling edge"
+    // are pulled in -- and "neither ordering" contains the substring
+    // "either order", which false-positives the assertion below.
+    let claude_after_heading = claude
         .split("### Lock Acquisition Order")
         .nth(1)
         .expect("CLAUDE.md should include a lock acquisition order section");
+    let claude_section_end = ["\n## ", "\n### "]
+        .iter()
+        .filter_map(|marker| claude_after_heading.find(marker))
+        .min()
+        .unwrap_or(claude_after_heading.len());
+    let claude_section = &claude_after_heading[..claude_section_end];
     let write_apply_section = write_apply
         .split("//! # Lock Acquisition Order")
         .nth(1)
@@ -206,7 +243,7 @@ fn test_lock_acquisition_order_documented() {
             "{name} should document `outgoing` and `incoming` as separate ordered entries"
         );
         assert!(
-            !section.contains("either order"),
+            !contains_whole_phrase(section, "either order"),
             "{name} should not allow outgoing and incoming adjacency indexes in either order"
         );
     }


### PR DESCRIPTION
Closes #3516

> This PR now carries **two** independent test-only trunk-restore fixes so it can go green on its own and become the single merge that restores trunk. The restore manifest-path fix (originally PR #3518) is cherry-picked in; #3518 is superseded by this PR.

---

## Fix 1 — lock-order doc validation false-positive (`tests/documentation_validation.rs`)

### Summary

Test-only fix for a false-positive that fails `test_lock_acquisition_order_documented` (`tests/documentation_validation.rs`) on **pristine trunk** (HEAD `d7573c1`), breaking the macOS Test Suite + Code Coverage + Mutants baseline on every PR branched from trunk (including #3503).

### Root cause

The test extracted `claude.split("### Lock Acquisition Order").nth(1)` — i.e. **everything** after that heading — and ran a naive `section.contains("either order")`. #3502 added a Known Limitations paragraph to CLAUDE.md containing the word **"neither ordering"**, and `"neither ordering"` contains the substring `"either order"` (`n[either order]ing`). The substring check therefore false-positived and the assertion at `documentation_validation.rs:208` began panicking.

### Before / After

- **Before:** the doc test fails on unmodified trunk because a distant, unrelated sentence ("so neither ordering can commit a new dangling edge") is scanned and its `"neither ordering"` matches the `"either order"` substring.
- **After:** the test is section-scoped and word-boundary-safe, so it only trips on a genuine `"... in either order"` statement about the adjacency-index lock order — its real intent is preserved.

### The fix (Option A, test-only)

1. **Scope** the CLAUDE.md slice to just the Lock Acquisition Order subsection (heading → next markdown heading `\n## ` / `\n### `), so unrelated later prose is not scanned.
2. **Word-boundary-safe match:** a new `contains_whole_phrase(haystack, needle)` helper replaces `.contains("either order")`. It requires the char immediately before the match and the char immediately after to be non-alphabetic, so `"neither ordering"` (preceded by `n`, followed by `ing`) does not match, while `"... in either order."` does. No new dependency (`regex` is not a dev-dependency; a manual boundary check is used).

`CLAUDE.md` is **unchanged** by this PR.

### Acceptance-criteria evidence

- **RED (pristine trunk):** `cargo test --test documentation_validation test_lock_acquisition_order_documented` → `FAILED`, panic at `documentation_validation.rs:208` ("...should not allow outgoing and incoming adjacency indexes in either order").
- **GREEN (after fix):** `cargo test --test documentation_validation` → `test result: ok. 7 passed; 0 failed`.
- **Red-proof:** temporarily inserting "...they may be acquired in either order." into the Lock Acquisition Order subsection of CLAUDE.md makes the test `FAILED` again (proving the assertion still catches real violations); CLAUDE.md then reverted (`git checkout -- CLAUDE.md`), `git status` clean.

---

## Fix 2 — restore E2E manifest-path assertion (`tests/cli_aletheia.rs`, cherry-picked from #3518)

Cherry-picked commits `3e78eb7` + `a6f6fbe` (test-only, both touch only `tests/cli_aletheia.rs`; no file overlap with Fix 1). Credit: PR #3518 ("test: fix wrong-path manifest assertion in restore E2E test"). This fixes a **different** deterministic trunk failure that this branch would otherwise inherit.

### Root cause

`restore_into_fresh_dir_succeeds_and_materializes` asserted `data_dir/indexes/manifest.idx` with a bare `.exists()`. That shallow path is never written on current trunk, so the test **failed deterministically**:

- **#3495** added the test asserting the old, shallow path `indexes/manifest.idx`.
- **#3497** intentionally moved the restored manifest to the canonical `indexes/indexes/manifest.idx` (the durable layout `durable_config_for_data_dir`/`open` reads) but did not update the #3495 test.
- Both are ancestors of trunk (`d7573c1`), so the test checked a path the manifest is no longer written to → deterministic wrong-path failure (not a timing race; the manifest is written synchronously by `materialize_to_dir` → `atomic_write`).

### The fix (test-only)

The test now asserts the **canonical** `data_dir/indexes/indexes/manifest.idx` via a shared bounded-poll helper (`wait_for_nonempty_file`) that keeps the assertion strict (must exist AND be non-empty; polls every 100ms up to 15s, normally passing on the first probe). The helper is written with a `std::fs::metadata(...).map(...).unwrap_or(false)` combinator (avoiding let_chains for stable-toolchain / MSRV compatibility and keeping gate-1 clippy clean).

### Evidence

- `cargo test --test cli_aletheia --features "config-toml,mcp-server,sharding-rpc"` → `test result: ok. 25 passed; 0 failed` (including `restore_into_fresh_dir_succeeds_and_materializes ... ok`).

---

## Combined gates (both fixes present)

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` — clean.
- `git diff --stat origin/trunk` — exactly two test files: `tests/cli_aletheia.rs`, `tests/documentation_validation.rs`. No source / CLAUDE.md changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TozNjpq2aidaW6HV7bucKC

---
_Generated by [Claude Code](https://claude.ai/code/session_01TozNjpq2aidaW6HV7bucKC)_