### PR TITLE
Issue #3500: isolate test WAL dirs (unique_wal_dir helper + regression guard)

### DIFF
--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -173,6 +173,66 @@ pub fn create_test_db_at(wal_dir: PathBuf) -> Result<AletheiaDB> {
     AletheiaDB::with_unified_config(config)
 }
 
+/// Return a fresh, process-unique temporary directory to use as an isolated WAL
+/// directory in a test that builds its own [`AletheiaDBConfig`].
+///
+/// # Why this exists (Issue #3500)
+///
+/// The default `WalConfig::wal_dir` is the **CWD-relative** path
+/// `"aletheiadb/wal"` (`src/config.rs`). Every durable-config test that forgets
+/// to set an explicit `wal_dir` therefore writes into the SAME `./aletheiadb/wal`
+/// directory within a single `cargo test` process. Because DB startup eagerly
+/// decodes the ENTIRE WAL directory, a stray segment left behind by one test is
+/// then read by a later test's startup and can hard-error with
+/// `CorruptedData("Unknown WAL operation type: ...")`. That makes it an
+/// order-dependent, cross-pollinating flake rather than a deterministic failure.
+///
+/// Recovery-style tests that reopen the same `wal_dir` across DB drops cannot use
+/// [`create_test_db`] (which returns a live DB and owns its own tempdir), so they
+/// build their own config. `unique_wal_dir()` gives those tests a one-liner for an
+/// isolated directory: each call returns a DISTINCT OS temp dir, so two tests can
+/// never share a WAL directory.
+///
+/// ```ignore
+/// use aletheiadb::test_utils::unique_wal_dir;
+/// use aletheiadb::config::{AletheiaDBConfig, WalConfigBuilder};
+///
+/// let wal_home = unique_wal_dir();
+/// let config = AletheiaDBConfig::builder()
+///     .wal(WalConfigBuilder::new().wal_dir(wal_home.path().join("wal")).build())
+///     .build();
+/// // ... keep `wal_home` in scope for the lifetime of the DB(s) using it ...
+/// ```
+///
+/// # Note
+///
+/// **You MUST keep the returned `TempDir` in scope** for as long as any database
+/// uses it; dropping it deletes the directory (mirroring [`create_test_db`]).
+///
+/// # Panics
+///
+/// Panics if the OS temporary directory cannot be created. This is acceptable in
+/// test code and consistent with `tempfile::tempdir()` usage across the suite.
+pub fn unique_wal_dir() -> tempfile::TempDir {
+    tempfile::tempdir().expect("failed to create unique temp dir for WAL isolation")
+}
+
+/// Return a fresh, process-unique temporary directory to use as an isolated
+/// persistence/data directory in a test that builds its own config.
+///
+/// Analogous to [`unique_wal_dir`]; see its docs for the CWD-relative-default
+/// cross-pollution rationale (Issue #3500). Provided as a companion so a test
+/// that isolates both a `wal_dir` and a `data_dir` reads clearly at the call
+/// site. Like [`unique_wal_dir`], each call returns a DISTINCT directory that
+/// **must be kept in scope** for the lifetime of the database.
+///
+/// # Panics
+///
+/// Panics if the OS temporary directory cannot be created.
+pub fn unique_data_dir() -> tempfile::TempDir {
+    tempfile::tempdir().expect("failed to create unique temp dir for data isolation")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -221,5 +281,93 @@ mod tests {
         }
 
         assert!(!temp_dir_path.exists());
+    }
+
+    /// T1: `unique_wal_dir()` returns DISTINCT paths across two calls, each an
+    /// existing empty directory.
+    #[test]
+    fn test_unique_wal_dir_returns_distinct_existing_dirs() {
+        let a = unique_wal_dir();
+        let b = unique_wal_dir();
+
+        assert!(a.path().exists(), "first unique_wal_dir should exist");
+        assert!(b.path().exists(), "second unique_wal_dir should exist");
+        assert_ne!(
+            a.path(),
+            b.path(),
+            "two unique_wal_dir() calls must return distinct paths"
+        );
+
+        // Each is a fresh, empty directory.
+        assert_eq!(
+            std::fs::read_dir(a.path()).unwrap().count(),
+            0,
+            "first unique_wal_dir should start empty"
+        );
+        assert_eq!(
+            std::fs::read_dir(b.path()).unwrap().count(),
+            0,
+            "second unique_wal_dir should start empty"
+        );
+
+        // `unique_data_dir()` behaves the same and is distinct from the wal dirs.
+        let d = unique_data_dir();
+        assert!(d.path().exists());
+        assert_ne!(d.path(), a.path());
+        assert_ne!(d.path(), b.path());
+    }
+
+    /// T2: two databases built with `unique_wal_dir()` do NOT cross-pollute.
+    ///
+    /// DB A writes into its own isolated WAL dir and drops; DB B writes into a
+    /// DIFFERENT isolated WAL dir, drops, and is reopened via WAL replay. B must
+    /// see only its own data and must NOT hard-error decoding A's segments
+    /// (the `CorruptedData("Unknown WAL operation type")` cross-pollution
+    /// symptom from Issue #3500).
+    #[test]
+    fn test_unique_wal_dir_prevents_cross_pollution() {
+        fn durable_config(home: &std::path::Path) -> AletheiaDBConfig {
+            AletheiaDBConfig::builder()
+                .wal(WalConfigBuilder::new().wal_dir(home.join("wal")).build())
+                .persistence(PersistenceConfig {
+                    enabled: true,
+                    data_dir: home.join("data"),
+                    load_on_startup: true,
+                    ..Default::default()
+                })
+                .build()
+        }
+
+        // DB A: write 3 nodes into its own isolated WAL dir, then drop.
+        let home_a = unique_wal_dir();
+        {
+            let db = AletheiaDB::with_unified_config(durable_config(home_a.path())).unwrap();
+            for _ in 0..3 {
+                db.create_node("A", PropertyMapBuilder::new().build())
+                    .unwrap();
+            }
+        }
+
+        // DB B: write 5 nodes into a DIFFERENT isolated WAL dir, then drop.
+        let home_b = unique_wal_dir();
+        {
+            let db = AletheiaDB::with_unified_config(durable_config(home_b.path())).unwrap();
+            for _ in 0..5 {
+                db.create_node("B", PropertyMapBuilder::new().build())
+                    .unwrap();
+            }
+        }
+
+        // Force B to reconstruct from its WAL by removing its persisted indexes,
+        // then reopen. With isolated dirs this decodes ONLY B's segments.
+        std::fs::remove_dir_all(home_b.path().join("data").join("indexes")).ok();
+        let db_b = AletheiaDB::with_unified_config(durable_config(home_b.path()))
+            .expect("reopening B must not decode A's segments (no CorruptedData)");
+
+        assert_eq!(
+            db_b.node_count(),
+            5,
+            "DB B must see only its own 5 nodes, never A's segments"
+        );
     }
 }

