### PR TITLE
Issue #383: per-entity temporal vector snapshot policy

### DIFF
--- a/src/db/vector.rs
+++ b/src/db/vector.rs
@@ -240,6 +240,108 @@ impl AletheiaDB {
         self.current.is_temporal_vector_index_enabled()
     }
 
+    /// Set the per-entity temporal vector snapshot policy for a node (Issue #383).
+    ///
+    /// Temporal vector snapshots are captured by a pre-anchor hook that fires
+    /// when an entity's graph anchor is created. Historically this was global —
+    /// every anchor on any entity re-snapshotted the whole vector index, even
+    /// for entities whose embedding never changed. This method gives
+    /// **per-entity control**: marking a node [`SnapshotPolicy::Skip`] keeps its
+    /// graph anchors but suppresses its vector snapshots, while
+    /// [`SnapshotPolicy::Snapshot`] (the default) preserves the prior behavior.
+    ///
+    /// Combine with [`set_default_node_vector_snapshot_policy`](Self::set_default_node_vector_snapshot_policy)
+    /// for an opt-in model (default `Skip`, opt specific nodes back in).
+    ///
+    /// [`SnapshotPolicy`]: crate::storage::historical::SnapshotPolicy
+    /// [`SnapshotPolicy::Skip`]: crate::storage::historical::SnapshotPolicy::Skip
+    /// [`SnapshotPolicy::Snapshot`]: crate::storage::historical::SnapshotPolicy::Snapshot
+    pub fn set_node_vector_snapshot_policy(
+        &self,
+        node_id: NodeId,
+        policy: crate::storage::historical::SnapshotPolicy,
+    ) {
+        self.historical
+            .write()
+            .set_node_snapshot_policy(node_id, policy);
+    }
+
+    /// Set the per-entity temporal vector snapshot policy for an edge (Issue #383).
+    ///
+    /// The edge counterpart of
+    /// [`set_node_vector_snapshot_policy`](Self::set_node_vector_snapshot_policy).
+    pub fn set_edge_vector_snapshot_policy(
+        &self,
+        edge_id: crate::core::id::EdgeId,
+        policy: crate::storage::historical::SnapshotPolicy,
+    ) {
+        self.historical
+            .write()
+            .set_edge_snapshot_policy(edge_id, policy);
+    }
+
+    /// Remove a node's per-entity snapshot policy override, reverting it to the
+    /// current default node policy (Issue #383). Returns the removed override.
+    pub fn clear_node_vector_snapshot_policy(
+        &self,
+        node_id: NodeId,
+    ) -> Option<crate::storage::historical::SnapshotPolicy> {
+        self.historical.write().clear_node_snapshot_policy(node_id)
+    }
+
+    /// Remove an edge's per-entity snapshot policy override, reverting it to the
+    /// current default edge policy (Issue #383). Returns the removed override.
+    pub fn clear_edge_vector_snapshot_policy(
+        &self,
+        edge_id: crate::core::id::EdgeId,
+    ) -> Option<crate::storage::historical::SnapshotPolicy> {
+        self.historical.write().clear_edge_snapshot_policy(edge_id)
+    }
+
+    /// Set the fall-through default node snapshot policy (Issue #383).
+    ///
+    /// Flip to [`SnapshotPolicy::Skip`] for an opt-in model where only nodes
+    /// explicitly set to [`SnapshotPolicy::Snapshot`] are snapshotted.
+    ///
+    /// [`SnapshotPolicy::Skip`]: crate::storage::historical::SnapshotPolicy::Skip
+    /// [`SnapshotPolicy::Snapshot`]: crate::storage::historical::SnapshotPolicy::Snapshot
+    pub fn set_default_node_vector_snapshot_policy(
+        &self,
+        policy: crate::storage::historical::SnapshotPolicy,
+    ) {
+        self.historical
+            .write()
+            .set_default_node_snapshot_policy(policy);
+    }
+
+    /// Set the fall-through default edge snapshot policy (Issue #383).
+    pub fn set_default_edge_vector_snapshot_policy(
+        &self,
+        policy: crate::storage::historical::SnapshotPolicy,
+    ) {
+        self.historical
+            .write()
+            .set_default_edge_snapshot_policy(policy);
+    }
+
+    /// Resolve the effective snapshot policy for a node (override if set, else
+    /// the default node policy) (Issue #383).
+    pub fn node_vector_snapshot_policy(
+        &self,
+        node_id: NodeId,
+    ) -> crate::storage::historical::SnapshotPolicy {
+        self.historical.read().node_snapshot_policy(node_id)
+    }
+
+    /// Resolve the effective snapshot policy for an edge (override if set, else
+    /// the default edge policy) (Issue #383).
+    pub fn edge_vector_snapshot_policy(
+        &self,
+        edge_id: crate::core::id::EdgeId,
+    ) -> crate::storage::historical::SnapshotPolicy {
+        self.historical.read().edge_snapshot_policy(edge_id)
+    }
+
     /// List all property names that have temporal vector indexes enabled.
     ///
     /// Returns a vector of property names that have temporal vector indexing configured.
