### PR TITLE
Fix snapshot-isolation: keep superseded version's valid_to append-only (#3504)

### DIFF
--- a/src/db/extent.rs
+++ b/src/db/extent.rs
@@ -562,12 +562,13 @@ mod tests {
             Some(t1),
             "per-label earliest must be the min start (backdated t1), not the newest"
         );
-        // The superseded version's valid interval was closed at t2 (the
-        // update's valid start); latest must reach it.
+        // #3504: the superseded version's valid interval stays OPEN
+        // (append-only), so `latest` reaches t2 via the UPDATE version's valid
+        // start (the max of interval starts), not via a closed end.
         assert_eq!(
             person.valid_time.latest,
             Some(t2),
-            "per-label latest must reach the superseded version's closed end"
+            "per-label latest must reach the update version's valid start"
         );
 
         assert_breakdown_consistent_with_overall(&extent);

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -1742,10 +1742,15 @@ mod tests {
                 "create + update + retraction = 3 versions, zero loss"
             );
 
-            // v1: [t_create, t_update) — closed by the update.
+            // v1: [t_create, open). #3504: the update supersedes v1 on the
+            // transaction-time dimension only; v1's valid interval stays
+            // open-ended (append-only), exactly like the retraction case below.
             let v1 = &history.versions[0];
             assert_eq!(v1.temporal.valid_time().start(), t_create);
-            assert_eq!(v1.temporal.valid_time().end(), t_update);
+            assert!(
+                v1.temporal.valid_time().is_current(),
+                "superseded v1's valid interval must stay open (#3504, append-only)"
+            );
 
             // v2: the pre-retraction head. Its VALID interval must remain
             // open-ended (append-only: retraction never rewrites the past

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -11006,7 +11006,7 @@ mod temporal_bounds_tests {
     }
 
     #[test]
