### PR TITLE
test(parity): black-box parity harness pinning HTTP + MCP surface behavior

### DIFF
--- a/src/mcp/auth_tests.rs
+++ b/src/mcp/auth_tests.rs
@@ -1082,3 +1082,105 @@ fn classification_uses_known_classes_only() {
         );
     }
 }
+
+// ============================================================================
+// 6. Live tool-inventory golden (drift detection for the external mirror)
+//
+// The external `tests/parity_mcp.rs::tool_inventory_golden_is_stable` test can
+// only validate a hardcoded 44-tool constant against itself, because the live
+// registry (`list_tools_for_test` / `TOOL_ACCESS_CLASSES`) is `pub(crate)` and
+// unreachable from an external test crate. This in-crate test closes that gap:
+// it derives the LIVE advertised `(tool_name, access_class)` set from the
+// registry and asserts it equals a hardcoded golden snapshot of the 44 pairs.
+// A tool that is added, removed, renamed, or reclassified FAILS here — the
+// authoritative drift detector the external mirror points back to.
+// ============================================================================
+
+/// AC3 (drift): the LIVE advertised MCP tool inventory — every name paired
+/// with the `AccessClass` the registry assigns it — must equal this hardcoded
+/// golden set of exactly 44 pairs. Adding, dropping, renaming, or
+/// reclassifying a tool changes the live set and fails this assertion; update
+/// the golden here AND the external mirror (`tests/parity_mcp.rs`) +
+/// `tests/parity/inventory.json` deliberately when that happens.
+#[test]
+fn live_tool_inventory_matches_golden() {
+    /// The 44 `(tool_name, access_class)` pairs the server is expected to
+    /// advertise, derived from the current live `TOOL_ACCESS_CLASSES`.
+    const GOLDEN: [(&str, AccessClass); 44] = [
+        // Read (31)
+        ("get_node", AccessClass::Read),
+        ("list_nodes", AccessClass::Read),
+        ("count_nodes", AccessClass::Read),
+        ("get_edge", AccessClass::Read),
+        ("list_edges", AccessClass::Read),
+        ("count_edges", AccessClass::Read),
+        ("get_outgoing_edges", AccessClass::Read),
+        ("get_incoming_edges", AccessClass::Read),
+        ("traverse", AccessClass::Read),
+        ("find_similar", AccessClass::Read),
+        ("list_vector_indexes", AccessClass::Read),
+        ("list_unique_constraints", AccessClass::Read),
+        ("get_node_at_time", AccessClass::Read),
+        ("get_edge_at_time", AccessClass::Read),
+        ("find_nodes_at_time", AccessClass::Read),
+        ("list_changes", AccessClass::Read),
+        ("get_node_at_valid_time", AccessClass::Read),
+        ("get_node_at_transaction_time", AccessClass::Read),
+        ("get_node_history", AccessClass::Read),
+        ("diff_node_versions", AccessClass::Read),
+        ("get_edge_at_valid_time", AccessClass::Read),
+        ("get_edge_at_transaction_time", AccessClass::Read),
+        ("get_edge_history", AccessClass::Read),
+        ("diff_edge_versions", AccessClass::Read),
+        ("hybrid_query", AccessClass::Read),
+        ("query", AccessClass::Read),
+        ("get_schema", AccessClass::Read),
+        ("temporal_extent", AccessClass::Read),
+        ("lineage_upstream", AccessClass::Read),
+        ("lineage_downstream", AccessClass::Read),
+        ("audit_export", AccessClass::Read),
+        // Metrics (1)
+        ("database_stats", AccessClass::Metrics),
+        // Write (12)
+        ("create_node", AccessClass::Write),
+        ("update_node", AccessClass::Write),
+        ("delete_node", AccessClass::Write),
+        ("delete_node_cascade", AccessClass::Write),
+        ("retract_node", AccessClass::Write),
+        ("create_edge", AccessClass::Write),
+        ("update_edge", AccessClass::Write),
+        ("delete_edge", AccessClass::Write),
+        ("retract_edge", AccessClass::Write),
+        ("apply_batch", AccessClass::Write),
+        ("enable_vector_index", AccessClass::Write),
+        ("enable_unique_constraint", AccessClass::Write),
+    ];
+
+    // Golden as a set of (name, class-string) pairs.
+    let golden: std::collections::BTreeSet<(String, String)> = GOLDEN
+        .iter()
+        .map(|(name, class)| ((*name).to_string(), class.to_string()))
+        .collect();
+    assert_eq!(golden.len(), 44, "golden must be 44 unique tool names");
+
+    // Live set derived from the advertised registry + classification table.
+    let server = AletheiaMcpServer::new(db());
+    let live: std::collections::BTreeSet<(String, String)> = server
+        .list_tools_for_test()
+        .into_iter()
+        .map(|tool| {
+            let class = tool_access_class(&tool)
+                .unwrap_or_else(|| panic!("advertised tool '{tool}' is unclassified"))
+                .to_string();
+            (tool, class)
+        })
+        .collect();
+
+    assert_eq!(
+        live, golden,
+        "the LIVE advertised MCP tool inventory drifted from the golden \
+         44-pair set — a tool was added, removed, renamed, or reclassified. \
+         Update GOLDEN here, tests/parity_mcp.rs::TOOL_INVENTORY, and \
+         tests/parity/inventory.json deliberately."
+    );
+}

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -38,6 +38,17 @@ Driven black-box through the public per-tool typed methods
 (`server.get_node(GetNodeRequest{..}) -> String`) and the public `McpErrorCode`
 enum. Access classes: 31 read, 12 write, 1 metrics (`database_stats`), 0 admin.
 