@@ -1028,5 +1130,89 @@ mod coverage_tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(format!("{}", err).contains("HNSW configuration is required"));
+    }
+
+    // --- Issue #383: per-entity snapshot policy wrappers, end-to-end through AletheiaDB ---
+    //
+    // These exercise the public `AletheiaDB` surface end-to-end (set/get/clear/
+    // default, node + edge) through the historical `RwLock`. The *behavioral*
+    // proof that the policy gates the pre-anchor snapshot hook per entity lives
+    // in `src/storage/historical/tests.rs` (recording-hook tests), where the
+    // anchor-hook trigger is observed directly and in isolation from the
+    // orthogonal transaction-strategy snapshot path.
+
+    use crate::core::id::EdgeId;
+    use crate::storage::historical::SnapshotPolicy;
+
+    /// The default resolved policy is `Snapshot` for both nodes and edges,
+    /// preserving pre-#383 behavior when nothing is configured.
+    #[test]
+    fn test_snapshot_policy_wrappers_default_is_snapshot() {
+        let db = AletheiaDB::new().unwrap();
+        assert_eq!(
+            db.node_vector_snapshot_policy(NodeId::new(1).unwrap()),
+            SnapshotPolicy::Snapshot
+        );
+        assert_eq!(
+            db.edge_vector_snapshot_policy(EdgeId::new(1).unwrap()),
+            SnapshotPolicy::Snapshot
+        );
+    }
+
+    /// Setting, reading back, and clearing a per-node override round-trips
+    /// through the historical `RwLock`.
+    #[test]
+    fn test_snapshot_policy_wrappers_node_set_get_clear() {
+        let db = AletheiaDB::new().unwrap();
+        let node = NodeId::new(7).unwrap();
+
+        db.set_node_vector_snapshot_policy(node, SnapshotPolicy::Skip);
+        assert_eq!(db.node_vector_snapshot_policy(node), SnapshotPolicy::Skip);
+
+        assert_eq!(
+            db.clear_node_vector_snapshot_policy(node),
+            Some(SnapshotPolicy::Skip)
+        );
+        assert_eq!(
+            db.node_vector_snapshot_policy(node),
+            SnapshotPolicy::Snapshot,
+            "cleared override reverts to default"
+        );
+    }
+
+    /// The default-node policy setter creates an opt-in model; edges are a
+    /// separate registry and remain at their own default.
+    #[test]
+    fn test_snapshot_policy_wrappers_default_opt_in_node_edge_independent() {
+        let db = AletheiaDB::new().unwrap();
+
+        db.set_default_node_vector_snapshot_policy(SnapshotPolicy::Skip);
+        // Every unset node now resolves to Skip...
+        assert_eq!(
+            db.node_vector_snapshot_policy(NodeId::new(99).unwrap()),
+            SnapshotPolicy::Skip
+        );
+        // ...but a specific node can be opted back in.
+        db.set_node_vector_snapshot_policy(NodeId::new(1).unwrap(), SnapshotPolicy::Snapshot);
+        assert_eq!(
+            db.node_vector_snapshot_policy(NodeId::new(1).unwrap()),
+            SnapshotPolicy::Snapshot
+        );
+
+        // Edges are an independent registry — unaffected by the node default.
+        assert_eq!(
+            db.edge_vector_snapshot_policy(EdgeId::new(1).unwrap()),
+            SnapshotPolicy::Snapshot
+        );
+        db.set_default_edge_vector_snapshot_policy(SnapshotPolicy::Skip);
+        db.set_edge_vector_snapshot_policy(EdgeId::new(2).unwrap(), SnapshotPolicy::Snapshot);
+        assert_eq!(
+            db.edge_vector_snapshot_policy(EdgeId::new(1).unwrap()),
+            SnapshotPolicy::Skip
+        );
+        assert_eq!(
+            db.edge_vector_snapshot_policy(EdgeId::new(2).unwrap()),
+            SnapshotPolicy::Snapshot
+        );
     }
 }

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -33,9 +33,12 @@ use std::time::Duration;
 use tracing;
 
 mod hooks;
+mod snapshot_policy;
 
 use hooks::{AnchorHookContext, HookMetrics};
 pub use hooks::{HookMetricsSnapshot, PreAnchorHook};
+pub use snapshot_policy::SnapshotPolicy;
+use snapshot_policy::SnapshotPolicyRegistry;
 
 /// Default maximum number of versions per entity (DoS protection)
 pub const DEFAULT_MAX_VERSIONS_PER_ENTITY: usize = 1_000;