--- a/tests/wal_dir_isolation_guard.rs
+++ b/tests/wal_dir_isolation_guard.rs
@@ -1,0 +1,283 @@
+//! Regression guard for Issue #3500 — shared relative `wal_dir` test cross-pollution.
+//!
+//! The default `WalConfig::wal_dir` is the CWD-relative path `"aletheiadb/wal"`
+//! (`src/config.rs`). Any durable-config test that sets `wal_dir` (or a durable
+//! `data_dir`) to a RELATIVE string literal instead of a per-test tempdir makes
+//! every such test in one `cargo test` process write into the SAME directory.
+//! Because DB startup eagerly decodes the entire WAL directory, a stray segment
+//! from one test then corrupts a later test's startup with
+//! `CorruptedData("Unknown WAL operation type: ...")` — an order-dependent flake.
+//!
+//! This meta-test scans the integration-test sources under `tests/` and fails if
+//! any test assigns a relative string literal to `wal_dir`/`data_dir` (a builder
+//! `.wal_dir("...")` / `.data_dir("...")` call, or a `wal_dir: "..."` /
+//! `data_dir: PathBuf::from("...")` field). Tempdir-derived paths
+//! (`temp.path().join("wal")`), variables, and absolute literals are allowed. Use
+//! `aletheiadb::test_utils::unique_wal_dir()` for an isolated directory.
+//!
+//! There are ZERO offenders today (the historical offender, `redb_file_locking`,
+//! was fixed in PR #3487); this guard keeps the footgun from silently returning.
+
+use std::path::{Path, PathBuf};
+
+/// Markers that introduce a WAL/data directory value.
+const DIR_MARKERS: &[&str] = &[".wal_dir(", ".data_dir(", "wal_dir:", "data_dir:"];
+
+/// A `PathBuf::from(...)` wrapper that may sit between a marker and a literal.
+const PATHBUF_WRAP: &str = "PathBuf::from(";
+
+/// Strip Rust line (`//`) and block (`/* */`) comments from source, preserving
+/// newlines (so line numbers stay accurate) and respecting string literals (so a
+/// `//` inside a `"..."` is not treated as a comment). This prevents false
+/// positives on prose that merely mentions `wal_dir:`/`data_dir:` in a comment.
+fn strip_comments(src: &str) -> String {
+    let b = src.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(b.len());
+    let mut i = 0;
+
+    enum S {
+        Normal,
+        Str,
+        Line,
+        Block,
+    }
+    let mut state = S::Normal;
+
+    while i < b.len() {
+        let c = b[i];
+        let n = if i + 1 < b.len() { b[i + 1] } else { 0 };
+        match state {
+            S::Normal => {
+                if c == b'"' {
+                    state = S::Str;
+                    out.push(c);
+                    i += 1;
+                } else if c == b'/' && n == b'/' {
+                    state = S::Line;
+                    i += 2;
+                } else if c == b'/' && n == b'*' {
+                    state = S::Block;
+                    i += 2;
+                } else {
+                    out.push(c);
+                    i += 1;
+                }
+            }
+            S::Str => {
+                if c == b'\\' {
+                    // Preserve the escape and the escaped byte verbatim.
+                    out.push(c);
+                    if i + 1 < b.len() {
+                        out.push(b[i + 1]);
+                    }
+                    i += 2;
+                } else if c == b'"' {
+                    state = S::Normal;
+                    out.push(c);
+                    i += 1;
+                } else {
+                    out.push(c);
+                    i += 1;
+                }
+            }
+            S::Line => {
+                if c == b'\n' {
+                    state = S::Normal;
+                    out.push(b'\n');
+                }
+                i += 1;
+            }
+            S::Block => {
+                if c == b'*' && n == b'/' {
+                    state = S::Normal;
+                    i += 2;
+                } else {
+                    if c == b'\n' {
+                        out.push(b'\n');
+                    }
+                    i += 1;
+                }
+            }
+        }
+    }
+
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// A relative literal is any bare string-literal path that is not absolute. The
+/// #3500 footgun is specifically the CWD-relative default; absolute literals do
+/// not share a directory across tests via the CWD.
+fn is_relative_literal(lit: &str) -> bool {
+    !lit.starts_with('/')
+}
+
+/// Scan source text and return `(line_number, snippet)` for each `wal_dir`/
+/// `data_dir` assigned to a RELATIVE string literal. Comments are stripped first.
+fn find_relative_dir_literals(src: &str) -> Vec<(usize, String)> {
+    let src = strip_comments(src);
+    let bytes = src.as_bytes();
+    let mut offenders = Vec::new();
+
+    for marker in DIR_MARKERS {
+        let mut search_from = 0;
+        while let Some(rel) = src[search_from..].find(marker) {
+            let start = search_from + rel;
+            let after = start + marker.len();
+            search_from = after;
+
+            // Skip whitespace after the marker.
+            let mut i = after;
+            while i < bytes.len() && (bytes[i] as char).is_whitespace() {
+                i += 1;
+            }
+
+            // Optionally step over a `PathBuf::from(` wrapper (and its whitespace).
+            if src[i..].starts_with(PATHBUF_WRAP) {
+                i += PATHBUF_WRAP.len();
+                while i < bytes.len() && (bytes[i] as char).is_whitespace() {
+                    i += 1;
+                }
+            }
+
+            // The value must be a string literal to be a static relative path.
+            // Anything else (a variable, `temp.path().join(...)`, etc.) is fine.
+            if i < bytes.len() && bytes[i] == b'"' {
+                let lit_start = i + 1;
+                if let Some(end_rel) = src[lit_start..].find('"') {
+                    let literal = &src[lit_start..lit_start + end_rel];
+                    if is_relative_literal(literal) {
+                        let line = src[..start].bytes().filter(|&b| b == b'\n').count() + 1;
+                        offenders.push((line, format!("{}\"{}\"", marker, literal)));
+                    }
+                }
+            }
+        }
+    }
+
+    offenders
+}
+
+/// Recursively collect `*.rs` files under `dir`.
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs_files(&path, out);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// T3 (guard self-test): the detector must FLAG the anti-pattern and NOT flag
+/// legitimate isolated forms. A guard that always passes proves nothing.
+#[test]
+fn test_detector_flags_bad_and_ignores_good() {
+    // BAD — relative string literal assigned to wal_dir/data_dir (the #3500 footgun).
+    let bad_builder = r#"let c = WalConfigBuilder::new().wal_dir("aletheiadb/wal").build();"#;
+    let bad_field = r#"let c = WalConfig { wal_dir: "wal".into(), ..Default::default() };"#;
+    let bad_pathbuf = r#"let c = WalConfig { data_dir: PathBuf::from("data/x") };"#;
+    let bad_dot_rel = r#"let c = WalConfigBuilder::new().wal_dir("./aletheiadb/wal").build();"#;
+
+    assert!(
+        !find_relative_dir_literals(bad_builder).is_empty(),
+        "must flag a relative .wal_dir(\"...\") builder literal"
+    );
+    assert!(
+        !find_relative_dir_literals(bad_field).is_empty(),
+        "must flag a relative wal_dir: \"...\" field literal"
+    );
+    assert!(
+        !find_relative_dir_literals(bad_pathbuf).is_empty(),
+        "must flag a relative data_dir: PathBuf::from(\"...\") literal"
+    );
+    assert!(
+        !find_relative_dir_literals(bad_dot_rel).is_empty(),
+        "must flag a relative ./-prefixed wal_dir literal"
+    );
+
+    // GOOD — tempdir-derived paths, variables, and absolute literals.
+    let good_builder =
+        r#"let c = WalConfigBuilder::new().wal_dir(temp.path().join("wal")).build();"#;
+    let good_var = r#"let c = WalConfigBuilder::new().wal_dir(wal_dir.clone()).build();"#;
+    let good_field = r#"let c = WalConfig { data_dir: temp_dir.path().join("data") };"#;
+    let good_absolute =
+        r#"let c = WalConfigBuilder::new().wal_dir("/tmp/isolated-xyz/wal").build();"#;
+    let good_type_annotation = r#"let wal_dir: PathBuf = temp.path().join("wal");"#;
+
+    assert!(
+        find_relative_dir_literals(good_builder).is_empty(),
+        "must NOT flag a tempdir .join(\"wal\") builder path"
+    );
+    assert!(
+        find_relative_dir_literals(good_var).is_empty(),
+        "must NOT flag a variable wal_dir argument"
+    );
+    assert!(
+        find_relative_dir_literals(good_field).is_empty(),
+        "must NOT flag a tempdir .join(\"data\") field path"
+    );
+    assert!(
+        find_relative_dir_literals(good_absolute).is_empty(),
+        "must NOT flag an absolute wal_dir literal"
+    );
+    assert!(
+        find_relative_dir_literals(good_type_annotation).is_empty(),
+        "must NOT flag a `let wal_dir: PathBuf = ...` type annotation"
+    );
+
+    // GOOD — a comment that merely mentions the footgun must be ignored (this is
+    // the exact shape of tests/regressions/persistence_default_isolation.rs).
+    let good_line_comment = r#"// historically data_dir: "data" was the default footgun"#;
+    let good_doc_comment = "//! Before the fix, the default was `data_dir: \"data\"`, so\n";
+    assert!(
+        find_relative_dir_literals(good_line_comment).is_empty(),
+        "must NOT flag a wal_dir/data_dir mention inside a line comment"
+    );
+    assert!(
+        find_relative_dir_literals(good_doc_comment).is_empty(),
+        "must NOT flag a data_dir literal inside a doc comment"
+    );
+}
+
+/// T4: the guard passes over the real current test tree (0 offenders).
+#[test]
+fn test_no_test_uses_relative_shared_wal_dir() {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let tests_dir = Path::new(manifest).join("tests");
+
+    let mut files = Vec::new();
+    collect_rs_files(&tests_dir, &mut files);
+    assert!(
+        !files.is_empty(),
+        "expected to find test source files under {}",
+        tests_dir.display()
+    );
+
+    // This guard's own fixtures contain deliberate bad snippets; do not scan it.
+    let this_file = "wal_dir_isolation_guard.rs";
+
+    let mut offenders: Vec<String> = Vec::new();
+    for file in &files {
+        if file.file_name().and_then(|n| n.to_str()) == Some(this_file) {
+            continue;
+        }
+        let src = std::fs::read_to_string(file).unwrap_or_default();
+        for (line, snippet) in find_relative_dir_literals(&src) {
+            offenders.push(format!("{}:{} -> {}", file.display(), line, snippet));
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "Found test(s) assigning a relative/shared wal_dir or data_dir string literal instead \
+         of a per-test tempdir (Issue #3500). This can cross-pollute other tests via the eager \
+         full-directory WAL decode. Use aletheiadb::test_utils::unique_wal_dir() and pass \
+         `dir.path().join(\"wal\")`. Offenders:\n{}",
+        offenders.join("\n")
+    );
+}


### PR DESCRIPTION
## Summary

Test-hygiene fix for **Issue #3500**: prevent durable-config tests from sharing the CWD-relative default `wal_dir` and cross-polluting within one test process.

**Before** -&gt; the default `WalConfig::wal_dir` is the CWD-relative `"aletheiadb/wal"` (`src/config.rs`). Any durable-config test that omits an explicit `wal_dir` writes into the *same* `./aletheiadb/wal` for the whole `cargo test` process. Because DB startup eagerly decodes the **entire** WAL directory, a stray segment left by one test is read by a later test's startup and hard-errors with `CorruptedData("Unknown WAL operation type: 0")` -- an order-dependent, cross-pollinating flake (exactly how it surfaced in PR #3487).

**After** -&gt; a `unique_wal_dir()` test helper gives reopen-across-drop recovery tests an isolated per-test directory, and a CI regression guard fails if any test assigns a relative/shared `wal_dir`/`data_dir` string literal instead of a tempdir -- so the footgun can't silently return.

This is **TEST-ONLY**: the production `WalConfig` default is unchanged.

## Changes

- **`src/test_utils.rs`**
  - `unique_wal_dir() -&gt; tempfile::TempDir` and `unique_data_dir() -&gt; tempfile::TempDir`: each call returns a distinct OS temp dir, for tests that build their own `AletheiaDBConfig` and must reopen the same `wal_dir` across DB drops (which `create_test_db*` -- returning a live DB -- can't cover).
  - `test_unique_wal_dir_returns_distinct_existing_dirs` (T1): two calls return distinct, existing, empty dirs.
  - `test_unique_wal_dir_prevents_cross_pollution` (T2): DB A writes 3 nodes into its own isolated dir and drops; DB B writes 5 into a different isolated dir, drops, and reopens via WAL replay -- it sees only its own 5 nodes and never decodes A's segments.
- **`tests/wal_dir_isolation_guard.rs`** (new meta-test, mirrors `tests/documentation_validation.rs` style)
  - A comment-aware detector flags a `wal_dir`/`data_dir` assigned to a **relative string literal** (`.wal_dir("aletheiadb/wal")`, `wal_dir: "wal".into()`, `data_dir: PathBuf::from("data/x")`), while allowing tempdir-derived paths, variables, and absolute literals.
  - `test_detector_flags_bad_and_ignores_good` (T3, guard self-test): asserts the detector flags known-bad fixtures **and** ignores known-good ones (tempdir-join, variable, absolute, comment mentions) -- proving the guard is not "always-passing theater".
  - `test_no_test_uses_relative_shared_wal_dir` (T4): scans `tests/**/*.rs` and asserts **0 offenders** on the current tree.

## Approaches considered

1. **Test helper + CI regression guard (CHOSEN, test-only).** Zero production-behavior change; matches the issue's framing ("prevent tests from sharing the relative default").
2. **Make the default `wal_dir` a process-unique temp path.** Rejected: changes **durability semantics for default configs** (an ephemeral, non-restart-stable location), silently breaking default-config durability users -- a product decision, not appropriate under a `type:test` ticket. (#3388's analog was safe only because it made the persistence default *inert*, `enabled:false`, not *relocated*.)
3. **Weaken the startup corruption check to skip stray segments.** Rejected by the issue itself -- masking mid-stream corruption in a durability-focused DB is dangerous.

## Preventive, not a cleanup

**0 current offenders** -- the one historical offender (`tests/redb_file_locking.rs`) was fixed in PR #3487. This PR is a regression guard so a future test can't reintroduce the hazard.

## Acceptance-criteria evidence

Issue #3500 frames requirements as a goal ("prevent tests from sharing the relative default") plus "Recommended fixes (pick one or both)" and two hard constraints (test-only; do not weaken corruption checks). ACs below are derived from that framing; all evidence is at commit `be77726`.

| # | Acceptance criterion (derived from #3500) | Status | Evidence (file:line / test) |
|---|---|---|---|
| AC1 | Provide a shared test helper giving an isolated per-test `wal_dir` for durable-config tests that build their own config (recommended fix #1, helper) | Met | `unique_wal_dir()` `src/test_utils.rs:216`; T1 `test_unique_wal_dir_returns_distinct_existing_dirs` `src/test_utils.rs:288` proves two calls yield distinct, existing, empty dirs |
| AC2 | Provide a lint/CI guard that fails fast if a test assigns a relative/shared `wal_dir`/`data_dir` instead of a per-test tempdir (recommended fix #1, grep) | Met | `tests/wal_dir_isolation_guard.rs`; detector `find_relative_dir_literals` `:116`; T4 `test_no_test_uses_relative_shared_wal_dir` `:248` scans `tests/**` and asserts 0 offenders |
| AC3 | Guard is not always-passing theater -- proven to flag the real anti-pattern and ignore legitimate isolated forms | Met | T3 `test_detector_flags_bad_and_ignores_good` `tests/wal_dir_isolation_guard.rs:178` (flags builder / `.into()` field / `PathBuf::from` / `./`-relative literals; ignores `.join()`, variables, absolute, comments) |
| AC4 | Helper prevents the cross-pollution `CorruptedData` symptom (DB reopen sees only its own data) | ✅ verified-locally | T2 `test_unique_wal_dir_prevents_cross_pollution` `src/test_utils.rs:327`: DB A/B in distinct dirs, B reopens via WAL replay, sees only its 5 nodes, no `CorruptedData` -- runtime GREEN observed locally (see Local verification status) |
| AC5 | Fix is TEST-ONLY: production `WalConfig` default unchanged; corruption checks not weakened; default not relocated | Met | Diff touches only `src/test_utils.rs` + `tests/wal_dir_isolation_guard.rs` (`git diff --stat`); `src/config.rs:139` default `"aletheiadb/wal"` untouched; no production/startup files in diff |
| AC6 | Extend coverage to the `data_dir` CWD-relative default ("consider the same treatment", #3500 / related #3388) | Met | `unique_data_dir()` `src/test_utils.rs:232`; guard markers include `.data_dir(` / `data_dir:` `:24`; T3 flags a `data_dir: PathBuf::from("data/x")` literal |
| AC7 | Guard is comment-aware: prose mentioning `wal_dir:`/`data_dir:` in a comment does not false-positive | Met | `strip_comments` `tests/wal_dir_isolation_guard.rs:33`; T3 asserts line/doc comments are ignored `:233`; validated against the real doc-comment at `tests/regressions/persistence_default_isolation.rs:4` (the only marker hit in the tree, correctly stripped) |

### Local verification status

- **Guard GREEN locally:** the meta-test (T3 + T4) is fully green; `find_relative_dir_literals` is comment-aware and reports 0 offenders across the current `tests/` tree.
- **RED -&gt; GREEN captured (guard, T3):** with the detector stubbed to return empty, T3 FAILED (`must flag a relative .wal_dir("...")` builder literal); with the real detector it passes.
- **RED -&gt; GREEN captured (helper, T1/T2):** with the helper absent, the lib tests fail to compile (`cannot find function unique_wal_dir`); with it present they compile clean.
- **Clippy:** `cargo clippy --lib --tests --features config-toml -- -D warnings` -&gt; clean. **fmt:** `cargo fmt --all` applied.

> **T1/T2 (and T3/T4) now VERIFIED LOCALLY PASSING (AC4 runtime GREEN):** the earlier local ENOSPC blocker (`rustc-LLVM ERROR: No space left on device` while linking the lib-test binary) has been cleared and the helper tests were executed locally to completion. T1/T2 runtime GREEN is now directly observed (no longer deferred to CI):
>
> ```
> running 2 tests
> test test_utils::tests::test_unique_wal_dir_returns_distinct_existing_dirs ... ok
> test test_utils::tests::test_unique_wal_dir_prevents_cross_pollution ... ok
> test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 3683 filtered out
> ```
>
> The guard tests `test_detector_flags_bad_and_ignores_good` (T3) and `test_no_test_uses_relative_shared_wal_dir` (T4) also pass locally.

`--all-features` clippy and the full test matrix are deferred to CI.

Refs #3500

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeUojPxfbkSTXosNT1Df3z)_