### PR TITLE
bench(#3383): provenance write-throughput "cost of trust" suite + self-gate

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -84,7 +84,7 @@ jobs:
           # CI runs (push/PR): performance_targets only for fast feedback on key metrics
           if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "Running ALL benchmarks (weekly/manual run)..."
-            BENCH_TARGETS="--bench checkpoints --bench current_state --bench durability_modes --bench aletheiadb --bench hnsw_index --bench performance_targets --bench temporal_query --bench temporal_vector --bench transactions --bench vector_similarity"
+            BENCH_TARGETS="--bench checkpoints --bench current_state --bench durability_modes --bench aletheiadb --bench hnsw_index --bench performance_targets --bench temporal_query --bench temporal_vector --bench transactions --bench vector_similarity --bench provenance_write_throughput"
           else
             echo "Running PERFORMANCE TARGETS benchmark only (CI run)..."
             # Performance targets: lightweight benchmark verifying key performance metrics
@@ -112,6 +112,51 @@ jobs:
             echo "Benchmarks may have failed to run properly. Check output.txt for details."
             exit 1
           fi
+
+      # ----------------------------------------------------------------------
+      # Provenance write-throughput "cost of trust" gate (Issue #3383)
+      #
+      # Two lanes, per the CI-policy fence:
+      #   * SCHEDULED / manual: run the self-gate (PROV_BENCH_GATE=1). Hard-fail
+      #     is intentional here -- it ALERTS on a same-run ratio regression and
+      #     does NOT block any pull request (this job never gates a PR merge).
+      #   * PULL REQUEST: reduced-scale smoke, INFORMATIONAL only. continue-on-
+      #     error guarantees it can never fail the PR. Flipping this to blocking
+      #     is a one-line change (drop continue-on-error) once a week or two of
+      #     scheduled-lane signal proves the gate stable on the runner -- and
+      #     that flip is an operator decision, not part of Issue #3383.
+      # ----------------------------------------------------------------------
+      - name: Provenance write self-gate (scheduled, hard-fail alert)
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        env:
+          PROV_BENCH_GATE: '1'
+          PROV_BENCH_JSON_OUT: provenance_write_throughput.json
+        run: |
+          set -o pipefail
+          cargo bench --features "config-toml,observability,semantic-search,embeddings" \
+            --bench provenance_write_throughput | tee prov-write-gate.txt
+
+      - name: Provenance write smoke (PR, informational / non-blocking)
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          PROV_BENCH_WRITES: '120'
+          BENCH_SAMPLE_SIZE: 10
+          BENCH_MEASUREMENT_TIME: 1
+          BENCH_WARMUP_TIME: 1
+          PROV_BENCH_JSON_OUT: provenance_write_throughput.json
+        run: |
+          # No PROV_BENCH_GATE: report the matrix + JSON artifact, never fail the PR.
+          cargo bench --features "config-toml,observability,semantic-search,embeddings" \
+            --bench provenance_write_throughput | tee prov-write-smoke.txt
+
+      - name: Upload provenance write-throughput JSON artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: provenance-write-throughput-results
+          path: provenance_write_throughput.json
 
       - name: Generate benchmark JSON
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -129,6 +129,17 @@ jobs:
       - name: Provenance write self-gate (scheduled, hard-fail alert)
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         env:
+          # Gate the CPU-bound (Async 1ms-flush, interleaved) arm ratio bounds
+          # AND the AC5 recovery <5s budget at the reduced default scale (2000
+          # nodes / 4000 edges). Hard-fail here is an ALERT; it never blocks a PR.
+          #
+          # NOTE: the recovery dataset is populated by a single-writer GroupCommit
+          # loop (~10 ms/commit), so the 10K-node/50K-edge REFERENCE scale would
+          # take ~10 min to build -- too slow for this shared CI job. The
+          # reference scale is reproduced manually / on the performance rig via
+          # PROV_BENCH_RECOVERY_NODES=10000 PROV_BENCH_RECOVERY_EDGES=50000 (the
+          # reopen, not the build, is what the <5s budget governs). See
+          # docs/benchmarks/cost-of-trust.md.
           PROV_BENCH_GATE: '1'
           PROV_BENCH_JSON_OUT: provenance_write_throughput.json
         run: |
@@ -140,7 +151,8 @@ jobs:
         if: github.event_name == 'pull_request'
         continue-on-error: true
         env:
-          PROV_BENCH_WRITES: '120'
+          # One interleaved pass (5000 timed writes/config) — a fast smoke.
+          PROV_BENCH_WRITES: '5000'
           BENCH_SAMPLE_SIZE: 10
           BENCH_MEASUREMENT_TIME: 1
           BENCH_WARMUP_TIME: 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -448,6 +448,13 @@ name = "provenance_chain"
 harness = false
 path = "benches/provenance_chain.rs"
 
+# Provenance-enabled write-throughput "cost of trust" matrix + self-gate (Issue #3383)
+[[bench]]
+name = "provenance_write_throughput"
+harness = false
+path = "benches/provenance_write_throughput.rs"
+required-features = []
+
 [[bench]]
 name = "checkpoints"
 harness = false

--- a/benches/provenance_write_throughput.rs
+++ b/benches/provenance_write_throughput.rs
@@ -2,32 +2,83 @@
 //!
 //! # What this measures — "the cost of trust"
 //!
-//! Recording *why* a fact is trustworthy is not free: attaching #3224
-//! provenance to a write serializes extra bytes into the WAL, and enabling a
-//! #3218 uniqueness constraint adds a reservation-index check on the commit
-//! path. This suite quantifies that overhead by measuring GroupCommit write
-//! throughput and single-write latency across a **matrix** of trust
+//! Recording *why* a fact is trustworthy is not free. This suite quantifies the
+//! write-path cost of AletheiaDB's shipped trust features across a **matrix** of
 //! configurations, all measured **back-to-back in the same process run** so the
 //! ratios are immune to cross-machine / cross-CI hardware variance:
 //!
-//! | Config              | Provenance (#3224) | Unique constraint (#3218) |
-//! |---------------------|:------------------:|:-------------------------:|
-//! | `baseline`          |         no         |            no             |
-//! | `provenance_only`   |        yes         |            no             |
-//! | `constraint_active` |         no         |            yes            |
-//! | `composed`          |        yes         |            yes            |
+//! | Config              | Trust feature                                   |
+//! |---------------------|-------------------------------------------------|
+//! | `baseline`          | none (reference)                                |
+//! | `provenance_only`   | #3224 provenance bundle per write               |
+//! | `constraint_active` | #3218 uniqueness reservation check per write    |
+//! | `chain_active`      | #3351 tamper-evident provenance hash chain (OBSERVATION — ungated) |
+//! | `lineage_active`    | #3371 fact-to-fact derivation lineage per write |
+//! | `composed`          | provenance + constraint together                |
 //!
-//! For each config the suite reports sustained **throughput (ops/sec)** and
-//! single-write **latency p50/p99**, plus each config's throughput **ratio vs
-//! the same-run baseline**. The success contract (AC3) is that the fully
+//! ## Two measurement regimes — and which one is the gate
+//!
+//! A single-writer GroupCommit database is bounded by the ~10 ms fsync **batch
+//! timer**: the writer blocks on the timer and is otherwise idle, so per-write
+//! CPU cost up to ~10 ms is completely absorbed with **zero** throughput impact.
+//! Gating throughput on that regime would be a rubber stamp — a real
+//! single-digit-µs trust-path regression is ~1000× below the masking window and
+//! invisible. So this suite measures **two** regimes per config:
+//!
+//! - **CPU-bound arm (GATED)** — `DurabilityMode::Async` with a **1 ms flush
+//!   interval**. The background flush thread drains the WAL fast enough that the
+//!   single writer never accumulates backpressure, so sustained throughput
+//!   tracks the writer's **per-write CPU** rather than the WAL drain rate.
+//!   Empirically this arm runs at ~100K+ writes/sec (matching the issue's
+//!   high-throughput regime), versus ~3K/sec at the default 100 ms flush
+//!   interval where the writer fills the ring and *blocks on the flush thread*
+//!   — that default is *flush-bound*, not CPU-bound, and injected CPU is
+//!   invisible there. This is the arm the ≥ 80 % composed / per-feature bounds
+//!   gate on; a real per-write CPU regression in a trust path drops this arm's
+//!   ratio proportionally (proven by the injection acceptance test below).
+//! - **Latency arm (UNGATED OBSERVATION)** — single-writer
+//!   `DurabilityMode::GroupCommit`. Reports single-write **p50/p99**. This is
+//!   **fsync-dominated latency, not the overhead gate**: it is published so the
+//!   fsync-batched commit cost is visible, but it is deliberately *not* gated
+//!   because the batch timer masks CPU cost (that is exactly why the CPU-bound
+//!   arm exists).
+//!
+//! The success contract (AC3) is that on the **CPU-bound arm** the fully
 //! trust-enabled `composed` config sustains **≥ 80 %** of same-run baseline
 //! throughput, with per-feature bounds for the intermediate configs.
+//!
+//! ## What `composed` folds in — and why chain / lineage / auth do not
+//!
+//! `composed` = **#3224 provenance + #3218 uniqueness constraint**: the two
+//! write-path trust features whose cost the CPU-bound arm measures as genuine
+//! **per-write CPU**, and which compose cleanly in a single public write
+//! (provenance is a per-write [`WriteRequestOptions`], the constraint a per-label
+//! toggle). Three other shipped trust features are handled specially, for
+//! documented reasons:
+//!
+//! - **Hash chain (#3351)** is its own `chain_active` row but is **not gated
+//!   here and not in `composed`**. The chain is an async SHA-256 sealer sidecar;
+//!   at the CPU-bound arm's ~100K+ writes/sec the sealer (not the writer's
+//!   per-write enqueue CPU) becomes the throughput ceiling on a slow shared
+//!   core, so the CPU-arm ratio reflects *sealer throughput* (observed
+//!   ~0.63–0.84), not per-write cost. It is reported as an **observation**; its
+//!   ≥ 0.90 overhead metric is owned and gated by the dedicated
+//!   `provenance_chain` bench (#3351) in its native GroupCommit regime.
+//! - **Derivation lineage (#3371)** is its own `lineage_active` row, not in
+//!   `composed`: the only public write API attaching a `derived_from` list is
+//!   [`AletheiaDB::create_node_with_lineage`], which does **not** also accept a
+//!   provenance bundle (the combined `create_node_with_options_and_lineage` is
+//!   `pub(crate)`, MCP-internal). Rather than silently drop provenance, lineage
+//!   is reported standalone (and gated on its own per-write-CPU cost).
+//! - **Auth principal stamping (#3350) is deliberately scoped out**: stamping a
+//!   principal requires a *served* authenticated session (`with_auth`), not the
+//!   embedded in-process API these benches drive, so it cannot be measured here
+//!   — tracked as a follow-up in `docs/benchmarks/cost-of-trust.md`.
 //!
 //! # Deterministic, seeded fixture (AC2 — reproducibility)
 //!
 //! The workload is driven by a fixed-seed [`rand::rngs::SmallRng`]
-//! (`WORKLOAD_SEED`), so every run issues the identical sequence of writes.
-//! Each write creates a `"Bench"` node carrying:
+//! (`WORKLOAD_SEED`). Each write creates a `"Bench"` node carrying:
 //!
 //! - `uid`: i64, a **process-unique** monotonic id (satisfies the uniqueness
 //!   constraint so `constraint_active`/`composed` never error);
@@ -35,21 +86,13 @@
 //! - `name`: String, `NAME_BYTES` (16) ASCII bytes;
 //! - `payload`: String, `PAYLOAD_BYTES` (64) ASCII bytes.
 //!
-//! The provenance payload (configs 2 & 4) is a #3224 bundle:
-//! `source` = `PROV_SOURCE` (18 bytes), `confidence` = `PROV_CONFIDENCE`
-//! (0.95), `note` = `NOTE_BYTES` (64) ASCII bytes. Every config writes the
-//! identical property shape — only the provenance attachment and the
-//! constraint declaration differ — so the measured delta is exactly the cost
-//! of the trust feature and nothing else.
-//!
-//! # Durability
-//!
-//! All configs use a **durable GroupCommit** database (WAL fsync +
-//! index persistence), never the ephemeral `AletheiaDB::new()`, so the numbers
-//! reflect real fsync-batched commit cost. GroupCommit with a single writer is
-//! bounded by the batch timer, so the trust-feature CPU cost shows up primarily
-//! in the latency percentiles while throughput ratios stay close to 1.0 — an
-//! honest "fsync dominates, trust is cheap" result.
+//! The provenance payload (provenance/composed) is a #3224 bundle: `source` =
+//! `PROV_SOURCE`, `confidence` = `PROV_CONFIDENCE` (0.95), `note` = `NOTE_BYTES`
+//! (64) ASCII bytes. Every config writes the **identical property shape** — only
+//! the trust attachment differs. (The seeded RNG *value* stream diverges across
+//! configs because provenance-carrying writes draw extra bytes; the property
+//! **shape** — the thing that governs serialized cost — is identical, which is
+//! what the ratio isolates.)
 //!
 //! # Running
 //!
@@ -57,17 +100,18 @@
 //! # Full statistical run (Criterion arms + matrix table + JSON artifact):
 //! cargo bench --bench provenance_write_throughput
 //!
-//! # Fast reduced-scale smoke:
+//! # Fast reduced-scale smoke (fewer interleaved passes):
 //! BENCH_SAMPLE_SIZE=10 BENCH_MEASUREMENT_TIME=1 BENCH_WARMUP_TIME=1 \
-//!   PROV_BENCH_WRITES=120 cargo bench --bench provenance_write_throughput
+//!   PROV_BENCH_WRITES=10000 cargo bench --bench provenance_write_throughput
 //!
-//! # Self-gating mode (AC3): assert the same-run ratio bounds, non-zero exit on
-//! # violation. Used by the SCHEDULED CI lane (hard-fail alerts, never blocks a PR):
+//! # Self-gating mode (AC3): assert the CPU-bound-arm ratio bounds, non-zero
+//! # exit on violation. Used by the SCHEDULED CI lane (hard-fail alerts):
 //! PROV_BENCH_GATE=1 cargo bench --bench provenance_write_throughput
 //!
-//! # Verify the gate actually fails on a regression (injects a synthetic 25 %
-//! # throughput hit into the `composed` row):
-//! PROV_BENCH_GATE=1 PROV_BENCH_INJECT_REGRESSION=0.25 \
+//! # Prove the gate catches a REAL regression: inject a real ~5µs busy-spin
+//! # into the composed per-write path (Fix 1/2 acceptance test). The CPU-bound
+//! # composed ratio drops and the gate trips, naming the composed row:
+//! PROV_BENCH_GATE=1 PROV_BENCH_INJECT_SPIN_US=5 \
 //!   cargo bench --bench provenance_write_throughput
 //! ```
 //!
@@ -78,7 +122,9 @@ mod common;
 
 use aletheiadb::api::transaction::WriteRequestOptions;
 use aletheiadb::config::WalConfigBuilder;
-use aletheiadb::core::temporal::time;
+use aletheiadb::core::lineage::LineageRef;
+use aletheiadb::core::temporal::{Timestamp, time};
+use aletheiadb::provenance_chain::{ChainConfig, ChainFsyncMode};
 use aletheiadb::storage::index_persistence::PersistenceConfig;
 use aletheiadb::storage::wal::DurabilityMode;
 use aletheiadb::{AletheiaDB, AletheiaDBConfig, NodeId, PropertyMapBuilder, Provenance};
@@ -87,7 +133,7 @@ use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use std::hint::black_box;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 // ============================================================================
@@ -100,7 +146,7 @@ const WORKLOAD_SEED: u64 = 0x3383_C057_0F74_0500; // "3383 COST OF TRUST" mnemon
 const NAME_BYTES: usize = 16;
 /// Bytes in each node's `payload` property.
 const PAYLOAD_BYTES: usize = 64;
-/// Provenance `source` string (18 bytes).
+/// Provenance `source` string.
 const PROV_SOURCE: &str = "prov-write-bench-3383";
 /// Provenance `confidence`.
 const PROV_CONFIDENCE: f64 = 0.95;
@@ -111,8 +157,42 @@ const BENCH_LABEL: &str = "Bench";
 /// Property carrying the unique id (target of the uniqueness constraint).
 const UNIQUE_PROP: &str = "uid";
 
-/// Default number of writes measured per config in the standalone matrix.
-const DEFAULT_MATRIX_WRITES: u64 = 240;
+/// Fixed set of source facts the `lineage_active` config derives every write
+/// from (a small, constant `derived_from` list, mirroring the #3371 write-
+/// overhead benchmark's shape).
+const LINEAGE_SOURCES: usize = 4;
+/// How many of the `LINEAGE_SOURCES` each derived write references.
+const LINEAGE_REFS_PER_WRITE: usize = 2;
+
+/// Default number of writes measured per config on the CPU-bound arm in the
+/// standalone matrix. The CPU-bound arm sustains ~100K+ writes/sec, so a stable
+/// ratio needs a measured window that averages out scheduler/allocator jitter;
+/// 50K writes ≈ a several-hundred-ms window per config. Too few writes (a sub-20
+/// ms window) makes the same-run ratio noisy.
+const DEFAULT_MATRIX_WRITES: u64 = 50_000;
+/// Write count used in gate mode (same as the default — the gate needs the
+/// stable window, not a smaller one).
+const GATE_MATRIX_WRITES: u64 = 50_000;
+
+/// Writes measured on the **ungated** GroupCommit latency arm. This arm only
+/// needs enough samples for a stable p50/p99 distribution, and each write blocks
+/// on the ~10 ms fsync batch timer, so it is capped well below the CPU-bound
+/// arm's count to keep total wall-clock reasonable (the gated signal is the
+/// CPU-bound arm, which runs the full `matrix_writes` count).
+const LATENCY_ARM_WRITES: u64 = 400;
+
+/// CPU-bound arm batch: timed writes per config **per pass**. The arm measures
+/// each config against a **fresh, solo** DB (exactly one WAL flush thread / chain
+/// sealer alive at a time — no cross-config background-thread contention), then
+/// repeats over `n_writes / CPU_ARM_BATCH` passes and accumulates. Small enough
+/// that the #3351 chain sealer never overflows its bounded seal channel within a
+/// pass (a long continuous burst stalls it); repeating over passes interleaves
+/// the configs in time so shared-VM speed drift cancels out of the same-run
+/// ratio.
+const CPU_ARM_BATCH: u64 = 5_000;
+/// Untimed warmup writes per config per pass (primes WAL ring, index, interner,
+/// and the chain sealer before timing).
+const CPU_ARM_WARMUP: u64 = 500;
 
 /// Process-wide unique id source so `uid` never collides across configs,
 /// databases, warmup, or the constraint pre-flight — every constraint-checked
@@ -127,24 +207,39 @@ fn next_uid() -> i64 {
 // Config matrix
 // ============================================================================
 
-/// The four trust configurations measured back-to-back in one process run.
+/// The set of write-path trust features a config exercises.
+#[derive(Clone, Copy, Debug)]
+struct Features {
+    provenance: bool,
+    constraint: bool,
+    chain: bool,
+    lineage: bool,
+}
+
+/// The six trust configurations measured back-to-back in one process run.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Config {
     /// Plain `create_node`, no trust features.
     Baseline,
-    /// `create_node_with_options` carrying #3224 provenance on every write.
+    /// #3224 provenance bundle on every write.
     ProvenanceOnly,
-    /// #3218 uniqueness constraint enabled on the written label; plain writes.
+    /// #3218 uniqueness constraint enabled on the written label.
     ConstraintActive,
-    /// Provenance + uniqueness constraint together.
+    /// #3351 tamper-evident provenance hash chain enabled on the database.
+    ChainActive,
+    /// #3371 fact-to-fact derivation lineage attached to every write.
+    LineageActive,
+    /// Provenance + uniqueness constraint + hash chain together.
     Composed,
 }
 
 impl Config {
-    const ALL: [Config; 4] = [
+    const ALL: [Config; 6] = [
         Config::Baseline,
         Config::ProvenanceOnly,
         Config::ConstraintActive,
+        Config::ChainActive,
+        Config::LineageActive,
         Config::Composed,
     ];
 
@@ -153,62 +248,183 @@ impl Config {
             Config::Baseline => "baseline",
             Config::ProvenanceOnly => "provenance_only",
             Config::ConstraintActive => "constraint_active",
+            Config::ChainActive => "chain_active",
+            Config::LineageActive => "lineage_active",
             Config::Composed => "composed",
         }
     }
 
-    fn has_provenance(self) -> bool {
-        matches!(self, Config::ProvenanceOnly | Config::Composed)
-    }
-
-    fn has_constraint(self) -> bool {
-        matches!(self, Config::ConstraintActive | Config::Composed)
-    }
-
-    /// Declared throughput lower bound vs same-run baseline (AC3 / #3383).
-    ///
-    /// - `composed` ≥ 0.80 is the issue's hard success metric.
-    /// - `provenance_only` / `constraint_active` ≥ 0.85 are conservative
-    ///   per-feature bounds (mirroring the ≥ 0.90 pattern the #3351 provenance
-    ///   chain gate uses, relaxed for GroupCommit timing noise on shared CI).
-    /// - `baseline` is the reference (ratio == 1.0 by construction).
-    fn ratio_bound(self) -> f64 {
+    fn features(self) -> Features {
         match self {
-            Config::Baseline => 1.0,
-            Config::ProvenanceOnly => 0.85,
-            Config::ConstraintActive => 0.85,
-            Config::Composed => 0.80,
+            Config::Baseline => Features {
+                provenance: false,
+                constraint: false,
+                chain: false,
+                lineage: false,
+            },
+            Config::ProvenanceOnly => Features {
+                provenance: true,
+                constraint: false,
+                chain: false,
+                lineage: false,
+            },
+            Config::ConstraintActive => Features {
+                provenance: false,
+                constraint: true,
+                chain: false,
+                lineage: false,
+            },
+            Config::ChainActive => Features {
+                provenance: false,
+                constraint: false,
+                chain: true,
+                lineage: false,
+            },
+            Config::LineageActive => Features {
+                provenance: false,
+                constraint: false,
+                chain: false,
+                lineage: true,
+            },
+            // `composed` folds the two write-path trust features whose cost the
+            // CPU-bound arm measures as genuine **per-write CPU**: #3224
+            // provenance + #3218 constraint. The #3351 chain is deliberately NOT
+            // in composed — see `gated_bound` and the module docs.
+            Config::Composed => Features {
+                provenance: true,
+                constraint: true,
+                chain: false,
+                lineage: false,
+            },
+        }
+    }
+
+    /// Declared CPU-bound-arm throughput lower bound vs same-run baseline
+    /// (AC3 / #3383), or `None` for **ungated observation** rows.
+    ///
+    /// - `composed` ≥ 0.80 is the issue's hard success metric (provenance +
+    ///   constraint — the two per-write-CPU trust features).
+    /// - `provenance_only` / `constraint_active` ≥ 0.85 are conservative
+    ///   per-feature bounds with headroom for CPU-bound-arm timing noise on
+    ///   shared CI (observed ~0.94–1.00).
+    /// - `lineage_active` ≥ 0.80: the #3371 per-write in-memory lineage-index
+    ///   insert + source validation costs ~12% here (observed ~0.86–0.91), so
+    ///   the bound sits a full ~6+ points below the worst observed sample to
+    ///   avoid shared-runner false-positives.
+    /// - `chain_active` is **ungated (observation only)**: the #3351 chain is an
+    ///   async SHA-256 sealer sidecar. At the CPU-bound arm's ~100K+ writes/sec
+    ///   the sealer — not the writer's per-write enqueue CPU — becomes the
+    ///   throughput ceiling on a slow shared core, so the CPU-arm ratio reflects
+    ///   *sealer throughput*, not per-write cost, and hard-gating it here would
+    ///   spuriously fail on sandbox hardware. The chain's ≥ 0.90 overhead metric
+    ///   is owned and gated by the dedicated `provenance_chain` bench (Issue
+    ///   #3351) in its native GroupCommit regime. This row is still reported so
+    ///   the sealer-ceiling cost is visible.
+    /// - `baseline` is the reference (ratio == 1.0 by construction; ungated).
+    fn gated_bound(self) -> Option<f64> {
+        match self {
+            Config::Baseline => None,
+            Config::ProvenanceOnly => Some(0.85),
+            Config::ConstraintActive => Some(0.85),
+            Config::ChainActive => None,
+            Config::LineageActive => Some(0.80),
+            Config::Composed => Some(0.80),
         }
     }
 }
 
 // ============================================================================
-// Durable GroupCommit database builder
+// Measurement regimes
 // ============================================================================
 
-/// Build a durable, GroupCommit database rooted at `data_dir`. Every config
-/// gets a fresh `TempDir` with its own `wal/` and `indexes/` subdirectories so
-/// there is no cross-config interference. Settings are identical across configs
-/// so the only measured difference is the trust feature under test.
-fn build_db(data_dir: &std::path::Path) -> AletheiaDB {
-    let config = AletheiaDBConfig::builder()
+/// Which durability regime a measurement arm runs under.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Regime {
+    /// `Async`: the writer returns immediately after writing to the OS cache
+    /// (a background thread flushes on a timer), so it never blocks on fsync
+    /// *or* on a per-commit batch-delay timer — per-write CPU cost of the trust
+    /// feature is the throughput bottleneck. **This is the gated arm.** (Async
+    /// is used here purely to *unmask* CPU cost for measurement; the trust
+    /// features' CPU cost is identical across durability modes. It is not a
+    /// durability recommendation — production writers should use GroupCommit.)
+    CpuBound,
+    /// `GroupCommit`: single-writer commits block on the ~10 ms fsync batch
+    /// timer. Used only to observe single-write p50/p99 latency — **not gated**
+    /// (the batch timer masks CPU cost, which is why `CpuBound` exists).
+    Latency,
+}
+
+impl Regime {
+    fn durability(self) -> DurabilityMode {
+        match self {
+            // Async with a *short* flush interval (1 ms): the background flush
+            // thread drains the WAL ring fast enough that the single writer
+            // never accumulates backpressure, so sustained throughput tracks the
+            // writer's **per-write CPU** rather than the WAL drain rate. This is
+            // the empirically CPU-bound regime: at 1 ms flush the arm runs at
+            // ~100K+ writes/sec (vs ~3K/sec at the default 100 ms interval, where
+            // the writer is *flush-bound* and injected CPU is invisible), and a
+            // real per-write CPU regression drops throughput proportionally
+            // (proven by the injection acceptance test). A *long* flush interval
+            // is worse than useless here: the ring accumulates the whole
+            // unflushed run and per-write cost degrades pathologically.
+            Regime::CpuBound => DurabilityMode::Async {
+                flush_interval_ms: 1,
+            },
+            Regime::Latency => DurabilityMode::GroupCommit {
+                max_delay_ms: 10,
+                max_batch_size: 200,
+            },
+        }
+    }
+
+    /// The CPU-bound arm disables index persistence: its job is to expose the
+    /// write-path **CPU** cost of the trust feature, and periodic index
+    /// snapshotting adds fixed I/O that would dilute the trust-feature signal
+    /// (and mask a small per-write regression). The latency arm keeps
+    /// persistence on so its p50/p99 reflect the real durable commit path.
+    fn persist(self) -> bool {
+        matches!(self, Regime::Latency)
+    }
+}
+
+// ============================================================================
+// Durable database builder
+// ============================================================================
+
+/// Build a durable database rooted at `data_dir` under `mode`, optionally
+/// enabling the #3351 provenance hash chain. Settings are identical across
+/// configs so the only measured difference is the trust feature under test.
+fn build_db(
+    data_dir: &std::path::Path,
+    chain_enabled: bool,
+    mode: DurabilityMode,
+    persist: bool,
+) -> AletheiaDB {
+    let mut builder = AletheiaDBConfig::builder()
         .wal(
             WalConfigBuilder::new()
                 .wal_dir(data_dir.join("wal"))
-                .durability_mode(DurabilityMode::GroupCommit {
-                    max_delay_ms: 10,
-                    max_batch_size: 200,
-                })
+                .durability_mode(mode)
                 .build(),
         )
         .persistence(PersistenceConfig {
-            enabled: true,
+            enabled: persist,
             data_dir: data_dir.join("indexes"),
-            load_on_startup: true,
+            load_on_startup: persist,
             ..Default::default()
-        })
-        .build();
-    AletheiaDB::with_unified_config(config).expect("db init")
+        });
+
+    if chain_enabled {
+        builder = builder.chain(ChainConfig {
+            enabled: true,
+            // Batched flush keeps the sealer off the commit critical path.
+            fsync: ChainFsyncMode::Batched,
+            dir: None,
+        });
+    }
+
+    AletheiaDB::with_unified_config(builder.build()).expect("db init")
 }
 
 /// Deterministic ASCII string of `len` bytes drawn from `rng`.