@@ -229,6 +232,20 @@ pub struct HistoricalStorage {
     hook_timeout: Option<Duration>,
     /// Observability counters for pre-anchor hook execution (Issue #3525).
     hook_metrics: HookMetrics,
+    /// Per-node temporal vector snapshot policy (Issue #383).
+    ///
+    /// Consulted at node-anchor creation to decide whether that entity's anchor
+    /// should trigger the pre-anchor snapshot hooks. Entities resolving to
+    /// [`SnapshotPolicy::Skip`] form graph anchors normally but do **not** run
+    /// the snapshot hooks, decoupling graph anchors from vector snapshots. The
+    /// default policy is [`SnapshotPolicy::Snapshot`], reproducing the pre-#383
+    /// global behavior when no per-entity policy is configured.
+    node_snapshot_policies: SnapshotPolicyRegistry<NodeId>,
+    /// Per-edge temporal vector snapshot policy (Issue #383).
+    ///
+    /// The edge counterpart of [`node_snapshot_policies`](Self::node_snapshot_policies);
+    /// resolved independently at edge-anchor creation.
+    edge_snapshot_policies: SnapshotPolicyRegistry<EdgeId>,
     /// Optional tiered storage for cold data access.
     ///
     /// When configured, versions not found in hot storage will be looked up
@@ -366,6 +383,8 @@ impl HistoricalStorage {
             pre_edge_anchor_hooks: Vec::new(),
             hook_timeout: None,
             hook_metrics: HookMetrics::default(),
+            node_snapshot_policies: SnapshotPolicyRegistry::default(),
+            edge_snapshot_policies: SnapshotPolicyRegistry::default(),
             tiered_storage: None,
             temporal_indexes: None,
             temporal_adjacency_index: None,
@@ -556,6 +575,86 @@ impl HistoricalStorage {
     /// surface for graceful degradation (Issue #3525).
     pub fn hook_metrics(&self) -> HookMetricsSnapshot {
         self.hook_metrics.snapshot()
+    }
+
+    // --- Per-entity temporal vector snapshot policy (Issue #383) ---------------
+    //
+    // These control, per node/edge, whether that entity's anchor triggers the
+    // pre-anchor snapshot hooks (registered via the #3525 multi-hook API).
+    // Replacing the single global anchor hook, they let production deployments
+    // snapshot only the vectors that actually change instead of re-snapshotting
+    // the whole index on every anchor. The default policy is
+    // [`SnapshotPolicy::Snapshot`], so a database that configures nothing behaves
+    // exactly as before Issue #383.
+
+    /// Set the temporal vector snapshot policy for a specific node (Issue #383).
+    ///
+    /// A [`SnapshotPolicy::Skip`] node still forms graph anchors normally but no
+    /// longer runs the pre-anchor snapshot hooks, so no vector snapshot is
+    /// captured for its anchors. Overrides the default policy for this node
+    /// until [`clear_node_snapshot_policy`](Self::clear_node_snapshot_policy) is
+    /// called.
+    pub fn set_node_snapshot_policy(&mut self, node_id: NodeId, policy: SnapshotPolicy) {
+        self.node_snapshot_policies.set(node_id, policy);
+    }
+
+    /// Set the temporal vector snapshot policy for a specific edge (Issue #383).
+    ///
+    /// The edge counterpart of
+    /// [`set_node_snapshot_policy`](Self::set_node_snapshot_policy).
+    pub fn set_edge_snapshot_policy(&mut self, edge_id: EdgeId, policy: SnapshotPolicy) {
+        self.edge_snapshot_policies.set(edge_id, policy);
+    }
+
+    /// Remove any per-node snapshot policy override, reverting the node to the
+    /// current default node policy (Issue #383). Returns the removed override,
+    /// if any.
+    pub fn clear_node_snapshot_policy(&mut self, node_id: NodeId) -> Option<SnapshotPolicy> {
+        self.node_snapshot_policies.clear(node_id)
+    }
+
+    /// Remove any per-edge snapshot policy override, reverting the edge to the
+    /// current default edge policy (Issue #383). Returns the removed override,
+    /// if any.
+    pub fn clear_edge_snapshot_policy(&mut self, edge_id: EdgeId) -> Option<SnapshotPolicy> {
+        self.edge_snapshot_policies.clear(edge_id)
+    }
+
+    /// Set the fall-through default snapshot policy for **nodes** without an
+    /// explicit override (Issue #383).
+    ///
+    /// Flipping this to [`SnapshotPolicy::Skip`] gives an opt-in model: no node
+    /// is snapshotted unless individually set to [`SnapshotPolicy::Snapshot`].
+    pub fn set_default_node_snapshot_policy(&mut self, policy: SnapshotPolicy) {
+        self.node_snapshot_policies.set_default(policy);
+    }
+
+    /// Set the fall-through default snapshot policy for **edges** without an
+    /// explicit override (Issue #383).
+    pub fn set_default_edge_snapshot_policy(&mut self, policy: SnapshotPolicy) {
+        self.edge_snapshot_policies.set_default(policy);
+    }
+
+    /// Return the current default node snapshot policy (Issue #383).
+    pub fn default_node_snapshot_policy(&self) -> SnapshotPolicy {
+        self.node_snapshot_policies.default_policy()
+    }
+
+    /// Return the current default edge snapshot policy (Issue #383).
+    pub fn default_edge_snapshot_policy(&self) -> SnapshotPolicy {
+        self.edge_snapshot_policies.default_policy()
+    }
+
+    /// Resolve the effective snapshot policy for a node: its explicit override
+    /// if set, otherwise the default node policy (Issue #383).
+    pub fn node_snapshot_policy(&self, node_id: NodeId) -> SnapshotPolicy {
+        self.node_snapshot_policies.resolve(node_id)
+    }
+
+    /// Resolve the effective snapshot policy for an edge: its explicit override
+    /// if set, otherwise the default edge policy (Issue #383).
+    pub fn edge_snapshot_policy(&self, edge_id: EdgeId) -> SnapshotPolicy {
+        self.edge_snapshot_policies.resolve(edge_id)
     }
 
     /// Add a new version of a node.
@@ -755,8 +854,20 @@ impl HistoricalStorage {
         };
         version.provenance = provenance;
 
-        // Handle pre-anchor hooks (BEFORE storing)
-        if version.is_anchor() {
+        // Handle pre-anchor hooks (BEFORE storing).
+        //
+        // Issue #383: the per-entity snapshot policy gates whether this anchor
+        // triggers the (potentially whole-index) snapshot hooks. A `Skip` entity
+        // still forms the anchor above but runs no snapshot hooks, so no vector
+        // snapshot is captured for it — decoupling graph anchors from vector
+        // snapshots. The default policy is `Snapshot`, so absent any per-entity
+        // configuration this is identical to the pre-#383 behavior.
+        if version.is_anchor()
+            && self
+                .node_snapshot_policies
+                .resolve(node_id)
+                .should_snapshot()
+        {
             self.run_pre_anchor_hooks_into(
                 &self.pre_node_anchor_hooks,
                 AnchorHookContext {
@@ -1081,8 +1192,17 @@ impl HistoricalStorage {
         };
         version.provenance = provenance;
 
-        // Handle pre-anchor hooks (BEFORE storing)
-        if version.is_anchor() {
+        // Handle pre-anchor hooks (BEFORE storing).
+        //
+        // Issue #383: gated by the per-edge snapshot policy, symmetric with the
+        // node path above. See `snapshot_policy` for the rationale and the
+        // backward-compatible default (`Snapshot`).
+        if version.is_anchor()
+            && self
+                .edge_snapshot_policies
+                .resolve(edge_id)
+                .should_snapshot()
+        {
             self.run_pre_anchor_hooks_into(
                 &self.pre_edge_anchor_hooks,
                 AnchorHookContext {

--- a/src/storage/historical/snapshot_policy.rs
+++ b/src/storage/historical/snapshot_policy.rs
@@ -1,0 +1,188 @@
+//! Per-entity temporal vector snapshot policy (Issue #383).
+//!
+//! The pre-anchor hook machinery (Issue #3525) fires a hook **before** every
+//! anchor is stored so an external index (e.g. a temporal vector index) can
+//! create a synchronized snapshot. Historically that hook was *global*: every
+//! anchor on **any** entity triggered a whole-index vector snapshot, even for
+//! entities whose embedding never changed. At production scale this is far too
+//! coarse — updating a single node re-snapshots every indexed vector.
+//!
+//! This module adds **per-entity control** over whether an entity's anchor
+//! triggers the pre-anchor snapshot hooks. A [`SnapshotPolicyRegistry`] maps
+//! individual entities (nodes or edges) to a [`SnapshotPolicy`], falling back to
+//! a configurable default. The historical write path consults the resolved
+//! policy at anchor time and **skips** the snapshot hooks entirely for entities
+//! whose policy is [`SnapshotPolicy::Skip`], decoupling graph anchors from
+//! vector snapshots.
+//!
+//! ## Backward compatibility
+//!
+//! The default policy is [`SnapshotPolicy::Snapshot`], so a database that never
+//! configures a per-entity policy behaves **exactly** as before Issue #383:
+//! every anchor runs the registered pre-anchor hooks. Callers opt into
+//! fine-grained control by setting per-entity overrides (mark stable entities
+//! `Skip`) or by flipping the default to `Skip` and opting specific entities
+//! back in with `Snapshot`.
+//!
+//! ## Locking
+//!
+//! The registry is a plain in-struct map. It is consulted while the caller
+//! already holds the `historical` write lock — the same critical section that
+//! runs the hooks — so it acquires **no new** synchronization primitive, never
+//! calls back into `wal` / `current_timestamp` / the adjacency indexes, and can
+//! only ever *reduce* the work done under the lock (a `Skip` decision avoids the
+//! hook run altogether). The lock-order contract in `CLAUDE.md` and the #3525
+//! bounded-hook-execution guarantees are therefore fully preserved.
+
+use crate::core::version::FastHashMap;
+use std::hash::Hash;
+
+/// Per-entity decision for whether an anchor triggers the temporal vector
+/// snapshot (pre-anchor) hooks (Issue #383).
+///
+/// This gates the **trigger**, not the graph anchor itself: a `Skip` entity
+/// still forms graph anchors normally; only its vector-snapshot hook run is
+/// suppressed, so no vector snapshot is captured for that anchor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum SnapshotPolicy {
+    /// Run the registered pre-anchor snapshot hooks when this entity anchors.
+    ///
+    /// This is the default and reproduces the pre-#383 global behavior.
+    #[default]
+    Snapshot,
+    /// Do **not** run the pre-anchor snapshot hooks when this entity anchors —
+    /// no vector snapshot is captured for the entity's anchors.
+    Skip,
+}
+
+impl SnapshotPolicy {
+    /// Returns `true` if this policy means the pre-anchor snapshot hooks should
+    /// run for the entity's anchor.
+    #[inline]
+    pub fn should_snapshot(self) -> bool {
+        matches!(self, SnapshotPolicy::Snapshot)
+    }
+}
+
+/// A registry mapping individual entities of one kind (nodes **or** edges) to a
+/// [`SnapshotPolicy`], with a configurable fall-through default.
+///
+/// Resolution is: per-entity override if present, otherwise the registry
+/// default. The default default (sic) is [`SnapshotPolicy::Snapshot`] for
+/// backward compatibility (Issue #383).
+///
+/// Keyed by an entity id (`NodeId` / `EdgeId`), which are cheap `Copy` newtypes
+/// over `u64`; the [`FastHashMap`] identity hasher makes lookups near-free on
+/// the write path.
+#[derive(Debug, Clone)]
+pub(crate) struct SnapshotPolicyRegistry<K: Eq + Hash + Copy> {
+    /// Per-entity policy overrides. Absent key ⇒ use `default_policy`.
+    overrides: FastHashMap<K, SnapshotPolicy>,
+    /// Policy applied to any entity without an explicit override.
+    default_policy: SnapshotPolicy,
+}
+
+impl<K: Eq + Hash + Copy> Default for SnapshotPolicyRegistry<K> {
+    fn default() -> Self {
+        Self {
+            overrides: FastHashMap::default(),
+            default_policy: SnapshotPolicy::default(),
+        }
+    }
+}
+
+impl<K: Eq + Hash + Copy> SnapshotPolicyRegistry<K> {
+    /// Resolve the effective policy for `key`: the per-entity override if one is
+    /// set, otherwise the registry default.
+    #[inline]
+    pub(crate) fn resolve(&self, key: K) -> SnapshotPolicy {
+        self.overrides
+            .get(&key)
+            .copied()
+            .unwrap_or(self.default_policy)
+    }
+
+    /// Set an explicit per-entity policy override for `key`.
+    pub(crate) fn set(&mut self, key: K, policy: SnapshotPolicy) {
+        self.overrides.insert(key, policy);
+    }
+
+    /// Remove any explicit override for `key`, reverting it to the default.
+    ///
+    /// Returns the override that was removed, if any.
+    pub(crate) fn clear(&mut self, key: K) -> Option<SnapshotPolicy> {
+        self.overrides.remove(&key)
+    }
+
+    /// Set the fall-through default policy applied to entities without an
+    /// explicit override.
+    pub(crate) fn set_default(&mut self, policy: SnapshotPolicy) {
+        self.default_policy = policy;
+    }
+
+    /// Return the current fall-through default policy.
+    #[inline]
+    pub(crate) fn default_policy(&self) -> SnapshotPolicy {
+        self.default_policy
+    }
+
+    /// Number of explicit per-entity overrides currently registered.
+    ///
+    /// Primarily for observability/testing.
+    #[cfg(test)]
+    pub(crate) fn override_count(&self) -> usize {
+        self.overrides.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::id::NodeId;
+
+    fn nid(v: u64) -> NodeId {
+        NodeId::new(v).unwrap()
+    }
+
+    #[test]
+    fn default_policy_is_snapshot_backward_compat() {
+        let reg: SnapshotPolicyRegistry<NodeId> = SnapshotPolicyRegistry::default();
+        // No overrides, default default => Snapshot for every entity.
+        assert_eq!(reg.resolve(nid(1)), SnapshotPolicy::Snapshot);
+        assert!(reg.resolve(nid(999)).should_snapshot());
+        assert_eq!(reg.override_count(), 0);
+    }
+
+    #[test]
+    fn override_beats_default() {
+        let mut reg: SnapshotPolicyRegistry<NodeId> = SnapshotPolicyRegistry::default();
+        reg.set(nid(1), SnapshotPolicy::Skip);
+        assert_eq!(reg.resolve(nid(1)), SnapshotPolicy::Skip);
+        assert!(!reg.resolve(nid(1)).should_snapshot());
+        // Other entities still follow the default.
+        assert_eq!(reg.resolve(nid(2)), SnapshotPolicy::Snapshot);
+        assert_eq!(reg.override_count(), 1);
+    }
+
+    #[test]
+    fn set_default_flips_fallthrough_but_not_overrides() {
+        let mut reg: SnapshotPolicyRegistry<NodeId> = SnapshotPolicyRegistry::default();
+        reg.set(nid(1), SnapshotPolicy::Snapshot); // explicit opt-in
+        reg.set_default(SnapshotPolicy::Skip);
+        assert_eq!(reg.default_policy(), SnapshotPolicy::Skip);
+        // Opted-in entity keeps Snapshot; everything else follows the new default.
+        assert_eq!(reg.resolve(nid(1)), SnapshotPolicy::Snapshot);
+        assert_eq!(reg.resolve(nid(2)), SnapshotPolicy::Skip);
+    }
+
+    #[test]
+    fn clear_reverts_to_default() {
+        let mut reg: SnapshotPolicyRegistry<NodeId> = SnapshotPolicyRegistry::default();
+        reg.set(nid(1), SnapshotPolicy::Skip);
+        assert_eq!(reg.clear(nid(1)), Some(SnapshotPolicy::Skip));
+        assert_eq!(reg.resolve(nid(1)), SnapshotPolicy::Snapshot);
+        // Clearing an absent key is a no-op.
+        assert_eq!(reg.clear(nid(1)), None);
+        assert_eq!(reg.override_count(), 0);
+    }
+}

--- a/src/storage/historical/tests.rs
+++ b/src/storage/historical/tests.rs
@@ -6013,3 +6013,286 @@ fn test_rebuild_edge_version_chains_preserves_restored_links_across_cold_gap() {
     assert_eq!(v3.next_version, None);
     assert_eq!(storage.get_current_edge_version(edge_id), Some(v3_id));
 }
+
+// ============================================================================
+// Issue #383: Per-entity temporal vector snapshot policy
+//
+// These tests exercise the per-entity snapshot-policy gate that decides, per
+// node/edge, whether that entity's anchor triggers the pre-anchor snapshot
+// hooks (the #3525 multi-hook API). They use a *recording* hook that captures
+// the `entity_id` it is invoked with, so we can assert that the temporal vector
+// index is triggered for **exactly** the entities whose policy opted in.
+// ============================================================================
+
+/// A pre-anchor hook that records every `entity_id` it is invoked for and
+/// returns a fixed snapshot id, so tests can observe which entities' anchors
+/// actually triggered the snapshot hooks.
+fn recording_hook(sink: &Arc<std::sync::Mutex<Vec<u64>>>, snapshot_id: usize) -> PreAnchorHook {
+    let sink = Arc::clone(sink);
+    Arc::new(move |_entity_type, entity_id, _timestamp, _properties| {
+        sink.lock().unwrap().push(entity_id);
+        Ok(Some(snapshot_id))
+    })
+}
+
+/// Create a first (anchor) edge version for `id` and return its stored vector
+/// snapshot id (mirrors `add_first_node_anchor`).
+fn add_first_edge_anchor(storage: &mut HistoricalStorage, id: u64) -> Option<usize> {
+    let edge_id = EdgeId::new(id).unwrap();
+    let label = GLOBAL_INTERNER.intern("LINKS").unwrap();
+    let vid = VersionId::new(10_000 + id).unwrap();
+    storage
+        .add_edge_version(
+            edge_id,
+            vid,
+            1000.into(),
+            1000.into(),
+            label,
+            NodeId::new(1).unwrap(),
+            NodeId::new(2).unwrap(),
+            PropertyMapBuilder::new().build(),
+            false,
+        )
+        .unwrap();
+    let version = storage.get_edge_version(vid).unwrap();
+    assert!(version.is_anchor());
+    version.data.get_vector_snapshot_id()
+}
+
+/// Backward compatibility: with no policy configured the default is `Snapshot`,
+/// so every anchor triggers the hook exactly as before Issue #383.
+#[test]
+fn test_snapshot_policy_default_is_backward_compat() {
+    let mut storage = HistoricalStorage::new();
+    let seen = Arc::new(std::sync::Mutex::new(Vec::<u64>::new()));
+    storage.add_pre_node_anchor_hook(recording_hook(&seen, 7));
+
+    // Default resolves to Snapshot for any entity.
+    assert_eq!(
+        storage.node_snapshot_policy(NodeId::new(1).unwrap()),
+        SnapshotPolicy::Snapshot
+    );
+    assert_eq!(
+        storage.default_node_snapshot_policy(),
+        SnapshotPolicy::Snapshot
+    );
+
+    let s1 = add_first_node_anchor(&mut storage, 1);
+    let s2 = add_first_node_anchor(&mut storage, 2);
+
+    assert_eq!(s1, Some(7));
+    assert_eq!(s2, Some(7));
+    assert_eq!(
+        *seen.lock().unwrap(),
+        vec![1, 2],
+        "both anchors triggered the hook"
+    );
+    assert_eq!(storage.hook_metrics().invocations, 2);
+}
+
+/// A node marked `Skip` still forms its graph anchor, but the snapshot hooks are
+/// not run for it: no snapshot id is stored and no invocation is counted.
+#[test]
+fn test_snapshot_policy_skip_node_suppresses_hook() {
+    let mut storage = HistoricalStorage::new();
+    let seen = Arc::new(std::sync::Mutex::new(Vec::<u64>::new()));
+    storage.add_pre_node_anchor_hook(recording_hook(&seen, 42));
+
+    storage.set_node_snapshot_policy(NodeId::new(1).unwrap(), SnapshotPolicy::Skip);
+    assert_eq!(
+        storage.node_snapshot_policy(NodeId::new(1).unwrap()),
+        SnapshotPolicy::Skip
+    );
+
+    let snapshot = add_first_node_anchor(&mut storage, 1);
+
+    // Graph anchor was still created (asserted inside the helper), but with no
+    // vector snapshot and no hook invocation.
+    assert_eq!(
+        snapshot, None,
+        "Skip entity must not capture a vector snapshot"
+    );
+    assert!(
+        seen.lock().unwrap().is_empty(),
+        "Skip entity must not invoke the hook"
+    );
+    assert_eq!(storage.hook_metrics().invocations, 0);
+}
+
+/// Two entities with different policies are snapshotted independently: the
+/// temporal index is triggered for exactly the opted-in entity.
+#[test]
+fn test_snapshot_policy_two_nodes_independent() {
+    let mut storage = HistoricalStorage::new();
+    let seen = Arc::new(std::sync::Mutex::new(Vec::<u64>::new()));
+    storage.add_pre_node_anchor_hook(recording_hook(&seen, 5));
+
+    storage.set_node_snapshot_policy(NodeId::new(1).unwrap(), SnapshotPolicy::Skip);
+    // Node 2 keeps the default (Snapshot).
+
+    let s1 = add_first_node_anchor(&mut storage, 1);
+    let s2 = add_first_node_anchor(&mut storage, 2);
+
+    assert_eq!(s1, None);
+    assert_eq!(s2, Some(5));
+    assert_eq!(
+        *seen.lock().unwrap(),
+        vec![2],
+        "exactly the opted-in node triggered a snapshot"
+    );
+    assert_eq!(storage.hook_metrics().invocations, 1);
+}
+
+/// Flipping the default to `Skip` gives an opt-in model: only nodes explicitly
+/// set to `Snapshot` trigger the hook.
+#[test]
+fn test_snapshot_policy_default_skip_opt_in() {
+    let mut storage = HistoricalStorage::new();
+    let seen = Arc::new(std::sync::Mutex::new(Vec::<u64>::new()));
+    storage.add_pre_node_anchor_hook(recording_hook(&seen, 3));
+
+    storage.set_default_node_snapshot_policy(SnapshotPolicy::Skip);
+    assert_eq!(storage.default_node_snapshot_policy(), SnapshotPolicy::Skip);
+    storage.set_node_snapshot_policy(NodeId::new(5).unwrap(), SnapshotPolicy::Snapshot);
+
+    let s5 = add_first_node_anchor(&mut storage, 5);
+    let s6 = add_first_node_anchor(&mut storage, 6);
+
+    assert_eq!(s5, Some(3), "opted-in node snapshotted");
+    assert_eq!(s6, None, "default-Skip node not snapshotted");
+    assert_eq!(*seen.lock().unwrap(), vec![5]);
+    assert_eq!(storage.hook_metrics().invocations, 1);
+}
+
+/// The gate wraps the whole ordered multi-hook run: a `Snapshot` entity runs all
+/// hooks in registration order (last `Ok(Some)` wins), while a `Skip` entity
+/// runs none of them.
+#[test]
+fn test_snapshot_policy_multi_hook_ordering_preserved_and_gated() {
+    use std::sync::Mutex;
+
+    let mut storage = HistoricalStorage::new();
+    let order = Arc::new(Mutex::new(Vec::<(u64, usize)>::new()));
+
+    for i in 0..2usize {
+        let order_clone = Arc::clone(&order);
+        let hook: PreAnchorHook =
+            Arc::new(move |_entity_type, entity_id, _timestamp, _properties| {
+                order_clone.lock().unwrap().push((entity_id, i));
+                Ok(Some(100 + i))
+            });
+        storage.add_pre_node_anchor_hook(hook);
+    }
+
+    storage.set_node_snapshot_policy(NodeId::new(2).unwrap(), SnapshotPolicy::Skip);
+
+    let s1 = add_first_node_anchor(&mut storage, 1); // Snapshot (default)
+    let s2 = add_first_node_anchor(&mut storage, 2); // Skip
+
+    assert_eq!(s1, Some(101), "last hook wins for the Snapshot node");
+    assert_eq!(s2, None, "Skip node runs no hooks");
+    assert_eq!(
+        *order.lock().unwrap(),
+        vec![(1, 0), (1, 1)],
+        "both hooks ran in order for node 1 only; node 2 ran none",
+    );
+    // Two invocations total (node 1's two hooks); node 2 contributed none.
+    assert_eq!(storage.hook_metrics().invocations, 2);
+}
+
+/// Node and edge policies are independent registries: making nodes default-Skip
+/// does not affect edge snapshotting, and vice versa.
+#[test]
+fn test_snapshot_policy_node_and_edge_independent() {
+    let mut storage = HistoricalStorage::new();
+    let node_seen = Arc::new(std::sync::Mutex::new(Vec::<u64>::new()));
+    let edge_seen = Arc::new(std::sync::Mutex::new(Vec::<u64>::new()));
+    storage.add_pre_node_anchor_hook(recording_hook(&node_seen, 1));
+    storage.add_pre_edge_anchor_hook(recording_hook(&edge_seen, 2));
+
+    // Nodes default to Skip; edges keep the Snapshot default.
+    storage.set_default_node_snapshot_policy(SnapshotPolicy::Skip);
+
+    let ns = add_first_node_anchor(&mut storage, 1);
+    let es = add_first_edge_anchor(&mut storage, 1);
+
+    assert_eq!(ns, None, "node default Skip suppresses node snapshot");
+    assert_eq!(
+        es,
+        Some(2),
+        "edge default (Snapshot) is unaffected by node policy"
+    );
+    assert!(node_seen.lock().unwrap().is_empty());
+    assert_eq!(*edge_seen.lock().unwrap(), vec![1]);
+}
+
+/// An edge marked `Skip` suppresses the edge snapshot hook, symmetric with nodes.
+#[test]
+fn test_snapshot_policy_edge_skip_suppresses() {
+    let mut storage = HistoricalStorage::new();
+    let edge_seen = Arc::new(std::sync::Mutex::new(Vec::<u64>::new()));
+    storage.add_pre_edge_anchor_hook(recording_hook(&edge_seen, 9));
+
+    storage.set_edge_snapshot_policy(EdgeId::new(1).unwrap(), SnapshotPolicy::Skip);
+    assert_eq!(
+        storage.edge_snapshot_policy(EdgeId::new(1).unwrap()),
+        SnapshotPolicy::Skip
+    );
+
+    let es = add_first_edge_anchor(&mut storage, 1);
+
+    assert_eq!(es, None);
+    assert!(edge_seen.lock().unwrap().is_empty());
+    assert_eq!(storage.hook_metrics().invocations, 0);
+}
+
+/// `clear_node_snapshot_policy` reverts a node to the current default; the
+/// resolved getter reflects overrides and their removal.
+#[test]
+fn test_snapshot_policy_clear_reverts_to_default() {
+    let mut storage = HistoricalStorage::new();
+    let node = NodeId::new(1).unwrap();
+
+    storage.set_node_snapshot_policy(node, SnapshotPolicy::Skip);
+    assert_eq!(storage.node_snapshot_policy(node), SnapshotPolicy::Skip);
+
+    assert_eq!(
+        storage.clear_node_snapshot_policy(node),
+        Some(SnapshotPolicy::Skip)
+    );
+    assert_eq!(
+        storage.node_snapshot_policy(node),
+        SnapshotPolicy::Snapshot,
+        "cleared node reverts to the default policy",
+    );
+    // Clearing again is a no-op.
+    assert_eq!(storage.clear_node_snapshot_policy(node), None);
+}
+
+/// Lock-order / no-deadlock smoke test: a sequence of many anchors with mixed
+/// per-entity policies (and a configured hook timeout) completes normally,
+/// exercising the gate on the write path under the historical lock.
+#[test]
+fn test_snapshot_policy_mixed_sequence_completes() {
+    let mut storage = HistoricalStorage::new();
+    let seen = Arc::new(std::sync::Mutex::new(Vec::<u64>::new()));
+    storage.add_pre_node_anchor_hook(recording_hook(&seen, 1));
+    // A generous timeout exercises the detached-thread hook path under the gate.
+    storage.set_pre_anchor_hook_timeout(Some(std::time::Duration::from_secs(5)));
+
+    // Even ids Skip, odd ids Snapshot.
+    for id in 1..=20u64 {
+        if id % 2 == 0 {
+            storage.set_node_snapshot_policy(NodeId::new(id).unwrap(), SnapshotPolicy::Skip);
+        }
+    }
+    for id in 1..=20u64 {
+        add_first_node_anchor(&mut storage, id);
+    }
+
+    let seen = seen.lock().unwrap();
+    // Exactly the 10 odd ids triggered the snapshot hook.
+    let expected: Vec<u64> = (1..=20u64).filter(|id| id % 2 == 1).collect();
+    assert_eq!(*seen, expected);
+    assert_eq!(storage.hook_metrics().invocations, 10);
+}


### PR DESCRIPTION
## Before / After (plain language)

**Before.** Temporal vector snapshots were driven by a single **global anchor hook**. When
temporal vector indexing is enabled, `enable_temporal_vector_index` registers one pre-anchor
hook that calls `create_snapshot_for_anchor` — so **every** anchor on **any** entity
re-snapshots the whole vector index, even for entities whose embedding never changed. At
production scale, updating one node re-snapshots every indexed vector (the issue's "updating a
single book node triggers vector snapshots for ALL characters/authors/books").

**After.** The historical storage layer now decides, **per node / per edge**, whether that
entity's anchor triggers the pre-anchor snapshot hooks. A `Skip` entity still forms its graph
anchor normally but runs **no** snapshot hooks — decoupling graph anchors from vector
snapshots. The default policy is `Snapshot`, so a database that configures nothing behaves
**exactly** as before this change.

## How

Built on the merged #3525 multi-hook API (`pre_node_anchor_hooks` / `pre_edge_anchor_hooks`,
`run_pre_anchor_hooks_into`, hook timeout + metrics).

- **New submodule `src/storage/historical/snapshot_policy.rs`**
  - `pub enum SnapshotPolicy { Snapshot, Skip }` with `should_snapshot()`.
  - `pub(crate) struct SnapshotPolicyRegistry<K>` = per-entity overrides map + configurable
    default (`Snapshot`). Resolution = override if present, else default.
- **`HistoricalStorage`** gains independent `node_snapshot_policies` / `edge_snapshot_policies`
  registries. At the two anchor call sites the existing hook run is wrapped in a gate:
  `if version.is_anchor() && self.<kind>_snapshot_policies.resolve(id).should_snapshot()`.
  Deltas already skip hooks and are untouched. Public API (additive):
  `set_/clear_/set_default_/default_/<kind>_snapshot_policy` for nodes and edges.
- **`AletheiaDB` wrappers** (`src/db/vector.rs`) expose the control end-to-end:
  `set_node_vector_snapshot_policy`, edge + default variants, and resolved getters.

Prior global-snapshot callers are unchanged: default registries resolve to `Snapshot`.

### Scope note — two snapshot paths
The temporal vector index has two independent snapshot triggers: (1) the **pre-anchor hook**
(the "global anchor-hook" this issue names) — gated here per entity; and (2) a
**transaction-strategy** path via `VectorIndexObserver` / `on_transaction`, which lives in
`src/index/vector/temporal/**` / current storage (issue Option 3's territory, a separate lane).
This change targets (1), the mechanism the issue calls out. Gating (2) is a documented
follow-up. Because db-level `snapshot_count` conflates (1)+(2), the behavioral proof of the gate
is done at the historical layer with a recording hook that observes the anchor-hook trigger in
isolation; the AletheiaDB tests assert the wrapper wiring.

## LOCKING ANALYSIS

Lock order (CLAUDE.md): `current_timestamp → wal → historical → temporal_indexes → id gens →
outgoing → incoming`.

The per-entity policy is a plain in-struct map consulted **while the `historical` write lock is
already held** — the same critical section that runs the pre-anchor hooks (in
`add_node_version_with_provenance` / edge equivalent). The gate:

- acquires **no new** synchronization primitive (just a `HashMap` read with the identity hasher);
- **never calls back** into `wal`, `current_timestamp`, or the adjacency indexes;
- is **infallible and panic-free** (`resolve` returns an enum by value), so it introduces no new
  poisoning or unwind risk;
- can only ever **reduce** the work done under the lock — a `Skip` decision skips the entire hook
  run, so it strictly **shortens** lock-hold versus today (which always ran the hooks).

Therefore the lock-order contract and the #3525 bounded-hook-execution guarantees are fully
preserved; no deadlock or inversion is introduced. The gate was also exercised by a mixed-policy
sequence under a configured hook timeout (detached-thread path) with no hang.

## AC evidence table (Issue #383)

The issue proposes 4 options for "per-entity temporal vector snapshot control, replacing global
anchor-hook snapshots." This lane (owner of `src/storage/historical/mod.rs`) delivers the
per-entity control at the layer that owns the global anchor-hook mechanism.

| Acceptance criterion (from #383) | Code | Test(s) — all passing |
|---|---|---|
| Per-entity control replacing the one global anchor-hook (decide per node/edge whether its embedding is snapshotted) | `snapshot_policy.rs` gate at anchor sites in `mod.rs` | `test_snapshot_policy_skip_node_suppresses_hook`, `test_snapshot_policy_edge_skip_suppresses` |
| Only snapshot entities that opt in — no wasted snapshots for unchanged entities | policy gate + `SnapshotPolicy::Skip` | `test_snapshot_policy_two_nodes_independent`, `test_snapshot_policy_default_skip_opt_in`, `test_snapshot_policy_mixed_sequence_completes` |
| Fine-grained per-entity control (independent policies) | `SnapshotPolicyRegistry` per node/edge | `test_snapshot_policy_two_nodes_independent`, `test_snapshot_policy_node_and_edge_independent` |
| Decouple vector snapshots from graph anchors | anchor still formed under `Skip`; only hook run gated | `test_snapshot_policy_skip_node_suppresses_hook` (asserts anchor formed, snapshot suppressed) |
| Backward-compatible default (existing global-snapshot behavior when unconfigured) | default policy `Snapshot` | `test_snapshot_policy_default_is_backward_compat`, `test_snapshot_policy_wrappers_default_is_snapshot`, registry `default_policy_is_snapshot_backward_compat` |
| Integrates with #3525 multi-hook ordering | gate wraps the whole ordered hook run | `test_snapshot_policy_multi_hook_ordering_preserved_and_gated` |
| Lock-order safe / no deadlock | see LOCKING ANALYSIS | `test_snapshot_policy_mixed_sequence_completes` (mixed policies + hook timeout) |
| Public API reachable end-to-end | `AletheiaDB` wrappers | `test_snapshot_policy_wrappers_node_set_get_clear`, `test_snapshot_policy_wrappers_default_opt_in_node_edge_independent` |
| Override/clear/resolve semantics | registry `set`/`clear`/`resolve` | `test_snapshot_policy_clear_reverts_to_default`, registry `override_beats_default` / `set_default_flips_fallthrough_but_not_overrides` / `clear_reverts_to_default` |

**RED verification:** temporarily removing the two `&& …should_snapshot()` gate clauses causes
the 7 gating tests to fail for the right reason (Skip entities still invoke the hook / capture a
snapshot id), while the pure-registry and backward-compat tests still pass — confirming the tests
pin the new behavior.

## Gates
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all` — applied
- `cargo test --all-features` — completed exit 0; the 16 new tests pass (`cargo test --lib snapshot_policy`: 16 passed, 0 failed)

## Follow-ups (out of scope)
- Gate the orthogonal transaction-strategy snapshot path (issue Option 3).
- Optional predicate / property-driven policy and per-property policy.
- Snapshot batching (issue Option 4).

Closes #383

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEiTkeBP9LYFteGKaE5GMH)_