### PR TITLE
test(cypher): prove #550/#551/#552 temporal AS OF / BETWEEN already implemented (compat + edge tests + docs)

### DIFF
--- a/docs/guides/cypher-compatibility.md
+++ b/docs/guides/cypher-compatibility.md
@@ -101,11 +101,11 @@ correctly.
 | Chained `WITH` | `WITH a WHERE ... WITH a WHERE ... RETURN a` | |
 | Standalone `UNWIND` | `UNWIND [1,2,3] AS x RETURN x` | list literal / `$param` / `null`; `RETURN x`, `DISTINCT`, `ORDER BY x`, `SKIP`, `LIMIT` |
 | `OPTIONAL MATCH` (left-outer) | `MATCH (a:Person) OPTIONAL MATCH (a)-[:KNOWS]->(x) RETURN x` | unmatched preserves base row, binds null; single pattern, unlabeled continuation node |
-| `AS OF TIMESTAMP` | `MATCH (n:Person) AS OF TIMESTAMP '2024-01-15T10:00:00Z' RETURN n` | *convert-only in the suite* (avoids seeding bi-temporal history) |
-| `AS OF VALID_TIME` / `AS OF SYSTEM_TIME` | `... AS OF VALID_TIME '2024-01-15' RETURN n` | *convert-only* |
-| `FOR SYSTEM_TIME AS OF` | `... FOR SYSTEM_TIME AS OF '2024-01-15' RETURN n` | *convert-only* |
-| Bi-temporal | `... AS OF VALID_TIME '...' AS OF SYSTEM_TIME '...' RETURN n` | *convert-only* |
-| `BETWEEN ... AND` | `... BETWEEN '2024-01-01' AND '2024-12-31' RETURN n` | *convert-only* |
+| `AS OF TIMESTAMP` (#550) | `MATCH (n:Person) AS OF TIMESTAMP '2024-01-15T10:00:00Z' RETURN n` | *convert-only in the suite* (avoids seeding bi-temporal history). Timestamp literal accepts ISO-8601 with `Z` **or** numeric offset (`+00:00`), date-only (midnight UTC), and Unix microseconds — all pinned. **Runtime** reconstruction is proven end-to-end in `src/cypher/tests.rs` (`test_e2e_as_of_timestamp_*`) |
+| `AS OF VALID_TIME` / `AS OF SYSTEM_TIME` / `FOR VALID_TIME AS OF` (#551) | `... AS OF VALID_TIME '2024-01-15' RETURN n` | *convert-only* in the suite; runtime-proven in `tests.rs` |
+| `FOR SYSTEM_TIME AS OF` (#551) | `... FOR SYSTEM_TIME AS OF '2024-01-15' RETURN n` | *convert-only*; runtime-proven (`test_e2e_for_system_time_as_of_honored_by_label_scan`) |
+| Bi-temporal (#551) | `... AS OF VALID_TIME '...' AS OF SYSTEM_TIME '...' RETURN n` | *convert-only*; runtime-proven (`test_e2e_as_of_bitemporal_valid_and_system`, `test_e2e_as_of_asymmetric_bitemporal`) |
+| `BETWEEN ... AND` (valid-time range, #552) | `... BETWEEN '2024-01-01' AND '2024-12-31' RETURN n` | *convert-only*; half-open `[start, end)` (start-inclusive, end-exclusive). Runtime-proven in `tests.rs` (`test_e2e_between_*`, incl. boundary inclusivity) |
 | Vector similarity in `ORDER BY` | `RETURN d ORDER BY vector.similarity(d.embedding, $q) DESC LIMIT 10` | *convert-only* (needs an `Embedding` param) |
 | Parameters | `MATCH (n:Person {name:$name}) RETURN n` | `$param` bindings |
 
@@ -138,6 +138,9 @@ can be produced. The suite pins the exact variant and a message substring.
 | `WITH` computed / property / aggregate projection | `MATCH (a:Person) WITH a.name AS x RETURN x` | `UnsupportedFeature` | `WITH` can only project a bound variable (optionally aliased) |
 | `RETURN` of a `WITH`-dropped variable | `MATCH (a:Person) WITH a AS p WHERE p.age > 30 RETURN a` | `SemanticError` | `a` is out of scope after the `WITH` renamed/dropped it |
 | Unbound parameter | `MATCH (n:Person {name:$name}) RETURN n` (no binding) | `ParameterError` | `$name` was never bound |
+| `FOR SYSTEM_TIME BETWEEN` (tx-time range, #551/#552) | `... FOR SYSTEM_TIME BETWEEN '2024-01-01' AND '2024-03-31' RETURN n` | `ParseError` | **Design decision**: transaction-time RANGE scans are not exposed through Cypher; the parser requires `AS OF` after `SYSTEM_TIME`. (The tx-range context is reachable only via the `QueryBuilder` API, where the planner rejects it as an `UnsupportedFeature` — see `test_e2e_transaction_time_between_rejected`.) |
+| Inverted `BETWEEN` range (#552) | `... BETWEEN '2024-12-31' AND '2024-01-01' RETURN n` | `InvalidTemporalClause` | start/end are validated (`start > end` rejected during lowering), never silently treated as empty |
+| Unparseable `AS OF TIMESTAMP` literal (#550) | `... AS OF TIMESTAMP 'not-a-timestamp' RETURN n` | `InvalidTimestamp` | a malformed timestamp is rejected during lowering, never a silent `now()` fallback |
 
 ---
 

--- a/src/cypher/compat.rs
+++ b/src/cypher/compat.rs
@@ -126,10 +126,8 @@ enum RejectKind {
     /// [`CypherError::ParameterError`].
     Parameter,
     /// [`CypherError::InvalidTemporalClause`].
-    #[allow(dead_code)]
     Temporal,
     /// [`CypherError::InvalidTimestamp`].
-    #[allow(dead_code)]
     Timestamp,
 }
 
@@ -651,6 +649,36 @@ fn supported_parse_cases() -> Vec<Case> {
             "MATCH (n:Person) BETWEEN '2024-01-01' AND '2024-12-31' RETURN n",
             Parses,
         ),
+        // #550 timestamp-format coverage: every documented AS OF TIMESTAMP
+        // literal form (ISO 8601 with `Z`, ISO 8601 with numeric offset, date
+        // only, and Unix microseconds) must parse+lower without error.
+        Case::new(
+            "temporal",
+            "as_of_timestamp_offset",
+            "MATCH (n:Person) AS OF TIMESTAMP '2024-01-15T10:00:00+00:00' RETURN n",
+            Parses,
+        ),
+        Case::new(
+            "temporal",
+            "as_of_timestamp_date_only",
+            "MATCH (n:Person) AS OF TIMESTAMP '2024-01-15' RETURN n",
+            Parses,
+        ),
+        Case::new(
+            "temporal",
+            "as_of_timestamp_unix_micros",
+            "MATCH (n:Person) AS OF TIMESTAMP '1705315200000000' RETURN n",
+            Parses,
+        ),
+        // #551: the `FOR VALID_TIME AS OF` spelling (SQL:2011-style) is the
+        // symmetric counterpart to `FOR SYSTEM_TIME AS OF` and lowers to a
+        // valid-time AS OF context.
+        Case::new(
+            "temporal",
+            "for_valid_time_as_of",
+            "MATCH (n:Person) FOR VALID_TIME AS OF '2024-01-15' RETURN n",
+            Parses,
+        ),
         // ---- where null-check parse+convert (absent-prop semantics deviate;
         //      pinned in compat_known_deviations) -----------------------------
         Case::new(
@@ -685,7 +713,7 @@ fn supported_parse_cases() -> Vec<Case> {
 
 fn rejected_cases() -> Vec<Case> {
     use Expect::Rejected;
-    use RejectKind::{Parameter, Parse, Semantic, Unsupported};
+    use RejectKind::{Parameter, Parse, Semantic, Temporal, Timestamp, Unsupported};
 
     vec![
         // ---- mutating clauses -> ParseError --------------------------------
@@ -822,6 +850,36 @@ fn rejected_cases() -> Vec<Case> {
             "unbound_parameter",
             "MATCH (n:Person {name: $name}) RETURN n",
             Rejected(Parameter, "unbound parameter"),
+        ),
+        // ---- temporal: intentionally-unsupported / invalid shapes ----------
+        // #551/#552 design decision: transaction-time RANGE scans are NOT
+        // exposed through Cypher. `FOR SYSTEM_TIME BETWEEN` is rejected at the
+        // parser (it expects `AS OF` after `SYSTEM_TIME`), never silently
+        // answered. (The tx-range context is reachable only via the
+        // `QueryBuilder` API, where the planner rejects it as an
+        // `UnsupportedFeature`; see the executor-level e2e test.)
+        Case::new(
+            "temporal",
+            "for_system_time_between_rejected",
+            "MATCH (n:Person) FOR SYSTEM_TIME BETWEEN '2024-01-01' AND '2024-03-31' RETURN n",
+            Rejected(Parse, ""),
+        ),
+        // #552: `BETWEEN` start/end are validated -- an inverted range
+        // (start > end) is rejected during lowering with a structured
+        // `InvalidTemporalClause`, not silently treated as empty.
+        Case::new(
+            "temporal",
+            "between_inverted_range",
+            "MATCH (n:Person) BETWEEN '2024-12-31' AND '2024-01-01' RETURN n",
+            Rejected(Temporal, "invalid time range"),
+        ),
+        // #550: an unparseable timestamp literal is rejected with a structured
+        // `InvalidTimestamp` during lowering (not a silent now()-fallback).
+        Case::new(
+            "temporal",
+            "as_of_timestamp_invalid",
+            "MATCH (n:Person) AS OF TIMESTAMP 'not-a-timestamp' RETURN n",
+            Rejected(Timestamp, "not-a-timestamp"),
         ),
     ]
 }

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -4237,6 +4237,106 @@ fn test_e2e_transaction_time_between_rejected() {
     }
 }
 
+/// #550 (timestamp-format equivalence): the four documented `AS OF TIMESTAMP`
+/// literal forms that all denote the SAME instant resolve identically
+/// end-to-end. A far-FUTURE instant is used deliberately: `AS OF TIMESTAMP`
+/// pins BOTH valid and transaction time to the literal, so a future coordinate
+/// includes every already-committed current node -- each equivalent spelling
+/// must therefore return the full current set, proving the ISO-8601 (`Z` and
+/// numeric-offset), date-only, and Unix-microsecond forms parse to one instant
+/// AND flow through the executor.
+#[test]
+fn test_e2e_as_of_timestamp_formats_equivalent() {
+    let db = AletheiaDB::new().unwrap();
+    db.create_node("Person", person("Alice")).unwrap();
+    db.create_node("Person", person("Bob")).unwrap();
+
+    // 2999-01-01T00:00:00Z expressed in every accepted spelling.
+    let micros = "2999-01-01T00:00:00Z"
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .unwrap()
+        .timestamp_micros();
+    let forms = [
+        "2999-01-01".to_string(),                // date only (midnight UTC)
+        "2999-01-01T00:00:00Z".to_string(),      // ISO 8601 with 'Z'
+        "2999-01-01T00:00:00+00:00".to_string(), // ISO 8601 with numeric offset
+        micros.to_string(),                      // Unix microseconds
+    ];
+
+    let expected = vec!["Alice".to_string(), "Bob".to_string()];
+    for form in &forms {
+        let q = format!("MATCH (n:Person) AS OF TIMESTAMP '{form}' RETURN n");
+        let names = sorted_names(&collect_rows(db.execute_cypher(&q).unwrap()));
+        assert_eq!(
+            names, expected,
+            "AS OF TIMESTAMP form `{form}` must resolve to the same current set"
+        );
+    }
+}
+
+/// #551/#552 (Cypher-surface design decision): `FOR SYSTEM_TIME BETWEEN`
+/// (a transaction-time RANGE) is NOT part of the Cypher surface. The parser
+/// requires `AS OF` after `SYSTEM_TIME`, so the query is rejected -- an LLM
+/// never receives present-day data in response to a tx-range query. This
+/// complements `test_e2e_transaction_time_between_rejected`, which pins the
+/// same decision at the QueryBuilder/planner layer.
+#[test]
+fn test_e2e_cypher_for_system_time_between_rejected() {
+    let db = AletheiaDB::new().unwrap();
+    db.create_node("Person", person("Alice")).unwrap();
+
+    let result = db.execute_cypher(
+        "MATCH (n:Person) FOR SYSTEM_TIME BETWEEN '2024-01-01' AND '2024-03-31' RETURN n",
+    );
+    assert!(
+        result.is_err(),
+        "FOR SYSTEM_TIME BETWEEN must be rejected at the Cypher surface, not answered"
+    );
+}
+
+/// #552 (exact boundaries): `BETWEEN` is the half-open valid-time window
+/// `[start, end)`. A version whose validity begins exactly at `start` is
+/// INCLUDED (start-inclusive); one whose validity begins exactly at `end` is
+/// EXCLUDED (end-exclusive). Cross-checked against the oracle union over
+/// sampled in-range instants.
+#[test]
+fn test_e2e_between_boundary_inclusivity() {
+    let db = AletheiaDB::new().unwrap();
+
+    // "AtStart": valid_from == start (exact lower boundary -- included).
+    let start = temporal_anchor(&db);
+    db.create_node_with_valid_time("Person", person("AtStart"), Some(start))
+        .unwrap();
+    // "InWindow": valid_from strictly inside (start, end).
+    let mid = temporal_anchor(&db);
+    db.create_node_with_valid_time("Person", person("InWindow"), Some(mid))
+        .unwrap();
+    // "AtEnd": valid_from == end (exact upper boundary -- excluded).
+    let end = temporal_anchor(&db);
+    db.create_node_with_valid_time("Person", person("AtEnd"), Some(end))
+        .unwrap();
+
+    let q = format!(
+        "MATCH (n:Person) BETWEEN '{}' AND '{}' RETURN n",
+        anchor_micros(start),
+        anchor_micros(end)
+    );
+    let names = sorted_names(&collect_rows(db.execute_cypher(&q).unwrap()));
+
+    assert_eq!(
+        names,
+        vec!["AtStart".to_string(), "InWindow".to_string()],
+        "BETWEEN [start, end) must include the start-boundary version and \
+         exclude the end-boundary version"
+    );
+    // Oracle: union of AS OF (v, now) over in-range instants (both < end).
+    let oracle = oracle_union_names_at(&db, "Person", &[start, mid], time_now());
+    assert_eq!(
+        names, oracle,
+        "BETWEEN must equal the oracle in-range union"
+    );
+}
+
 // ============================================================================
 // WITH clause semantics (Issue #556): projection, scoping, ORDER BY/SKIP/LIMIT
 // ============================================================================


### PR DESCRIPTION
## Summary

Issues **#550** (`AS OF TIMESTAMP`), **#551** (`FOR SYSTEM_TIME` / bi-temporal), and **#552** (`BETWEEN` valid-time range) are **already implemented on trunk** — parser (`src/cypher/parser.rs`), converter/lowering (`src/cypher/converter.rs`), and executor (`src/query/executor/iterators.rs` + `src/query/planner/mod.rs`). This PR adds **no production code**. It adds openCypher-style **compat cases** and **runtime edge-case tests** proving the acceptance criteria that existing tests did not yet cover, and refreshes the compatibility guide. **Recommendation: close #550, #551, #552 as done.**

### Before / After (plain language)

- **Before:** The three temporal clauses worked and had runtime e2e tests, but a few acceptance-criteria edges were unpinned: the *timestamp literal formats* for `AS OF TIMESTAMP` (numeric offset / date-only / Unix micros) were only exercised implicitly; `BETWEEN` **boundary inclusivity** and **range validation** were not directly asserted; and the `FOR SYSTEM_TIME BETWEEN` non-support was pinned only at the `QueryBuilder`/planner layer, not at the Cypher surface.
- **After:** Each of those edges has an explicit, green test. The compat matrix (`docs/guides/cypher-compatibility.md`) documents the timestamp-format coverage, the half-open `[start, end)` `BETWEEN` window, and the `FOR SYSTEM_TIME BETWEEN` design decision.

### How

Scope is limited to `src/cypher/**` and `docs/guides/cypher-compatibility.md`.

- **`src/cypher/compat.rs`** (table-driven openCypher suite):
  - `supported_parse_cases`: `AS OF TIMESTAMP` with ISO-8601 **numeric offset** (`+00:00`), **date-only**, and **Unix microseconds**; plus `FOR VALID_TIME AS OF`.
  - `rejected_cases` (new `temporal` category): `FOR SYSTEM_TIME BETWEEN` → `ParseError`; **inverted** `BETWEEN` (start > end) → `InvalidTemporalClause`; unparseable `AS OF TIMESTAMP 'not-a-timestamp'` → `InvalidTimestamp`. These activate the previously-unused `RejectKind::Temporal` / `::Timestamp` variants (removed their `#[allow(dead_code)]`).
- **`src/cypher/tests.rs`** (runtime e2e, against real bi-temporal history):
  - `test_e2e_as_of_timestamp_formats_equivalent` — all four literal forms denoting one instant resolve identically end-to-end.
  - `test_e2e_cypher_for_system_time_between_rejected` — tx-time range rejected at the Cypher layer (complements the existing planner-level `test_e2e_transaction_time_between_rejected`).
  - `test_e2e_between_boundary_inclusivity` — half-open `[start, end)`: start-inclusive, end-exclusive; cross-checked against the oracle union.
- **`docs/guides/cypher-compatibility.md`** — §1/§2 temporal rows updated; no stale deviation entry introduced; the `IS NULL` deviation section is untouched.

### AC-evidence table

| Issue | Acceptance criterion | Implementation (file:line) | Proving test |
|-------|----------------------|----------------------------|--------------|
| #550 | `AS OF TIMESTAMP` parses | `parser.rs:1091-1097` / `:1155-1159` → `CypherTemporal::AsOfTimestamp` | `tests.rs::test_parse_as_of_timestamp`; `compat.rs` `temporal/as_of_timestamp` |
| #550 | ISO-8601 timestamps parse (incl. numeric offset) | `converter.rs::parse_timestamp_string:1634-1655` (`chrono::DateTime<Utc>`) | `compat.rs` `temporal/as_of_timestamp_offset`; `tests.rs::test_e2e_as_of_timestamp_formats_equivalent` |
| #550 | Date-only literal (midnight UTC) | `converter.rs:1648-1652` (`NaiveDate`) | `compat.rs` `temporal/as_of_timestamp_date_only`; `test_e2e_as_of_timestamp_formats_equivalent` |
| #550 | Unix microseconds parse | `converter.rs:1638-1640` | `compat.rs` `temporal/as_of_timestamp_unix_micros`; `test_e2e_as_of_timestamp_formats_equivalent` |
| #550 | Temporal context flows to executor / historical versions returned | `converter.rs:1442-1445` → `TemporalContext::as_of`; `planner/mod.rs:700-740` | `tests.rs::test_e2e_as_of_timestamp_returns_historical_state`, `test_e2e_as_of_middle_version`, `test_e2e_as_of_finds_since_deleted_node` |
| #550 | Invalid timestamp rejected (no silent fallback) | `converter.rs:1654` → `InvalidTimestamp` | `compat.rs` `temporal/as_of_timestamp_invalid` |
| #551 | `FOR SYSTEM_TIME AS OF` parses | `parser.rs:1202-1210` → `AsOfSystemTime` | `tests.rs::test_parse_as_of_system_time`; `compat.rs` `temporal/for_system_time_as_of` |
| #551 | `FOR VALID_TIME AS OF` parses | `parser.rs:1211-1217` → `AsOfValidTime` | `compat.rs` `temporal/for_valid_time_as_of` |
| #551 | Bi-temporal (both clauses) works | `parser.rs:1161-1188` → `BiTemporal`; `converter.rs:1455-1462` → `as_of(vt, st)` | `tests.rs::test_e2e_as_of_bitemporal_valid_and_system`, `test_e2e_as_of_asymmetric_bitemporal` |
| #551 | Correct records per time dimension | `converter.rs:1447-1453`; executor point-in-time selector | `test_e2e_for_system_time_as_of_honored_by_label_scan`, `test_e2e_as_of_asymmetric_bitemporal` |
| #551 | `FOR SYSTEM_TIME BETWEEN` — **intentionally not supported** (see design note) | parser requires `AS OF` after `SYSTEM_TIME` (`parser.rs:1204-1210`); planner rejects tx-range (`planner/mod.rs:745-749`, `UnsupportedFeature`) | `compat.rs` `temporal/for_system_time_between_rejected`; `tests.rs::test_e2e_cypher_for_system_time_between_rejected`, `test_e2e_transaction_time_between_rejected` |
| #552 | `BETWEEN` clause parses | `parser.rs:1120-1129` / `:1222-1231` → `Between{start,end}` | `tests.rs::test_parse_between`; `compat.rs` `temporal/between` |
| #552 | Start/end validated (inverted rejected) | `converter.rs:1466-1468` (`TimeRange::new` → `InvalidTemporalClause`) | `compat.rs` `temporal/between_inverted_range` |
| #552 | Overlapping versions returned; excludes superseded/out-of-range; no dups | `converter.rs:1463-1475` → `QueryOp::Between`; `iterators.rs::TemporalNodeRangeScanIterator:1255-1289` (`overlaps`) | `test_e2e_between_is_as_of_now_snapshot_excludes_superseded`, `test_e2e_between_excludes_out_of_range_versions`, `test_e2e_between_excludes_superseded_and_no_duplicates` |
| #552 | Exact boundaries handled (half-open `[start, end)`) | `temporal.rs::TimeRange::overlaps:260-265` (`start < other.end && other.start < self.end`) | `tests.rs::test_e2e_between_boundary_inclusivity` |

### Design decision: `FOR SYSTEM_TIME BETWEEN`

Per #551/#552, a **transaction-time range** (`FOR SYSTEM_TIME BETWEEN ...`) is **deliberately not exposed through Cypher**. The parser requires `AS OF` after `SYSTEM_TIME`, so the clause is rejected with a structured error rather than silently answered with present-day data. (The tx-range context is reachable only via the `QueryBuilder` API, where the planner rejects it as `UnsupportedFeature`.) This PR pins that decision at both layers and does **not** implement tx-range Cypher support.

### Test results

`cargo test --features "config-toml,mcp-server,sharding-rpc,simulation,cypher" --lib`: **4606 passed, 2 failed, 3 ignored**. All new tests pass. `clippy --all-targets` (target feature set **and** `--all-features`) clean; `cargo fmt --all` applied.

> ⚠️ **Two failing lib tests are PRE-EXISTING on trunk (`54e384d`) and unrelated to this PR** — both reproduce on a pristine checkout with this branch's changes stashed:
> - `cypher::compat::compat_known_deviations` — the `IS NULL`/`IS NOT NULL` *absent-property* deviation appears to have been fixed on trunk (now returns the openCypher-correct row counts), but its pinning test + `docs §3` were not updated. **Left untouched here** (out of scope for #550/#551/#552; the fix belongs with whoever changed the null-comparison semantics).
> - `mcp::auth_tests::live_tool_inventory_matches_golden` — in `src/mcp/**`, not touched by this PR.
>
> Recommend the maintainer address these separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tp8D1QkQgozovHQGqtaJxF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tp8D1QkQgozovHQGqtaJxF)_