### PR TITLE
🎻 Bard: [documentation update] Fix redundant explicit links

### DIFF
--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -1656,7 +1656,7 @@ impl WriteTransaction {
     ///   (`valid_to == valid_from` is allowed and yields an empty interval).
     /// - [`TemporalError::ValidTimeTooFarInFuture`](crate::core::error::TemporalError::ValidTimeTooFarInFuture)
     ///   if `valid_to` is more than one year in the future.
-    /// - [`StorageError::NodeNotFound`](crate::core::error::StorageError::NodeNotFound)
+    /// - [`StorageError::NodeNotFound`]
     ///   if the node never existed.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn retract_node(
@@ -1668,7 +1668,7 @@ impl WriteTransaction {
     }
 
     /// Buffer a valid-time retraction of a node, stamping a write-time
-    /// [`Provenance`](crate::core::provenance::Provenance) bundle recording the
+    /// [`Provenance`] bundle recording the
     /// acting principal onto the retraction version (Issue #3427).
     ///
     /// Behaves identically to [`retract_node`](Self::retract_node) other than
@@ -1795,7 +1795,7 @@ impl WriteTransaction {
     ///
     /// See [`retract_node`](Self::retract_node) for the bi-temporal
     /// semantics, idempotency contract, and errors (with
-    /// [`StorageError::EdgeNotFound`](crate::core::error::StorageError::EdgeNotFound)
+    /// [`StorageError::EdgeNotFound`]
     /// for a never-existing edge).
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn retract_edge(
@@ -1807,7 +1807,7 @@ impl WriteTransaction {
     }
 
     /// Buffer a valid-time retraction of an edge, stamping a write-time
-    /// [`Provenance`](crate::core::provenance::Provenance) bundle recording the
+    /// [`Provenance`] bundle recording the
     /// acting principal onto the retraction version (Issue #3427).
     ///
     /// See [`retract_node_with_provenance`](Self::retract_node_with_provenance)

--- a/src/db/lineage.rs
+++ b/src/db/lineage.rs
@@ -112,7 +112,7 @@ impl AletheiaDB {
     ///
     /// # Errors
     ///
-    /// - [`LineageError::SourceNotFound`] (as [`Error::Lineage`](crate::core::error::Error::Lineage))
+    /// - [`LineageError::SourceNotFound`] (as [`Error::Lineage`])
     ///   if any reference does not resolve to an existing fact version — the
     ///   node is **not** created.
     /// - Any error [`create_node`](Self::create_node) can return.

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -506,7 +506,7 @@ impl AletheiaDB {
     ///
     /// This is the *discovery* counterpart to the per-entity history/diff APIs: it answers
     /// "**which** entities were created, modified, or deleted between T1 and T2?" without the
-    /// caller already knowing any IDs. Each returned [`ChangeRecord`](crate::core::ChangeRecord)
+    /// caller already knowing any IDs. Each returned [`ChangeRecord`]
     /// carries the entity id, kind, change type, and the version's transaction- and valid-time
     /// bounds, so a caller can then drill in with `get_node_history` / `diff_node_versions`.
     ///

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -553,7 +553,7 @@ impl HistoricalStorage {
     }
 
     /// Add a new version of a node, optionally attaching a write-time
-    /// [`Provenance`](crate::core::provenance::Provenance) bundle (Issue #3224).
+    /// [`Provenance`] bundle (Issue #3224).
     ///
     /// Behaves identically to [`add_node_version`](Self::add_node_version) other
     /// than persisting `provenance` on the created version (anchor or delta).
@@ -610,7 +610,7 @@ impl HistoricalStorage {
     }
 
     /// Add a *retraction* version of a node (Issue #3230), optionally attaching a
-    /// write-time [`Provenance`](crate::core::provenance::Provenance) bundle
+    /// write-time [`Provenance`] bundle
     /// recording the acting principal (Issue #3427).
     ///
     /// Behaves identically to
@@ -854,7 +854,7 @@ impl HistoricalStorage {
     }
 
     /// Add a new version of an edge, optionally attaching a write-time
-    /// [`Provenance`](crate::core::provenance::Provenance) bundle (Issue #3224).
+    /// [`Provenance`] bundle (Issue #3224).
     ///
     /// Behaves identically to [`add_edge_version`](Self::add_edge_version) other
     /// than persisting `provenance` on the created version (anchor or delta).
@@ -919,7 +919,7 @@ impl HistoricalStorage {
     }
 
     /// Add a *retraction* version of an edge (Issue #3230), optionally attaching a
-    /// write-time [`Provenance`](crate::core::provenance::Provenance) bundle
+    /// write-time [`Provenance`] bundle
     /// recording the acting principal (Issue #3427). See
     /// [`add_retracted_node_version_with_provenance`](Self::add_retracted_node_version_with_provenance).
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
📖 Chapter: `api/transaction/write`, `db/lineage`, `db/temporal`, `storage/historical`
🔦 Insight: Removed explicit link paths (`(crate::core...)`) that duplicate the implicit link resolution `[`Item`]`, cleaning up numerous `rustdoc::redundant_explicit_links` warnings. Opted to ignore unresolved private links for now as removing brackets violates the "must be clickable" persona rule.
🧪 Example: N/A - formatting only.
🖼️ Preview: Documentation continues to render perfectly clickable links, without the linter clutter.

---
*PR created automatically by Jules for task [10448119029774451836](https://jules.google.com/task/10448119029774451836) started by @madmax983*