### PR TITLE
feat(cypher): Cypher write clauses — CREATE / SET / DELETE / DETACH DELETE (#560)

### DIFF
--- a/docs/guides/cypher-compatibility.md
+++ b/docs/guides/cypher-compatibility.md
@@ -138,10 +138,37 @@ against a **fresh seed graph per case**.
 | `DETACH DELETE` | `MATCH (n:Person {name:'A'}) DETACH DELETE n` | cascade-removes the node and its relationships (maps to `delete_node_cascade`) |
 | `RETURN` after write | `CREATE (n:X {..}) RETURN n`, `... SET n.p=1 RETURN n` | bound variables (bare or `AS`-aliased) / `*`; re-read post-write (a `SET`-updated node reflects the new value) |
 
-Deferred to follow-ups (rejected cleanly — see §2): `MERGE`, `REMOVE`, label
-mutation (`SET n:Label`), whole-entity replacement (`SET n = {...}` / `+=`),
-variable-length relationships in a write, and aggregate/property `RETURN`
-projections after a write.
+Deferred to follow-ups (rejected cleanly — see §2): `MERGE` (#3548), `REMOVE`
+(#3549), label mutation (`SET n:Label`), whole-entity replacement
+(`SET n = {...}` / `+=`), variable-length relationships in a write, and
+aggregate/property `RETURN` projections after a write.
+
+#### Write-clause v1 deviations & limitations
+
+- **`SET n.prop = null` stores an explicit `Null`, it does not remove the key.**
+  openCypher treats `SET x.p = null` as *deleting* the property. AletheiaDB's
+  native update is PATCH-merge with no per-key tombstone, so v1 stores an
+  explicit `PropertyValue::Null` under the key instead. True key deletion (and
+  the `REMOVE` clause) are blocked on a replace/tombstone write API tracked in
+  **#3549**. Pinned by `set_null_stores_explicit_null_v1_deviation`.
+- **`RETURN` after a write re-reads current state post-commit.** The returned
+  rows reflect the entity's state *after* the statement commits (a `SET`-updated
+  node shows the new value); a returned entity that the statement *deleted* falls
+  back to the pre-delete snapshot captured during matching.
+- **The reading `MATCH` is evaluated before the write transaction opens
+  (check-then-act window).** Matching reads current state, then all writes run in
+  one transaction. The *writes* are atomic (all-or-nothing, one commit
+  timestamp), but a concurrent committer could change the matched set between the
+  match and the write. v1 accepts this window; a snapshot-consistent match-inside-
+  the-write-tx is a follow-up.
+- **Per-row versioning.** A `SET`/`DELETE` whose reading `MATCH` binds the same
+  entity in multiple rows applies once per row (can record multiple versions).
+  Multiple `SET` items targeting one entity in a single row are coalesced into
+  one version.
+- **Same-statement create-then-delete-endpoint.** `CREATE (a)-[:R]->(b) DELETE a`
+  (plain) is **refused** with the friendly "use `DETACH DELETE`" message via a
+  statement-local created-edge ledger (rather than aborting at commit);
+  `DETACH DELETE` of such an endpoint works (cascade unions the buffered CREATE).
 
 ---
 
@@ -152,8 +179,8 @@ can be produced. The suite pins the exact variant and a message substring.
 
 | Construct | Example | Error variant | Why |
 |-----------|---------|---------------|-----|
-| `MERGE` | `MERGE (n:Person {name:'Z'}) RETURN n` | `ParseError` | **deferred** (Issue #560): match-or-create is its own design problem; not yet a lexer keyword, so it fails `expect(MATCH)`. Rejects cleanly, never partially applies |
-| `REMOVE` | `MATCH (n) REMOVE n.age` | `ParseError` | **deferred** (Issue #560): property removal needs a replace/tombstone write API the native surface does not expose (update is PATCH-merge only), and label removal conflicts with the single-label model |
+| `MERGE` | `MERGE (n:Person {name:'Z'}) RETURN n` | `ParseError` | **deferred to #3548**: match-or-create is its own design problem; not yet a lexer keyword, so it fails `expect(MATCH)`. Rejects cleanly, never partially applies |
+| `REMOVE` | `MATCH (n) REMOVE n.age` | `ParseError` | **deferred to #3549**: property/label removal needs a replace/tombstone write API the native surface does not expose (update is PATCH-merge only); label removal also conflicts with the single-label model |
 | `FOREACH` | `FOREACH (x IN [1] | SET ...)` | `ParseError` | mutating/procedural clause |
 | `CALL` | `CALL db.labels()` | `ParseError` | procedure calls not supported |
 | `LOAD CSV` | `LOAD CSV FROM 'f.csv' AS row RETURN row` | `ParseError` | data-loading clause not supported |

--- a/docs/guides/cypher-compatibility.md
+++ b/docs/guides/cypher-compatibility.md
@@ -1,11 +1,20 @@
 # openCypher Compatibility Matrix (Issue #561)
 
-AletheiaDB implements a **read-only subset** of openCypher with bi-temporal and
-vector extensions. This document is the authoritative, machine-verified contract
-for **what that subset is** and **how out-of-subset queries fail**. Every row in
-the tables below is pinned by an executable case in the compatibility suite
-(`src/cypher/compat.rs`); the doc and the suite are kept in lockstep — if they
-disagree, that is a bug.
+AletheiaDB implements a growing subset of openCypher with bi-temporal and
+vector extensions. The read subset is complemented by a **core write subset**
+(Issue #560: `CREATE` / `SET` / `DELETE` / `DETACH DELETE`), executed through the
+native bi-temporal write APIs. This document is the authoritative,
+machine-verified contract for **what that subset is** and **how out-of-subset
+queries fail**. Every row in the tables below is pinned by an executable case in
+the compatibility suite (`src/cypher/compat.rs`); the doc and the suite are kept
+in lockstep — if they disagree, that is a bug.
+
+> **Writes are `execute_cypher`-only.** The MCP `query` tool and HTTP `/query`
+> endpoint remain strictly read-only: every mutating clause is rejected by the
+> text-level guard `crate::query::read_only::detect_mutating_clause` *before the
+> parser runs*, so a write can never execute through those surfaces. Mutations
+> are reachable only via `AletheiaDB::execute_cypher` /
+> `execute_cypher_with_params`.
 
 The design goal is **honesty over coverage**: a construct is either *supported*
 (parses/executes correctly) or *rejected with a structured error*. AletheiaDB
@@ -111,6 +120,29 @@ correctly.
 | Vector similarity in `ORDER BY` | `RETURN d ORDER BY vector.similarity(d.embedding, $q) DESC LIMIT 10` | *convert-only* (needs an `Embedding` param) |
 | Parameters | `MATCH (n:Person {name:$name}) RETURN n` | `$param` bindings |
 
+### Write clauses (Issue #560, `execute_cypher`-only)
+
+Executed through the native write APIs in one transaction (all-or-nothing, one
+commit timestamp), so each mutation records the correct bi-temporal version.
+Deeper side-effect and bi-temporal assertions live in `src/cypher/tests.rs`
+(`cypher::tests::mutations`); the compat suite pins the row-count contract
+against a **fresh seed graph per case**.
+
+| Construct | Example | Notes / caveats |
+|-----------|---------|-----------------|
+| `CREATE` node | `CREATE (n:Person {name:'Zed'}) RETURN n` | exactly one label per new node (single-label model); inline properties supported; `RETURN` yields the created node |
+| `CREATE` relationship | `CREATE (a:Team {name:'X'})-[:HAS]->(b:Member {name:'Y'})` | directed (`->`/`<-`), exactly one type; endpoints may be new or reference matched/earlier-created variables |
+| `MATCH ... CREATE` | `MATCH (a:Person {name:'A'}),(b:Person {name:'B'}) CREATE (a)-[:KNOWS]->(b)` | creates once per matched row |
+| `SET` property | `MATCH (n:Person {name:'Alice'}) SET n.age = 31` | PATCH-merge (adds/overwrites the named key, preserves others); multiple `n.p = v` items coalesce into one new version; also applies to relationship variables |
+| `DELETE` | `MATCH (a)-[r:KNOWS]->(b) DELETE r` | deletes node and/or relationship variables; a plain `DELETE` of a node that still has relationships is **refused** (openCypher safety rule) |
+| `DETACH DELETE` | `MATCH (n:Person {name:'A'}) DETACH DELETE n` | cascade-removes the node and its relationships (maps to `delete_node_cascade`) |
+| `RETURN` after write | `CREATE (n:X {..}) RETURN n`, `... SET n.p=1 RETURN n` | bound variables (bare or `AS`-aliased) / `*`; re-read post-write (a `SET`-updated node reflects the new value) |
+
+Deferred to follow-ups (rejected cleanly — see §2): `MERGE`, `REMOVE`, label
+mutation (`SET n:Label`), whole-entity replacement (`SET n = {...}` / `+=`),
+variable-length relationships in a write, and aggregate/property `RETURN`
+projections after a write.
+
 ---
 
 ## 2. Intentionally-unsupported constructs (rejected, never silent)
@@ -120,12 +152,8 @@ can be produced. The suite pins the exact variant and a message substring.
 
 | Construct | Example | Error variant | Why |
 |-----------|---------|---------------|-----|
-| `CREATE` | `CREATE (n) RETURN n` | `ParseError` | read-only subset; `CREATE` is not a lexer keyword, so it fails `expect(MATCH)` |
-| `SET` | `MATCH (n) SET n.x = 1` | `ParseError` | mutating clause not in the read-only grammar |
-| `MERGE` | `MERGE (n:Person {name:'Z'}) RETURN n` | `ParseError` | mutating clause |
-| `DELETE` | `MATCH (n) DELETE n` | `ParseError` | mutating clause |
-| `REMOVE` | `MATCH (n) REMOVE n.age` | `ParseError` | mutating clause |
-| `DETACH DELETE` | `MATCH (n) DETACH DELETE n` | `ParseError` | mutating clause |
+| `MERGE` | `MERGE (n:Person {name:'Z'}) RETURN n` | `ParseError` | **deferred** (Issue #560): match-or-create is its own design problem; not yet a lexer keyword, so it fails `expect(MATCH)`. Rejects cleanly, never partially applies |
+| `REMOVE` | `MATCH (n) REMOVE n.age` | `ParseError` | **deferred** (Issue #560): property removal needs a replace/tombstone write API the native surface does not expose (update is PATCH-merge only), and label removal conflicts with the single-label model |
 | `FOREACH` | `FOREACH (x IN [1] | SET ...)` | `ParseError` | mutating/procedural clause |
 | `CALL` | `CALL db.labels()` | `ParseError` | procedure calls not supported |
 | `LOAD CSV` | `LOAD CSV FROM 'f.csv' AS row RETURN row` | `ParseError` | data-loading clause not supported |

--- a/src/cypher/ast.rs
+++ b/src/cypher/ast.rs
@@ -89,6 +89,81 @@ pub enum CypherStatement {
     ///
     /// Same nesting rules as [`CypherStatement::Explain`].
     Profile(Box<CypherStatement>),
+
+    /// A write statement (Issue #560): `CREATE` / `SET` / `DELETE` /
+    /// `DETACH DELETE`, optionally preceded by a reading `MATCH` and followed by
+    /// a `RETURN`.
+    ///
+    /// Write statements are **not** lowered into the read-only [`Query`] IR;
+    /// they are executed directly against the database's native write APIs (so
+    /// each mutation records the correct bi-temporal version). They are reachable
+    /// only through `AletheiaDB::execute_cypher` / `execute_cypher_with_params`;
+    /// the MCP `query` tool rejects every mutating clause *before* the parser
+    /// runs (`crate::query::read_only::detect_mutating_clause`), so this variant
+    /// never executes through that read-only surface.
+    ///
+    /// [`Query`]: crate::query::Query
+    Write(CypherWriteStatement),
+}
+
+/// A complete Cypher write statement (Issue #560).
+///
+/// Grammar (v1):
+///
+/// ```text
+/// write_stmt := [reading] write_clause+ [RETURN ...]
+/// reading    := MATCH pattern_list [WHERE expr]
+/// write_clause := CREATE pattern_list
+///               | SET set_item (',' set_item)*
+///               | [DETACH] DELETE variable (',' variable)*
+/// set_item   := variable '.' property '=' value
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct CypherWriteStatement {
+    /// An optional leading reading clause (`MATCH ... [WHERE ...]`) whose matched
+    /// rows drive the write clauses. `None` for a statement that opens directly
+    /// with `CREATE`.
+    pub reading: Option<CypherReadingClause>,
+    /// One or more write clauses, applied in source order per matched row.
+    pub clauses: Vec<CypherWriteClause>,
+    /// An optional trailing `RETURN` projecting the affected entities.
+    pub return_clause: Option<CypherReturn>,
+}
+
+/// The reading (`MATCH ... [WHERE ...]`) part of a write statement.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CypherReadingClause {
+    /// One or more comma-separated graph patterns to match.
+    pub pattern: Vec<CypherPattern>,
+    /// An optional `WHERE` clause filtering matched rows.
+    pub where_clause: Option<CypherExpr>,
+}
+
+/// A single write clause within a [`CypherWriteStatement`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum CypherWriteClause {
+    /// `CREATE <pattern_list>` -- create the described nodes and relationships.
+    Create(Vec<CypherPattern>),
+    /// `SET <set_item> (',' <set_item>)*` -- assign properties on bound entities.
+    Set(Vec<CypherSetItem>),
+    /// `[DETACH] DELETE <variable> (',' <variable>)*` -- delete bound entities.
+    Delete {
+        /// Whether this is a `DETACH DELETE` (cascade-remove connected edges).
+        detach: bool,
+        /// The variables to delete (nodes or relationships).
+        targets: Vec<String>,
+    },
+}
+
+/// A single `SET n.prop = value` assignment.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CypherSetItem {
+    /// The variable whose property is being set.
+    pub variable: String,
+    /// The property key to assign.
+    pub property: String,
+    /// The literal (or parameter) value assigned.
+    pub value: CypherValue,
 }
 
 /// A subsequent `OPTIONAL MATCH` clause within a `MATCH` statement.

--- a/src/cypher/compat.rs
+++ b/src/cypher/compat.rs
@@ -624,6 +624,52 @@ fn supported_execute_cases() -> Vec<Case> {
             Executes(2),
         )
         .with_params(vec![("dept", CypherParameterValue::String("Eng".into()))]),
+        // ---- write clauses (Issue #560) ------------------------------------
+        // Row-count contracts against a FRESH seed graph per case (the runner
+        // rebuilds `compat_db` per case so these mutations are isolated).
+        // Deeper side-effect assertions live in `cypher::tests::mutations`.
+        Case::new(
+            "mutating",
+            "create_returns_created",
+            "CREATE (n:Person {name: 'Zed'}) RETURN n",
+            Executes(1),
+        ),
+        Case::new(
+            "mutating",
+            "create_no_return",
+            "CREATE (n:Person {name: 'Zed'})",
+            Executes(0),
+        ),
+        Case::new(
+            "mutating",
+            "create_relationship",
+            "CREATE (a:Team {name: 'X'})-[:HAS]->(b:Member {name: 'Y'}) RETURN a, b",
+            Executes(1),
+        ),
+        Case::new(
+            "mutating",
+            "set_all_persons",
+            "MATCH (n:Person) SET n.active = 1 RETURN n",
+            Executes(4),
+        ),
+        Case::new(
+            "mutating",
+            "set_no_match",
+            "MATCH (n:Person {name: 'Nobody'}) SET n.age = 1 RETURN n",
+            Executes(0),
+        ),
+        Case::new(
+            "mutating",
+            "delete_relationship",
+            "MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(b) DELETE r",
+            Executes(0),
+        ),
+        Case::new(
+            "mutating",
+            "detach_delete_company",
+            "MATCH (c:Company {name: 'Acme'}) DETACH DELETE c",
+            Executes(0),
+        ),
     ]
 }
 
@@ -733,19 +779,14 @@ fn rejected_cases() -> Vec<Case> {
     use RejectKind::{Parameter, Parse, Semantic, Temporal, Timestamp, Unsupported};
 
     vec![
-        // ---- mutating clauses -> ParseError --------------------------------
-        Case::new(
-            "mutating",
-            "create",
-            "CREATE (n:Person {name: 'Zed'}) RETURN n",
-            Rejected(Parse, ""),
-        ),
-        Case::new(
-            "mutating",
-            "set",
-            "MATCH (n:Person) SET n.age = 1 RETURN n",
-            Rejected(Parse, ""),
-        ),
+        // ---- mutating clauses still intentionally unsupported ---------------
+        // CREATE / SET / DELETE / DETACH DELETE are now *supported* and executed
+        // (see supported_execute_cases). MERGE and REMOVE are deferred to
+        // follow-ups (Issue #560): MERGE (match-or-create) is its own design
+        // problem; REMOVE (property/label deletion) needs a replace/tombstone
+        // write API the native surface does not yet expose (update is
+        // PATCH-merge only) and label mutation conflicts with the single-label
+        // model. Both must still reject cleanly rather than partially apply.
         Case::new(
             "mutating",
             "merge",
@@ -754,20 +795,8 @@ fn rejected_cases() -> Vec<Case> {
         ),
         Case::new(
             "mutating",
-            "delete",
-            "MATCH (n:Person) DELETE n",
-            Rejected(Parse, ""),
-        ),
-        Case::new(
-            "mutating",
             "remove",
             "MATCH (n:Person) REMOVE n.age",
-            Rejected(Parse, ""),
-        ),
-        Case::new(
-            "mutating",
-            "detach_delete",
-            "MATCH (n:Person) DETACH DELETE n",
             Rejected(Parse, ""),
         ),
         Case::new(
@@ -925,12 +954,16 @@ fn assert_no_failures(runner: &str, total: usize, failures: Vec<String>) {
 
 #[test]
 fn compat_supported_execute() {
-    let db = compat_db();
     let cases = supported_execute_cases();
     let total = cases.len();
     let mut failures = Vec::new();
 
     for case in &cases {
+        // A FRESH seed graph per case (Issue #560): the corpus now includes
+        // executing write cases (CREATE / SET / DELETE / DETACH DELETE) that
+        // mutate the graph, so cases must not share state. Read-only cases are
+        // unaffected -- the seed is deterministic.
+        let db = compat_db();
         let result = if case.params.is_empty() {
             db.execute_cypher(case.query)
         } else {

--- a/src/cypher/converter.rs
+++ b/src/cypher/converter.rs
@@ -432,6 +432,17 @@ impl CypherConverter {
                         .to_string(),
                 ))
             }
+            // Write statements (Issue #560) are executed directly against the
+            // native write APIs by `crate::cypher::mutation`, not lowered into
+            // the read-only `Query` IR. Reject conversion explicitly rather than
+            // fabricate a read plan for a mutation.
+            CypherStatement::Write(_) => Err(CypherError::UnsupportedFeature(
+                "write statements (CREATE / SET / DELETE) do not lower into the \
+                 read-only query pipeline; execute them via \
+                 AletheiaDB::execute_cypher, which applies the mutation through \
+                 the native write APIs"
+                    .to_string(),
+            )),
         }
     }
 

--- a/src/cypher/exec.rs
+++ b/src/cypher/exec.rs
@@ -98,6 +98,18 @@ pub enum CypherExecution {
     /// per-operator instrumentation and return the annotated plan as a single
     /// `plan` row.
     Profile(Query),
+    /// A write statement (Issue #560): `CREATE` / `SET` / `DELETE` /
+    /// `DETACH DELETE`, optionally with a reading `MATCH` and a `RETURN`.
+    ///
+    /// Carried unconverted (writes do not lower to the read-only [`Query`] IR)
+    /// and dispatched to `AletheiaDB::execute_mutation`, which needs the database
+    /// handle to apply the mutation through the native write APIs.
+    Mutation {
+        /// The parsed write statement to execute.
+        statement: Box<CypherStatement>,
+        /// Parameter bindings for `$param` references.
+        params: HashMap<String, CypherParameterValue>,
+    },
 }
 
 /// Parse and plan a Cypher string with no bound parameters.
@@ -141,6 +153,15 @@ pub fn plan_cypher_with_params(
         CypherStatement::Profile(inner) => {
             let query = lower_for_plan(*inner, params, "PROFILE")?;
             Ok(CypherExecution::Profile(query))
+        }
+        stmt @ CypherStatement::Write(_) => {
+            // A write statement is executed directly against the native write
+            // APIs (see `crate::cypher::mutation`); it has no read-only `Query`
+            // representation, so it is carried unconverted.
+            Ok(CypherExecution::Mutation {
+                statement: Box::new(stmt),
+                params,
+            })
         }
         other if needs_multi_binding(&other) => {
             // A multi-variable / multi-pattern MATCH has no faithful
@@ -188,6 +209,13 @@ fn lower_for_plan(
         CypherStatement::Explain(_) | CypherStatement::Profile(_) => Err(
             CypherError::UnsupportedFeature(format!("{verb} cannot wrap another EXPLAIN/PROFILE")),
         ),
+        // A write statement has no read-only `Query` plan to display or profile,
+        // and EXPLAIN/PROFILE must never execute a mutation as a side effect, so
+        // reject rather than mis-lower.
+        CypherStatement::Write(_) => Err(CypherError::UnsupportedFeature(format!(
+            "{verb} is not supported for write statements (CREATE / SET / DELETE); \
+             EXPLAIN/PROFILE describe read-only query plans"
+        ))),
         // A multi-variable / multi-pattern MATCH (Issue #549) is dispatched to
         // the dedicated evaluator, which has no physical `Query` plan; there is
         // nothing to lower here, so reject rather than mis-lower.

--- a/src/cypher/lexer.rs
+++ b/src/cypher/lexer.rs
@@ -38,6 +38,16 @@ pub enum TokenKind {
     /// `UNWIND`
     Unwind,
 
+    // -- Keywords: write clauses (Issue #560) -------------------------------
+    /// `CREATE`
+    Create,
+    /// `SET`
+    Set,
+    /// `DELETE`
+    Delete,
+    /// `DETACH` (used in `DETACH DELETE`)
+    Detach,
+
     // -- Keywords: ordering / projection ------------------------------------
     /// `ORDER`
     Order,
@@ -638,6 +648,12 @@ impl<'a> CypherLexer<'a> {
             "WITH" => TokenKind::With,
             "UNWIND" => TokenKind::Unwind,
 
+            // Write clauses (Issue #560)
+            "CREATE" => TokenKind::Create,
+            "SET" => TokenKind::Set,
+            "DELETE" => TokenKind::Delete,
+            "DETACH" => TokenKind::Detach,
+
             // Ordering / projection
             "ORDER" => TokenKind::Order,
             "BY" => TokenKind::By,
@@ -705,6 +721,10 @@ mod unit_tests {
             "RETURN",
             "WITH",
             "UNWIND",
+            "CREATE",
+            "SET",
+            "DELETE",
+            "DETACH",
             "ORDER",
             "BY",
             "LIMIT",

--- a/src/cypher/mod.rs
+++ b/src/cypher/mod.rs
@@ -55,6 +55,7 @@ mod error;
 pub mod exec;
 pub mod lexer;
 pub mod multi_pattern;
+pub mod mutation;
 pub mod parser;
 
 pub use ast::*;

--- a/src/cypher/multi_pattern.rs
+++ b/src/cypher/multi_pattern.rs
@@ -72,7 +72,7 @@ use super::error::CypherError;
 // TODO(perf #549-followup): carry entity *ids* instead of cloned entities
 // through the Cartesian product; a wide product currently clones each entity
 // once per surviving branch.
-type Binding = Vec<(String, EntityResult)>;
+pub(crate) type Binding = Vec<(String, EntityResult)>;
 
 /// A projected row paired with its still-full pattern binding (needed to
 /// evaluate `ORDER BY` expressions and `DISTINCT` keys after projection).
@@ -320,6 +320,119 @@ pub fn evaluate(
         .collect();
 
     Ok(QueryResults::new(Box::new(VecResultIterator::new(rows))))
+}
+
+/// Match a reading pattern list into its raw per-row variable bindings
+/// (Issue #560).
+///
+/// This exposes the nested-loop pattern matcher used by [`evaluate`] for reuse
+/// by the write-statement executor (`crate::cypher::mutation`): it returns every
+/// consistent `variable -> entity` binding (all bound node **and** relationship
+/// variables), *before* any projection, so the caller can drive `SET` / `DELETE`
+/// off the matched entities.
+///
+/// Current-state only: patterns are matched against the live graph. The caller
+/// is responsible for rejecting unsupported reading shapes (variable-length
+/// relationships, etc.) before calling.
+///
+/// # Errors
+///
+/// Returns [`CypherError::SemanticError`] for a structurally malformed pattern
+/// and [`CypherError::UnsupportedFeature`] if the intermediate binding count
+/// exceeds the configured cap (mirroring [`evaluate`]).
+pub(crate) fn match_bindings(
+    db: &AletheiaDB,
+    pattern: &[CypherPattern],
+    where_clause: Option<&CypherExpr>,
+    params: &HashMap<String, CypherParameterValue>,
+) -> Result<Vec<Binding>, CypherError> {
+    // Materialize the current-state node set once (sorted by id for a
+    // deterministic candidate enumeration and stable output order), mirroring
+    // `evaluate`.
+    let mut nodes: Vec<Node> = db.current.all_nodes().collect();
+    nodes.sort_by_key(|n| n.id);
+    let mut node_by_id: HashMap<NodeId, usize> = HashMap::with_capacity(nodes.len());
+    for (idx, node) in nodes.iter().enumerate() {
+        node_by_id.insert(node.id, idx);
+    }
+
+    let binding_cap = db.historical.read().max_schema_as_of_entities();
+
+    let eval = MultiEval {
+        db,
+        params,
+        nodes,
+        node_by_id,
+    };
+
+    // Per-pattern first-node candidate memoization (base-independent scan).
+    let mut first_memos: Vec<Vec<Node>> = Vec::with_capacity(pattern.len());
+    for p in pattern {
+        let memo = match p.elements.first() {
+            Some(CypherPatternElement::Node(first)) => eval.scan_node_candidates(first)?,
+            _ => Vec::new(),
+        };
+        first_memos.push(memo);
+    }
+
+    // Nested-loop binding matcher: extend the binding set by each pattern.
+    let mut env: Vec<PartialBinding> = vec![PartialBinding::default()];
+    for (p, first_memo) in pattern.iter().zip(first_memos.iter()) {
+        let mut next: Vec<PartialBinding> = Vec::new();
+        for base in &env {
+            eval.match_pattern_extends(p, base, first_memo, &mut next)?;
+            if next.len() > binding_cap {
+                return Err(CypherError::UnsupportedFeature(format!(
+                    "write reading pattern exceeds {binding_cap} intermediate bindings; add a \
+                     more selective WHERE filter or labels to narrow the match (configurable via \
+                     max_schema_as_of_entities)"
+                )));
+            }
+        }
+        env = next;
+    }
+
+    // WHERE filter (three-valued: keep a row iff its predicate is `Tri::True`).
+    if let Some(predicate) = where_clause {
+        let mut filtered = Vec::with_capacity(env.len());
+        for binding in env {
+            if eval.eval_predicate(predicate, &binding.vars)? == Tri::True {
+                filtered.push(binding);
+            }
+        }
+        env = filtered;
+    }
+
+    Ok(env.into_iter().map(|b| b.vars).collect())
+}
+
+/// Convert a Cypher literal (resolving a `$param`) into a [`PropertyValue`]
+/// (Issue #560).
+///
+/// Shared by the multi-pattern evaluator and the write-statement executor so
+/// both resolve inline/`SET`/`CREATE` values identically.
+///
+/// # Errors
+///
+/// Returns [`CypherError::ParameterError`] if a referenced `$param` is unbound.
+pub(crate) fn cypher_value_to_property(
+    value: &CypherValue,
+    params: &HashMap<String, CypherParameterValue>,
+) -> Result<PropertyValue, CypherError> {
+    Ok(match value {
+        CypherValue::Null => PropertyValue::Null,
+        CypherValue::Bool(b) => PropertyValue::Bool(*b),
+        CypherValue::Int(n) => PropertyValue::Int(*n),
+        CypherValue::Float(f) => PropertyValue::Float(*f),
+        CypherValue::String(s) => PropertyValue::String(std::sync::Arc::from(s.as_str())),
+        CypherValue::Vector(v) => PropertyValue::Vector(std::sync::Arc::clone(v)),
+        CypherValue::Parameter(name) => {
+            let param = params.get(name).ok_or_else(|| {
+                CypherError::ParameterError(format!("unbound parameter: ${name}"))
+            })?;
+            param_to_property(param)
+        }
+    })
 }
 
 /// Shared evaluation context: the database handle, bound parameters, and the
@@ -576,20 +689,7 @@ impl MultiEval<'_> {
 
     /// Convert a Cypher literal (resolving a `$param`) into a [`PropertyValue`].
     fn cypher_value_to_property(&self, value: &CypherValue) -> Result<PropertyValue, CypherError> {
-        Ok(match value {
-            CypherValue::Null => PropertyValue::Null,
-            CypherValue::Bool(b) => PropertyValue::Bool(*b),
-            CypherValue::Int(n) => PropertyValue::Int(*n),
-            CypherValue::Float(f) => PropertyValue::Float(*f),
-            CypherValue::String(s) => PropertyValue::String(std::sync::Arc::from(s.as_str())),
-            CypherValue::Vector(v) => PropertyValue::Vector(std::sync::Arc::clone(v)),
-            CypherValue::Parameter(name) => {
-                let param = self.params.get(name).ok_or_else(|| {
-                    CypherError::ParameterError(format!("unbound parameter: ${name}"))
-                })?;
-                param_to_property(param)
-            }
-        })
+        cypher_value_to_property(value, self.params)
     }
 
     // -- Predicate / scalar evaluation ------------------------------------

--- a/src/cypher/mutation.rs
+++ b/src/cypher/mutation.rs
@@ -102,6 +102,12 @@ pub fn execute(
         // same statement already removed.
         let mut deleted_nodes: HashSet<NodeId> = HashSet::new();
         let mut deleted_edges: HashSet<EdgeId> = HashSet::new();
+        // Relationships CREATEd by THIS statement, as (edge, source, target).
+        // The committed adjacency reads used by the plain-DELETE safety check do
+        // not yet see a buffered same-statement CREATE, so this statement-local
+        // ledger lets a plain DELETE of such an endpoint refuse cleanly instead
+        // of aborting at commit with a cryptic dangling-edge error (Minor 1).
+        let mut created_edges: Vec<(EdgeId, NodeId, NodeId)> = Vec::new();
 
         for base in &base_rows {
             let mut binding = base.clone();
@@ -113,6 +119,7 @@ pub fn execute(
                     params,
                     &mut deleted_nodes,
                     &mut deleted_edges,
+                    &mut created_edges,
                 )?;
             }
             if let Some(ret) = &write.return_clause {
@@ -224,6 +231,7 @@ fn validate_return(ret: &CypherReturn) -> std::result::Result<(), CypherError> {
 // Clause application
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::too_many_arguments)]
 fn apply_clause(
     tx: &mut crate::api::transaction::WriteTransaction,
     clause: &CypherWriteClause,
@@ -231,18 +239,27 @@ fn apply_clause(
     params: &Params,
     deleted_nodes: &mut HashSet<NodeId>,
     deleted_edges: &mut HashSet<EdgeId>,
+    created_edges: &mut Vec<(EdgeId, NodeId, NodeId)>,
 ) -> Result<()> {
     match clause {
         CypherWriteClause::Create(patterns) => {
             for pattern in patterns {
-                create_pattern(tx, pattern, binding, params)?;
+                create_pattern(tx, pattern, binding, params, created_edges)?;
             }
             Ok(())
         }
-        CypherWriteClause::Set(items) => apply_set(tx, items, binding, params, deleted_nodes),
-        CypherWriteClause::Delete { detach, targets } => {
-            apply_delete(tx, *detach, targets, binding, deleted_nodes, deleted_edges)
+        CypherWriteClause::Set(items) => {
+            apply_set(tx, items, binding, params, deleted_nodes, deleted_edges)
         }
+        CypherWriteClause::Delete { detach, targets } => apply_delete(
+            tx,
+            *detach,
+            targets,
+            binding,
+            deleted_nodes,
+            deleted_edges,
+            created_edges,
+        ),
     }
 }
 
@@ -253,6 +270,7 @@ fn create_pattern(
     pattern: &CypherPattern,
     binding: &mut Binding,
     params: &Params,
+    created_edges: &mut Vec<(EdgeId, NodeId, NodeId)>,
 ) -> Result<()> {
     let mut prev_node: Option<NodeId> = None;
     let mut idx = 0;
@@ -292,6 +310,7 @@ fn create_pattern(
                 };
                 let props = build_props(&rel.properties, params)?;
                 let edge_id = tx.create_edge(source, target, rel_type, props)?;
+                created_edges.push((edge_id, source, target));
                 if let Some(var) = &rel.variable {
                     bind(binding, var, EntityResult::EdgeId(edge_id));
                 }
@@ -357,6 +376,7 @@ fn apply_set(
     binding: &Binding,
     params: &Params,
     deleted_nodes: &HashSet<NodeId>,
+    deleted_edges: &HashSet<EdgeId>,
 ) -> Result<()> {
     // Accumulate per-target property maps in first-seen order.
     let mut node_updates: Vec<(NodeId, PropertyMapBuilder)> = Vec::new();
@@ -384,6 +404,9 @@ fn apply_set(
             };
             take_insert(slot, &item.property, value);
         } else if let Some(edge_id) = edge_id_of(entity) {
+            if deleted_edges.contains(&edge_id) {
+                continue; // no-op on an edge this statement already deleted
+            }
             let slot = match edge_updates.iter_mut().find(|(id, _)| *id == edge_id) {
                 Some((_, builder)) => builder,
                 None => {
@@ -423,6 +446,7 @@ fn apply_delete(
     binding: &Binding,
     deleted_nodes: &mut HashSet<NodeId>,
     deleted_edges: &mut HashSet<EdgeId>,
+    created_edges: &[(EdgeId, NodeId, NodeId)],
 ) -> Result<()> {
     // Partition targets into edges and nodes.
     let mut edge_targets: Vec<EdgeId> = Vec::new();
@@ -461,18 +485,39 @@ fn apply_delete(
         }
         if detach {
             // Record the connected edges as deleted so a later plain DELETE does
-            // not mis-count them, then cascade.
+            // not mis-count them, then cascade. `delete_node_cascade` itself
+            // unions committed adjacency with same-transaction buffered CREATEs,
+            // so a relationship created earlier in this statement is removed too;
+            // we mirror that here into `deleted_edges` for the plain-DELETE check.
             for edge_id in connected_edges(tx, node_id)? {
                 deleted_edges.insert(edge_id);
+            }
+            for (edge_id, source, target) in created_edges {
+                if *source == node_id || *target == node_id {
+                    deleted_edges.insert(*edge_id);
+                }
             }
             tx.delete_node_cascade(node_id)?;
         } else {
             // openCypher safety rule: refuse to orphan edges. Ignore edges this
-            // same statement already deleted.
-            let remaining: Vec<EdgeId> = connected_edges(tx, node_id)?
+            // same statement already deleted. Committed adjacency does not yet
+            // include a relationship CREATEd earlier in this same statement
+            // (it is still buffered), so fold the statement-local created-edge
+            // ledger in too — otherwise this plain DELETE would slip past the
+            // check and abort at commit with a cryptic dangling-edge error
+            // (Minor 1).
+            let mut remaining: Vec<EdgeId> = connected_edges(tx, node_id)?
                 .into_iter()
                 .filter(|e| !deleted_edges.contains(e))
                 .collect();
+            for (edge_id, source, target) in created_edges {
+                if (*source == node_id || *target == node_id)
+                    && !deleted_edges.contains(edge_id)
+                    && !remaining.contains(edge_id)
+                {
+                    remaining.push(*edge_id);
+                }
+            }
             if !remaining.is_empty() {
                 return Err(TransactionError::ValidationFailed {
                     reason: format!(

--- a/src/cypher/mutation.rs
+++ b/src/cypher/mutation.rs
@@ -1,0 +1,644 @@
+//! Cypher write-statement execution (Issue #560).
+//!
+//! Executes the mutating Cypher subset -- `CREATE`, `SET`, `DELETE`, and
+//! `DETACH DELETE` -- by driving AletheiaDB's **native write APIs** (via a single
+//! [`WriteTransaction`](crate::api::transaction::WriteTransaction)) rather than
+//! lowering into the read-only [`Query`](crate::query::Query) IR. Going through
+//! the native APIs means every mutation records the correct bi-temporal version
+//! (a new transaction-time record; a `SET`/`DELETE` supersedes without erasing
+//! history) exactly as the direct Rust API would.
+//!
+//! # Reachability / read-only guarantee
+//!
+//! This path is reached **only** through
+//! [`AletheiaDB::execute_cypher`](crate::db::AletheiaDB::execute_cypher) /
+//! `execute_cypher_with_params`. The MCP `query` tool and HTTP `/query` endpoint
+//! reject every mutating clause *before the parser runs*
+//! (`crate::query::read_only::detect_mutating_clause`), so a write statement can
+//! never execute through those read-only surfaces.
+//!
+//! # Atomicity
+//!
+//! All writes produced by one statement commit in a single
+//! [`AletheiaDB::write`](crate::db::AletheiaDB::write) transaction: they are
+//! applied all-or-nothing and share one commit timestamp. The reading `MATCH`
+//! is evaluated against current state *before* the write transaction opens
+//! (a v1 check-then-act window, acceptable because the writes themselves are
+//! atomic).
+//!
+//! # v1 scope (honest structured rejections, never a silently-wrong write)
+//!
+//! - `CREATE` of single-labelled nodes and typed, directed relationships, with
+//!   inline properties; endpoints may reference matched/earlier-created
+//!   variables.
+//! - `SET n.prop = value` (PATCH-merge onto the existing property map).
+//! - `DELETE` / `DETACH DELETE` of node and relationship variables, with the
+//!   openCypher safety rule: a plain `DELETE` of a node that still has
+//!   relationships is refused (use `DETACH DELETE`).
+//! - `RETURN` of bound variables (bare or `AS`-aliased).
+//!
+//! Deferred to follow-ups and rejected cleanly: `MERGE`, `REMOVE`, label
+//! mutation (`SET n:Label`), whole-entity replacement (`SET n = {...}`),
+//! variable-length relationships in a write, and aggregate/property `RETURN`
+//! projections.
+
+use std::collections::HashSet;
+
+use crate::api::transaction::{ReadOps, WriteOps};
+use crate::core::error::{Error, Result, TransactionError};
+use crate::core::id::{EdgeId, NodeId};
+use crate::core::property::{PropertyMap, PropertyMapBuilder};
+use crate::db::AletheiaDB;
+use crate::query::executor::{EntityResult, QueryResults, QueryRow};
+
+use super::ast::{
+    CypherDirection, CypherNodePattern, CypherPattern, CypherPatternElement, CypherReturn,
+    CypherReturnItem, CypherSetItem, CypherStatement, CypherValue, CypherWriteClause,
+    CypherWriteStatement,
+};
+use super::converter::CypherParameterValue;
+use super::error::CypherError;
+use super::multi_pattern::{Binding, cypher_value_to_property, match_bindings};
+
+type Params = std::collections::HashMap<String, CypherParameterValue>;
+
+/// Execute a parsed Cypher write statement (Issue #560).
+///
+/// # Errors
+///
+/// Returns a query error for any unsupported construct (mapped from
+/// [`CypherError`]) or a storage/transaction error from the underlying write.
+pub fn execute(
+    db: &AletheiaDB,
+    statement: &CypherStatement,
+    params: &Params,
+) -> Result<QueryResults> {
+    let CypherStatement::Write(write) = statement else {
+        return Err(CypherError::UnsupportedFeature(
+            "mutation executor requires a write statement".to_string(),
+        )
+        .into());
+    };
+
+    // Static validation independent of the data (fails before any transaction).
+    validate(write)?;
+
+    // Read phase: matched rows drive the write clauses. A statement with no
+    // reading part (a bare `CREATE`) runs once against a single empty binding.
+    let base_rows: Vec<Binding> = match &write.reading {
+        Some(reading) => {
+            match_bindings(db, &reading.pattern, reading.where_clause.as_ref(), params)?
+        }
+        None => vec![Vec::new()],
+    };
+
+    // Write phase: apply every clause per row inside ONE transaction so the whole
+    // statement commits all-or-nothing. RETURN snapshots are captured here and
+    // materialized (with fresh post-commit reads) afterwards.
+    let mut return_snapshots: Vec<Vec<(String, EntityResult)>> = Vec::new();
+    db.write::<_, (), Error>(|tx| {
+        // Track entities deleted by this statement so a later clause/row does not
+        // double-delete, and so the plain-DELETE safety check ignores edges this
+        // same statement already removed.
+        let mut deleted_nodes: HashSet<NodeId> = HashSet::new();
+        let mut deleted_edges: HashSet<EdgeId> = HashSet::new();
+
+        for base in &base_rows {
+            let mut binding = base.clone();
+            for clause in &write.clauses {
+                apply_clause(
+                    tx,
+                    clause,
+                    &mut binding,
+                    params,
+                    &mut deleted_nodes,
+                    &mut deleted_edges,
+                )?;
+            }
+            if let Some(ret) = &write.return_clause {
+                return_snapshots.push(collect_return_snapshots(ret, &binding)?);
+            }
+        }
+        Ok(())
+    })?;
+
+    // Materialize RETURN rows after commit: re-read each entity for its
+    // post-write state, falling back to the captured snapshot for entities the
+    // statement deleted.
+    let mut rows = Vec::with_capacity(return_snapshots.len());
+    for snapshot in return_snapshots {
+        rows.push(materialize_row(db, snapshot));
+    }
+    Ok(QueryResults::from_rows(rows))
+}
+
+// ---------------------------------------------------------------------------
+// Static validation
+// ---------------------------------------------------------------------------
+
+/// Reject unsupported write shapes up front, before any transaction opens.
+fn validate(write: &CypherWriteStatement) -> std::result::Result<(), CypherError> {
+    if let Some(reading) = &write.reading {
+        for pattern in &reading.pattern {
+            reject_varlength(pattern, "the reading MATCH of a write statement")?;
+        }
+    }
+    for clause in &write.clauses {
+        if let CypherWriteClause::Create(patterns) = clause {
+            for pattern in patterns {
+                reject_varlength(pattern, "a CREATE pattern")?;
+                validate_create_pattern(pattern)?;
+            }
+        }
+    }
+    if let Some(ret) = &write.return_clause {
+        validate_return(ret)?;
+    }
+    Ok(())
+}
+
+/// Reject a variable-length relationship anywhere in a pattern.
+fn reject_varlength(pattern: &CypherPattern, ctx: &str) -> std::result::Result<(), CypherError> {
+    for element in &pattern.elements {
+        if let CypherPatternElement::Relationship(rel) = element
+            && rel.depth.is_some()
+        {
+            return Err(CypherError::UnsupportedFeature(format!(
+                "variable-length relationships are not supported in {ctx}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Statically validate a `CREATE` pattern's relationships (direction + type).
+fn validate_create_pattern(pattern: &CypherPattern) -> std::result::Result<(), CypherError> {
+    for element in &pattern.elements {
+        if let CypherPatternElement::Relationship(rel) = element {
+            if matches!(rel.direction, CypherDirection::Both) {
+                return Err(CypherError::UnsupportedFeature(
+                    "CREATE requires a directed relationship (use -> or <-), not an undirected -"
+                        .to_string(),
+                ));
+            }
+            if rel.rel_types.len() != 1 {
+                return Err(CypherError::UnsupportedFeature(
+                    "CREATE requires exactly one relationship type, e.g. -[:KNOWS]->".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate the `RETURN` of a write statement: only bound variables (bare or
+/// `AS`-aliased) or `*`, with no ordering/pagination/deduplication in v1.
+fn validate_return(ret: &CypherReturn) -> std::result::Result<(), CypherError> {
+    if ret.distinct || !ret.order_by.is_empty() || ret.skip.is_some() || ret.limit.is_some() {
+        return Err(CypherError::UnsupportedFeature(
+            "DISTINCT / ORDER BY / SKIP / LIMIT are not supported on the RETURN of a write \
+             statement in v1"
+                .to_string(),
+        ));
+    }
+    for item in &ret.items {
+        match item {
+            CypherReturnItem::Star | CypherReturnItem::Variable(_) => {}
+            CypherReturnItem::Expression {
+                expr: super::ast::CypherExpr::Variable(_),
+                ..
+            } => {}
+            _ => {
+                return Err(CypherError::UnsupportedFeature(
+                    "RETURN after a write supports only bound variables (optionally AS-aliased) \
+                     or *; property, function, and aggregate projections are not supported in v1"
+                        .to_string(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Clause application
+// ---------------------------------------------------------------------------
+
+fn apply_clause(
+    tx: &mut crate::api::transaction::WriteTransaction,
+    clause: &CypherWriteClause,
+    binding: &mut Binding,
+    params: &Params,
+    deleted_nodes: &mut HashSet<NodeId>,
+    deleted_edges: &mut HashSet<EdgeId>,
+) -> Result<()> {
+    match clause {
+        CypherWriteClause::Create(patterns) => {
+            for pattern in patterns {
+                create_pattern(tx, pattern, binding, params)?;
+            }
+            Ok(())
+        }
+        CypherWriteClause::Set(items) => apply_set(tx, items, binding, params, deleted_nodes),
+        CypherWriteClause::Delete { detach, targets } => {
+            apply_delete(tx, *detach, targets, binding, deleted_nodes, deleted_edges)
+        }
+    }
+}
+
+/// Create the nodes and relationships described by one `CREATE` pattern,
+/// binding each named element into `binding`.
+fn create_pattern(
+    tx: &mut crate::api::transaction::WriteTransaction,
+    pattern: &CypherPattern,
+    binding: &mut Binding,
+    params: &Params,
+) -> Result<()> {
+    let mut prev_node: Option<NodeId> = None;
+    let mut idx = 0;
+    while idx < pattern.elements.len() {
+        match &pattern.elements[idx] {
+            CypherPatternElement::Node(node) => {
+                let id = resolve_or_create_node(tx, node, binding, params)?;
+                prev_node = Some(id);
+                idx += 1;
+            }
+            CypherPatternElement::Relationship(rel) => {
+                let left = prev_node.ok_or_else(|| {
+                    Error::from(CypherError::SemanticError(
+                        "a relationship must be preceded by a node in a CREATE pattern".to_string(),
+                    ))
+                })?;
+                let Some(CypherPatternElement::Node(right_pat)) = pattern.elements.get(idx + 1)
+                else {
+                    return Err(CypherError::SemanticError(
+                        "a relationship must be followed by a node in a CREATE pattern".to_string(),
+                    )
+                    .into());
+                };
+                let right = resolve_or_create_node(tx, right_pat, binding, params)?;
+
+                // Direction/type validated statically; exactly one type present.
+                let rel_type = &rel.rel_types[0];
+                let (source, target) = match rel.direction {
+                    CypherDirection::Outgoing => (left, right),
+                    CypherDirection::Incoming => (right, left),
+                    CypherDirection::Both => {
+                        return Err(CypherError::UnsupportedFeature(
+                            "CREATE requires a directed relationship".to_string(),
+                        )
+                        .into());
+                    }
+                };
+                let props = build_props(&rel.properties, params)?;
+                let edge_id = tx.create_edge(source, target, rel_type, props)?;
+                if let Some(var) = &rel.variable {
+                    bind(binding, var, EntityResult::EdgeId(edge_id));
+                }
+                prev_node = Some(right);
+                idx += 2;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Resolve a node element to an existing bound node, or create a new node and
+/// bind it. A bound variable is reused; an unbound/anonymous node is created and
+/// must carry exactly one label.
+fn resolve_or_create_node(
+    tx: &mut crate::api::transaction::WriteTransaction,
+    node: &CypherNodePattern,
+    binding: &mut Binding,
+    params: &Params,
+) -> Result<NodeId> {
+    if let Some(var) = &node.variable
+        && let Some(existing) = lookup(binding, var)
+    {
+        // Reusing a bound variable: it must already be a node, and CREATE must
+        // not also (re)specify a label/properties on it.
+        let Some(id) = node_id_of(existing) else {
+            return Err(CypherError::SemanticError(format!(
+                "variable '{var}' is bound to a relationship and cannot be used as a node in CREATE"
+            ))
+            .into());
+        };
+        if !node.labels.is_empty() || !node.properties.is_empty() {
+            return Err(CypherError::UnsupportedFeature(format!(
+                "CREATE cannot re-declare labels or properties on already-bound variable '{var}'"
+            ))
+            .into());
+        }
+        return Ok(id);
+    }
+
+    // Creating a new node: AletheiaDB nodes are single-labelled.
+    if node.labels.len() != 1 {
+        return Err(CypherError::UnsupportedFeature(
+            "CREATE requires exactly one label per new node (AletheiaDB nodes are single-labelled)"
+                .to_string(),
+        )
+        .into());
+    }
+    let props = build_props(&node.properties, params)?;
+    let id = tx.create_node(&node.labels[0], props)?;
+    if let Some(var) = &node.variable {
+        bind(binding, var, EntityResult::NodeId(id));
+    }
+    Ok(id)
+}
+
+/// Apply a `SET` clause: PATCH-merge each `n.prop = value` onto its bound
+/// entity. Assignments to the same variable are coalesced into one update so a
+/// multi-property `SET` records a single new version.
+fn apply_set(
+    tx: &mut crate::api::transaction::WriteTransaction,
+    items: &[CypherSetItem],
+    binding: &Binding,
+    params: &Params,
+    deleted_nodes: &HashSet<NodeId>,
+) -> Result<()> {
+    // Accumulate per-target property maps in first-seen order.
+    let mut node_updates: Vec<(NodeId, PropertyMapBuilder)> = Vec::new();
+    let mut edge_updates: Vec<(EdgeId, PropertyMapBuilder)> = Vec::new();
+
+    for item in items {
+        let entity = lookup(binding, &item.variable).ok_or_else(|| {
+            Error::from(CypherError::SemanticError(format!(
+                "SET references unbound variable '{}'",
+                item.variable
+            )))
+        })?;
+        let value = cypher_value_to_property(&item.value, params)?;
+
+        if let Some(node_id) = node_id_of(entity) {
+            if deleted_nodes.contains(&node_id) {
+                continue; // no-op on an entity this statement already deleted
+            }
+            let slot = match node_updates.iter_mut().find(|(id, _)| *id == node_id) {
+                Some((_, builder)) => builder,
+                None => {
+                    node_updates.push((node_id, PropertyMapBuilder::new()));
+                    &mut node_updates.last_mut().expect("just pushed").1
+                }
+            };
+            take_insert(slot, &item.property, value);
+        } else if let Some(edge_id) = edge_id_of(entity) {
+            let slot = match edge_updates.iter_mut().find(|(id, _)| *id == edge_id) {
+                Some((_, builder)) => builder,
+                None => {
+                    edge_updates.push((edge_id, PropertyMapBuilder::new()));
+                    &mut edge_updates.last_mut().expect("just pushed").1
+                }
+            };
+            take_insert(slot, &item.property, value);
+        } else {
+            return Err(CypherError::SemanticError(format!(
+                "SET target variable '{}' is not bound to a node or relationship",
+                item.variable
+            ))
+            .into());
+        }
+    }
+
+    for (node_id, builder) in node_updates {
+        tx.update_node(node_id, builder.build())?;
+    }
+    for (edge_id, builder) in edge_updates {
+        tx.update_edge(edge_id, builder.build())?;
+    }
+    Ok(())
+}
+
+/// Apply a `DELETE` / `DETACH DELETE` clause.
+///
+/// Relationships are deleted before nodes so that `DELETE r, a` and `DELETE a, r`
+/// behave identically (openCypher deletes are order-independent). A plain
+/// `DELETE` of a node that still has relationships (excluding any this statement
+/// already deleted) is refused; `DETACH DELETE` cascade-removes them.
+fn apply_delete(
+    tx: &mut crate::api::transaction::WriteTransaction,
+    detach: bool,
+    targets: &[String],
+    binding: &Binding,
+    deleted_nodes: &mut HashSet<NodeId>,
+    deleted_edges: &mut HashSet<EdgeId>,
+) -> Result<()> {
+    // Partition targets into edges and nodes.
+    let mut edge_targets: Vec<EdgeId> = Vec::new();
+    let mut node_targets: Vec<NodeId> = Vec::new();
+    for var in targets {
+        let entity = lookup(binding, var).ok_or_else(|| {
+            Error::from(CypherError::SemanticError(format!(
+                "DELETE references unbound variable '{var}'"
+            )))
+        })?;
+        if let Some(edge_id) = edge_id_of(entity) {
+            edge_targets.push(edge_id);
+        } else if let Some(node_id) = node_id_of(entity) {
+            node_targets.push(node_id);
+        } else {
+            return Err(CypherError::SemanticError(format!(
+                "DELETE target variable '{var}' is not bound to a node or relationship"
+            ))
+            .into());
+        }
+    }
+
+    // Delete relationships first.
+    for edge_id in edge_targets {
+        if deleted_edges.contains(&edge_id) || tx.get_edge(edge_id).is_err() {
+            continue; // already gone
+        }
+        tx.delete_edge(edge_id)?;
+        deleted_edges.insert(edge_id);
+    }
+
+    // Then nodes.
+    for node_id in node_targets {
+        if deleted_nodes.contains(&node_id) || tx.get_node(node_id).is_err() {
+            continue;
+        }
+        if detach {
+            // Record the connected edges as deleted so a later plain DELETE does
+            // not mis-count them, then cascade.
+            for edge_id in connected_edges(tx, node_id)? {
+                deleted_edges.insert(edge_id);
+            }
+            tx.delete_node_cascade(node_id)?;
+        } else {
+            // openCypher safety rule: refuse to orphan edges. Ignore edges this
+            // same statement already deleted.
+            let remaining: Vec<EdgeId> = connected_edges(tx, node_id)?
+                .into_iter()
+                .filter(|e| !deleted_edges.contains(e))
+                .collect();
+            if !remaining.is_empty() {
+                return Err(TransactionError::ValidationFailed {
+                    reason: format!(
+                        "Cannot delete node {} because it still has {} relationship(s); use \
+                         DETACH DELETE to remove the node and its relationships",
+                        node_id.as_u64(),
+                        remaining.len()
+                    ),
+                }
+                .into());
+            }
+            tx.delete_node(node_id)?;
+        }
+        deleted_nodes.insert(node_id);
+    }
+    Ok(())
+}
+
+/// Distinct edge ids connected to a node (a self-loop counts once).
+fn connected_edges(
+    tx: &mut crate::api::transaction::WriteTransaction,
+    node_id: NodeId,
+) -> Result<Vec<EdgeId>> {
+    let mut ids = tx.get_outgoing_edges(node_id)?;
+    ids.extend(tx.get_incoming_edges(node_id)?);
+    ids.sort_unstable();
+    ids.dedup();
+    Ok(ids)
+}
+
+// ---------------------------------------------------------------------------
+// RETURN
+// ---------------------------------------------------------------------------
+
+/// Capture the bound entities a `RETURN` projects, as `(output_name, snapshot)`
+/// pairs, from the row's final binding. Snapshots are materialized (re-read)
+/// after commit.
+fn collect_return_snapshots(
+    ret: &CypherReturn,
+    binding: &Binding,
+) -> Result<Vec<(String, EntityResult)>> {
+    let mut out = Vec::new();
+    for item in &ret.items {
+        match item {
+            CypherReturnItem::Star => {
+                for (name, entity) in binding {
+                    out.push((name.clone(), entity.clone()));
+                }
+            }
+            CypherReturnItem::Variable(name) => {
+                out.push((name.clone(), lookup_owned(binding, name)?));
+            }
+            CypherReturnItem::Expression {
+                expr: super::ast::CypherExpr::Variable(name),
+                alias,
+            } => {
+                let output = alias.clone().unwrap_or_else(|| name.clone());
+                out.push((output, lookup_owned(binding, name)?));
+            }
+            _ => {
+                return Err(CypherError::UnsupportedFeature(
+                    "RETURN after a write supports only bound variables or *".to_string(),
+                )
+                .into());
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Materialize one RETURN row: re-read each captured entity for its post-write
+/// state, falling back to the captured snapshot when the entity was deleted.
+fn materialize_row(db: &AletheiaDB, snapshot: Vec<(String, EntityResult)>) -> QueryRow {
+    let fresh: Vec<(String, EntityResult)> = snapshot
+        .into_iter()
+        .map(|(name, entity)| (name, refresh_entity(db, entity)))
+        .collect();
+
+    if fresh.len() == 1 {
+        let (_, entity) = fresh.into_iter().next().expect("len == 1");
+        QueryRow::from_entity(entity)
+    } else {
+        QueryRow::from_bindings(fresh, None)
+    }
+}
+
+/// Re-read an entity's current state by id, keeping the snapshot if it is gone.
+fn refresh_entity(db: &AletheiaDB, entity: EntityResult) -> EntityResult {
+    if let Some(node_id) = node_id_of(&entity) {
+        return db
+            .get_node(node_id)
+            .map(EntityResult::Node)
+            .unwrap_or(entity);
+    }
+    if let Some(edge_id) = edge_id_of(&entity) {
+        return db
+            .get_edge(edge_id)
+            .map(EntityResult::Edge)
+            .unwrap_or(entity);
+    }
+    entity
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+/// Build a [`PropertyMap`] from pattern/`SET` `(key, value)` pairs.
+fn build_props(
+    props: &[(String, CypherValue)],
+    params: &Params,
+) -> std::result::Result<PropertyMap, CypherError> {
+    let mut builder = PropertyMapBuilder::new();
+    for (key, value) in props {
+        let pv = cypher_value_to_property(value, params)?;
+        builder = builder.insert(key, pv);
+    }
+    Ok(builder.build())
+}
+
+/// Insert into a builder held behind a mutable reference (builder methods are
+/// by-value, so swap through a temporary).
+fn take_insert(
+    slot: &mut PropertyMapBuilder,
+    key: &str,
+    value: crate::core::property::PropertyValue,
+) {
+    let taken = std::mem::take(slot);
+    *slot = taken.insert(key, value);
+}
+
+/// Look up a variable's binding by name.
+fn lookup<'b>(binding: &'b Binding, var: &str) -> Option<&'b EntityResult> {
+    binding.iter().find(|(name, _)| name == var).map(|(_, e)| e)
+}
+
+/// Look up a variable, cloning its binding, erroring if unbound.
+fn lookup_owned(binding: &Binding, var: &str) -> Result<EntityResult> {
+    lookup(binding, var).cloned().ok_or_else(|| {
+        CypherError::SemanticError(format!("RETURN references unbound variable '{var}'")).into()
+    })
+}
+
+/// Bind (or rebind) a variable to an entity.
+fn bind(binding: &mut Binding, var: &str, entity: EntityResult) {
+    if let Some(slot) = binding.iter_mut().find(|(name, _)| name == var) {
+        slot.1 = entity;
+    } else {
+        binding.push((var.to_string(), entity));
+    }
+}
+
+/// The node id an [`EntityResult`] refers to, if it is a node.
+fn node_id_of(entity: &EntityResult) -> Option<NodeId> {
+    match entity {
+        EntityResult::Node(n) => Some(n.id),
+        EntityResult::NodeId(id) => Some(*id),
+        _ => None,
+    }
+}
+
+/// The edge id an [`EntityResult`] refers to, if it is an edge.
+fn edge_id_of(entity: &EntityResult) -> Option<EdgeId> {
+    match entity {
+        EntityResult::Edge(e) => Some(e.id),
+        EntityResult::EdgeId(id) => Some(*id),
+        _ => None,
+    }
+}

--- a/src/cypher/parser.rs
+++ b/src/cypher/parser.rs
@@ -230,9 +230,143 @@ impl CypherParser {
             return self.parse_unwind();
         }
 
-        // Now expect a MATCH (or OPTIONAL MATCH).
+        // A statement that opens directly with `CREATE` is a write statement
+        // with no reading part (Issue #560). A leading temporal clause has no
+        // meaning for a write, so reject the combination rather than silently
+        // dropping the qualifier.
+        if self.at(TokenKind::Create) {
+            if temporal.is_some() {
+                return Err(self.error(
+                    "a temporal clause (AS OF / FOR / BETWEEN) cannot precede a CREATE statement",
+                ));
+            }
+            return self.parse_write_statement(None);
+        }
+
+        // Now expect a MATCH (or OPTIONAL MATCH), which may turn out to be the
+        // reading part of a write statement (`MATCH ... SET/DELETE/CREATE ...`).
         let stmt = self.parse_match(temporal)?;
         Ok(stmt)
+    }
+
+    /// Returns `true` if the current token starts a write clause
+    /// (`CREATE` / `SET` / `DELETE` / `DETACH DELETE`), Issue #560.
+    fn at_write_clause(&self) -> bool {
+        matches!(
+            self.peek().kind,
+            TokenKind::Create | TokenKind::Set | TokenKind::Delete | TokenKind::Detach
+        )
+    }
+
+    /// Parse a write statement (Issue #560): one or more write clauses followed
+    /// by an optional `RETURN`.
+    ///
+    /// `reading` is the already-parsed reading part (`MATCH ... [WHERE ...]`),
+    /// or `None` for a statement opening directly with `CREATE`.
+    fn parse_write_statement(
+        &mut self,
+        reading: Option<CypherReadingClause>,
+    ) -> Result<CypherStatement, CypherError> {
+        let mut clauses = Vec::new();
+        loop {
+            match self.peek().kind {
+                TokenKind::Create => {
+                    self.advance();
+                    let patterns = self.parse_pattern_list()?;
+                    clauses.push(CypherWriteClause::Create(patterns));
+                }
+                TokenKind::Set => {
+                    self.advance();
+                    let items = self.parse_set_items()?;
+                    clauses.push(CypherWriteClause::Set(items));
+                }
+                TokenKind::Detach => {
+                    self.advance();
+                    self.expect(TokenKind::Delete)?;
+                    let targets = self.parse_delete_targets()?;
+                    clauses.push(CypherWriteClause::Delete {
+                        detach: true,
+                        targets,
+                    });
+                }
+                TokenKind::Delete => {
+                    self.advance();
+                    let targets = self.parse_delete_targets()?;
+                    clauses.push(CypherWriteClause::Delete {
+                        detach: false,
+                        targets,
+                    });
+                }
+                _ => break,
+            }
+        }
+
+        if clauses.is_empty() {
+            return Err(self.error("expected a write clause (CREATE / SET / DELETE)"));
+        }
+
+        let return_clause = if self.at(TokenKind::Return) {
+            Some(self.parse_return()?)
+        } else {
+            None
+        };
+
+        Ok(CypherStatement::Write(CypherWriteStatement {
+            reading,
+            clauses,
+            return_clause,
+        }))
+    }
+
+    /// Parse the items of a `SET` clause: `n.prop = value (, n.prop = value)*`.
+    ///
+    /// v1 supports only property assignment (`SET n.prop = value`). Label
+    /// mutation (`SET n:Label`) and whole-entity replacement (`SET n = {...}`,
+    /// `SET n += {...}`) are rejected with a structured
+    /// [`CypherError::UnsupportedFeature`] -- AletheiaDB nodes are single-labeled
+    /// and the native update API is PATCH-merge only.
+    fn parse_set_items(&mut self) -> Result<Vec<CypherSetItem>, CypherError> {
+        let mut items = Vec::new();
+        loop {
+            let var_tok = self.expect(TokenKind::Identifier)?;
+            if self.at(TokenKind::Colon) {
+                return Err(CypherError::UnsupportedFeature(
+                    "SET n:Label (label assignment) is not supported; AletheiaDB nodes are \
+                     single-labeled"
+                        .to_string(),
+                ));
+            }
+            if self.at(TokenKind::Eq) {
+                return Err(CypherError::UnsupportedFeature(
+                    "SET n = {...} / SET n += {...} (whole-entity property replacement) is not \
+                     supported; use SET n.prop = value"
+                        .to_string(),
+                ));
+            }
+            self.expect(TokenKind::Dot)?;
+            let prop_tok = self.expect(TokenKind::Identifier)?;
+            self.expect(TokenKind::Eq)?;
+            let value = self.parse_value()?;
+            items.push(CypherSetItem {
+                variable: var_tok.text,
+                property: prop_tok.text,
+                value,
+            });
+            if !self.eat(TokenKind::Comma) {
+                break;
+            }
+        }
+        Ok(items)
+    }
+
+    /// Parse the target variables of a `DELETE` / `DETACH DELETE` clause:
+    /// `variable (',' variable)*`.
+    fn parse_delete_targets(&mut self) -> Result<Vec<String>, CypherError> {
+        let mut targets = vec![self.expect(TokenKind::Identifier)?.text];
+        while self.eat(TokenKind::Comma) {
+            targets.push(self.expect(TokenKind::Identifier)?.text);
+        }
+        Ok(targets)
     }
 
     /// Parse a standalone `UNWIND <list> AS <var> RETURN ...` statement.
@@ -277,6 +411,19 @@ impl CypherParser {
         } else {
             None
         };
+
+        // A write clause here (`MATCH ... SET/DELETE/CREATE ...`) makes this the
+        // reading part of a write statement (Issue #560). This is only valid for
+        // a plain, non-temporal `MATCH` in v1: `OPTIONAL MATCH` and temporal
+        // qualifiers are not combinable with writes, so they fall through to the
+        // read path (and a subsequent write clause would then be a parse error).
+        if !optional && temporal.is_none() && self.at_write_clause() {
+            let reading = CypherReadingClause {
+                pattern,
+                where_clause,
+            };
+            return self.parse_write_statement(Some(reading));
+        }
 
         // Check for post-pattern temporal clause (between WHERE and RETURN).
         // If a leading temporal clause was already parsed, this is skipped.

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -5117,6 +5117,7 @@ mod unwind {
             CypherExecution::Explain(_) | CypherExecution::Profile(_) => {
                 panic!("UNWIND must plan to Rows, not an Explain/Profile")
             }
+            CypherExecution::Mutation { .. } => panic!("UNWIND must plan to Rows, not a Mutation"),
         }
         match plan_cypher("MATCH (n:Person) RETURN n").unwrap() {
             CypherExecution::Query(_) => {}
@@ -5127,6 +5128,7 @@ mod unwind {
             CypherExecution::Explain(_) | CypherExecution::Profile(_) => {
                 panic!("plain MATCH must plan to a Query, not an Explain/Profile")
             }
+            CypherExecution::Mutation { .. } => panic!("plain MATCH must plan to a Query"),
         }
     }
 
@@ -6474,5 +6476,481 @@ mod multi_pattern {
             Err(Error::Query(QueryError::UnsupportedFeature { .. })) => {}
             Err(other) => panic!("expected UnsupportedFeature cap error, got {other:?}"),
         }
+    }
+}
+
+// ===========================================================================
+// Write clauses (Issue #560): CREATE / SET / DELETE / DETACH DELETE
+//
+// End-to-end mutation tests exercising the execute_cypher-only write path. Each
+// asserts the real side effect against the graph, plus bi-temporal correctness
+// (a CREATE is invisible AS OF before it; a SET records a new version while the
+// old version is still visible AS OF earlier).
+// ===========================================================================
+mod mutations {
+    use crate::AletheiaDB;
+    use crate::api::WriteOps;
+    use crate::core::error::Error;
+    use crate::core::property::{PropertyMapBuilder, PropertyValue};
+    use crate::core::temporal::time;
+    use crate::query::executor::{EntityResult, QueryRow};
+
+    fn run(db: &AletheiaDB, query: &str) -> Vec<QueryRow> {
+        db.execute_cypher(query).unwrap().collect_all().unwrap()
+    }
+
+    fn str_prop(entity: &EntityResult, key: &str) -> Option<String> {
+        match entity {
+            EntityResult::Node(n) => n.get_property(key).and_then(|v| match v {
+                PropertyValue::String(s) => Some(s.to_string()),
+                _ => None,
+            }),
+            _ => None,
+        }
+    }
+
+    fn int_prop_node(db: &AletheiaDB, label: &str, name: &str, key: &str) -> Option<i64> {
+        for id in db.scan_nodes_by_label(label) {
+            let node = db.get_node(id).unwrap();
+            if node.get_property("name") == Some(&PropertyValue::from(name)) {
+                return node.get_property(key).and_then(|v| match v {
+                    PropertyValue::Int(n) => Some(*n),
+                    _ => None,
+                });
+            }
+        }
+        None
+    }
+
+    fn node_id_by_name(db: &AletheiaDB, label: &str, name: &str) -> crate::core::id::NodeId {
+        for id in db.scan_nodes_by_label(label) {
+            let node = db.get_node(id).unwrap();
+            if node.get_property("name") == Some(&PropertyValue::from(name)) {
+                return id;
+            }
+        }
+        panic!("no {label} named {name}");
+    }
+
+    // ---- CREATE ----------------------------------------------------------
+
+    #[test]
+    fn create_node_persists_and_returns() {
+        let db = AletheiaDB::new().unwrap();
+        let rows = run(&db, "CREATE (n:Person {name: 'Zed', age: 41}) RETURN n");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(str_prop(&rows[0].entity, "name").unwrap(), "Zed");
+        // Side effect: the node exists in current state.
+        assert_eq!(db.scan_nodes_by_label("Person").count(), 1);
+        assert_eq!(int_prop_node(&db, "Person", "Zed", "age"), Some(41));
+    }
+
+    #[test]
+    fn create_node_without_return_yields_no_rows_but_persists() {
+        let db = AletheiaDB::new().unwrap();
+        let rows = run(&db, "CREATE (n:Widget {sku: 'A1'})");
+        assert!(rows.is_empty());
+        assert_eq!(db.scan_nodes_by_label("Widget").count(), 1);
+    }
+
+    #[test]
+    fn create_relationship_between_new_nodes() {
+        let db = AletheiaDB::new().unwrap();
+        let rows = run(
+            &db,
+            "CREATE (a:Person {name: 'Alice'})-[r:KNOWS {since: 2020}]->(b:Person {name: 'Bob'}) \
+             RETURN a, r, b",
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(db.scan_nodes_by_label("Person").count(), 2);
+        assert_eq!(db.edge_count(), 1);
+        let alice = node_id_by_name(&db, "Person", "Alice");
+        let bob = node_id_by_name(&db, "Person", "Bob");
+        let out = db.get_outgoing_edges(alice);
+        assert_eq!(out.len(), 1);
+        let edge = db.get_edge(out[0]).unwrap();
+        assert_eq!(edge.target, bob);
+        assert!(edge.has_label_str("KNOWS"));
+    }
+
+    #[test]
+    fn match_then_create_relationship_binds_existing() {
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "A").build(),
+            )
+            .unwrap();
+        let b = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "B").build(),
+            )
+            .unwrap();
+        run(
+            &db,
+            "MATCH (a:Person {name: 'A'}), (b:Person {name: 'B'}) CREATE (a)-[:KNOWS]->(b)",
+        );
+        assert_eq!(db.edge_count(), 1);
+        let out = db.get_outgoing_edges(a);
+        assert_eq!(out.len(), 1);
+        assert_eq!(db.get_edge(out[0]).unwrap().target, b);
+    }
+
+    // ---- SET -------------------------------------------------------------
+
+    #[test]
+    fn set_overwrites_existing_property() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .insert("age", 30i64)
+                .build(),
+        )
+        .unwrap();
+        let rows = run(
+            &db,
+            "MATCH (n:Person {name: 'Alice'}) SET n.age = 31 RETURN n",
+        );
+        assert_eq!(rows.len(), 1);
+        // RETURN reflects the post-update value.
+        assert_eq!(
+            rows[0].entity.as_node().unwrap().get_property("age"),
+            Some(&PropertyValue::Int(31))
+        );
+        assert_eq!(int_prop_node(&db, "Person", "Alice", "age"), Some(31));
+    }
+
+    #[test]
+    fn set_creates_missing_property_and_keeps_others() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .insert("age", 30i64)
+                .build(),
+        )
+        .unwrap();
+        run(
+            &db,
+            "MATCH (n:Person {name: 'Alice'}) SET n.city = 'London'",
+        );
+        let id = node_id_by_name(&db, "Person", "Alice");
+        let node = db.get_node(id).unwrap();
+        assert_eq!(
+            node.get_property("city"),
+            Some(&PropertyValue::from("London"))
+        );
+        // PATCH semantics: pre-existing props survive.
+        assert_eq!(node.get_property("age"), Some(&PropertyValue::Int(30)));
+        assert_eq!(
+            node.get_property("name"),
+            Some(&PropertyValue::from("Alice"))
+        );
+    }
+
+    #[test]
+    fn set_multiple_properties_one_statement() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .unwrap();
+        run(
+            &db,
+            "MATCH (n:Person {name: 'Alice'}) SET n.age = 40, n.city = 'Paris'",
+        );
+        let node = db
+            .get_node(node_id_by_name(&db, "Person", "Alice"))
+            .unwrap();
+        assert_eq!(node.get_property("age"), Some(&PropertyValue::Int(40)));
+        assert_eq!(
+            node.get_property("city"),
+            Some(&PropertyValue::from("Paris"))
+        );
+    }
+
+    #[test]
+    fn set_all_matched_nodes() {
+        let db = AletheiaDB::new().unwrap();
+        for name in ["A", "B", "C"] {
+            db.create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", name).build(),
+            )
+            .unwrap();
+        }
+        let rows = run(&db, "MATCH (n:Person) SET n.active = 1 RETURN n");
+        assert_eq!(rows.len(), 3);
+        for id in db.scan_nodes_by_label("Person") {
+            assert_eq!(
+                db.get_node(id).unwrap().get_property("active"),
+                Some(&PropertyValue::Int(1))
+            );
+        }
+    }
+
+    #[test]
+    fn set_on_no_match_is_noop() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .unwrap();
+        let rows = run(
+            &db,
+            "MATCH (n:Person {name: 'Nobody'}) SET n.age = 99 RETURN n",
+        );
+        assert!(rows.is_empty());
+        assert_eq!(int_prop_node(&db, "Person", "Alice", "age"), None);
+    }
+
+    // ---- DELETE / DETACH DELETE -----------------------------------------
+
+    #[test]
+    fn delete_unconnected_node() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .unwrap();
+        run(&db, "MATCH (n:Person {name: 'Alice'}) DELETE n");
+        assert_eq!(db.scan_nodes_by_label("Person").count(), 0);
+    }
+
+    #[test]
+    fn plain_delete_of_connected_node_is_refused() {
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "A").build(),
+            )
+            .unwrap();
+        let b = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "B").build(),
+            )
+            .unwrap();
+        db.create_edge(a, b, "KNOWS", crate::core::property::PropertyMap::new())
+            .unwrap();
+        // openCypher safety rule: refuse to orphan the edge.
+        let err = db.execute_cypher("MATCH (n:Person {name: 'A'}) DELETE n");
+        assert!(err.is_err(), "expected refusal, got Ok");
+        // Nothing deleted (atomic).
+        assert_eq!(db.scan_nodes_by_label("Person").count(), 2);
+        assert_eq!(db.edge_count(), 1);
+    }
+
+    #[test]
+    fn detach_delete_removes_node_and_edges() {
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "A").build(),
+            )
+            .unwrap();
+        let b = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "B").build(),
+            )
+            .unwrap();
+        db.create_edge(a, b, "KNOWS", crate::core::property::PropertyMap::new())
+            .unwrap();
+        run(&db, "MATCH (n:Person {name: 'A'}) DETACH DELETE n");
+        assert!(db.get_node(a).is_err());
+        // The connected edge is gone (no orphan).
+        assert_eq!(db.edge_count(), 0);
+        // B survives.
+        assert!(db.get_node(b).is_ok());
+    }
+
+    #[test]
+    fn delete_relationship_variable() {
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "A").build(),
+            )
+            .unwrap();
+        let b = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "B").build(),
+            )
+            .unwrap();
+        db.create_edge(a, b, "KNOWS", crate::core::property::PropertyMap::new())
+            .unwrap();
+        run(&db, "MATCH (a:Person {name: 'A'})-[r:KNOWS]->(b) DELETE r");
+        // Both nodes survive; the relationship is gone.
+        assert_eq!(db.edge_count(), 0);
+        assert!(db.get_node(a).is_ok());
+        assert!(db.get_node(b).is_ok());
+    }
+
+    #[test]
+    fn delete_node_and_its_relationship_together() {
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "A").build(),
+            )
+            .unwrap();
+        let b = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "B").build(),
+            )
+            .unwrap();
+        db.create_edge(a, b, "KNOWS", crate::core::property::PropertyMap::new())
+            .unwrap();
+        // Deleting both the node and its (only) edge in one clause is allowed
+        // regardless of listing order (edges are deleted before nodes).
+        run(
+            &db,
+            "MATCH (a:Person {name: 'A'})-[r:KNOWS]->(b) DELETE a, r",
+        );
+        assert!(db.get_node(a).is_err());
+        assert_eq!(db.edge_count(), 0);
+    }
+
+    // ---- Bi-temporal correctness ----------------------------------------
+
+    #[test]
+    fn created_node_is_invisible_as_of_before_creation() {
+        let db = AletheiaDB::new().unwrap();
+        let before = time::now();
+        // Small delay is unnecessary: `before` was captured prior to the write.
+        run(&db, "CREATE (n:Person {name: 'Zed'})");
+        let id = node_id_by_name(&db, "Person", "Zed");
+        // Visible now.
+        assert!(db.get_node(id).is_ok());
+        // Invisible as of a transaction time strictly before the create.
+        assert!(
+            db.get_node_at_time(id, before, before).is_err(),
+            "node should not exist as of before its creation"
+        );
+    }
+
+    #[test]
+    fn set_records_new_version_old_still_visible_as_of_earlier() {
+        let db = AletheiaDB::new().unwrap();
+        let (id, t0) = db
+            .write_with_timestamp(|tx| {
+                tx.create_node(
+                    "Person",
+                    PropertyMapBuilder::new()
+                        .insert("name", "Alice")
+                        .insert("age", 30i64)
+                        .build(),
+                )
+            })
+            .unwrap();
+        run(&db, "MATCH (n:Person {name: 'Alice'}) SET n.age = 31");
+        // Current state: new version.
+        assert_eq!(
+            db.get_node(id).unwrap().get_property("age"),
+            Some(&PropertyValue::Int(30 + 1))
+        );
+        // AS OF the create commit: the old version (age 30) is still visible.
+        let old = db.get_node_at_time(id, t0, t0).unwrap();
+        assert_eq!(old.get_property("age"), Some(&PropertyValue::Int(30)));
+    }
+
+    // ---- Rejections (structured, never silently-wrong) -------------------
+
+    fn assert_query_error(db: &AletheiaDB, query: &str) {
+        match db.execute_cypher(query) {
+            Ok(_) => panic!("expected an error for `{query}`, got Ok"),
+            Err(Error::Query(_)) => {}
+            Err(other) => panic!("expected a Query error for `{query}`, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn merge_is_rejected() {
+        let db = AletheiaDB::new().unwrap();
+        // MERGE is deferred to a follow-up; it must reject cleanly (parse error),
+        // never partially apply.
+        assert!(
+            db.execute_cypher("MERGE (n:Person {name: 'Zed'}) RETURN n")
+                .is_err()
+        );
+        assert_eq!(db.node_count(), 0);
+    }
+
+    #[test]
+    fn remove_is_rejected() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .insert("age", 30i64)
+                .build(),
+        )
+        .unwrap();
+        // REMOVE is deferred (the native update API is PATCH-merge only).
+        assert!(db.execute_cypher("MATCH (n:Person) REMOVE n.age").is_err());
+        // No mutation happened.
+        assert_eq!(int_prop_node(&db, "Person", "Alice", "age"), Some(30));
+    }
+
+    #[test]
+    fn set_label_is_rejected() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .unwrap();
+        assert_query_error(&db, "MATCH (n:Person) SET n:Admin");
+    }
+
+    #[test]
+    fn create_undirected_relationship_is_rejected() {
+        let db = AletheiaDB::new().unwrap();
+        assert_query_error(&db, "CREATE (a:Person)-[:KNOWS]-(b:Person)");
+        assert_eq!(
+            db.node_count(),
+            0,
+            "no partial writes on a rejected statement"
+        );
+    }
+
+    #[test]
+    fn create_node_without_label_is_rejected() {
+        let db = AletheiaDB::new().unwrap();
+        assert_query_error(&db, "CREATE (n {name: 'x'})");
+    }
+
+    #[test]
+    fn set_replace_all_properties_is_rejected() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .unwrap();
+        assert_query_error(&db, "MATCH (n:Person) SET n = {age: 1}");
+    }
+
+    #[test]
+    fn explain_write_is_rejected_and_has_no_side_effect() {
+        let db = AletheiaDB::new().unwrap();
+        assert_query_error(&db, "EXPLAIN CREATE (n:Person {name: 'Zed'})");
+        assert_eq!(db.node_count(), 0);
     }
 }

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -6953,4 +6953,240 @@ mod mutations {
         assert_query_error(&db, "EXPLAIN CREATE (n:Person {name: 'Zed'})");
         assert_eq!(db.node_count(), 0);
     }
+
+    // ---- Test hardening (coordinator review follow-ups) ------------------
+
+    /// Multiple SET items in one statement must record exactly ONE new version
+    /// (create = v1, the coalesced multi-property SET = v2), not one per item.
+    #[test]
+    fn set_multiple_items_produce_exactly_one_version() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .unwrap();
+        let id = node_id_by_name(&db, "Person", "Alice");
+        assert_eq!(db.get_node_history(id).unwrap().version_count(), 1);
+        run(
+            &db,
+            "MATCH (n:Person {name: 'Alice'}) SET n.a = 1, n.b = 2, n.c = 3",
+        );
+        // Exactly one additional version, not three.
+        assert_eq!(db.get_node_history(id).unwrap().version_count(), 2);
+        let node = db.get_node(id).unwrap();
+        assert_eq!(node.get_property("a"), Some(&PropertyValue::Int(1)));
+        assert_eq!(node.get_property("b"), Some(&PropertyValue::Int(2)));
+        assert_eq!(node.get_property("c"), Some(&PropertyValue::Int(3)));
+    }
+
+    /// A self-loop is one connected edge (counted/removed once) under DETACH.
+    #[test]
+    fn detach_delete_self_loop_removed_once() {
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node("P", PropertyMapBuilder::new().insert("name", "A").build())
+            .unwrap();
+        db.create_edge(a, a, "LOOP", crate::core::property::PropertyMap::new())
+            .unwrap();
+        // Self-loop is one distinct connected edge.
+        assert_eq!(db.count_connected_edges(a).unwrap(), 1);
+        run(&db, "MATCH (n:P) DETACH DELETE n");
+        assert!(db.get_node(a).is_err());
+        assert_eq!(db.edge_count(), 0);
+    }
+
+    /// Same-statement CREATE with a comma-separated pattern that reuses an
+    /// earlier-created variable (`(a:X), (a)-[:R]->(b:Y)`).
+    #[test]
+    fn create_with_reused_variable_ref() {
+        let db = AletheiaDB::new().unwrap();
+        run(&db, "CREATE (a:X {name: 'A'}), (a)-[:R]->(b:Y {name: 'B'})");
+        assert_eq!(db.scan_nodes_by_label("X").count(), 1);
+        assert_eq!(db.scan_nodes_by_label("Y").count(), 1);
+        assert_eq!(db.edge_count(), 1);
+        let a = node_id_by_name(&db, "X", "A");
+        let out = db.get_outgoing_edges(a);
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            db.get_edge(out[0]).unwrap().target,
+            node_id_by_name(&db, "Y", "B")
+        );
+    }
+
+    /// RETURN after DELETE yields the pre-delete snapshot (materialize_row
+    /// fallback path), and the node is actually gone.
+    #[test]
+    fn return_after_delete_yields_snapshot() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .unwrap();
+        let rows = run(&db, "MATCH (n:Person {name: 'Alice'}) DELETE n RETURN n");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(str_prop(&rows[0].entity, "name").unwrap(), "Alice");
+        assert_eq!(db.scan_nodes_by_label("Person").count(), 0);
+    }
+
+    /// An empty MATCH performs zero mutations for both CREATE and DELETE.
+    #[test]
+    fn empty_match_zero_mutations() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .unwrap();
+        // CREATE driven by an empty match creates nothing.
+        run(&db, "MATCH (g:Ghost) CREATE (m:New {x: 1})");
+        assert_eq!(db.scan_nodes_by_label("New").count(), 0);
+        // DELETE driven by an empty match deletes nothing.
+        run(&db, "MATCH (g:Ghost) DELETE g");
+        assert_eq!(db.scan_nodes_by_label("Person").count(), 1);
+    }
+
+    /// A multi-row `DELETE` where one matched row is connected must roll back
+    /// ALL rows' deletes (atomic across rows), not just refuse the connected one.
+    #[test]
+    fn multi_row_delete_is_atomic_across_rows() {
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "A").build(),
+            )
+            .unwrap();
+        let b = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "B").build(),
+            )
+            .unwrap();
+        let _c = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "C").build(),
+            )
+            .unwrap();
+        db.create_edge(a, b, "KNOWS", crate::core::property::PropertyMap::new())
+            .unwrap();
+        // A (and B) are connected; a plain DELETE of all Persons must refuse and
+        // leave EVERY node + the edge intact.
+        assert!(db.execute_cypher("MATCH (n:Person) DELETE n").is_err());
+        assert_eq!(db.scan_nodes_by_label("Person").count(), 3);
+        assert_eq!(db.edge_count(), 1);
+    }
+
+    /// `SET` on a relationship variable.
+    #[test]
+    fn set_on_edge_property() {
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "A").build(),
+            )
+            .unwrap();
+        let b = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "B").build(),
+            )
+            .unwrap();
+        db.create_edge(a, b, "KNOWS", crate::core::property::PropertyMap::new())
+            .unwrap();
+        run(
+            &db,
+            "MATCH (a:Person {name: 'A'})-[r:KNOWS]->(b) SET r.since = 2020",
+        );
+        let edge = db.get_edge(db.get_outgoing_edges(a)[0]).unwrap();
+        assert_eq!(edge.get_property("since"), Some(&PropertyValue::Int(2020)));
+    }
+
+    /// Minor 1: create-edge-then-plain-delete-endpoint refuses cleanly (friendly
+    /// DETACH-DELETE message) instead of aborting at commit, and stays atomic.
+    #[test]
+    fn create_edge_then_plain_delete_endpoint_is_refused() {
+        let db = AletheiaDB::new().unwrap();
+        let err = db.execute_cypher("CREATE (a:P {name: 'A'})-[:R]->(b:P {name: 'B'}) DELETE a");
+        assert!(
+            err.is_err(),
+            "plain DELETE of a just-created edge endpoint must be refused"
+        );
+        // Atomic: neither node nor the edge was committed.
+        assert_eq!(db.node_count(), 0);
+        assert_eq!(db.edge_count(), 0);
+    }
+
+    /// Minor 1 companion: DETACH DELETE of a same-statement-created edge endpoint
+    /// works (delete_node_cascade unions the buffered CREATE), no orphan.
+    #[test]
+    fn create_edge_then_detach_delete_endpoint_works() {
+        let db = AletheiaDB::new().unwrap();
+        run(
+            &db,
+            "CREATE (a:P {name: 'A'})-[:R]->(b:P {name: 'B'}) DETACH DELETE a",
+        );
+        // `a` and the relationship are gone; `b` survives; no orphaned edge.
+        assert_eq!(db.scan_nodes_by_label("P").count(), 1);
+        assert_eq!(db.edge_count(), 0);
+        assert_eq!(str_prop_of_only_p(&db), "B");
+    }
+
+    fn str_prop_of_only_p(db: &AletheiaDB) -> String {
+        let id = db.scan_nodes_by_label("P").next().unwrap();
+        match db.get_node(id).unwrap().get_property("name") {
+            Some(PropertyValue::String(s)) => s.to_string(),
+            _ => panic!("missing name"),
+        }
+    }
+
+    /// Minor 3: `SET r.x = 1` after `DELETE r` in one statement is a no-op on the
+    /// deleted edge (symmetric with the node path), not a not-found abort.
+    #[test]
+    fn set_on_edge_deleted_earlier_in_statement_is_noop() {
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "A").build(),
+            )
+            .unwrap();
+        let b = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "B").build(),
+            )
+            .unwrap();
+        db.create_edge(a, b, "KNOWS", crate::core::property::PropertyMap::new())
+            .unwrap();
+        // DELETE r then SET r.x must succeed (the SET is skipped), edge gone.
+        db.execute_cypher("MATCH (a:Person {name: 'A'})-[r:KNOWS]->(b) DELETE r SET r.x = 1")
+            .expect("SET on an already-deleted edge must be a no-op, not an error");
+        assert_eq!(db.edge_count(), 0);
+    }
+
+    /// Document + pin the openCypher `SET x = null` deviation: we store an
+    /// explicit Null value rather than removing the property key (true key
+    /// deletion is future work tied to REMOVE / a replace-tombstone write API).
+    #[test]
+    fn set_null_stores_explicit_null_v1_deviation() {
+        let db = AletheiaDB::new().unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .insert("age", 30i64)
+                .build(),
+        )
+        .unwrap();
+        run(&db, "MATCH (n:Person {name: 'Alice'}) SET n.age = null");
+        let node = db
+            .get_node(node_id_by_name(&db, "Person", "Alice"))
+            .unwrap();
+        // v1: the key is present with an explicit Null (NOT removed).
+        assert_eq!(node.get_property("age"), Some(&PropertyValue::Null));
+    }
 }

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -344,6 +344,9 @@ impl AletheiaDB {
             }
             crate::cypher::CypherExecution::Explain(query) => self.explain_cypher_query(query),
             crate::cypher::CypherExecution::Profile(query) => self.profile_cypher_query(query),
+            crate::cypher::CypherExecution::Mutation { statement, params } => {
+                self.execute_mutation(&statement, &params)
+            }
         }
     }
 
@@ -393,7 +396,27 @@ impl AletheiaDB {
             }
             crate::cypher::CypherExecution::Explain(query) => self.explain_cypher_query(query),
             crate::cypher::CypherExecution::Profile(query) => self.profile_cypher_query(query),
+            crate::cypher::CypherExecution::Mutation { statement, params } => {
+                self.execute_mutation(&statement, &params)
+            }
         }
+    }
+
+    /// Execute a Cypher write statement (Issue #560): `CREATE` / `SET` /
+    /// `DELETE` / `DETACH DELETE`.
+    ///
+    /// Dispatched here (rather than through the read-only `Query` pipeline)
+    /// because mutations are applied against the native write APIs so each
+    /// records the correct bi-temporal version. Reached only via
+    /// [`Self::execute_cypher`] / [`Self::execute_cypher_with_params`]; the MCP
+    /// `query` tool rejects mutating clauses before the parser runs
+    /// (`crate::query::read_only::detect_mutating_clause`).
+    fn execute_mutation(
+        &self,
+        statement: &crate::cypher::ast::CypherStatement,
+        params: &std::collections::HashMap<String, crate::cypher::CypherParameterValue>,
+    ) -> Result<QueryResults> {
+        crate::cypher::mutation::execute(self, statement, params)
     }
 
     /// Execute a multi-variable, multi-pattern `MATCH` (Issue #549).

