### PR TITLE
Issue #3506: serialize WAL labels as UTF-8 (WAL v13/v14)

### DIFF
--- a/src/api/import/tests.rs
+++ b/src/api/import/tests.rs
@@ -373,7 +373,7 @@ fn handle_row_failure_io_is_fatal_in_skip_mode() {
     let importer = db.import().failure_mode(FailureMode::SkipAndReport);
 
     // Build a synthetic Io error by wrapping a std::io::Error (the variant holds its string).
-    let io_err = std::io::Error::new(std::io::ErrorKind::Other, "synthetic mid-stream I/O");
+    let io_err = std::io::Error::other("synthetic mid-stream I/O");
     let mut report = ImportReport::default();
     let result = importer.handle_row_failure(ImportError::Io(io_err.to_string()), &mut report);
 

--- a/src/storage/wal/concurrent.rs
+++ b/src/storage/wal/concurrent.rs
@@ -1081,17 +1081,18 @@ mod sentry_tests {
         // Calculate size needed for payload
         // CreateNode overhead:
         // Fixed: 24 bytes (LSN + Time + Checksum)
-        // Variable: 1 (op) + 8 (node_id) + 4 (label) + 12 (time) = 25 bytes
+        // Variable: 1 (op) + 8 (node_id) + 8 (label [len:4]["Test":4], #3506)
+        //           + 12 (time) = 29 bytes
         // PropertyMap overhead:
         // 4 (count) + 4 (key_len) + key_bytes + 1 (tag_string) + 4 (val_len) + val_bytes
 
         // Let's use a key "k" (1 byte)
-        // Overhead = 24 + 25 + 4 + 4 + 1 + 1 + 4 + 1 (provenance presence byte) = 64 bytes
-        // Total = 64 + val_bytes
+        // Overhead = 24 + 29 + 4 + 4 + 1 + 1 + 4 + 1 (provenance presence byte) = 68 bytes
+        // Total = 68 + val_bytes
         // Target = MAX_WAL_ENTRY_SIZE
-        // val_bytes = MAX_WAL_ENTRY_SIZE - 64
+        // val_bytes = MAX_WAL_ENTRY_SIZE - 68
 
-        let overhead = 64;
+        let overhead = 68;
         let target_val_len = MAX_WAL_ENTRY_SIZE - overhead;
 
         // Create a string of target length
@@ -1135,7 +1136,7 @@ mod sentry_tests {
         let wal = ConcurrentWal::new(config).unwrap();
 
         // Use same calculation as above but +1 byte
-        let overhead = 64;
+        let overhead = 68;
         let target_val_len = MAX_WAL_ENTRY_SIZE - overhead + 1;
 
         let big_string = "x".repeat(target_val_len);

--- a/src/storage/wal/entry.rs
+++ b/src/storage/wal/entry.rs
@@ -375,14 +375,13 @@ mod sentry_tests {
         let mut buffer = Vec::new();
         serialize_entry_into(&original_entry, &mut buffer).expect("Serialization failed");
 
-        // Deserialize. Serialization always writes the principal-carrying
-        // provenance payload shape now (Issues #3224 + #3350), so parsing
-        // must use the matching version to consume the same bytes that were
-        // written.
+        // Deserialize. Serialization always writes the newest payload shape now
+        // (string labels, Issue #3506), so parsing must use the matching
+        // version to consume the same bytes that were written.
         let (parsed_entry, consumed) = parse_entry_at(
             &buffer,
             0,
-            crate::storage::wal::segment_reader::WAL_VERSION_PROVENANCE_PRINCIPAL,
+            crate::storage::wal::segment_reader::WAL_VERSION_STRING_LABELS,
         )
         .expect("Deserialization failed");
 
@@ -395,6 +394,10 @@ mod sentry_tests {
         // This validates that the checksum in the buffer is indeed what we expect
         // for this data (since parse_entry_at verifies it).
         original_entry.checksum = parsed_entry.checksum;
+        // Parsing at a framing-capable version (v13 >= v7) flags the entry
+        // `framed`; the freshly-built original defaults to false. Normalize it
+        // (like the checksum) so the comparison targets the payload fidelity.
+        original_entry.framed = parsed_entry.framed;
 
         // Now assert strict equality
         assert_eq!(

--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -45,8 +45,7 @@ use super::ring_buffer::PendingEntry;
 use crate::core::error::{Error, Result, StorageError};
 
 use super::segment_reader::{
-    WAL_HEADER_SIZE, WAL_MAGIC, WAL_VERSION_DESTRUCTIVE_PROVENANCE,
-    WAL_VERSION_ENCRYPTED_DESTRUCTIVE_PROVENANCE,
+    WAL_HEADER_SIZE, WAL_MAGIC, WAL_VERSION_ENCRYPTED_STRING_LABELS, WAL_VERSION_STRING_LABELS,
 };
 
 /// Metadata about a WAL segment's LSN range.
@@ -432,23 +431,24 @@ impl FlushCoordinator {
             return Ok(());
         }
 
-        // New segments use the destructive-op provenance format (Issue #3427):
-        // WAL_VERSION_ENCRYPTED_DESTRUCTIVE_PROVENANCE (v12) for encrypted
-        // segments, WAL_VERSION_DESTRUCTIVE_PROVENANCE (v11) for plaintext. It
-        // is a strict superset of the delete-version-id format (Issue #3406,
-        // v9/v10) — itself a superset of the transaction-framing format (Issue
-        // #3413) and the principal-carrying provenance format (Issues #3224 +
-        // #3350) — additionally appending an optional provenance blob to the
-        // delete/retract payloads so the acting principal on a destructive op
-        // survives crash recovery. It keeps the BeginTx/CommitTx framing
-        // markers AND the tombstone/retraction version_id. Non-transactional
-        // producers simply omit the framing markers; the version bump signals
-        // that the markers AND the extended payloads MAY be present so old
-        // readers reject the segment cleanly rather than misparsing.
+        // New segments use the string-label format (Issue #3506):
+        // WAL_VERSION_ENCRYPTED_STRING_LABELS (v14) for encrypted segments,
+        // WAL_VERSION_STRING_LABELS (v13) for plaintext. It is a strict
+        // superset of the destructive-op provenance format (Issue #3427,
+        // v11/v12) — itself a superset of the delete-version-id (Issue #3406),
+        // transaction-framing (Issue #3413), and principal-carrying provenance
+        // (Issues #3224 + #3350) formats — changing only how the
+        // node/edge/constraint LABEL is encoded: length-prefixed UTF-8 that is
+        // re-interned on read instead of a raw interner id, so labels are
+        // correct under any interner layout on replay. It keeps every prior
+        // field (framing markers, tombstone/retraction version_id, destructive
+        // provenance). The version bump signals the new label encoding so old
+        // readers reject the segment cleanly rather than mis-lengthing the
+        // variable-width label payload.
         let write_version = if self.config.wal_cipher.is_some() {
-            WAL_VERSION_ENCRYPTED_DESTRUCTIVE_PROVENANCE
+            WAL_VERSION_ENCRYPTED_STRING_LABELS
         } else {
-            WAL_VERSION_DESTRUCTIVE_PROVENANCE
+            WAL_VERSION_STRING_LABELS
         };
 
         // Allocate the next segment id, rolling past any existing non-empty
@@ -1130,27 +1130,35 @@ mod tests {
         use crate::core::provenance::Provenance;
         use crate::core::temporal::time;
         use crate::storage::wal::segment_reader::{WAL_VERSION_PROVENANCE, read_entries_from_dir};
-        use crate::storage::wal::serialization::serialize_entry_into;
+        use crate::storage::wal::serialization::{OP_CREATE_NODE, serialize_entry_into};
         use crate::storage::wal::{WalEntry, WalOperation};
 
         let dir = tempdir().unwrap();
 
-        // Hand-write a v3-header segment at id 1 containing one valid entry.
-        // A provenance-less entry's bytes are identical across the v3 and v5
-        // payload formats (the principal slot only exists inside a present
-        // provenance bundle), so this file replays cleanly as v3.
-        let old_entry = WalEntry::new(
-            LSN(1),
-            WalOperation::CreateNode {
-                node_id: NodeId::new(1).unwrap(),
-                label: GLOBAL_INTERNER.intern("Legacy").unwrap(),
-                properties: PropertyMap::new(),
-                valid_from: time::now(),
-                provenance: None,
-            },
-        );
+        // Hand-write a genuine v3-header segment at id 1 containing one valid,
+        // provenance-less CreateNode with a RAW 4-byte interner-id label (the
+        // pre-#3506 label encoding). We build it by hand rather than via the
+        // modern serializer, which now writes string labels at v13 — a v13 body
+        // under a v3 header would not replay. A provenance-less entry's other
+        // bytes are identical across the v3/v5 payload formats, so this file
+        // replays cleanly as v3.
+        let legacy_label = GLOBAL_INTERNER.intern("Legacy").unwrap();
+        let legacy_ts = time::now();
         let mut old_bytes = Vec::new();
-        serialize_entry_into(&old_entry, &mut old_bytes).unwrap();
+        old_bytes.extend_from_slice(&LSN(1).0.to_le_bytes());
+        legacy_ts.serialize_into(&mut old_bytes);
+        let cs = old_bytes.len();
+        old_bytes.extend_from_slice(&[0u8; 4]);
+        old_bytes.push(OP_CREATE_NODE);
+        old_bytes.extend_from_slice(&NodeId::new(1).unwrap().as_u64().to_le_bytes());
+        old_bytes.extend_from_slice(&legacy_label.as_u32().to_le_bytes()); // raw id label
+        PropertyMap::new().serialize_into(&mut old_bytes).unwrap();
+        legacy_ts.serialize_into(&mut old_bytes);
+        old_bytes.push(0u8); // provenance: absent
+        let mut hasher = crc32fast::Hasher::new();
+        hasher.update(&old_bytes[0..20]);
+        hasher.update(&old_bytes[cs + 4..]);
+        old_bytes[cs..cs + 4].copy_from_slice(&hasher.finalize().to_le_bytes());
         let mut v3_segment = Vec::new();
         v3_segment.extend_from_slice(&WAL_MAGIC);
         v3_segment.push(WAL_VERSION_PROVENANCE);
@@ -1200,11 +1208,11 @@ mod tests {
         );
 
         // ...the write must have rolled forward to a fresh segment with the
-        // current writer (v11 destructive-provenance) header...
+        // current writer (v13 string-labels) header...
         assert_eq!(coordinator.current_segment_id(), 2);
         let new_segment = std::fs::read(dir.path().join("000002.log")).unwrap();
         assert_eq!(&new_segment[0..4], &WAL_MAGIC);
-        assert_eq!(new_segment[4], WAL_VERSION_DESTRUCTIVE_PROVENANCE);
+        assert_eq!(new_segment[4], WAL_VERSION_STRING_LABELS);
 
         // ...and a full-directory replay succeeds, with the new entry's
         // principal intact.
@@ -1524,7 +1532,7 @@ mod tests {
 
         assert!(data.len() >= WAL_HEADER_SIZE);
         assert_eq!(&data[0..4], &WAL_MAGIC);
-        assert_eq!(data[4], WAL_VERSION_DESTRUCTIVE_PROVENANCE);
+        assert_eq!(data[4], WAL_VERSION_STRING_LABELS);
     }
 
     #[test]

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -2071,6 +2071,115 @@ mod tests {
         );
     }
 
+    /// Issue #3506 — crash-recovery corruption path: a v13+ label whose
+    /// length-prefixed bytes are not valid UTF-8 must be rejected as
+    /// `CorruptedData` (not silently mis-decoded), so a torn/garbled segment
+    /// fails the replay loudly instead of interning a bogus label.
+    #[test]
+    fn read_label_v13_rejects_invalid_utf8() {
+        // [len = 2][0xFF, 0xFF] — 0xFF 0xFF is never valid UTF-8.
+        let mut buffer = Vec::new();
+        buffer.extend_from_slice(&2u32.to_le_bytes());
+        buffer.extend_from_slice(&[0xFF, 0xFF]);
+        let mut offset = 0usize;
+        let err = read_label(
+            &buffer,
+            &mut offset,
+            WAL_VERSION_STRING_LABELS,
+            "CreateNode label",
+        )
+        .expect_err("invalid UTF-8 label bytes must be rejected");
+        match err {
+            Error::Storage(StorageError::CorruptedData(msg)) => assert!(
+                msg.contains("Invalid UTF-8 in WAL label"),
+                "unexpected CorruptedData message: {msg}"
+            ),
+            other => panic!("expected CorruptedData, got {other:?}"),
+        }
+    }
+
+    /// Issue #3506 — crash-recovery corruption path: a v13+ label whose declared
+    /// length overruns the remaining buffer must fail `require_bytes` with a
+    /// `CorruptedData` error naming the read context, rather than slicing out of
+    /// bounds or allocating on a crafted length.
+    #[test]
+    fn read_label_v13_rejects_length_overrun() {
+        // [len = 100] but zero label bytes follow.
+        let mut buffer = Vec::new();
+        buffer.extend_from_slice(&100u32.to_le_bytes());
+        let mut offset = 0usize;
+        let err = read_label(
+            &buffer,
+            &mut offset,
+            WAL_VERSION_STRING_LABELS,
+            "CreateEdge label",
+        )
+        .expect_err("length-overrun label must be rejected");
+        match err {
+            Error::Storage(StorageError::CorruptedData(msg)) => assert!(
+                msg.contains("CreateEdge label"),
+                "unexpected CorruptedData message: {msg}"
+            ),
+            other => panic!("expected CorruptedData, got {other:?}"),
+        }
+    }
+
+    /// Issue #3506 — crash-recovery corruption path: a v13+ segment truncated
+    /// mid-way through the 4-byte label length prefix must fail the initial
+    /// `require_bytes` guard rather than reading past the buffer end.
+    #[test]
+    fn read_label_v13_rejects_truncated_length_prefix() {
+        // Only 2 of the 4 length-prefix bytes are present.
+        let buffer = [0x01u8, 0x00];
+        let mut offset = 0usize;
+        let err = read_label(
+            &buffer,
+            &mut offset,
+            WAL_VERSION_STRING_LABELS,
+            "UpdateNode label",
+        )
+        .expect_err("truncated label length prefix must be rejected");
+        match err {
+            Error::Storage(StorageError::CorruptedData(msg)) => assert!(
+                msg.contains("UpdateNode label"),
+                "unexpected CorruptedData message: {msg}"
+            ),
+            other => panic!("expected CorruptedData, got {other:?}"),
+        }
+    }
+
+    /// Issue #3506 — happy-path unit coverage for the v13 label decode in
+    /// isolation: a well-formed `[len][utf8]` label re-interns to the exact
+    /// string and advances `offset` past the whole field.
+    #[test]
+    fn read_label_v13_round_trips_and_advances_offset() {
+        let label_str = "Straße3506"; // multi-byte to exercise len != char count
+        let bytes = label_str.as_bytes();
+        let mut buffer = Vec::new();
+        buffer.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+        buffer.extend_from_slice(bytes);
+        buffer.push(0xAB); // trailing sentinel: offset must stop before this
+        let mut offset = 0usize;
+        let interned = read_label(
+            &buffer,
+            &mut offset,
+            WAL_VERSION_STRING_LABELS,
+            "CreateNode label",
+        )
+        .expect("well-formed v13 label must decode");
+        assert_eq!(
+            offset,
+            4 + bytes.len(),
+            "offset must advance past [len][utf8]"
+        );
+        assert!(
+            GLOBAL_INTERNER
+                .resolve_with(interned, |s| s == label_str)
+                .unwrap(),
+            "decoded label must re-intern to the original string"
+        );
+    }
+
     /// Issue #3413: `CommitTx` serializes and parses back byte-for-byte under
     /// the transaction-framing version, and the parsed entry is flagged
     /// `framed`.

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -168,8 +168,40 @@ pub(crate) const WAL_VERSION_DESTRUCTIVE_PROVENANCE: u8 = 11;
 /// [`WAL_VERSION_DESTRUCTIVE_PROVENANCE`]).
 pub(crate) const WAL_VERSION_ENCRYPTED_DESTRUCTIVE_PROVENANCE: u8 = 12;
 
+/// WAL format version that serializes node/edge/constraint **label** strings as
+/// length-prefixed UTF-8 (`[len: u32-LE][utf8 bytes]`) and re-interns them on
+/// read, instead of persisting a raw [`InternedString`] id (Issue #3506).
+///
+/// A strict superset of [`WAL_VERSION_DESTRUCTIVE_PROVENANCE`]: it keeps every
+/// prior field (tx framing, tombstone/retraction `version_id`, destructive-op
+/// provenance) and only changes how the label field of `CreateNode`,
+/// `CreateEdge`, `UpdateNode`, `UpdateEdge`, `DeclareUniqueConstraint`, and
+/// `DropUniqueConstraint` is encoded. Prior versions wrote the label as a raw
+/// 4-byte interner id and replayed it via [`InternedString::from_raw`] WITHOUT
+/// re-interning the underlying string — correct only when the replaying
+/// process reproduced the exact id→string layout of the writer. In a
+/// non-identity interner layout (multiple `AletheiaDB` instances sharing the
+/// process-global interner, repeated open/close, or the WAL-only replay path
+/// that performs no interner restore) a raw-id label silently resolved to the
+/// wrong string. v13+ segments carry the string itself, so labels are correct
+/// under any interner layout, exactly as property keys/values already are.
+///
+/// The [`carries_string_labels`] gate is an independent monotonic `>=` boolean
+/// on the same version byte, composing with the framing/delete-version-id/
+/// destructive-provenance gates. ≤v12 segments keep the raw-id decode path
+/// (best-effort, identity-layout only — we cannot retroactively recover a
+/// string that was never written); v13+ segments are unconditionally correct.
+/// Bumping the header version makes an older reader reject the file cleanly
+/// rather than mis-length the variable-width label payload, following the
+/// #3224/#3406/#3413/#3427 precedent.
+pub(crate) const WAL_VERSION_STRING_LABELS: u8 = 13;
+
+/// WAL format version for encrypted segments whose decrypted payload uses the
+/// string-label entry format (i.e. [`WAL_VERSION_STRING_LABELS`], Issue #3506).
+pub(crate) const WAL_VERSION_ENCRYPTED_STRING_LABELS: u8 = 14;
+
 /// Maximum supported WAL version (inclusive).
-const WAL_VERSION_MAX: u8 = WAL_VERSION_ENCRYPTED_DESTRUCTIVE_PROVENANCE;
+const WAL_VERSION_MAX: u8 = WAL_VERSION_ENCRYPTED_STRING_LABELS;
 
 /// Returns `true` if `version` denotes an encrypted segment (the original
 /// encrypted format or one of its provenance/framing-carrying successors).
@@ -181,6 +213,7 @@ fn is_encrypted_version(version: u8) -> bool {
         || version == WAL_VERSION_ENCRYPTED_TX_FRAMING
         || version == WAL_VERSION_ENCRYPTED_DELETE_VERSION_ID
         || version == WAL_VERSION_ENCRYPTED_DESTRUCTIVE_PROVENANCE
+        || version == WAL_VERSION_ENCRYPTED_STRING_LABELS
 }
 
 /// Returns `true` if `version` (a plaintext/payload version) supports the
@@ -215,6 +248,17 @@ fn carries_destructive_provenance(version: u8) -> bool {
     version >= WAL_VERSION_DESTRUCTIVE_PROVENANCE
 }
 
+/// Returns `true` if `version` (a plaintext/payload version) serializes labels
+/// as length-prefixed UTF-8 and re-interns them on read (Issue #3506).
+///
+/// Independent of the framing/delete-version-id/destructive-provenance gates:
+/// all are monotonic `>=` predicates on the same version byte, so v13/v14
+/// segments carry every prior field AND string labels.
+#[inline]
+fn carries_string_labels(version: u8) -> bool {
+    version >= WAL_VERSION_STRING_LABELS
+}
+
 /// Map a segment/container format version to the logical *payload* version
 /// used to gate field parsing (e.g. `version >= WAL_VERSION_PROVENANCE`).
 ///
@@ -230,6 +274,7 @@ fn payload_version(version: u8) -> u8 {
         WAL_VERSION_ENCRYPTED_TX_FRAMING => WAL_VERSION_TX_FRAMING,
         WAL_VERSION_ENCRYPTED_DELETE_VERSION_ID => WAL_VERSION_DELETE_VERSION_ID,
         WAL_VERSION_ENCRYPTED_DESTRUCTIVE_PROVENANCE => WAL_VERSION_DESTRUCTIVE_PROVENANCE,
+        WAL_VERSION_ENCRYPTED_STRING_LABELS => WAL_VERSION_STRING_LABELS,
         v => v,
     }
 }
@@ -250,7 +295,7 @@ fn payload_version(version: u8) -> u8 {
 /// and fails the entry checksum.
 ///
 /// History of the newest plaintext version: #3224→3, #3421→5, #3413→7,
-/// #3406→9, #3427→11. Bump on every WAL plaintext format increase.
+/// #3406→9, #3427→11, #3506→13. Bump on every WAL plaintext format increase.
 #[inline]
 // Only referenced by the fuzz-only `crate::fuzzing` module, so it is compiled
 // only under `any(fuzzing, feature = "fuzzing")`; on non-fuzzing builds it is
@@ -1378,17 +1423,40 @@ fn read_provenance(buffer: &[u8], offset: &mut usize, version: u8) -> Result<Opt
     Ok(Some(provenance))
 }
 
-/// Read a 4-byte InternedString label ID from `buffer` at `offset`, advancing `offset` by 4.
+/// Read a label from `buffer` at `offset`, advancing `offset` past it.
+///
+/// For v13+ segments ([`carries_string_labels`], Issue #3506) the label is a
+/// length-prefixed UTF-8 string (`[len: u32-LE][utf8 bytes]`) which is
+/// re-interned into the process-global interner on read, so it resolves to the
+/// correct string under ANY interner layout (byte-identical to the property-key
+/// codec). For ≤v12 segments the label is a raw 4-byte [`InternedString`] id
+/// wrapped via [`InternedString::from_raw`] — correct only when the replaying
+/// process reproduces the writer's interner layout (the pre-#3506 behavior,
+/// preserved for backward compatibility).
 #[inline]
 fn read_label(
     buffer: &[u8],
     offset: &mut usize,
+    version: u8,
     context: &str,
 ) -> Result<crate::core::interning::InternedString> {
-    require_bytes(buffer, *offset, 4, context)?;
-    let label_id = u32::from_le_bytes(buffer[*offset..*offset + 4].try_into().unwrap());
-    advance(offset, 4)?;
-    Ok(crate::core::interning::InternedString::from_raw(label_id))
+    if carries_string_labels(version) {
+        require_bytes(buffer, *offset, 4, context)?;
+        let len = u32::from_le_bytes(buffer[*offset..*offset + 4].try_into().unwrap()) as usize;
+        advance(offset, 4)?;
+        require_bytes(buffer, *offset, len, context)?;
+        let s = std::str::from_utf8(&buffer[*offset..*offset + len]).map_err(|e| {
+            StorageError::CorruptedData(format!("Invalid UTF-8 in WAL label ({context}): {e}"))
+        })?;
+        let interned = crate::core::interning::GLOBAL_INTERNER.intern(s)?;
+        advance(offset, len)?;
+        Ok(interned)
+    } else {
+        require_bytes(buffer, *offset, 4, context)?;
+        let label_id = u32::from_le_bytes(buffer[*offset..*offset + 4].try_into().unwrap());
+        advance(offset, 4)?;
+        Ok(crate::core::interning::InternedString::from_raw(label_id))
+    }
 }
 
 /// Read a PropertyMap and valid_from HybridTimestamp for version 1+ entries.
@@ -1420,7 +1488,7 @@ fn parse_create_node_op(
 ) -> Result<WalOperation> {
     let node_id = deserialize_node_id(buffer, *offset, "CreateNode")?;
     advance(offset, 8)?;
-    let label = read_label(buffer, offset, "CreateNode label")?;
+    let label = read_label(buffer, offset, version, "CreateNode label")?;
     let (properties, valid_from) =
         read_props_and_valid_from(buffer, offset, version, tx_timestamp)?;
     let provenance = read_provenance(buffer, offset, version)?;
@@ -1445,7 +1513,7 @@ fn parse_create_edge_op(
     advance(offset, 8)?;
     let target = deserialize_node_id(buffer, *offset, "CreateEdge target")?;
     advance(offset, 8)?;
-    let label = read_label(buffer, offset, "CreateEdge label")?;
+    let label = read_label(buffer, offset, version, "CreateEdge label")?;
     let (properties, valid_from) =
         read_props_and_valid_from(buffer, offset, version, tx_timestamp)?;
     let provenance = read_provenance(buffer, offset, version)?;
@@ -1471,7 +1539,7 @@ fn parse_update_node_op(
     let version_id = deserialize_version_id(buffer, *offset, "UpdateNode")?;
     advance(offset, 8)?;
     let (label, properties, valid_from) = if version >= WAL_VERSION {
-        let label = read_label(buffer, offset, "UpdateNode label")?;
+        let label = read_label(buffer, offset, version, "UpdateNode label")?;
         let (props, valid_from) = read_props_and_valid_from(buffer, offset, version, tx_timestamp)?;
         (label, props, valid_from)
     } else {
@@ -1501,14 +1569,21 @@ fn parse_update_edge_op(
     // Upfront check is required: for V1 it pre-validates EdgeId+VersionId+LabelId (20 bytes)
     // as a unit, producing the "UpdateEdge" error message that tests assert on.
     // Removing it would shift the failure to read_label with a different message.
-    let required = if version >= WAL_VERSION { 20 } else { 16 };
+    // For v13+ (Issue #3506) the label is a variable-width UTF-8 string, so the
+    // fixed 4-byte label slot no longer exists — pre-validate only the fixed
+    // EdgeId+VersionId (16 bytes) and let read_label validate the label bytes.
+    let required = if version >= WAL_VERSION && !carries_string_labels(version) {
+        20
+    } else {
+        16
+    };
     require_bytes(buffer, *offset, required, "UpdateEdge")?;
     let edge_id = deserialize_edge_id(buffer, *offset, "UpdateEdge")?;
     advance(offset, 8)?;
     let version_id = deserialize_version_id(buffer, *offset, "UpdateEdge")?;
     advance(offset, 8)?;
     let (label, properties, valid_from) = if version >= WAL_VERSION {
-        let label = read_label(buffer, offset, "UpdateEdge label")?;
+        let label = read_label(buffer, offset, version, "UpdateEdge label")?;
         let (props, valid_from) = read_props_and_valid_from(buffer, offset, version, tx_timestamp)?;
         (label, props, valid_from)
     } else {
@@ -1787,13 +1862,18 @@ pub(crate) fn parse_entry_at(
         OP_RETRACT_EDGE => parse_retract_edge_op(buffer, &mut cur, version)?,
         OP_CHECKPOINT => parse_checkpoint_op(buffer, &mut cur)?,
         OP_DECLARE_UNIQUE_CONSTRAINT => {
-            let label = read_label(buffer, &mut cur, "DeclareUniqueConstraint.label")?;
-            let property = read_label(buffer, &mut cur, "DeclareUniqueConstraint.property")?;
+            let label = read_label(buffer, &mut cur, version, "DeclareUniqueConstraint.label")?;
+            let property = read_label(
+                buffer,
+                &mut cur,
+                version,
+                "DeclareUniqueConstraint.property",
+            )?;
             WalOperation::DeclareUniqueConstraint { label, property }
         }
         OP_DROP_UNIQUE_CONSTRAINT => {
-            let label = read_label(buffer, &mut cur, "DropUniqueConstraint.label")?;
-            let property = read_label(buffer, &mut cur, "DropUniqueConstraint.property")?;
+            let label = read_label(buffer, &mut cur, version, "DropUniqueConstraint.label")?;
+            let property = read_label(buffer, &mut cur, version, "DropUniqueConstraint.property")?;
             WalOperation::DropUniqueConstraint { label, property }
         }
         OP_BEGIN_TX => parse_begin_tx_op(buffer, &mut cur)?,
@@ -1948,16 +2028,31 @@ mod tests {
     /// `framed == false`, keeping them on the legacy immediate-apply path.
     #[test]
     fn test_pre_framing_version_not_flagged_framed() {
-        let op = WalOperation::CreateNode {
-            node_id: NodeId::new(1).unwrap(),
-            label: GLOBAL_INTERNER.intern("Legacy").unwrap(),
-            properties: PropertyMap::new(),
-            valid_from: time::now(),
-            provenance: None,
-        };
-        let entry = WalEntry::new(LSN(1), op);
+        use crate::storage::wal::serialization::OP_CREATE_NODE;
+        // Hand-build a genuine v6 (pre-framing) CreateNode carrying a RAW 4-byte
+        // interner-id label — the pre-#3506 label encoding. The modern
+        // serializer writes string labels only at v13+, so we cannot use it to
+        // produce a v6-parseable entry; the framing flag under test is a pure
+        // function of the segment version, independent of the label codec.
+        let label = GLOBAL_INTERNER.intern("Legacy").unwrap();
+        let node_id = NodeId::new(1).unwrap();
+        let valid_from = time::now();
         let mut buffer = Vec::new();
-        serialize_entry_into(&entry, &mut buffer).unwrap();
+        buffer.extend_from_slice(&LSN(1).0.to_le_bytes());
+        valid_from.serialize_into(&mut buffer);
+        let cs = buffer.len();
+        buffer.extend_from_slice(&[0u8; 4]);
+        buffer.push(OP_CREATE_NODE);
+        buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
+        buffer.extend_from_slice(&label.as_u32().to_le_bytes()); // raw id label
+        PropertyMap::new().serialize_into(&mut buffer).unwrap();
+        valid_from.serialize_into(&mut buffer);
+        buffer.push(0u8); // provenance: absent (v6 blob presence byte)
+        let mut h = crc32fast::Hasher::new();
+        h.update(&buffer[0..20]);
+        h.update(&buffer[cs + 4..]);
+        buffer[cs..cs + 4].copy_from_slice(&h.finalize().to_le_bytes());
+
         let (parsed, _) = parse_entry_at(&buffer, 0, WAL_VERSION_PROVENANCE_PRINCIPAL).unwrap();
         assert!(
             !parsed.framed,
@@ -1998,7 +2093,7 @@ mod tests {
             let segment_path = dir.path().join(format!("{}.log", seg_id));
             let mut file = File::create(&segment_path).unwrap();
             file.write_all(&WAL_MAGIC).unwrap();
-            file.write_all(&[WAL_VERSION_PROVENANCE]).unwrap();
+            file.write_all(&[WAL_VERSION_STRING_LABELS]).unwrap();
             for lsn in *lsns {
                 let operation = WalOperation::CreateNode {
                     node_id: NodeId::new(*lsn).unwrap(),
@@ -2029,7 +2124,7 @@ mod tests {
         use std::io::Write;
         let mut file = File::create(path).unwrap();
         file.write_all(&WAL_MAGIC).unwrap();
-        file.write_all(&[WAL_VERSION_PROVENANCE]).unwrap();
+        file.write_all(&[WAL_VERSION_STRING_LABELS]).unwrap();
         let mut last_entry_bytes = Vec::new();
         for lsn in lsns {
             let operation = WalOperation::CreateNode {
@@ -2356,7 +2451,7 @@ mod tests {
         use std::io::Write;
         let mut file = File::create(path).unwrap();
         file.write_all(&WAL_MAGIC).unwrap();
-        file.write_all(&[WAL_VERSION_ENCRYPTED_DELETE_VERSION_ID])
+        file.write_all(&[WAL_VERSION_ENCRYPTED_STRING_LABELS])
             .unwrap();
         file.sync_all().unwrap();
     }
@@ -2527,7 +2622,7 @@ mod tests {
         // payload shape now (Issue #3224), so parsing must use the matching
         // version to consume the same bytes that were written.
         let (parsed_entry, bytes_consumed) =
-            parse_entry_at(&buffer, 0, WAL_VERSION_PROVENANCE).unwrap();
+            parse_entry_at(&buffer, 0, WAL_VERSION_STRING_LABELS).unwrap();
 
         // Verify
         assert_eq!(parsed_entry.lsn, LSN(1));
@@ -2572,7 +2667,7 @@ mod tests {
         serialize_entry_into(&entry, &mut buffer).unwrap();
 
         let (parsed_entry, bytes_consumed) =
-            parse_entry_at(&buffer, 0, WAL_VERSION_PROVENANCE_PRINCIPAL).unwrap();
+            parse_entry_at(&buffer, 0, WAL_VERSION_STRING_LABELS).unwrap();
 
         assert_eq!(parsed_entry.lsn, LSN(5));
         assert_eq!(bytes_consumed, buffer.len());
@@ -2593,32 +2688,40 @@ mod tests {
     /// their own payload version with `principal: None`.
     #[test]
     fn test_parse_pre_v5_provenance_bytes_yields_no_principal() {
-        // Build genuine v3-format bytes. Start from the current (v5)
-        // serializer with `principal: None` -- whose only difference from
-        // v3 is a single trailing absent-principal presence byte -- drop
-        // that byte, and re-stamp the CRC (bytes 20..24, computed over
-        // LSN+timestamp and the operation data).
-        let operation = WalOperation::CreateNode {
-            node_id: NodeId::new(9).unwrap(),
-            label: GLOBAL_INTERNER.intern("Doc").unwrap(),
-            properties: PropertyMap::new(),
-            valid_from: time::now(),
-            provenance: Some(Provenance::builder().source("importer").build().unwrap()),
-        };
-        let entry = WalEntry::new(LSN(9), operation);
+        // Hand-build genuine v3-format bytes: a CreateNode with a RAW 4-byte
+        // interner-id label (the pre-#3506 encoding) and a v3 provenance
+        // bundle that ends at `correlation_id` (no principal slot). The modern
+        // serializer writes string labels + a principal slot (v13), so we
+        // assemble the v3 shape by hand and stamp its CRC.
+        use crate::storage::wal::serialization::OP_CREATE_NODE;
+        let label = GLOBAL_INTERNER.intern("Doc").unwrap();
+        let node_id = NodeId::new(9).unwrap();
+        let valid_from = time::now();
         let mut buffer = Vec::new();
-        serialize_entry_into(&entry, &mut buffer).unwrap();
-        assert_eq!(
-            *buffer.last().unwrap(),
-            0,
-            "v5 buffer must end with the absent-principal presence byte"
-        );
-        buffer.pop(); // v3 bundles end at correlation_id
+        buffer.extend_from_slice(&LSN(9).0.to_le_bytes());
+        valid_from.serialize_into(&mut buffer);
+        let cs = buffer.len();
+        buffer.extend_from_slice(&[0u8; 4]);
+        buffer.push(OP_CREATE_NODE);
+        buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
+        buffer.extend_from_slice(&label.as_u32().to_le_bytes()); // raw id label
+        PropertyMap::new().serialize_into(&mut buffer).unwrap();
+        valid_from.serialize_into(&mut buffer);
+        // v3 provenance blob: presence(1) + source("importer") + confidence(absent)
+        // + note(absent) + correlation_id(absent). NO trailing principal slot.
+        buffer.push(1); // provenance present
+        let src = b"importer";
+        buffer.push(1); // source present
+        buffer.extend_from_slice(&(src.len() as u32).to_le_bytes());
+        buffer.extend_from_slice(src);
+        buffer.push(0); // confidence absent
+        buffer.push(0); // note absent
+        buffer.push(0); // correlation_id absent
         let mut hasher = crc32fast::Hasher::new();
         hasher.update(&buffer[0..20]);
-        hasher.update(&buffer[24..]);
+        hasher.update(&buffer[cs + 4..]);
         let checksum = hasher.finalize();
-        buffer[20..24].copy_from_slice(&checksum.to_le_bytes());
+        buffer[cs..cs + 4].copy_from_slice(&checksum.to_le_bytes());
 
         let (parsed_entry, bytes_consumed) =
             parse_entry_at(&buffer, 0, WAL_VERSION_PROVENANCE).unwrap();
@@ -2663,7 +2766,7 @@ mod tests {
         // payload shape now (Issue #3224), so parsing must use the matching
         // version to consume the same bytes that were written.
         let (parsed_entry, bytes_consumed) =
-            parse_entry_at(&buffer, 0, WAL_VERSION_PROVENANCE).unwrap();
+            parse_entry_at(&buffer, 0, WAL_VERSION_STRING_LABELS).unwrap();
 
         // Verify
         assert_eq!(parsed_entry.lsn, LSN(2));
@@ -3371,7 +3474,7 @@ mod tests {
         // payload shape now (Issue #3224), so parsing must use the matching
         // version to consume the same bytes that were written.
         let (parsed_entry, bytes_consumed) =
-            parse_entry_at(&buffer, 0, WAL_VERSION_PROVENANCE).unwrap();
+            parse_entry_at(&buffer, 0, WAL_VERSION_STRING_LABELS).unwrap();
 
         // Verify
         assert_eq!(parsed_entry.lsn, LSN(3));
@@ -3414,7 +3517,7 @@ mod tests {
         // payload shape now (Issue #3224), so parsing must use the matching
         // version to consume the same bytes that were written.
         let (parsed_entry, bytes_consumed) =
-            parse_entry_at(&buffer, 0, WAL_VERSION_PROVENANCE).unwrap();
+            parse_entry_at(&buffer, 0, WAL_VERSION_STRING_LABELS).unwrap();
 
         // Verify
         assert_eq!(parsed_entry.lsn, LSN(4));
@@ -3595,7 +3698,7 @@ mod tests {
         // provenance-carrying payload shape now (Issue #3224), so parsing
         // must use the matching version to consume the same bytes written.
         let (parsed_entry, bytes_consumed) =
-            parse_entry_at(&buffer, offset1_end, WAL_VERSION_PROVENANCE).unwrap();
+            parse_entry_at(&buffer, offset1_end, WAL_VERSION_STRING_LABELS).unwrap();
 
         // Verify
         assert_eq!(parsed_entry.lsn, LSN(2));
@@ -3748,8 +3851,10 @@ mod tests {
         // Corrupt the checksum (bytes 20-24)
         buffer[20] ^= 0xFF; // Flip all bits in first checksum byte
 
-        // Should return error for checksum mismatch
-        let result = parse_entry_at(&buffer, 0, WAL_VERSION);
+        // Should return error for checksum mismatch. Parse at the version the
+        // serializer stamps (v13 string labels) so the op parses cleanly and
+        // the failure is the corrupted checksum, not a label-misalignment.
+        let result = parse_entry_at(&buffer, 0, WAL_VERSION_STRING_LABELS);
         assert!(result.is_err());
         if let Err(e) = result {
             let error_msg = format!("{}", e);
@@ -3868,7 +3973,7 @@ mod tests {
         // (always-provenance-carrying) format, so the header must declare
         // WAL_VERSION_PROVENANCE for the reader to parse them correctly.
         file.write_all(&WAL_MAGIC).unwrap();
-        file.write_all(&[WAL_VERSION_PROVENANCE]).unwrap();
+        file.write_all(&[WAL_VERSION_STRING_LABELS]).unwrap();
 
         // Create and write many entries to simulate a large segment
         // We'll create 1000 entries, which should be several MB
@@ -3929,7 +4034,7 @@ mod tests {
             // declare WAL_VERSION_PROVENANCE for the reader to parse them
             // correctly.
             file.write_all(&WAL_MAGIC).unwrap();
-            file.write_all(&[WAL_VERSION_PROVENANCE]).unwrap();
+            file.write_all(&[WAL_VERSION_STRING_LABELS]).unwrap();
 
             // Write entries for this segment
             for i in 0..entries_per_segment {
@@ -3983,7 +4088,7 @@ mod tests {
         // (always-provenance-carrying) format, so the header must declare
         // WAL_VERSION_PROVENANCE for the reader to parse them correctly.
         file.write_all(&WAL_MAGIC).unwrap();
-        file.write_all(&[WAL_VERSION_PROVENANCE]).unwrap();
+        file.write_all(&[WAL_VERSION_STRING_LABELS]).unwrap();
 
         // Write 100 entries with LSN 1-100
         for i in 1..=100 {
@@ -4061,7 +4166,7 @@ mod tests {
         // (always-provenance-carrying) format, so the header must declare
         // WAL_VERSION_PROVENANCE for the reader to parse it correctly.
         file.write_all(&WAL_MAGIC).unwrap();
-        file.write_all(&[WAL_VERSION_PROVENANCE]).unwrap();
+        file.write_all(&[WAL_VERSION_STRING_LABELS]).unwrap();
 
         // Write one complete entry
         let operation = WalOperation::CreateNode {
@@ -4667,6 +4772,9 @@ mod fuzz_tests {
 #[cfg(test)]
 mod sentry_tests {
     use super::*;
+    use crate::core::interning::GLOBAL_INTERNER;
+    use crate::core::temporal::time;
+    use crate::storage::wal::serialization::serialize_entry_into;
     use std::fs::File;
     use std::io::Write;
     use tempfile::TempDir;
@@ -4792,5 +4900,274 @@ mod sentry_tests {
             "⚡ Bolt: Vector should be pre-allocated with capacity based on file size. Capacity was {}",
             entries.capacity()
         );
+    }
+
+    // =====================================================================
+    // Issue #3506 — labels serialized as UTF-8 + re-interned on read (v13/v14)
+    // =====================================================================
+
+    /// T1: every label-bearing operation round-trips its label STRING through a
+    /// v13 serialize → parse. The parsed label must resolve to the original
+    /// string.
+    #[test]
+    fn v13_roundtrip_preserves_all_labels() {
+        use crate::core::id::VersionId;
+        use crate::core::property::PropertyMap;
+        use crate::core::{EdgeId, NodeId};
+
+        let node_label = GLOBAL_INTERNER.intern("PersonV13").unwrap();
+        let edge_label = GLOBAL_INTERNER.intern("KNOWS_V13").unwrap();
+        let c_label = GLOBAL_INTERNER.intern("CustomerV13").unwrap();
+        let c_prop = GLOBAL_INTERNER.intern("emailV13").unwrap();
+
+        let ops = vec![
+            WalOperation::CreateNode {
+                node_id: NodeId::new(1).unwrap(),
+                label: node_label,
+                properties: PropertyMap::new(),
+                valid_from: time::now(),
+                provenance: None,
+            },
+            WalOperation::CreateEdge {
+                edge_id: EdgeId::new(1).unwrap(),
+                source: NodeId::new(1).unwrap(),
+                target: NodeId::new(2).unwrap(),
+                label: edge_label,
+                properties: PropertyMap::new(),
+                valid_from: time::now(),
+                provenance: None,
+            },
+            WalOperation::UpdateNode {
+                node_id: NodeId::new(1).unwrap(),
+                version_id: VersionId::new(1).unwrap(),
+                label: node_label,
+                properties: PropertyMap::new(),
+                valid_from: time::now(),
+                provenance: None,
+            },
+            WalOperation::UpdateEdge {
+                edge_id: EdgeId::new(1).unwrap(),
+                version_id: VersionId::new(1).unwrap(),
+                label: edge_label,
+                properties: PropertyMap::new(),
+                valid_from: time::now(),
+                provenance: None,
+            },
+            WalOperation::DeclareUniqueConstraint {
+                label: c_label,
+                property: c_prop,
+            },
+            WalOperation::DropUniqueConstraint {
+                label: c_label,
+                property: c_prop,
+            },
+        ];
+
+        for op in ops {
+            let entry = WalEntry::new(LSN(1), op.clone());
+            let mut buffer = Vec::new();
+            serialize_entry_into(&entry, &mut buffer).unwrap();
+            let (parsed, consumed) = parse_entry_at(&buffer, 0, WAL_VERSION_STRING_LABELS).unwrap();
+            assert_eq!(consumed, buffer.len(), "must consume whole entry: {op:?}");
+
+            let (got_label, got_extra) = match parsed.operation {
+                WalOperation::CreateNode { label, .. } | WalOperation::UpdateNode { label, .. } => {
+                    (label, None)
+                }
+                WalOperation::CreateEdge { label, .. } | WalOperation::UpdateEdge { label, .. } => {
+                    (label, None)
+                }
+                WalOperation::DeclareUniqueConstraint { label, property }
+                | WalOperation::DropUniqueConstraint { label, property } => (label, Some(property)),
+                other => panic!("unexpected parsed op: {other:?}"),
+            };
+            let expected_label = match &op {
+                WalOperation::CreateNode { label, .. }
+                | WalOperation::UpdateNode { label, .. }
+                | WalOperation::CreateEdge { label, .. }
+                | WalOperation::UpdateEdge { label, .. }
+                | WalOperation::DeclareUniqueConstraint { label, .. }
+                | WalOperation::DropUniqueConstraint { label, .. } => *label,
+                other => panic!("unexpected op: {other:?}"),
+            };
+            // The re-interned label resolves to the same string, hence the same
+            // id in this append-only process interner.
+            let resolve = |s| GLOBAL_INTERNER.resolve_with(s, |v| v.to_owned());
+            assert_eq!(
+                resolve(got_label),
+                resolve(expected_label),
+                "label string must round-trip for {op:?}"
+            );
+            if let Some(p) = got_extra {
+                assert_eq!(
+                    resolve(p),
+                    resolve(c_prop),
+                    "constraint property string must round-trip"
+                );
+            }
+        }
+    }
+
+    /// A v13 buffer (variable-width UTF-8 label) must NOT parse at a ≤v12
+    /// version: the old raw-id decoder reads the label's 4-byte length prefix
+    /// as an id and misaligns the rest, so the entry checksum fails. This
+    /// proves the on-disk format genuinely changed at v13 (not a silent
+    /// same-bytes overlap).
+    #[test]
+    fn v13_buffer_rejected_at_v12() {
+        use crate::core::NodeId;
+        use crate::core::property::PropertyMap;
+
+        // A label whose UTF-8 length is large enough that the raw-id
+        // misinterpretation shifts the parse.
+        let op = WalOperation::CreateNode {
+            node_id: NodeId::new(7).unwrap(),
+            label: GLOBAL_INTERNER.intern("SufficientlyLongLabel3506").unwrap(),
+            properties: PropertyMap::new(),
+            valid_from: time::now(),
+            provenance: None,
+        };
+        let entry = WalEntry::new(LSN(3), op);
+        let mut buffer = Vec::new();
+        serialize_entry_into(&entry, &mut buffer).unwrap();
+
+        // Correct at v13.
+        assert!(parse_entry_at(&buffer, 0, WAL_VERSION_STRING_LABELS).is_ok());
+        // Misparsed / checksum failure at v12 (encrypted-container payload maps
+        // to v11 raw-id decode).
+        assert!(
+            parse_entry_at(&buffer, 0, WAL_VERSION_DESTRUCTIVE_PROVENANCE).is_err(),
+            "a v13 string-label buffer must not silently parse at v11 (raw id)"
+        );
+    }
+
+    /// T2: a hand-built ≤v12 (v11) CreateNode with a RAW 4-byte interner-id
+    /// label must still parse via the `from_raw` path — the identity-layout
+    /// backward-compat contract. Bytes are fully consumed, no over-read.
+    #[test]
+    fn v11_raw_id_label_still_parses() {
+        use crate::core::NodeId;
+        use crate::core::property::PropertyMap;
+        use crate::storage::wal::serialization::OP_CREATE_NODE;
+
+        let label = GLOBAL_INTERNER.intern("LegacyRawLabel3506").unwrap();
+        let node_id = NodeId::new(11).unwrap();
+        let valid_from = time::now();
+
+        // Assemble a v11-shaped entry by hand: the label is a raw 4-byte id
+        // (the pre-#3506 encoding), everything else identical to the current
+        // create-node payload (props, valid_from, absent-provenance byte).
+        let mut buffer = Vec::new();
+        buffer.extend_from_slice(&LSN(9).0.to_le_bytes()); // LSN (8)
+        valid_from.serialize_into(&mut buffer); // entry timestamp (12)
+        let checksum_offset = buffer.len();
+        buffer.extend_from_slice(&[0u8; 4]); // checksum placeholder (4)
+
+        // Payload:
+        buffer.push(OP_CREATE_NODE);
+        buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
+        buffer.extend_from_slice(&label.as_u32().to_le_bytes()); // RAW id label
+        PropertyMap::new().serialize_into(&mut buffer).unwrap();
+        valid_from.serialize_into(&mut buffer);
+        buffer.push(0u8); // provenance: absent (v11 blob)
+
+        // CRC over LSN+timestamp (bytes 0..20) + payload (bytes 24..).
+        let mut hasher = crc32fast::Hasher::new();
+        hasher.update(&buffer[0..20]);
+        hasher.update(&buffer[checksum_offset + 4..]);
+        let checksum = hasher.finalize();
+        buffer[checksum_offset..checksum_offset + 4].copy_from_slice(&checksum.to_le_bytes());
+
+        let (parsed, consumed) =
+            parse_entry_at(&buffer, 0, WAL_VERSION_DESTRUCTIVE_PROVENANCE).unwrap();
+        assert_eq!(
+            consumed,
+            buffer.len(),
+            "v11 buffer fully consumed, no over-read"
+        );
+        match parsed.operation {
+            WalOperation::CreateNode { label: got, .. } => {
+                // raw-id path: the decoded label is the same raw id, which in
+                // this identity-layout process resolves to the original string.
+                assert_eq!(got.as_u32(), label.as_u32());
+                assert_eq!(
+                    GLOBAL_INTERNER.resolve_with(got, |v| v.to_owned()),
+                    GLOBAL_INTERNER.resolve_with(label, |v| v.to_owned())
+                );
+            }
+            other => panic!("expected CreateNode, got {other:?}"),
+        }
+    }
+
+    /// T4: a mixed-version WAL directory (one v11 raw-id segment + one v13
+    /// string-label segment) replays correctly together — each segment header
+    /// carries its own version, threaded independently into every parse.
+    #[test]
+    fn mixed_version_segments_replay_together() {
+        use crate::core::NodeId;
+        use crate::core::property::PropertyMap;
+
+        let dir = TempDir::new().unwrap();
+
+        // --- Segment 1: v13 (string labels), written via the real serializer. ---
+        let op_new = WalOperation::CreateNode {
+            node_id: NodeId::new(100).unwrap(),
+            label: GLOBAL_INTERNER.intern("NewSegLabel3506").unwrap(),
+            properties: PropertyMap::new(),
+            valid_from: time::now(),
+            provenance: None,
+        };
+        let mut seg1 = Vec::new();
+        seg1.extend_from_slice(&WAL_MAGIC);
+        seg1.push(WAL_VERSION_STRING_LABELS);
+        let entry_new = WalEntry::new(LSN(2), op_new);
+        let mut body = Vec::new();
+        serialize_entry_into(&entry_new, &mut body).unwrap();
+        seg1.extend_from_slice(&body);
+        let mut f1 = std::fs::File::create(dir.path().join("000001.log")).unwrap();
+        f1.write_all(&seg1).unwrap();
+        f1.sync_all().unwrap();
+
+        // --- Segment 2: v11 (raw id label), hand-built. ---
+        let label_old = GLOBAL_INTERNER.intern("OldSegLabel3506").unwrap();
+        let node_old = NodeId::new(50).unwrap();
+        let valid_from = time::now();
+        let mut seg2 = Vec::new();
+        seg2.extend_from_slice(&WAL_MAGIC);
+        seg2.push(WAL_VERSION_DESTRUCTIVE_PROVENANCE);
+        let mut entry = Vec::new();
+        entry.extend_from_slice(&LSN(1).0.to_le_bytes());
+        valid_from.serialize_into(&mut entry);
+        let cs_off = entry.len();
+        entry.extend_from_slice(&[0u8; 4]);
+        entry.push(crate::storage::wal::serialization::OP_CREATE_NODE);
+        entry.extend_from_slice(&node_old.as_u64().to_le_bytes());
+        entry.extend_from_slice(&label_old.as_u32().to_le_bytes());
+        PropertyMap::new().serialize_into(&mut entry).unwrap();
+        valid_from.serialize_into(&mut entry);
+        entry.push(0u8);
+        let mut h = crc32fast::Hasher::new();
+        h.update(&entry[0..20]);
+        h.update(&entry[cs_off + 4..]);
+        entry[cs_off..cs_off + 4].copy_from_slice(&h.finalize().to_le_bytes());
+        seg2.extend_from_slice(&entry);
+        let mut f2 = std::fs::File::create(dir.path().join("000002.log")).unwrap();
+        f2.write_all(&seg2).unwrap();
+        f2.sync_all().unwrap();
+
+        let entries = read_entries_from_dir(dir.path(), LSN(0)).unwrap();
+        assert_eq!(entries.len(), 2, "both segments must replay");
+
+        let mut labels: Vec<String> = entries
+            .iter()
+            .map(|e| match &e.operation {
+                WalOperation::CreateNode { label, .. } => GLOBAL_INTERNER
+                    .resolve_with(*label, |v| v.to_string())
+                    .unwrap(),
+                other => panic!("unexpected op: {other:?}"),
+            })
+            .collect();
+        labels.sort();
+        assert_eq!(labels, vec!["NewSegLabel3506", "OldSegLabel3506"]);
     }
 }

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -1987,6 +1987,90 @@ mod tests {
         assert!(entries.is_empty());
     }
 
+    /// Issue #3506 (review) — the load-bearing corruption-proof test. Under a
+    /// deliberately NON-IDENTITY interner layout, the pre-#3506 raw-id label
+    /// encoding decodes a `CreateNode` label to the WRONG string, while the v13
+    /// string-label encoding decodes it to the RIGHT string. This is the test
+    /// that would FAIL on the pre-#3506 raw-id decode and PASSES with the string
+    /// decode — unlike the WAL-only reopen smoke test in
+    /// `tests/wal_string_labels_recovery.rs`, which passes on both codecs because
+    /// the process-global interner never reassigns ids in-process.
+    #[test]
+    fn raw_id_decode_corrupts_under_nonidentity_layout_string_decode_does_not() {
+        use crate::storage::wal::serialization::OP_CREATE_NODE;
+
+        // The foreign writer's raw id for "PersonTarget3506" happens to mean
+        // "DecoyMeaning3506" in THIS process's interner layout (non-identity):
+        // we store `decoy`'s id as the raw-id label, standing in for a foreign
+        // id whose numeric value resolves to a different string in this process.
+        let target = GLOBAL_INTERNER.intern("PersonTarget3506").unwrap();
+        let decoy = GLOBAL_INTERNER.intern("DecoyMeaning3506").unwrap();
+        assert_ne!(target.as_u32(), decoy.as_u32());
+
+        let node_id = NodeId::new(3506).unwrap();
+        let valid_from = time::now();
+
+        // Build a CreateNode entry whose label portion is written by `write_label`;
+        // the surrounding framing (header, node id, props, valid_from, provenance,
+        // CRC) is identical to a real entry. Only the label codec differs between
+        // the two variants below.
+        let build_entry = |write_label: &dyn Fn(&mut Vec<u8>)| -> Vec<u8> {
+            let mut buffer = Vec::new();
+            buffer.extend_from_slice(&LSN(3506).0.to_le_bytes());
+            valid_from.serialize_into(&mut buffer);
+            let cs = buffer.len();
+            buffer.extend_from_slice(&[0u8; 4]); // checksum placeholder
+            buffer.push(OP_CREATE_NODE);
+            buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
+            write_label(&mut buffer);
+            PropertyMap::new().serialize_into(&mut buffer).unwrap();
+            valid_from.serialize_into(&mut buffer);
+            buffer.push(0u8); // provenance: absent
+            let mut h = crc32fast::Hasher::new();
+            h.update(&buffer[0..20]);
+            h.update(&buffer[cs + 4..]);
+            buffer[cs..cs + 4].copy_from_slice(&h.finalize().to_le_bytes());
+            buffer
+        };
+
+        // ---- Old format (v11 raw id): stores decoy's raw id as the label. ----
+        let old = build_entry(&|buf| buf.extend_from_slice(&decoy.as_u32().to_le_bytes()));
+        let (old_entry, _) = parse_entry_at(&old, 0, WAL_VERSION_DESTRUCTIVE_PROVENANCE).unwrap();
+        let old_label = match old_entry.operation {
+            WalOperation::CreateNode { label, .. } => label,
+            other => panic!("expected CreateNode, got {other:?}"),
+        };
+        // THE BUG: the raw-id decode resolves to the DECOY string, not the
+        // intended target — the corruption the raw-id encoding caused under a
+        // non-identity interner layout.
+        assert!(
+            GLOBAL_INTERNER
+                .resolve_with(old_label, |s| s == "DecoyMeaning3506")
+                .unwrap(),
+            "pre-#3506 raw-id decode must corrupt the label to \"DecoyMeaning3506\""
+        );
+
+        // ---- New format (v13 string): stores the STRING "PersonTarget3506". ----
+        let new = build_entry(&|buf| {
+            let bytes = "PersonTarget3506".as_bytes();
+            buf.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+            buf.extend_from_slice(bytes);
+        });
+        let (new_entry, _) = parse_entry_at(&new, 0, WAL_VERSION_STRING_LABELS).unwrap();
+        let new_label = match new_entry.operation {
+            WalOperation::CreateNode { label, .. } => label,
+            other => panic!("expected CreateNode, got {other:?}"),
+        };
+        // THE FIX: the string decode re-interns and resolves to the intended
+        // target string under ANY interner layout.
+        assert!(
+            GLOBAL_INTERNER
+                .resolve_with(new_label, |s| s == "PersonTarget3506")
+                .unwrap(),
+            "v13 string decode must recover the correct label \"PersonTarget3506\""
+        );
+    }
+
     /// Issue #3413: `CommitTx` serializes and parses back byte-for-byte under
     /// the transaction-framing version, and the parsed entry is flagged
     /// `framed`.
@@ -2472,6 +2556,21 @@ mod tests {
             .expect("encrypted final-segment torn tail must be tolerated");
         let lsns: Vec<u64> = entries.iter().map(|e| e.lsn.0).collect();
         assert_eq!(lsns, vec![5, 7]);
+
+        // Issue #3506: the decrypted v14 (encrypted string-label) entries must
+        // recover their label STRING, not just their LSNs — the string-label
+        // survival across the encrypted decode path is asserted explicitly.
+        for entry in &entries {
+            match &entry.operation {
+                WalOperation::CreateNode { label, .. } => assert!(
+                    GLOBAL_INTERNER
+                        .resolve_with(*label, |s| s == "TornTail3433")
+                        .unwrap(),
+                    "decrypted v14 CreateNode label must resolve to \"TornTail3433\""
+                ),
+                other => panic!("expected CreateNode, got {other:?}"),
+            }
+        }
     }
 
     /// #3433 must-hard-error (b): in an encrypted final segment, an undecodable

--- a/src/storage/wal/serialization.rs
+++ b/src/storage/wal/serialization.rs
@@ -1096,6 +1096,70 @@ mod tests {
             );
         }
     }
+
+    /// Issue #3506 — write-side corruption guard: serializing a label whose
+    /// interner id does not resolve (a foreign / dangling `InternedString`) must
+    /// fail with a structured `InconsistentState` error naming the offending id,
+    /// rather than silently emitting a garbage label into the WAL.
+    #[test]
+    fn serialize_operation_rejects_unresolvable_label() {
+        // A raw id far beyond anything the process-global interner has allocated;
+        // `resolve_with` returns `None`, driving `serialize_label_str`'s error arm.
+        let bogus = InternedString::from_raw(u32::MAX);
+        let op = WalOperation::CreateNode {
+            node_id: NodeId::new(1).unwrap(),
+            label: bogus,
+            properties: PropertyMapBuilder::new().build(),
+            valid_from: test_timestamp(),
+            provenance: None,
+        };
+        let mut buffer = Vec::new();
+        let err = serialize_operation_into(LSN(1), test_timestamp(), &op, &mut buffer)
+            .expect_err("unresolvable label must fail serialization");
+        match err {
+            crate::core::error::Error::Storage(
+                crate::core::error::StorageError::InconsistentState { reason },
+            ) => {
+                assert!(
+                    reason.contains("not found in interner")
+                        && reason.contains(&u32::MAX.to_string()),
+                    "unexpected InconsistentState reason: {reason}"
+                );
+            }
+            other => panic!("expected InconsistentState, got {other:?}"),
+        }
+    }
+
+    /// Issue #3506 — the constraint ops carry two labels; an unresolvable
+    /// *property* id (second label slot) must also surface the write-side
+    /// `InconsistentState` guard, and `label_serialized_size` must fall back to
+    /// its `4` length-prefix estimate for such an id without panicking.
+    #[test]
+    fn serialize_constraint_rejects_unresolvable_property_and_size_falls_back() {
+        let good_label = GLOBAL_INTERNER.intern("Cust3506Guard").unwrap();
+        let bogus_property = InternedString::from_raw(u32::MAX);
+
+        // label_serialized_size falls back to `4` (bare length prefix) for an
+        // unresolvable id — the pre-allocation hint must not panic.
+        assert_eq!(label_serialized_size(bogus_property), 4);
+
+        let op = WalOperation::DeclareUniqueConstraint {
+            label: good_label,
+            property: bogus_property,
+        };
+        let mut buffer = Vec::new();
+        let err = serialize_operation_into(LSN(1), test_timestamp(), &op, &mut buffer)
+            .expect_err("unresolvable constraint property must fail serialization");
+        assert!(
+            matches!(
+                err,
+                crate::core::error::Error::Storage(
+                    crate::core::error::StorageError::InconsistentState { .. }
+                )
+            ),
+            "expected InconsistentState, got {err:?}"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/storage/wal/serialization.rs
+++ b/src/storage/wal/serialization.rs
@@ -36,7 +36,7 @@ use super::entry::WalEntry;
 use super::entry::{LSN, WalOperation};
 use crate::core::error::Result;
 use crate::core::id::VersionId;
-use crate::core::interning::InternedString;
+use crate::core::interning::{GLOBAL_INTERNER, InternedString};
 use crate::core::provenance::Provenance;
 use crate::core::temporal::Timestamp;
 
@@ -68,10 +68,44 @@ pub(crate) const OP_COMMIT_TX: u8 = 12;
 /// or above `WAL_VERSION_TX_FRAMING`.
 pub(crate) const OP_BEGIN_TX: u8 = 13;
 
-/// Helper to serialize an InternedString into the buffer (4-byte ID)
-#[inline(always)]
-fn serialize_interned_string(s: InternedString, buffer: &mut Vec<u8>) {
-    buffer.extend_from_slice(&s.as_u32().to_le_bytes());
+/// Serialize a label as length-prefixed UTF-8: `[len: u32-LE][utf8 bytes]`
+/// (Issue #3506, WAL v13/v14).
+///
+/// Byte-identical to the property-key codec ([`crate::core::property::PropertyMap::serialize_into`]).
+/// Persisting the string itself (rather than a raw interner id) makes the label
+/// correct under ANY interner layout on replay: the reader re-interns it into
+/// the process-global interner instead of trusting a persisted id whose meaning
+/// is layout-relative. Returns [`StorageError::InconsistentState`] if the label
+/// cannot be resolved from the interner (data corruption).
+#[inline]
+fn serialize_label_str(s: InternedString, buffer: &mut Vec<u8>) -> Result<()> {
+    GLOBAL_INTERNER
+        .resolve_with(s, |label_str| {
+            let bytes = label_str.as_bytes();
+            buffer.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+            buffer.extend_from_slice(bytes);
+        })
+        .ok_or_else(|| {
+            crate::core::error::Error::Storage(
+                crate::core::error::StorageError::InconsistentState {
+                    reason: format!(
+                        "Label {} not found in interner - data corruption detected",
+                        s.as_u32()
+                    ),
+                },
+            )
+        })
+}
+
+/// Byte length of a label as serialized by [`serialize_label_str`]
+/// (`4` length prefix + UTF-8 bytes). Falls back to `4` for an unresolvable id
+/// (the write itself will error via [`serialize_label_str`]); this is only a
+/// pre-allocation hint, so an underestimate merely costs a `Vec` realloc.
+#[inline]
+fn label_serialized_size(s: InternedString) -> usize {
+    4 + GLOBAL_INTERNER
+        .resolve_with(s, |label_str| label_str.len())
+        .unwrap_or(0)
 }
 
 /// Serialize an optional tombstone/retraction `version_id` as a fixed 8-byte LE
@@ -238,39 +272,43 @@ pub(crate) fn estimate_entry_capacity(operation: &WalOperation) -> usize {
 
     let variable_size = match operation {
         WalOperation::CreateNode {
+            label,
             properties,
             provenance,
             ..
         } => {
-            // op type (1) + node_id (8) + label (4-byte InternedString ID) + properties + valid_from (12) + provenance
-            let base = 1 + 8 + 4 + TIMESTAMP_SIZE;
+            // op type (1) + node_id (8) + label ([len:4][utf8], #3506) + properties + valid_from (12) + provenance
+            let base = 1 + 8 + label_serialized_size(*label) + TIMESTAMP_SIZE;
             base + properties.serialized_size() + provenance_serialized_size(provenance.as_ref())
         }
         WalOperation::CreateEdge {
+            label,
             properties,
             provenance,
             ..
         } => {
-            // op type (1) + edge_id (8) + source (8) + target (8) + label (4-byte InternedString ID) + properties + valid_from (12) + provenance
-            let base = 1 + 8 + 8 + 8 + 4 + TIMESTAMP_SIZE;
+            // op type (1) + edge_id (8) + source (8) + target (8) + label ([len:4][utf8], #3506) + properties + valid_from (12) + provenance
+            let base = 1 + 8 + 8 + 8 + label_serialized_size(*label) + TIMESTAMP_SIZE;
             base + properties.serialized_size() + provenance_serialized_size(provenance.as_ref())
         }
         WalOperation::UpdateNode {
+            label,
             properties,
             provenance,
             ..
         } => {
-            // op type (1) + node_id (8) + version_id (8) + label (4-byte InternedString ID) + properties + valid_from (12) + provenance
-            let base = 1 + 8 + 8 + 4 + TIMESTAMP_SIZE;
+            // op type (1) + node_id (8) + version_id (8) + label ([len:4][utf8], #3506) + properties + valid_from (12) + provenance
+            let base = 1 + 8 + 8 + label_serialized_size(*label) + TIMESTAMP_SIZE;
             base + properties.serialized_size() + provenance_serialized_size(provenance.as_ref())
         }
         WalOperation::UpdateEdge {
+            label,
             properties,
             provenance,
             ..
         } => {
-            // op type (1) + edge_id (8) + version_id (8) + label (4-byte InternedString ID) + properties + valid_from (12) + provenance
-            let base = 1 + 8 + 8 + 4 + TIMESTAMP_SIZE;
+            // op type (1) + edge_id (8) + version_id (8) + label ([len:4][utf8], #3506) + properties + valid_from (12) + provenance
+            let base = 1 + 8 + 8 + label_serialized_size(*label) + TIMESTAMP_SIZE;
             base + properties.serialized_size() + provenance_serialized_size(provenance.as_ref())
         }
         WalOperation::DeleteNode { provenance, .. } => {
@@ -297,10 +335,10 @@ pub(crate) fn estimate_entry_capacity(operation: &WalOperation) -> usize {
             // op type (1) + lsn (8) + timestamp (12)
             1 + 8 + 12
         }
-        WalOperation::DeclareUniqueConstraint { .. }
-        | WalOperation::DropUniqueConstraint { .. } => {
-            // op type (1) + label (4) + property (4)
-            1 + 4 + 4
+        WalOperation::DeclareUniqueConstraint { label, property }
+        | WalOperation::DropUniqueConstraint { label, property } => {
+            // op type (1) + label ([len:4][utf8]) + property ([len:4][utf8], #3506)
+            1 + label_serialized_size(*label) + label_serialized_size(*property)
         }
         WalOperation::BeginTx { .. } => {
             // op type (1) + tx_id (8)
@@ -391,7 +429,7 @@ pub(crate) fn serialize_operation_into(
         } => {
             buffer.push(OP_CREATE_NODE);
             buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
-            serialize_interned_string(*label, buffer);
+            serialize_label_str(*label, buffer)?;
             properties.serialize_into(buffer)?;
             valid_from.serialize_into(buffer);
             serialize_provenance_into(provenance.as_ref(), buffer);
@@ -409,7 +447,7 @@ pub(crate) fn serialize_operation_into(
             buffer.extend_from_slice(&edge_id.as_u64().to_le_bytes());
             buffer.extend_from_slice(&source.as_u64().to_le_bytes());
             buffer.extend_from_slice(&target.as_u64().to_le_bytes());
-            serialize_interned_string(*label, buffer);
+            serialize_label_str(*label, buffer)?;
             properties.serialize_into(buffer)?;
             valid_from.serialize_into(buffer);
             serialize_provenance_into(provenance.as_ref(), buffer);
@@ -425,7 +463,7 @@ pub(crate) fn serialize_operation_into(
             buffer.push(OP_UPDATE_NODE);
             buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
             buffer.extend_from_slice(&version_id.as_u64().to_le_bytes());
-            serialize_interned_string(*label, buffer);
+            serialize_label_str(*label, buffer)?;
             properties.serialize_into(buffer)?;
             valid_from.serialize_into(buffer);
             serialize_provenance_into(provenance.as_ref(), buffer);
@@ -441,7 +479,7 @@ pub(crate) fn serialize_operation_into(
             buffer.push(OP_UPDATE_EDGE);
             buffer.extend_from_slice(&edge_id.as_u64().to_le_bytes());
             buffer.extend_from_slice(&version_id.as_u64().to_le_bytes());
-            serialize_interned_string(*label, buffer);
+            serialize_label_str(*label, buffer)?;
             properties.serialize_into(buffer)?;
             valid_from.serialize_into(buffer);
             serialize_provenance_into(provenance.as_ref(), buffer);
@@ -511,13 +549,13 @@ pub(crate) fn serialize_operation_into(
         }
         WalOperation::DeclareUniqueConstraint { label, property } => {
             buffer.push(OP_DECLARE_UNIQUE_CONSTRAINT);
-            serialize_interned_string(*label, buffer);
-            serialize_interned_string(*property, buffer);
+            serialize_label_str(*label, buffer)?;
+            serialize_label_str(*property, buffer)?;
         }
         WalOperation::DropUniqueConstraint { label, property } => {
             buffer.push(OP_DROP_UNIQUE_CONSTRAINT);
-            serialize_interned_string(*label, buffer);
-            serialize_interned_string(*property, buffer);
+            serialize_label_str(*label, buffer)?;
+            serialize_label_str(*property, buffer)?;
         }
         WalOperation::BeginTx { tx_id } => {
             buffer.push(OP_BEGIN_TX);
@@ -743,9 +781,10 @@ mod tests {
     fn test_estimate_capacity_create_node_empty_properties() {
         // CreateNode with empty properties, no provenance:
         // Fixed: 24 bytes (LSN + Timestamp + Checksum)
-        // op type (1) + node_id (8) + label (4-byte InternedString) + properties (4 for empty count)
-        // + valid_from (12) + provenance presence byte (1, absent)
-        // = 24 + 1 + 8 + 4 + 4 + 12 + 1 = 54 bytes
+        // op type (1) + node_id (8) + label ([len:4]["test":4] = 8, #3506)
+        // + properties (4 for empty count) + valid_from (12)
+        // + provenance presence byte (1, absent)
+        // = 24 + 1 + 8 + 8 + 4 + 12 + 1 = 58 bytes
         let op = WalOperation::CreateNode {
             node_id: NodeId::new(1).unwrap(),
             label: GLOBAL_INTERNER.intern("test").unwrap(),
@@ -756,8 +795,9 @@ mod tests {
 
         let estimated = estimate_entry_capacity(&op);
         assert_eq!(
-            estimated, 54,
-            "CreateNode with empty properties (no provenance) should be 54 bytes"
+            estimated, 58,
+            "CreateNode with empty properties (no provenance) should be 58 bytes \
+             (label is now length-prefixed UTF-8, #3506)"
         );
 
         // Verify by actually serializing
@@ -932,6 +972,129 @@ mod tests {
             estimated,
             buffer.len()
         );
+    }
+
+    // ===================================================================
+    // Issue #3506 — labels serialized as length-prefixed UTF-8 (write side)
+    // ===================================================================
+
+    /// The serialized CreateNode payload must contain the label's UTF-8 bytes
+    /// (`[len:u32-LE]["Person"]`), not a raw 4-byte interner id. This is the
+    /// observable write-side change: the label string is now self-describing
+    /// and survives any interner layout.
+    #[test]
+    fn create_node_serializes_label_as_utf8_string() {
+        let op = WalOperation::CreateNode {
+            node_id: NodeId::new(1).unwrap(),
+            label: GLOBAL_INTERNER.intern("Person3506Node").unwrap(),
+            properties: PropertyMapBuilder::new().build(),
+            valid_from: test_timestamp(),
+            provenance: None,
+        };
+        let mut buffer = Vec::new();
+        serialize_operation_into(LSN(1), test_timestamp(), &op, &mut buffer).unwrap();
+
+        let needle = b"Person3506Node";
+        let contains = buffer.windows(needle.len()).any(|w| w == needle);
+        assert!(
+            contains,
+            "serialized CreateNode must embed the UTF-8 label string, not a raw id"
+        );
+
+        // The length prefix (LE u32) for the label must precede the bytes.
+        let label_bytes = needle;
+        let len_prefix = (label_bytes.len() as u32).to_le_bytes();
+        let mut framed = Vec::new();
+        framed.extend_from_slice(&len_prefix);
+        framed.extend_from_slice(label_bytes);
+        assert!(
+            buffer.windows(framed.len()).any(|w| w == framed.as_slice()),
+            "label must be length-prefixed UTF-8 [len][bytes]"
+        );
+    }
+
+    /// The two unique-constraint ops carry TWO label strings (label + property);
+    /// both must be serialized as UTF-8.
+    #[test]
+    fn constraint_ops_serialize_both_labels_as_utf8() {
+        for op in [
+            WalOperation::DeclareUniqueConstraint {
+                label: GLOBAL_INTERNER.intern("Cust3506").unwrap(),
+                property: GLOBAL_INTERNER.intern("email3506").unwrap(),
+            },
+            WalOperation::DropUniqueConstraint {
+                label: GLOBAL_INTERNER.intern("Cust3506").unwrap(),
+                property: GLOBAL_INTERNER.intern("email3506").unwrap(),
+            },
+        ] {
+            let mut buffer = Vec::new();
+            serialize_operation_into(LSN(1), test_timestamp(), &op, &mut buffer).unwrap();
+            for needle in [b"Cust3506".as_slice(), b"email3506".as_slice()] {
+                assert!(
+                    buffer.windows(needle.len()).any(|w| w == needle),
+                    "constraint op must embed UTF-8 label/property strings"
+                );
+            }
+        }
+    }
+
+    /// `estimate_entry_capacity` must account for the variable UTF-8 length of a
+    /// long / multi-byte label — the pre-allocation must be >= the actual
+    /// serialized size so the hot path never under-allocates (T6).
+    #[test]
+    fn estimate_capacity_covers_long_multibyte_label() {
+        // A multi-byte (non-ASCII) label longer than the old fixed 4-byte slot.
+        let long_label = "Ключ-Étiquette-🏷️-VeryLongLabelName-3506";
+        let ops = [
+            WalOperation::CreateNode {
+                node_id: NodeId::new(1).unwrap(),
+                label: GLOBAL_INTERNER.intern(long_label).unwrap(),
+                properties: PropertyMapBuilder::new().build(),
+                valid_from: test_timestamp(),
+                provenance: None,
+            },
+            WalOperation::CreateEdge {
+                edge_id: EdgeId::new(1).unwrap(),
+                source: NodeId::new(1).unwrap(),
+                target: NodeId::new(2).unwrap(),
+                label: GLOBAL_INTERNER.intern(long_label).unwrap(),
+                properties: PropertyMapBuilder::new().build(),
+                valid_from: test_timestamp(),
+                provenance: None,
+            },
+            WalOperation::UpdateNode {
+                node_id: NodeId::new(1).unwrap(),
+                version_id: VersionId::new(1).unwrap(),
+                label: GLOBAL_INTERNER.intern(long_label).unwrap(),
+                properties: PropertyMapBuilder::new().build(),
+                valid_from: test_timestamp(),
+                provenance: None,
+            },
+            WalOperation::UpdateEdge {
+                edge_id: EdgeId::new(1).unwrap(),
+                version_id: VersionId::new(1).unwrap(),
+                label: GLOBAL_INTERNER.intern(long_label).unwrap(),
+                properties: PropertyMapBuilder::new().build(),
+                valid_from: test_timestamp(),
+                provenance: None,
+            },
+            WalOperation::DeclareUniqueConstraint {
+                label: GLOBAL_INTERNER.intern(long_label).unwrap(),
+                property: GLOBAL_INTERNER.intern(long_label).unwrap(),
+            },
+        ];
+        for op in ops {
+            let estimated = estimate_entry_capacity(&op);
+            let mut buffer = Vec::new();
+            serialize_operation_into(LSN(1), test_timestamp(), &op, &mut buffer).unwrap();
+            // estimate_entry_capacity includes the 24-byte fixed overhead
+            // (LSN+ts+checksum) that serialize_operation_into also writes.
+            assert!(
+                estimated >= buffer.len(),
+                "estimate {estimated} must cover actual serialized size {} for {op:?}",
+                buffer.len()
+            );
+        }
     }
 }
 

--- a/tests/http_run_server_body_limit.rs
+++ b/tests/http_run_server_body_limit.rs
@@ -63,13 +63,13 @@ fn post_status(addr: &str, path: &str, body: &[u8]) -> Option<u16> {
     // with BrokenPipe/ConnectionReset even though a valid `413` status line is
     // already waiting to be read. Tolerate those write errors and still attempt
     // the read — the status line, not a clean write, is the real assertion.
-    if let Err(e) = stream.write_all(body) {
-        if !matches!(
+    if let Err(e) = stream.write_all(body)
+        && !matches!(
             e.kind(),
             std::io::ErrorKind::BrokenPipe | std::io::ErrorKind::ConnectionReset
-        ) {
-            return None;
-        }
+        )
+    {
+        return None;
     }
     let _ = stream.flush();
 

--- a/tests/wal_string_labels_recovery.rs
+++ b/tests/wal_string_labels_recovery.rs
@@ -1,0 +1,128 @@
+//! Issue #3506 — end-to-end crash-recovery proof that node/edge/constraint
+//! **label** strings survive pure WAL replay.
+//!
+//! Mirrors `tests/destructive_provenance_recovery.rs`: a durable database
+//! (real WAL + index persistence) records the writes, then the database is
+//! dropped **without persisting indexes** so a reopen is forced to reconstruct
+//! state purely from WAL replay. Before #3506 the label was written to the WAL
+//! as a raw `InternedString` id and replayed via `from_raw` without
+//! re-interning — correct only when the replaying process reproduced the exact
+//! interner layout of the writer. v13/v14 segments serialize the label string
+//! itself and re-intern on read, so labels are correct under any layout.
+
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+
+fn person(name: &str) -> aletheiadb::core::PropertyMap {
+    PropertyMapBuilder::new().insert("name", name).build()
+}
+
+/// Nodes, edges, and a unique constraint all recorded with distinct label
+/// strings must recover with those exact labels after a WAL-only replay
+/// (no index snapshot). This is the config the issue names as unprotected
+/// (`persistence_manager.is_none()` / WAL-only replay path).
+#[test]
+fn crash_recovery_preserves_node_edge_and_constraint_labels() {
+    let tempdir = tempfile::tempdir().expect("create tempdir");
+    let data_dir = tempdir.path().join("db");
+
+    let alice: u64;
+    let bob: u64;
+
+    {
+        let db = AletheiaDB::open(&data_dir).expect("open durable db");
+
+        // A unique constraint declaration carries two label strings through
+        // the WAL (the label and the property).
+        db.unique_constraint("Person", "email")
+            .enable()
+            .expect("declare unique constraint");
+
+        let a = db
+            .create_node("Person", person("Alice"))
+            .expect("create Alice");
+        let b = db
+            .create_node("Organization", person("Acme"))
+            .expect("create Acme");
+        alice = a.as_u64();
+        bob = b.as_u64();
+        db.create_edge(a, b, "WORKS_AT", PropertyMapBuilder::new().build())
+            .expect("create edge");
+
+        // Deliberately NO db.persist_indexes(): recovery must come from the
+        // WAL alone.
+        drop(db);
+    }
+
+    // Reopen — forces WAL replay (no index snapshot exists).
+    let db = AletheiaDB::open(&data_dir).expect("reopen durable db");
+
+    // Node labels recovered exactly: the label-keyed index is populated only
+    // if the replayed label string matches.
+    let persons = db.get_nodes_by_label("Person");
+    assert_eq!(persons.len(), 1, "exactly one Person after WAL replay");
+    assert_eq!(persons[0].id.as_u64(), alice);
+
+    let orgs = db.get_nodes_by_label("Organization");
+    assert_eq!(orgs.len(), 1, "exactly one Organization after WAL replay");
+    assert_eq!(orgs[0].id.as_u64(), bob);
+
+    // A wrong-label lookup finds nothing (guards against a silent mislabel
+    // resolving to some other interned string).
+    assert!(
+        db.get_nodes_by_label("email").is_empty(),
+        "no node should be mislabeled to the constraint's property string"
+    );
+
+    // The unique constraint declaration recovered with both label strings.
+    let constraints = db.list_unique_constraints();
+    assert!(
+        constraints
+            .iter()
+            .any(|(l, p)| l == "Person" && p == "email"),
+        "unique constraint (Person, email) must survive WAL replay, got {constraints:?}"
+    );
+}
+
+/// Two databases in the same process share the process-global interner, so the
+/// second `open()` shifts the interner layout relative to the first. Recovering
+/// the first database from its WAL under that shifted layout must still resolve
+/// labels to the correct strings — the exact non-identity-layout scenario the
+/// raw-id encoding got wrong.
+#[test]
+fn crash_recovery_correct_under_shifted_interner_layout() {
+    let tmp_a = tempfile::tempdir().expect("tempdir A");
+    let dir_a = tmp_a.path().join("db_a");
+
+    let widget: u64;
+    {
+        let db = AletheiaDB::open(&dir_a).expect("open db A");
+        let w = db
+            .create_node("Widget", person("W1"))
+            .expect("create Widget");
+        widget = w.as_u64();
+        drop(db);
+    }
+
+    // Open a SECOND database and intern a pile of unrelated label strings,
+    // advancing the process-global interner's id space so any raw label id
+    // recorded by db A no longer aligns with the same string.
+    {
+        let tmp_b = tempfile::tempdir().expect("tempdir B");
+        let db_b = AletheiaDB::open(tmp_b.path().join("db_b")).expect("open db B");
+        for i in 0..64 {
+            db_b.create_node(&format!("DecoyLabel{i}"), person("decoy"))
+                .expect("create decoy");
+        }
+        drop(db_b);
+    }
+
+    // Reopen db A from its WAL under the now-shifted interner layout.
+    let db = AletheiaDB::open(&dir_a).expect("reopen db A");
+    let widgets = db.get_nodes_by_label("Widget");
+    assert_eq!(
+        widgets.len(),
+        1,
+        "Widget label must resolve correctly under a shifted interner layout"
+    );
+    assert_eq!(widgets[0].id.as_u64(), widget);
+}

--- a/tests/wal_string_labels_recovery.rs
+++ b/tests/wal_string_labels_recovery.rs
@@ -83,13 +83,19 @@ fn crash_recovery_preserves_node_edge_and_constraint_labels() {
     );
 }
 
-/// Two databases in the same process share the process-global interner, so the
-/// second `open()` shifts the interner layout relative to the first. Recovering
-/// the first database from its WAL under that shifted layout must still resolve
-/// labels to the correct strings — the exact non-identity-layout scenario the
-/// raw-id encoding got wrong.
+/// WAL-only reopen smoke test: a durable database dropped **without** persisting
+/// its indexes must recover its node labels purely from WAL replay (the
+/// drop-index → WAL-replay path). A second database is opened in between to
+/// exercise a reopen under a process-global interner whose id space has advanced
+/// since the writer ran. This test exercises the reopen/replay pipeline
+/// end-to-end; it is a smoke test and does NOT by itself prove the v13 string
+/// encoding fixes raw-id label corruption (the process-global interner never
+/// reassigns ids in-process, so this would also pass on the pre-#3506 raw-id
+/// code). The deterministic corruption-proof lives in the
+/// `raw_id_decode_corrupts_under_nonidentity_layout_string_decode_does_not` unit
+/// test in `src/storage/wal/segment_reader.rs`.
 #[test]
-fn crash_recovery_correct_under_shifted_interner_layout() {
+fn crash_recovery_wal_only_reopen_preserves_labels() {
     let tmp_a = tempfile::tempdir().expect("tempdir A");
     let dir_a = tmp_a.path().join("db_a");
 


### PR DESCRIPTION
## Summary

Fixes the last asymmetric case in the WAL codec: node/edge/**unique-constraint** label strings were persisted as raw `StringInterner` ids and replayed by wrapping the raw id back into an `InternedString` **without re-interning the underlying string**. Property keys and string values were already written as UTF-8 and re-interned on read — labels were the sole exception. Reference: Issue #3506.

### Before → After (plain language)

- **Before:** a label was written as a 4-byte interner id and, on replay, `from_raw(id)` wrapped that id back into an `InternedString` with no lookup. Correct **only** when the replaying process reproduces the writer&#39;s exact id→string interner layout. Under a non-identity layout — multiple `AletheiaDB` instances sharing the process-global interner, repeated open/close (the interner is never `clear()`ed), or the WAL-only replay path (`persistence_manager.is_none()`) that does no interner restore — a replayed label **silently resolved to the wrong string (or none)**, corrupting node/edge labels, `get_nodes_by_label`, and WAL-recovered unique constraints with no checksum/type error to catch it.
- **After:** labels are serialized as length-prefixed UTF-8 (`[len:u32-LE][utf8 bytes]`) and **re-interned on read** — byte-identical to the existing property-key codec (`PropertyMap::serialize_into`). Labels are now correct under **any** interner layout, removing the cross-process-layout assumption entirely.

### The v13/v14 layout

Version-gated codec (follows the #3224/#3406/#3427 precedent):

| Ver | Const | Meaning |
|-----|-------|---------|
| 13 | `WAL_VERSION_STRING_LABELS` | labels as UTF-8 (plaintext) |
| 14 | `WAL_VERSION_ENCRYPTED_STRING_LABELS` | encrypted counterpart |

- `WAL_VERSION_MAX` bumped to 14; `is_encrypted_version` / `payload_version` extended (14→13).
- New `carries_string_labels(version) = version &gt;= 13` gate.
- `read_label` gained a `version` param: **v13+** reads `[len][utf8]` + `GLOBAL_INTERNER.intern(...)`; **≤v12** keeps the raw-id `from_raw` path unchanged.
- The 8 serialize sites now write UTF-8 via `GLOBAL_INTERNER.resolve_with(...)`; `estimate_entry_capacity` sizes labels by their UTF-8 length.
- **Writer/reader lockstep:** `flush_coordinator::ensure_segment_open` stamps v13 (plaintext) / v14 (encrypted), so every new segment&#39;s string-label body parses at the version its header declares (avoids the #3427-class checksum-mismatch-on-replay bug).

### Entry variants touched

`CreateNode`, `CreateEdge`, `UpdateNode`, `UpdateEdge`, `DeclareUniqueConstraint` (label + property), `DropUniqueConstraint` (label + property). Delete/Retract/Checkpoint/Begin/CommitTx carry no label and are untouched. Framed (tx) entries share the per-op codec, so they are covered identically.

### Backward compatibility

- **≤v12 segments** keep the raw-id `from_raw` decode (best-effort, identity-layout only — we cannot recover a string that was never written). New **v13+** segments are unconditionally correct.
- **Mixed-version WAL dirs** replay correctly: each segment header carries its own version, threaded independently into every parse.
- `recovery.rs` / `db/config.rs` need no change — labels arrive already-correct once `read_label` re-interns.

## Tests

New `tests/wal_string_labels_recovery.rs` (end-to-end):
- `crash_recovery_preserves_node_edge_and_constraint_labels` — WAL-only replay (no index snapshot) recovers node labels, edge labels, and a unique constraint&#39;s two label strings.
- `crash_recovery_wal_only_reopen_preserves_labels` — WAL-only reopen smoke test (drop-index → WAL-replay), reopened under an advanced process-global interner id space. (Renamed from `crash_recovery_correct_under_shifted_interner_layout`; see review-hardening note below.)

New in-module (`serialization.rs` / `segment_reader.rs`): label-serialized-as-UTF-8 (write side), constraint-both-labels-UTF-8, capacity-covers-long-multibyte-label, v13 round-trip for all label-bearing ops, v13-buffer-rejected-at-v12, v11 raw-id backward-compat, mixed-version-dir replay, and the new deterministic corruption-proof test `raw_id_decode_corrupts_under_nonidentity_layout_string_decode_does_not`.

Existing round-trip / byte-layout tests updated to the v13 format; pre-format tests (`pre_v5`, `pre_framing`, `flush_coordinator` roll-past) rebuilt with hand-crafted raw-id bytes so they keep exercising the ≤v12 path.

**Codecov patch coverage:** Codecov&#39;s 21 flagged uncovered patch lines — the WAL string-label corruption/truncation error paths in `segment_reader.rs` and `serialization.rs` — are now covered by 6 targeted unit tests; the full WAL lib suite is green (**288 passed**).

### Review hardening (PR #3526 review)

- **Real corruption-proof test added.** The prior `crash_recovery_correct_under_shifted_interner_layout` was theatre — the process-global interner never reassigns ids in-process, so it passed on the pre-#3506 raw-id code too. It is redocumented/renamed to `crash_recovery_wal_only_reopen_preserves_labels` (an honest WAL-only reopen smoke test), and a new deterministic unit test `raw_id_decode_corrupts_under_nonidentity_layout_string_decode_does_not` (in `segment_reader.rs`) constructs a genuine non-identity layout and asserts the **old raw-id decode resolves to the WRONG string** (&#34;DecoyMeaning3506&#34;) while the **v13 string decode resolves to the RIGHT string** (&#34;PersonTarget3506&#34;). This is the test that would FAIL on pre-#3506 code and PASSES now.
- **Encrypted-v14 label asserted.** `test_replay_tolerates_encrypted_torn_tail` now asserts each decrypted `CreateNode`&#39;s label resolves to `&#34;TornTail3433&#34;`, so v14 label-string survival across the decrypt path is explicit, not implicit-via-LSN.
- **Gemini DoS comment addressed as already-mitigated (declined, with rationale).** No fixed 65536 cap added: `read_label` calls `require_bytes(buffer, offset, len, ...)` before the slice/allocation (crafted length → `CorruptedData`, allocation bounded by the actual on-disk segment size), and `GLOBAL_INTERNER.intern` is the capacity-checked variant (`CapacityExceeded`, not OOM). A label-only cap would also be inconsistent with the property-key/value WAL codec, which imposes none. [Reply on the thread.](https://github.com/madmax983/AletheiaDB/pull/3526#discussion_r3566893307)

### Gates run locally

- `cargo fmt --all` ✔
- `cargo test --features config-toml` for `storage::wal::` + `storage::recovery::` → **307 passed, 0 failed**; new integration file → **2 passed**; new corruption-proof + encrypted tests → **2 passed**.
- `cargo clippy --lib --features config-toml -- -D warnings` → clean.
- `cargo clippy --all-targets --all-features -- -D warnings` → **VERIFIED CLEAN locally (exit 0, zero warnings)** as of commit `3c7f55c5` — the two clippy 1.94.0 lints in `src/api/import/tests.rs` and `tests/http_run_server_body_limit.rs` were fixed.

**Deferred to CI:** `just check-features` (per repo build-resource constraints). No `unsafe` touched → no Miri.

## Acceptance-criteria evidence

| AC (from Issue #3506 fix-direction #1) | Status | Evidence (file:line / test / commit) |
|---|---|---|
| Labels serialized as length-prefixed UTF-8 (`[len:u32-LE][utf8]`) in the WAL, not a raw interner id | ✅ | `serialize_label_str` `src/storage/wal/serialization.rs:81`; tests `create_node_serializes_label_as_utf8_string`, `constraint_ops_serialize_both_labels_as_utf8` |
| Re-intern the label string on read (`read_label`) | ✅ | v13+ branch `src/storage/wal/segment_reader.rs:1443-1453` (`GLOBAL_INTERNER.intern`) |
| Change gated behind a WAL version bump | ✅ | `WAL_VERSION_STRING_LABELS=13` `:197`, `WAL_VERSION_ENCRYPTED_STRING_LABELS=14` `:201`, `carries_string_labels` `:258`, `WAL_VERSION_MAX=14` `:204` |
| All label-bearing entry variants covered (Create/Update Node/Edge + Declare/Drop unique constraint, label + property) | ✅ | serialize sites in `serialization.rs`; parse `parse_entry_at` `segment_reader.rs:1855-1877`; v13 round-trip tests per op |
| Correct under a **non-identity** interner layout (the core bug: old→wrong string, new→right string) | ✅ | NEW `raw_id_decode_corrupts_under_nonidentity_layout_string_decode_does_not` (`segment_reader.rs`), commit `141c748` |
| WAL-only config (`persistence_manager.is_none()`) recovers labels correctly | ✅ | integration `crash_recovery_preserves_node_edge_and_constraint_labels` + `crash_recovery_wal_only_reopen_preserves_labels` (`tests/wal_string_labels_recovery.rs`) |
| Encrypted counterpart (v14) preserves the label string through decrypt | ✅ | `test_replay_tolerates_encrypted_torn_tail` now asserts label == `&#34;TornTail3433&#34;` (`segment_reader.rs`), commit `141c748` |
| Backward compatibility: ≤v12 segments still decode via the raw-id path | ✅ | `read_label` else branch `segment_reader.rs:1454-1459`; `test_pre_framing_version_not_flagged_framed`, v11 round-trip tests |
| Consistent with the property key/value codec (no cross-process-layout assumption) | ✅ | `serialize_label_str` mirrors `PropertyMap::serialize_into`; read re-interns like `src/core/property/map.rs:291` |
| DoS-safety of the length-prefixed read (bounded allocation, capacity-checked intern) | ✅ | `require_bytes` before slice/alloc `segment_reader.rs:1447`; capacity-checked `GLOBAL_INTERNER.intern`; [Gemini reply](https://github.com/madmax983/AletheiaDB/pull/3526#discussion_r3566893307) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeUojPxfbkSTXosNT1Df3z