### PR TITLE
⚡ Bolt: Remove intermediate vector allocation in apply_changes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**[Avoid intermediate Vec allocation when chaining maps]**
+**Learning:** Using `.collect::<Vec<_>>().into_iter()` on an iterator chain creates an unnecessary intermediate heap allocation.
+**Action:** Change the receiver to accept `impl Iterator<Item = T>` and remove the `.collect()` call, avoiding the O(N) allocation entirely.

--- a/src/api/transaction/write/apply.rs
+++ b/src/api/transaction/write/apply.rs
@@ -408,13 +408,14 @@ pub(crate) fn apply_edge_retract(
 /// # Arguments
 ///
 /// * `tombstone_ids` - Iterator of pre-generated Version IDs for tombstones. This optimization
-///   avoids acquiring the ID generator lock for every delete operation.
+///   avoids acquiring the ID generator lock for every delete operation. By accepting a generic
+///   Iterator instead of `IntoIter`, we avoid an intermediate Vec allocation when mapping VersionIds to u64s.
 pub(crate) fn apply_single_write(
     tx: &WriteTransaction,
     write: &crate::api::transaction::BufferedWrite,
     commit_timestamp: Timestamp,
     historical: &mut HistoricalStorage,
-    tombstone_ids: &mut std::vec::IntoIter<u64>,
+    tombstone_ids: &mut impl Iterator<Item = u64>,
     num_deletes: usize,
 ) -> Result<()> {
     match write {
@@ -647,11 +648,7 @@ pub(crate) fn apply_changes<'a>(
     // so the identical ids are recorded in the WAL and applied here. We simply
     // replay them in the same buffer order they were generated and logged.
     let num_deletes = closing_version_ids.len();
-    let mut tombstone_ids = closing_version_ids
-        .iter()
-        .map(|v| v.as_u64())
-        .collect::<Vec<u64>>()
-        .into_iter();
+    let mut tombstone_ids = closing_version_ids.iter().map(|v| v.as_u64());
 
     for write in tx.buffer.operations() {
         apply_single_write(


### PR DESCRIPTION
💡 What: Removed `.collect::<Vec<u64>>().into_iter()` when generating `tombstone_ids` in `apply_changes`.
🎯 Why: Pre-generating tombstone IDs created an unnecessary `Vec` heap allocation for every transaction with deletions. By accepting a generic Iterator, we avoid an intermediate Vec allocation when mapping VersionIds to u64s.
📊 Impact: Eliminates one O(N) heap allocation per transaction with deletes, where N is the number of deletes.
🔬 Measurement: Verified with `cargo test api::transaction::write::tests` and standard clippy checks.

---
*PR created automatically by Jules for task [10365600120620663761](https://jules.google.com/task/10365600120620663761) started by @madmax983*