--- a/src/query/read_only.rs
+++ b/src/query/read_only.rs
@@ -158,4 +158,32 @@ mod tests {
             None
         );
     }
+
+    /// Issue #560 false-positive hardening: a mutating keyword that appears only
+    /// inside a DOUBLE-quoted string literal, or as a substring of an ordinary
+    /// identifier / property key, must NOT trip the guard — a read stays allowed.
+    /// But a mutating keyword in any letter-case IS a whole-token match and must
+    /// be rejected.
+    #[test]
+    fn issue_560_guard_false_positive_and_case_hardening() {
+        // Double-quoted literal containing a keyword → read is allowed.
+        assert_eq!(
+            detect_mutating_clause(r#"MATCH (n {note: "DELETE"}) RETURN n"#),
+            None
+        );
+        // Substring identifiers (`created` / `deleted`) as a property key or
+        // variable are not the whole tokens CREATE / DELETE → allowed.
+        assert_eq!(
+            detect_mutating_clause("MATCH (n:Event) RETURN n.created, n.deleted"),
+            None
+        );
+        assert_eq!(
+            detect_mutating_clause("MATCH (created) RETURN created"),
+            None
+        );
+        // A mixed-case mutating keyword is still a whole-token match → rejected
+        // (the guard is case-insensitive, matching the case-insensitive lexer).
+        assert_eq!(detect_mutating_clause("CrEaTe (n)"), Some("CREATE"));
+        assert_eq!(detect_mutating_clause("match (n) DeLeTe n"), Some("DELETE"));
+    }
 }

