### PR TITLE
fix(ci): merge-base diff for Mutants PR scope (stop spurious failures)

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -88,7 +88,8 @@ jobs:
       - name: Generate diff against base branch
         run: |
           BASE_REF="${{ github.base_ref }}"
-          git diff "origin/${BASE_REF:-trunk}"..HEAD > mutants-diff.patch
+          # Three-dot: diff from merge-base so only PR-introduced changes are mutated, not drifted trunk code.
+          git diff "origin/${BASE_REF:-trunk}"...HEAD > mutants-diff.patch
           wc -c mutants-diff.patch
 
       - name: Run mutation tests on diff


### PR DESCRIPTION
## Summary

The Mutants PR-diff workflow computes the mutation scope with a **two-dot** git diff (`origin/trunk..HEAD`), which diffs the base *tip* against HEAD. When a PR branched before trunk advanced, unrelated drifted trunk code gets swept into the diff, so cargo-mutants (`--in-diff mutants-diff.patch`) mutates production code the PR never touched.

**Before:** A PR branched before trunk advanced gets unrelated drifted trunk code swept into the mutation scope, so cargo-mutants mutates code the PR never touched and can fail the 60% score gate on it. Real examples: docs-only PR #3524 and test-only PR #3527 both went red on import/cypher code they didn't modify.

**After:** Scope is computed from the merge-base (three-dot `origin/trunk...HEAD`), matching GitHub's "Files changed" view — only PR-introduced changes are mutated.

**How:** One-line change in `.github/workflows/mutants.yml` (two-dot `..HEAD` → three-dot `...HEAD`). Checkout already uses `fetch-depth: 0`, so the merge-base commit is present and resolves. No restructuring.

## Note

Mutants remains informational / non-required — this doesn't change its gating status, it just stops it from failing on code the PR didn't change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01APqmD4oqVe2h2Ec35KKUoG)_