### PR TITLE
test(#3535): backfill mutation coverage for import parse + cypher exec error paths

### DIFF
--- a/src/api/import/parse.rs
+++ b/src/api/import/parse.rs
@@ -398,3 +398,492 @@ pub(crate) fn jsonl_rows(path: &Path) -> Result<RowIter, ImportError> {
 
     Ok(Box::new(iter))
 }
+
+#[cfg(test)]
+mod tests {
+    //! Coercion / error-path coverage (Issue #3535 mutation backfill).
+    //!
+    //! These tests pin the exact `Err(...)` messages and `Ok(...)` values of the
+    //! row-reader coercion helpers so the surviving mutants on this file's error
+    //! branches (surfaced by the PR #3527 Mutants run) are killed: each test
+    //! fails if the branch it targets is deleted or its return value swapped.
+
+    use super::*;
+
+    // --- get_str -----------------------------------------------------------
+
+    #[test]
+    fn get_str_returns_present_column_value() {
+        let mut cells = HashMap::new();
+        cells.insert("name".to_string(), Cell::Str("Alice".to_string()));
+        let row = Row::new(1, cells);
+        assert_eq!(row.get_str("name").unwrap(), "Alice");
+    }
+
+    #[test]
+    fn get_str_missing_column_is_err_with_column_name() {
+        let row = Row::new(1, HashMap::new());
+        let err = row.get_str("nope").unwrap_err();
+        assert_eq!(err, "missing column 'nope'");
+    }
+
+    // --- cell_to_string ----------------------------------------------------
+
+    #[test]
+    fn cell_to_string_covers_every_arm() {
+        assert_eq!(cell_to_string(&Cell::Str("hi".to_string())), "hi");
+        assert_eq!(
+            cell_to_string(&Cell::Json(serde_json::Value::String("js".to_string()))),
+            "js"
+        );
+        // JSON null renders as an empty string (treated as a blank cell).
+        assert_eq!(cell_to_string(&Cell::Json(serde_json::Value::Null)), "");
+        // A non-string JSON value renders via its JSON `to_string`.
+        assert_eq!(
+            cell_to_string(&Cell::Json(serde_json::json!(5))),
+            "5".to_string()
+        );
+        assert_eq!(
+            cell_to_string(&Cell::Json(serde_json::json!(true))),
+            "true".to_string()
+        );
+    }
+
+    // --- coerce_str error + success arms -----------------------------------
+
+    #[test]
+    fn coerce_str_string_preserves_raw_untrimmed() {
+        // The String arm uses `raw`, not the trimmed value.
+        assert_eq!(
+            coerce_str(" pad ", ColumnType::String).unwrap(),
+            PropertyValue::string(" pad ")
+        );
+    }
+
+    #[test]
+    fn coerce_str_int_ok_empty_and_error() {
+        assert_eq!(
+            coerce_str("42", ColumnType::Int).unwrap(),
+            PropertyValue::Int(42)
+        );
+        assert_eq!(
+            coerce_str("   ", ColumnType::Int).unwrap(),
+            PropertyValue::Null
+        );
+        assert_eq!(
+            coerce_str("x", ColumnType::Int).unwrap_err(),
+            "cannot coerce 'x' to Int"
+        );
+    }
+
+    #[test]
+    fn coerce_str_float_ok_empty_and_error() {
+        assert_eq!(
+            coerce_str("1.5", ColumnType::Float).unwrap(),
+            PropertyValue::Float(1.5)
+        );
+        assert_eq!(
+            coerce_str("", ColumnType::Float).unwrap(),
+            PropertyValue::Null
+        );
+        assert_eq!(
+            coerce_str("x", ColumnType::Float).unwrap_err(),
+            "cannot coerce 'x' to Float"
+        );
+    }
+
+    #[test]
+    fn coerce_str_bool_ok_empty_and_error() {
+        assert_eq!(
+            coerce_str("true", ColumnType::Bool).unwrap(),
+            PropertyValue::Bool(true)
+        );
+        assert_eq!(
+            coerce_str("", ColumnType::Bool).unwrap(),
+            PropertyValue::Null
+        );
+        assert_eq!(
+            coerce_str("maybe", ColumnType::Bool).unwrap_err(),
+            "cannot coerce 'maybe' to Bool"
+        );
+    }
+
+    #[test]
+    fn coerce_str_timestamp_ok_and_empty() {
+        assert_eq!(
+            coerce_str("1000", ColumnType::Timestamp).unwrap(),
+            PropertyValue::Int(1000)
+        );
+        assert_eq!(
+            coerce_str("", ColumnType::Timestamp).unwrap(),
+            PropertyValue::Null
+        );
+    }
+
+    #[test]
+    fn coerce_str_embedding_ok_empty_and_non_json_error() {
+        assert_eq!(
+            coerce_str("[1, 2, 3]", ColumnType::Embedding).unwrap(),
+            PropertyValue::try_vector([1.0f32, 2.0, 3.0]).unwrap()
+        );
+        assert_eq!(
+            coerce_str("", ColumnType::Embedding).unwrap(),
+            PropertyValue::Null
+        );
+        assert_eq!(
+            coerce_str("not-json", ColumnType::Embedding).unwrap_err(),
+            "cannot coerce 'not-json' to Embedding (expected JSON array)"
+        );
+    }
+
+    // --- json_to_embedding -------------------------------------------------
+
+    #[test]
+    fn json_to_embedding_non_array_is_err() {
+        assert_eq!(
+            json_to_embedding(&serde_json::json!({"a": 1})).unwrap_err(),
+            "cannot coerce non-array JSON to Embedding"
+        );
+        assert_eq!(
+            json_to_embedding(&serde_json::json!(7)).unwrap_err(),
+            "cannot coerce non-array JSON to Embedding"
+        );
+    }
+
+    #[test]
+    fn json_to_embedding_non_number_element_is_err() {
+        assert_eq!(
+            json_to_embedding(&serde_json::json!([1, "x", 3])).unwrap_err(),
+            "embedding element \"x\" is not a number"
+        );
+    }
+
+    #[test]
+    fn json_to_embedding_valid_array_builds_vector() {
+        assert_eq!(
+            json_to_embedding(&serde_json::json!([1.0, 2.0, 3.0])).unwrap(),
+            PropertyValue::try_vector([1.0f32, 2.0, 3.0]).unwrap()
+        );
+    }
+
+    // --- coerce_json error + success arms ----------------------------------
+
+    #[test]
+    fn coerce_json_null_is_null_for_any_type() {
+        assert_eq!(
+            coerce_json(&serde_json::Value::Null, ColumnType::Int).unwrap(),
+            PropertyValue::Null
+        );
+        assert_eq!(
+            coerce_json(&serde_json::Value::Null, ColumnType::Embedding).unwrap(),
+            PropertyValue::Null
+        );
+    }
+
+    #[test]
+    fn coerce_json_string_arms() {
+        assert_eq!(
+            coerce_json(&serde_json::json!("hi"), ColumnType::String).unwrap(),
+            PropertyValue::string("hi")
+        );
+        // Non-string JSON coerced to a String column stringifies.
+        assert_eq!(
+            coerce_json(&serde_json::json!(5), ColumnType::String).unwrap(),
+            PropertyValue::string("5")
+        );
+    }
+
+    #[test]
+    fn coerce_json_int_number_non_integer_is_err() {
+        // 1.5 has no i64 representation -> the `as_i64` error arm fires.
+        assert_eq!(
+            coerce_json(&serde_json::json!(1.5), ColumnType::Int).unwrap_err(),
+            "cannot coerce '1.5' to Int"
+        );
+        assert_eq!(
+            coerce_json(&serde_json::json!(9), ColumnType::Int).unwrap(),
+            PropertyValue::Int(9)
+        );
+    }
+
+    #[test]
+    fn coerce_json_int_string_delegates() {
+        assert_eq!(
+            coerce_json(&serde_json::json!("7"), ColumnType::Int).unwrap(),
+            PropertyValue::Int(7)
+        );
+        assert_eq!(
+            coerce_json(&serde_json::json!("x"), ColumnType::Int).unwrap_err(),
+            "cannot coerce 'x' to Int"
+        );
+    }
+
+    #[test]
+    fn coerce_json_float_and_bool_arms() {
+        assert_eq!(
+            coerce_json(&serde_json::json!(2.5), ColumnType::Float).unwrap(),
+            PropertyValue::Float(2.5)
+        );
+        assert_eq!(
+            coerce_json(&serde_json::json!("3.5"), ColumnType::Float).unwrap(),
+            PropertyValue::Float(3.5)
+        );
+        assert_eq!(
+            coerce_json(&serde_json::json!(true), ColumnType::Bool).unwrap(),
+            PropertyValue::Bool(true)
+        );
+        assert_eq!(
+            coerce_json(&serde_json::json!("false"), ColumnType::Bool).unwrap(),
+            PropertyValue::Bool(false)
+        );
+    }
+
+    #[test]
+    fn coerce_json_timestamp_number_non_integer_is_err() {
+        assert_eq!(
+            coerce_json(&serde_json::json!(1.25), ColumnType::Timestamp).unwrap_err(),
+            "cannot coerce '1.25' to Timestamp"
+        );
+        assert_eq!(
+            coerce_json(&serde_json::json!(1000), ColumnType::Timestamp).unwrap(),
+            PropertyValue::Int(1000)
+        );
+    }
+
+    #[test]
+    fn coerce_json_embedding_arms() {
+        assert_eq!(
+            coerce_json(&serde_json::json!([1.0, 2.0, 3.0]), ColumnType::Embedding).unwrap(),
+            PropertyValue::try_vector([1.0f32, 2.0, 3.0]).unwrap()
+        );
+        assert_eq!(
+            coerce_json(&serde_json::json!("[4, 5, 6]"), ColumnType::Embedding).unwrap(),
+            PropertyValue::try_vector([4.0f32, 5.0, 6.0]).unwrap()
+        );
+    }
+
+    #[test]
+    fn coerce_json_catch_all_type_mismatch_is_err() {
+        // A JSON bool coerced to an Int column hits the final catch-all arm.
+        assert_eq!(
+            coerce_json(&serde_json::json!(true), ColumnType::Int).unwrap_err(),
+            "cannot coerce JSON true to Int"
+        );
+    }
+
+    #[test]
+    fn coerce_dispatches_str_and_json() {
+        assert_eq!(
+            coerce(&Cell::Str("5".to_string()), ColumnType::Int).unwrap(),
+            PropertyValue::Int(5)
+        );
+        assert_eq!(
+            coerce(&Cell::Json(serde_json::json!(6)), ColumnType::Int).unwrap(),
+            PropertyValue::Int(6)
+        );
+    }
+
+    // --- parse_bool --------------------------------------------------------
+
+    #[test]
+    fn parse_bool_truthy_tokens() {
+        for t in ["true", "1", "yes", "t", "TRUE", "Yes"] {
+            assert_eq!(parse_bool(t), Some(true), "token {t}");
+        }
+    }
+
+    #[test]
+    fn parse_bool_falsy_tokens() {
+        for f in ["false", "0", "no", "f", "FALSE", "No"] {
+            assert_eq!(parse_bool(f), Some(false), "token {f}");
+        }
+    }
+
+    #[test]
+    fn parse_bool_unknown_is_none() {
+        assert_eq!(parse_bool("maybe"), None);
+        assert_eq!(parse_bool("2"), None);
+        assert_eq!(parse_bool(""), None);
+    }
+
+    // --- parse_valid_time --------------------------------------------------
+
+    #[test]
+    fn parse_valid_time_empty_is_err() {
+        assert_eq!(
+            parse_valid_time("   ").unwrap_err(),
+            "empty valid_time value"
+        );
+    }
+
+    #[test]
+    fn parse_valid_time_bare_integer_micros() {
+        assert_eq!(parse_valid_time("1000000").unwrap().wallclock(), 1_000_000);
+    }
+
+    #[test]
+    fn parse_valid_time_rfc3339_utc_and_offset() {
+        let z = parse_valid_time("2024-01-15T00:00:00Z").unwrap();
+        let off = parse_valid_time("2024-01-15T02:00:00+02:00").unwrap();
+        // Same instant expressed two ways -> identical micros.
+        assert_eq!(z.wallclock(), off.wallclock());
+    }
+
+    #[test]
+    fn parse_valid_time_naive_datetime_assumed_utc() {
+        let naive = parse_valid_time("2024-01-15T00:00:00").unwrap();
+        let utc = parse_valid_time("2024-01-15T00:00:00Z").unwrap();
+        assert_eq!(naive.wallclock(), utc.wallclock());
+    }
+
+    #[test]
+    fn parse_valid_time_bare_date_is_midnight_utc() {
+        let date = parse_valid_time("2024-01-15").unwrap();
+        let midnight = parse_valid_time("2024-01-15T00:00:00Z").unwrap();
+        assert_eq!(date.wallclock(), midnight.wallclock());
+    }
+
+    #[test]
+    fn parse_valid_time_garbage_is_err() {
+        assert_eq!(
+            parse_valid_time("not-a-date").unwrap_err(),
+            "could not parse valid_time 'not-a-date'"
+        );
+    }
+
+    // --- parquet-only helpers ---------------------------------------------
+
+    #[cfg(feature = "parquet")]
+    #[test]
+    fn property_value_to_string_covers_every_arm() {
+        assert_eq!(property_value_to_string(&PropertyValue::Null), "");
+        assert_eq!(property_value_to_string(&PropertyValue::Bool(true)), "true");
+        assert_eq!(property_value_to_string(&PropertyValue::Int(7)), "7");
+        assert_eq!(property_value_to_string(&PropertyValue::Float(1.5)), "1.5");
+        assert_eq!(property_value_to_string(&PropertyValue::string("hi")), "hi");
+        // The catch-all arm Debug-formats (e.g. a Vector).
+        let vector = PropertyValue::try_vector([1.0f32, 2.0, 3.0]).unwrap();
+        let rendered = property_value_to_string(&vector);
+        assert!(
+            rendered.contains("Vector"),
+            "expected Debug of a Vector, got {rendered}"
+        );
+    }
+
+    #[cfg(feature = "parquet")]
+    #[test]
+    fn cell_to_string_native_arm() {
+        assert_eq!(cell_to_string(&Cell::Native(PropertyValue::Int(9))), "9");
+        assert_eq!(cell_to_string(&Cell::Native(PropertyValue::Null)), "");
+    }
+
+    #[cfg(feature = "parquet")]
+    #[test]
+    fn coerce_native_null_is_null() {
+        assert_eq!(
+            coerce_native(&PropertyValue::Null, ColumnType::Int).unwrap(),
+            PropertyValue::Null
+        );
+    }
+
+    #[cfg(feature = "parquet")]
+    #[test]
+    fn coerce_native_string_arms() {
+        assert_eq!(
+            coerce_native(&PropertyValue::string("hi"), ColumnType::String).unwrap(),
+            PropertyValue::string("hi")
+        );
+        // A non-string widens via property_value_to_string.
+        assert_eq!(
+            coerce_native(&PropertyValue::Int(4), ColumnType::String).unwrap(),
+            PropertyValue::string("4")
+        );
+    }
+
+    #[cfg(feature = "parquet")]
+    #[test]
+    fn coerce_native_int_arms_and_error() {
+        assert_eq!(
+            coerce_native(&PropertyValue::Int(3), ColumnType::Int).unwrap(),
+            PropertyValue::Int(3)
+        );
+        assert_eq!(
+            coerce_native(&PropertyValue::string("7"), ColumnType::Int).unwrap(),
+            PropertyValue::Int(7)
+        );
+        assert_eq!(
+            coerce_native(&PropertyValue::Bool(true), ColumnType::Int).unwrap_err(),
+            "cannot coerce bool to Int"
+        );
+    }
+
+    #[cfg(feature = "parquet")]
+    #[test]
+    fn coerce_native_float_arms_and_error() {
+        assert_eq!(
+            coerce_native(&PropertyValue::Float(2.5), ColumnType::Float).unwrap(),
+            PropertyValue::Float(2.5)
+        );
+        // Int widens to Float.
+        assert_eq!(
+            coerce_native(&PropertyValue::Int(4), ColumnType::Float).unwrap(),
+            PropertyValue::Float(4.0)
+        );
+        assert_eq!(
+            coerce_native(&PropertyValue::string("1.5"), ColumnType::Float).unwrap(),
+            PropertyValue::Float(1.5)
+        );
+        assert_eq!(
+            coerce_native(&PropertyValue::Bool(false), ColumnType::Float).unwrap_err(),
+            "cannot coerce bool to Float"
+        );
+    }
+
+    #[cfg(feature = "parquet")]
+    #[test]
+    fn coerce_native_bool_arms_and_error() {
+        assert_eq!(
+            coerce_native(&PropertyValue::Bool(true), ColumnType::Bool).unwrap(),
+            PropertyValue::Bool(true)
+        );
+        assert_eq!(
+            coerce_native(&PropertyValue::string("no"), ColumnType::Bool).unwrap(),
+            PropertyValue::Bool(false)
+        );
+        assert_eq!(
+            coerce_native(&PropertyValue::Int(1), ColumnType::Bool).unwrap_err(),
+            "cannot coerce int to Bool"
+        );
+    }
+
+    #[cfg(feature = "parquet")]
+    #[test]
+    fn coerce_native_timestamp_arms_and_error() {
+        assert_eq!(
+            coerce_native(&PropertyValue::Int(1000), ColumnType::Timestamp).unwrap(),
+            PropertyValue::Int(1000)
+        );
+        assert_eq!(
+            coerce_native(&PropertyValue::string("2000"), ColumnType::Timestamp).unwrap(),
+            PropertyValue::Int(2000)
+        );
+        assert_eq!(
+            coerce_native(&PropertyValue::Bool(true), ColumnType::Timestamp).unwrap_err(),
+            "cannot coerce bool to Timestamp"
+        );
+    }
+
+    #[cfg(feature = "parquet")]
+    #[test]
+    fn coerce_native_embedding_arms_and_error() {
+        let vector = PropertyValue::try_vector([1.0f32, 2.0, 3.0]).unwrap();
+        assert_eq!(
+            coerce_native(&vector, ColumnType::Embedding).unwrap(),
+            vector
+        );
+        assert_eq!(
+            coerce_native(&PropertyValue::Int(1), ColumnType::Embedding).unwrap_err(),
+            "cannot coerce int to Embedding"
+        );
+    }
+}

--- a/src/api/import/parse.rs
+++ b/src/api/import/parse.rs
@@ -509,7 +509,7 @@ mod tests {
     }
 
     #[test]
-    fn coerce_str_timestamp_ok_and_empty() {
+    fn coerce_str_timestamp_ok_empty_and_parse_failure() {
         assert_eq!(
             coerce_str("1000", ColumnType::Timestamp).unwrap(),
             PropertyValue::Int(1000)
@@ -517,6 +517,12 @@ mod tests {
         assert_eq!(
             coerce_str("", ColumnType::Timestamp).unwrap(),
             PropertyValue::Null
+        );
+        // A non-empty, unparseable value must propagate the parse_valid_time
+        // error (the Timestamp arm has no error message of its own).
+        assert_eq!(
+            coerce_str("garbage", ColumnType::Timestamp).unwrap_err(),
+            "could not parse valid_time 'garbage'"
         );
     }
 
@@ -564,6 +570,18 @@ mod tests {
             json_to_embedding(&serde_json::json!([1.0, 2.0, 3.0])).unwrap(),
             PropertyValue::try_vector([1.0f32, 2.0, 3.0]).unwrap()
         );
+    }
+
+    #[test]
+    fn json_to_embedding_try_vector_failure_propagates() {
+        // A dimension over MAX_VECTOR_DIMENSIONS makes `try_vector` fail; the
+        // `.map_err(|e| e.to_string())` arm must surface that as a non-empty
+        // error string (not an Ok, not an empty string).
+        use crate::core::vector::constants::MAX_VECTOR_DIMENSIONS;
+        let oversized =
+            serde_json::Value::Array(vec![serde_json::json!(0.0); MAX_VECTOR_DIMENSIONS + 1]);
+        let err = json_to_embedding(&oversized).unwrap_err();
+        assert!(!err.is_empty(), "try_vector error must not be empty");
     }
 
     // --- coerce_json error + success arms ----------------------------------
@@ -651,6 +669,19 @@ mod tests {
     }
 
     #[test]
+    fn coerce_json_timestamp_string_delegates() {
+        // The (Timestamp, String) arm routes through coerce_str.
+        assert_eq!(
+            coerce_json(&serde_json::json!("2000"), ColumnType::Timestamp).unwrap(),
+            PropertyValue::Int(2000)
+        );
+        assert_eq!(
+            coerce_json(&serde_json::json!("garbage"), ColumnType::Timestamp).unwrap_err(),
+            "could not parse valid_time 'garbage'"
+        );
+    }
+
+    #[test]
     fn coerce_json_embedding_arms() {
         assert_eq!(
             coerce_json(&serde_json::json!([1.0, 2.0, 3.0]), ColumnType::Embedding).unwrap(),
@@ -721,26 +752,31 @@ mod tests {
         assert_eq!(parse_valid_time("1000000").unwrap().wallclock(), 1_000_000);
     }
 
+    // 2024-01-15T00:00:00Z is exactly 1_705_276_800 s = 1_705_276_800_000_000 µs
+    // since the Unix epoch. Pinning the absolute value catches a uniform
+    // conversion-corrupting mutant that a relative (x == Z-form) check misses.
+    const JAN_15_2024_UTC_MICROS: i64 = 1_705_276_800_000_000;
+
     #[test]
     fn parse_valid_time_rfc3339_utc_and_offset() {
         let z = parse_valid_time("2024-01-15T00:00:00Z").unwrap();
         let off = parse_valid_time("2024-01-15T02:00:00+02:00").unwrap();
-        // Same instant expressed two ways -> identical micros.
-        assert_eq!(z.wallclock(), off.wallclock());
+        // Absolute instant (kills uniform-offset mutants), and the same instant
+        // expressed two ways -> identical micros.
+        assert_eq!(z.wallclock(), JAN_15_2024_UTC_MICROS);
+        assert_eq!(off.wallclock(), JAN_15_2024_UTC_MICROS);
     }
 
     #[test]
     fn parse_valid_time_naive_datetime_assumed_utc() {
         let naive = parse_valid_time("2024-01-15T00:00:00").unwrap();
-        let utc = parse_valid_time("2024-01-15T00:00:00Z").unwrap();
-        assert_eq!(naive.wallclock(), utc.wallclock());
+        assert_eq!(naive.wallclock(), JAN_15_2024_UTC_MICROS);
     }
 
     #[test]
     fn parse_valid_time_bare_date_is_midnight_utc() {
         let date = parse_valid_time("2024-01-15").unwrap();
-        let midnight = parse_valid_time("2024-01-15T00:00:00Z").unwrap();
-        assert_eq!(date.wallclock(), midnight.wallclock());
+        assert_eq!(date.wallclock(), JAN_15_2024_UTC_MICROS);
     }
 
     #[test]

--- a/src/cypher/exec.rs
+++ b/src/cypher/exec.rs
@@ -827,3 +827,897 @@ fn is_aggregate_name(name: &str) -> bool {
         "COUNT" | "SUM" | "AVG" | "MIN" | "MAX" | "COLLECT"
     )
 }
+
+#[cfg(test)]
+mod tests {
+    //! Standalone-UNWIND error-path coverage (Issue #3535 mutation backfill).
+    //!
+    //! These tests pin the exact `Err(...)` variants/messages and `Ok(...)`
+    //! values of the UNWIND planning/validation/evaluation helpers so the
+    //! surviving mutants on this file's error branches (surfaced by the
+    //! PR #3527 Mutants run) are killed: each test fails if the branch it
+    //! targets is deleted or its return value swapped.
+
+    use super::*;
+    use crate::cypher::ast::CypherOrderItem;
+
+    // --- helpers -----------------------------------------------------------
+
+    fn no_params() -> HashMap<String, CypherParameterValue> {
+        HashMap::new()
+    }
+
+    fn ret_var(variable: &str) -> CypherReturn {
+        CypherReturn {
+            distinct: false,
+            items: vec![CypherReturnItem::Variable(variable.to_string())],
+            order_by: vec![],
+            skip: None,
+            limit: None,
+        }
+    }
+
+    /// Build one `UnwindRow` for the `order_kind` / `order_rows` helpers.
+    fn urow(value: PropertyValue) -> UnwindRow {
+        (value.clone(), vec![("x".to_string(), value)])
+    }
+
+    /// Plan a standalone UNWIND and collect the first output column of each row.
+    fn run_unwind_params(
+        cypher: &str,
+        params: HashMap<String, CypherParameterValue>,
+    ) -> Vec<PropertyValue> {
+        match plan_cypher_with_params(cypher, params).expect("plan should succeed") {
+            CypherExecution::Rows(results) => results
+                .collect_all()
+                .expect("collect should succeed")
+                .into_iter()
+                .map(|row| {
+                    row.columns.expect("standalone UNWIND rows carry columns")[0]
+                        .1
+                        .clone()
+                })
+                .collect(),
+            _ => panic!("expected CypherExecution::Rows for a standalone UNWIND"),
+        }
+    }
+
+    fn run_unwind(cypher: &str) -> Vec<PropertyValue> {
+        run_unwind_params(cypher, no_params())
+    }
+
+    // --- unwind_source_values ---------------------------------------------
+
+    #[test]
+    fn source_null_literal_is_empty() {
+        let src = CypherExpr::Value(CypherValue::Null);
+        assert!(
+            unwind_source_values(&src, "x", &no_params())
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn source_list_literal_yields_elements() {
+        let src = CypherExpr::List(vec![
+            CypherExpr::Value(CypherValue::Int(1)),
+            CypherExpr::Value(CypherValue::Int(2)),
+        ]);
+        assert_eq!(
+            unwind_source_values(&src, "x", &no_params()).unwrap(),
+            vec![PropertyValue::Int(1), PropertyValue::Int(2)]
+        );
+    }
+
+    #[test]
+    fn source_grouped_recurses() {
+        let src = CypherExpr::Grouped(Box::new(CypherExpr::List(vec![CypherExpr::Value(
+            CypherValue::Int(7),
+        )])));
+        assert_eq!(
+            unwind_source_values(&src, "x", &no_params()).unwrap(),
+            vec![PropertyValue::Int(7)]
+        );
+    }
+
+    #[test]
+    fn source_unbound_parameter_is_parameter_error() {
+        let src = CypherExpr::Value(CypherValue::Parameter("missing".to_string()));
+        let err = unwind_source_values(&src, "x", &no_params()).unwrap_err();
+        assert!(
+            matches!(err, CypherError::ParameterError(ref m) if m == "unbound parameter: $missing"),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn source_null_parameter_is_empty() {
+        let mut params = no_params();
+        params.insert("p".to_string(), CypherParameterValue::Null);
+        let src = CypherExpr::Value(CypherValue::Parameter("p".to_string()));
+        assert!(unwind_source_values(&src, "x", &params).unwrap().is_empty());
+    }
+
+    #[test]
+    fn source_list_parameter_yields_elements() {
+        let mut params = no_params();
+        params.insert(
+            "p".to_string(),
+            CypherParameterValue::List(vec![
+                CypherParameterValue::Int(1),
+                CypherParameterValue::Int(2),
+            ]),
+        );
+        let src = CypherExpr::Value(CypherValue::Parameter("p".to_string()));
+        assert_eq!(
+            unwind_source_values(&src, "x", &params).unwrap(),
+            vec![PropertyValue::Int(1), PropertyValue::Int(2)]
+        );
+    }
+
+    #[test]
+    fn source_embedding_parameter_expands_to_floats() {
+        let mut params = no_params();
+        params.insert(
+            "p".to_string(),
+            CypherParameterValue::Embedding(Arc::from([1.0f32, 2.0].as_slice())),
+        );
+        let src = CypherExpr::Value(CypherValue::Parameter("p".to_string()));
+        assert_eq!(
+            unwind_source_values(&src, "x", &params).unwrap(),
+            vec![PropertyValue::Float(1.0), PropertyValue::Float(2.0)]
+        );
+    }
+
+    #[test]
+    fn source_scalar_parameter_is_semantic_error() {
+        let mut params = no_params();
+        params.insert("p".to_string(), CypherParameterValue::Int(5));
+        let src = CypherExpr::Value(CypherValue::Parameter("p".to_string()));
+        let err = unwind_source_values(&src, "x", &params).unwrap_err();
+        match err {
+            CypherError::SemanticError(m) => {
+                assert!(m.contains("is a"), "got {m}");
+                assert!(m.contains("scalar"), "got {m}");
+            }
+            other => panic!("expected SemanticError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn source_row_dependent_expression_is_semantic_error() {
+        // A bare property access is neither a list nor null -> the catch-all
+        // `other` arm rejects it.
+        let src = CypherExpr::Property {
+            variable: "n".to_string(),
+            property: "tags".to_string(),
+        };
+        let err = unwind_source_values(&src, "x", &no_params()).unwrap_err();
+        match err {
+            CypherError::SemanticError(m) => {
+                assert!(m.contains("scalar or row-dependent"), "got {m}");
+            }
+            other => panic!("expected SemanticError, got {other:?}"),
+        }
+    }
+
+    // --- eval_element ------------------------------------------------------
+
+    #[test]
+    fn eval_element_depth_guard_is_parse_error() {
+        let expr = CypherExpr::Value(CypherValue::Int(1));
+        let err = eval_element(&expr, &no_params(), MAX_UNWIND_DEPTH + 1).unwrap_err();
+        match err {
+            CypherError::ParseError { message, .. } => {
+                assert_eq!(
+                    message,
+                    "UNWIND list nesting too deep for evaluation (max 256)"
+                );
+            }
+            other => panic!("expected ParseError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn eval_element_value_and_nested_list() {
+        assert_eq!(
+            eval_element(&CypherExpr::Value(CypherValue::Int(3)), &no_params(), 0).unwrap(),
+            PropertyValue::Int(3)
+        );
+        let nested = CypherExpr::List(vec![CypherExpr::Value(CypherValue::Int(1))]);
+        let out = eval_element(&nested, &no_params(), 0).unwrap();
+        assert_eq!(
+            out,
+            PropertyValue::Array(Arc::new(vec![PropertyValue::Int(1)]))
+        );
+    }
+
+    #[test]
+    fn eval_element_grouped_recurses() {
+        let expr = CypherExpr::Grouped(Box::new(CypherExpr::Value(CypherValue::Int(8))));
+        assert_eq!(
+            eval_element(&expr, &no_params(), 0).unwrap(),
+            PropertyValue::Int(8)
+        );
+    }
+
+    #[test]
+    fn eval_element_row_dependent_is_unsupported() {
+        let expr = CypherExpr::Property {
+            variable: "n".to_string(),
+            property: "k".to_string(),
+        };
+        let err = eval_element(&expr, &no_params(), 0).unwrap_err();
+        match err {
+            CypherError::UnsupportedFeature(m) => {
+                assert!(m.contains("row-dependent expression"), "got {m}");
+            }
+            other => panic!("expected UnsupportedFeature, got {other:?}"),
+        }
+    }
+
+    // --- value_to_property -------------------------------------------------
+
+    #[test]
+    fn value_to_property_all_literal_variants() {
+        let p = no_params();
+        assert_eq!(
+            value_to_property(&CypherValue::Null, &p).unwrap(),
+            PropertyValue::Null
+        );
+        assert_eq!(
+            value_to_property(&CypherValue::Bool(true), &p).unwrap(),
+            PropertyValue::Bool(true)
+        );
+        assert_eq!(
+            value_to_property(&CypherValue::Int(4), &p).unwrap(),
+            PropertyValue::Int(4)
+        );
+        assert_eq!(
+            value_to_property(&CypherValue::Float(1.5), &p).unwrap(),
+            PropertyValue::Float(1.5)
+        );
+        assert_eq!(
+            value_to_property(&CypherValue::String("hi".to_string()), &p).unwrap(),
+            PropertyValue::String(Arc::from("hi"))
+        );
+    }
+
+    #[test]
+    fn value_to_property_unbound_parameter_is_parameter_error() {
+        let err =
+            value_to_property(&CypherValue::Parameter("q".to_string()), &no_params()).unwrap_err();
+        assert!(
+            matches!(err, CypherError::ParameterError(ref m) if m == "unbound parameter: $q"),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn value_to_property_bound_parameter_resolves() {
+        let mut params = no_params();
+        params.insert("q".to_string(), CypherParameterValue::Int(42));
+        assert_eq!(
+            value_to_property(&CypherValue::Parameter("q".to_string()), &params).unwrap(),
+            PropertyValue::Int(42)
+        );
+    }
+
+    // --- param_to_property -------------------------------------------------
+
+    #[test]
+    fn param_to_property_depth_guard_is_parse_error() {
+        let err =
+            param_to_property(&CypherParameterValue::Int(1), MAX_UNWIND_DEPTH + 1).unwrap_err();
+        match err {
+            CypherError::ParseError { message, .. } => {
+                assert_eq!(
+                    message,
+                    "UNWIND list parameter nesting too deep for evaluation (max 256)"
+                );
+            }
+            other => panic!("expected ParseError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn param_to_property_variants_and_list_recursion() {
+        assert_eq!(
+            param_to_property(&CypherParameterValue::Null, 0).unwrap(),
+            PropertyValue::Null
+        );
+        assert_eq!(
+            param_to_property(&CypherParameterValue::Bool(true), 0).unwrap(),
+            PropertyValue::Bool(true)
+        );
+        assert_eq!(
+            param_to_property(&CypherParameterValue::Float(2.0), 0).unwrap(),
+            PropertyValue::Float(2.0)
+        );
+        assert_eq!(
+            param_to_property(&CypherParameterValue::String("s".to_string()), 0).unwrap(),
+            PropertyValue::String(Arc::from("s"))
+        );
+        let nested = CypherParameterValue::List(vec![CypherParameterValue::Int(9)]);
+        assert_eq!(
+            param_to_property(&nested, 0).unwrap(),
+            PropertyValue::Array(Arc::new(vec![PropertyValue::Int(9)]))
+        );
+    }
+
+    // --- validate_return_items --------------------------------------------
+
+    #[test]
+    fn validate_return_items_accepts_star_and_variable() {
+        let star = CypherReturn {
+            items: vec![CypherReturnItem::Star],
+            ..ret_var("x")
+        };
+        assert!(validate_return_items(&star, "x").is_ok());
+        assert!(validate_return_items(&ret_var("x"), "x").is_ok());
+    }
+
+    #[test]
+    fn validate_return_items_rejects_other_variable() {
+        let err = validate_return_items(&ret_var("y"), "x").unwrap_err();
+        match err {
+            CypherError::UnsupportedFeature(m) => {
+                assert!(m.contains("RETURN references variable 'y'"), "got {m}");
+            }
+            other => panic!("expected UnsupportedFeature, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_return_items_accepts_expression_of_unwound_variable() {
+        let ret = CypherReturn {
+            items: vec![CypherReturnItem::Expression {
+                expr: CypherExpr::Variable("x".to_string()),
+                alias: Some("out".to_string()),
+            }],
+            ..ret_var("x")
+        };
+        assert!(validate_return_items(&ret, "x").is_ok());
+    }
+
+    #[test]
+    fn validate_return_items_rejects_expression_of_other_variable() {
+        let ret = CypherReturn {
+            items: vec![CypherReturnItem::Expression {
+                expr: CypherExpr::Variable("y".to_string()),
+                alias: None,
+            }],
+            ..ret_var("x")
+        };
+        let err = validate_return_items(&ret, "x").unwrap_err();
+        assert!(
+            matches!(err, CypherError::UnsupportedFeature(ref m) if m.contains("RETURN references variable 'y'")),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_return_items_rejects_aggregate() {
+        let ret = CypherReturn {
+            items: vec![CypherReturnItem::Expression {
+                expr: CypherExpr::FunctionCall {
+                    name: "count".to_string(),
+                    args: vec![CypherExpr::Star],
+                    distinct: false,
+                },
+                alias: None,
+            }],
+            ..ret_var("x")
+        };
+        let err = validate_return_items(&ret, "x").unwrap_err();
+        match err {
+            CypherError::UnsupportedFeature(m) => {
+                assert!(m.contains("aggregation (count)"), "got {m}");
+            }
+            other => panic!("expected UnsupportedFeature, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_return_items_rejects_other_expression() {
+        let ret = CypherReturn {
+            items: vec![CypherReturnItem::Expression {
+                expr: CypherExpr::Property {
+                    variable: "x".to_string(),
+                    property: "k".to_string(),
+                },
+                alias: None,
+            }],
+            ..ret_var("x")
+        };
+        let err = validate_return_items(&ret, "x").unwrap_err();
+        match err {
+            CypherError::UnsupportedFeature(m) => {
+                assert!(m.contains("is not supported after a standalone"), "got {m}");
+            }
+            other => panic!("expected UnsupportedFeature, got {other:?}"),
+        }
+    }
+
+    // --- validate_order_by -------------------------------------------------
+
+    #[test]
+    fn validate_order_by_empty_returns_false() {
+        assert!(!validate_order_by(&ret_var("x"), "x").unwrap());
+    }
+
+    #[test]
+    fn validate_order_by_by_variable_returns_true() {
+        let ret = CypherReturn {
+            order_by: vec![CypherOrderItem {
+                expr: CypherExpr::Variable("x".to_string()),
+                descending: false,
+            }],
+            ..ret_var("x")
+        };
+        assert!(validate_order_by(&ret, "x").unwrap());
+    }
+
+    #[test]
+    fn validate_order_by_by_alias_returns_true() {
+        let ret = CypherReturn {
+            items: vec![CypherReturnItem::Expression {
+                expr: CypherExpr::Variable("x".to_string()),
+                alias: Some("a".to_string()),
+            }],
+            order_by: vec![CypherOrderItem {
+                expr: CypherExpr::Variable("a".to_string()),
+                descending: false,
+            }],
+            ..ret_var("x")
+        };
+        assert!(validate_order_by(&ret, "x").unwrap());
+    }
+
+    #[test]
+    fn validate_order_by_non_variable_expr_is_unsupported() {
+        let ret = CypherReturn {
+            order_by: vec![CypherOrderItem {
+                expr: CypherExpr::Property {
+                    variable: "x".to_string(),
+                    property: "k".to_string(),
+                },
+                descending: false,
+            }],
+            ..ret_var("x")
+        };
+        let err = validate_order_by(&ret, "x").unwrap_err();
+        assert!(
+            matches!(err, CypherError::UnsupportedFeature(ref m) if m.contains("ORDER BY")),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_order_by_wrong_variable_is_unsupported() {
+        let ret = CypherReturn {
+            order_by: vec![CypherOrderItem {
+                expr: CypherExpr::Variable("z".to_string()),
+                descending: false,
+            }],
+            ..ret_var("x")
+        };
+        let err = validate_order_by(&ret, "x").unwrap_err();
+        match err {
+            CypherError::UnsupportedFeature(m) => {
+                assert!(m.contains("ORDER BY 'z'"), "got {m}");
+            }
+            other => panic!("expected UnsupportedFeature, got {other:?}"),
+        }
+    }
+
+    // --- order_kind --------------------------------------------------------
+
+    #[test]
+    fn order_kind_homogeneous_kinds() {
+        assert!(matches!(
+            order_kind(&[urow(PropertyValue::Int(1)), urow(PropertyValue::Float(2.0))]).unwrap(),
+            OrderKind::Numeric
+        ));
+        assert!(matches!(
+            order_kind(&[urow(PropertyValue::String(Arc::from("a")))]).unwrap(),
+            OrderKind::Text
+        ));
+        assert!(matches!(
+            order_kind(&[urow(PropertyValue::Bool(true))]).unwrap(),
+            OrderKind::Boolean
+        ));
+    }
+
+    #[test]
+    fn order_kind_all_null_defaults_to_numeric() {
+        assert!(matches!(
+            order_kind(&[urow(PropertyValue::Null)]).unwrap(),
+            OrderKind::Numeric
+        ));
+        assert!(matches!(order_kind(&[]).unwrap(), OrderKind::Numeric));
+    }
+
+    #[test]
+    fn order_kind_non_scalar_is_unsupported() {
+        let arr = PropertyValue::Array(Arc::new(vec![PropertyValue::Int(1)]));
+        match order_kind(&[urow(arr)]) {
+            Err(CypherError::UnsupportedFeature(m)) => {
+                assert!(m.contains("only scalar values"), "got {m}");
+            }
+            Ok(_) => panic!("expected an error, got Ok"),
+            Err(other) => panic!("expected UnsupportedFeature, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn order_kind_heterogeneous_is_unsupported() {
+        match order_kind(&[
+            urow(PropertyValue::Int(1)),
+            urow(PropertyValue::String(Arc::from("a"))),
+        ]) {
+            Err(CypherError::UnsupportedFeature(m)) => {
+                assert!(m.contains("homogeneous scalar"), "got {m}");
+            }
+            Ok(_) => panic!("expected an error, got Ok"),
+            Err(other) => panic!("expected UnsupportedFeature, got {other:?}"),
+        }
+    }
+
+    // --- order_rows / compare_scalar --------------------------------------
+
+    fn first_values(rows: &[UnwindRow]) -> Vec<PropertyValue> {
+        rows.iter().map(|(v, _)| v.clone()).collect()
+    }
+
+    #[test]
+    fn order_rows_ascending_and_descending_ints() {
+        let mut rows = vec![
+            urow(PropertyValue::Int(3)),
+            urow(PropertyValue::Int(1)),
+            urow(PropertyValue::Int(2)),
+        ];
+        order_rows(&mut rows, false).unwrap();
+        assert_eq!(
+            first_values(&rows),
+            vec![
+                PropertyValue::Int(1),
+                PropertyValue::Int(2),
+                PropertyValue::Int(3)
+            ]
+        );
+        order_rows(&mut rows, true).unwrap();
+        assert_eq!(
+            first_values(&rows),
+            vec![
+                PropertyValue::Int(3),
+                PropertyValue::Int(2),
+                PropertyValue::Int(1)
+            ]
+        );
+    }
+
+    #[test]
+    fn order_rows_large_ints_keep_precision() {
+        // Two distinct integers above 2^53 must not collapse to a tie.
+        let a = (1_i64 << 53) + 1;
+        let b = (1_i64 << 53) + 2;
+        let mut rows = vec![urow(PropertyValue::Int(b)), urow(PropertyValue::Int(a))];
+        order_rows(&mut rows, false).unwrap();
+        assert_eq!(
+            first_values(&rows),
+            vec![PropertyValue::Int(a), PropertyValue::Int(b)]
+        );
+    }
+
+    #[test]
+    fn order_rows_strings_and_bools() {
+        let mut rows = vec![
+            urow(PropertyValue::String(Arc::from("b"))),
+            urow(PropertyValue::String(Arc::from("a"))),
+        ];
+        order_rows(&mut rows, false).unwrap();
+        assert_eq!(
+            first_values(&rows),
+            vec![
+                PropertyValue::String(Arc::from("a")),
+                PropertyValue::String(Arc::from("b"))
+            ]
+        );
+
+        let mut bools = vec![
+            urow(PropertyValue::Bool(true)),
+            urow(PropertyValue::Bool(false)),
+        ];
+        order_rows(&mut bools, false).unwrap();
+        assert_eq!(
+            first_values(&bools),
+            vec![PropertyValue::Bool(false), PropertyValue::Bool(true)]
+        );
+    }
+
+    #[test]
+    fn order_rows_null_placement() {
+        // Ascending: nulls last.
+        let mut asc = vec![
+            urow(PropertyValue::Null),
+            urow(PropertyValue::Int(2)),
+            urow(PropertyValue::Int(1)),
+        ];
+        order_rows(&mut asc, false).unwrap();
+        assert_eq!(
+            first_values(&asc),
+            vec![
+                PropertyValue::Int(1),
+                PropertyValue::Int(2),
+                PropertyValue::Null
+            ]
+        );
+        // Descending: nulls first.
+        let mut desc = vec![
+            urow(PropertyValue::Int(1)),
+            urow(PropertyValue::Null),
+            urow(PropertyValue::Int(2)),
+        ];
+        order_rows(&mut desc, true).unwrap();
+        assert_eq!(
+            first_values(&desc),
+            vec![
+                PropertyValue::Null,
+                PropertyValue::Int(2),
+                PropertyValue::Int(1)
+            ]
+        );
+    }
+
+    // --- is_aggregate_name -------------------------------------------------
+
+    #[test]
+    fn is_aggregate_name_recognizes_aggregates_case_insensitively() {
+        for name in ["count", "SUM", "Avg", "min", "MAX", "collect"] {
+            assert!(is_aggregate_name(name), "{name} should be an aggregate");
+        }
+        assert!(!is_aggregate_name("length"));
+        assert!(!is_aggregate_name("similarity"));
+    }
+
+    // --- needs_multi_binding ----------------------------------------------
+
+    fn parse_stmt(input: &str) -> CypherStatement {
+        CypherParser::parse(input).expect("parse should succeed")
+    }
+
+    #[test]
+    fn needs_multi_binding_single_terminal_variable_is_false() {
+        assert!(!needs_multi_binding(&parse_stmt("MATCH (n) RETURN n")));
+        assert!(!needs_multi_binding(&parse_stmt(
+            "MATCH (a)-[:R]->(b) RETURN b"
+        )));
+    }
+
+    #[test]
+    fn needs_multi_binding_multiple_referenced_vars_is_true() {
+        assert!(needs_multi_binding(&parse_stmt(
+            "MATCH (a)-[:R]->(b) RETURN a, b"
+        )));
+    }
+
+    #[test]
+    fn needs_multi_binding_anonymous_terminal_is_true() {
+        // Terminal node is anonymous, but `a` is referenced -> routed to the
+        // multi-pattern evaluator.
+        assert!(needs_multi_binding(&parse_stmt(
+            "MATCH (a)-[:R]->() RETURN a"
+        )));
+    }
+
+    #[test]
+    fn needs_multi_binding_non_match_is_false() {
+        assert!(!needs_multi_binding(&parse_stmt(
+            "UNWIND [1] AS x RETURN x"
+        )));
+    }
+
+    // --- end-to-end execute_unwind ----------------------------------------
+
+    #[test]
+    fn unwind_empty_and_null_expand_to_zero_rows() {
+        assert!(run_unwind("UNWIND [] AS x RETURN x").is_empty());
+        assert!(run_unwind("UNWIND null AS x RETURN x").is_empty());
+    }
+
+    #[test]
+    fn unwind_order_by_asc_and_desc() {
+        assert_eq!(
+            run_unwind("UNWIND [3, 1, 2] AS x RETURN x ORDER BY x"),
+            vec![
+                PropertyValue::Int(1),
+                PropertyValue::Int(2),
+                PropertyValue::Int(3)
+            ]
+        );
+        assert_eq!(
+            run_unwind("UNWIND [3, 1, 2] AS x RETURN x ORDER BY x DESC"),
+            vec![
+                PropertyValue::Int(3),
+                PropertyValue::Int(2),
+                PropertyValue::Int(1)
+            ]
+        );
+    }
+
+    #[test]
+    fn unwind_distinct_dedups() {
+        assert_eq!(
+            run_unwind("UNWIND [1, 1, 2] AS x RETURN DISTINCT x"),
+            vec![PropertyValue::Int(1), PropertyValue::Int(2)]
+        );
+    }
+
+    #[test]
+    fn unwind_skip_and_limit_paginate() {
+        assert_eq!(
+            run_unwind("UNWIND [1, 2, 3, 4] AS x RETURN x SKIP 1 LIMIT 2"),
+            vec![PropertyValue::Int(2), PropertyValue::Int(3)]
+        );
+    }
+
+    #[test]
+    fn unwind_parameter_list_end_to_end() {
+        let mut params = no_params();
+        params.insert(
+            "p".to_string(),
+            CypherParameterValue::List(vec![
+                CypherParameterValue::Int(10),
+                CypherParameterValue::Int(20),
+            ]),
+        );
+        assert_eq!(
+            run_unwind_params("UNWIND $p AS x RETURN x", params),
+            vec![PropertyValue::Int(10), PropertyValue::Int(20)]
+        );
+    }
+
+    // --- sharper boundary / discrimination tests --------------------------
+    // These pin operator, guard, size-hint, and depth-arithmetic mutants that
+    // a coarse "MAX+1" / message-only assertion leaves alive.
+
+    #[test]
+    fn vec_result_iterator_size_hint_is_exact() {
+        let it = VecResultIterator::new(vec![
+            QueryRow::from_columns(vec![("x".to_string(), PropertyValue::Int(1))]),
+            QueryRow::from_columns(vec![("x".to_string(), PropertyValue::Int(2))]),
+        ]);
+        // Exact `(len, Some(len))` -- distinguishes every wrong-tuple mutant.
+        assert_eq!(it.size_hint(), (2, Some(2)));
+    }
+
+    #[test]
+    fn eval_element_depth_boundary_is_inclusive() {
+        // At exactly MAX_UNWIND_DEPTH the guard (`depth > MAX`) must NOT fire;
+        // this kills the `>` -> `>=` mutant that an over-limit test cannot.
+        assert_eq!(
+            eval_element(
+                &CypherExpr::Value(CypherValue::Int(1)),
+                &no_params(),
+                MAX_UNWIND_DEPTH
+            )
+            .unwrap(),
+            PropertyValue::Int(1)
+        );
+    }
+
+    #[test]
+    fn param_to_property_depth_boundary_is_inclusive() {
+        assert_eq!(
+            param_to_property(&CypherParameterValue::Int(1), MAX_UNWIND_DEPTH).unwrap(),
+            PropertyValue::Int(1)
+        );
+    }
+
+    #[test]
+    fn eval_element_list_recursion_increments_depth() {
+        // A list nested deeper than MAX must trip the guard. The `depth + 1`
+        // increment is what accumulates toward the cap; a `depth * 1` mutant
+        // would leave depth pinned at 0 and never error.
+        let mut expr = CypherExpr::Value(CypherValue::Int(1));
+        for _ in 0..(MAX_UNWIND_DEPTH + 40) {
+            expr = CypherExpr::List(vec![expr]);
+        }
+        assert!(
+            matches!(
+                eval_element(&expr, &no_params(), 0),
+                Err(CypherError::ParseError { .. })
+            ),
+            "deeply nested list should trip the depth guard"
+        );
+    }
+
+    #[test]
+    fn eval_element_grouped_recursion_increments_depth() {
+        let mut expr = CypherExpr::Value(CypherValue::Int(1));
+        for _ in 0..(MAX_UNWIND_DEPTH + 40) {
+            expr = CypherExpr::Grouped(Box::new(expr));
+        }
+        assert!(matches!(
+            eval_element(&expr, &no_params(), 0),
+            Err(CypherError::ParseError { .. })
+        ));
+    }
+
+    #[test]
+    fn param_to_property_list_recursion_increments_depth() {
+        let mut param = CypherParameterValue::Int(1);
+        for _ in 0..(MAX_UNWIND_DEPTH + 40) {
+            param = CypherParameterValue::List(vec![param]);
+        }
+        assert!(matches!(
+            param_to_property(&param, 0),
+            Err(CypherError::ParseError { .. })
+        ));
+    }
+
+    #[test]
+    fn validate_return_items_non_aggregate_function_is_generic_error() {
+        // A non-aggregate function call must hit the generic `other` arm, NOT
+        // the aggregate arm -- this kills the `is_aggregate_name(name)` guard
+        // being replaced with `true`.
+        let ret = CypherReturn {
+            items: vec![CypherReturnItem::Expression {
+                expr: CypherExpr::FunctionCall {
+                    name: "length".to_string(),
+                    args: vec![CypherExpr::Variable("x".to_string())],
+                    distinct: false,
+                },
+                alias: None,
+            }],
+            ..ret_var("x")
+        };
+        match validate_return_items(&ret, "x") {
+            Err(CypherError::UnsupportedFeature(m)) => {
+                assert!(m.contains("is not supported after a standalone"), "got {m}");
+                assert!(!m.contains("aggregation"), "got {m}");
+            }
+            other => panic!("expected UnsupportedFeature, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn needs_multi_binding_comma_patterns_route_on_pattern_count() {
+        // Two comma-separated patterns with a single referenced terminal var:
+        // the ONLY clause making this multi-binding is `pattern.len() > 1`.
+        // Kills the `>` -> `<` and the `||` -> `&&` mutants on that clause.
+        assert!(needs_multi_binding(&parse_stmt("MATCH (a), (b) RETURN b")));
+    }
+
+    #[test]
+    fn plan_routes_multi_pattern_vs_single_entity() {
+        // The `needs_multi_binding` match guard in `plan_cypher_with_params`
+        // decides MultiPattern vs Query routing.
+        assert!(matches!(
+            plan_cypher("MATCH (a)-[:R]->(b) RETURN a, b").unwrap(),
+            CypherExecution::MultiPattern { .. }
+        ));
+        assert!(matches!(
+            plan_cypher("MATCH (n) RETURN n").unwrap(),
+            CypherExecution::Query(_)
+        ));
+    }
+
+    #[test]
+    fn explain_rejects_multi_pattern_but_plans_single() {
+        // The `needs_multi_binding` guard in `lower_for_plan`.
+        assert!(matches!(
+            plan_cypher("EXPLAIN MATCH (n) RETURN n").unwrap(),
+            CypherExecution::Explain(_)
+        ));
+        match plan_cypher("EXPLAIN MATCH (a)-[:R]->(b) RETURN a, b") {
+            Err(CypherError::UnsupportedFeature(m)) => {
+                assert!(m.contains("multi-pattern"), "got {m}");
+            }
+            Ok(_) => panic!("expected an error, got a plannable execution"),
+            Err(other) => panic!("expected UnsupportedFeature, got {other:?}"),
+        }
+    }
+}

--- a/src/cypher/exec.rs
+++ b/src/cypher/exec.rs
@@ -978,7 +978,6 @@ mod tests {
         let err = unwind_source_values(&src, "x", &params).unwrap_err();
         match err {
             CypherError::SemanticError(m) => {
-                assert!(m.contains("is a"), "got {m}");
                 assert!(m.contains("scalar"), "got {m}");
             }
             other => panic!("expected SemanticError, got {other:?}"),
@@ -1082,6 +1081,11 @@ mod tests {
             value_to_property(&CypherValue::String("hi".to_string()), &p).unwrap(),
             PropertyValue::String(Arc::from("hi"))
         );
+        let vec: Arc<[f32]> = Arc::from([1.0f32, 2.0, 3.0].as_slice());
+        assert_eq!(
+            value_to_property(&CypherValue::Vector(Arc::clone(&vec)), &p).unwrap(),
+            PropertyValue::Vector(vec)
+        );
     }
 
     #[test]
@@ -1143,6 +1147,13 @@ mod tests {
         assert_eq!(
             param_to_property(&nested, 0).unwrap(),
             PropertyValue::Array(Arc::new(vec![PropertyValue::Int(9)]))
+        );
+        // The Embedding arm maps to a dense Vector (distinct from the
+        // list-source expansion in unwind_source_values).
+        let emb: Arc<[f32]> = Arc::from([1.0f32, 2.0].as_slice());
+        assert_eq!(
+            param_to_property(&CypherParameterValue::Embedding(Arc::clone(&emb)), 0).unwrap(),
+            PropertyValue::Vector(emb)
         );
     }
 
@@ -1516,6 +1527,39 @@ mod tests {
     fn needs_multi_binding_non_match_is_false() {
         assert!(!needs_multi_binding(&parse_stmt(
             "UNWIND [1] AS x RETURN x"
+        )));
+    }
+
+    #[test]
+    fn needs_multi_binding_empty_referenced_is_false() {
+        // `RETURN *` binds no entity var into `referenced`, so with a single
+        // node pattern `referenced` is empty: original returns false, but the
+        // `referenced.len() > 1` -> `< 1` (== 0) mutant would flip it to true
+        // (0 < 1) because the `any()` over the empty set does NOT mask at len 0.
+        assert!(!needs_multi_binding(&parse_stmt("MATCH (n) RETURN *")));
+    }
+
+    #[test]
+    fn needs_multi_binding_varless_pattern_is_false() {
+        // All-anonymous pattern -> entity_vars empty -> early-return false.
+        assert!(!needs_multi_binding(&parse_stmt("MATCH () RETURN *")));
+    }
+
+    #[test]
+    fn needs_multi_binding_where_reference_counts() {
+        // The second entity var `a` is referenced ONLY via WHERE; without the
+        // where-clause collection path it would look single-terminal (`b`).
+        assert!(needs_multi_binding(&parse_stmt(
+            "MATCH (a)-[:R]->(b) WHERE a.age > 1 RETURN b"
+        )));
+    }
+
+    #[test]
+    fn needs_multi_binding_order_by_reference_counts() {
+        // The second entity var `a` is referenced ONLY via ORDER BY; this pins
+        // the order_by collection path.
+        assert!(needs_multi_binding(&parse_stmt(
+            "MATCH (a)-[:R]->(b) RETURN b ORDER BY a.age"
         )));
     }
 


### PR DESCRIPTION
Closes #3535.

## Before / After

**Before:** `src/api/import/parse.rs` and `src/cypher/exec.rs` had **zero** in-file unit tests. Their coercion and standalone-`UNWIND` error paths were exercised only indirectly (or not at all), so the PR #3527 Mutants run surfaced missed mutants on those error branches: no test asserted the specific `Err` variant / message / branch outcome, so mutating the branch away (or swapping its return) went undetected.

**After:** both files carry a test-only `#[cfg(test)] mod tests` block (zero production-code changes) that pins the **exact** error message / `Err` variant / `Ok` value of every error-path branch. Each test fails if its target branch is deleted or its return value swapped.

## How

- **parse.rs:** assert every arm of `get_str` (missing column), `cell_to_string`, `property_value_to_string` (parquet), `coerce_str` (Int/Float/Bool/Timestamp — incl. parse-failure — /Embedding), `json_to_embedding` (non-array, non-number element, **try_vector failure**), `coerce_json` (numeric-coerce failures, **Timestamp/String delegation**, type-mismatch catch-all), `coerce_native` (parquet error arms), `parse_bool`, and `parse_valid_time` (empty / integer / RFC3339 / naive / date pinned to an **absolute instant** / garbage).
- **exec.rs:** assert the standalone-`UNWIND` validation/evaluation error paths — `unwind_source_values`, `eval_element` / `param_to_property` (depth guard + boundary + deep-nesting recursion), `value_to_property` (incl. **Vector** arm), `param_to_property` (incl. **Embedding** arm), `validate_return_items`, `validate_order_by`, `order_kind`, `order_rows`/`compare_scalar` — plus discrimination tests for the observed operator/guard/size-hint mutants and `needs_multi_binding` routing (comma-pattern, **empty-referenced**, var-less, WHERE-ref, ORDER-BY-ref).

**Only test code was added.** No production logic in either file changed (verified: `git diff` is +test lines only).

## Mutant → killing test

The exact 12 were **not** machine-readable: the "Mutants (PR diff)" job on #3527 was **cancelled** mid-run (still on `src/query/executor/mod.rs` when killed) and never reached these two files, and #3535 references but does not enumerate them. I scoped `cargo-mutants` to the two files to enumerate the real survivors and added a test for each error branch.

| Mutant (file:fn — mutation) | Killing test |
|------------------------------|--------------|
| parse.rs `get_str` — delete `None` arm / body replace | `get_str_missing_column_is_err_with_column_name` |
| parse.rs `coerce_str` Int/Float/Bool — Err arms | `coerce_str_int_ok_empty_and_error`, `coerce_str_float_ok_empty_and_error`, `coerce_str_bool_ok_empty_and_error` |
| parse.rs `coerce_str` Timestamp — **parse-failure** arm | `coerce_str_timestamp_ok_empty_and_parse_failure` |
| parse.rs `coerce_str` Embedding — non-JSON arm | `coerce_str_embedding_ok_empty_and_non_json_error` |
| parse.rs `json_to_embedding` — non-array / non-number / **try_vector `map_err`** | `json_to_embedding_non_array_is_err`, `json_to_embedding_non_number_element_is_err`, `json_to_embedding_try_vector_failure_propagates` |
| parse.rs `coerce_json` — Int/Timestamp `as_i64` Err, **Timestamp/String**, catch-all | `coerce_json_int_number_non_integer_is_err`, `coerce_json_timestamp_number_non_integer_is_err`, `coerce_json_timestamp_string_delegates`, `coerce_json_catch_all_type_mismatch_is_err` |
| parse.rs `coerce_native` (parquet) — per-type Err arms | `coerce_native_int_arms_and_error`, `..._float_...`, `..._bool_...`, `..._timestamp_...`, `..._embedding_...` |
| parse.rs `parse_bool` — `_ => None` / arm swaps | `parse_bool_unknown_is_none`, `parse_bool_truthy_tokens`, `parse_bool_falsy_tokens` |
| parse.rs `parse_valid_time` — empty / catch-all Err, body replace, **uniform-conversion** | `parse_valid_time_empty_is_err`, `parse_valid_time_garbage_is_err`, `parse_valid_time_rfc3339_utc_and_offset` (absolute instant) |
| exec.rs `unwind_source_values` — unbound/scalar-param, row-dependent Err arms | `source_unbound_parameter_is_parameter_error`, `source_scalar_parameter_is_semantic_error`, `source_row_dependent_expression_is_semantic_error` |
| exec.rs `eval_element`/`param_to_property` — depth guard `>` (+ boundary + `+`→`*`) | `eval_element_depth_guard_is_parse_error`, `eval_element_depth_boundary_is_inclusive`, `param_to_property_depth_boundary_is_inclusive`, `*_recursion_increments_depth` |
| exec.rs `value_to_property` — unbound param + **Vector** arm | `value_to_property_unbound_parameter_is_parameter_error`, `value_to_property_all_literal_variants` |
| exec.rs `param_to_property` — **Embedding** arm | `param_to_property_variants_and_list_recursion` |
| exec.rs `validate_return_items` — other-var / aggregate / non-aggregate-guard / other-expr arms | `validate_return_items_rejects_other_variable`, `..._rejects_aggregate`, `..._non_aggregate_function_is_generic_error`, `..._rejects_other_expression` |
| exec.rs `validate_order_by` / `order_kind` — non-variable, wrong-var, non-scalar, heterogeneous Err arms | `validate_order_by_non_variable_expr_is_unsupported`, `..._wrong_variable_is_unsupported`, `order_kind_non_scalar_is_unsupported`, `order_kind_heterogeneous_is_unsupported` |
| exec.rs `needs_multi_binding` — `referenced.len() > 1` → `< 1`, `pattern.len() > 1` → `< 1`, `||`→`&&`, reference-collection paths | `needs_multi_binding_empty_referenced_is_false`, `..._comma_patterns_route_on_pattern_count`, `..._varless_pattern_is_false`, `..._where_reference_counts`, `..._order_by_reference_counts` |
| exec.rs `VecResultIterator::size_hint` / plan routing / EXPLAIN | `vec_result_iterator_size_hint_is_exact`, `plan_routes_multi_pattern_vs_single_entity`, `explain_rejects_multi_pattern_but_plans_single` |

## cargo-mutants evidence & honest caveat

`cargo-mutants` **was** installed and the baseline built/passed, but a faithful confirmation run is **infeasible in this environment**:

- A **scoped** run (`--file parse.rs --file exec.rs`, tests filtered to the two new modules) **over-reports**: it excludes the integration tests that catch most non-error-path mutants, so nearly everything shows MISSED regardless of coverage — the CI "12 survivors" came from the **full** suite.
- A **full-suite** scoped run is disk/time-bound: one debug build consumes ~28G on a ~30G runner (concurrent builds already triggered an `ld` **Bus error** from disk exhaustion); 118 mutants × per-mutant rebuild ≈ multiple hours.

**In lieu of the full re-run**, kills were proven by **targeted manual-mutation spot-checks** — injecting the exact `cargo-mutants` mutation, confirming a test fails, then reverting:
- `Ok(Default::default())` body-replacement of `parse_valid_time` / `validate_return_items` → **8** tests fail (arm-deletion / body-replacement class killed).
- `referenced.len() > 1` → `< 1` in `needs_multi_binding` → `needs_multi_binding_empty_referenced_is_false` fails (this mutant is **killed**, not unkillable).

**No documented-unkillable mutants remain.** (An earlier draft called the `referenced.len() > 1` → `< 1` mutant unkillable; that was wrong — the `any()`-masking argument only holds at len ≥ 2, and `MATCH (n) RETURN *` produces an empty `referenced` set where it diverges. It is now killed.)

## Gate evidence

- `cargo fmt --all` — clean.
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation,cypher" -- -D warnings` — **0 warnings**.
- `cargo clippy --all-targets --all-features -- -D warnings` — **0 warnings**.
- `cargo test --features "config-toml,mcp-server,sharding-rpc,simulation,cypher,parquet" --lib` — **4833 passed**, 3 ignored (uid-0 havoc), **1 failed**: `mcp::auth_tests::live_tool_inventory_matches_golden` (pre-existing Lane-4 trunk break — the live registry advertises `export_chain_head`/`verify_chain` not yet in the golden; unrelated to this PR). All new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)