--- a/src/query/read_only.rs
+++ b/src/query/read_only.rs
@@ -112,4 +112,50 @@ mod tests {
         );
         assert_eq!(detect_mutating_clause("match (n) set n.x = 1"), Some("SET"));
     }
+
+    /// Issue #560 guardrail: now that `execute_cypher` supports these write
+    /// clauses, the text-level read-only guard shared by the MCP `query` tool
+    /// and the HTTP `/query` RBAC classification MUST still reject every one of
+    /// them *before the parser runs*, so a mutation can never slip through the
+    /// read-only surface. This is intentionally redundant with the MCP-layer
+    /// tests (`src/mcp/tests.rs`) -- it pins the contract from the guard's own
+    /// module, which the Cypher lane owns.
+    #[test]
+    fn issue_560_write_clauses_stay_rejected_by_the_read_only_guard() {
+        let cases = [
+            ("CREATE (n:Person {name: 'Zed'}) RETURN n", "CREATE"),
+            ("MATCH (n:Person) SET n.age = 41 RETURN n", "SET"),
+            ("MATCH (n:Person {name: 'Alice'}) DELETE n", "DELETE"),
+            ("MATCH (n:Person) DETACH DELETE n", "DETACH"),
+            ("MATCH (n:Person) REMOVE n.age", "REMOVE"),
+            ("MERGE (n:Person {name: 'Zed'}) RETURN n", "MERGE"),
+            (
+                "MATCH (a:Person {name: 'A'})-[r:KNOWS]->(b) DELETE r",
+                "DELETE",
+            ),
+            ("CREATE (a:Team)-[:HAS]->(b:Member) RETURN a, b", "CREATE"),
+        ];
+        for (query, expected) in cases {
+            assert_eq!(
+                detect_mutating_clause(query),
+                Some(expected),
+                "read-only guard must reject `{query}` (found no mutating clause)"
+            );
+        }
+    }
+
+    /// The read-only guard must not be fooled into a *false positive* by a
+    /// mutating keyword that only appears as string-literal content, a node
+    /// label, or a property key -- a plain read stays allowed even next to those.
+    #[test]
+    fn issue_560_reads_with_keywordish_identifiers_still_pass() {
+        assert_eq!(
+            detect_mutating_clause("MATCH (n:Person {note: 'please CREATE later'}) RETURN n"),
+            None
+        );
+        assert_eq!(
+            detect_mutating_clause("MATCH (n:Create) RETURN n.delete"),
+            None
+        );
+    }
 }


