### PR TITLE
Cypher: flip compat known-deviation after IS NULL fix (#3510/#3511 follow-up)

### DIFF
--- a/docs/guides/cypher-compatibility.md
+++ b/docs/guides/cypher-compatibility.md
@@ -61,7 +61,9 @@ Nodes:
 - `Company` **Acme** `{name:'Acme', cid:1}`
 - `Company` **Globex** `{name:'Globex', cid:2}`
 
-No node has an `email` property (used to pin `IS NULL` / `IS NOT NULL`).
+No node has an `email` property (used to pin openCypher-correct `IS NULL` /
+`IS NOT NULL` on an absent property: `IS NULL` matches all 4 Persons,
+`IS NOT NULL` matches 0 — fixed in #3511).
 
 Edges:
 
@@ -88,7 +90,7 @@ correctly.
 | `WHERE` boolean logic | `WHERE n.age > 30 AND n.dept = 'Sales'` | `AND` / `OR` / `NOT` |
 | `WHERE ... IN` | `WHERE n.dept IN ['Eng','Sales']` | list membership |
 | `STARTS WITH` / `ENDS WITH` / `CONTAINS` | `WHERE n.name STARTS WITH 'A'` | case-sensitive |
-| `IS NULL` / `IS NOT NULL` | `WHERE n.name IS NULL` | parses/executes; **openCypher-correct only for *present* properties** — absent-property semantics deviate (see [§3](#3-known-limitations-executes-with-documented-caveats)) |
+| `IS NULL` / `IS NOT NULL` | `WHERE n.email IS NULL` | openCypher-correct for both **present** and **absent** properties: a missing property *is* null, so `n.email IS NULL` matches all rows and `IS NOT NULL` matches none (absent-property inversion fixed in #3511) |
 | Outgoing / incoming / undirected | `-[:KNOWS]->`, `<-[:KNOWS]-`, `-[:KNOWS]-` | |
 | Relationship-type traversal | `MATCH (a)-[:KNOWS]->(b) RETURN b` | |
 | Variable-length paths | `-[:KNOWS*1..3]->`, `*2`, `*`, `*2..`, `*..2` | **node-distinct / shortest-path reachability** (v1 simplification of trail semantics); open-ended bounds capped at depth 10 |
@@ -155,25 +157,16 @@ can be produced. The suite pins the exact variant and a message substring.
   (`DEFAULT_MAX_TRAVERSAL_DEPTH`).
 - **`RETURN DISTINCT <scalar projection>`** deduplicates by entity id, not the
   projected value (property projection is not yet lowered into the row model).
-- **`IS NULL` / `IS NOT NULL` on an *absent* property deviate from openCypher.**
-  The Cypher converter lowers `x IS NULL` → `Eq{value: Null}` and
-  `x IS NOT NULL` → `Ne{value: Null}`; the executor treats a **missing**
-  property as non-matching for `Eq` and matching for `Ne`. So for a property
-  that no node carries:
 
-  | Query | AletheiaDB (actual) | openCypher (expected) |
-  |-------|---------------------|-----------------------|
-  | `n.email IS NULL`     | 0 rows | all rows (a missing property *is* null) |
-  | `n.email IS NOT NULL` | all rows | 0 rows |
+> **Fixed (#3511):** `IS NULL` / `IS NOT NULL` on an *absent* property was
+> previously inverted vs openCypher (a missing property matched `IS NOT NULL`
+> instead of `IS NULL`). #3511 re-lowered property-access `x IS NULL` →
+> `Or(NotExists, Eq(Null))` and `x IS NOT NULL` → `And(Exists, Ne(Null))`, so a
+> missing property now correctly *is* null. This is now asserted as
+> openCypher-correct in the supported corpus (`is_null_absent_prop` /
+> `is_not_null_absent_prop` in `src/cypher/compat.rs`), no longer a deviation.
 
-  For **present** properties the behavior is openCypher-correct. This inversion
-  is a genuine deviation (not merely a missing feature); it is pinned — as a
-  deviation, **not** asserted as correct — by `compat_known_deviations` in
-  `src/cypher/compat.rs`, so a future fix will trip that test and prompt an
-  update here.
-
-Apart from that documented deviation, no case in the suite asserts a wrong
-answer as correct.
+No case in the suite asserts a wrong answer as correct.
 
 ---
 

--- a/src/cypher/compat.rs
+++ b/src/cypher/compat.rs
@@ -48,7 +48,9 @@ use super::error::CypherError;
 /// - `Company` Acme   {name:'Acme',   cid:1}
 /// - `Company` Globex {name:'Globex', cid:2}
 ///
-/// No node carries an `email` property (pins `IS NULL` / `IS NOT NULL`).
+/// No node carries an `email` property (pins openCypher-correct `IS NULL` /
+/// `IS NOT NULL` on an absent property: `IS NULL` matches all 4, `IS NOT NULL`
+/// matches 0 -- fixed in #3511).
 ///
 /// Edges:
 /// - Alice -[:KNOWS]-> Bob -[:KNOWS]-> Carol -[:KNOWS]-> Dave (a linear chain)
@@ -325,9 +327,12 @@ fn supported_execute_cases() -> Vec<Case> {
             "MATCH (n:Person) WHERE n.name CONTAINS 'ar' RETURN n",
             Executes(1),
         ),
-        // NOTE: `IS NULL` / `IS NOT NULL` are openCypher-correct for *present*
-        // properties (below). Their behavior for *absent* properties deviates
-        // from openCypher and is pinned separately in `compat_known_deviations`.
+        // `IS NULL` / `IS NOT NULL` are openCypher-correct for both *present*
+        // and *absent* properties. Present: `name` is set on all 4 Persons, so
+        // `IS NULL` -> 0, `IS NOT NULL` -> 4. Absent: no Person has `email`, so
+        // (per openCypher, a missing property IS null) `IS NULL` -> 4,
+        // `IS NOT NULL` -> 0. The absent-property cases were previously an
+        // openCypher deviation (inverted); fixed in #3511.
         Case::new(
             "where",
             "is_null_present_prop",
@@ -339,6 +344,18 @@ fn supported_execute_cases() -> Vec<Case> {
             "is_not_null_present_prop",
             "MATCH (n:Person) WHERE n.name IS NOT NULL RETURN n",
             Executes(4),
+        ),
+        Case::new(
+            "where",
+            "is_null_absent_prop",
+            "MATCH (n:Person) WHERE n.email IS NULL RETURN n",
+            Executes(4),
+        ),
+        Case::new(
+            "where",
+            "is_not_null_absent_prop",
+            "MATCH (n:Person) WHERE n.email IS NOT NULL RETURN n",
+            Executes(0),
         ),
         // ---- patterns ------------------------------------------------------
         Case::new(
@@ -651,8 +668,8 @@ fn supported_parse_cases() -> Vec<Case> {
             "MATCH (n:Person) BETWEEN '2024-01-01' AND '2024-12-31' RETURN n",
             Parses,
         ),
-        // ---- where null-check parse+convert (absent-prop semantics deviate;
-        //      pinned in compat_known_deviations) -----------------------------
+        // ---- where null-check parse+convert (absent-prop execution semantics
+        //      asserted in supported_execute_cases; openCypher-correct post-#3511)
         Case::new(
             "where",
             "is_null_parses",
@@ -966,62 +983,4 @@ fn compat_rejected() {
     }
 
     assert_no_failures("rejected", total, failures);
-}
-
-// ---------------------------------------------------------------------------
-// Known deviations from openCypher (pinned, NOT asserted as correct)
-// ---------------------------------------------------------------------------
-
-/// Pin the **actual** (openCypher-*deviating*) behavior of `IS NULL` /
-/// `IS NOT NULL` against an **absent** property, so a regression is caught, but
-/// without misrepresenting it as openCypher-conformant.
-///
-/// # The deviation
-///
-/// The Cypher converter lowers `x IS NULL` to `Predicate::Eq { value: Null }`
-/// and `x IS NOT NULL` to `Predicate::Ne { value: Null }`. The executor's
-/// `evaluate_eq` treats a **missing** property as non-matching (`false`) and
-/// `evaluate_ne` treats it as matching (`true`). Consequently, for a property
-/// that is entirely absent:
-///
-/// | Query | AletheiaDB (actual) | openCypher (expected) |
-/// |-------|---------------------|-----------------------|
-/// | `n.email IS NULL`     | 0 rows | 4 rows (a missing property IS null) |
-/// | `n.email IS NOT NULL` | 4 rows | 0 rows |
-///
-/// For **present** properties the behavior is openCypher-correct (see the
-/// `is_null_present_prop` / `is_not_null_present_prop` supported cases). This
-/// test documents the absent-property inversion; see the "Known limitations"
-/// section of docs/guides/cypher-compatibility.md.
-#[test]
-fn compat_known_deviations() {
-    let db = compat_db();
-
-    // DEVIATION: openCypher would return all 4 Persons (email is null/absent).
-    let is_null_absent = db
-        .execute_cypher("MATCH (n:Person) WHERE n.email IS NULL RETURN n")
-        .unwrap()
-        .collect_all()
-        .unwrap();
-    assert_eq!(
-        is_null_absent.len(),
-        0,
-        "KNOWN DEVIATION: `IS NULL` on an absent property matches 0 rows in \
-         AletheiaDB (openCypher would match all 4). If this changed, the \
-         deviation may be fixed -- update docs/guides/cypher-compatibility.md."
-    );
-
-    // DEVIATION: openCypher would return 0 Persons (email is null/absent).
-    let is_not_null_absent = db
-        .execute_cypher("MATCH (n:Person) WHERE n.email IS NOT NULL RETURN n")
-        .unwrap()
-        .collect_all()
-        .unwrap();
-    assert_eq!(
-        is_not_null_absent.len(),
-        4,
-        "KNOWN DEVIATION: `IS NOT NULL` on an absent property matches all rows \
-         in AletheiaDB (openCypher would match 0). If this changed, the \
-         deviation may be fixed -- update docs/guides/cypher-compatibility.md."
-    );
 }


### PR DESCRIPTION
## Why

Wave-4 Cypher PRs #3510 (openCypher compatibility suite) and #3511 (IS NULL / IS NOT NULL absent-property fix) merged to trunk back-to-back **without** the coordinated "compat flip". #3510 shipped a `compat_known_deviations` change-detector test that pinned the **pre-fix (buggy)** `IS NULL` behavior; #3511 fixed that behavior. With both on trunk, the change-detector tripped and trunk's compat suite went **red**.

## Before / After

The compat seed graph has 4 `Person` nodes, none with an `email` property.

| Query | Pre-fix (pinned by #3510) | Post-#3511 (openCypher-correct) |
|-------|---------------------------|---------------------------------|
| `WHERE n.email IS NULL`     | 0 rows | **4 rows** (a missing property *is* null) |
| `WHERE n.email IS NOT NULL` | 4 rows | **0 rows** |

Verified red on trunk: `compat_known_deviations` panicked (`left: 4, right: 0`).

## What this does

- Removes the now-obsolete `compat_known_deviations` change-detector test (it asserted the old buggy output).
- Adds `is_null_absent_prop` → `Executes(4)` and `is_not_null_absent_prop` → `Executes(0)` to the **supported** execute corpus, pinning the now-correct openCypher behavior.
- Updates `docs/guides/cypher-compatibility.md`: moves the `IS NULL`/`IS NOT NULL` absent-property entry out of "Known Limitations" into the Supported table, noting it was fixed by #3511.

## Verification

- `cargo test --features cypher --lib cypher::compat` → green (3 tests).
- `cargo test --features cypher --lib` → 4089 passed, 0 failed.
- `cargo clippy --all-targets --features cypher -- -D warnings` → clean.
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` → clean.
- `cargo fmt --all` applied.

Unblocks trunk (turns the compat suite back green).

_No PR template exists in the repo; this description is ad hoc._

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDxuBsxZU6SLfsTr7jtBbX)_