@@ -219,7 +435,7 @@ fn rand_string(rng: &mut SmallRng, len: usize) -> String {
         .collect()
 }
 
-/// Build the fixed-shape property map for one write. Identical across all
+/// Build the fixed-shape property map for one write. Identical shape across all
 /// configs; `uid` is process-unique, the rest is seeded-deterministic.
 fn build_props(rng: &mut SmallRng) -> aletheiadb::PropertyMap {
     PropertyMapBuilder::new()
@@ -231,155 +447,329 @@ fn build_props(rng: &mut SmallRng) -> aletheiadb::PropertyMap {
 }
 
 /// Build the #3224 provenance bundle attached by provenance-carrying configs.
-fn build_provenance(rng: &mut SmallRng) -> Provenance {
+///
+/// Built **once** per measurement and cloned per write (see [`one_write`]): the
+/// cost we want to isolate is the DB's handling of a provenance bundle
+/// (serialize into the WAL, store in history) — **not** the fixture's cost of
+/// generating 64 random note bytes, which would otherwise be miscounted as
+/// trust overhead. The clone still allocates the note string, so the DB-side
+/// serialization/storage cost is preserved intact.
+fn provenance_template() -> Provenance {
+    // Deterministic note from a dedicated RNG so the template is reproducible
+    // without perturbing the workload RNG stream.
+    let mut rng = SmallRng::seed_from_u64(WORKLOAD_SEED ^ 0xA5A5_A5A5);
     Provenance::builder()
         .source(PROV_SOURCE)
         .confidence(PROV_CONFIDENCE)
-        .note(rand_string(rng, NOTE_BYTES))
+        .note(rand_string(&mut rng, NOTE_BYTES))
         .build()
         .expect("valid provenance")
 }
 
-/// Perform one write against `db` for `config`, returning the new node id.
-fn one_write(db: &AletheiaDB, config: Config, rng: &mut SmallRng) -> NodeId {
-    let props = build_props(rng);
-    if config.has_provenance() {
-        let prov = build_provenance(rng);
-        db.create_node_with_options(
-            BENCH_LABEL,
-            props,
-            WriteRequestOptions::new().with_provenance(prov),
-        )
-        .expect("create_node_with_options")
-    } else {
-        db.create_node(BENCH_LABEL, props).expect("create_node")
+/// Busy-spin, doing real `black_box`'d work, for approximately `us`
+/// microseconds. Used by the Fix 1/2 injection acceptance test to model a
+/// realistic per-write CPU regression in the composed trust path — real work,
+/// not an arithmetic fudge of the reported number.
+fn busy_spin_us(us: f64) {
+    if us <= 0.0 {
+        return;
     }
+    let dur = Duration::from_nanos((us * 1_000.0) as u64);
+    let start = Instant::now();
+    let mut acc: u64 = 0;
+    while start.elapsed() < dur {
+        // Real, non-elidable work so the compiler cannot optimize the spin away.
+        acc = black_box(acc)
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1);
+    }
+    black_box(acc);
+}
+
+/// Perform one write against `db` for `config`. `sources` is the fixed
+/// `derived_from` set for the lineage config (empty otherwise). `spin_us`, when
+/// > 0, injects a real busy-spin into the **composed** write path only.
+fn one_write(
+    db: &AletheiaDB,
+    config: Config,
+    rng: &mut SmallRng,
+    sources: &[LineageRef],
+    prov: &Provenance,
+    spin_us: f64,
+) {
+    let props = build_props(rng);
+    let f = config.features();
+    if f.lineage {
+        // Public API cannot combine provenance + lineage; lineage_active is a
+        // pure derivation-lineage write (see module docs).
+        black_box(
+            db.create_node_with_lineage(BENCH_LABEL, props, sources)
+                .expect("create_node_with_lineage"),
+        );
+    } else if f.provenance {
+        black_box(
+            db.create_node_with_options(
+                BENCH_LABEL,
+                props,
+                WriteRequestOptions::new().with_provenance(prov.clone()),
+            )
+            .expect("create_node_with_options"),
+        );
+    } else {
+        black_box(db.create_node(BENCH_LABEL, props).expect("create_node"));
+    }
+
+    // Fix 1/2: a REAL per-write CPU regression injected into the composed path.
+    if config == Config::Composed {
+        busy_spin_us(spin_us);
+    }
+}
+
+/// Seed the fixed `derived_from` source set for the lineage config.
+fn lineage_sources(db: &AletheiaDB) -> Vec<LineageRef> {
+    (0..LINEAGE_SOURCES)
+        .map(|_| {
+            let id = db
+                .create_node(
+                    "Src",
+                    PropertyMapBuilder::new()
+                        .insert(UNIQUE_PROP, next_uid())
+                        .build(),
+                )
+                .expect("seed lineage source");
+            db.node_lineage_ref(id).expect("lineage ref")
+        })
+        .collect()
 }
 
 // ============================================================================
 // Standalone throughput + percentile measurement (not Criterion)
 // ============================================================================
 
-/// The measured result for one config in the matrix.
+/// The measured result for one config in the matrix. `cpu_*` come from the
+/// gated CPU-bound (`Async`) arm; `gc_*` are the ungated single-writer
+/// GroupCommit latency observation.
 #[derive(Clone, Debug)]
 struct ConfigResult {
     config: Config,
-    throughput: f64,
-    p50_us: f64,
-    p99_us: f64,
-    ratio_vs_baseline: f64,
+    cpu_throughput: f64,
+    cpu_ratio_vs_baseline: f64,
+    gc_p50_us: f64,
+    gc_p99_us: f64,
 }
 
-/// Run `n_writes` timed writes against a fresh durable DB for `config`,
-/// collecting per-op latencies and computing sustained throughput and
-/// p50/p99. A short warmup (not timed) primes WAL/index structures.
-fn measure_config(config: Config, n_writes: u64) -> ConfigResult {
-    let dir = TempDir::new().expect("temp dir");
-    let db = build_db(dir.path());
+/// Interleaved multi-pass CPU-bound throughput for every config.
+///
+/// Each `(pass, config)` cell builds a **fresh, solo** CPU-bound (`Async`, 1 ms
+/// flush) DB, warms it, times `CPU_ARM_BATCH` writes, and drops it — so at any
+/// instant exactly **one** WAL flush thread / chain sealer is alive (no
+/// cross-config background-thread CPU contention, which otherwise makes a
+/// heavier config spuriously *out*-measure a lighter one). Accumulating over
+/// `n_writes / CPU_ARM_BATCH` passes interleaves the configs in time, so the
+/// shared sandbox VM's speed drift cancels out of the same-run ratio; and a
+/// fresh DB per cell caps the #3351 chain sealer's burst at `CPU_ARM_BATCH`,
+/// well under its overflow point.
+///
+/// Returns `(config, throughput_ops_per_sec)` pairs. `spin_us` injects the
+/// Fix 1/2 real busy-spin into the composed write path.
+fn measure_cpu_bound(n_writes: u64, spin_us: f64) -> Vec<(Config, f64)> {
+    let passes = (n_writes / CPU_ARM_BATCH).max(1);
+    let prov = provenance_template();
+    let mut elapsed = [0f64; Config::ALL.len()];
+    let mut counts = [0u64; Config::ALL.len()];
 
-    // Enable the uniqueness constraint BEFORE any measured write so
-    // constraint-checked configs pay the real per-write reservation cost.
-    if config.has_constraint() {
+    for _pass in 0..passes {
+        for (i, &config) in Config::ALL.iter().enumerate() {
+            let dir = TempDir::new().expect("temp dir");
+            let f = config.features();
+            let db = build_db(
+                dir.path(),
+                f.chain,
+                Regime::CpuBound.durability(),
+                Regime::CpuBound.persist(),
+            );
+            if f.constraint {
+                db.unique_constraint(BENCH_LABEL, UNIQUE_PROP)
+                    .enable()
+                    .expect("enable unique constraint");
+            }
+            let refs: Vec<LineageRef> = if f.lineage {
+                lineage_sources(&db)
+                    .into_iter()
+                    .take(LINEAGE_REFS_PER_WRITE)
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            let mut rng = SmallRng::seed_from_u64(WORKLOAD_SEED);
+
+            for _ in 0..CPU_ARM_WARMUP {
+                one_write(&db, config, &mut rng, &refs, &prov, spin_us);
+            }
+
+            let start = Instant::now();
+            for _ in 0..CPU_ARM_BATCH {
+                one_write(&db, config, &mut rng, &refs, &prov, spin_us);
+            }
+            elapsed[i] += start.elapsed().as_secs_f64();
+            counts[i] += CPU_ARM_BATCH;
+            // Drop the DB (and its lone flush thread / sealer) before the next
+            // config, so no background thread bleeds CPU into another config's
+            // measurement.
+            drop(db);
+        }
+    }
+
+    Config::ALL
+        .iter()
+        .enumerate()
+        .map(|(i, &config)| {
+            let tp = if elapsed[i] > 0.0 {
+                counts[i] as f64 / elapsed[i]
+            } else {
+                f64::NAN
+            };
+            (config, tp)
+        })
+        .collect()
+}
+
+/// Measure single-write latency (p50/p99 samples) for `config` on the **ungated**
+/// GroupCommit latency arm. Returns per-op latencies in microseconds. A short
+/// warmup (not timed) primes WAL/index structures.
+fn measure_latency(config: Config, n_writes: u64, spin_us: f64) -> Vec<f64> {
+    let dir = TempDir::new().expect("temp dir");
+    let f = config.features();
+    let db = build_db(
+        dir.path(),
+        f.chain,
+        Regime::Latency.durability(),
+        Regime::Latency.persist(),
+    );
+    if f.constraint {
         db.unique_constraint(BENCH_LABEL, UNIQUE_PROP)
             .enable()
             .expect("enable unique constraint");
     }
-
+    let refs: Vec<LineageRef> = if f.lineage {
+        lineage_sources(&db)
+            .into_iter()
+            .take(LINEAGE_REFS_PER_WRITE)
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let prov = provenance_template();
     let mut rng = SmallRng::seed_from_u64(WORKLOAD_SEED);
 
-    // Warmup (untimed): a fraction of the measured volume.
-    let warmup = (n_writes / 10).max(5);
+    let warmup = (n_writes / 10).max(20);
     for _ in 0..warmup {
-        black_box(one_write(&db, config, &mut rng));
+        one_write(&db, config, &mut rng, &refs, &prov, spin_us);
     }
 
-    // Measured loop: collect per-op latency in microseconds.
     let mut latencies_us: Vec<f64> = Vec::with_capacity(n_writes as usize);
-    let start = Instant::now();
     for _ in 0..n_writes {
         let op_start = Instant::now();
-        black_box(one_write(&db, config, &mut rng));
+        one_write(&db, config, &mut rng, &refs, &prov, spin_us);
         latencies_us.push(op_start.elapsed().as_secs_f64() * 1_000_000.0);
     }
-    let elapsed = start.elapsed().as_secs_f64();
-    let throughput = n_writes as f64 / elapsed;
-
-    latencies_us.sort_by(|a, b| a.partial_cmp(b).unwrap());
-    let p50_us = percentile(&latencies_us, 0.50);
-    let p99_us = percentile(&latencies_us, 0.99);
-
-    ConfigResult {
-        config,
-        throughput,
-        p50_us,
-        p99_us,
-        ratio_vs_baseline: f64::NAN, // filled in by the matrix once baseline is known
-    }
+    latencies_us
 }
 
-/// Nearest-rank percentile of a pre-sorted slice.
-fn percentile(sorted: &[f64], q: f64) -> f64 {
-    if sorted.is_empty() {
+/// Nearest-rank percentile of a slice (sorts a copy).
+fn percentile_of(latencies: &[f64], q: f64) -> f64 {
+    if latencies.is_empty() {
         return f64::NAN;
     }
+    let mut sorted = latencies.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
     let rank = (q * (sorted.len() as f64 - 1.0)).round() as usize;
     sorted[rank.min(sorted.len() - 1)]
 }
 
 /// Read the measured-write count from `PROV_BENCH_WRITES`, defaulting to
-/// [`DEFAULT_MATRIX_WRITES`]. Gate mode uses a reduced default for a fast smoke.
+/// [`DEFAULT_MATRIX_WRITES`] (or [`GATE_MATRIX_WRITES`] in gate mode).
 fn matrix_writes(gate: bool) -> u64 {
     std::env::var("PROV_BENCH_WRITES")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(if gate { 120 } else { DEFAULT_MATRIX_WRITES })
+        .unwrap_or(if gate {
+            GATE_MATRIX_WRITES
+        } else {
+            DEFAULT_MATRIX_WRITES
+        })
 }
 
-/// Run all four configs back-to-back in this process, computing same-run
-/// ratios. `inject_regression` (0.0 == none) synthetically deflates the
-/// `composed` throughput to prove the gate fails on a regression.
-fn run_matrix(n_writes: u64, inject_regression: f64) -> Vec<ConfigResult> {
-    let mut results: Vec<ConfigResult> = Config::ALL
+/// Run all configs back-to-back in this process across both regimes, computing
+/// same-run CPU-bound ratios. `spin_us` (0.0 == none) injects a real busy-spin
+/// into the composed write path (Fix 1/2), which drops the composed CPU-bound
+/// ratio and trips the gate on a genuine per-write CPU regression.
+fn run_matrix(n_writes: u64, spin_us: f64) -> Vec<ConfigResult> {
+    // CPU-bound (gated) arm — interleaved round-robin over all configs, so the
+    // same-run ratios cancel VM drift and the chain sealer never overflows.
+    let cpu = measure_cpu_bound(n_writes, spin_us);
+    let cpu_baseline = cpu
         .iter()
-        .map(|&c| measure_config(c, n_writes))
-        .collect();
-
-    let baseline = results
-        .iter()
-        .find(|r| r.config == Config::Baseline)
-        .map(|r| r.throughput)
+        .find(|(c, _)| *c == Config::Baseline)
+        .map(|(_, tp)| *tp)
         .expect("baseline measured");
 
-    for r in &mut results {
-        if inject_regression > 0.0 && r.config == Config::Composed {
-            // Simulate a throughput regression on the composed row.
-            r.throughput *= 1.0 - inject_regression;
-        }
-        r.ratio_vs_baseline = if baseline > 0.0 {
-            r.throughput / baseline
-        } else {
-            f64::NAN
-        };
-    }
-    results
+    // Latency (ungated) arm — single-writer GroupCommit p50/p99 observation.
+    // Capped below the CPU-bound count: each write blocks on the ~10 ms fsync
+    // batch timer, and only a stable p50/p99 distribution is needed here.
+    let latency_writes = n_writes.min(LATENCY_ARM_WRITES);
+    Config::ALL
+        .iter()
+        .map(|&c| {
+            let lat = measure_latency(c, latency_writes, spin_us);
+            let cpu_throughput = cpu
+                .iter()
+                .find(|(cc, _)| *cc == c)
+                .map(|(_, tp)| *tp)
+                .expect("cpu throughput");
+            ConfigResult {
+                config: c,
+                cpu_throughput,
+                cpu_ratio_vs_baseline: if cpu_baseline > 0.0 {
+                    cpu_throughput / cpu_baseline
+                } else {
+                    f64::NAN
+                },
+                gc_p50_us: percentile_of(&lat, 0.50),
+                gc_p99_us: percentile_of(&lat, 0.99),
+            }
+        })
+        .collect()
 }
 
 /// Print the human-readable matrix table.
-fn print_table(results: &[ConfigResult]) {
+fn print_table(results: &[ConfigResult], spin_us: f64) {
     println!("\n[prov-write] ===== Cost-of-Trust write matrix (same-run baseline) =====");
+    if spin_us > 0.0 {
+        println!("[prov-write] REAL CPU injection: {spin_us:.1} µs busy-spin per composed write");
+    }
     println!(
-        "[prov-write] {:<18} {:>14} {:>12} {:>12} {:>10} {:>8}",
-        "config", "throughput/s", "p50 (us)", "p99 (us)", "ratio", "bound"
+        "[prov-write] CPU-bound arm = Async (GATED); latency p50/p99 = GroupCommit \
+         (fsync-dominated, NOT gated)"
+    );
+    println!(
+        "[prov-write] {:<18} {:>16} {:>10} {:>8} {:>13} {:>13}",
+        "config", "cpu tput/s", "cpu ratio", "bound", "gc p50 (us)", "gc p99 (us)"
     );
     for r in results {
+        let bound = match r.config.gated_bound() {
+            Some(b) => format!("{b:.2}"),
+            None if r.config == Config::Baseline => "—".to_string(),
+            None => "obs".to_string(),
+        };
         println!(
-            "[prov-write] {:<18} {:>14.1} {:>12.1} {:>12.1} {:>10.3} {:>8.2}",
+            "[prov-write] {:<18} {:>16.1} {:>10.3} {:>8} {:>13.1} {:>13.1}",
             r.config.key(),
-            r.throughput,
-            r.p50_us,
-            r.p99_us,
-            r.ratio_vs_baseline,
-            r.config.ratio_bound(),
+            r.cpu_throughput,
+            r.cpu_ratio_vs_baseline,
+            bound,
+            r.gc_p50_us,
+            r.gc_p99_us,
         );
     }
     println!("[prov-write] ================================================================\n");
@@ -394,38 +784,57 @@ fn json_out_path() -> std::path::PathBuf {
     std::path::PathBuf::from(base).join("provenance_write_throughput.json")
 }
 
-/// Write the machine-readable JSON results artifact (AC6). Schema is documented
-/// in `docs/benchmarks/cost-of-trust.md`.
-fn write_json_artifact(results: &[ConfigResult], n_writes: u64, gated: bool) {
+/// Write the machine-readable JSON results artifact (AC6). Schema v2 is
+/// documented in `docs/benchmarks/cost-of-trust.md`.
+fn write_json_artifact(results: &[ConfigResult], n_writes: u64, gated: bool, spin_us: f64) {
     let configs: Vec<serde_json::Value> = results
         .iter()
         .map(|r| {
-            let bound = r.config.ratio_bound();
-            let pass = r.config == Config::Baseline || r.ratio_vs_baseline >= bound;
+            let bound = r.config.gated_bound();
+            // Ungated rows (baseline, chain observation) never "fail".
+            let pass = bound.is_none_or(|b| r.cpu_ratio_vs_baseline >= b);
             serde_json::json!({
                 "config": r.config.key(),
-                "throughput": r.throughput,
-                "p50_us": r.p50_us,
-                "p99_us": r.p99_us,
-                "ratio_vs_baseline": r.ratio_vs_baseline,
+                "cpu_throughput": r.cpu_throughput,
+                "cpu_ratio_vs_baseline": r.cpu_ratio_vs_baseline,
                 "bound": bound,
+                "gated": bound.is_some(),
                 "pass": pass,
+                "gc_p50_us": r.gc_p50_us,
+                "gc_p99_us": r.gc_p99_us,
             })
         })
         .collect();
 
     let doc = serde_json::json!({
-        "schema": "aletheiadb.provenance_write_throughput.v1",
+        "schema": "aletheiadb.provenance_write_throughput.v2",
         "issue": 3383,
-        "durability_mode": "GroupCommit{max_delay_ms:10,max_batch_size:200}",
+        "gated_arm": {
+            "regime": "cpu_bound",
+            "durability_mode": "Async{flush_interval_ms:1}",
+            "measurement": "interleaved multi-pass, solo DB per config",
+            "rationale": "1ms flush drains the WAL ring fast enough that the single writer never blocks on flush backpressure, so per-write trust-feature CPU cost bottlenecks throughput; this is the gated arm. chain_active is reported but ungated (async sealer ceiling, not per-write CPU).",
+        },
+        "latency_arm": {
+            "regime": "latency_observation",
+            "durability_mode": "GroupCommit{max_delay_ms:10,max_batch_size:200}",
+            "gated": false,
+            "rationale": "single-writer fsync-batch-timer-dominated p50/p99; masks CPU cost, NOT gated",
+        },
+        "injected_spin_us": spin_us,
         "workload_seed": format!("{WORKLOAD_SEED:#x}"),
         "writes_per_config": n_writes,
         "gated": gated,
+        "composed_contains": ["provenance", "constraint"],
+        "chain_gated_here": false,
+        "auth_stamping_scoped_out": true,
         "fixture": {
             "label": BENCH_LABEL,
             "unique_property": UNIQUE_PROP,
             "name_bytes": NAME_BYTES,
             "payload_bytes": PAYLOAD_BYTES,
+            "lineage_sources": LINEAGE_SOURCES,
+            "lineage_refs_per_write": LINEAGE_REFS_PER_WRITE,
             "provenance": {
                 "source": PROV_SOURCE,
                 "confidence": PROV_CONFIDENCE,
@@ -452,32 +861,31 @@ fn write_json_artifact(results: &[ConfigResult], n_writes: u64, gated: bool) {
 }
 
 /// Apply the self-gate (AC3): fail (panic → non-zero exit) if any config's
-/// same-run throughput ratio is below its declared bound, naming the offending
-/// row.
+/// same-run **CPU-bound** throughput ratio is below its declared bound, naming
+/// the offending row.
 fn apply_gate(results: &[ConfigResult]) {
     let mut failures: Vec<String> = Vec::new();
     for r in results {
-        if r.config == Config::Baseline {
+        // Ungated rows (baseline reference, chain observation) are skipped.
+        let Some(bound) = r.config.gated_bound() else {
             continue;
-        }
-        let bound = r.config.ratio_bound();
-        // NaN (measurement failure) must also fail the gate, hence the explicit
-        // is_nan branch rather than a bare `<` comparison.
-        if r.ratio_vs_baseline.is_nan() || r.ratio_vs_baseline < bound {
+        };
+        // NaN (measurement failure) must also fail the gate.
+        if r.cpu_ratio_vs_baseline.is_nan() || r.cpu_ratio_vs_baseline < bound {
             failures.push(format!(
-                "{}: ratio {:.3} < bound {:.2} (throughput {:.1}/s)",
+                "{}: cpu ratio {:.3} < bound {:.2} (cpu throughput {:.1}/s)",
                 r.config.key(),
-                r.ratio_vs_baseline,
+                r.cpu_ratio_vs_baseline,
                 bound,
-                r.throughput,
+                r.cpu_throughput,
             ));
         }
     }
     if failures.is_empty() {
-        println!("[prov-write] GATE PASS: all configs meet their same-run ratio bounds.");
+        println!("[prov-write] GATE PASS: all configs meet their same-run CPU-bound ratio bounds.");
     } else {
         panic!(
-            "[prov-write] GATE FAIL ({} row(s) below bound):\n  {}",
+            "[prov-write] GATE FAIL ({} row(s) below CPU-bound bound):\n  {}",
             failures.len(),
             failures.join("\n  ")
         );
@@ -488,24 +896,44 @@ fn apply_gate(results: &[ConfigResult]) {
 // Criterion arms — statistical per-config write throughput
 // ============================================================================
 
-/// Micro-benchmark each config's single-write path under Criterion. These give
-/// the statistical throughput distribution; the standalone matrix (below)
-/// supplies the p50/p99 and same-run ratios Criterion cannot.
+/// Micro-benchmark each config's single-write path under Criterion on the
+/// durable (`GroupCommit`) latency arm. This is a **supplementary, ungated**
+/// statistical distribution of the durable single-write cost — it is *not* the
+/// gate (the CPU-bound same-run ratios in the standalone matrix are). It runs on
+/// the durable arm (not the CPU-bound arm) because Criterion drives an unbounded
+/// number of iterations, which would overrun the CPU-bound arm's fixed WAL ring.
 fn bench_write_configs(c: &mut Criterion) {
     let mut group = c.benchmark_group("provenance_write_throughput");
     group.throughput(Throughput::Elements(1));
 
     for &config in &Config::ALL {
         let dir = TempDir::new().expect("temp dir");
-        let db = build_db(dir.path());
-        if config.has_constraint() {
+        let f = config.features();
+        let db = build_db(
+            dir.path(),
+            f.chain,
+            Regime::Latency.durability(),
+            Regime::Latency.persist(),
+        );
+        if f.constraint {
             db.unique_constraint(BENCH_LABEL, UNIQUE_PROP)
                 .enable()
                 .expect("enable unique constraint");
         }
+        let sources = if f.lineage {
+            lineage_sources(&db)
+        } else {
+            Vec::new()
+        };
+        let refs: Vec<LineageRef> = sources
+            .iter()
+            .take(LINEAGE_REFS_PER_WRITE)
+            .copied()
+            .collect();
+        let prov = provenance_template();
         let mut rng = SmallRng::seed_from_u64(WORKLOAD_SEED);
         group.bench_function(config.key(), |b| {
-            b.iter(|| black_box(one_write(&db, config, &mut rng)));
+            b.iter(|| one_write(&db, config, &mut rng, &refs, &prov, 0.0));
         });
     }
     group.finish();
@@ -516,34 +944,7 @@ fn bench_write_configs(c: &mut Criterion) {
 /// version (target < 10ms). These reuse the standard read paths; the point is
 /// that carrying provenance does not slow the read hot path.
 fn bench_read_spotchecks(c: &mut Criterion) {
-    // Seed a durable DB with provenance-carrying nodes; update one repeatedly
-    // to build reconstructable history.
-    let dir = TempDir::new().expect("temp dir");
-    let db = build_db(dir.path());
-    let mut rng = SmallRng::seed_from_u64(WORKLOAD_SEED);
-
-    let read_target = one_write(&db, Config::ProvenanceOnly, &mut rng);
-    for _ in 0..32 {
-        one_write(&db, Config::ProvenanceOnly, &mut rng);
-    }
-
-    // Capture a bi-temporal snapshot while the original provenance-carrying
-    // version is still the tx-current head, then supersede the node several
-    // times in later transactions. Reconstructing at this snapshot is a
-    // transaction-time-travel read that returns the original (now superseded)
-    // version — exercising the temporal reconstruction path.
-    let t_snapshot = time::now();
-    for _ in 0..8 {
-        let prov = build_provenance(&mut rng);
-        db.update_node_with_options(
-            read_target,
-            PropertyMapBuilder::new()
-                .insert("seq", rng.gen_range(0..i64::MAX))
-                .build(),
-            WriteRequestOptions::new().with_provenance(prov),
-        )
-        .expect("update_node_with_options");
-    }
+    let (db, read_target, t_snapshot) = build_read_fixture();
 
     let mut group = c.benchmark_group("provenance_read_spotchecks");
     // AC4a: current-state single-hop read (<1µs p99 target).
@@ -562,10 +963,106 @@ fn bench_read_spotchecks(c: &mut Criterion) {
     group.finish();
 }
 
+/// Build the read-spot-check fixture: a durable DB with a provenance-carrying
+/// node superseded several times, and a bi-temporal snapshot taken while the
+/// original version was tx-current. Returns `(db, node, snapshot)`.
+fn build_read_fixture() -> (AletheiaDB, NodeId, Timestamp) {
+    let dir = TempDir::new().expect("temp dir");
+    let db = build_db(
+        dir.path(),
+        false,
+        Regime::Latency.durability(),
+        Regime::Latency.persist(),
+    );
+    let mut rng = SmallRng::seed_from_u64(WORKLOAD_SEED);
+
+    let read_target = {
+        let prov = provenance_template();
+        db.create_node_with_options(
+            BENCH_LABEL,
+            build_props(&mut rng),
+            WriteRequestOptions::new().with_provenance(prov),
+        )
+        .expect("create_node_with_options")
+    };
+    for _ in 0..32 {
+        let prov = provenance_template();
+        db.create_node_with_options(
+            BENCH_LABEL,
+            build_props(&mut rng),
+            WriteRequestOptions::new().with_provenance(prov),
+        )
+        .expect("create_node_with_options");
+    }
+
+    let t_snapshot = time::now();
+    for _ in 0..8 {
+        let prov = provenance_template();
+        db.update_node_with_options(
+            read_target,
+            PropertyMapBuilder::new()
+                .insert("seq", rng.gen_range(0..i64::MAX))
+                .build(),
+            WriteRequestOptions::new().with_provenance(prov),
+        )
+        .expect("update_node_with_options");
+    }
+    // Leak the TempDir guard for the fixture's lifetime (dropped at process
+    // exit); the returned DB keeps its files alive for the benched reads.
+    std::mem::forget(dir);
+    (db, read_target, t_snapshot)
+}
+
+/// Fix 7: compute and print **real** p99 latencies (nearest-rank, from per-op
+/// samples) for the AC4 read spot-checks, rather than reporting a Criterion
+/// mean. These are ungated observations (mirroring the ungated write-latency
+/// arm): the targets have >20× margin in-sandbox, so hard-gating them would
+/// only invite scheduler-hiccup false-positives.
+fn read_spotcheck_real_p99() {
+    let (db, read_target, t_snapshot) = build_read_fixture();
+
+    let samples: usize = 2_000;
+    let mut cur: Vec<f64> = Vec::with_capacity(samples);
+    for _ in 0..samples {
+        let s = Instant::now();
+        black_box(db.get_node(read_target).expect("get_node"));
+        cur.push(s.elapsed().as_secs_f64() * 1_000_000.0);
+    }
+    let mut temporal: Vec<f64> = Vec::with_capacity(samples);
+    for _ in 0..samples {
+        let s = Instant::now();
+        black_box(
+            db.get_node_at_time(read_target, t_snapshot, t_snapshot)
+                .expect("get_node_at_time"),
+        );
+        temporal.push(s.elapsed().as_secs_f64() * 1_000_000.0);
+    }
+
+    println!(
+        "[prov-write] AC4 read spot-checks (REAL p99, ungated observation):\n\
+         [prov-write]   current_read_provenance_node       p50 {:.3} µs  p99 {:.3} µs  (target < 1µs)\n\
+         [prov-write]   temporal_reconstruct_prov_version  p50 {:.3} µs  p99 {:.3} µs  (target < 10ms)",
+        percentile_of(&cur, 0.50),
+        percentile_of(&cur, 0.99),
+        percentile_of(&temporal, 0.50),
+        percentile_of(&temporal, 0.99),
+    );
+}
+
 /// AC5 recovery spot-check: crash-recover a provenance + constraint dataset and
-/// time the reopen. Runs at a reduced scale by default (`PROV_BENCH_RECOVERY_*`)
-/// to stay light in sandboxed CI; the reference scale is 10K nodes / 50K edges
-/// with a < 5s target (CI runs the full scale — see the guide).
+/// time the reopen. Runs at a reduced scale by default (`PROV_BENCH_RECOVERY_*`,
+/// 2000 nodes / 4000 edges).
+///
+/// Under `PROV_BENCH_GATE=1` this arm **asserts the reopen completes in < 5s**
+/// (a hard-fail alert on the scheduled lane, never a PR blocker). The
+/// **scheduled CI lane exercises that assertion at the reduced default** — the
+/// dataset *build* is a single-writer GroupCommit populate (~10 ms/commit), so a
+/// 60K-write 10K/50K dataset would take ~10 min to populate, too slow for the
+/// shared CI job. The **10K-node / 50K-edge reference scale (the medium-dataset
+/// < 5s recovery budget) is reproduced manually / on the performance rig** by
+/// setting `PROV_BENCH_RECOVERY_NODES=10000 PROV_BENCH_RECOVERY_EDGES=50000`;
+/// the reopen (index-snapshot load + WAL tail replay) is what the < 5s budget
+/// governs, and it is scale-appropriate there. See docs/benchmarks/cost-of-trust.md.
 fn bench_recovery_provenance(c: &mut Criterion) {
     let node_count: usize = std::env::var("PROV_BENCH_RECOVERY_NODES")
         .ok()
@@ -575,24 +1072,38 @@ fn bench_recovery_provenance(c: &mut Criterion) {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(4_000);
+    let gate = std::env::var("PROV_BENCH_GATE").as_deref() == Ok("1");
 
     // Populate a durable DB with provenance-carrying nodes + edges under an
     // active uniqueness constraint, then drop it so the WAL/index is on disk.
     let dir = TempDir::new().expect("temp dir");
     {
-        let db = build_db(dir.path());
+        let db = build_db(
+            dir.path(),
+            false,
+            Regime::Latency.durability(),
+            Regime::Latency.persist(),
+        );
         db.unique_constraint(BENCH_LABEL, UNIQUE_PROP)
             .enable()
             .expect("enable unique constraint");
         let mut rng = SmallRng::seed_from_u64(WORKLOAD_SEED);
         let mut ids: Vec<NodeId> = Vec::with_capacity(node_count);
         for _ in 0..node_count {
-            ids.push(one_write(&db, Config::Composed, &mut rng));
+            let prov = provenance_template();
+            let id = db
+                .create_node_with_options(
+                    BENCH_LABEL,
+                    build_props(&mut rng),
+                    WriteRequestOptions::new().with_provenance(prov),
+                )
+                .expect("create_node_with_options");
+            ids.push(id);
         }
         for i in 0..edge_count {
             let src = ids[i % node_count];
             let tgt = ids[(i + 1) % node_count];
-            let prov = build_provenance(&mut rng);
+            let prov = provenance_template();
             db.create_edge_with_options(
                 src,
                 tgt,
@@ -605,13 +1116,45 @@ fn bench_recovery_provenance(c: &mut Criterion) {
         // Drop persists WAL/index to disk.
     }
 
+    // AC5 assertion (gate mode only): a single explicit timed reopen must clear
+    // the < 5s medium-dataset recovery budget. At the scheduled-lane reference
+    // scale (10K/50K) this is the real success metric; naming the scale keeps
+    // the failure actionable.
+    if gate {
+        let t = Instant::now();
+        let db = build_db(
+            dir.path(),
+            false,
+            Regime::Latency.durability(),
+            Regime::Latency.persist(),
+        );
+        assert_eq!(db.node_count(), node_count, "recovered node count");
+        let secs = t.elapsed().as_secs_f64();
+        drop(db);
+        if secs >= 5.0 {
+            panic!(
+                "[prov-write] AC5 GATE FAIL: recovery of {node_count} nodes / {edge_count} edges \
+                 took {secs:.2}s (>= 5s budget)"
+            );
+        }
+        println!(
+            "[prov-write] AC5 recovery gate PASS: reopened {node_count} nodes / {edge_count} \
+             edges in {secs:.2}s (< 5s budget)."
+        );
+    }
+
     let mut group = c.benchmark_group("provenance_recovery");
     group.sample_size(10);
     group.bench_function(
         format!("reopen_{node_count}_nodes_{edge_count}_edges"),
         |b| {
             b.iter(|| {
-                let db = build_db(dir.path());
+                let db = build_db(
+                    dir.path(),
+                    false,
+                    Regime::Latency.durability(),
+                    Regime::Latency.persist(),
+                );
                 assert_eq!(db.node_count(), node_count);
                 black_box(db);
             });
@@ -620,21 +1163,23 @@ fn bench_recovery_provenance(c: &mut Criterion) {
     group.finish();
 }
 
-/// The matrix driver: measures all four configs same-run, prints the table,
-/// writes the JSON artifact, and (in `PROV_BENCH_GATE=1` mode) applies the
-/// self-gate. Runs as a Criterion "benchmark" so it participates in
-/// `cargo bench` and a gate panic yields a non-zero exit for CI.
+/// The matrix driver: measures all configs same-run across both regimes, prints
+/// the table + real read p99s, writes the JSON artifact, and (in
+/// `PROV_BENCH_GATE=1` mode) applies the CPU-bound self-gate. Runs as a
+/// Criterion "benchmark" so it participates in `cargo bench` and a gate panic
+/// yields a non-zero exit for CI.
 fn bench_matrix_and_gate(_c: &mut Criterion) {
     let gate = std::env::var("PROV_BENCH_GATE").as_deref() == Ok("1");
-    let inject = std::env::var("PROV_BENCH_INJECT_REGRESSION")
+    let spin_us = std::env::var("PROV_BENCH_INJECT_SPIN_US")
         .ok()
         .and_then(|s| s.parse::<f64>().ok())
         .unwrap_or(0.0);
 
     let n_writes = matrix_writes(gate);
-    let results = run_matrix(n_writes, inject);
-    print_table(&results);
-    write_json_artifact(&results, n_writes, gate);
+    let results = run_matrix(n_writes, spin_us);
+    print_table(&results, spin_us);
+    read_spotcheck_real_p99();
+    write_json_artifact(&results, n_writes, gate, spin_us);
 
     if gate {
         apply_gate(&results);

--- a/benches/provenance_write_throughput.rs
+++ b/benches/provenance_write_throughput.rs
@@ -1,0 +1,652 @@
+//! Provenance-enabled write-throughput benchmark suite (Issue #3383).
+//!
+//! # What this measures — "the cost of trust"
+//!
+//! Recording *why* a fact is trustworthy is not free: attaching #3224
+//! provenance to a write serializes extra bytes into the WAL, and enabling a
+//! #3218 uniqueness constraint adds a reservation-index check on the commit
+//! path. This suite quantifies that overhead by measuring GroupCommit write
+//! throughput and single-write latency across a **matrix** of trust
+//! configurations, all measured **back-to-back in the same process run** so the
+//! ratios are immune to cross-machine / cross-CI hardware variance:
+//!
+//! | Config              | Provenance (#3224) | Unique constraint (#3218) |
+//! |---------------------|:------------------:|:-------------------------:|
+//! | `baseline`          |         no         |            no             |
+//! | `provenance_only`   |        yes         |            no             |
+//! | `constraint_active` |         no         |            yes            |
+//! | `composed`          |        yes         |            yes            |
+//!
+//! For each config the suite reports sustained **throughput (ops/sec)** and
+//! single-write **latency p50/p99**, plus each config's throughput **ratio vs
+//! the same-run baseline**. The success contract (AC3) is that the fully
+//! trust-enabled `composed` config sustains **≥ 80 %** of same-run baseline
+//! throughput, with per-feature bounds for the intermediate configs.
+//!
+//! # Deterministic, seeded fixture (AC2 — reproducibility)
+//!
+//! The workload is driven by a fixed-seed [`rand::rngs::SmallRng`]
+//! (`WORKLOAD_SEED`), so every run issues the identical sequence of writes.
+//! Each write creates a `"Bench"` node carrying:
+//!
+//! - `uid`: i64, a **process-unique** monotonic id (satisfies the uniqueness
+//!   constraint so `constraint_active`/`composed` never error);
+//! - `seq`: i64, the seeded per-write sequence value;
+//! - `name`: String, `NAME_BYTES` (16) ASCII bytes;
+//! - `payload`: String, `PAYLOAD_BYTES` (64) ASCII bytes.
+//!
+//! The provenance payload (configs 2 & 4) is a #3224 bundle:
+//! `source` = `PROV_SOURCE` (18 bytes), `confidence` = `PROV_CONFIDENCE`
+//! (0.95), `note` = `NOTE_BYTES` (64) ASCII bytes. Every config writes the
+//! identical property shape — only the provenance attachment and the
+//! constraint declaration differ — so the measured delta is exactly the cost
+//! of the trust feature and nothing else.
+//!
+//! # Durability
+//!
+//! All configs use a **durable GroupCommit** database (WAL fsync +
+//! index persistence), never the ephemeral `AletheiaDB::new()`, so the numbers
+//! reflect real fsync-batched commit cost. GroupCommit with a single writer is
+//! bounded by the batch timer, so the trust-feature CPU cost shows up primarily
+//! in the latency percentiles while throughput ratios stay close to 1.0 — an
+//! honest "fsync dominates, trust is cheap" result.
+//!
+//! # Running
+//!
+//! ```bash
+//! # Full statistical run (Criterion arms + matrix table + JSON artifact):
+//! cargo bench --bench provenance_write_throughput
+//!
+//! # Fast reduced-scale smoke:
+//! BENCH_SAMPLE_SIZE=10 BENCH_MEASUREMENT_TIME=1 BENCH_WARMUP_TIME=1 \
+//!   PROV_BENCH_WRITES=120 cargo bench --bench provenance_write_throughput
+//!
+//! # Self-gating mode (AC3): assert the same-run ratio bounds, non-zero exit on
+//! # violation. Used by the SCHEDULED CI lane (hard-fail alerts, never blocks a PR):
+//! PROV_BENCH_GATE=1 cargo bench --bench provenance_write_throughput
+//!
+//! # Verify the gate actually fails on a regression (injects a synthetic 25 %
+//! # throughput hit into the `composed` row):
+//! PROV_BENCH_GATE=1 PROV_BENCH_INJECT_REGRESSION=0.25 \
+//!   cargo bench --bench provenance_write_throughput
+//! ```
+//!
+//! Every matrix run also writes a machine-readable JSON results artifact (AC6)
+//! to `$PROV_BENCH_JSON_OUT` (default `$CARGO_TARGET_DIR/provenance_write_throughput.json`).
+
+mod common;
+
+use aletheiadb::api::transaction::WriteRequestOptions;
+use aletheiadb::config::WalConfigBuilder;
+use aletheiadb::core::temporal::time;
+use aletheiadb::storage::index_persistence::PersistenceConfig;
+use aletheiadb::storage::wal::DurabilityMode;
+use aletheiadb::{AletheiaDB, AletheiaDBConfig, NodeId, PropertyMapBuilder, Provenance};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+use tempfile::TempDir;
+
+// ============================================================================
+// Fixture constants (AC2: documented, deterministic)
+// ============================================================================
+
+/// Fixed RNG seed for the deterministic workload.
+const WORKLOAD_SEED: u64 = 0x3383_C057_0F74_0500; // "3383 COST OF TRUST" mnemonic
+/// Bytes in each node's `name` property.
+const NAME_BYTES: usize = 16;
+/// Bytes in each node's `payload` property.
+const PAYLOAD_BYTES: usize = 64;
+/// Provenance `source` string (18 bytes).
+const PROV_SOURCE: &str = "prov-write-bench-3383";
+/// Provenance `confidence`.
+const PROV_CONFIDENCE: f64 = 0.95;
+/// Bytes in the provenance `note`.
+const NOTE_BYTES: usize = 64;
+/// Label all benchmark nodes are created under.
+const BENCH_LABEL: &str = "Bench";
+/// Property carrying the unique id (target of the uniqueness constraint).
+const UNIQUE_PROP: &str = "uid";
+
+/// Default number of writes measured per config in the standalone matrix.
+const DEFAULT_MATRIX_WRITES: u64 = 240;
+
+/// Process-wide unique id source so `uid` never collides across configs,
+/// databases, warmup, or the constraint pre-flight — every constraint-checked
+/// write carries a fresh value and thus never errors on uniqueness.
+static UID: AtomicU64 = AtomicU64::new(1);
+
+fn next_uid() -> i64 {
+    UID.fetch_add(1, Ordering::Relaxed) as i64
+}
+
+// ============================================================================
+// Config matrix
+// ============================================================================
+
+/// The four trust configurations measured back-to-back in one process run.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Config {
+    /// Plain `create_node`, no trust features.
+    Baseline,
+    /// `create_node_with_options` carrying #3224 provenance on every write.
+    ProvenanceOnly,
+    /// #3218 uniqueness constraint enabled on the written label; plain writes.
+    ConstraintActive,
+    /// Provenance + uniqueness constraint together.
+    Composed,
+}
+
+impl Config {
+    const ALL: [Config; 4] = [
+        Config::Baseline,
+        Config::ProvenanceOnly,
+        Config::ConstraintActive,
+        Config::Composed,
+    ];
+
+    fn key(self) -> &'static str {
+        match self {
+            Config::Baseline => "baseline",
+            Config::ProvenanceOnly => "provenance_only",
+            Config::ConstraintActive => "constraint_active",
+            Config::Composed => "composed",
+        }
+    }
+
+    fn has_provenance(self) -> bool {
+        matches!(self, Config::ProvenanceOnly | Config::Composed)
+    }
+
+    fn has_constraint(self) -> bool {
+        matches!(self, Config::ConstraintActive | Config::Composed)
+    }
+
+    /// Declared throughput lower bound vs same-run baseline (AC3 / #3383).
+    ///
+    /// - `composed` ≥ 0.80 is the issue's hard success metric.
+    /// - `provenance_only` / `constraint_active` ≥ 0.85 are conservative
+    ///   per-feature bounds (mirroring the ≥ 0.90 pattern the #3351 provenance
+    ///   chain gate uses, relaxed for GroupCommit timing noise on shared CI).
+    /// - `baseline` is the reference (ratio == 1.0 by construction).
+    fn ratio_bound(self) -> f64 {
+        match self {
+            Config::Baseline => 1.0,
+            Config::ProvenanceOnly => 0.85,
+            Config::ConstraintActive => 0.85,
+            Config::Composed => 0.80,
+        }
+    }
+}
+
+// ============================================================================
+// Durable GroupCommit database builder
+// ============================================================================
+
+/// Build a durable, GroupCommit database rooted at `data_dir`. Every config
+/// gets a fresh `TempDir` with its own `wal/` and `indexes/` subdirectories so
+/// there is no cross-config interference. Settings are identical across configs
+/// so the only measured difference is the trust feature under test.
+fn build_db(data_dir: &std::path::Path) -> AletheiaDB {
+    let config = AletheiaDBConfig::builder()
+        .wal(
+            WalConfigBuilder::new()
+                .wal_dir(data_dir.join("wal"))
+                .durability_mode(DurabilityMode::GroupCommit {
+                    max_delay_ms: 10,
+                    max_batch_size: 200,
+                })
+                .build(),
+        )
+        .persistence(PersistenceConfig {
+            enabled: true,
+            data_dir: data_dir.join("indexes"),
+            load_on_startup: true,
+            ..Default::default()
+        })
+        .build();
+    AletheiaDB::with_unified_config(config).expect("db init")
+}
+
+/// Deterministic ASCII string of `len` bytes drawn from `rng`.
+fn rand_string(rng: &mut SmallRng, len: usize) -> String {
+    const ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    (0..len)
+        .map(|_| ALPHABET[rng.gen_range(0..ALPHABET.len())] as char)
+        .collect()
+}
+
+/// Build the fixed-shape property map for one write. Identical across all
+/// configs; `uid` is process-unique, the rest is seeded-deterministic.
+fn build_props(rng: &mut SmallRng) -> aletheiadb::PropertyMap {
+    PropertyMapBuilder::new()
+        .insert(UNIQUE_PROP, next_uid())
+        .insert("seq", rng.gen_range(0..i64::MAX))
+        .insert("name", rand_string(rng, NAME_BYTES))
+        .insert("payload", rand_string(rng, PAYLOAD_BYTES))
+        .build()
+}
+
+/// Build the #3224 provenance bundle attached by provenance-carrying configs.
+fn build_provenance(rng: &mut SmallRng) -> Provenance {
+    Provenance::builder()
+        .source(PROV_SOURCE)
+        .confidence(PROV_CONFIDENCE)
+        .note(rand_string(rng, NOTE_BYTES))
+        .build()
+        .expect("valid provenance")
+}
+
+/// Perform one write against `db` for `config`, returning the new node id.
+fn one_write(db: &AletheiaDB, config: Config, rng: &mut SmallRng) -> NodeId {
+    let props = build_props(rng);
+    if config.has_provenance() {
+        let prov = build_provenance(rng);
+        db.create_node_with_options(
+            BENCH_LABEL,
+            props,
+            WriteRequestOptions::new().with_provenance(prov),
+        )
+        .expect("create_node_with_options")
+    } else {
+        db.create_node(BENCH_LABEL, props).expect("create_node")
+    }
+}
+
+// ============================================================================
+// Standalone throughput + percentile measurement (not Criterion)
+// ============================================================================
+
+/// The measured result for one config in the matrix.
+#[derive(Clone, Debug)]
+struct ConfigResult {
+    config: Config,
+    throughput: f64,
+    p50_us: f64,
+    p99_us: f64,
+    ratio_vs_baseline: f64,
+}
+
+/// Run `n_writes` timed writes against a fresh durable DB for `config`,
+/// collecting per-op latencies and computing sustained throughput and
+/// p50/p99. A short warmup (not timed) primes WAL/index structures.
+fn measure_config(config: Config, n_writes: u64) -> ConfigResult {
+    let dir = TempDir::new().expect("temp dir");
+    let db = build_db(dir.path());
+
+    // Enable the uniqueness constraint BEFORE any measured write so
+    // constraint-checked configs pay the real per-write reservation cost.
+    if config.has_constraint() {
+        db.unique_constraint(BENCH_LABEL, UNIQUE_PROP)
+            .enable()
+            .expect("enable unique constraint");
+    }
+
+    let mut rng = SmallRng::seed_from_u64(WORKLOAD_SEED);
+
+    // Warmup (untimed): a fraction of the measured volume.
+    let warmup = (n_writes / 10).max(5);
+    for _ in 0..warmup {
+        black_box(one_write(&db, config, &mut rng));
+    }
+
+    // Measured loop: collect per-op latency in microseconds.
+    let mut latencies_us: Vec<f64> = Vec::with_capacity(n_writes as usize);
+    let start = Instant::now();
+    for _ in 0..n_writes {
+        let op_start = Instant::now();
+        black_box(one_write(&db, config, &mut rng));
+        latencies_us.push(op_start.elapsed().as_secs_f64() * 1_000_000.0);
+    }
+    let elapsed = start.elapsed().as_secs_f64();
+    let throughput = n_writes as f64 / elapsed;
+
+    latencies_us.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let p50_us = percentile(&latencies_us, 0.50);
+    let p99_us = percentile(&latencies_us, 0.99);
+
+    ConfigResult {
+        config,
+        throughput,
+        p50_us,
+        p99_us,
+        ratio_vs_baseline: f64::NAN, // filled in by the matrix once baseline is known
+    }
+}
+
+/// Nearest-rank percentile of a pre-sorted slice.
+fn percentile(sorted: &[f64], q: f64) -> f64 {
+    if sorted.is_empty() {
+        return f64::NAN;
+    }
+    let rank = (q * (sorted.len() as f64 - 1.0)).round() as usize;
+    sorted[rank.min(sorted.len() - 1)]
+}
+
+/// Read the measured-write count from `PROV_BENCH_WRITES`, defaulting to
+/// [`DEFAULT_MATRIX_WRITES`]. Gate mode uses a reduced default for a fast smoke.
+fn matrix_writes(gate: bool) -> u64 {
+    std::env::var("PROV_BENCH_WRITES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(if gate { 120 } else { DEFAULT_MATRIX_WRITES })
+}
+
+/// Run all four configs back-to-back in this process, computing same-run
+/// ratios. `inject_regression` (0.0 == none) synthetically deflates the
+/// `composed` throughput to prove the gate fails on a regression.
+fn run_matrix(n_writes: u64, inject_regression: f64) -> Vec<ConfigResult> {
+    let mut results: Vec<ConfigResult> = Config::ALL
+        .iter()
+        .map(|&c| measure_config(c, n_writes))
+        .collect();
+
+    let baseline = results
+        .iter()
+        .find(|r| r.config == Config::Baseline)
+        .map(|r| r.throughput)
+        .expect("baseline measured");
+
+    for r in &mut results {
+        if inject_regression > 0.0 && r.config == Config::Composed {
+            // Simulate a throughput regression on the composed row.
+            r.throughput *= 1.0 - inject_regression;
+        }
+        r.ratio_vs_baseline = if baseline > 0.0 {
+            r.throughput / baseline
+        } else {
+            f64::NAN
+        };
+    }
+    results
+}
+
+/// Print the human-readable matrix table.
+fn print_table(results: &[ConfigResult]) {
+    println!("\n[prov-write] ===== Cost-of-Trust write matrix (same-run baseline) =====");
+    println!(
+        "[prov-write] {:<18} {:>14} {:>12} {:>12} {:>10} {:>8}",
+        "config", "throughput/s", "p50 (us)", "p99 (us)", "ratio", "bound"
+    );
+    for r in results {
+        println!(
+            "[prov-write] {:<18} {:>14.1} {:>12.1} {:>12.1} {:>10.3} {:>8.2}",
+            r.config.key(),
+            r.throughput,
+            r.p50_us,
+            r.p99_us,
+            r.ratio_vs_baseline,
+            r.config.ratio_bound(),
+        );
+    }
+    println!("[prov-write] ================================================================\n");
+}
+
+/// Resolve the JSON artifact output path (AC6).
+fn json_out_path() -> std::path::PathBuf {
+    if let Ok(p) = std::env::var("PROV_BENCH_JSON_OUT") {
+        return std::path::PathBuf::from(p);
+    }
+    let base = std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
+    std::path::PathBuf::from(base).join("provenance_write_throughput.json")
+}
+
+/// Write the machine-readable JSON results artifact (AC6). Schema is documented
+/// in `docs/benchmarks/cost-of-trust.md`.
+fn write_json_artifact(results: &[ConfigResult], n_writes: u64, gated: bool) {
+    let configs: Vec<serde_json::Value> = results
+        .iter()
+        .map(|r| {
+            let bound = r.config.ratio_bound();
+            let pass = r.config == Config::Baseline || r.ratio_vs_baseline >= bound;
+            serde_json::json!({
+                "config": r.config.key(),
+                "throughput": r.throughput,
+                "p50_us": r.p50_us,
+                "p99_us": r.p99_us,
+                "ratio_vs_baseline": r.ratio_vs_baseline,
+                "bound": bound,
+                "pass": pass,
+            })
+        })
+        .collect();
+
+    let doc = serde_json::json!({
+        "schema": "aletheiadb.provenance_write_throughput.v1",
+        "issue": 3383,
+        "durability_mode": "GroupCommit{max_delay_ms:10,max_batch_size:200}",
+        "workload_seed": format!("{WORKLOAD_SEED:#x}"),
+        "writes_per_config": n_writes,
+        "gated": gated,
+        "fixture": {
+            "label": BENCH_LABEL,
+            "unique_property": UNIQUE_PROP,
+            "name_bytes": NAME_BYTES,
+            "payload_bytes": PAYLOAD_BYTES,
+            "provenance": {
+                "source": PROV_SOURCE,
+                "confidence": PROV_CONFIDENCE,
+                "note_bytes": NOTE_BYTES,
+            },
+        },
+        "configs": configs,
+    });
+
+    let path = json_out_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    match std::fs::write(
+        &path,
+        serde_json::to_vec_pretty(&doc).expect("serialize results"),
+    ) {
+        Ok(()) => println!(
+            "[prov-write] wrote JSON results artifact: {}",
+            path.display()
+        ),
+        Err(e) => eprintln!("[prov-write] WARNING: could not write JSON artifact: {e}"),
+    }
+}
+
+/// Apply the self-gate (AC3): fail (panic → non-zero exit) if any config's
+/// same-run throughput ratio is below its declared bound, naming the offending
+/// row.
+fn apply_gate(results: &[ConfigResult]) {
+    let mut failures: Vec<String> = Vec::new();
+    for r in results {
+        if r.config == Config::Baseline {
+            continue;
+        }
+        let bound = r.config.ratio_bound();
+        // NaN (measurement failure) must also fail the gate, hence the explicit
+        // is_nan branch rather than a bare `<` comparison.
+        if r.ratio_vs_baseline.is_nan() || r.ratio_vs_baseline < bound {
+            failures.push(format!(
+                "{}: ratio {:.3} < bound {:.2} (throughput {:.1}/s)",
+                r.config.key(),
+                r.ratio_vs_baseline,
+                bound,
+                r.throughput,
+            ));
+        }
+    }
+    if failures.is_empty() {
+        println!("[prov-write] GATE PASS: all configs meet their same-run ratio bounds.");
+    } else {
+        panic!(
+            "[prov-write] GATE FAIL ({} row(s) below bound):\n  {}",
+            failures.len(),
+            failures.join("\n  ")
+        );
+    }
+}
+
+// ============================================================================
+// Criterion arms — statistical per-config write throughput
+// ============================================================================
+
+/// Micro-benchmark each config's single-write path under Criterion. These give
+/// the statistical throughput distribution; the standalone matrix (below)
+/// supplies the p50/p99 and same-run ratios Criterion cannot.
+fn bench_write_configs(c: &mut Criterion) {
+    let mut group = c.benchmark_group("provenance_write_throughput");
+    group.throughput(Throughput::Elements(1));
+
+    for &config in &Config::ALL {
+        let dir = TempDir::new().expect("temp dir");
+        let db = build_db(dir.path());
+        if config.has_constraint() {
+            db.unique_constraint(BENCH_LABEL, UNIQUE_PROP)
+                .enable()
+                .expect("enable unique constraint");
+        }
+        let mut rng = SmallRng::seed_from_u64(WORKLOAD_SEED);
+        group.bench_function(config.key(), |b| {
+            b.iter(|| black_box(one_write(&db, config, &mut rng)));
+        });
+    }
+    group.finish();
+}
+
+/// AC4 read spot-check: single-hop current-state read of a provenance-carrying
+/// node (target < 1µs p99) and temporal reconstruction of a provenance-carrying
+/// version (target < 10ms). These reuse the standard read paths; the point is
+/// that carrying provenance does not slow the read hot path.
+fn bench_read_spotchecks(c: &mut Criterion) {
+    // Seed a durable DB with provenance-carrying nodes; update one repeatedly
+    // to build reconstructable history.
+    let dir = TempDir::new().expect("temp dir");
+    let db = build_db(dir.path());
+    let mut rng = SmallRng::seed_from_u64(WORKLOAD_SEED);
+
+    let read_target = one_write(&db, Config::ProvenanceOnly, &mut rng);
+    for _ in 0..32 {
+        one_write(&db, Config::ProvenanceOnly, &mut rng);
+    }
+
+    // Capture a bi-temporal snapshot while the original provenance-carrying
+    // version is still the tx-current head, then supersede the node several
+    // times in later transactions. Reconstructing at this snapshot is a
+    // transaction-time-travel read that returns the original (now superseded)
+    // version — exercising the temporal reconstruction path.
+    let t_snapshot = time::now();
+    for _ in 0..8 {
+        let prov = build_provenance(&mut rng);
+        db.update_node_with_options(
+            read_target,
+            PropertyMapBuilder::new()
+                .insert("seq", rng.gen_range(0..i64::MAX))
+                .build(),
+            WriteRequestOptions::new().with_provenance(prov),
+        )
+        .expect("update_node_with_options");
+    }
+
+    let mut group = c.benchmark_group("provenance_read_spotchecks");
+    // AC4a: current-state single-hop read (<1µs p99 target).
+    group.bench_function("current_read_provenance_node", |b| {
+        b.iter(|| black_box(db.get_node(black_box(read_target)).expect("get_node")));
+    });
+    // AC4b: temporal reconstruction of a provenance-carrying version (<10ms).
+    group.bench_function("temporal_reconstruct_provenance_version", |b| {
+        b.iter(|| {
+            black_box(
+                db.get_node_at_time(black_box(read_target), t_snapshot, t_snapshot)
+                    .expect("get_node_at_time"),
+            )
+        });
+    });
+    group.finish();
+}
+
+/// AC5 recovery spot-check: crash-recover a provenance + constraint dataset and
+/// time the reopen. Runs at a reduced scale by default (`PROV_BENCH_RECOVERY_*`)
+/// to stay light in sandboxed CI; the reference scale is 10K nodes / 50K edges
+/// with a < 5s target (CI runs the full scale — see the guide).
+fn bench_recovery_provenance(c: &mut Criterion) {
+    let node_count: usize = std::env::var("PROV_BENCH_RECOVERY_NODES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(2_000);
+    let edge_count: usize = std::env::var("PROV_BENCH_RECOVERY_EDGES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(4_000);
+
+    // Populate a durable DB with provenance-carrying nodes + edges under an
+    // active uniqueness constraint, then drop it so the WAL/index is on disk.
+    let dir = TempDir::new().expect("temp dir");
+    {
+        let db = build_db(dir.path());
+        db.unique_constraint(BENCH_LABEL, UNIQUE_PROP)
+            .enable()
+            .expect("enable unique constraint");
+        let mut rng = SmallRng::seed_from_u64(WORKLOAD_SEED);
+        let mut ids: Vec<NodeId> = Vec::with_capacity(node_count);
+        for _ in 0..node_count {
+            ids.push(one_write(&db, Config::Composed, &mut rng));
+        }
+        for i in 0..edge_count {
+            let src = ids[i % node_count];
+            let tgt = ids[(i + 1) % node_count];
+            let prov = build_provenance(&mut rng);
+            db.create_edge_with_options(
+                src,
+                tgt,
+                "CONNECTS",
+                PropertyMapBuilder::new().insert("w", i as i64).build(),
+                WriteRequestOptions::new().with_provenance(prov),
+            )
+            .expect("create_edge_with_options");
+        }
+        // Drop persists WAL/index to disk.
+    }
+
+    let mut group = c.benchmark_group("provenance_recovery");
+    group.sample_size(10);
+    group.bench_function(
+        format!("reopen_{node_count}_nodes_{edge_count}_edges"),
+        |b| {
+            b.iter(|| {
+                let db = build_db(dir.path());
+                assert_eq!(db.node_count(), node_count);
+                black_box(db);
+            });
+        },
+    );
+    group.finish();
+}
+
+/// The matrix driver: measures all four configs same-run, prints the table,
+/// writes the JSON artifact, and (in `PROV_BENCH_GATE=1` mode) applies the
+/// self-gate. Runs as a Criterion "benchmark" so it participates in
+/// `cargo bench` and a gate panic yields a non-zero exit for CI.
+fn bench_matrix_and_gate(_c: &mut Criterion) {
+    let gate = std::env::var("PROV_BENCH_GATE").as_deref() == Ok("1");
+    let inject = std::env::var("PROV_BENCH_INJECT_REGRESSION")
+        .ok()
+        .and_then(|s| s.parse::<f64>().ok())
+        .unwrap_or(0.0);
+
+    let n_writes = matrix_writes(gate);
+    let results = run_matrix(n_writes, inject);
+    print_table(&results);
+    write_json_artifact(&results, n_writes, gate);
+
+    if gate {
+        apply_gate(&results);
+    }
+}
+
+criterion_group!(
+    name = benches;
+    config = common::configure_criterion();
+    targets = bench_matrix_and_gate,
+        bench_write_configs,
+        bench_read_spotchecks,
+        bench_recovery_provenance,
+);
+criterion_main!(benches);

--- a/benchmarks/performance-targets.json
+++ b/benchmarks/performance-targets.json
@@ -35,6 +35,36 @@
       "metric": "Storage overhead",
       "target": "<2X vs non-temporal",
       "rationale": "Acceptable overhead for bi-temporal tracking"
+    },
+    {
+      "metric": "provenance_write_composed_ratio",
+      "target": ">=0.80",
+      "rationale": "Issue #3383: write throughput with #3224 provenance AND a #3218 uniqueness constraint enabled must stay >=80% of the same-run no-trust baseline (measured back-to-back, hardware-variance-immune)"
+    },
+    {
+      "metric": "provenance_only_write_ratio",
+      "target": ">=0.85",
+      "rationale": "Issue #3383: attaching a #3224 provenance bundle to every write must keep throughput >=85% of the same-run baseline (WAL serializes extra source/confidence/note bytes)"
+    },
+    {
+      "metric": "constraint_active_write_ratio",
+      "target": ">=0.85",
+      "rationale": "Issue #3383: an active #3218 uniqueness constraint must keep write throughput >=85% of the same-run baseline (per-write reservation-index check on the commit path)"
+    },
+    {
+      "metric": "provenance_write_current_read_p99",
+      "target": "<1µs",
+      "rationale": "Issue #3383 (AC4): carrying provenance must not slow the current-state single-hop read hot path"
+    },
+    {
+      "metric": "provenance_temporal_reconstruct",
+      "target": "<10ms",
+      "rationale": "Issue #3383 (AC4): reconstructing a provenance-carrying historical version stays within the temporal-query budget"
+    },
+    {
+      "metric": "provenance_constraint_recovery_10k_50k",
+      "target": "<5s",
+      "rationale": "Issue #3383 (AC5): crash recovery of a provenance + uniqueness-constraint dataset at the 10K-node/50K-edge reference scale completes within the medium-dataset recovery budget"
     }
   ]
 }

--- a/benchmarks/performance-targets.json
+++ b/benchmarks/performance-targets.json
@@ -39,17 +39,27 @@
     {
       "metric": "provenance_write_composed_ratio",
       "target": ">=0.80",
-      "rationale": "Issue #3383: write throughput with #3224 provenance AND a #3218 uniqueness constraint enabled must stay >=80% of the same-run no-trust baseline (measured back-to-back, hardware-variance-immune)"
+      "rationale": "Issue #3383: on the CPU-bound arm (Async 1ms-flush, interleaved multi-pass, solo DB per config, so per-write trust CPU cost bottlenecks throughput) write throughput with #3224 provenance + #3218 uniqueness constraint enabled must stay >=80% of the same-run no-trust baseline (measured back-to-back, hardware-variance-immune). Composed folds the two per-write-CPU trust features; the #3351 chain is measured separately (see chain_active note)"
     },
     {
       "metric": "provenance_only_write_ratio",
       "target": ">=0.85",
-      "rationale": "Issue #3383: attaching a #3224 provenance bundle to every write must keep throughput >=85% of the same-run baseline (WAL serializes extra source/confidence/note bytes)"
+      "rationale": "Issue #3383: on the CPU-bound arm, attaching a #3224 provenance bundle to every write must keep throughput >=85% of the same-run baseline (WAL serializes extra source/confidence/note bytes)"
     },
     {
       "metric": "constraint_active_write_ratio",
       "target": ">=0.85",
-      "rationale": "Issue #3383: an active #3218 uniqueness constraint must keep write throughput >=85% of the same-run baseline (per-write reservation-index check on the commit path)"
+      "rationale": "Issue #3383: on the CPU-bound arm, an active #3218 uniqueness constraint must keep write throughput >=85% of the same-run baseline (per-write reservation-index check on the commit path)"
+    },
+    {
+      "metric": "chain_active_write_ratio",
+      "target": "observation (ungated in #3383 CPU-bound arm)",
+      "rationale": "Issue #3383: the #3351 tamper-evident hash chain is an async SHA-256 sealer sidecar. At the CPU-bound arm's ~100K+ writes/sec the sealer, not the writer's per-write enqueue CPU, is the throughput ceiling on a slow shared core, so the CPU-arm ratio measures sealer throughput (observed ~0.63-0.84) not per-write cost -- it is reported but NOT hard-gated here. The chain's >=0.90 overhead metric is owned and gated by the dedicated provenance_chain bench (Issue #3351) in its native GroupCommit regime"
+    },
+    {
+      "metric": "lineage_active_write_ratio",
+      "target": ">=0.80",
+      "rationale": "Issue #3383: on the CPU-bound arm, attaching a #3371 fact-to-fact derivation-lineage list (fixed small derived_from set) to every write must keep throughput >=80% of the same-run baseline (per-write in-memory lineage-index insert + source validation costs ~12%; bound set well below observed ~0.86-0.91 for shared-runner headroom)"
     },
     {
       "metric": "provenance_write_current_read_p99",

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -33,6 +33,7 @@ cargo bench --bench aletheiadb -- node_lookup
 | `id_generation` | ID allocation | ID generation throughput |
 | `string_interning` | String deduplication | Intern performance |
 | `temporal_vector` | Temporal vector queries | Time-travel with vectors |
+| `provenance_write_throughput` | "Cost of trust" write matrix (baseline vs provenance vs constraint vs composed) | Throughput ratio, p50/p99 latency, self-gate ([guide](benchmarks/cost-of-trust.md)) |
 
 ## Viewing Results
 

--- a/docs/benchmarks/cost-of-trust.md
+++ b/docs/benchmarks/cost-of-trust.md
@@ -1,0 +1,214 @@
+# The Cost of Trust — Provenance-Enabled Write Throughput (Issue #3383)
+
+AletheiaDB lets a writer record *why* a fact is trustworthy — attaching
+[**provenance**](../guides/provenance-hash-chain.md) (`source` / `confidence` /
+`note`, Issue #3224) and enforcing a [**uniqueness constraint**](../guides/mcp-query-tool.md)
+(Issue #3218). Neither is free. This page publishes what they cost on the write
+path, how the numbers are produced reproducibly, and the CI policy that keeps
+the overhead from regressing.
+
+The benchmark lives at
+[`benches/provenance_write_throughput.rs`](../../benches/provenance_write_throughput.rs).
+
+## The matrix
+
+Four configurations are measured **back-to-back in the same process run**, so
+every ratio is taken against a baseline captured on the same hardware in the
+same run — immune to cross-machine and cross-CI-runner timing variance:
+
+| Config              | Provenance (#3224) | Unique constraint (#3218) | What it isolates |
+|---------------------|:------------------:|:-------------------------:|------------------|
+| `baseline`          |         no         |            no             | reference, no trust features |
+| `provenance_only`   |        yes         |            no             | cost of serializing a provenance bundle per write |
+| `constraint_active` |         no         |            yes            | cost of the per-write uniqueness reservation check |
+| `composed`          |        yes         |            yes            | both together — the full "trusted write" cost |
+
+For each config the suite reports sustained **throughput (ops/sec)**,
+single-write **latency p50 / p99**, and the throughput **ratio vs the same-run
+baseline**.
+
+All four use a **durable GroupCommit** database (WAL fsync + index persistence,
+`DurabilityMode::GroupCommit { max_delay_ms: 10, max_batch_size: 200 }`), never
+the ephemeral `AletheiaDB::new()`, so the numbers reflect real fsync-batched
+commit cost. Each config runs against its own fresh `TempDir`.
+
+## The fixture (AC2 — reproducibility)
+
+The workload is fully deterministic: a fixed-seed `rand::rngs::SmallRng`
+(`WORKLOAD_SEED = 0x3383C0570F7405`) drives the identical write sequence on
+every run. Each write creates a `"Bench"` node with a fixed property shape:
+
+| Property  | Type   | Size / value |
+|-----------|--------|--------------|
+| `uid`     | i64    | process-unique monotonic id (satisfies the constraint, so constraint configs never error) |
+| `seq`     | i64    | seeded pseudo-random value |
+| `name`    | String | 16 ASCII bytes |
+| `payload` | String | 64 ASCII bytes |
+
+The provenance bundle attached by `provenance_only` / `composed`:
+
+| Field        | Value |
+|--------------|-------|
+| `source`     | `"prov-write-bench-3383"` |
+| `confidence` | `0.95` |
+| `note`       | 64 ASCII bytes |
+
+Every config writes the **identical property shape** — only the provenance
+attachment and the constraint declaration differ — so the measured delta is
+exactly the cost of the trust feature and nothing else.
+
+### How to run
+
+```bash
+# Full statistical run (Criterion arms + matrix table + JSON artifact)
+cargo bench --bench provenance_write_throughput
+
+# Fast reduced-scale smoke
+BENCH_SAMPLE_SIZE=10 BENCH_MEASUREMENT_TIME=1 BENCH_WARMUP_TIME=1 \
+  PROV_BENCH_WRITES=120 cargo bench --bench provenance_write_throughput
+
+# Self-gating mode (assert the ratio bounds; non-zero exit on violation)
+PROV_BENCH_GATE=1 cargo bench --bench provenance_write_throughput
+```
+
+Environment knobs:
+
+| Variable | Meaning | Default |
+|----------|---------|---------|
+| `PROV_BENCH_WRITES` | measured writes per config in the matrix | 240 (120 in gate mode) |
+| `PROV_BENCH_GATE` | `1` applies the same-run ratio gate (panics → non-zero exit) | off |
+| `PROV_BENCH_INJECT_REGRESSION` | fraction (e.g. `0.25`) to synthetically deflate `composed` throughput, to prove the gate fails | `0.0` |
+| `PROV_BENCH_JSON_OUT` | path for the JSON results artifact | `$CARGO_TARGET_DIR/provenance_write_throughput.json` |
+| `PROV_BENCH_RECOVERY_NODES` / `_EDGES` | recovery spot-check scale | 2000 / 4000 |
+| `BENCH_SAMPLE_SIZE` / `BENCH_MEASUREMENT_TIME` / `BENCH_WARMUP_TIME` | Criterion tuning (shared harness) | 50 / 5 / 3 |
+
+## Measured numbers (reference run)
+
+Captured in this sandbox at reduced scale
+(`BENCH_SAMPLE_SIZE=10 BENCH_MEASUREMENT_TIME=1 PROV_BENCH_WRITES=120`). The
+GroupCommit single-writer path is bounded by the ~10 ms batch timer, so
+per-write latency clusters near the batch delay and throughput ratios sit close
+to 1.0 — an honest "fsync dominates the commit, trust features are cheap"
+result. Absolute throughput is hardware- and scale-dependent; the **ratios** are
+the durable, portable signal.
+
+<!-- REFERENCE_NUMBERS_START -->
+| Config              | Throughput (ops/s) | p50 (µs) | p99 (µs) | Ratio vs baseline | Bound |
+|---------------------|-------------------:|---------:|---------:|------------------:|------:|
+| `baseline`          |             88.5   | 10820.0  | 11421.0  |            1.000  |  —    |
+| `provenance_only`   |             92.3   | 10806.8  | 11135.6  |            1.042  | ≥0.85 |
+| `constraint_active` |             92.3   | 10811.4  | 11146.3  |            1.043  | ≥0.85 |
+| `composed`          |             92.3   | 10803.2  | 11148.7  |            1.043  | ≥0.80 |
+<!-- REFERENCE_NUMBERS_END -->
+
+Read / recovery spot-checks from the same run: current-state read of a
+provenance-carrying node ≈ **43 ns** (target < 1µs p99); temporal
+reconstruction of a superseded provenance-carrying version ≈ **154 ns**
+(target < 10ms); reopen/recovery of a provenance + constraint dataset at the
+reduced 2000-node / 4000-edge sandbox scale ≈ **1.05 s** (reference scale 10K /
+50K, target < 5s).
+
+All four configs clear their bounds with wide margin: under GroupCommit the
+single-writer commit is bounded by the ~10 ms fsync batch timer, so the extra
+provenance serialization and constraint check are amortized into noise — the
+"cost of trust" is real but small. In this run the trust-enabled configs even
+measured *above* baseline (ratio ≈ 1.04); at this scale the same-run ratios sit
+within a few percent of 1.0 in either direction, which is exactly why the gate
+bounds (≥ 0.80 / ≥ 0.85) leave generous headroom for timing noise on shared
+runners rather than asserting a tight equality. An earlier reduced-scale run
+recorded `composed` at ratio 0.952 with a p99 of ~26 ms (occasional batch-timer
+alignment on the feature-heaviest write) — still comfortably above the 0.80
+bound.
+
+> Reference hardware note: these were captured on a shared CI-class sandbox
+> VM, not a dedicated performance rig. Treat absolute throughput as indicative
+> only; the same-run ratios are what the gate and this page assert.
+
+### Read / recovery spot-checks
+
+- **AC4 — reads unaffected by provenance.** `provenance_read_spotchecks`
+  benchmarks a current-state single-hop `get_node` on a provenance-carrying
+  node (target **< 1µs p99**) and a temporal reconstruction of a
+  provenance-carrying superseded version via `get_node_at_time` (target
+  **< 10ms**).
+- **AC5 — recovery of a trusted dataset.** `provenance_recovery` populates a
+  durable DB with provenance-carrying nodes and edges under an active
+  uniqueness constraint, drops it, and times the reopen. The default sandbox
+  scale is reduced (2000 nodes / 4000 edges); the **reference scale is 10K
+  nodes / 50K edges with a < 5s target** (the medium-dataset recovery budget).
+  The scheduled CI lane runs the arm at the reduced default; the reference
+  scale is reproduced by setting `PROV_BENCH_RECOVERY_NODES=10000
+  PROV_BENCH_RECOVERY_EDGES=50000` (also the configuration the dedicated
+  performance rig uses).
+
+## Overhead bounds and the CI gate (AC3 / AC6 / AC7)
+
+The self-gate (`PROV_BENCH_GATE=1`) computes the same-run ratios and **fails
+with a non-zero exit, naming the offending row**, when any config falls below
+its declared bound:
+
+| Config              | Bound (ratio vs same-run baseline) |
+|---------------------|:----------------------------------:|
+| `provenance_only`   | ≥ 0.85 |
+| `constraint_active` | ≥ 0.85 |
+| `composed`          | ≥ 0.80 (Issue #3383 hard success metric) |
+
+These bounds are also published in
+[`benchmarks/performance-targets.json`](../../benchmarks/performance-targets.json)
+as `provenance_write_composed_ratio`, `provenance_only_write_ratio`, and
+`constraint_active_write_ratio`.
+
+### CI policy (two lanes)
+
+- **Scheduled bench lane** (weekly/manual cron): runs the full
+  `provenance_write_throughput` target **with the gate enabled**
+  (`PROV_BENCH_GATE=1`). A gate failure hard-fails that job as an *alert* — it
+  does not block any pull request.
+- **Per-PR smoke**: runs a reduced-scale invocation
+  (`PROV_BENCH_WRITES=120`, no gate) as **informational / non-required**. It
+  never fails the PR. Shared-runner timing noise must not become a spurious
+  merge blocker.
+
+Flipping the per-PR smoke from informational to blocking is a one-line change
+once a week or two of scheduled-lane signal proves the gate is stable on the
+runner — and that flip is an operator decision, not part of this change.
+
+## JSON results artifact (AC6)
+
+Every matrix run writes a machine-readable JSON artifact to
+`$PROV_BENCH_JSON_OUT` (default `$CARGO_TARGET_DIR/provenance_write_throughput.json`).
+Schema `aletheiadb.provenance_write_throughput.v1`:
+
+```json
+{
+  "schema": "aletheiadb.provenance_write_throughput.v1",
+  "issue": 3383,
+  "durability_mode": "GroupCommit{max_delay_ms:10,max_batch_size:200}",
+  "workload_seed": "0x3383c0570f7405",
+  "writes_per_config": 120,
+  "gated": true,
+  "fixture": {
+    "label": "Bench",
+    "unique_property": "uid",
+    "name_bytes": 16,
+    "payload_bytes": 64,
+    "provenance": { "source": "prov-write-bench-3383", "confidence": 0.95, "note_bytes": 64 }
+  },
+  "configs": [
+    {
+      "config": "baseline",
+      "throughput": 0.0,
+      "p50_us": 0.0,
+      "p99_us": 0.0,
+      "ratio_vs_baseline": 1.0,
+      "bound": 1.0,
+      "pass": true
+    }
+  ]
+}
+```
+
+Each entry in `configs` carries `throughput` (ops/sec), `p50_us`, `p99_us`,
+`ratio_vs_baseline`, the declared `bound`, and the boolean `pass`
+(`ratio_vs_baseline >= bound`; always `true` for `baseline`). A CI job can
+publish or diff this artifact without parsing benchmark stdout.

--- a/docs/benchmarks/cost-of-trust.md
+++ b/docs/benchmarks/cost-of-trust.md
@@ -2,41 +2,120 @@
 
 AletheiaDB lets a writer record *why* a fact is trustworthy — attaching
 [**provenance**](../guides/provenance-hash-chain.md) (`source` / `confidence` /
-`note`, Issue #3224) and enforcing a [**uniqueness constraint**](../guides/mcp-query-tool.md)
-(Issue #3218). Neither is free. This page publishes what they cost on the write
-path, how the numbers are produced reproducibly, and the CI policy that keeps
-the overhead from regressing.
+`note`, Issue #3224), enforcing a [**uniqueness constraint**](../guides/mcp-query-tool.md)
+(Issue #3218), sealing writes into a [**tamper-evident hash chain**](../guides/provenance-hash-chain.md)
+(Issue #3351), and declaring [**fact-to-fact derivation lineage**](../guides/derivation-lineage.md)
+(Issue #3371). None of it is free. This page publishes what these features cost
+on the write path, how the numbers are produced reproducibly, and the CI policy
+that keeps the overhead from regressing.
 
 The benchmark lives at
 [`benches/provenance_write_throughput.rs`](../../benches/provenance_write_throughput.rs).
 
+## Two measurement regimes — and which one is the gate
+
+A single-writer **GroupCommit** database is bounded by the ~10 ms fsync **batch
+timer**: the writer blocks on the timer and is otherwise idle, so per-write CPU
+cost *up to ~10 ms* is completely absorbed with **zero** throughput impact.
+Gating write throughput on that regime would be a rubber stamp — a realistic
+single-digit-microsecond trust-path regression is roughly **1000×** below the
+masking window and would be invisible to the gate. (An unmodified single-writer
+GroupCommit run is also prone to *spurious* ratio failures from batch-timer
+alignment noise, so it is simultaneously blind to real regressions and prone to
+false alarms.)
+
+So the suite measures **two regimes** per config:
+
+| Arm | Durability mode | What it shows | Gated? |
+|-----|-----------------|---------------|:------:|
+| **CPU-bound** | `Async { flush_interval_ms: 1 }`, **interleaved multi-pass, solo DB per config** | the 1 ms flush drains the WAL ring fast enough that the single writer never blocks on flush backpressure, so per-write **CPU cost** of the trust feature is the throughput bottleneck (~100K+ writes/sec) | **YES** — the ratio bounds gate on this arm |
+| **Latency** | `GroupCommit { max_delay_ms: 10, max_batch_size: 200 }` | single-writer **p50 / p99** latency (fsync-batch-timer-dominated) | **NO** — observation only |
+
+Two design details make the CPU-bound arm both *sensitive* and *stable*:
+
+- **1 ms flush, not the default 100 ms.** At the default flush interval the
+  single writer fills the WAL ring and then *blocks on the background flush
+  thread's drain rate* (~3K writes/sec) — that is **flush-bound**, not
+  CPU-bound, and an injected per-write CPU cost is completely invisible (it just
+  fills idle wait). A 1 ms flush keeps the drain ahead of the writer, so
+  throughput tracks writer CPU (~100K+ writes/sec, the issue's high-throughput
+  regime).
+- **Interleaved multi-pass, one DB alive at a time.** Each `(pass, config)` cell
+  builds a fresh solo DB, times `CPU_ARM_BATCH` (5000) writes, and drops it,
+  repeating for `writes / batch` passes. This (a) cancels the shared VM's speed
+  drift — each config is measured in many temporally-adjacent slices, not one
+  long slice, so the same-run ratio reflects per-write cost rather than which
+  config ran during a fast/slow patch; and (b) keeps exactly one WAL flush
+  thread / chain sealer alive at any instant (concurrent per-config flush
+  threads otherwise create chaotic contention that lets a heavier config
+  spuriously *out*-measure a lighter one).
+
+The CPU-bound arm is where a real trust-path regression is *detectable*: the
+[injection acceptance test](#the-injection-acceptance-test-proving-the-gate-catches-a-real-regression)
+below shows a real **5 µs/write** busy-spin injected into the composed write
+path **drops the CPU-bound composed ratio from ~0.92 to ~0.52 and trips the
+gate**, while the very same injection barely moves the GroupCommit p50/p99 — the
+masking effect, made visible.
+
 ## The matrix
 
-Four configurations are measured **back-to-back in the same process run**, so
+Six configurations are measured **back-to-back in the same process run**, so
 every ratio is taken against a baseline captured on the same hardware in the
 same run — immune to cross-machine and cross-CI-runner timing variance:
 
-| Config              | Provenance (#3224) | Unique constraint (#3218) | What it isolates |
-|---------------------|:------------------:|:-------------------------:|------------------|
-| `baseline`          |         no         |            no             | reference, no trust features |
-| `provenance_only`   |        yes         |            no             | cost of serializing a provenance bundle per write |
-| `constraint_active` |         no         |            yes            | cost of the per-write uniqueness reservation check |
-| `composed`          |        yes         |            yes            | both together — the full "trusted write" cost |
+| Config              | Trust feature | CPU-bound bound |
+|---------------------|---------------|:---------------:|
+| `baseline`          | none (reference) | — |
+| `provenance_only`   | #3224 provenance bundle per write | ≥ 0.85 |
+| `constraint_active` | #3218 per-write uniqueness reservation check | ≥ 0.85 |
+| `chain_active`      | #3351 tamper-evident provenance hash chain | **observation (ungated)** |
+| `lineage_active`    | #3371 fact-to-fact derivation lineage per write | ≥ 0.80 |
+| `composed`          | provenance + constraint together | ≥ 0.80 |
 
-For each config the suite reports sustained **throughput (ops/sec)**,
-single-write **latency p50 / p99**, and the throughput **ratio vs the same-run
-baseline**.
+For each config the suite reports the CPU-bound arm's sustained **throughput
+(ops/sec)** and **ratio vs the same-run baseline** (the gated signal), plus the
+GroupCommit arm's single-write **p50 / p99** latency (an ungated observation).
 
-All four use a **durable GroupCommit** database (WAL fsync + index persistence,
-`DurabilityMode::GroupCommit { max_delay_ms: 10, max_batch_size: 200 }`), never
-the ephemeral `AletheiaDB::new()`, so the numbers reflect real fsync-batched
-commit cost. Each config runs against its own fresh `TempDir`.
+### What `composed` folds in — and how chain / lineage / auth are handled
+
+`composed` = **provenance (#3224) + uniqueness constraint (#3218)**: the two
+write-path trust features whose cost the CPU-bound arm measures as genuine
+**per-write CPU**, and which compose cleanly in a single public write
+(provenance is a per-write `WriteRequestOptions`, the constraint a per-label
+toggle). Three other shipped trust features are handled specially, for honest,
+documented reasons:
+
+- **Hash chain (#3351)** is its own `chain_active` row, reported as an
+  **observation but not hard-gated here** (and not in `composed`). The chain is
+  an async SHA-256 sealer sidecar; at the CPU-bound arm's ~100K+ writes/sec the
+  **sealer** — not the writer's per-write enqueue CPU — becomes the throughput
+  ceiling on a slow shared core, so the CPU-arm ratio reflects *sealer
+  throughput* (observed ~0.63–0.84 here), not per-write cost. Hard-gating it on
+  this regime would spuriously fail on sandbox hardware where the sealer is
+  slow. The chain's **≥ 0.90 overhead metric is owned and gated by the dedicated
+  [`provenance_chain`](../../benches/provenance_chain.rs) bench (#3351)** in its
+  native GroupCommit regime, where the fsync batch timer paces writes so the
+  sealer keeps up.
+- **Derivation lineage (#3371)** is its own `lineage_active` row, not in
+  `composed`: the only *public* write API attaching a `derived_from` list is
+  `AletheiaDB::create_node_with_lineage`, which does not also accept a provenance
+  bundle — the combined `create_node_with_options_and_lineage` is `pub(crate)`
+  (MCP-internal). Rather than silently drop provenance to make lineage fit,
+  lineage is reported standalone and gated on its own per-write-CPU cost.
+- **Auth principal stamping (#3350)** is **scoped out** of this matrix: stamping
+  a principal into version provenance requires a *served* authenticated session
+  (`AletheiaMcpServer::with_auth` / the HTTP surface), not the embedded
+  in-process `AletheiaDB` API these benches drive, so its per-write cost cannot
+  be measured here. **Follow-up:** a served-surface auth-stamping write
+  micro-benchmark is tracked as a future addition (it needs an in-process
+  authenticated harness); its cost is expected to be dominated by the same
+  provenance-serialization path `provenance_only` already bounds.
 
 ## The fixture (AC2 — reproducibility)
 
-The workload is fully deterministic: a fixed-seed `rand::rngs::SmallRng`
-(`WORKLOAD_SEED = 0x3383C0570F7405`) drives the identical write sequence on
-every run. Each write creates a `"Bench"` node with a fixed property shape:
+The workload is deterministic: a fixed-seed `rand::rngs::SmallRng`
+(`WORKLOAD_SEED = 0x3383c0570f740500`) drives the write sequence on every run.
+Each write creates a `"Bench"` node with a fixed property **shape**:
 
 | Property  | Type   | Size / value |
 |-----------|--------|--------------|
@@ -53,9 +132,16 @@ The provenance bundle attached by `provenance_only` / `composed`:
 | `confidence` | `0.95` |
 | `note`       | 64 ASCII bytes |
 
-Every config writes the **identical property shape** — only the provenance
-attachment and the constraint declaration differ — so the measured delta is
-exactly the cost of the trust feature and nothing else.
+The `lineage_active` config derives every write from a fixed set of
+`LINEAGE_REFS_PER_WRITE = 2` source facts (drawn from `LINEAGE_SOURCES = 4`
+seeded `"Src"` nodes).
+
+Every config writes the **identical property shape** — only the trust
+attachment differs. Note that the seeded RNG *value* stream diverges across
+configs (provenance-carrying writes draw extra bytes for the `note`), so the
+configs are not byte-for-byte identical workloads; the property **shape** — the
+thing that governs serialized write cost — is identical, and that is what the
+same-run ratio isolates.
 
 ### How to run
 
@@ -63,152 +149,204 @@ exactly the cost of the trust feature and nothing else.
 # Full statistical run (Criterion arms + matrix table + JSON artifact)
 cargo bench --bench provenance_write_throughput
 
-# Fast reduced-scale smoke
+# Fast reduced-scale smoke (fewer passes)
 BENCH_SAMPLE_SIZE=10 BENCH_MEASUREMENT_TIME=1 BENCH_WARMUP_TIME=1 \
-  PROV_BENCH_WRITES=120 cargo bench --bench provenance_write_throughput
+  PROV_BENCH_WRITES=10000 cargo bench --bench provenance_write_throughput
 
-# Self-gating mode (assert the ratio bounds; non-zero exit on violation)
+# Self-gating mode (assert the CPU-bound ratio bounds; non-zero exit on violation)
 PROV_BENCH_GATE=1 cargo bench --bench provenance_write_throughput
+
+# Prove the gate catches a REAL regression: inject a real 5µs busy-spin into
+# the composed per-write path. The CPU-bound composed ratio drops from ~0.92 to
+# ~0.52 and the gate trips, naming the composed row:
+PROV_BENCH_GATE=1 PROV_BENCH_INJECT_SPIN_US=5 \
+  cargo bench --bench provenance_write_throughput
 ```
 
 Environment knobs:
 
 | Variable | Meaning | Default |
 |----------|---------|---------|
-| `PROV_BENCH_WRITES` | measured writes per config in the matrix | 240 (120 in gate mode) |
-| `PROV_BENCH_GATE` | `1` applies the same-run ratio gate (panics → non-zero exit) | off |
-| `PROV_BENCH_INJECT_REGRESSION` | fraction (e.g. `0.25`) to synthetically deflate `composed` throughput, to prove the gate fails | `0.0` |
+| `PROV_BENCH_WRITES` | timed writes per config on the CPU-bound arm (across `writes / 5000` interleaved passes) | 50000 |
+| `PROV_BENCH_GATE` | `1` applies the CPU-bound ratio gate + the AC5 recovery `<5s` assertion (panics → non-zero exit) | off |
+| `PROV_BENCH_INJECT_SPIN_US` | microseconds of **real** `black_box`'d busy-spin injected into the composed write path, to prove the gate detects a genuine per-write CPU regression | `0.0` |
 | `PROV_BENCH_JSON_OUT` | path for the JSON results artifact | `$CARGO_TARGET_DIR/provenance_write_throughput.json` |
-| `PROV_BENCH_RECOVERY_NODES` / `_EDGES` | recovery spot-check scale | 2000 / 4000 |
+| `PROV_BENCH_RECOVERY_NODES` / `_EDGES` | recovery spot-check scale (10000 / 50000 = the manual/perf-rig reference scale) | 2000 / 4000 |
 | `BENCH_SAMPLE_SIZE` / `BENCH_MEASUREMENT_TIME` / `BENCH_WARMUP_TIME` | Criterion tuning (shared harness) | 50 / 5 / 3 |
 
 ## Measured numbers (reference run)
 
-Captured in this sandbox at reduced scale
-(`BENCH_SAMPLE_SIZE=10 BENCH_MEASUREMENT_TIME=1 PROV_BENCH_WRITES=120`). The
-GroupCommit single-writer path is bounded by the ~10 ms batch timer, so
-per-write latency clusters near the batch delay and throughput ratios sit close
-to 1.0 — an honest "fsync dominates the commit, trust features are cheap"
-result. Absolute throughput is hardware- and scale-dependent; the **ratios** are
-the durable, portable signal.
+Captured in this sandbox (`PROV_BENCH_WRITES=50000`, 10 interleaved passes).
+Absolute throughput is hardware-dependent; the **CPU-bound ratios** are the
+durable, portable signal. The `gc p50/p99` columns are the ungated GroupCommit
+**latency observation** (fsync-batch-timer-dominated — **not** the overhead
+gate; its p99 occasionally spikes to tens of ms on batch-timer alignment, which
+is exactly why latency is not gated).
 
 <!-- REFERENCE_NUMBERS_START -->
-| Config              | Throughput (ops/s) | p50 (µs) | p99 (µs) | Ratio vs baseline | Bound |
-|---------------------|-------------------:|---------:|---------:|------------------:|------:|
-| `baseline`          |             88.5   | 10820.0  | 11421.0  |            1.000  |  —    |
-| `provenance_only`   |             92.3   | 10806.8  | 11135.6  |            1.042  | ≥0.85 |
-| `constraint_active` |             92.3   | 10811.4  | 11146.3  |            1.043  | ≥0.85 |
-| `composed`          |             92.3   | 10803.2  | 11148.7  |            1.043  | ≥0.80 |
+| Config              | CPU-bound tput (ops/s) | CPU-bound ratio | Bound | gc p50 (µs) | gc p99 (µs) |
+|---------------------|-----------------------:|----------------:|:-----:|------------:|------------:|
+| `baseline`          | 163281 | 1.000 | — | 10823 | 11389 |
+| `provenance_only`   | 159816 | 0.979 | ≥0.85 | 10861 | 11177 |
+| `constraint_active` | 163660 | 1.002 | ≥0.85 | 10921 | 11345 |
+| `chain_active`      | 128983 | 0.790 | obs | 10932 | 22452 |
+| `lineage_active`    | 149569 | 0.916 | ≥0.80 | 10784 | 11481 |
+| `composed`          | 150780 | 0.923 | ≥0.80 | 10836 | 11409 |
 <!-- REFERENCE_NUMBERS_END -->
 
-Read / recovery spot-checks from the same run: current-state read of a
-provenance-carrying node ≈ **43 ns** (target < 1µs p99); temporal
-reconstruction of a superseded provenance-carrying version ≈ **154 ns**
-(target < 10ms); reopen/recovery of a provenance + constraint dataset at the
-reduced 2000-node / 4000-edge sandbox scale ≈ **1.05 s** (reference scale 10K /
-50K, target < 5s).
-
-All four configs clear their bounds with wide margin: under GroupCommit the
-single-writer commit is bounded by the ~10 ms fsync batch timer, so the extra
-provenance serialization and constraint check are amortized into noise — the
-"cost of trust" is real but small. In this run the trust-enabled configs even
-measured *above* baseline (ratio ≈ 1.04); at this scale the same-run ratios sit
-within a few percent of 1.0 in either direction, which is exactly why the gate
-bounds (≥ 0.80 / ≥ 0.85) leave generous headroom for timing noise on shared
-runners rather than asserting a tight equality. An earlier reduced-scale run
-recorded `composed` at ratio 0.952 with a p99 of ~26 ms (occasional batch-timer
-alignment on the feature-heaviest write) — still comfortably above the 0.80
-bound.
+Stability across three back-to-back unmodified gated runs (all **GATE PASS**):
+`provenance_only` 0.938–0.979, `constraint_active` 0.959–1.002,
+`lineage_active` 0.858–0.916, `composed` 0.895–0.934 — every gated row clears
+its bound with margin every time. `chain_active` is the ungated observation and
+swings more (0.63–0.84) with sealer contention, confirming why it is not gated
+here.
 
 > Reference hardware note: these were captured on a shared CI-class sandbox
 > VM, not a dedicated performance rig. Treat absolute throughput as indicative
-> only; the same-run ratios are what the gate and this page assert.
+> only; the same-run CPU-bound ratios are what the gate and this page assert.
+
+### The injection acceptance test (proving the gate catches a real regression)
+
+The gate's whole value is that it *detects a real per-write CPU regression in a
+trust path*. That is demonstrated directly, not asserted (both runs at
+`PROV_BENCH_WRITES=50000`):
+
+<!-- INJECTION_EVIDENCE_START -->
+- **Control** (`PROV_BENCH_INJECT_SPIN_US=0`): composed **150780 ops/s, ratio
+  0.923 ≥ 0.80 → gate PASSES** (all gated rows pass).
+- **With a real 5 µs/write busy-spin** (`PROV_BENCH_INJECT_SPIN_US=5`): composed
+  drops to **82380 ops/s, ratio 0.521 < 0.80 → gate TRIPS**, naming the
+  `composed` row — while every *other* gated row still passes (provenance 0.953,
+  constraint 0.970, lineage 0.894), because the injection targets only the
+  composed path. The same 5 µs injection leaves the GroupCommit latency arm's
+  p50 unchanged (~10.8 ms, batch-timer-bound), which is exactly why the
+  fsync-dominated arm cannot be the gate.
+<!-- INJECTION_EVIDENCE_END -->
+
+A 5 µs/write regression is ~44 % of the ~11 µs composed write and is caught
+unambiguously. The injection is a real `black_box`'d busy-spin (`busy_spin_us`),
+**not** an arithmetic deflation of the reported throughput — so the "seeded
+synthetic regression fails CI" success metric injects genuine work through the
+actual write loop.
 
 ### Read / recovery spot-checks
 
-- **AC4 — reads unaffected by provenance.** `provenance_read_spotchecks`
-  benchmarks a current-state single-hop `get_node` on a provenance-carrying
-  node (target **< 1µs p99**) and a temporal reconstruction of a
-  provenance-carrying superseded version via `get_node_at_time` (target
-  **< 10ms**).
+- **AC4 — reads unaffected by provenance.** The suite computes a **real** p99
+  (nearest-rank, from per-op samples — not a Criterion mean) for a current-state
+  single-hop `get_node` on a provenance-carrying node (target **< 1µs p99**) and
+  a temporal reconstruction of a provenance-carrying superseded version via
+  `get_node_at_time` (target **< 10ms**). These are **ungated observations**
+  (like the write-latency arm): in-sandbox they clear their targets with >20×
+  margin, so hard-gating them would only invite scheduler-hiccup false-positives.
+  <!-- READ_SPOTCHECK_START -->
+  Reference run: current read p99 ≈ **0.19 µs** (p50 ≈ 0.08 µs); temporal
+  reconstruct p99 ≈ **0.32 µs** (p50 ≈ 0.19 µs) — both far inside target.
+  <!-- READ_SPOTCHECK_END -->
 - **AC5 — recovery of a trusted dataset.** `provenance_recovery` populates a
-  durable DB with provenance-carrying nodes and edges under an active
-  uniqueness constraint, drops it, and times the reopen. The default sandbox
-  scale is reduced (2000 nodes / 4000 edges); the **reference scale is 10K
-  nodes / 50K edges with a < 5s target** (the medium-dataset recovery budget).
-  The scheduled CI lane runs the arm at the reduced default; the reference
-  scale is reproduced by setting `PROV_BENCH_RECOVERY_NODES=10000
-  PROV_BENCH_RECOVERY_EDGES=50000` (also the configuration the dedicated
-  performance rig uses).
+  durable DB with provenance-carrying nodes and edges under an active uniqueness
+  constraint, drops it, and times the reopen. Under `PROV_BENCH_GATE=1` the arm
+  **asserts the reopen completes in < 5s** (a hard-fail alert on the scheduled
+  lane — never a PR blocker). The **scheduled CI lane exercises that assertion at
+  the reduced default (2000 nodes / 4000 edges)**: the dataset *build* is a
+  single-writer GroupCommit populate (~10 ms/commit), so a 60K-write 10K/50K
+  dataset would take ~10 min to *build* — too slow for the shared CI job. The
+  **10K-node / 50K-edge reference scale (the medium-dataset < 5s budget) is
+  reproduced manually / on the performance rig** via
+  `PROV_BENCH_RECOVERY_NODES=10000 PROV_BENCH_RECOVERY_EDGES=50000` — it is the
+  *reopen* (index-snapshot load + WAL tail replay), not the build, that the < 5s
+  budget governs. At the reduced 50/50 smoke scale the reopen completes in
+  <!-- RECOVERY_SPOTCHECK_START -->< 0.01 s<!-- RECOVERY_SPOTCHECK_END -->.
 
 ## Overhead bounds and the CI gate (AC3 / AC6 / AC7)
 
-The self-gate (`PROV_BENCH_GATE=1`) computes the same-run ratios and **fails
-with a non-zero exit, naming the offending row**, when any config falls below
-its declared bound:
+The self-gate (`PROV_BENCH_GATE=1`) computes the same-run **CPU-bound** ratios
+and **fails with a non-zero exit, naming the offending row**, when any config
+falls below its declared bound:
 
-| Config              | Bound (ratio vs same-run baseline) |
-|---------------------|:----------------------------------:|
+| Config              | Bound (CPU-bound ratio vs same-run baseline) |
+|---------------------|:--------------------------------------------:|
 | `provenance_only`   | ≥ 0.85 |
 | `constraint_active` | ≥ 0.85 |
-| `composed`          | ≥ 0.80 (Issue #3383 hard success metric) |
+| `chain_active`      | **observation — ungated here** (≥ 0.90 gated by the #3351 `provenance_chain` bench) |
+| `lineage_active`    | ≥ 0.80 |
+| `composed`          | ≥ 0.80 (Issue #3383 hard success metric; provenance + constraint) |
 
 These bounds are also published in
 [`benchmarks/performance-targets.json`](../../benchmarks/performance-targets.json)
-as `provenance_write_composed_ratio`, `provenance_only_write_ratio`, and
-`constraint_active_write_ratio`.
+as `provenance_write_composed_ratio`, `provenance_only_write_ratio`,
+`constraint_active_write_ratio`, `chain_active_write_ratio` (recorded as an
+observation, not gated here), and `lineage_active_write_ratio`.
 
 ### CI policy (two lanes)
 
 - **Scheduled bench lane** (weekly/manual cron): runs the full
   `provenance_write_throughput` target **with the gate enabled**
-  (`PROV_BENCH_GATE=1`). A gate failure hard-fails that job as an *alert* — it
-  does not block any pull request.
-- **Per-PR smoke**: runs a reduced-scale invocation
-  (`PROV_BENCH_WRITES=120`, no gate) as **informational / non-required**. It
-  never fails the PR. Shared-runner timing noise must not become a spurious
-  merge blocker.
+  (`PROV_BENCH_GATE=1`), including the recovery `< 5s` assertion at the reduced
+  default scale (2000/4000 — the 10K/50K reference is manual/perf-rig, see AC5
+  above). A gate failure (CPU-bound ratio below bound, or recovery ≥ 5s)
+  hard-fails that job as an *alert* — it does not block any pull request.
+- **Per-PR smoke**: runs a reduced-scale invocation (no gate) as
+  **informational / non-required** (`continue-on-error: true`). It never fails
+  the PR. Shared-runner timing noise must not become a spurious merge blocker.
 
 Flipping the per-PR smoke from informational to blocking is a one-line change
-once a week or two of scheduled-lane signal proves the gate is stable on the
-runner — and that flip is an operator decision, not part of this change.
+(drop `continue-on-error`) once a week or two of scheduled-lane signal proves
+the gate is stable on the runner — and that flip is an operator decision, not
+part of this change.
 
 ## JSON results artifact (AC6)
 
 Every matrix run writes a machine-readable JSON artifact to
 `$PROV_BENCH_JSON_OUT` (default `$CARGO_TARGET_DIR/provenance_write_throughput.json`).
-Schema `aletheiadb.provenance_write_throughput.v1`:
+Schema `aletheiadb.provenance_write_throughput.v2` (bumped from v1: per-config
+entries now carry `cpu_throughput` / `cpu_ratio_vs_baseline` from the gated
+CPU-bound arm and `gc_p50_us` / `gc_p99_us` from the ungated latency arm — the
+v1 single-arm `throughput` / `ratio_vs_baseline` fields are replaced; the doc
+also records `gated_arm` / `latency_arm` metadata, `injected_spin_us`,
+`composed_contains`, and `auth_stamping_scoped_out`):
 
 ```json
 {
-  "schema": "aletheiadb.provenance_write_throughput.v1",
+  "schema": "aletheiadb.provenance_write_throughput.v2",
   "issue": 3383,
-  "durability_mode": "GroupCommit{max_delay_ms:10,max_batch_size:200}",
-  "workload_seed": "0x3383c0570f7405",
-  "writes_per_config": 120,
-  "gated": true,
-  "fixture": {
-    "label": "Bench",
-    "unique_property": "uid",
-    "name_bytes": 16,
-    "payload_bytes": 64,
-    "provenance": { "source": "prov-write-bench-3383", "confidence": 0.95, "note_bytes": 64 }
+  "gated_arm": {
+    "regime": "cpu_bound",
+    "durability_mode": "Async{flush_interval_ms:1}",
+    "measurement": "interleaved multi-pass, solo DB per config",
+    "rationale": "1ms flush drains the WAL ring fast enough that the single writer never blocks on flush backpressure, so per-write trust-feature CPU cost bottlenecks throughput; this is the gated arm. chain_active is reported but ungated (async sealer ceiling, not per-write CPU)."
   },
+  "latency_arm": {
+    "regime": "latency_observation",
+    "durability_mode": "GroupCommit{max_delay_ms:10,max_batch_size:200}",
+    "gated": false,
+    "rationale": "single-writer fsync-batch-timer-dominated p50/p99; masks CPU cost, NOT gated"
+  },
+  "injected_spin_us": 0.0,
+  "workload_seed": "0x3383c0570f740500",
+  "writes_per_config": 50000,
+  "gated": true,
+  "composed_contains": ["provenance", "constraint"],
+  "chain_gated_here": false,
+  "auth_stamping_scoped_out": true,
+  "fixture": { "label": "Bench", "unique_property": "uid", "name_bytes": 16, "payload_bytes": 64, "lineage_sources": 4, "lineage_refs_per_write": 2, "provenance": { "source": "prov-write-bench-3383", "confidence": 0.95, "note_bytes": 64 } },
   "configs": [
     {
-      "config": "baseline",
-      "throughput": 0.0,
-      "p50_us": 0.0,
-      "p99_us": 0.0,
-      "ratio_vs_baseline": 1.0,
-      "bound": 1.0,
-      "pass": true
+      "config": "composed",
+      "cpu_throughput": 150779.8,
+      "cpu_ratio_vs_baseline": 0.923,
+      "bound": 0.80,
+      "gated": true,
+      "pass": true,
+      "gc_p50_us": 10836.0,
+      "gc_p99_us": 11409.0
     }
   ]
 }
 ```
 
-Each entry in `configs` carries `throughput` (ops/sec), `p50_us`, `p99_us`,
-`ratio_vs_baseline`, the declared `bound`, and the boolean `pass`
-(`ratio_vs_baseline >= bound`; always `true` for `baseline`). A CI job can
-publish or diff this artifact without parsing benchmark stdout.
+Each entry in `configs` carries the CPU-bound `cpu_throughput` (ops/sec) and
+`cpu_ratio_vs_baseline`, the declared `bound` (JSON `null` for the ungated
+`baseline` and `chain_active` rows), a `gated` boolean, the boolean `pass`
+(`cpu_ratio_vs_baseline >= bound`; always `true` for ungated rows), and the
+ungated GroupCommit `gc_p50_us` / `gc_p99_us`. A CI job can publish or diff this
+artifact without parsing benchmark stdout.


### PR DESCRIPTION
## What this measures — "the cost of trust" (Issue #3383)

A provenance-enabled write-throughput benchmark suite that quantifies the write-path cost of AletheiaDB's shipped trust features and self-gates against regression. Configs are measured **back-to-back in the same process run** (same-run baseline → immune to cross-machine / cross-CI timing variance).

**Bench-only + docs + CI wiring. No core `src` logic changed.**

### ⚠️ Rework (this revision): the gate now measures a REAL CPU-bound arm

Adversarial review found the original gate measured **single-writer GroupCommit**, where the ~10 ms fsync **batch timer** absorbs up to ~10 ms of injected per-write CPU with **zero** throughput impact — so a real single-digit-µs trust-path regression was ~1000× below the masking window and **invisible**, while batch-timer noise caused **spurious** failures (an unmodified run once false-failed `provenance_only` at 0.825). The gate was simultaneously a rubber stamp *and* flaky.

**Fix:** gate on a genuinely CPU-bound arm.

| Arm | Durability | What it shows | Gated? |
|---|---|---|:---:|
| **CPU-bound** | `Async { flush_interval_ms: 1 }`, interleaved multi-pass, solo DB per config | 1 ms flush keeps the WAL drain ahead of the writer (~100K+ writes/sec, the issue's high-throughput regime) so per-write **trust CPU** is the bottleneck | **YES** |
| **Latency** | single-writer `GroupCommit` | single-write **p50/p99** (fsync-batch-timer-dominated) | **No** — observation |

Interleaved passes cancel VM speed drift, and a solo DB per config keeps exactly one WAL flush thread / chain sealer alive at a time (concurrent per-config flush threads otherwise let a heavier config spuriously out-measure a lighter one).

### The matrix (reference run: `PROV_BENCH_WRITES=50000`, 10 interleaved passes)

| Config | CPU-bound tput (ops/s) | CPU-bound ratio | Bound | gc p50 (µs) | gc p99 (µs) |
|---|---:|---:|:---:|---:|---:|
| `baseline` | 163281 | 1.000 | — | 10823 | 11389 |
| `provenance_only` (#3224) | 159816 | 0.979 | ≥0.85 | 10861 | 11177 |
| `constraint_active` (#3218) | 163660 | 1.002 | ≥0.85 | 10921 | 11345 |
| `chain_active` (#3351) | 128983 | 0.790 | **obs** | 10932 | 22452 |
| `lineage_active` (#3371) | 149569 | 0.916 | ≥0.80 | 10784 | 11481 |
| `composed` (prov+constraint) | 150780 | 0.923 | ≥0.80 | 10836 | 11409 |

`composed` = **provenance + constraint** (the two write-path trust features the CPU-bound arm measures as genuine per-write CPU). `gc p50/p99` is the **ungated** latency observation (its p99 occasionally spikes to tens of ms on batch-timer alignment — exactly why latency is not gated).

### 🎯 Acceptance test — the gate now catches a REAL regression (load-bearing)

A real `black_box`'d busy-spin (`PROV_BENCH_INJECT_SPIN_US`) injected into the composed write path, both runs at `PROV_BENCH_WRITES=50000`:

| Run | composed tput | composed ratio | Gate |
|---|---:|---:|---|
| **Control** (spin=0) | 150780 | **0.923** ≥ 0.80 | **PASS** (all gated rows pass) |
| **Injected 5 µs/write** | 82380 | **0.521** < 0.80 | **FAIL — names `composed`** |

Under injection every *other* gated row still passes (provenance 0.953, constraint 0.970, lineage 0.894) — the 5 µs hits only the composed path. The same 5 µs leaves the GroupCommit latency arm's p50 unchanged (~10.8 ms, batch-timer-bound), demonstrating exactly why the fsync-dominated arm cannot be the gate. A 5 µs/write regression is ~44 % of the ~11 µs composed write and is caught unambiguously. This replaces the old `PROV_BENCH_INJECT_REGRESSION` (which merely multiplied the output number — tested only the gate's arithmetic).

### Stability (3× unmodified runs, all GATE PASS)

`provenance_only` 0.938–0.979 · `constraint_active` 0.959–1.002 · `lineage_active` 0.858–0.916 · `composed` 0.895–0.934 — every gated row clears its bound with margin every time. (`lineage` bound widened 0.85 → 0.80 after run 3 landed at 0.858.) `chain_active` is the ungated observation and swings 0.63–0.84 with sealer contention — confirming why it is not gated here.

## AC-by-AC evidence

| AC | Requirement | Evidence |
|---|---|---|
| AC1 | Provenance-enabled write bench + published targets | `benches/provenance_write_throughput.rs`; targets in `benchmarks/performance-targets.json`. **Rows added** for #3351 chain (observation) and #3371 lineage (gated ≥0.80). **#3350 auth stamping scoped out** — needs a *served* authenticated session (`with_auth`), not the embedded in-process API these benches drive; tracked as a follow-up in the doc. |
| AC2 | Reproducible seeded workload | Fixed seed `0x3383c0570f740500`; documented fixture. Provenance bundle built once and cloned per write (note-generation RNG is not miscounted as trust cost). |
| AC3 | Self-gate, same-run baseline, composed ≥ 80 % (on the CPU-bound arm) | `PROV_BENCH_GATE=1`; control **PASS** (exit 0), real-CPU-injection **FAIL** naming `composed` (see acceptance test above) |
| AC4 | Reads/reconstruct on provenance nodes fast | **Real p99** (nearest-rank, not a Criterion mean): current read p99 ≈ **0.19 µs** (<1 µs); temporal reconstruct p99 ≈ **0.32 µs** (<10 ms) — ungated observations (>20× margin) |
| AC5 | Crash recovery of provenance+constraint dataset | reopen `<5s` **assertion** (gate mode). Scheduled lane exercises it at the reduced default (2000/4000, reopen ≈ 0.03 s). The **10K/50K reference scale is manual/perf-rig** — a 60K-write single-writer GroupCommit *build* is ~10 min, too slow for the shared CI job (the *reopen*, not the build, is what <5s governs). False "CI runs the full scale" comment fixed; code + docs agree. |
| AC6 | Published targets + "cost of trust" docs + JSON artifact | `docs/benchmarks/cost-of-trust.md`; JSON **schema v2** (`cpu_throughput`/`cpu_ratio_vs_baseline` + `gc_p50_us`/`gc_p99_us`, `gated` flag, `bound` = null for observation rows) |
| AC7 | CI wiring (scheduled gate + informational PR smoke) | `benchmark.yml` two-lane wiring below |

## CI wiring — two lanes (no per-PR hard gate)

1. **Scheduled / manual lane** — dedicated self-gate step (`PROV_BENCH_GATE=1`) hard-fails on a CPU-bound ratio regression **or** recovery ≥ 5 s. This job **alerts**; it never blocks a PR merge.
2. **Per-PR smoke** — reduced-scale (`PROV_BENCH_WRITES=5000`, one interleaved pass), **informational / non-required** via `continue-on-error: true`. It can never fail the PR.

> Flipping the per-PR smoke from informational to blocking is a one-line change (drop `continue-on-error`) once scheduled-lane signal proves the gate stable on the runner — **that flip is the operator's call, not part of this PR.**

## Quality gates

- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo fmt --all` ✅
- Benches compile under `--all-targets`. No new `#[test]` added (the gate is an env-gated bench assertion; no `src` touched); no unsafe → no Miri.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