### PR DESCRIPTION
## Before / After

**Before:** Cypher was read-only. `db.execute_cypher("CREATE (n:Person {name:'Zed'})")` failed with a parse error; the AST modeled `MATCH` only.

**After:** `execute_cypher` / `execute_cypher_with_params` support the core write subset — `CREATE` (nodes + relationships), `SET` (property updates), `DELETE`, and `DETACH DELETE` — plus `RETURN` of the affected entities. Every mutation goes through AletheiaDB's native bi-temporal write APIs in a **single all-or-nothing transaction**, so it records the correct historical version exactly as the direct Rust API would.

**The MCP `query` tool and HTTP `/query` stay strictly read-only** — this PR does not touch `src/mcp/server.rs` or its guard.

## How

- **AST** (`src/cypher/ast.rs`): new `CypherStatement::Write { reading, clauses, return_clause }`.
- **Lexer** (`src/cypher/lexer.rs`): `CREATE` / `SET` / `DELETE` / `DETACH` keyword tokens.
- **Parser** (`src/cypher/parser.rs`): a write clause after `MATCH ... [WHERE]` (or a leading `CREATE`) routes to `parse_write_statement`.
- **Executor** (new `src/cypher/mutation.rs`): applies clauses over the native `WriteOps` inside one `db.write(|tx| …)`. Reuses the #549 multi-pattern matcher via a new `multi_pattern::match_bindings` entry point.
- **Dispatch**: `exec.rs` carries `CypherExecution::Mutation`; `db/query.rs` dispatches to `execute_mutation`. `convert()` and `EXPLAIN`/`PROFILE` reject writes.
- **Compat** (`src/cypher/compat.rs`): mutation cases moved to `supported_execute_cases`; the execute runner rebuilds a **fresh seed graph per case**.

