### PR TITLE
Fix MCP tool-inventory golden drift: add verify_chain + export_chain_head

### DIFF
--- a/src/mcp/auth_tests.rs
+++ b/src/mcp/auth_tests.rs
@@ -1087,27 +1087,27 @@ fn classification_uses_known_classes_only() {
 // 6. Live tool-inventory golden (drift detection for the external mirror)
 //
 // The external `tests/parity_mcp.rs::tool_inventory_golden_is_stable` test can
-// only validate a hardcoded 44-tool constant against itself, because the live
+// only validate a hardcoded 46-tool constant against itself, because the live
 // registry (`list_tools_for_test` / `TOOL_ACCESS_CLASSES`) is `pub(crate)` and
 // unreachable from an external test crate. This in-crate test closes that gap:
 // it derives the LIVE advertised `(tool_name, access_class)` set from the
-// registry and asserts it equals a hardcoded golden snapshot of the 44 pairs.
+// registry and asserts it equals a hardcoded golden snapshot of the 46 pairs.
 // A tool that is added, removed, renamed, or reclassified FAILS here — the
 // authoritative drift detector the external mirror points back to.
 // ============================================================================
 
 /// AC3 (drift): the LIVE advertised MCP tool inventory — every name paired
 /// with the `AccessClass` the registry assigns it — must equal this hardcoded
-/// golden set of exactly 44 pairs. Adding, dropping, renaming, or
+/// golden set of exactly 46 pairs. Adding, dropping, renaming, or
 /// reclassifying a tool changes the live set and fails this assertion; update
 /// the golden here AND the external mirror (`tests/parity_mcp.rs`) +
 /// `tests/parity/inventory.json` deliberately when that happens.
 #[test]
 fn live_tool_inventory_matches_golden() {
-    /// The 44 `(tool_name, access_class)` pairs the server is expected to
+    /// The 46 `(tool_name, access_class)` pairs the server is expected to
     /// advertise, derived from the current live `TOOL_ACCESS_CLASSES`.
-    const GOLDEN: [(&str, AccessClass); 44] = [
-        // Read (31)
+    const GOLDEN: [(&str, AccessClass); 46] = [
+        // Read (33)
         ("get_node", AccessClass::Read),
         ("list_nodes", AccessClass::Read),
         ("count_nodes", AccessClass::Read),
@@ -1139,6 +1139,8 @@ fn live_tool_inventory_matches_golden() {
         ("lineage_upstream", AccessClass::Read),
         ("lineage_downstream", AccessClass::Read),
         ("audit_export", AccessClass::Read),
+        ("verify_chain", AccessClass::Read),
+        ("export_chain_head", AccessClass::Read),
         // Metrics (1)
         ("database_stats", AccessClass::Metrics),
         // Write (12)
@@ -1161,7 +1163,7 @@ fn live_tool_inventory_matches_golden() {
         .iter()
         .map(|(name, class)| ((*name).to_string(), class.to_string()))
         .collect();
-    assert_eq!(golden.len(), 44, "golden must be 44 unique tool names");
+    assert_eq!(golden.len(), 46, "golden must be 46 unique tool names");
 
     // Live set derived from the advertised registry + classification table.
     let server = AletheiaMcpServer::new(db());
@@ -1179,7 +1181,7 @@ fn live_tool_inventory_matches_golden() {
     assert_eq!(
         live, golden,
         "the LIVE advertised MCP tool inventory drifted from the golden \
-         44-pair set — a tool was added, removed, renamed, or reclassified. \
+         46-pair set — a tool was added, removed, renamed, or reclassified. \
          Update GOLDEN here, tests/parity_mcp.rs::TOOL_INVENTORY, and \
          tests/parity/inventory.json deliberately."
     );

--- a/tests/parity/inventory.json
+++ b/tests/parity/inventory.json
@@ -1,9 +1,9 @@
 {
-  "$comment": "Machine-readable parity inventory for the AletheiaDB HTTP + MCP surfaces. Consumed by the framework-migration/design lane. Pinned against branch feature/parity-harness at the current tip of work (scout commit 8351ff4). Every 'pinned_by' names a test in this repo that asserts the behavior; 'referenced' means the behavior is pinned by a pre-existing in-crate test (not re-implemented in the parity suites, to avoid duplication). TWO KINDS OF MCP PIN: (1) 'behavior-pinned' tools — get_node, create_node, create_edge, traverse — carry black-box RUNTIME assertions in tests/parity_mcp.rs (success/error envelopes, temporal block, vector elision, roundtrip reachability); (2) 'inventory-pinned' tools — the remaining 40 — have only their name + access class pinned via the golden set. Live drift detection of the full 44-tool name/class registry (a tool added/removed/renamed/reclassified) is provided by the in-crate golden test src/mcp/auth_tests.rs::live_tool_inventory_matches_golden; the external tests/parity_mcp.rs::tool_inventory_golden_is_stable is only a cross-crate mirror of that constant and cannot itself read the live registry.",
+  "$comment": "Machine-readable parity inventory for the AletheiaDB HTTP + MCP surfaces. Consumed by the framework-migration/design lane. Pinned against branch feature/parity-harness at the current tip of work (scout commit 8351ff4). Every 'pinned_by' names a test in this repo that asserts the behavior; 'referenced' means the behavior is pinned by a pre-existing in-crate test (not re-implemented in the parity suites, to avoid duplication). TWO KINDS OF MCP PIN: (1) 'behavior-pinned' tools — get_node, create_node, create_edge, traverse — carry black-box RUNTIME assertions in tests/parity_mcp.rs (success/error envelopes, temporal block, vector elision, roundtrip reachability); (2) 'inventory-pinned' tools — the remaining 42 — have only their name + access class pinned via the golden set. Live drift detection of the full 46-tool name/class registry (a tool added/removed/renamed/reclassified) is provided by the in-crate golden test src/mcp/auth_tests.rs::live_tool_inventory_matches_golden; the external tests/parity_mcp.rs::tool_inventory_golden_is_stable is only a cross-crate mirror of that constant and cannot itself read the live registry.",
   "generated_for": "framework port parity harness",
   "totals": {
     "http_routes": 5,
-    "mcp_tools": 44,
+    "mcp_tools": 46,
     "mcp_budgetable_read_tools": 13
   },
   "http": {
@@ -52,7 +52,7 @@
         ],
         "referenced": {
           "429_wall_clock_timeout": "not forceable deterministically over the wire; pinned by enforce_query_limits unit tests in src/http/handlers.rs (see tests/http_query_limits.rs header). RESOURCE_EXHAUSTED + Retry-After:1, retriable:true for reads.",
-          "413_request_body_limit": "tests/parity_http.rs::run_server_enforces_request_body_413 (real-socket production run_server stack, Issue #3426)",
+          "413_request_body_limit": "tests/http_run_server_body_limit.rs::run_server_enforces_413_over_the_wire (real-socket production run_server stack, Issue #3426)",
           "otel_trace_id": "tests/http_otel_tracing.rs (observability/otel features)"
         }
       },
@@ -117,7 +117,7 @@
       "pinned_by": "tests/parity_mcp.rs::vectors_elided_by_default_and_restorable"
     },
     "inventory_golden": "tests/parity_mcp.rs::tool_inventory_golden_is_stable (external mirror — internal-consistency only)",
-    "inventory_live_drift_detector": "src/mcp/auth_tests.rs::live_tool_inventory_matches_golden (in-crate; derives the advertised (name, class) set from the live registry and asserts it equals the golden 44 pairs — the authoritative drift detector)",
+    "inventory_live_drift_detector": "src/mcp/auth_tests.rs::live_tool_inventory_matches_golden (in-crate; derives the advertised (name, class) set from the live registry and asserts it equals the golden 46 pairs — the authoritative drift detector)",
     "budgetable_read_tools": ["get_node", "list_nodes", "get_edge", "list_edges", "get_outgoing_edges", "get_incoming_edges", "traverse", "find_similar", "hybrid_query", "query", "find_nodes_at_time", "get_node_history", "get_schema"],
     "tools": [
       {"name": "get_node", "access_class": "read", "budgetable": true, "pinned_by": ["tests/parity_mcp.rs::not_found_structured_error", "tests/parity_mcp.rs::out_of_range_id_is_non_retriable_structured_error", "tests/parity_mcp.rs::vectors_elided_by_default_and_restorable", "tests/parity_mcp.rs::success_envelope_and_temporal_block"]},
@@ -163,6 +163,8 @@
       {"name": "lineage_upstream", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
       {"name": "lineage_downstream", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
       {"name": "audit_export", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "verify_chain", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
+      {"name": "export_chain_head", "access_class": "read", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]},
       {"name": "database_stats", "access_class": "metrics", "budgetable": false, "pinned_by": ["tests/parity_mcp.rs::tool_inventory_golden_is_stable"]}
     ]
   },
@@ -172,8 +174,8 @@
       "area": "MCP advertised-tool dispatch sweep",
       "status": "partially closed",
       "why": "tool_definitions()/list_tools_for_test()/dispatch_tool are pub(crate); the rmcp ServerHandler list_tools/call_tool entry is not reachable from an external test crate (rmcp is not a dev-dependency and is not re-exported). Per house rules we do not add pub to production code.",
-      "closed_part": "Full 44-name/class DRIFT DETECTION is now closed: the in-crate golden src/mcp/auth_tests.rs::live_tool_inventory_matches_golden reads the live registry and fails on any tool added/removed/renamed/reclassified. The external tests/parity_mcp.rs::tool_inventory_golden_is_stable mirrors that constant cross-crate.",
-      "remaining_gap": "What stays external-unreachable is per-tool RUNTIME BEHAVIOR for the 40 non-behavior-tested tools: only the 4 behavior-pinned tools (get_node, create_node, create_edge, traverse) have black-box runtime assertions in tests/parity_mcp.rs; the other 40 are name/class-pinned only. Their dispatch/error-on-invalid-args behavior remains enforced in-crate.",
+      "closed_part": "Full 46-name/class DRIFT DETECTION is now closed: the in-crate golden src/mcp/auth_tests.rs::live_tool_inventory_matches_golden reads the live registry and fails on any tool added/removed/renamed/reclassified. The external tests/parity_mcp.rs::tool_inventory_golden_is_stable mirrors that constant cross-crate.",
+      "remaining_gap": "What stays external-unreachable is per-tool RUNTIME BEHAVIOR for the 42 non-behavior-tested tools: only the 4 behavior-pinned tools (get_node, create_node, create_edge, traverse) have black-box runtime assertions in tests/parity_mcp.rs; the other 42 are name/class-pinned only. Their dispatch/error-on-invalid-args behavior remains enforced in-crate.",
       "referenced_test": "src/mcp/tests.rs::every_advertised_tool_returns_structured_error_on_invalid_arguments (~line 9257); src/mcp/auth_tests.rs::live_tool_inventory_matches_golden"
     },
     {

--- a/tests/parity_mcp.rs
+++ b/tests/parity_mcp.rs
@@ -33,7 +33,7 @@
 //! (via the public `McpErrorCode` enum — the single source of truth for the
 //! wire codes), the success + structured-error envelope shapes, the temporal
 //! block on read responses, and the vector-elision default. It also pins the
-//! full 44-tool inventory + access-class table as a golden constant that a
+//! full 46-tool inventory + access-class table as a golden constant that a
 //! porter must keep in lockstep with the server.
 //!
 //! Run with:
@@ -348,7 +348,7 @@ fn representative_tool_roundtrip_is_wellformed() {
 }
 
 // ===========================================================================
-// Golden tool inventory — the 44-tool advertised set + access classes.
+// Golden tool inventory — the 46-tool advertised set + access classes.
 //
 // This is the one place the FULL registry is pinned from an external test:
 // because the advertised list (`tool_definitions`) is not reachable through the
@@ -360,7 +360,7 @@ fn representative_tool_roundtrip_is_wellformed() {
 /// (tool_name, access_class) for every advertised MCP tool, per
 /// `src/mcp/auth.rs::TOOL_ACCESS_CLASSES`. Access class ∈ {read, write, metrics}
 /// (MCP advertises no admin-class tools).
-const TOOL_INVENTORY: [(&str, &str); 44] = [
+const TOOL_INVENTORY: [(&str, &str); 46] = [
     ("get_node", "read"),
     ("create_node", "write"),
     ("update_node", "write"),
@@ -404,14 +404,16 @@ const TOOL_INVENTORY: [(&str, &str); 44] = [
     ("lineage_upstream", "read"),
     ("lineage_downstream", "read"),
     ("audit_export", "read"),
+    ("verify_chain", "read"),
+    ("export_chain_head", "read"),
     ("database_stats", "metrics"),
 ];
 
 /// PARITY (external mirror, NOT a live drift detector): this constant is a
-/// cross-crate reference copy of the 44-tool inventory. Because the live
+/// cross-crate reference copy of the 46-tool inventory. Because the live
 /// registry (`list_tools_for_test` / `TOOL_ACCESS_CLASSES`) is `pub(crate)`
 /// and unreachable from this external test crate, this test only validates the
-/// mirror's internal consistency (44 tools, unique names, MCP-legal classes,
+/// mirror's internal consistency (46 tools, unique names, MCP-legal classes,
 /// exactly one metrics tool) — it does NOT read the server, so it cannot by
 /// itself catch a tool added/removed/renamed/reclassified in the registry.
 ///
@@ -422,7 +424,7 @@ const TOOL_INVENTORY: [(&str, &str); 44] = [
 /// `tests/parity/inventory.json` in lockstep when the inventory changes.
 #[test]
 fn tool_inventory_golden_is_stable() {
-    assert_eq!(TOOL_INVENTORY.len(), 44, "MCP advertises exactly 44 tools");
+    assert_eq!(TOOL_INVENTORY.len(), 46, "MCP advertises exactly 46 tools");
 
     // Names unique.
     let mut names: Vec<&str> = TOOL_INVENTORY.iter().map(|(n, _)| *n).collect();


### PR DESCRIPTION
## Summary

Trunk-red hotfix. The in-crate live-registry golden test
`src/mcp/auth_tests.rs::live_tool_inventory_matches_golden` is RED on trunk.

**Root cause — a semantic merge conflict between two PRs that were each green alone:**

- **PR #3527** pinned the exact **44-tool** name/`AccessClass` golden set (the authoritative live-registry-vs-golden drift detector).
- **PR #3513** (provenance hash-chain work, Issue #3351) registered **two NEW MCP tools** — `verify_chain` and `export_chain_head` — in `src/mcp/auth.rs::TOOL_ACCESS_CLASSES`.

Each PR passed CI in isolation. Merged together (same minute), the live registry now advertises 46 tools while the hardcoded golden still expects 44, so the sweep fails. **This is exactly the drift the golden was designed to catch** — the golden did its job; it just needs the deliberate update the two-way merge never got.

## Confirmed AccessClass (from code)

Both new tools are **reader-class** (`AccessClass::Read`), confirmed directly from the registry at `src/mcp/auth.rs:105-106`:

```rust
// Provenance hash chain verification / anchor export — read-only (Issue #3351).
("verify_chain", AccessClass::Read),
("export_chain_head", AccessClass::Read),
```

They read/verify the provenance hash chain and export the current chain head — no mutation — so `Read` is correct.

## Changes (golden/inventory reconciliation only — no behavior or semantics changed)

- **`src/mcp/auth_tests.rs`** — add `verify_chain` and `export_chain_head` (`AccessClass::Read`) to `GOLDEN`; bump the pinned total **44 → 46** and the Read count **31 → 33** (array length, `golden.len()` assertion, doc comments, drift message).
- **`tests/parity_mcp.rs`** — mirror both tools into the external `TOOL_INVENTORY` constant; **44 → 46** (length, assertion, doc comments) to keep the cross-crate mirror in lockstep.
- **`tests/parity/inventory.json`** — add the two `read`/non-budgetable tool rows; `totals.mcp_tools` **44 → 46** and the associated count prose (inventory-pinned **40 → 42**, registry **44 → 46**).
- **Folded-in stale-label fix (`tests/parity/inventory.json`)** — the Issue #3426 413 entry referenced `parity_http.rs::run_server_enforces_request_body_413`, but the real over-the-wire test is `http_run_server_body_limit.rs::run_server_enforces_413_over_the_wire`. Corrected the reference.

The `write_and_metrics_sets_match_hardcoded_snapshot` Read-count check (33) was already consistent with the live registry and needed no change.

## Verification (isolated target dir)

- `live_tool_inventory_matches_golden` → `test result: ok. 1 passed`
- Full `mcp::auth_tests::` module → `test result: ok. 33 passed`
- `parity_mcp` (incl. `tool_inventory_golden_is_stable`) → `test result: ok. 7 passed`
- `parity_http` (`--features http-server`) → `test result: ok. 23 passed`
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01US9RGTLAzSymm8eMtqdt3T

---
_Generated by [Claude Code](https://claude.ai/code/session_01US9RGTLAzSymm8eMtqdt3T)_