+**Two kinds of MCP pin.** Four tools are **behavior-pinned** — `get_node`,
+`create_node`, `create_edge`, `traverse` carry black-box *runtime* assertions
+(envelopes, temporal block, vector elision, roundtrip reachability). The other
+40 are **inventory-pinned** — only their name + access class are fixed via the
+golden set. Live drift detection of the whole 44-name/class registry (a tool
+added/removed/renamed/reclassified) is done in-crate by
+`src/mcp/auth_tests.rs::live_tool_inventory_matches_golden`, which reads the
+live registry and fails on drift. The external
+`tool_inventory_golden_is_stable` is only a cross-crate mirror of that constant
+(internal-consistency only — it cannot read the registry).
+
 **Error envelope:** `{error:{code, message, retriable, details?}}` with `code` in
 the 9-value `McpErrorCode` enum (`NOT_FOUND`, `INVALID_ARGUMENT`,
 `CONSTRAINT_VIOLATION`, `FAILED_PRECONDITION`, `CONFLICT`, `UNAVAILABLE`,
@@ -65,21 +76,31 @@ properties are elided to `{type,dim,elided:true}` unless `include_vectors:true`.
 
 ## Coverage gaps (honest, no silent skips)
 
-The MCP registry sweep, RBAC enforcement, token-budget ladder, and cursor paging
-are **not reachable** through the public black-box API (`dispatch_tool` /
-`list_tools_for_test` / `apply_budget` / `authorize_tool` are `pub(crate)`; the
-`rmcp::ServerHandler` entry is not nameable from an external test crate, and the
-public per-tool methods bypass the dispatch-path auth/budget/cursor logic). Per
-the harness house rules we do not add `pub` to production code. These are pinned
-by the existing in-crate suites and only referenced here:
+Per-tool RUNTIME BEHAVIOR for the 40 non-behavior-tested tools, RBAC
+enforcement, the token-budget ladder, and cursor paging are **not reachable**
+through the public black-box API (`dispatch_tool` / `list_tools_for_test` /
+`apply_budget` / `authorize_tool` are `pub(crate)`; the `rmcp::ServerHandler`
+entry is not nameable from an external test crate, and the public per-tool
+methods bypass the dispatch-path auth/budget/cursor logic). Per the harness
+house rules we do not add `pub` to production code. These are pinned by the
+existing in-crate suites and only referenced here:
 
-- Registry sweep → `src/mcp/tests.rs::every_advertised_tool_returns_structured_error_on_invalid_arguments`
+- Registry name/class **drift** → **now closed in-crate** by
+  `src/mcp/auth_tests.rs::live_tool_inventory_matches_golden` (reads the live
+  registry). What remains external-unreachable is per-tool runtime behavior for
+  the 40 inventory-pinned tools.
+- Registry dispatch sweep → `src/mcp/tests.rs::every_advertised_tool_returns_structured_error_on_invalid_arguments`
 - RBAC matrix → `src/mcp/auth_tests.rs::every_advertised_tool_has_a_classification`
 - Token budget → `src/mcp/tests.rs` budget suite
 - HTTP 429 timeout → `src/http/handlers.rs` `enforce_query_limits` unit tests
 - HTTP OTel `trace_id`/`x-trace-id` → `tests/http_otel_tracing.rs` (observability/otel features)
+- HTTP **500 / INTERNAL envelope shape** → asserted only **indirectly** (as
+  "not 500" on the malformed path, `query_malformed_payload_is_400_not_500`);
+  the Internal-variant body shape is covered by the `src/http/error.rs`
+  `IntoResponse` unit tests, not positively pinned over the wire.
 
 The 44-tool inventory + access classes are mirrored as a golden constant
-(`tool_inventory_golden_is_stable`) that a porter must keep in lockstep with the
-server. See `inventory.json` for the full per-route/per-tool table and the
-`coverage_gaps` array.
+(`tool_inventory_golden_is_stable`, cross-crate mirror) and drift-checked live
+in-crate (`live_tool_inventory_matches_golden`); a porter must keep both in
+lockstep with the server. See `inventory.json` for the full per-route/per-tool
+table and the `coverage_gaps` array.

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -1,0 +1,85 @@
+# AletheiaDB Parity Harness
+
+Black-box golden tests that pin the **current, observed** behavior of the two
+network surfaces so a future port to another framework must pass them
+**unchanged**. If a parity test fails after a port, the port changed observable
+behavior — fix the port, not the assertion.
+
+- HTTP suite: [`tests/parity_http.rs`](../parity_http.rs) — gate `--features http-server`
+- MCP suite: [`tests/parity_mcp.rs`](../parity_mcp.rs) — gate `--features mcp-server`
+- Machine-readable inventory: [`inventory.json`](./inventory.json)
+
+Run both:
+
+```bash
+cargo test --features http-server,mcp-server --test parity_http --test parity_mcp
+```
+
+## HTTP surface — 5 routes
+
+| Method | Path | Access | Success | Error statuses | Pinned by |
+|--------|------|--------|---------|----------------|-----------|
+| GET  | `/status` | metrics | 200 `{"status":"healthy"}` | 401 | `status_*` |
+| POST | `/query` | per-operation | 200 `{success,data?,truncated?}` | 400/401/403/404/413/422/429/500 | `query_*`, `run_server_enforces_request_body_413` |
+| POST | `/admin/keys` | admin | 200 `{data:{key,id,role}}` | 400/401/403 | `admin_create_key_*` |
+| GET  | `/admin/keys` | admin | 200 masked list | 401/403 | `admin_list_keys_*` |
+| POST | `/admin/keys/revoke` | admin | 200 `{data:{revoked,id}}` | 401/403/404 | `admin_revoke_*` |
+
+**Error envelope:** `{success:false, error, code?, retriable?, details?, trace_id?}`.
+`code`/`retriable`/`details` are additive — present only on auth (401/403) and
+resource-limit (413/422/429) variants. Plain 400/404/500 keep the minimal
+`{success,error}` shape. HTTP limit errors use `RESOURCE_EXHAUSTED`; the uniform
+401 carries `WWW-Authenticate: Bearer` and a byte-identical body across every
+route.
+
+## MCP surface — 44 tools
+
+Driven black-box through the public per-tool typed methods
+(`server.get_node(GetNodeRequest{..}) -> String`) and the public `McpErrorCode`
+enum. Access classes: 31 read, 12 write, 1 metrics (`database_stats`), 0 admin.
+
+**Error envelope:** `{error:{code, message, retriable, details?}}` with `code` in
+the 9-value `McpErrorCode` enum (`NOT_FOUND`, `INVALID_ARGUMENT`,
+`CONSTRAINT_VIOLATION`, `FAILED_PRECONDITION`, `CONFLICT`, `UNAVAILABLE`,
+`INTERNAL`, `UNAUTHENTICATED`, `PERMISSION_DENIED`); `retriable` is `true` only
+for `CONFLICT`/`UNAVAILABLE`. Read responses carry a `temporal` block; vector
+properties are elided to `{type,dim,elided:true}` unless `include_vectors:true`.
+
+**13 budgetable read tools:** `get_node`, `list_nodes`, `get_edge`, `list_edges`,
+`get_outgoing_edges`, `get_incoming_edges`, `traverse`, `find_similar`,
+`hybrid_query`, `query`, `find_nodes_at_time`, `get_node_history`, `get_schema`.
+
+## Key parity asymmetries (HTTP vs MCP)
+
+1. **Code vocabulary differs:** HTTP limit errors are `RESOURCE_EXHAUSTED`; MCP
+   has no such code. HTTP emits `code` only on auth+limit variants; MCP emits
+   `code` on every error.
+2. **Auth transport:** HTTP is per-request header (`Bearer`/`x-api-key`); MCP is
+   a session-scoped credential re-verified per call.
+3. **Admin surface:** HTTP has admin-class routes (`/admin/keys*`); MCP has no
+   admin tools.
+4. **Result model:** HTTP maps to status codes (200/4xx/5xx); MCP is a flat
+   `is_error` + JSON `code`.
+5. **Anonymous default:** `AletheiaMcpServer::new` is anonymous; HTTP derives the
+   mode from config (default required, no startup refusal in `build_test_router`).
+
+## Coverage gaps (honest, no silent skips)
+
+The MCP registry sweep, RBAC enforcement, token-budget ladder, and cursor paging
+are **not reachable** through the public black-box API (`dispatch_tool` /
+`list_tools_for_test` / `apply_budget` / `authorize_tool` are `pub(crate)`; the
+`rmcp::ServerHandler` entry is not nameable from an external test crate, and the
+public per-tool methods bypass the dispatch-path auth/budget/cursor logic). Per
+the harness house rules we do not add `pub` to production code. These are pinned
+by the existing in-crate suites and only referenced here:
+
+- Registry sweep → `src/mcp/tests.rs::every_advertised_tool_returns_structured_error_on_invalid_arguments`
+- RBAC matrix → `src/mcp/auth_tests.rs::every_advertised_tool_has_a_classification`
+- Token budget → `src/mcp/tests.rs` budget suite
+- HTTP 429 timeout → `src/http/handlers.rs` `enforce_query_limits` unit tests
+- HTTP OTel `trace_id`/`x-trace-id` → `tests/http_otel_tracing.rs` (observability/otel features)
+
+The 44-tool inventory + access classes are mirrored as a golden constant
+(`tool_inventory_golden_is_stable`) that a porter must keep in lockstep with the
+server. See `inventory.json` for the full per-route/per-tool table and the
+`coverage_gaps` array.

--- a/tests/parity/inventory.json
+++ b/tests/parity/inventory.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Machine-readable parity inventory for the AletheiaDB HTTP + MCP surfaces. Consumed by the framework-migration/design lane. Pinned against branch feature/parity-harness at the current tip of work (scout commit 8351ff4). Every 'pinned_by' names a test in this repo that asserts the behavior; 'referenced' means the behavior is pinned by a pre-existing in-crate test (not re-implemented in the parity suites, to avoid duplication).",
+  "$comment": "Machine-readable parity inventory for the AletheiaDB HTTP + MCP surfaces. Consumed by the framework-migration/design lane. Pinned against branch feature/parity-harness at the current tip of work (scout commit 8351ff4). Every 'pinned_by' names a test in this repo that asserts the behavior; 'referenced' means the behavior is pinned by a pre-existing in-crate test (not re-implemented in the parity suites, to avoid duplication). TWO KINDS OF MCP PIN: (1) 'behavior-pinned' tools — get_node, create_node, create_edge, traverse — carry black-box RUNTIME assertions in tests/parity_mcp.rs (success/error envelopes, temporal block, vector elision, roundtrip reachability); (2) 'inventory-pinned' tools — the remaining 40 — have only their name + access class pinned via the golden set. Live drift detection of the full 44-tool name/class registry (a tool added/removed/renamed/reclassified) is provided by the in-crate golden test src/mcp/auth_tests.rs::live_tool_inventory_matches_golden; the external tests/parity_mcp.rs::tool_inventory_golden_is_stable is only a cross-crate mirror of that constant and cannot itself read the live registry.",
   "generated_for": "framework port parity harness",
   "totals": {
     "http_routes": 5,
@@ -41,7 +41,7 @@
         "pinned_by": [
           "tests/parity_http.rs::query_success_envelope_shape",
           "tests/parity_http.rs::query_not_found_minimal_error_envelope",
-          "tests/parity_http.rs::query_malformed_payload_is_4xx_not_500",
+          "tests/parity_http.rs::query_malformed_payload_is_400_not_500",
           "tests/parity_http.rs::query_error_envelope_has_no_trace_id_without_observability",
           "tests/parity_http.rs::query_missing_credential_is_uniform_401",
           "tests/parity_http.rs::query_reader_write_is_403_permission_denied",
@@ -116,7 +116,8 @@
       "opt_out": "include_vectors:true returns full array",
       "pinned_by": "tests/parity_mcp.rs::vectors_elided_by_default_and_restorable"
     },
-    "inventory_golden": "tests/parity_mcp.rs::tool_inventory_golden_is_stable",
+    "inventory_golden": "tests/parity_mcp.rs::tool_inventory_golden_is_stable (external mirror — internal-consistency only)",
+    "inventory_live_drift_detector": "src/mcp/auth_tests.rs::live_tool_inventory_matches_golden (in-crate; derives the advertised (name, class) set from the live registry and asserts it equals the golden 44 pairs — the authoritative drift detector)",
     "budgetable_read_tools": ["get_node", "list_nodes", "get_edge", "list_edges", "get_outgoing_edges", "get_incoming_edges", "traverse", "find_similar", "hybrid_query", "query", "find_nodes_at_time", "get_node_history", "get_schema"],
     "tools": [
       {"name": "get_node", "access_class": "read", "budgetable": true, "pinned_by": ["tests/parity_mcp.rs::not_found_structured_error", "tests/parity_mcp.rs::out_of_range_id_is_non_retriable_structured_error", "tests/parity_mcp.rs::vectors_elided_by_default_and_restorable", "tests/parity_mcp.rs::success_envelope_and_temporal_block"]},
@@ -169,9 +170,11 @@
     {
       "id": "mcp-registry-sweep-not-external",
       "area": "MCP advertised-tool dispatch sweep",
+      "status": "partially closed",
       "why": "tool_definitions()/list_tools_for_test()/dispatch_tool are pub(crate); the rmcp ServerHandler list_tools/call_tool entry is not reachable from an external test crate (rmcp is not a dev-dependency and is not re-exported). Per house rules we do not add pub to production code.",
-      "mitigation": "The 44-tool inventory + access classes are mirrored as a golden constant (tests/parity_mcp.rs::tool_inventory_golden_is_stable) that a porter must keep in lockstep. The server-side sweep remains enforced in-crate.",
-      "referenced_test": "src/mcp/tests.rs::every_advertised_tool_returns_structured_error_on_invalid_arguments (~line 9257)"
+      "closed_part": "Full 44-name/class DRIFT DETECTION is now closed: the in-crate golden src/mcp/auth_tests.rs::live_tool_inventory_matches_golden reads the live registry and fails on any tool added/removed/renamed/reclassified. The external tests/parity_mcp.rs::tool_inventory_golden_is_stable mirrors that constant cross-crate.",
+      "remaining_gap": "What stays external-unreachable is per-tool RUNTIME BEHAVIOR for the 40 non-behavior-tested tools: only the 4 behavior-pinned tools (get_node, create_node, create_edge, traverse) have black-box runtime assertions in tests/parity_mcp.rs; the other 40 are name/class-pinned only. Their dispatch/error-on-invalid-args behavior remains enforced in-crate.",
+      "referenced_test": "src/mcp/tests.rs::every_advertised_tool_returns_structured_error_on_invalid_arguments (~line 9257); src/mcp/auth_tests.rs::live_tool_inventory_matches_golden"
     },
     {
       "id": "mcp-rbac-not-external",
@@ -207,6 +210,13 @@
       "why": "populated only under the observability/otel features; under the parity suite's feature set the field is absent (pinned as absent).",
       "mitigation": "Absence pinned by query_error_envelope_has_no_trace_id_without_observability.",
       "referenced_test": "tests/http_otel_tracing.rs, tests/http_otel_parent_sampling.rs, tests/http_otel_sampled_out.rs"
+    },
+    {
+      "id": "http-500-internal-shape-indirect",
+      "area": "HTTP 500 / INTERNAL error-envelope shape",
+      "why": "The 500 (Internal/StateMissing) path cannot be triggered deterministically over the black-box surface without injecting a fault, so its {success:false, error} envelope is NOT positively pinned. It is only asserted INDIRECTLY, as a negative: the malformed-payload path is pinned to 400 ('4xx/400, never 500') by query_malformed_payload_is_400_not_500, and the error_envelope.additive_fields_note documents that plain 500 keeps the minimal {success,error} shape (code_str maps Internal/StateMissing -> INTERNAL for the trace span only, never the body).",
+      "mitigation": "The Internal-variant body shape (minimal {success,error}, no code) is covered in-crate by the src/http/error.rs IntoResponse unit tests; over the wire it is asserted only as 'not 500' on the malformed path.",
+      "referenced_test": "src/http/error.rs IntoResponse unit tests (~error.rs:403 BadRequest/NotFound body_json cases); tests/parity_http.rs::query_malformed_payload_is_400_not_500 (indirect)"
     }
   ]
 }

--- a/tests/parity/inventory.json
+++ b/tests/parity/inventory.json
@@ -1,0 +1,212 @@
+{
+  "$comment": "Machine-readable parity inventory for the AletheiaDB HTTP + MCP surfaces. Consumed by the framework-migration/design lane. Pinned against branch feature/parity-harness at the current tip of work (scout commit 8351ff4). Every 'pinned_by' names a test in this repo that asserts the behavior; 'referenced' means the behavior is pinned by a pre-existing in-crate test (not re-implemented in the parity suites, to avoid duplication).",
+  "generated_for": "framework port parity harness",
+  "totals": {
+    "http_routes": 5,
+    "mcp_tools": 44,
+    "mcp_budgetable_read_tools": 13
+  },
+  "http": {
+    "surface_files": ["src/http/mod.rs", "src/http/server.rs", "src/http/handlers.rs", "src/http/admin.rs", "src/http/auth.rs", "src/http/error.rs", "src/http/config.rs"],
+    "parity_suite": "tests/parity_http.rs",
+    "route_inventory_source": "src/http/handlers.rs::all_routes()",
+    "error_envelope": {
+      "shape": "{success:false, error:<string>, code?, retriable?, details?, trace_id?}",
+      "additive_fields_note": "code/retriable/details are present ONLY for auth (401/403) and resource-limit (413/422/429) variants; plain 400/404/500 keep the minimal {success,error} shape.",
+      "trace_id_note": "trace_id body field + x-trace-id header are populated only under the observability/otel features (pinned by tests/http_otel_tracing.rs). Absent otherwise.",
+      "code_vocabulary": ["UNAUTHENTICATED", "PERMISSION_DENIED", "RESOURCE_EXHAUSTED", "INVALID_ARGUMENT"],
+      "vocabulary_asymmetry_vs_mcp": "HTTP uses RESOURCE_EXHAUSTED for limit errors; MCP has no such code. HTTP emits `code` only on auth+limit variants; MCP emits `code` on every error."
+    },
+    "routes": [
+      {
+        "method": "GET",
+        "path": "/status",
+        "handler": "health_check",
+        "handler_loc": "src/http/handlers.rs:65",
+        "access_class": "metrics",
+        "success_status": 200,
+        "success_body": "{\"status\":\"healthy\"}",
+        "error_statuses": [401],
+        "pinned_by": ["tests/parity_http.rs::status_success_shape", "tests/parity_http.rs::status_requires_credential_in_required_mode", "tests/parity_http.rs::route_inventory_is_the_known_five"]
+      },
+      {
+        "method": "POST",
+        "path": "/query",
+        "handler": "handle_query",
+        "handler_loc": "src/http/handlers.rs:838",
+        "access_class": "per-operation (query_access_class): read for find_node/get_node/bulk_get_nodes/find_neighbors; write for create/bulk_create/bulk_update/bulk_delete; execute_query/bulk_execute_query read iff no mutating clause",
+        "success_status": 200,
+        "success_body": "{success:true, data?, truncated?}",
+        "error_statuses": [400, 401, 403, 404, 413, 422, 429, 500],
+        "pinned_by": [
+          "tests/parity_http.rs::query_success_envelope_shape",
+          "tests/parity_http.rs::query_not_found_minimal_error_envelope",
+          "tests/parity_http.rs::query_malformed_payload_is_4xx_not_500",
+          "tests/parity_http.rs::query_error_envelope_has_no_trace_id_without_observability",
+          "tests/parity_http.rs::query_missing_credential_is_uniform_401",
+          "tests/parity_http.rs::query_reader_write_is_403_permission_denied",
+          "tests/parity_http.rs::query_row_cap_reject_is_413_resource_exhausted",
+          "tests/parity_http.rs::query_byte_cap_is_413_resource_exhausted",
+          "tests/parity_http.rs::query_over_ceiling_override_is_422_invalid_argument",
+          "tests/parity_http.rs::query_auth_precedes_limit_validation"
+        ],
+        "referenced": {
+          "429_wall_clock_timeout": "not forceable deterministically over the wire; pinned by enforce_query_limits unit tests in src/http/handlers.rs (see tests/http_query_limits.rs header). RESOURCE_EXHAUSTED + Retry-After:1, retriable:true for reads.",
+          "413_request_body_limit": "tests/parity_http.rs::run_server_enforces_request_body_413 (real-socket production run_server stack, Issue #3426)",
+          "otel_trace_id": "tests/http_otel_tracing.rs (observability/otel features)"
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/admin/keys",
+        "handler": "create_key",
+        "handler_loc": "src/http/admin.rs:40",
+        "access_class": "admin",
+        "success_status": 200,
+        "success_body": "{success:true, data:{key (plaintext once, aletheia_sk_ prefix), id, role}}",
+        "error_statuses": [400, 401, 403],
+        "pinned_by": ["tests/parity_http.rs::admin_create_key_success_shape", "tests/parity_http.rs::admin_create_key_non_admin_is_403", "tests/parity_http.rs::admin_create_key_invalid_name_is_400"]
+      },
+      {
+        "method": "GET",
+        "path": "/admin/keys",
+        "handler": "list_keys",
+        "handler_loc": "src/http/admin.rs:69",
+        "access_class": "admin",
+        "success_status": 200,
+        "success_body": "{success:true, data:{keys:[{id, key_prefix, role, ...}]}} — never full key material",
+        "error_statuses": [401, 403],
+        "pinned_by": ["tests/parity_http.rs::admin_list_keys_masks_material", "tests/parity_http.rs::admin_list_keys_non_admin_is_403"]
+      },
+      {
+        "method": "POST",
+        "path": "/admin/keys/revoke",
+        "handler": "revoke_key",
+        "handler_loc": "src/http/admin.rs:93",
+        "access_class": "admin",
+        "success_status": 200,
+        "success_body": "{success:true, data:{revoked:true, id}}",
+        "error_statuses": [401, 403, 404],
+        "pinned_by": ["tests/parity_http.rs::admin_revoke_key_success_and_immediate_effect", "tests/parity_http.rs::admin_revoke_unknown_id_is_404", "tests/parity_http.rs::admin_revoke_non_admin_is_403"]
+      }
+    ],
+    "cross_route_invariants": {
+      "uniform_401": "tests/parity_http.rs::every_route_uniform_401_without_credential — every route returns a byte-identical 401 body + WWW-Authenticate: Bearer when no credential is presented in required mode.",
+      "route_inventory_fixed": "tests/parity_http.rs::route_inventory_is_the_known_five"
+    }
+  },
+  "mcp": {
+    "surface_files": ["src/mcp/mod.rs", "src/mcp/server.rs", "src/mcp/auth.rs", "src/mcp/error.rs", "src/mcp/tools.rs", "src/mcp/batch.rs", "src/mcp/budget.rs", "src/mcp/cursor.rs"],
+    "parity_suite": "tests/parity_mcp.rs",
+    "access_class_source": "src/mcp/auth.rs::TOOL_ACCESS_CLASSES",
+    "advertised_tool_source": "src/mcp/server.rs::tool_definitions()",
+    "error_envelope": {
+      "shape": "{error:{code, message, retriable, details?}, <legacy top-level fields>?}",
+      "code_enum": ["NOT_FOUND", "INVALID_ARGUMENT", "CONSTRAINT_VIOLATION", "FAILED_PRECONDITION", "CONFLICT", "UNAVAILABLE", "INTERNAL", "UNAUTHENTICATED", "PERMISSION_DENIED"],
+      "retriable_true_only_for": ["CONFLICT", "UNAVAILABLE"],
+      "pinned_by": "tests/parity_mcp.rs::error_code_vocabulary_is_stable"
+    },
+    "success_envelope": {
+      "shape": "bare entity JSON (no wrapper) with a `temporal` block on read responses",
+      "temporal_block": "{valid_from, transaction_from (RFC3339), valid_to, transaction_to (null when open), is_current}",
+      "pinned_by": "tests/parity_mcp.rs::success_envelope_and_temporal_block"
+    },
+    "vector_elision": {
+      "default": "{type:'vector', dim, elided:true} (or {type:'sparse_vector', dim, nnz, elided:true})",
+      "opt_out": "include_vectors:true returns full array",
+      "pinned_by": "tests/parity_mcp.rs::vectors_elided_by_default_and_restorable"
+    },
+    "inventory_golden": "tests/parity_mcp.rs::tool_inventory_golden_is_stable",
+    "budgetable_read_tools": ["get_node", "list_nodes", "get_edge", "list_edges", "get_outgoing_edges", "get_incoming_edges", "traverse", "find_similar", "hybrid_query", "query", "find_nodes_at_time", "get_node_history", "get_schema"],
+    "tools": [
+      {"name": "get_node", "access_class": "read", "budgetable": true, "pinned_by": ["tests/parity_mcp.rs::not_found_structured_error", "tests/parity_mcp.rs::out_of_range_id_is_non_retriable_structured_error", "tests/parity_mcp.rs::vectors_elided_by_default_and_restorable", "tests/parity_mcp.rs::success_envelope_and_temporal_block"]},
+      {"name": "create_node", "access_class": "write", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::success_envelope_and_temporal_block", "tests/parity_mcp.rs::representative_tool_roundtrip_is_wellformed"]},
+      {"name": "update_node", "access_class": "write", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "delete_node", "access_class": "write", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "retract_node", "access_class": "write", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "retract_edge", "access_class": "write", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "delete_node_cascade", "access_class": "write", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "list_nodes", "access_class": "read", "budgetable": true, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "count_nodes", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "get_edge", "access_class": "read", "budgetable": true, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "create_edge", "access_class": "write", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::representative_tool_roundtrip_is_wellformed"]},
+      {"name": "update_edge", "access_class": "write", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "delete_edge", "access_class": "write", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "apply_batch", "access_class": "write", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"], "referenced": "src/mcp/tests.rs apply_batch suite"},
+      {"name": "list_edges", "access_class": "read", "budgetable": true, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "count_edges", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "get_outgoing_edges", "access_class": "read", "budgetable": true, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "get_incoming_edges", "access_class": "read", "budgetable": true, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "traverse", "access_class": "read", "budgetable": true, "pinned_by": ["tests/parity_mcp.rs::representative_tool_roundtrip_is_wellformed"]},
+      {"name": "find_similar", "access_class": "read", "budgetable": true, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "enable_vector_index", "access_class": "write", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "list_vector_indexes", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "enable_unique_constraint", "access_class": "write", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "list_unique_constraints", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "get_node_at_time", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "get_edge_at_time", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "find_nodes_at_time", "access_class": "read", "budgetable": true, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "list_changes", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "get_node_at_valid_time", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "get_node_at_transaction_time", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "get_node_history", "access_class": "read", "budgetable": true, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "diff_node_versions", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "get_edge_at_valid_time", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "get_edge_at_transaction_time", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "get_edge_history", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "diff_edge_versions", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "hybrid_query", "access_class": "read", "budgetable": true, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "query", "access_class": "read", "budgetable": true, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "get_schema", "access_class": "read", "budgetable": true, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "temporal_extent", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "lineage_upstream", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "lineage_downstream", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "audit_export", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "database_stats", "access_class": "metrics", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]}
+    ]
+  },
+  "coverage_gaps": [
+    {
+      "id": "mcp-registry-sweep-not-external",
+      "area": "MCP advertised-tool dispatch sweep",
+      "why": "tool_definitions()/list_tools_for_test()/dispatch_tool are pub(crate); the rmcp ServerHandler list_tools/call_tool entry is not reachable from an external test crate (rmcp is not a dev-dependency and is not re-exported). Per house rules we do not add pub to production code.",
+      "mitigation": "The 44-tool inventory + access classes are mirrored as a golden constant (tests/parity_mcp.rs::tool_inventory_golden_is_stable) that a porter must keep in lockstep. The server-side sweep remains enforced in-crate.",
+      "referenced_test": "src/mcp/tests.rs::every_advertised_tool_returns_structured_error_on_invalid_arguments (~line 9257)"
+    },
+    {
+      "id": "mcp-rbac-not-external",
+      "area": "MCP RBAC enforcement (UNAUTHENTICATED / PERMISSION_DENIED)",
+      "why": "auth is enforced only inside dispatch_tool (pub(crate)); the public per-tool typed methods bypass the auth gate, so role enforcement cannot be exercised black-box through the public API.",
+      "mitigation": "Error-code vocabulary for UNAUTHENTICATED/PERMISSION_DENIED is pinned via the public McpErrorCode enum (error_code_vocabulary_is_stable).",
+      "referenced_test": "src/mcp/auth_tests.rs::every_advertised_tool_has_a_classification (~line 89) + the role x tool matrix and uniform-UNAUTHENTICATED sweep in the same file"
+    },
+    {
+      "id": "mcp-token-budget-not-external",
+      "area": "MCP token-budget degradation ladder (Issue #3353)",
+      "why": "apply_budget/shape_response run inside dispatch_tool; the public per-tool methods bypass budget shaping, so the elided_properties -> entity_summaries -> counts_and_handles ladder is not reachable black-box.",
+      "mitigation": "None external; budgetable-tool set documented above.",
+      "referenced_test": "src/mcp/tests.rs budget suite (see BUDGETABLE_READ_TOOLS conformance tests ~tests.rs:13971/13986)"
+    },
+    {
+      "id": "mcp-cursor-not-external",
+      "area": "MCP cursor continuation (Issue #3360)",
+      "why": "cursor paging is applied in the dispatch path, not in the public per-tool methods.",
+      "mitigation": "Cursorable tools documented; behavior remains enforced in-crate.",
+      "referenced_test": "src/mcp/tests.rs cursor suite + src/mcp/cursor.rs unit tests"
+    },
+    {
+      "id": "http-429-not-forced",
+      "area": "HTTP 429 wall-clock timeout",
+      "why": "a real slow query cannot be forced deterministically over the wire; the row/byte caps (413) and override ceiling (422) are the deterministic limit paths pinned here.",
+      "mitigation": "429 RESOURCE_EXHAUSTED + Retry-After:1 + retriable:true(reads)/false(writes) is pinned by enforce_query_limits unit tests.",
+      "referenced_test": "src/http/handlers.rs enforce_query_limits unit tests; tests/http_query_limits.rs (header note)"
+    },
+    {
+      "id": "http-otel-trace-id-gated",
+      "area": "HTTP trace_id body field / x-trace-id header",
+      "why": "populated only under the observability/otel features; under the parity suite's feature set the field is absent (pinned as absent).",
+      "mitigation": "Absence pinned by query_error_envelope_has_no_trace_id_without_observability.",
+      "referenced_test": "tests/http_otel_tracing.rs, tests/http_otel_parent_sampling.rs, tests/http_otel_sampled_out.rs"
+    }
+  ]
+}

--- a/tests/parity_http.rs
+++ b/tests/parity_http.rs
@@ -1,0 +1,785 @@
+//! HTTP surface PARITY harness (black-box golden pins).
+//!
+//! This file pins the *current, observed* behavior of the AletheiaDB HTTP
+//! server (`src/http/**`) so that a future re-implementation on another web
+//! framework must reproduce it **unchanged**. Every assertion here is a
+//! contract, not an aspiration: if one fails after a port, the port changed
+//! observable behavior and the change must be justified — not the test.
+//!
+//! Scope: the FULL registered route inventory (exactly 5 routes assembled by
+//! `handlers::all_routes()`), the success/error envelopes, the auth contract
+//! (401 uniform / 403 role denial), and the per-query + payload resource limits
+//! (413 / 422). Driven black-box through the public `build_test_router` /
+//! `build_test_router_with_auth` (autumn `TestApp`, Pattern A) plus one
+//! real-TCP-socket boot of the production `run_server` (Pattern B) for the
+//! request-body-limit 413, which only exists in the production layer stack.
+//!
+//! Companion machine-readable inventory: `tests/parity/inventory.json`.
+//!
+//! Run with:
+//!   cargo test --features http-server --test parity_http
+//!
+//! Deliberately NOT re-tested here (already pinned elsewhere; referenced in the
+//! inventory to avoid duplication):
+//!   - 429 RESOURCE_EXHAUSTED wall-clock timeout: cannot be forced
+//!     deterministically over the wire (see `tests/http_query_limits.rs` header
+//!     + the `enforce_query_limits` unit tests in `src/http/handlers.rs`).
+//!   - OTel `trace_id` body field / `x-trace-id` header population: requires the
+//!     `observability`/`otel` features (pinned by `tests/http_otel_tracing.rs`).
+//!     Under this file's feature set the field is simply absent — see
+//!     `query_error_envelope_has_no_trace_id_without_observability`.
+
+#![cfg(feature = "http-server")]
+
+use std::io::{Read as _, Write as _};
+use std::net::{TcpListener, TcpStream};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::auth::{AuthMode, AuthStore, Role};
+use aletheiadb::core::PropertyMapBuilder;
+use aletheiadb::http::{
+    AppState, AuthState, QueryLimitsConfig, RowOverflowPolicy, ServerConfig, build_test_router,
+    build_test_router_with_auth, run_server,
+};
+use autumn_web::test::{TestApp, TestClient};
+use serde_json::{Value, json};
+
+// ---------------------------------------------------------------------------
+// Fixtures / helpers (mirror the established patterns in tests/http_*.rs)
+// ---------------------------------------------------------------------------
+
+/// Anonymous-mode client over the real router (auth disabled).
+fn anon_client() -> (TestClient, Arc<AletheiaDB>) {
+    let db = Arc::new(AletheiaDB::new().expect("create DB"));
+    let state = AppState::new(db.clone());
+    let config = ServerConfig::builder()
+        .auth_mode(AuthMode::Anonymous)
+        .build();
+    let router = build_test_router(state, &config).expect("build router");
+    (TestApp::from_router(router), db)
+}
+
+/// Anonymous-mode client with explicit per-query limits.
+fn anon_client_with_limits(limits: QueryLimitsConfig) -> (TestClient, Arc<AletheiaDB>) {
+    let db = Arc::new(AletheiaDB::new().expect("create DB"));
+    let state = AppState::new(db.clone());
+    let config = ServerConfig::builder()
+        .auth_mode(AuthMode::Anonymous)
+        .query_limits(limits)
+        .build();
+    let router = build_test_router(state, &config).expect("build router");
+    (TestApp::from_router(router), db)
+}
+
+/// Required-auth client over the real router, returning the shared key store.
+fn required_client() -> (TestClient, Arc<AuthStore>, Arc<AletheiaDB>) {
+    let db = Arc::new(AletheiaDB::new().expect("create DB"));
+    let state = AppState::new(db.clone());
+    let store = Arc::new(AuthStore::new());
+    let auth = AuthState::new(store.clone(), AuthMode::Required);
+    let config = ServerConfig::default();
+    let router = build_test_router_with_auth(state, auth, &config).expect("build router");
+    (TestApp::from_router(router), store, db)
+}
+
+fn mint(store: &AuthStore, name: &str, role: Role) -> String {
+    let (_p, key) = store.create_key(name, role).expect("mint key");
+    key.to_string()
+}
+
+async fn post_query(client: &TestClient, body: &Value) -> (u16, Value) {
+    let resp = client.post("/query").json(body).send().await;
+    (
+        resp.status.as_u16(),
+        serde_json::from_slice::<Value>(&resp.body).unwrap_or(Value::Null),
+    )
+}
+
+async fn post_query_key(client: &TestClient, key: &str, body: &Value) -> (u16, Value) {
+    let resp = client
+        .post("/query")
+        .header("Authorization", &format!("Bearer {key}"))
+        .json(body)
+        .send()
+        .await;
+    (
+        resp.status.as_u16(),
+        serde_json::from_slice::<Value>(&resp.body).unwrap_or(Value::Null),
+    )
+}
+
+fn seed(db: &AletheiaDB, n: usize) {
+    for i in 0..n {
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("idx", i as i64).build(),
+        )
+        .expect("seed node");
+    }
+}
+
+fn find_people() -> Value {
+    json!({ "operation": "find_node", "label": "Person" })
+}
+
+// ===========================================================================
+// Route inventory — the whole surface is exactly 5 routes.
+// ===========================================================================
+
+/// PARITY: the registered route inventory is a fixed, known set. A port that
+/// adds, drops, or renames a route (or changes its method) fails here.
+#[tokio::test]
+async fn route_inventory_is_the_known_five() {
+    let routes = aletheiadb::http::handlers::all_routes();
+    let mut got: Vec<(String, String)> = routes
+        .iter()
+        .map(|r| (r.method.to_string(), r.path.to_string()))
+        .collect();
+    got.sort();
+
+    let mut want: Vec<(String, String)> = vec![
+        ("GET".into(), "/status".into()),
+        ("POST".into(), "/query".into()),
+        ("POST".into(), "/admin/keys".into()),
+        ("GET".into(), "/admin/keys".into()),
+        ("POST".into(), "/admin/keys/revoke".into()),
+    ];
+    want.sort();
+
+    assert_eq!(
+        got, want,
+        "HTTP route inventory changed — a framework port must preserve exactly \
+         these 5 routes (and update tests/parity/inventory.json)"
+    );
+}
+
+// ===========================================================================
+// GET /status — Metrics class, liveness probe.
+// ===========================================================================
+
+/// PARITY: `/status` returns 200 with the exact liveness body.
+#[tokio::test]
+async fn status_success_shape() {
+    let (client, _db) = anon_client();
+    let resp = client.get("/status").send().await;
+    assert_eq!(resp.status.as_u16(), 200);
+    let body: Value = serde_json::from_slice(&resp.body).expect("json");
+    assert_eq!(body, json!({ "status": "healthy" }));
+}
+
+/// PARITY: `/status` in required mode with no credential is the uniform 401.
+#[tokio::test]
+async fn status_requires_credential_in_required_mode() {
+    let (client, _store, _db) = required_client();
+    let resp = client.get("/status").send().await;
+    assert_eq!(resp.status.as_u16(), 401);
+    assert_eq!(resp.header("www-authenticate"), Some("Bearer"));
+    let body: Value = serde_json::from_slice(&resp.body).expect("json");
+    assert_eq!(body["success"], false);
+    assert_eq!(body["code"], "UNAUTHENTICATED");
+}
+
+// ===========================================================================
+// POST /query — success + error envelopes, auth, limits.
+// ===========================================================================
+
+/// PARITY: the `/query` success envelope is `{success:true, data:[...]}` with
+/// `error`/`truncated` OMITTED when not applicable.
+#[tokio::test]
+async fn query_success_envelope_shape() {
+    let (client, db) = anon_client();
+    seed(&db, 3);
+
+    let (status, body) = post_query(&client, &find_people()).await;
+    assert_eq!(status, 200);
+    assert_eq!(body["success"], true);
+    assert_eq!(body["data"].as_array().map(Vec::len), Some(3));
+    assert!(body.get("error").is_none(), "success omits `error`: {body}");
+    assert!(
+        body.get("truncated").is_none(),
+        "no truncation omits `truncated`: {body}"
+    );
+}
+
+/// PARITY: a not-found lookup is a 404 whose body keeps the MINIMAL error
+/// envelope — `{success:false, error:<string>}` with NO additive
+/// `code`/`retriable`/`details` fields (those are auth/limit-only).
+#[tokio::test]
+async fn query_not_found_minimal_error_envelope() {
+    let (client, _db) = anon_client();
+    let (status, body) = post_query(
+        &client,
+        &json!({ "operation": "get_node", "node_id": 999_999 }),
+    )
+    .await;
+    assert_eq!(status, 404);
+    assert_eq!(body["success"], false);
+    assert!(
+        body["error"].as_str().is_some_and(|s| !s.is_empty()),
+        "error must be a non-empty string: {body}"
+    );
+    assert!(body.get("code").is_none(), "404 carries no `code`: {body}");
+    assert!(
+        body.get("retriable").is_none(),
+        "404 carries no `retriable`: {body}"
+    );
+    assert!(
+        body.get("details").is_none(),
+        "404 carries no `details`: {body}"
+    );
+}
+
+/// PARITY: a malformed operation payload is a clean 4xx client error (never a
+/// 500). A nested-object property is rejected before any DB work.
+#[tokio::test]
+async fn query_malformed_payload_is_4xx_not_500() {
+    let (client, _db) = anon_client();
+    let (status, body) = post_query(
+        &client,
+        &json!({
+            "operation": "create_node",
+            "label": "Person",
+            "properties": { "nested": { "not": "allowed" } }
+        }),
+    )
+    .await;
+    assert!(
+        (400..500).contains(&status),
+        "nested property must be a 4xx client error, got {status}: {body}"
+    );
+    assert_eq!(body["success"], false);
+}
+
+/// PARITY: without the `observability` feature the error envelope carries no
+/// `trace_id` field (the population path is compiled out). The populated shape
+/// is pinned by `tests/http_otel_tracing.rs` under `observability`/`otel`.
+#[tokio::test]
+async fn query_error_envelope_has_no_trace_id_without_observability() {
+    let (client, _db) = anon_client();
+    let resp = client
+        .post("/query")
+        .json(&json!({ "operation": "get_node", "node_id": 999_999 }))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 404);
+    assert!(
+        resp.header("x-trace-id").is_none(),
+        "x-trace-id must be absent without the observability feature"
+    );
+    let body: Value = serde_json::from_slice(&resp.body).expect("json");
+    assert!(body.get("trace_id").is_none(), "no trace_id without otel");
+}
+
+// --- /query auth ---
+
+/// PARITY: `/query` with no credential (required mode) → uniform 401 +
+/// `WWW-Authenticate: Bearer`, body `code = UNAUTHENTICATED`.
+#[tokio::test]
+async fn query_missing_credential_is_uniform_401() {
+    let (client, _store, _db) = required_client();
+    let resp = client.post("/query").json(&find_people()).send().await;
+    assert_eq!(resp.status.as_u16(), 401);
+    assert_eq!(resp.header("www-authenticate"), Some("Bearer"));
+    let body: Value = serde_json::from_slice(&resp.body).expect("json");
+    assert_eq!(body["success"], false);
+    assert_eq!(body["code"], "UNAUTHENTICATED");
+    assert!(
+        body["error"].as_str().is_some_and(|s| !s.is_empty()),
+        "uniform 401 keeps a non-empty error string: {body}"
+    );
+}
+
+/// PARITY: a Reader performing a WRITE operation → 403 PERMISSION_DENIED.
+#[tokio::test]
+async fn query_reader_write_is_403_permission_denied() {
+    let (client, store, _db) = required_client();
+    let reader = mint(&store, "reader", Role::Reader);
+    let (status, body) = post_query_key(
+        &client,
+        &reader,
+        &json!({ "operation": "create_node", "label": "Person", "properties": {"name": "X"} }),
+    )
+    .await;
+    assert_eq!(status, 403, "reader may not write: {body}");
+    assert_eq!(body["success"], false);
+    assert_eq!(body["code"], "PERMISSION_DENIED");
+}
+
+// --- /query resource limits (Issue #3368) ---
+
+/// PARITY: result-row cap under the `Reject` policy → 413 with the structured
+/// `{code:RESOURCE_EXHAUSTED, retriable:false, details{dimension, limit,
+/// consumed}}` envelope.
+#[tokio::test]
+async fn query_row_cap_reject_is_413_resource_exhausted() {
+    let limits = QueryLimitsConfig {
+        enabled: true,
+        default_timeout_ms: 0,
+        max_timeout_ms: 0,
+        default_max_result_rows: 2,
+        max_result_rows: 0,
+        default_max_response_bytes: 0,
+        max_response_bytes: 0,
+        row_overflow: RowOverflowPolicy::Reject,
+    };
+    let (client, db) = anon_client_with_limits(limits);
+    seed(&db, 5);
+
+    let (status, body) = post_query(&client, &find_people()).await;
+    assert_eq!(status, 413, "reject policy over cap → 413: {body}");
+    assert_eq!(body["success"], false);
+    assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
+    assert_eq!(body["retriable"], false);
+    assert_eq!(body["details"]["dimension"], "result_rows");
+    assert_eq!(body["details"]["limit"], 2);
+    assert_eq!(body["details"]["consumed"], 5);
+}
+
+/// PARITY: result-byte cap → 413 with `details.dimension = result_bytes` and a
+/// `consumed` that reports the real serialized size.
+#[tokio::test]
+async fn query_byte_cap_is_413_resource_exhausted() {
+    let limits = QueryLimitsConfig {
+        enabled: true,
+        default_timeout_ms: 0,
+        max_timeout_ms: 0,
+        default_max_result_rows: 0,
+        max_result_rows: 0,
+        default_max_response_bytes: 16,
+        max_response_bytes: 0,
+        row_overflow: RowOverflowPolicy::Truncate,
+    };
+    let (client, db) = anon_client_with_limits(limits);
+    seed(&db, 3);
+
+    let (status, body) = post_query(&client, &find_people()).await;
+    assert_eq!(status, 413, "oversized response → 413: {body}");
+    assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
+    assert_eq!(body["details"]["dimension"], "result_bytes");
+    assert_eq!(body["details"]["limit"], 16);
+    assert!(body["details"]["consumed"].as_u64().unwrap() > 16);
+}
+
+/// PARITY: a per-call limit override above the operator ceiling is rejected
+/// 422 INVALID_ARGUMENT before any DB work, with `details{dimension, requested,
+/// ceiling}`.
+#[tokio::test]
+async fn query_over_ceiling_override_is_422_invalid_argument() {
+    let limits = QueryLimitsConfig {
+        enabled: true,
+        default_timeout_ms: 0,
+        max_timeout_ms: 0,
+        default_max_result_rows: 10,
+        max_result_rows: 100,
+        default_max_response_bytes: 0,
+        max_response_bytes: 0,
+        row_overflow: RowOverflowPolicy::Truncate,
+    };
+    let (client, _db) = anon_client_with_limits(limits);
+
+    let (status, body) = post_query(
+        &client,
+        &json!({
+            "operation": "find_node",
+            "label": "Person",
+            "limits": { "max_result_rows": 1000 }
+        }),
+    )
+    .await;
+    assert_eq!(status, 422, "over-ceiling override → 422: {body}");
+    assert_eq!(body["success"], false);
+    assert_eq!(body["code"], "INVALID_ARGUMENT");
+    assert_eq!(body["retriable"], false);
+    assert_eq!(body["details"]["dimension"], "result_rows");
+    assert_eq!(body["details"]["requested"], 1000);
+    assert_eq!(body["details"]["ceiling"], 100);
+}
+
+/// PARITY: auth is evaluated BEFORE limit validation — an unauthenticated
+/// request that also breaches a ceiling is a 401, never a 422/413.
+#[tokio::test]
+async fn query_auth_precedes_limit_validation() {
+    let db = Arc::new(AletheiaDB::new().expect("db"));
+    let state = AppState::new(db.clone());
+    let store = Arc::new(AuthStore::new());
+    let auth = AuthState::new(store, AuthMode::Required);
+    let limits = QueryLimitsConfig {
+        enabled: true,
+        default_timeout_ms: 0,
+        max_timeout_ms: 0,
+        default_max_result_rows: 10,
+        max_result_rows: 100,
+        default_max_response_bytes: 0,
+        max_response_bytes: 0,
+        row_overflow: RowOverflowPolicy::Truncate,
+    };
+    let config = ServerConfig::builder().query_limits(limits).build();
+    let router = build_test_router_with_auth(state, auth, &config).expect("router");
+    let client = TestApp::from_router(router);
+
+    let (status, body) = post_query(
+        &client,
+        &json!({
+            "operation": "find_node",
+            "label": "Person",
+            "limits": { "max_result_rows": 1000 }
+        }),
+    )
+    .await;
+    assert_eq!(status, 401, "auth rejects before limit logic: {body}");
+    assert_eq!(body["code"], "UNAUTHENTICATED");
+}
+
+// ===========================================================================
+// POST /admin/keys — create (Admin class).
+// ===========================================================================
+
+/// PARITY: an admin creating a key gets 200 with the plaintext key returned
+/// exactly once (prefixed `aletheia_sk_`), the principal id, and the role.
+#[tokio::test]
+async fn admin_create_key_success_shape() {
+    let (client, store, _db) = required_client();
+    let admin = mint(&store, "root", Role::Admin);
+
+    let resp = client
+        .post("/admin/keys")
+        .header("Authorization", &format!("Bearer {admin}"))
+        .json(&json!({ "name": "temp-reader", "role": "reader" }))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200);
+    let body: Value = serde_json::from_slice(&resp.body).expect("json");
+    assert_eq!(body["success"], true);
+    let key = body["data"]["key"].as_str().expect("plaintext key once");
+    assert!(key.starts_with("aletheia_sk_"), "key prefix: {key}");
+    assert!(
+        body["data"]["id"].as_str().is_some(),
+        "principal id present"
+    );
+    assert_eq!(body["data"]["role"], "reader");
+}
+
+/// PARITY: a non-admin role → 403 PERMISSION_DENIED on key creation.
+#[tokio::test]
+async fn admin_create_key_non_admin_is_403() {
+    let (client, store, _db) = required_client();
+    let writer = mint(&store, "writer", Role::Writer);
+    let resp = client
+        .post("/admin/keys")
+        .header("Authorization", &format!("Bearer {writer}"))
+        .json(&json!({ "name": "sneaky", "role": "admin" }))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 403);
+    let body: Value = serde_json::from_slice(&resp.body).expect("json");
+    assert_eq!(body["code"], "PERMISSION_DENIED");
+}
+
+/// PARITY: invalid create-key input (empty name) is a 400 (repairable client
+/// error), never a 500.
+#[tokio::test]
+async fn admin_create_key_invalid_name_is_400() {
+    let (client, store, _db) = required_client();
+    let admin = mint(&store, "root", Role::Admin);
+    let resp = client
+        .post("/admin/keys")
+        .header("Authorization", &format!("Bearer {admin}"))
+        .json(&json!({ "name": "", "role": "reader" }))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 400);
+    let body: Value = serde_json::from_slice(&resp.body).expect("json");
+    assert_eq!(body["success"], false);
+}
+
+// ===========================================================================
+// GET /admin/keys — masked list (Admin class).
+// ===========================================================================
+
+/// PARITY: the key list masks material — it exposes `key_prefix` per entry and
+/// NEVER a full key; the created key's plaintext is absent from the body.
+#[tokio::test]
+async fn admin_list_keys_masks_material() {
+    let (client, store, _db) = required_client();
+    let admin = mint(&store, "root", Role::Admin);
+    let bearer = format!("Bearer {admin}");
+
+    // Create a key so there is something to mask.
+    let created = client
+        .post("/admin/keys")
+        .header("Authorization", &bearer)
+        .json(&json!({ "name": "listed", "role": "reader" }))
+        .send()
+        .await;
+    let created: Value = serde_json::from_slice(&created.body).expect("json");
+    let full_key = created["data"]["key"].as_str().expect("key").to_string();
+
+    let resp = client
+        .get("/admin/keys")
+        .header("Authorization", &bearer)
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200);
+    let raw = String::from_utf8_lossy(&resp.body).to_string();
+    assert!(
+        !raw.contains(&full_key),
+        "the key list must never contain a full key"
+    );
+    let body: Value = serde_json::from_str(&raw).expect("json");
+    assert_eq!(body["success"], true);
+    let keys = body["data"]["keys"].as_array().expect("keys array");
+    assert!(!keys.is_empty());
+    let entry = keys
+        .iter()
+        .find(|k| {
+            k["key_prefix"]
+                .as_str()
+                .is_some_and(|p| full_key.starts_with(p))
+        })
+        .expect("listed entry with a masking prefix");
+    let prefix = entry["key_prefix"].as_str().unwrap();
+    assert!(
+        prefix.len() < full_key.len(),
+        "prefix must be a strict mask"
+    );
+}
+
+/// PARITY: a non-admin role → 403 on the list route.
+#[tokio::test]
+async fn admin_list_keys_non_admin_is_403() {
+    let (client, store, _db) = required_client();
+    let reader = mint(&store, "reader", Role::Reader);
+    let resp = client
+        .get("/admin/keys")
+        .header("Authorization", &format!("Bearer {reader}"))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 403);
+    let body: Value = serde_json::from_slice(&resp.body).expect("json");
+    assert_eq!(body["code"], "PERMISSION_DENIED");
+}
+
+// ===========================================================================
+// POST /admin/keys/revoke — revoke (Admin class).
+// ===========================================================================
+
+/// PARITY: revoking a real key → 200 `{revoked:true}` and the key stops
+/// authenticating (uniform 401 thereafter).
+#[tokio::test]
+async fn admin_revoke_key_success_and_immediate_effect() {
+    let (client, store, _db) = required_client();
+    let admin = mint(&store, "root", Role::Admin);
+    let bearer = format!("Bearer {admin}");
+
+    let created = client
+        .post("/admin/keys")
+        .header("Authorization", &bearer)
+        .json(&json!({ "name": "revoke-me", "role": "reader" }))
+        .send()
+        .await;
+    let created: Value = serde_json::from_slice(&created.body).expect("json");
+    let victim_key = created["data"]["key"].as_str().unwrap().to_string();
+    let victim_id = created["data"]["id"].as_str().unwrap().to_string();
+
+    let resp = client
+        .post("/admin/keys/revoke")
+        .header("Authorization", &bearer)
+        .json(&json!({ "id": victim_id }))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200);
+    let body: Value = serde_json::from_slice(&resp.body).expect("json");
+    assert_eq!(body["data"]["revoked"], true);
+
+    // Immediate revocation: the key is now a uniform 401.
+    let (status, body) = post_query_key(&client, &victim_key, &find_people()).await;
+    assert_eq!(status, 401);
+    assert_eq!(body["code"], "UNAUTHENTICATED");
+}
+
+/// PARITY: revoking an unknown id → 404.
+#[tokio::test]
+async fn admin_revoke_unknown_id_is_404() {
+    let (client, store, _db) = required_client();
+    let admin = mint(&store, "root", Role::Admin);
+    let resp = client
+        .post("/admin/keys/revoke")
+        .header("Authorization", &format!("Bearer {admin}"))
+        .json(&json!({ "id": "no-such-id" }))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 404);
+}
+
+/// PARITY: a non-admin role → 403 on the revoke route.
+#[tokio::test]
+async fn admin_revoke_non_admin_is_403() {
+    let (client, store, _db) = required_client();
+    let reader = mint(&store, "reader", Role::Reader);
+    let resp = client
+        .post("/admin/keys/revoke")
+        .header("Authorization", &format!("Bearer {reader}"))
+        .json(&json!({ "id": "whatever" }))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 403);
+    let body: Value = serde_json::from_slice(&resp.body).expect("json");
+    assert_eq!(body["code"], "PERMISSION_DENIED");
+}
+
+// ===========================================================================
+// Whole-inventory 401 sweep — a future handler that forgets the AuthContext
+// extractor is caught, and the 401 body is byte-identical everywhere.
+// ===========================================================================
+
+/// PARITY: every registered route returns the SAME uniform 401 body when no
+/// credential is presented (no route leaks a distinguishable shape).
+#[tokio::test]
+async fn every_route_uniform_401_without_credential() {
+    let (client, _store, _db) = required_client();
+    let routes = aletheiadb::http::handlers::all_routes();
+    assert!(!routes.is_empty());
+
+    let mut reference: Option<Vec<u8>> = None;
+    for route in &routes {
+        let builder = match route.method.as_str() {
+            "GET" => client.get(route.path),
+            "POST" => client.post(route.path).json(&json!({})),
+            other => panic!("unhandled method {other} for {}", route.path),
+        };
+        let resp = builder.send().await;
+        assert_eq!(
+            resp.status.as_u16(),
+            401,
+            "route {} {} must 401 without a credential",
+            route.method,
+            route.path
+        );
+        assert_eq!(resp.header("www-authenticate"), Some("Bearer"));
+        match &reference {
+            None => reference = Some(resp.body.clone()),
+            Some(r) => assert_eq!(
+                &resp.body, r,
+                "401 body diverged on {} {}",
+                route.method, route.path
+            ),
+        }
+    }
+}
+
+// ===========================================================================
+// Pattern B — production run_server over a real TCP socket: request-body
+// limit 413 (only present in the production layer stack, Issue #3426).
+// ===========================================================================
+
+fn reserve_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+
+fn raw_post_status(addr: &str, path: &str, body: &[u8]) -> Option<u16> {
+    let mut stream = TcpStream::connect(addr).ok()?;
+    stream.set_read_timeout(Some(Duration::from_secs(5))).ok()?;
+    let head = format!(
+        "POST {path} HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\n\
+         Content-Length: {len}\r\nConnection: close\r\n\r\n",
+        len = body.len()
+    );
+    stream.write_all(head.as_bytes()).ok()?;
+    // The server may RST after rejecting the oversized body before we finish
+    // writing; tolerate broken-pipe/reset and still read the status line.
+    if let Err(e) = stream.write_all(body)
+        && !matches!(
+            e.kind(),
+            std::io::ErrorKind::BrokenPipe | std::io::ErrorKind::ConnectionReset
+        )
+    {
+        return None;
+    }
+    let _ = stream.flush();
+    let mut resp = Vec::new();
+    let mut buf = [0u8; 4096];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                resp.extend_from_slice(&buf[..n]);
+                if resp.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    let text = String::from_utf8_lossy(&resp);
+    let line = text.lines().next()?;
+    line.split_whitespace().nth(1)?.parse::<u16>().ok()
+}
+
+fn post_when_ready(addr: &str, path: &str, body: &[u8]) -> u16 {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if let Some(s) = raw_post_status(addr, path, body) {
+            return s;
+        }
+        assert!(Instant::now() < deadline, "server at {addr} never came up");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// PARITY: the production `run_server` stack rejects an oversized request body
+/// with 413 over the wire, while a small legitimate body still serves 200.
+#[test]
+fn run_server_enforces_request_body_413() {
+    const LIMIT: usize = 4 * 1024;
+    let port = reserve_port();
+    let addr = format!("127.0.0.1:{port}");
+
+    let config = ServerConfig::builder()
+        .host("127.0.0.1")
+        .port(port)
+        .auth_mode(AuthMode::Anonymous)
+        .max_request_body_bytes(LIMIT)
+        .build();
+
+    // The autumn/axum run_server future cannot be tokio::spawn'ed (higher-ranked
+    // lifetime), so run it on a dedicated OS thread + current-thread runtime.
+    let _server = std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let _ = rt.block_on(run_server(config));
+    });
+
+    let big: Vec<Value> = (0..4_000).map(|_| json!(1)).collect();
+    let oversized = serde_json::to_vec(&json!({
+        "operation": "execute_query",
+        "query": "MATCH (n) RETURN n",
+        "parameters": { "v": big }
+    }))
+    .unwrap();
+    assert!(oversized.len() > LIMIT && oversized.len() < 2 * 1024 * 1024);
+    assert_eq!(
+        post_when_ready(&addr, "/query", &oversized),
+        413,
+        "production stack must reject oversized body with 413"
+    );
+
+    let small = serde_json::to_vec(&json!({
+        "operation": "create_node",
+        "label": "Person",
+        "properties": { "name": "Alice" }
+    }))
+    .unwrap();
+    assert!(small.len() < LIMIT);
+    assert_eq!(
+        post_when_ready(&addr, "/query", &small),
+        200,
+        "a small legitimate request must still serve 200"
+    );
+}