## Mutations are `execute_cypher`-only — the MCP query tool stays read-only

The guard `crate::query::read_only::detect_mutating_clause` is a **text-level scan that runs before the parser**, so implementing the parser/executor cannot weaken it. `src/mcp/server.rs` and its tests (`test_query_rejects_mutations_before_execution` and siblings) are untouched and remain green (28/28 `mcp::tests::query_tool_tests` pass). Positive guard tests in the module I own prove every newly-supported clause still rejects there: `query::read_only::tests::issue_560_write_clauses_stay_rejected_by_the_read_only_guard`, `issue_560_reads_with_keywordish_identifiers_still_pass`, and `issue_560_guard_false_positive_and_case_hardening` (double-quoted-literal / substring-identifier false positives allowed; mixed-case keyword rejected).

## Acceptance-criteria evidence

| # | Acceptance criterion | Where | Proving test(s) |
|---|----------------------|-------|-----------------|
| 1 | `CREATE` node/relationship support works | `mutation.rs` (`create_pattern`, `resolve_or_create_node`) | `mutations::create_node_persists_and_returns`, `create_relationship_between_new_nodes`, `match_then_create_relationship_binds_existing`, `create_with_reused_variable_ref`; compat `create_returns_created`, `create_relationship` |
| 2 | `SET` property updates work | `mutation.rs` (`apply_set`, PATCH-merge) | `set_overwrites_existing_property`, `set_creates_missing_property_and_keeps_others`, `set_multiple_properties_one_statement`, `set_all_matched_nodes`, `set_on_edge_property`, `set_multiple_items_produce_exactly_one_version` (exactly one new version, not N); compat `set_all_persons` |
| 3 | `DELETE` and `DETACH DELETE` with safety rules | `mutation.rs` (`apply_delete`) | `delete_unconnected_node`, `plain_delete_of_connected_node_is_refused`, `detach_delete_removes_node_and_edges`, `detach_delete_self_loop_removed_once`, `delete_relationship_variable`, `delete_node_and_its_relationship_together`, `multi_row_delete_is_atomic_across_rows`, `return_after_delete_yields_snapshot`, `empty_match_zero_mutations`; compat `delete_relationship`, `detach_delete_company` |
| 4 | Mutations preserve the bi-temporal model | native `WriteOps` versioning | `created_node_is_invisible_as_of_before_creation`, `set_records_new_version_old_still_visible_as_of_earlier`, `set_multiple_items_produce_exactly_one_version` |
| 5 | `MERGE` implemented or split into a follow-up | **filed as #3548** | `merge_is_rejected`; compat `mutating/merge`; guard test |