-    fn test_superseded_version_has_closed_bounds_and_is_not_current() {
+    fn test_superseded_version_has_open_valid_closed_tx_bound_and_is_not_current() {
         let server = create_test_server();
 
         let node_id = create_person(&server, "Alice")["id"].as_u64().unwrap();
@@ -11029,7 +11029,10 @@ mod temporal_bounds_tests {
         .expect("update must succeed");
 
         // The at-time read anchored before the update returns the superseded
-        // version: both bounds closed, not current.
+        // version. #3504: supersession is append-only on the valid dimension,
+        // so the superseded version's valid interval stays OPEN
+        // (valid_to == null); only its transaction-time bound is closed by the
+        // update. It is not current (its tx interval is closed).
         let at_time_response = server.get_node_at_time(GetNodeAtTimeRequest {
             node_id,
             valid_time: anchor.to_string(),
@@ -11041,18 +11044,18 @@ mod temporal_bounds_tests {
             "get_node_at_time failed: {at_time}"
         );
         let superseded = temporal_of(&at_time["node"]);
-        let valid_to = superseded["valid_to"].as_str().unwrap_or_else(|| {
-            panic!("superseded valid_to must be a closed RFC3339 bound: {superseded}")
-        });
+        assert!(
+            superseded["valid_to"].is_null(),
+            "superseded version's valid_to must stay open (#3504, append-only): {superseded}"
+        );
         let transaction_to = superseded["transaction_to"].as_str().unwrap_or_else(|| {
             panic!("superseded transaction_to must be a closed RFC3339 bound: {superseded}")
         });
-        assert!(rfc3339_to_micros(valid_to) > anchor);
         assert!(rfc3339_to_micros(transaction_to) > anchor);
         assert_eq!(
             superseded["is_current"],
             serde_json::json!(false),
-            "a superseded version must report is_current: false: {superseded}"
+            "a superseded version must report is_current: false (its tx interval is closed): {superseded}"
         );
 
         // A current read after the update shows the NEW version's bounds:

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -1090,15 +1090,23 @@ impl HistoricalStorage {
                 }
             }
 
-            // Update temporal adjacency index to reflect closed valid time
+            // #3504: the superseded version's OWN valid interval now stays open
+            // (append-only) -- close_previous_version_intervals no longer closes
+            // it. Mirror the version chain's masking in the denormalized temporal
+            // adjacency index by closing the prior entry's TRANSACTION time (the
+            // tx-close that still happens on supersession and that hides the
+            // superseded version from current-state reads) instead of its valid
+            // time. This keeps a deleted/updated edge from reappearing in
+            // traversals while preserving snapshot isolation for reads anchored
+            // before the supersession (an earlier-tx query still sees the entry).
             if let Some(ref adj_index) = self.temporal_adjacency_index {
                 let new_temporal = *prev.temporal();
-                if old_temporal.valid_time().end() != new_temporal.valid_time().end() {
-                    adj_index.close_edge_valid_time(
+                if old_temporal.transaction_time().end() != new_temporal.transaction_time().end() {
+                    adj_index.close_edge_transaction_time(
                         edge_id,
                         source,
                         target,
-                        new_temporal.valid_time().end(),
+                        new_temporal.transaction_time().end(),
                     );
                 }
             }
@@ -2983,11 +2991,18 @@ impl HistoricalStorage {
         // Work on a local copy, apply modifications, then write back
         let mut prev_temporal = *prev_version.temporal();
 
-        if prev_temporal.is_currently_valid()
-            && new_temporal.valid_time().start() > prev_temporal.valid_time().start()
-        {
-            prev_temporal = prev_temporal.close_valid_time(new_temporal.valid_time().start())?;
-        }
+        // #3504: The superseded version's valid-time interval must stay
+        // append-only -- we deliberately do NOT close it here. The version
+        // chain is a transaction-time partition: every write/replay path
+        // unconditionally tx-closes the prior head (below), so at any tx
+        // coordinate at most one version is visible and current-state reads
+        // already skip the superseded version. Closing its valid_to in place at
+        // the successor's valid_from would retroactively shrink an interval that
+        // earlier-tx-time read snapshots still observe (the prior version's
+        // transaction-time window remains open to them), making a node that was
+        // alive at snapshot time disappear -- a snapshot-isolation violation on
+        // the valid dimension (residual of #3435; #3437 fixed the tx-time half).
+        // The tx-close alone is both necessary and sufficient.
 
         if prev_temporal.is_currently_recorded()
             && new_temporal.transaction_time().start() > prev_temporal.transaction_time().start()

--- a/tests/hybrid_query_planner.rs
+++ b/tests/hybrid_query_planner.rs
@@ -932,10 +932,21 @@ fn test_execute_temporal_node_lookup_returns_historical_state() {
             prev_version_id, prev_version.temporal
         );
 
-        // Use a timestamp in the middle of the first version's interval
+        // #3504: the previous version's valid interval now stays OPEN
+        // (append-only) after being superseded by the update, so its end() is
+        // TIMESTAMP_MAX and can no longer bound the midpoint. Anchor instead
+        // between the previous version's valid_from and the CURRENT (successor)
+        // version's valid_from -- the window during which the previous version
+        // was the visible head. At that bi-temporal coordinate only the
+        // previous version is transaction-time-visible, so the query still
+        // targets that historical version.
         let start = prev_version.temporal.valid_time().start();
-        let end = prev_version.temporal.valid_time().end();
-        let midpoint = ((start.wallclock() + end.wallclock()) / 2).into();
+        let next_start = current_version.temporal.valid_time().start();
+        assert!(
+            start.wallclock() < next_start.wallclock(),
+            "premise: the successor version's valid_from must be strictly later"
+        );
+        let midpoint = ((start.wallclock() + next_start.wallclock()) / 2).into();
         println!("DEBUG: Using midpoint timestamp: {}", midpoint);
         midpoint
     };

--- a/tests/readops_snapshot_isolation.rs
+++ b/tests/readops_snapshot_isolation.rs
@@ -261,3 +261,168 @@ fn read_tx_edge_readable_for_edge_deleted_in_same_clock_tick() {
         "a fresh snapshot must not see the deleted edge"
     );
 }
+
+/// Issue #3504 regression (delete): a node deleted in the SAME wallclock tick as
+/// an existing read snapshot must stay visible to that snapshot on the *valid*
+/// dimension. `close_previous_version_intervals` used to close the superseded
+/// version's valid-time interval in place at the delete's `valid_from` whenever
+/// `new.valid_from > prev.valid_from`. Because the version chain is a
+/// transaction-time partition (the tx-time close already hides the version from
+/// current-state reads), that in-place valid-close was never needed for
+/// correctness -- but it retroactively excluded a snapshot whose valid
+/// coordinate equalled the delete's `valid_from`, yielding `NodeNotFound` for a
+/// node that was alive at snapshot time: a snapshot-isolation violation on the
+/// valid dimension (the residual half of #3435 that #3437 did not cover).
+///
+/// Frozen `SimulatedClock`: the snapshot is taken at `T0+1` (if-branch of the
+/// visibility check, `S=(T0+1, 0)`), and the delete commits at `T0+1` with its
+/// default `valid_from = T0+1 > T0` (the node's creation valid time), so the
+/// pre-fix code closed the node version to `[T0, T0+1)` and excluded `S`.
+#[cfg(feature = "simulation")]
+#[test]
+fn read_tx_sees_node_when_delete_valid_time_collides_with_snapshot() {
+    use aletheiadb::simulation::SimulatedClock;
+
+    let mut clock = SimulatedClock::new(1_700_000_000_000_000);
+    let _guard = clock.inject();
+
+    let db = AletheiaDB::new().unwrap();
+
+    // Created at the frozen instant T0 (valid_from == T0).
+    let node = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // Advance one tick and take a snapshot S=(T0+1, 0) while the node is alive.
+    clock.jump_to(1_700_000_000_000_001);
+    let read_tx = db.read_transaction().unwrap();
+    assert!(
+        read_tx.get_node(node).is_ok(),
+        "snapshot taken at T0+1 must see the node that was created at T0"
+    );
+
+    // Delete in the same tick (T0+1): its default valid_from (T0+1) is strictly
+    // greater than the node's creation valid_from (T0), triggering the buggy
+    // in-place valid-close of the superseded version.
+    db.write(|tx| tx.delete_node(node)).unwrap();
+
+    // The old snapshot must STILL see the pre-delete node on the valid
+    // dimension. Before the #3504 fix these all returned NodeNotFound because
+    // the superseded version's valid interval was retroactively closed at T0+1,
+    // excluding the snapshot's valid coordinate.
+    let outgoing = read_tx.get_outgoing_edges(node);
+    assert!(
+        outgoing.is_ok(),
+        "node alive at snapshot time must stay visible even when a delete \
+         commits with valid_from equal to the snapshot's valid coordinate, \
+         got {outgoing:?}"
+    );
+    assert!(outgoing.unwrap().is_empty());
+    assert!(
+        read_tx.get_incoming_edges(node).is_ok(),
+        "incoming-edge existence gate must still see the pre-delete node"
+    );
+    assert!(
+        read_tx.get_node(node).is_ok(),
+        "get_node must resolve the pre-delete version at the old snapshot, \
+         got {:?}",
+        read_tx.get_node(node)
+    );
+
+    // A fresh snapshot taken after the delete must NOT see the node.
+    let fresh_tx = db.read_transaction().unwrap();
+    assert!(
+        matches!(
+            fresh_tx.get_outgoing_edges(node),
+            Err(Error::Storage(StorageError::NodeNotFound(id))) if id == node
+        ),
+        "a fresh snapshot after the delete must not see the node"
+    );
+}
+
+/// Issue #3504 regression (backdated update): a node whose UPDATE carries an
+/// explicit `valid_from` that is later than the node's creation valid time but
+/// still at/before an existing read snapshot's valid coordinate must not vanish
+/// from that snapshot. This is the case the sibling
+/// `read_tx_sees_pre_update_version_for_node_updated_in_same_clock_tick` does
+/// NOT cover: there the update's `valid_from` equals the creation valid time
+/// (so `new.valid_from > prev.valid_from` is false and the buggy valid-close
+/// never fires). Here the update is backdated to a value strictly between the
+/// creation time and the snapshot, so the pre-fix in-place valid-close truncated
+/// the pre-update version's valid interval and excluded the snapshot.
+///
+/// Timeline (frozen `SimulatedClock`, T0 == initial):
+///   * create A (v == 1) at valid_from T0;
+///   * jump to T0+2, take snapshot S=(T0+2, 0) -- sees A;
+///   * update to B (v == 2) with backdated valid_from T0+1 (T0 < T0+1 < T0+2),
+///     committing at tx == T0+2. Pre-fix this closed A's valid interval to
+///     `[T0, T0+1)`, excluding the snapshot's valid coordinate T0+2 -> the old
+///     snapshot got NodeNotFound.
+#[cfg(feature = "simulation")]
+#[test]
+fn read_tx_sees_pre_update_version_when_backdated_update_valid_time_precedes_snapshot() {
+    use aletheiadb::core::hlc::HybridTimestamp;
+    use aletheiadb::simulation::SimulatedClock;
+
+    let mut clock = SimulatedClock::new(1_700_000_000_000_000);
+    let _guard = clock.inject();
+
+    let db = AletheiaDB::new().unwrap();
+
+    // Version A (v == 1), created at the frozen instant T0 (valid_from == T0).
+    let node = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("v", 1_i64).build(),
+        )
+        .unwrap();
+
+    // Advance two ticks so a value strictly between T0 and the snapshot exists,
+    // then take snapshot S=(T0+2, 0) while A is still current.
+    clock.jump_to(1_700_000_000_000_002);
+    let read_tx = db.read_transaction().unwrap();
+    let before = read_tx.get_node(node).unwrap();
+    assert_eq!(
+        before.properties.get("v").and_then(|p| p.as_int()),
+        Some(1),
+        "snapshot must see the pre-update value A (v == 1)"
+    );
+
+    // Backdated update to B (v == 2) with valid_from == T0+1 (> creation T0,
+    // < snapshot valid coordinate T0+2). Commits at tx == T0+2.
+    let backdated = HybridTimestamp::new(1_700_000_000_000_001, 0).unwrap();
+    db.update_node_with_valid_time(
+        node,
+        PropertyMapBuilder::new().insert("v", 2_i64).build(),
+        Some(backdated),
+    )
+    .unwrap();
+
+    // The old snapshot must still resolve the pre-update version A. Before the
+    // #3504 fix this returned NodeNotFound because A's valid interval was
+    // retroactively closed at T0+1, excluding the snapshot's valid coordinate.
+    let after = read_tx.get_node(node);
+    assert!(
+        after.is_ok(),
+        "a backdated update whose valid_from precedes an existing read \
+         snapshot must not vanish the node from that snapshot, got {after:?}"
+    );
+    assert_eq!(
+        after.unwrap().properties.get("v").and_then(|p| p.as_int()),
+        Some(1),
+        "the old snapshot must still observe the pre-update value A (v == 1)"
+    );
+
+    // A fresh snapshot taken after the update must see B (v == 2).
+    let fresh_tx = db.read_transaction().unwrap();
+    assert_eq!(
+        fresh_tx
+            .get_node(node)
+            .unwrap()
+            .properties
+            .get("v")
+            .and_then(|p| p.as_int()),
+        Some(2),
+        "a fresh snapshot after the update must observe the new value B (v == 2)"
+    );
+}

--- a/tests/recovery/replay_delete_tests.rs
+++ b/tests/recovery/replay_delete_tests.rs
@@ -222,9 +222,9 @@ fn test_replay_delete_edge_basic() -> Result<()> {
 fn test_replay_delete_node_preserves_temporal_intervals() -> Result<()> {
     // Issue #452: after replaying Create + Delete, the version chain must
     // carry exact bi-temporal intervals:
-    // - prior head: valid_from preserved, valid time closed at the
-    //   tombstone's LOGGED valid_from, transaction time closed at the delete
-    //   entry's LOGGED timestamp;
+    // - prior head: valid_from preserved, valid time stays OPEN (#3504:
+    //   supersession is append-only on the valid dimension), transaction time
+    //   closed at the delete entry's LOGGED timestamp;
     // - tombstone: empty valid interval anchored at the LOGGED valid_from
     //   (issue #3400: replay honors the logged value, mirroring the live
     //   path), transaction [delete ts, open).
@@ -278,10 +278,11 @@ fn test_replay_delete_node_preserves_temporal_intervals() -> Result<()> {
         vf,
         "prior head's valid_from must survive replay exactly"
     );
-    assert_eq!(
-        prior.temporal.valid_time().end(),
-        delete_vf,
-        "prior head's valid time must be closed exactly at the tombstone's LOGGED valid_from"
+    // #3504: the superseded prior head's valid interval stays OPEN (append-only);
+    // supersession only closes its transaction-time window (asserted below).
+    assert!(
+        prior.temporal.valid_time().is_current(),
+        "prior head's valid interval must stay open (append-only) after supersession"
     );
     assert_eq!(
         prior.temporal.transaction_time().start(),
@@ -402,10 +403,11 @@ fn test_replay_delete_edge_preserves_temporal_intervals() -> Result<()> {
         vf,
         "prior head's valid_from must survive replay exactly"
     );
-    assert_eq!(
-        prior.temporal.valid_time().end(),
-        delete_vf,
-        "prior head's valid time must be closed exactly at the tombstone's LOGGED valid_from"
+    // #3504: the superseded prior head's valid interval stays OPEN (append-only);
+    // supersession only closes its transaction-time window (asserted below).
+    assert!(
+        prior.temporal.valid_time().is_current(),
+        "prior head's valid interval must stay open (append-only) after supersession"
     );
     assert_eq!(
         prior.temporal.transaction_time().start(),
@@ -519,10 +521,11 @@ fn test_replay_delete_node_honors_logged_valid_from() -> Result<()> {
         tombstone.temporal.valid_time().is_empty(),
         "tombstone must carry an empty valid interval"
     );
-    assert_eq!(
-        prior.temporal.valid_time().end(),
-        delete_vf,
-        "prior head's valid_to must be closed at the LOGGED backdated valid_from"
+    // #3504: the superseded prior head's valid interval stays OPEN (append-only);
+    // backdating the tombstone's valid_from does not retroactively close it.
+    assert!(
+        prior.temporal.valid_time().is_current(),
+        "prior head's valid interval must stay open (append-only) after backdated supersession"
     );
     assert_eq!(
         tombstone.temporal.transaction_time().start(),
@@ -607,10 +610,11 @@ fn test_replay_delete_edge_honors_logged_valid_from() -> Result<()> {
         tombstone.temporal.valid_time().is_empty(),
         "tombstone must carry an empty valid interval"
     );
-    assert_eq!(
-        prior.temporal.valid_time().end(),
-        delete_vf,
-        "prior head's valid_to must be closed at the LOGGED backdated valid_from"
+    // #3504: the superseded prior head's valid interval stays OPEN (append-only);
+    // backdating the tombstone's valid_from does not retroactively close it.
+    assert!(
+        prior.temporal.valid_time().is_current(),
+        "prior head's valid interval must stay open (append-only) after backdated supersession"
     );
     assert_eq!(
         tombstone.temporal.transaction_time().start(),

--- a/tests/recovery/replay_update_tests.rs
+++ b/tests/recovery/replay_update_tests.rs
@@ -453,10 +453,14 @@ fn test_replay_update_preserves_temporal_intervals() -> Result<()> {
         vf1,
         "superseded version's valid_from must survive replay exactly"
     );
-    assert_eq!(
-        superseded.temporal.valid_time().end(),
-        vf2,
-        "superseded version's valid time must be closed at the successor's LOGGED valid_from"
+    // #3504: the superseded version's valid interval stays OPEN (append-only).
+    // The valid-time close was removed from close_previous_version_intervals
+    // because it violated snapshot isolation on the valid dimension; the
+    // transaction-time close (asserted below) is what partitions the version
+    // chain, so replay must reproduce the superseded valid interval open-ended.
+    assert!(
+        superseded.temporal.valid_time().is_current(),
+        "superseded version's valid time must stay open-ended after replay (#3504)"
     );
     assert_eq!(
         superseded.temporal.transaction_time().start(),
@@ -572,10 +576,13 @@ fn test_replay_update_edge_preserves_temporal_intervals() -> Result<()> {
         vf1,
         "superseded edge version's valid_from must survive replay exactly"
     );
-    assert_eq!(
-        superseded.temporal.valid_time().end(),
-        vf2,
-        "superseded edge version's valid time must be closed at the successor's LOGGED valid_from"
+    // #3504: the superseded edge version's valid interval stays OPEN
+    // (append-only) -- the valid-time close was removed from
+    // close_previous_version_intervals as a snapshot-isolation fix; only the
+    // transaction-time close (asserted below) partitions the version chain.
+    assert!(
+        superseded.temporal.valid_time().is_current(),
+        "superseded edge version's valid time must stay open-ended after replay (#3504)"
     );
     assert_eq!(
         superseded.temporal.transaction_time().start(),

--- a/tests/temporal_adjacency_integration_tests.rs
+++ b/tests/temporal_adjacency_integration_tests.rs
@@ -136,7 +136,8 @@ fn test_multiple_versions_track_temporal_changes() {
         )
         .unwrap();
 
-    // Update edge at t1 (closes previous valid time)
+    // Update edge at t1 (#3504: v1's valid interval stays OPEN/append-only;
+    // supersession is expressed on the transaction-time dimension only)
     std::thread::sleep(std::time::Duration::from_millis(10));
     let t1 = time::now();
     storage
@@ -153,7 +154,8 @@ fn test_multiple_versions_track_temporal_changes() {
         )
         .unwrap();
 
-    // Should find edge at both times (valid time was closed on v1, but v2 started)
+    // Should find edge at both times (#3504: v1's valid interval stays open, and
+    // v2 is tx-visible at t1, so each bi-temporal coordinate resolves one edge)
     let edges_at_t0 = index.get_outgoing_at_time(source, t0, t0);
     assert_eq!(edges_at_t0.len(), 1);
 

--- a/tests/temporal_adjacency_query_api_tests.rs
+++ b/tests/temporal_adjacency_query_api_tests.rs
@@ -256,6 +256,125 @@ fn test_deleted_edges_returned_before_deletion() {
     assert!(edges.contains(&edge));
 }
 
+/// #3504 affirmative snapshot-isolation regression guard for the temporal
+/// adjacency index (hunk 2 of the fix).
+///
+/// The pre-existing "before deletion" tests query with valid == tx, so they
+/// pass under the old in-place valid-close too and do not distinguish the fix.
+/// This test exercises the case the fix exists for: a bi-temporal AS-OF
+/// adjacency read at a valid coordinate AT/AFTER the delete's `valid_from`,
+/// but at a transaction coordinate BEFORE the delete was committed. Under
+/// snapshot isolation such a reader must STILL observe the since-deleted edge.
+///
+/// Timeline (deterministic, valid and tx coordinates deliberately diverge):
+///   create edge:  valid_from = t0,     tx = T0
+///   delete edge:  valid_from = t_del,  tx = T_del   (t0 < t_del, T0 < T_del)
+///   read snapshot: valid = t_del,      tx = t_mid    (T0 < t_mid < T_del)
+///
+/// #3504: under the removed in-place valid-close (the full pre-fix behavior),
+/// `close_previous_version_intervals` shrank the superseded entry's valid_to to
+/// t_del and the adjacency index mirrored that with `close_edge_valid_time`, so
+/// the read below returned 0 -- a node/edge alive at the snapshot vanished
+/// (valid-dimension snapshot-isolation violation). The fix keeps the valid
+/// interval open and instead tx-closes the adjacency entry, so the earlier-tx
+/// reader still sees the edge while a current-tx reader does not.
+#[test]
+fn deleted_edge_still_traversable_at_earlier_tx_snapshot_after_valid_from() {
+    let mut storage = HistoricalStorage::new();
+    let index = Arc::new(TemporalAdjacencyIndex::new(
+        TemporalAdjacencyConfig::default(),
+    ));
+    storage.set_temporal_adjacency_index(index.clone());
+
+    let source = NodeId::new(500).unwrap();
+    let target = NodeId::new(501).unwrap();
+    let edge = EdgeId::new(40).unwrap();
+    let label = InternedString::from_raw(5);
+
+    // Deterministic bi-temporal coordinates so valid/tx diverge and t0 < t_del,
+    // T0 < t_mid < T_del hold exactly (no wallclock/sleep flakiness).
+    let t0 = time::from_secs(1_000_000);
+    let big_t0 = time::from_secs(1_000_000);
+    let t_mid = time::from_secs(1_000_100);
+    let t_del = time::from_secs(1_000_200);
+    let big_t_del = time::from_secs(1_000_200);
+    let after_del = time::from_secs(1_000_300);
+
+    // Create the edge at (valid = t0, tx = T0). Source/target nodes stay alive.
+    storage
+        .add_edge_version(
+            edge,
+            VersionId::new(1).unwrap(),
+            t0,
+            big_t0,
+            label,
+            source,
+            target,
+            PropertyMap::default(),
+            false,
+        )
+        .unwrap();
+
+    // Delete (tombstone) the EDGE at (valid = t_del, tx = T_del), strictly after
+    // both the create's valid and tx coordinates.
+    storage
+        .add_edge_version(
+            edge,
+            VersionId::new(2).unwrap(),
+            t_del,
+            big_t_del,
+            label,
+            source,
+            target,
+            PropertyMap::default(),
+            true, // tombstone
+        )
+        .unwrap();
+
+    // Core #3504 assertion: an earlier-tx snapshot (T0 < t_mid < T_del) reading
+    // at a valid coordinate at/after the delete's valid_from must STILL see the
+    // edge. Under the removed valid-close this returned 0.
+    let out_earlier_tx = storage.get_outgoing_edges_at_time(source, t_del, t_mid);
+    assert_eq!(
+        out_earlier_tx.len(),
+        1,
+        "deleted edge must remain traversable outgoing at an earlier-tx snapshot"
+    );
+    assert!(out_earlier_tx.contains(&edge));
+
+    // Symmetric incoming direction.
+    let in_earlier_tx = storage.get_incoming_edges_at_time(target, t_del, t_mid);
+    assert_eq!(
+        in_earlier_tx.len(),
+        1,
+        "deleted edge must remain traversable incoming at an earlier-tx snapshot"
+    );
+    assert!(in_earlier_tx.contains(&edge));
+
+    // Guard against over-correction: at/after the delete's commit tx, the edge
+    // must be invisible (current-state traversal must not resurrect it). This is
+    // exactly what hunk 2's tx-close of the adjacency entry provides; reverting
+    // hunk 2 makes these return 1.
+    let out_at_del_tx = storage.get_outgoing_edges_at_time(source, t_del, big_t_del);
+    assert_eq!(
+        out_at_del_tx.len(),
+        0,
+        "deleted edge must be invisible at the delete's own commit tx"
+    );
+    let out_after_del_tx = storage.get_outgoing_edges_at_time(source, t_del, after_del);
+    assert_eq!(
+        out_after_del_tx.len(),
+        0,
+        "deleted edge must be invisible after the delete's commit tx"
+    );
+    let in_after_del_tx = storage.get_incoming_edges_at_time(target, t_del, after_del);
+    assert_eq!(
+        in_after_del_tx.len(),
+        0,
+        "deleted edge must be invisible incoming after the delete's commit tx"
+    );
+}
+
 /// Test that methods return empty vectors when index is not set.
 #[test]
 fn test_query_methods_return_empty_without_index() {

--- a/tests/temporal_edge_tests.rs
+++ b/tests/temporal_edge_tests.rs
@@ -346,25 +346,28 @@ fn test_temporal_edge_interval_closing() {
         )
     };
 
-    // Verify first version interval was closed
+    // #3504: after an update supersedes v1, v1's valid-time interval stays
+    // OPEN (append-only). Supersession is expressed purely on the
+    // transaction-time dimension (v1's tx window is closed at v2's tx start);
+    // the valid interval is never retroactively closed in place.
     {
         let historical = db.__test_historical_storage();
         let hist_guard = historical.read();
         let v1 = hist_guard.get_edge_version(v1_id).unwrap();
 
         assert!(
-            !v1.temporal.is_currently_valid(),
-            "First version should have closed valid_time interval"
+            v1.temporal.valid_time().is_current(),
+            "First version's valid_time interval must stay open (append-only) after supersession"
         );
         assert_eq!(
-            v1.temporal.valid_time().end(),
-            v2_start,
-            "First version's valid_time end should equal second version's start"
+            v1.temporal.transaction_time().end(),
+            v2_tx,
+            "First version's tx-time window should be closed at second version's tx start"
         );
-        println!("✓ Edge version interval properly closed");
+        println!("✓ Edge version tx interval properly closed; valid interval stays open");
         println!(
-            "  V1 interval: {} (closed at v2_start={})",
-            v1.temporal, v2_start
+            "  V1 interval: {} (tx-closed at v2_tx={}, valid stays open)",
+            v1.temporal, v2_tx
         );
     }
 

--- a/tests/wal_recovery_integration.rs
+++ b/tests/wal_recovery_integration.rs
@@ -30,7 +30,10 @@
 //! rather than exact bounds. Valid-time bounds ARE asserted exactly for every
 //! version, including delete tombstones — they are logged in the WAL and must
 //! be honored faithfully (issue #3400, pinned by the backdated-delete tests
-//! at the bottom of this file).
+//! at the bottom of this file). Note that a version superseded by an
+//! update/delete keeps its valid interval OPEN (#3504: supersession is
+//! append-only on the valid dimension); only its transaction-time window is
+//! closed.
 
 use aletheiadb::config::WalConfigBuilder;
 use aletheiadb::core::history::EntityHistory;
@@ -99,8 +102,10 @@ fn snapshot_history(history: &EntityHistory) -> Vec<VersionSnapshot> {
 ///
 /// Valid-time bounds are compared exactly for EVERY version, including delete
 /// tombstones: the tombstone's valid_from is logged in the WAL and honored by
-/// replay (issue #3400), so both its (empty) valid interval and the valid_to
-/// of the version it closes must survive recovery bit-for-bit.
+/// replay (issue #3400), so its (empty) valid interval must survive recovery
+/// bit-for-bit. Note (#3504): supersession is append-only on the valid
+/// dimension, so the predecessor of a tombstone keeps its valid_to OPEN -- the
+/// delete never retroactively closes it.
 ///
 /// Transaction-time bounds are compared structurally (open/closed + chain
 /// continuity), not exactly — see the module docs for why exact equality
@@ -146,8 +151,10 @@ fn assert_history_matches(entity: &str, pre: &[VersionSnapshot], recovered: &Ent
     // Chain continuity on the recovered history:
     // - each superseded version's tx-time closure must equal its successor's
     //   transaction start (both stamped from the same WAL entry);
-    // - a version closed by a tombstone must have its valid_to equal to the
-    //   tombstone's valid_from.
+    // - #3504: a version superseded by a delete tombstone keeps its valid_to
+    //   OPEN (append-only) -- supersession is expressed purely on the
+    //   transaction-time dimension, never by retroactively closing the prior
+    //   version's valid interval in place.
     for i in 0..recovered.versions.len().saturating_sub(1) {
         let closed_at = recovered.versions[i].temporal.transaction_time().end();
         let successor = &recovered.versions[i + 1];
@@ -157,10 +164,10 @@ fn assert_history_matches(entity: &str, pre: &[VersionSnapshot], recovered: &Ent
             "{entity} v{i}: tx-time closure must equal the successor's tx start after recovery"
         );
         if successor.temporal.valid_time().is_empty() {
-            assert_eq!(
-                recovered.versions[i].temporal.valid_time().end(),
-                successor.temporal.valid_time().start(),
-                "{entity} v{i}: valid_to must equal the closing tombstone's valid_from"
+            assert!(
+                recovered.versions[i].temporal.valid_time().is_current(),
+                "{entity} v{i}: superseded version's valid interval must stay open (#3504); \
+                 a delete tombstone does not retroactively close its predecessor's valid_to"
             );
         }
     }
@@ -617,14 +624,21 @@ fn backdated_delete_valid_from_survives_replay() {
             "live path stamps the tombstone with the backdated valid_from"
         );
 
-        // Divergence window: the pre-fix bug (replay substituting the entry
-        // timestamp for the LOGGED valid_from) is user-visible exactly at
-        // valid times strictly between the backdated t_delete and the
-        // delete's commit timestamp, with transaction time anchored before
-        // the delete's commit (here: at the create's tx start). At that
-        // coordinate the node must be invisible — the buggy replay would
-        // leave the prior head's valid_to open until the commit timestamp
-        // and make it visible.
+        // Divergence window: a valid-time probe strictly between the backdated
+        // t_delete and the delete's commit timestamp. Two distinct guarantees
+        // meet here, distinguished by which transaction time the read anchors:
+        //
+        // (1) #3504 snapshot isolation on the valid dimension: anchored BEFORE
+        //     the delete was recorded (at the create's tx start), the node must
+        //     still be VISIBLE at the probe -- the delete is append-only and
+        //     must not retroactively shrink the prior head's open valid interval
+        //     as observed by an earlier tx snapshot.
+        // (2) #3400 backdated tombstone valid_from: as of the CURRENT tx the
+        //     node's valid timeline ends at the LOGGED t_delete, so the same
+        //     probe (strictly after t_delete) is INVISIBLE. A buggy replay
+        //     substituting the entry timestamp for the logged valid_from would
+        //     move that boundary to ~commit time and wrongly make the probe
+        //     visible.
         let create_tx = history.versions[0].temporal.transaction_time().start();
         let tombstone_tx = history.versions[1].temporal.transaction_time().start();
         assert!(
@@ -640,8 +654,14 @@ fn backdated_delete_valid_from_survives_replay() {
         );
         assert!(
             db.get_node_at_time(node_id, probe_in_window, create_tx)
-                .is_err(),
-            "AS OF in the backdate-to-commit window must be invisible (live)"
+                .is_ok(),
+            "#3504: anchored before the delete's recorded tx the node must stay \
+             visible (append-only valid interval; live)"
+        );
+        assert!(
+            db.get_node_at_valid_time(node_id, probe_in_window).is_err(),
+            "#3400: at the current tx a valid probe past the backdated t_delete \
+             must be invisible (live)"
         );
         // Simulated crash: drop without a checkpoint.
     }
@@ -654,6 +674,12 @@ fn backdated_delete_valid_from_survives_replay() {
         t_delete,
         "replay must honor the LOGGED backdated delete valid_from, not the entry timestamp"
     );
+    // #3504: the prior head's valid interval stays OPEN after replay too --
+    // supersession by the tombstone is append-only on the valid dimension.
+    assert!(
+        history.versions[0].temporal.valid_time().is_current(),
+        "prior head's valid interval must stay open (append-only) after replay (#3504)"
+    );
     // Re-derive the tx anchor from the RECOVERED history: replay stamps
     // transaction time with the WAL entry's logged timestamp, which can
     // differ from the live commit timestamp by a few microseconds in either
@@ -662,15 +688,21 @@ fn backdated_delete_valid_from_survives_replay() {
     let recovered_create_tx = history.versions[0].temporal.transaction_time().start();
     assert!(
         db.get_node_at_time(node_id, probe_in_window, recovered_create_tx)
-            .is_err(),
-        "AS OF in the backdate-to-commit window must be invisible (post-replay)"
+            .is_ok(),
+        "#3504: snapshot-isolation visibility must survive replay -- the node is \
+         visible anchored before the delete's recorded tx (post-replay)"
+    );
+    assert!(
+        db.get_node_at_valid_time(node_id, probe_in_window).is_err(),
+        "#3400: after replay a current-tx valid probe past t_delete stays invisible"
     );
 }
 
 /// Edge counterpart of `backdated_delete_valid_from_survives_replay`
 /// (issue #3400): a backdated `delete_edge_with_valid_time` must recover with
-/// the tombstone stamped at the LOGGED backdated `valid_from`, and the prior
-/// head's valid_to closed at that same point.
+/// the tombstone stamped at the LOGGED backdated `valid_from`. Per #3504 the
+/// prior head's valid interval stays OPEN (append-only) -- supersession is
+/// expressed only on the transaction-time dimension.
 #[test]
 fn backdated_edge_delete_valid_from_survives_replay() {
     let temp_dir = tempfile::tempdir().unwrap();
@@ -718,10 +750,11 @@ fn backdated_edge_delete_valid_from_survives_replay() {
             "live path stamps the tombstone with the backdated valid_from"
         );
 
-        // Divergence window (see the node twin above): a valid-time probe
-        // strictly between the backdated t_delete and the delete's commit
-        // timestamp, with transaction time anchored at the create's tx
-        // start, must NOT see the edge.
+        // Divergence window (see the node twin above): the same probe pins two
+        // guarantees by which tx it anchors -- (1) #3504 snapshot isolation:
+        // anchored before the delete's recorded tx the edge stays VISIBLE
+        // (append-only valid interval); (2) #3400: at the current tx the
+        // backdated t_delete bounds the timeline, so the probe is INVISIBLE.
         let create_tx = history.versions[0].temporal.transaction_time().start();
         let tombstone_tx = history.versions[1].temporal.transaction_time().start();
         assert!(
@@ -737,8 +770,14 @@ fn backdated_edge_delete_valid_from_survives_replay() {
         );
         assert!(
             db.get_edge_at_time(edge_id, probe_in_window, create_tx)
-                .is_err(),
-            "AS OF in the backdate-to-commit window must be invisible (live)"
+                .is_ok(),
+            "#3504: anchored before the delete's recorded tx the edge must stay \
+             visible (append-only valid interval; live)"
+        );
+        assert!(
+            db.get_edge_at_valid_time(edge_id, probe_in_window).is_err(),
+            "#3400: at the current tx a valid probe past the backdated t_delete \
+             must be invisible (live)"
         );
         // Simulated crash: drop without a checkpoint.
     }
@@ -751,17 +790,23 @@ fn backdated_edge_delete_valid_from_survives_replay() {
         t_delete,
         "replay must honor the LOGGED backdated edge-delete valid_from, not the entry timestamp"
     );
-    assert_eq!(
-        history.versions[0].temporal.valid_time().end(),
-        t_delete,
-        "prior head's valid_to must be closed at the backdated tombstone valid_from after replay"
+    // #3504: the prior head's valid interval stays OPEN after replay --
+    // supersession by the tombstone is append-only on the valid dimension.
+    assert!(
+        history.versions[0].temporal.valid_time().is_current(),
+        "prior head's valid interval must stay open (append-only) after replay (#3504)"
     );
     // Re-derive the tx anchor from the RECOVERED history (see the node twin
     // above for why the pre-crash anchor is not reusable post-replay).
     let recovered_create_tx = history.versions[0].temporal.transaction_time().start();
     assert!(
         db.get_edge_at_time(edge_id, probe_in_window, recovered_create_tx)
-            .is_err(),
-        "AS OF in the backdate-to-commit window must be invisible (post-replay)"
+            .is_ok(),
+        "#3504: snapshot-isolation visibility must survive replay -- the edge is \
+         visible anchored before the delete's recorded tx (post-replay)"
+    );
+    assert!(
+        db.get_edge_at_valid_time(edge_id, probe_in_window).is_err(),
+        "#3400: after replay a current-tx valid probe past t_delete stays invisible"
     );
 }


### PR DESCRIPTION
## Before / After
**Before:** a read transaction that took its snapshot while a node or edge was still alive could return `NodeNotFound` if a *later* delete/update's valid-time landed on the snapshot's valid coordinate — a snapshot-isolation violation on the **valid** dimension. (Residual of #3435; #3437 fixed the transaction-time half. Deterministic on coarse clocks — the original macOS-CI failure mode.)
**After:** the superseded version's valid interval is kept append-only, so the earlier snapshot still resolves the node/edge; current-state reads still correctly hide deleted/superseded entities.

## Root cause
`close_previous_version_intervals` (`src/storage/historical/mod.rs`) closed the superseded version's `valid_time` **in place** when `new.valid_from > prev.valid_from`. That version's transaction-time window is still open, so a read snapshot at an earlier tx-time observed the retroactive valid-close. The version chain is a **transaction-time partition** — every write/replay path unconditionally tx-closes the prior head — so at any tx coordinate at most one version is visible. The in-place valid-close was never load-bearing for correctness (redundant at tx=now, wrong inside the prior version's recording window).

## Changes — production (2 hunks, both in `src/storage/historical/mod.rs`)
1. `close_previous_version_intervals` no longer closes the superseded version's `valid_time` (append-only `valid_to`); the transaction-time close is retained.
2. Edge temporal **adjacency** index: on supersession, close the entry's **transaction** time (`close_edge_transaction_time`) instead of its valid time — the direct analog of (1). Without this, deleted/superseded edges reappeared in current-tx traversals (surfaced by the full suite). Masks deleted edges at current-tx while preserving them for earlier-tx snapshots.

The read path (`src/api/transaction/read_tx.rs`) is intentionally unchanged: switching it to `valid=MAX` would regress future-dated (#3221/#3236) visibility and cannot fix the bug anyway.

## Observable behavior change
Point-in-time / history reads now report a superseded (non-tombstone) version's `valid_to` as **open** (`null`) instead of the successor's `valid_from` — the correct append-only bi-temporal model. **No WAL/on-disk format change:** the superseded `valid_to` is re-derived on replay, so old WAL files replay to the new open state. Pre-fix checkpoints retain already-closed intervals (append-only; benign).

## Acceptance criteria & evidence
| # | Acceptance criterion | Evidence |
|---|---|---|
| 1 | Snapshot taken while node alive + later same-valid-tick delete → node still visible | New `read_tx_sees_node_when_delete_valid_time_collides_with_snapshot` — RED on trunk, GREEN after fix |
| 2 | Same for a backdated **update** (valid_from precedes snapshot) | New `read_tx_sees_pre_update_version_when_backdated_update_valid_time_precedes_snapshot` — RED→GREEN |
| 3 | Superseded version's valid interval stays append-only (open) | valid-close removed; #452 replay assertions flipped to `is_current()`; index/compression review confirmed store↔index agree |
| 4 | Current-state reads still hide deleted/superseded nodes AND edges | Full suite caught deleted edges reappearing → hunk 2; `test_deleted_edges_not_returned_after_deletion` / `test_tombstone_closes_temporal_adjacency_entry` pass |
| 5 | Earlier-tx AS-OF traversal still returns a since-deleted edge | New **revert-proven** `deleted_edge_still_traversable_at_earlier_tx_snapshot_after_valid_from` |
| 6 | No wrong-version regression in valid-time-travel / AS-OF | Bitemporal review: no (valid,tx) cell flips A↔B; `temporal_state_space` (10) + `temporal_api_tests` (15) pass |
| 7 | Nodes + edges, updates + deletes, live + replay consistent | `recovery` 79 pass; replay assertions updated; node-parity + retraction ruled out |
| 8 | No on-disk/WAL format change | Superseded valid_to re-derived on replay, not persisted |
| 9 | Gates | Full suite 5809 pass (2 known sandbox fails); clippy CI-set + `--all-features` clean; fmt clean |

## Tests
2 new SimulatedClock snapshot-isolation regressions (delete + backdated update); 1 revert-proven adjacency AS-OF guard; ~11 delete/edge/planner assertions updated to open-interval; `hybrid_query_planner` midpoint re-anchored (was `i64::MAX` overflow).

## Reviews
Four adversarial reviews (bitemporal correctness/#452, temporal-index+compression, completeness+on-disk-compat, adjacency-hunk). Blockers found & fixed: incomplete test updates, the deleted-edge adjacency regression, the missing affirmative guard.

Closes #3504.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQGYDNyW8ShqfZQViKYmZt)_