--- a/tests/parity_http.rs
+++ b/tests/parity_http.rs
@@ -757,12 +757,14 @@ fn raw_post_status(addr: &str, path: &str, body: &[u8]) -> Option<u16> {
     stream.write_all(head.as_bytes()).ok()?;
     // The server may RST after rejecting the oversized body before we finish
     // writing; tolerate broken-pipe/reset and still read the status line.
-    if let Err(e) = stream.write_all(body)
-        && !matches!(
+    let write_failed_hard = match stream.write_all(body) {
+        Ok(()) => false,
+        Err(e) => !matches!(
             e.kind(),
             std::io::ErrorKind::BrokenPipe | std::io::ErrorKind::ConnectionReset
-        )
-    {
+        ),
+    };
+    if write_failed_hard {
         return None;
     }
     let _ = stream.flush();

--- a/tests/parity_http.rs
+++ b/tests/parity_http.rs
@@ -159,7 +159,9 @@ async fn route_inventory_is_the_known_five() {
 // GET /status — Metrics class, liveness probe.
 // ===========================================================================
 
-/// PARITY: `/status` returns 200 with the exact liveness body.
+/// PARITY: `/status` returns 200 with the exact liveness body. The top-level
+/// key set is pinned exactly (`{status}` only) so a port that ADDS a field
+/// (e.g. `version`, `uptime`) is caught here, not silently tolerated.
 #[tokio::test]
 async fn status_success_shape() {
     let (client, _db) = anon_client();
@@ -167,6 +169,19 @@ async fn status_success_shape() {
     assert_eq!(resp.status.as_u16(), 200);
     let body: Value = serde_json::from_slice(&resp.body).expect("json");
     assert_eq!(body, json!({ "status": "healthy" }));
+
+    // Exact top-level key-set pin (an ADDED field breaks this).
+    let keys: std::collections::BTreeSet<&str> = body
+        .as_object()
+        .expect("status body is an object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    assert_eq!(
+        keys,
+        std::collections::BTreeSet::from(["status"]),
+        "/status success body must carry exactly {{status}}: {body}"
+    );
 }
 
 /// PARITY: `/status` in required mode with no credential is the uniform 401.
@@ -229,12 +244,31 @@ async fn query_not_found_minimal_error_envelope() {
         body.get("details").is_none(),
         "404 carries no `details`: {body}"
     );
+
+    // Exact top-level key-set pin: the minimal error envelope is EXACTLY
+    // `{success, error}` — an ADDED field (e.g. a leaked `code`/`trace_id`)
+    // is caught here. Additive fields (code/details/retriable) are
+    // deliberately kept off this path so this exact-key-set pin is valid.
+    let keys: std::collections::BTreeSet<&str> = body
+        .as_object()
+        .expect("error body is an object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    assert_eq!(
+        keys,
+        std::collections::BTreeSet::from(["success", "error"]),
+        "minimal 404 error envelope must carry exactly {{success, error}}: {body}"
+    );
 }
 
-/// PARITY: a malformed operation payload is a clean 4xx client error (never a
-/// 500). A nested-object property is rejected before any DB work.
+/// PARITY: a malformed operation payload is a clean 400 client error (never a
+/// 500). A nested-object property is rejected before any DB work (BadRequest →
+/// 400) and keeps the MINIMAL `{success:false, error:<string>}` envelope with
+/// NO additive `code`/`retriable`/`details` (consistent with the not-found
+/// case; those additive fields are auth/limit-only).
 #[tokio::test]
-async fn query_malformed_payload_is_4xx_not_500() {
+async fn query_malformed_payload_is_400_not_500() {
     let (client, _db) = anon_client();
     let (status, body) = post_query(
         &client,
@@ -245,11 +279,24 @@ async fn query_malformed_payload_is_4xx_not_500() {
         }),
     )
     .await;
-    assert!(
-        (400..500).contains(&status),
-        "nested property must be a 4xx client error, got {status}: {body}"
+    assert_eq!(
+        status, 400,
+        "nested property must be a 400 client error, got {status}: {body}"
     );
     assert_eq!(body["success"], false);
+    assert!(
+        body["error"].as_str().is_some_and(|s| !s.is_empty()),
+        "error must be a non-empty string: {body}"
+    );
+    assert!(body.get("code").is_none(), "400 carries no `code`: {body}");
+    assert!(
+        body.get("retriable").is_none(),
+        "400 carries no `retriable`: {body}"
+    );
+    assert!(
+        body.get("details").is_none(),
+        "400 carries no `details`: {body}"
+    );
 }
 
 /// PARITY: without the `observability` feature the error envelope carries no
@@ -356,7 +403,12 @@ async fn query_byte_cap_is_413_resource_exhausted() {
 
     let (status, body) = post_query(&client, &find_people()).await;
     assert_eq!(status, 413, "oversized response → 413: {body}");
+    assert_eq!(body["success"], false);
     assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
+    assert_eq!(
+        body["retriable"], false,
+        "a byte cap is never retriable (symmetry with the row cap): {body}"
+    );
     assert_eq!(body["details"]["dimension"], "result_bytes");
     assert_eq!(body["details"]["limit"], 16);
     assert!(body["details"]["consumed"].as_u64().unwrap() > 16);
@@ -599,7 +651,9 @@ async fn admin_revoke_key_success_and_immediate_effect() {
     assert_eq!(body["code"], "UNAUTHENTICATED");
 }
 
-/// PARITY: revoking an unknown id → 404.
+/// PARITY: revoking an unknown id → 404 with the MINIMAL
+/// `{success:false, error:<string>}` envelope (NotFound → no additive
+/// `code`/`retriable`/`details`).
 #[tokio::test]
 async fn admin_revoke_unknown_id_is_404() {
     let (client, store, _db) = required_client();
@@ -611,6 +665,17 @@ async fn admin_revoke_unknown_id_is_404() {
         .send()
         .await;
     assert_eq!(resp.status.as_u16(), 404);
+    let body: Value = serde_json::from_slice(&resp.body).expect("json");
+    assert_eq!(body["success"], false);
+    assert!(
+        body["error"].as_str().is_some_and(|s| !s.is_empty()),
+        "error must be a non-empty string: {body}"
+    );
+    assert!(body.get("code").is_none(), "404 carries no `code`: {body}");
+    assert!(
+        body.get("retriable").is_none(),
+        "404 carries no `retriable`: {body}"
+    );
 }
 
 /// PARITY: a non-admin role → 403 on the revoke route.

--- a/tests/parity_mcp.rs
+++ b/tests/parity_mcp.rs
@@ -1,0 +1,405 @@
+//! MCP surface PARITY harness (black-box golden pins).
+//!
+//! Pins the *current, observed* behavior of the AletheiaDB MCP server
+//! (`src/mcp/**`) so a future re-implementation must reproduce it **unchanged**.
+//!
+//! ## Reachability note (important for the design lane)
+//!
+//! The MCP server is driven here through its **public** black-box surface only:
+//!
+//!   - `AletheiaMcpServer::new(db)` / `::with_auth(db, cfg)` constructors, and
+//!   - the per-tool typed methods (`server.get_node(GetNodeRequest{..}) ->
+//!     String`, etc.), each returning the tool's response JSON as a string.
+//!
+//! The registry dispatcher (`dispatch_tool`), the advertised-tool accessor
+//! (`list_tools_for_test`), the token-budget shaper (`apply_budget`), and the
+//! auth gate (`SessionAuth::authorize_tool`) are all `pub(crate)` or reached
+//! only via the `rmcp::ServerHandler` trait (`list_tools`/`call_tool`), which
+//! is NOT nameable from an external test crate (rmcp is not a dev-dependency and
+//! is not re-exported). Per the harness house rules we do NOT add `pub` to
+//! production code to reach them. Consequently the following are pinned by the
+//! EXISTING in-crate suites and only *referenced* in `tests/parity/inventory.json`
+//! (not duplicated here):
+//!
+//!   - advertised-tool registry sweep (every advertised tool dispatchable and
+//!     returns a well-formed structured error on invalid args):
+//!     `src/mcp/tests.rs::every_advertised_tool_returns_structured_error_on_invalid_arguments`
+//!   - RBAC class enforcement (uniform UNAUTHENTICATED, PERMISSION_DENIED
+//!     matrix, every-advertised-tool-classified):
+//!     `src/mcp/auth_tests.rs::every_advertised_tool_has_a_classification`
+//!   - token-budget degradation ladder: `src/mcp/tests.rs` budget suite.
+//!
+//! What this file DOES pin publicly: the structured error-code vocabulary
+//! (via the public `McpErrorCode` enum — the single source of truth for the
+//! wire codes), the success + structured-error envelope shapes, the temporal
+//! block on read responses, and the vector-elision default. It also pins the
+//! full 44-tool inventory + access-class table as a golden constant that a
+//! porter must keep in lockstep with the server.
+//!
+//! Run with:
+//!   cargo test --features mcp-server --test parity_mcp
+
+#![cfg(feature = "mcp-server")]
+
+use std::sync::Arc;
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::mcp::{
+    AletheiaMcpServer, CreateNodeRequest, GetNodeRequest, McpErrorCode, TraverseRequest,
+};
+use serde_json::{Value, json};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+fn server() -> AletheiaMcpServer {
+    AletheiaMcpServer::new(Arc::new(AletheiaDB::new().expect("create DB")))
+}
+
+/// The 9 stable structured error codes, in the enum's declared order.
+const ALL_CODES: [McpErrorCode; 9] = [
+    McpErrorCode::NotFound,
+    McpErrorCode::InvalidArgument,
+    McpErrorCode::ConstraintViolation,
+    McpErrorCode::FailedPrecondition,
+    McpErrorCode::Conflict,
+    McpErrorCode::Unavailable,
+    McpErrorCode::Internal,
+    McpErrorCode::Unauthenticated,
+    McpErrorCode::PermissionDenied,
+];
+
+fn code_strings() -> Vec<&'static str> {
+    ALL_CODES.iter().map(|c| c.as_str()).collect()
+}
+
+/// Assert a response string is a well-formed structured MCP error:
+/// `{error:{code ∈ enum, message: non-empty string, retriable: bool}}`.
+/// Returns the `code` string.
+fn assert_structured_error(resp: &str, ctx: &str) -> String {
+    let v: Value = serde_json::from_str(resp).unwrap_or_else(|e| panic!("[{ctx}] not JSON: {e}"));
+    let err = v
+        .get("error")
+        .unwrap_or_else(|| panic!("[{ctx}] missing `error`: {v}"));
+    let code = err["code"]
+        .as_str()
+        .unwrap_or_else(|| panic!("[{ctx}] error.code not a string: {v}"))
+        .to_string();
+    assert!(
+        code_strings().contains(&code.as_str()),
+        "[{ctx}] error.code `{code}` not in the stable enum: {v}"
+    );
+    assert!(
+        err["message"].as_str().is_some_and(|s| !s.is_empty()),
+        "[{ctx}] error.message must be a non-empty string: {v}"
+    );
+    assert!(
+        err["retriable"].is_boolean(),
+        "[{ctx}] error.retriable must be present and boolean: {v}"
+    );
+    code
+}
+
+/// Create a node via the public typed method, returning its parsed response.
+fn create_node(server: &AletheiaMcpServer, body: Value) -> Value {
+    let req: CreateNodeRequest =
+        serde_json::from_value(body).expect("valid CreateNodeRequest json");
+    let resp = server.create_node(req);
+    let v: Value = serde_json::from_str(&resp).expect("json");
+    assert!(v.get("error").is_none(), "create_node failed: {v}");
+    v
+}
+
+// ===========================================================================
+// Structured error-code vocabulary — the stability contract.
+// ===========================================================================
+
+/// PARITY: the wire representation of every `McpErrorCode` and its default
+/// retriable classification. A port MUST reproduce these exact strings and
+/// flags. Codes may be ADDED over time (extend this test), but an existing
+/// code changing its spelling or retriable default is a breaking change.
+#[test]
+fn error_code_vocabulary_is_stable() {
+    let pairs: Vec<(&str, bool)> = ALL_CODES
+        .iter()
+        .map(|c| (c.as_str(), c.default_retriable()))
+        .collect();
+
+    assert_eq!(
+        pairs,
+        vec![
+            ("NOT_FOUND", false),
+            ("INVALID_ARGUMENT", false),
+            ("CONSTRAINT_VIOLATION", false),
+            ("FAILED_PRECONDITION", false),
+            ("CONFLICT", true),
+            ("UNAVAILABLE", true),
+            ("INTERNAL", false),
+            ("UNAUTHENTICATED", false),
+            ("PERMISSION_DENIED", false),
+        ],
+        "MCP structured error vocabulary changed — a port must preserve these \
+         codes + retriable defaults (keep tests/parity/inventory.json in sync)"
+    );
+
+    // Only Conflict/Unavailable are transient-by-default.
+    assert!(McpErrorCode::Conflict.default_retriable());
+    assert!(McpErrorCode::Unavailable.default_retriable());
+    assert!(!McpErrorCode::NotFound.default_retriable());
+    assert!(!McpErrorCode::Internal.default_retriable());
+}
+
+// ===========================================================================
+// Success + structured-error envelope shapes (via public typed methods).
+// ===========================================================================
+
+/// PARITY: a create_node success response is a bare entity object carrying
+/// `id`, `label`, `properties`, and a `temporal` block with open (null) upper
+/// bounds and `is_current: true`. No `error` key on success.
+#[test]
+fn success_envelope_and_temporal_block() {
+    let s = server();
+    let v = create_node(
+        &s,
+        json!({ "label": "Person", "properties": { "name": "Alice" } }),
+    );
+
+    assert!(v["id"].as_u64().is_some(), "id must be a number: {v}");
+    assert_eq!(v["label"], "Person");
+    assert_eq!(v["properties"]["name"], "Alice");
+
+    let t = v
+        .get("temporal")
+        .unwrap_or_else(|| panic!("read response must carry a `temporal` block: {v}"));
+    // Lower bounds are RFC3339 strings; upper bounds are explicit JSON null.
+    assert!(
+        t["valid_from"].as_str().is_some(),
+        "valid_from RFC3339 string: {t}"
+    );
+    assert!(
+        t["transaction_from"].as_str().is_some(),
+        "transaction_from RFC3339 string: {t}"
+    );
+    assert!(
+        t.get("valid_to").is_some_and(Value::is_null),
+        "valid_to must be present as null for an open interval: {t}"
+    );
+    assert!(
+        t.get("transaction_to").is_some_and(Value::is_null),
+        "transaction_to must be present as null for an open interval: {t}"
+    );
+    assert_eq!(
+        t["is_current"],
+        json!(true),
+        "a live version is_current: {t}"
+    );
+}
+
+/// PARITY: a lookup of a non-existent (but syntactically valid) node id yields
+/// the structured error envelope with `code = NOT_FOUND`, `retriable = false`.
+#[test]
+fn not_found_structured_error() {
+    let s = server();
+    let req: GetNodeRequest = serde_json::from_value(json!({ "node_id": 999_999 })).unwrap();
+    let resp = s.get_node(req);
+    let code = assert_structured_error(&resp, "get_node/missing");
+    assert_eq!(code, "NOT_FOUND");
+
+    let v: Value = serde_json::from_str(&resp).unwrap();
+    assert_eq!(v["error"]["retriable"], json!(false));
+}
+
+/// PARITY: an out-of-range node id (beyond `MAX_VALID_ID`) is rejected as a
+/// caller-fault structured error (non-retriable) rather than panicking or
+/// succeeding. We pin the envelope + non-retriable flag; the exact code is
+/// asserted to be a caller-fault class.
+#[test]
+fn out_of_range_id_is_non_retriable_structured_error() {
+    let s = server();
+    let req: GetNodeRequest = serde_json::from_value(json!({ "node_id": u64::MAX })).unwrap();
+    let resp = s.get_node(req);
+    let code = assert_structured_error(&resp, "get_node/overflow");
+
+    let v: Value = serde_json::from_str(&resp).unwrap();
+    assert_eq!(
+        v["error"]["retriable"],
+        json!(false),
+        "an out-of-range id is caller-fault, never retriable: {v}"
+    );
+    // Caller-fault classification (not a transient class).
+    assert!(
+        matches!(code.as_str(), "INVALID_ARGUMENT" | "NOT_FOUND"),
+        "overflow id must classify as a caller-fault code, got {code}"
+    );
+}
+
+// ===========================================================================
+// Vector elision default (Issue #3220).
+// ===========================================================================
+
+/// PARITY: an embedding-valued property is elided by default to a
+/// `{type:"vector", dim, elided:true}` descriptor, and `include_vectors:true`
+/// restores the full float array losslessly.
+#[test]
+fn vectors_elided_by_default_and_restorable() {
+    let s = server();
+    let embedding: Vec<f32> = (0..8).map(|i| i as f32 * 0.25).collect();
+    let created = create_node(
+        &s,
+        json!({ "label": "Document", "properties": { "embedding": embedding.clone() } }),
+    );
+    let node_id = created["id"].as_u64().expect("node id");
+
+    // Default: elided descriptor.
+    let req: GetNodeRequest = serde_json::from_value(json!({ "node_id": node_id })).unwrap();
+    let elided: Value = serde_json::from_str(&s.get_node(req)).unwrap();
+    assert_eq!(
+        elided["properties"]["embedding"],
+        json!({ "type": "vector", "dim": 8, "elided": true }),
+        "embedding must be elided by default: {elided}"
+    );
+
+    // include_vectors:true: full array restored.
+    let req: GetNodeRequest =
+        serde_json::from_value(json!({ "node_id": node_id, "include_vectors": true })).unwrap();
+    let full: Value = serde_json::from_str(&s.get_node(req)).unwrap();
+    let got: Vec<f32> = full["properties"]["embedding"]
+        .as_array()
+        .expect("full array")
+        .iter()
+        .map(|v| v.as_f64().unwrap() as f32)
+        .collect();
+    assert_eq!(got, embedding, "include_vectors must be lossless");
+}
+
+// ===========================================================================
+// Representative black-box roundtrip through several tools — proves the public
+// typed entry points are dispatchable and return well-formed JSON.
+// ===========================================================================
+
+/// PARITY: a small graph built and traversed through public typed methods
+/// yields well-formed, non-error JSON (no envelope drift on the happy path).
+#[test]
+fn representative_tool_roundtrip_is_wellformed() {
+    let s = server();
+    let a = create_node(
+        &s,
+        json!({ "label": "Person", "properties": { "name": "A" } }),
+    );
+    let b = create_node(
+        &s,
+        json!({ "label": "Person", "properties": { "name": "B" } }),
+    );
+    let (a_id, b_id) = (a["id"].as_u64().unwrap(), b["id"].as_u64().unwrap());
+
+    // create_edge via JSON-built request.
+    let edge_req: aletheiadb::mcp::CreateEdgeRequest = serde_json::from_value(json!({
+        "source_id": a_id, "target_id": b_id, "label": "KNOWS"
+    }))
+    .unwrap();
+    let edge: Value = serde_json::from_str(&s.create_edge(edge_req)).unwrap();
+    assert!(edge.get("error").is_none(), "create_edge failed: {edge}");
+
+    // traverse from A over KNOWS.
+    let tr_req: TraverseRequest = serde_json::from_value(json!({
+        "start_node_id": a_id, "edge_label": "KNOWS", "depth": 1
+    }))
+    .unwrap();
+    let traversed: Value = serde_json::from_str(&s.traverse(tr_req)).unwrap();
+    assert!(
+        traversed.get("error").is_none(),
+        "traverse failed: {traversed}"
+    );
+}
+
+// ===========================================================================
+// Golden tool inventory — the 44-tool advertised set + access classes.
+//
+// This is the one place the FULL registry is pinned from an external test:
+// because the advertised list (`tool_definitions`) is not reachable through the
+// public API, we mirror it as a golden constant a porter must keep in lockstep
+// with the server and with tests/parity/inventory.json. The in-crate registry
+// sweep (src/mcp/tests.rs) enforces the server side; this enforces the mirror.
+// ===========================================================================
+
+/// (tool_name, access_class) for every advertised MCP tool, per
+/// `src/mcp/auth.rs::TOOL_ACCESS_CLASSES`. Access class ∈ {read, write, metrics}
+/// (MCP advertises no admin-class tools).
+const TOOL_INVENTORY: [(&str, &str); 44] = [
+    ("get_node", "read"),
+    ("create_node", "write"),
+    ("update_node", "write"),
+    ("delete_node", "write"),
+    ("retract_node", "write"),
+    ("retract_edge", "write"),
+    ("delete_node_cascade", "write"),
+    ("list_nodes", "read"),
+    ("count_nodes", "read"),
+    ("get_edge", "read"),
+    ("create_edge", "write"),
+    ("update_edge", "write"),
+    ("delete_edge", "write"),
+    ("apply_batch", "write"),
+    ("list_edges", "read"),
+    ("count_edges", "read"),
+    ("get_outgoing_edges", "read"),
+    ("get_incoming_edges", "read"),
+    ("traverse", "read"),
+    ("find_similar", "read"),
+    ("enable_vector_index", "write"),
+    ("list_vector_indexes", "read"),
+    ("enable_unique_constraint", "write"),
+    ("list_unique_constraints", "read"),
+    ("get_node_at_time", "read"),
+    ("get_edge_at_time", "read"),
+    ("find_nodes_at_time", "read"),
+    ("list_changes", "read"),
+    ("get_node_at_valid_time", "read"),
+    ("get_node_at_transaction_time", "read"),
+    ("get_node_history", "read"),
+    ("diff_node_versions", "read"),
+    ("get_edge_at_valid_time", "read"),
+    ("get_edge_at_transaction_time", "read"),
+    ("get_edge_history", "read"),
+    ("diff_edge_versions", "read"),
+    ("hybrid_query", "read"),
+    ("query", "read"),
+    ("get_schema", "read"),
+    ("temporal_extent", "read"),
+    ("lineage_upstream", "read"),
+    ("lineage_downstream", "read"),
+    ("audit_export", "read"),
+    ("database_stats", "metrics"),
+];
+
+/// PARITY: the advertised MCP tool inventory is exactly 44 tools with the
+/// documented access classes, and every name is unique. Adding/removing a tool
+/// (or reclassifying it) must update this golden AND tests/parity/inventory.json.
+#[test]
+fn tool_inventory_golden_is_stable() {
+    assert_eq!(TOOL_INVENTORY.len(), 44, "MCP advertises exactly 44 tools");
+
+    // Names unique.
+    let mut names: Vec<&str> = TOOL_INVENTORY.iter().map(|(n, _)| *n).collect();
+    let count = names.len();
+    names.sort_unstable();
+    names.dedup();
+    assert_eq!(names.len(), count, "tool names must be unique");
+
+    // Access classes are drawn from the MCP-legal set (no admin tools).
+    for (name, class) in TOOL_INVENTORY {
+        assert!(
+            matches!(class, "read" | "write" | "metrics"),
+            "tool `{name}` has an unexpected access class `{class}`"
+        );
+    }
+
+    // Exactly one metrics tool, and it is database_stats.
+    let metrics: Vec<&str> = TOOL_INVENTORY
+        .iter()
+        .filter(|(_, c)| *c == "metrics")
+        .map(|(n, _)| *n)
+        .collect();
+    assert_eq!(metrics, vec!["database_stats"]);
+}

--- a/tests/parity_mcp.rs
+++ b/tests/parity_mcp.rs
@@ -211,9 +211,10 @@ fn not_found_structured_error() {
 }
 
 /// PARITY: an out-of-range node id (beyond `MAX_VALID_ID`) is rejected as a
-/// caller-fault structured error (non-retriable) rather than panicking or
-/// succeeding. We pin the envelope + non-retriable flag; the exact code is
-/// asserted to be a caller-fault class.
+/// caller-fault structured error rather than panicking or succeeding. The code
+/// is DETERMINISTIC: `NodeId::new` rejects the overflow id and `get_node` maps
+/// that to `INVALID_ARGUMENT` (never `NOT_FOUND` — the id never resolves to a
+/// lookup), non-retriable. A port must reproduce this exact classification.
 #[test]
 fn out_of_range_id_is_non_retriable_structured_error() {
     let s = server();
@@ -227,10 +228,25 @@ fn out_of_range_id_is_non_retriable_structured_error() {
         json!(false),
         "an out-of-range id is caller-fault, never retriable: {v}"
     );
-    // Caller-fault classification (not a transient class).
-    assert!(
-        matches!(code.as_str(), "INVALID_ARGUMENT" | "NOT_FOUND"),
-        "overflow id must classify as a caller-fault code, got {code}"
+    // Exact, deterministic classification — the id-validation rejection.
+    assert_eq!(
+        code, "INVALID_ARGUMENT",
+        "an overflow id is an id-validation rejection → INVALID_ARGUMENT: {v}"
+    );
+
+    // Exact key-set pin on the error object: an id-validation error carries
+    // exactly `{code, message, retriable}` (no `details` on this path). An
+    // added/renamed error field is caught here.
+    let err_keys: std::collections::BTreeSet<&str> = v["error"]
+        .as_object()
+        .expect("error is an object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    assert_eq!(
+        err_keys,
+        std::collections::BTreeSet::from(["code", "message", "retriable"]),
+        "id-validation error object must be exactly {{code, message, retriable}}: {v}"
     );
 }
 
@@ -311,6 +327,24 @@ fn representative_tool_roundtrip_is_wellformed() {
         traversed.get("error").is_none(),
         "traverse failed: {traversed}"
     );
+
+    // The traversal must actually REACH node B — not merely return a
+    // well-formed empty page. Assert B is present in the results.
+    let results = traversed["results"]
+        .as_array()
+        .unwrap_or_else(|| panic!("traverse response must carry a `results` array: {traversed}"));
+    assert_eq!(
+        traversed["count"].as_u64(),
+        Some(1),
+        "one-hop KNOWS traversal from A reaches exactly B: {traversed}"
+    );
+    let reached_b = results
+        .iter()
+        .any(|r| r["node"]["id"].as_u64() == Some(b_id));
+    assert!(
+        reached_b,
+        "traversal over KNOWS must reach node B (id={b_id}): {traversed}"
+    );
 }
 
 // ===========================================================================
@@ -373,9 +407,19 @@ const TOOL_INVENTORY: [(&str, &str); 44] = [
     ("database_stats", "metrics"),
 ];
 
-/// PARITY: the advertised MCP tool inventory is exactly 44 tools with the
-/// documented access classes, and every name is unique. Adding/removing a tool
-/// (or reclassifying it) must update this golden AND tests/parity/inventory.json.
+/// PARITY (external mirror, NOT a live drift detector): this constant is a
+/// cross-crate reference copy of the 44-tool inventory. Because the live
+/// registry (`list_tools_for_test` / `TOOL_ACCESS_CLASSES`) is `pub(crate)`
+/// and unreachable from this external test crate, this test only validates the
+/// mirror's internal consistency (44 tools, unique names, MCP-legal classes,
+/// exactly one metrics tool) — it does NOT read the server, so it cannot by
+/// itself catch a tool added/removed/renamed/reclassified in the registry.
+///
+/// Live drift detection is performed in-crate by
+/// `src/mcp/auth_tests.rs::live_tool_inventory_matches_golden`, which derives
+/// the advertised `(name, class)` set from the registry and asserts it equals
+/// an identical hardcoded golden. Keep this mirror, that in-crate golden, and
+/// `tests/parity/inventory.json` in lockstep when the inventory changes.
 #[test]
 fn tool_inventory_golden_is_stable() {
     assert_eq!(TOOL_INVENTORY.len(), 44, "MCP advertises exactly 44 tools");


### PR DESCRIPTION
## Before / After

**Before:** there was no cross-surface behavioral safety net. A future port of the HTTP or MCP surface to another framework could silently change status codes, error envelopes, RBAC, limits, tool inventory, or vector-elision defaults and nothing would catch it.

**After:** a black-box parity harness pins the current, observed behavior of both network surfaces so a framework port must pass it **unchanged**:

- **23 HTTP golden tests** (`tests/parity_http.rs`) covering all 5 routes.
- **7 MCP golden tests** (`tests/parity_mcp.rs`) covering the error vocabulary, envelopes, temporal block, vector elision, roundtrip, and the 44-tool inventory mirror.
- **1 in-crate registry golden** (`src/mcp/auth_tests.rs::live_tool_inventory_matches_golden`) that reads the LIVE `pub(crate)` registry and fails on any tool added/removed/renamed/reclassified — the authoritative drift detector the external mirror cannot reach.
- **A machine-readable inventory** (`tests/parity/inventory.json`: 5 routes, 44 tools, 13 budgetable read tools) with honest `coverage_gaps`.

## Acceptance Criteria → Evidence

| AC | Evidence |
|----|----------|
| **AC1 — HTTP: every route pinned** (status / JSON / error-envelope / 401 / 403 / 413 / 422) | `route_inventory_is_the_known_five`, `status_success_shape` (exact key-set), `status_requires_credential_in_required_mode`, `query_success_envelope_shape`, `query_not_found_minimal_error_envelope` (exact key-set), `query_malformed_payload_is_400_not_500`, `query_error_envelope_has_no_trace_id_without_observability`, `query_missing_credential_is_uniform_401`, `query_reader_write_is_403_permission_denied`, `query_row_cap_reject_is_413_resource_exhausted`, `query_byte_cap_is_413_resource_exhausted` (retriable==false), `query_over_ceiling_override_is_422_invalid_argument`, `query_auth_precedes_limit_validation`, `admin_create_key_success_shape`, `admin_create_key_non_admin_is_403`, `admin_create_key_invalid_name_is_400`, `admin_list_keys_masks_material`, `admin_list_keys_non_admin_is_403`, `admin_revoke_key_success_and_immediate_effect`, `admin_revoke_unknown_id_is_404`, `admin_revoke_non_admin_is_403`, `every_route_uniform_401_without_credential`, `run_server_enforces_request_body_413` |
| **AC2 — MCP: inventory + structured error codes + RBAC + vector-elision + token-budget** | `error_code_vocabulary_is_stable`, `success_envelope_and_temporal_block`, `not_found_structured_error`, `out_of_range_id_is_non_retriable_structured_error` (exact code + key-set), `vectors_elided_by_default_and_restorable`, `representative_tool_roundtrip_is_wellformed` (reaches node B), `tool_inventory_golden_is_stable` (external mirror). **Live drift detection:** in-crate `src/mcp/auth_tests.rs::live_tool_inventory_matches_golden` reads the registry and equates it to the 44-pair golden. RBAC / token-budget / cursor per-behavior remain enforced by the pre-existing in-crate suites (referenced in the inventory). |
| **AC3 — machine-readable inventory** | `tests/parity/inventory.json` (5 routes, 44 tools, 13 budgetable) with honest `coverage_gaps` + `tests/parity/README.md` summary. |
| **Process — TDD** | Assertions written against observed live behavior; each pin verified against the running server before tightening (e.g. malformed path confirmed 400, overflow id confirmed `INVALID_ARGUMENT`). |
| **Process — 3-angle review** | Three code reviews applied: (1) wire the MCP inventory golden to the live registry; (2) tighten HTTP assertions; (3) tighten MCP assertions + inventory honesty. |
| **Process — gates green** | See Gate evidence below. |

## Coverage gaps (honest)

Not black-box reachable through the public API, and why — each pinned in-crate instead:

- **Per-tool runtime behavior for the 40 inventory-pinned MCP tools, RBAC enforcement, token-budget ladder, cursor paging** — `dispatch_tool` / `list_tools_for_test` / `apply_budget` / `authorize_tool` are `pub(crate)`, and the `rmcp::ServerHandler` entry is not nameable from an external test crate. Only 4 tools (`get_node`, `create_node`, `create_edge`, `traverse`) are behavior-pinned. Registry **name/class drift is now closed in-crate** by `live_tool_inventory_matches_golden`; RBAC by `every_advertised_tool_has_a_classification` + the role×tool matrix; budget/cursor by the `src/mcp/tests.rs` suites.
- **HTTP 429 wall-clock timeout** — not forceable deterministically over the wire; pinned by `enforce_query_limits` unit tests.
- **HTTP OTel `trace_id` / `x-trace-id`** — feature-gated behind `observability`/`otel`; absence pinned here, presence by `tests/http_otel_tracing.rs`.
- **HTTP 500 / INTERNAL envelope shape** — asserted only **indirectly** (as "not 500" on the malformed path); the Internal-variant body shape is covered by the `src/http/error.rs` `IntoResponse` unit tests, not positively pinned over the wire.

## Only touch outside `tests/`

A **single append-only `#[cfg(test)]` test fn** was added at the end of `src/mcp/auth_tests.rs`: `live_tool_inventory_matches_golden`. **Why it must live in-crate:** the advertised-tool registry (`list_tools_for_test`) and classification table (`TOOL_ACCESS_CLASSES` / `tool_access_class`) are `pub(crate)` and unreachable from an external test crate, so live drift detection is impossible from `tests/parity_mcp.rs`. The fn makes **zero production changes** and **zero visibility changes** (no `pub` added); it only uses names already in scope via the module's existing imports.

## Gate evidence

- `cargo fmt --all` — clean (no changes).
- CI clippy `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` — **0 warnings** (this compiles the new `auth_tests` fn).
- `cargo test --features "config-toml,http-server,mcp-server" --test parity_http --test parity_mcp` — **23 passed / 0 failed** (HTTP) + **7 passed / 0 failed** (MCP).
- `cargo test ... --lib mcp::auth_tests::live_tool_inventory_matches_golden` — **1 passed**.
- `--all-features` clippy on the changed targets — `-p aletheiadb --lib` clean, `--test parity_http --test parity_mcp` clean.
- **Total: 30 + 1 tests pass.**

The pre-existing `--all-features` `collapsible_if` clippy lint in `tests/http_run_server_body_limit.rs:66` is **NOT introduced by this PR** — it is already red at base `8351ff4`, is untouched here, and falls outside the CI feature set. Whole-workspace `--all-features` clippy stays red on it; the changed targets above are proven clean individually.

## Base note

Based on `trunk@8351ff4`. The diff is exactly **4 files under `tests/`** (`parity_http.rs`, `parity_mcp.rs`, `parity/inventory.json`, `parity/README.md`) **+ the 1 in-crate test fn** in `src/mcp/auth_tests.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018F7FJCwgbbd5hnJdpVw2vF

---
_Generated by [Claude Code](https://claude.ai/code/session_018F7FJCwgbbd5hnJdpVw2vF)_