All `cypher::tests::mutations` tests pass; the 3 compat runners pass with the new cases.

## Review-follow-up fixes (commit `c58c71b`)

- **Minor 1** — `CREATE (a)-[:R]->(b) DELETE a` (plain, same statement) previously bypassed the friendly refusal and aborted at commit with a cryptic dangling-edge error. **Path taken:** fixed **entirely within `mutation.rs`** using a statement-local created-edge ledger — plain DELETE of such an endpoint now refuses cleanly with the "use `DETACH DELETE`" message; `DETACH DELETE` of the endpoint works (`delete_node_cascade` unions the buffered CREATE). No `src/api/transaction/**` changes. Tests: `create_edge_then_plain_delete_endpoint_is_refused`, `create_edge_then_detach_delete_endpoint_works`.
- **Minor 3** — `apply_set` now consults `deleted_edges` symmetrically with `deleted_nodes`, so `SET r.x = 1` after `DELETE r` in one statement is a no-op on the deleted edge. Test: `set_on_edge_deleted_earlier_in_statement_is_noop`.

## Follow-up issues filed

- **#3548 — Cypher: MERGE (match-or-create) support.** MERGE deferred as its own design problem (needs match-or-create + `ON CREATE`/`ON MATCH SET`). Stays a clean `ParseError`; the read-only guard already rejects it, so no MCP exposure risk.
- **#3549 — Storage: replace/tombstone (non-PATCH) node/edge write API.** Prerequisite for `REMOVE` and for openCypher `SET x = null` key-deletion. `update_node`/`update_edge` are PATCH-merge only, so a property key cannot be deleted and a single label cannot be mutated. A storage lane will pick this up.

## v1 limitations (rejected cleanly / documented, never partial)

- **`REMOVE` deferred (#3549).** Property/label removal needs the replace/tombstone write API above. Rejected at parse (`remove_is_rejected`).
- **`SET n.prop = null` stores an explicit `Null`, does not remove the key** (openCypher deviation; blocked on #3549). Pinned by `set_null_stores_explicit_null_v1_deviation`.
- **`RETURN` after a write re-reads current state post-commit** (a `SET`-updated node shows the new value; a deleted entity falls back to its pre-delete snapshot).
- **The reading `MATCH` is evaluated before the write transaction opens** (check-then-act window under concurrent writers; the writes themselves are atomic — all-or-nothing, one commit timestamp).
- `SET n:Label` / `SET n = {...}` / `SET n += {...}` → structured `UnsupportedFeature`.
- Variable-length relationships in a write, and aggregate/property `RETURN` projections after a write → rejected.
- A `SET`/`DELETE` binding the same entity across multiple matched rows applies once per row (can record multiple versions); multiple `SET` items on one entity in one row coalesce into one version.

All of the above are documented in `docs/guides/cypher-compatibility.md` (§1 write-clause deviations & §2 rejections, in lockstep with the compat suite).

## Gates

- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation,cypher" -- -D warnings` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all` — applied
- `cargo test --features "config-toml,mcp-server,sharding-rpc,simulation,cypher" --lib` — **4665 passed, 1 failed, 3 ignored**. The single failure is the pre-existing Lane-4 trunk break `mcp::auth_tests::live_tool_inventory_matches_golden` (this PR adds no MCP tools). The 3 ignored are the uid-0 sandbox havoc tests. All Cypher, compat, and MCP read-only rejection tests are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)