### PR TITLE
Gate the VectorIndexObserver snapshot path on the per-entity SnapshotPolicy (#383 follow-up)

### DIFF
--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -657,6 +657,41 @@ impl HistoricalStorage {
         self.edge_snapshot_policies.resolve(edge_id)
     }
 
+    /// Whether a node's anchor should trigger a temporal vector snapshot
+    /// (Issue #383).
+    ///
+    /// This is the single per-entity decision consulted by BOTH anchor-driven
+    /// snapshot triggers so they can never diverge:
+    /// 1. the **pre-anchor hook** run in `add_node_version*` (returns a snapshot
+    ///    id stored on the anchor), and
+    /// 2. the **`NodeAnchorCreated` observer event** delivered right after the
+    ///    anchor is stored, which the [`VectorIndexObserver`] reacts to by
+    ///    calling `create_snapshot_for_anchor`.
+    ///
+    /// A `Skip` node still forms its graph anchor normally; only these two
+    /// vector-snapshot triggers are suppressed. The default policy is
+    /// `Snapshot`, so absent any per-entity configuration this is always `true`
+    /// — byte-identical to the pre-#383 behavior.
+    ///
+    /// [`VectorIndexObserver`]: crate::index::vector::temporal::VectorIndexObserver
+    #[inline]
+    fn node_anchor_triggers_vector_snapshot(&self, node_id: NodeId) -> bool {
+        self.node_snapshot_policies
+            .resolve(node_id)
+            .should_snapshot()
+    }
+
+    /// Edge counterpart of
+    /// [`node_anchor_triggers_vector_snapshot`](Self::node_anchor_triggers_vector_snapshot)
+    /// (Issue #383). Gates both the edge pre-anchor hook and the
+    /// `EdgeAnchorCreated` observer event on the shared per-edge policy.
+    #[inline]
+    fn edge_anchor_triggers_vector_snapshot(&self, edge_id: EdgeId) -> bool {
+        self.edge_snapshot_policies
+            .resolve(edge_id)
+            .should_snapshot()
+    }
+
     /// Add a new version of a node.
     ///
     /// This will automatically determine whether to create an anchor or delta
@@ -862,12 +897,7 @@ impl HistoricalStorage {
         // snapshot is captured for it — decoupling graph anchors from vector
         // snapshots. The default policy is `Snapshot`, so absent any per-entity
         // configuration this is identical to the pre-#383 behavior.
-        if version.is_anchor()
-            && self
-                .node_snapshot_policies
-                .resolve(node_id)
-                .should_snapshot()
-        {
+        if version.is_anchor() && self.node_anchor_triggers_vector_snapshot(node_id) {
             self.run_pre_anchor_hooks_into(
                 &self.pre_node_anchor_hooks,
                 AnchorHookContext {
@@ -955,7 +985,14 @@ impl HistoricalStorage {
                 is_anchor,
             },
         );
-        if is_anchor {
+        // Issue #383: the `NodeAnchorCreated` event is the second temporal
+        // vector snapshot trigger (the `VectorIndexObserver` reacts to it by
+        // calling `create_snapshot_for_anchor`). Gate it on the SAME per-entity
+        // policy as the pre-anchor hook above so a `Skip` node captures no
+        // snapshot via EITHER path. The general `NodeVersionCreated` event
+        // (emitted unconditionally above) stays available for metrics/audit
+        // observers, so this never over-suppresses non-vector observers.
+        if is_anchor && self.node_anchor_triggers_vector_snapshot(node_id) {
             notify_observers(
                 &self.observers,
                 &StorageEvent::NodeAnchorCreated {
@@ -1197,12 +1234,7 @@ impl HistoricalStorage {
         // Issue #383: gated by the per-edge snapshot policy, symmetric with the
         // node path above. See `snapshot_policy` for the rationale and the
         // backward-compatible default (`Snapshot`).
-        if version.is_anchor()
-            && self
-                .edge_snapshot_policies
-                .resolve(edge_id)
-                .should_snapshot()
-        {
+        if version.is_anchor() && self.edge_anchor_triggers_vector_snapshot(edge_id) {
             self.run_pre_anchor_hooks_into(
                 &self.pre_edge_anchor_hooks,
                 AnchorHookContext {
@@ -1306,7 +1338,10 @@ impl HistoricalStorage {
                 is_anchor,
             },
         );
-        if is_anchor {
+        // Issue #383: symmetric with the node path — gate the second snapshot
+        // trigger (`EdgeAnchorCreated`, consumed by `VectorIndexObserver`) on
+        // the per-edge policy. `EdgeVersionCreated` above remains ungated.
+        if is_anchor && self.edge_anchor_triggers_vector_snapshot(edge_id) {
             notify_observers(
                 &self.observers,
                 &StorageEvent::EdgeAnchorCreated {

--- a/src/storage/historical/tests.rs
+++ b/src/storage/historical/tests.rs
@@ -6296,3 +6296,269 @@ fn test_snapshot_policy_mixed_sequence_completes() {
     assert_eq!(*seen, expected);
     assert_eq!(storage.hook_metrics().invocations, 10);
 }
+
+// ============================================================================
+// Issue #383 (follow-up): the SECOND vector-snapshot trigger — the
+// `VectorIndexObserver` path — must ALSO honor the per-entity snapshot policy.
+//
+// The observer fires from `notify_observers(NodeAnchorCreated{node_id,..})`
+// right after an anchor is stored (same critical section as the pre-anchor
+// hook) and calls `create_snapshot_for_anchor`. These tests use a *recording
+// observer* that captures the entity id of each `*AnchorCreated` event (and
+// separately the entity id of each `*VersionCreated` event), so we can assert
+// the anchor-event (vector-snapshot) trigger is delivered for EXACTLY the
+// entities whose policy opted in, while the general per-version event is never
+// over-suppressed.
+// ============================================================================
+
+/// Observer that records which entity ids it received anchor events and
+/// version events for. Mirrors `recording_hook` but on the post-commit
+/// observer path (the second snapshot trigger).
+struct RecordingObserver {
+    node_anchors: StdMutex<Vec<u64>>,
+    edge_anchors: StdMutex<Vec<u64>>,
+    node_versions: StdMutex<Vec<u64>>,
+    edge_versions: StdMutex<Vec<u64>>,
+}
+
+impl RecordingObserver {
+    fn new() -> Self {
+        Self {
+            node_anchors: StdMutex::new(Vec::new()),
+            edge_anchors: StdMutex::new(Vec::new()),
+            node_versions: StdMutex::new(Vec::new()),
+            edge_versions: StdMutex::new(Vec::new()),
+        }
+    }
+}
+
+impl StorageObserver for RecordingObserver {
+    fn on_event(&self, event: &StorageEvent) -> Result<()> {
+        match event {
+            StorageEvent::NodeAnchorCreated { node_id, .. } => {
+                self.node_anchors.lock().unwrap().push(node_id.as_u64());
+            }
+            StorageEvent::EdgeAnchorCreated { edge_id, .. } => {
+                self.edge_anchors.lock().unwrap().push(edge_id.as_u64());
+            }
+            StorageEvent::NodeVersionCreated { node_id, .. } => {
+                self.node_versions.lock().unwrap().push(node_id.as_u64());
+            }
+            StorageEvent::EdgeVersionCreated { edge_id, .. } => {
+                self.edge_versions.lock().unwrap().push(edge_id.as_u64());
+            }
+        }
+        Ok(())
+    }
+}
+
+/// RED: a `Skip` node must NOT deliver a `NodeAnchorCreated` event to the
+/// observer (the second snapshot trigger), so the observer's
+/// `create_snapshot_for_anchor` never runs for it — mirroring the gated hook.
+#[test]
+fn test_snapshot_policy_skip_node_suppresses_observer() {
+    let mut storage = HistoricalStorage::new();
+    let observer = Arc::new(RecordingObserver::new());
+    storage.add_observer(observer.clone());
+
+    storage.set_node_snapshot_policy(NodeId::new(1).unwrap(), SnapshotPolicy::Skip);
+
+    add_first_node_anchor(&mut storage, 1);
+
+    assert!(
+        observer.node_anchors.lock().unwrap().is_empty(),
+        "Skip entity must not deliver a NodeAnchorCreated (no observer snapshot)"
+    );
+    // The general per-version event is NOT gated: metrics/audit observers still
+    // see the write.
+    assert_eq!(
+        *observer.node_versions.lock().unwrap(),
+        vec![1],
+        "the general NodeVersionCreated event must NOT be over-suppressed"
+    );
+}
+
+/// A default (Snapshot) node still delivers the anchor event to the observer.
+#[test]
+fn test_snapshot_policy_default_node_delivers_observer_anchor() {
+    let mut storage = HistoricalStorage::new();
+    let observer = Arc::new(RecordingObserver::new());
+    storage.add_observer(observer.clone());
+
+    add_first_node_anchor(&mut storage, 1);
+    add_first_node_anchor(&mut storage, 2);
+
+    assert_eq!(
+        *observer.node_anchors.lock().unwrap(),
+        vec![1, 2],
+        "default Snapshot policy delivers every anchor to the observer"
+    );
+}
+
+/// Two nodes with different policies are gated independently on the observer
+/// path: the anchor event reaches the observer for exactly the opted-in node.
+#[test]
+fn test_snapshot_policy_two_nodes_independent_observer() {
+    let mut storage = HistoricalStorage::new();
+    let observer = Arc::new(RecordingObserver::new());
+    storage.add_observer(observer.clone());
+
+    storage.set_node_snapshot_policy(NodeId::new(1).unwrap(), SnapshotPolicy::Skip);
+    // Node 2 keeps the default (Snapshot).
+
+    add_first_node_anchor(&mut storage, 1);
+    add_first_node_anchor(&mut storage, 2);
+
+    assert_eq!(
+        *observer.node_anchors.lock().unwrap(),
+        vec![2],
+        "exactly the opted-in node reaches the observer"
+    );
+    // Both writes still produce a general version event.
+    assert_eq!(*observer.node_versions.lock().unwrap(), vec![1, 2]);
+}
+
+/// Default flipped to `Skip` gives an opt-in model on the observer path too.
+#[test]
+fn test_snapshot_policy_default_skip_opt_in_observer() {
+    let mut storage = HistoricalStorage::new();
+    let observer = Arc::new(RecordingObserver::new());
+    storage.add_observer(observer.clone());
+
+    storage.set_default_node_snapshot_policy(SnapshotPolicy::Skip);
+    storage.set_node_snapshot_policy(NodeId::new(5).unwrap(), SnapshotPolicy::Snapshot);
+
+    for id in [4u64, 5, 6] {
+        add_first_node_anchor(&mut storage, id);
+    }
+
+    assert_eq!(
+        *observer.node_anchors.lock().unwrap(),
+        vec![5],
+        "only the explicitly opted-in node reaches the observer"
+    );
+}
+
+/// BOTH snapshot paths agree: with a recording hook AND a recording observer
+/// registered together, a `Skip` node triggers NEITHER and a `Snapshot` node
+/// triggers BOTH, for the same entity id.
+#[test]
+fn test_snapshot_policy_hook_and_observer_agree() {
+    let mut storage = HistoricalStorage::new();
+    let seen_hook = Arc::new(std::sync::Mutex::new(Vec::<u64>::new()));
+    storage.add_pre_node_anchor_hook(recording_hook(&seen_hook, 9));
+    let observer = Arc::new(RecordingObserver::new());
+    storage.add_observer(observer.clone());
+
+    storage.set_node_snapshot_policy(NodeId::new(1).unwrap(), SnapshotPolicy::Skip);
+    // Node 2 keeps default Snapshot.
+
+    let s1 = add_first_node_anchor(&mut storage, 1); // Skip
+    let s2 = add_first_node_anchor(&mut storage, 2); // Snapshot
+
+    // Skip node: neither trigger fired.
+    assert_eq!(s1, None, "Skip node stores no hook snapshot id");
+    assert!(
+        !seen_hook.lock().unwrap().contains(&1),
+        "Skip node ran no hook"
+    );
+    assert!(
+        !observer.node_anchors.lock().unwrap().contains(&1),
+        "Skip node reached no observer anchor"
+    );
+
+    // Snapshot node: both triggers fired for the same entity.
+    assert_eq!(s2, Some(9), "Snapshot node stores the hook snapshot id");
+    assert!(
+        seen_hook.lock().unwrap().contains(&2),
+        "Snapshot node ran the hook"
+    );
+    assert!(
+        observer.node_anchors.lock().unwrap().contains(&2),
+        "Snapshot node reached the observer anchor"
+    );
+}
+
+/// Edge symmetry: a `Skip` edge suppresses the edge anchor event to the observer.
+#[test]
+fn test_snapshot_policy_skip_edge_suppresses_observer() {
+    let mut storage = HistoricalStorage::new();
+    let observer = Arc::new(RecordingObserver::new());
+    storage.add_observer(observer.clone());
+
+    storage.set_edge_snapshot_policy(EdgeId::new(1).unwrap(), SnapshotPolicy::Skip);
+    // Edge 2 keeps the default (Snapshot).
+
+    add_first_edge_anchor(&mut storage, 1);
+    add_first_edge_anchor(&mut storage, 2);
+
+    assert_eq!(
+        *observer.edge_anchors.lock().unwrap(),
+        vec![2],
+        "exactly the opted-in edge reaches the observer"
+    );
+    assert_eq!(*observer.edge_versions.lock().unwrap(), vec![1, 2]);
+}
+
+/// Delta versions never deliver an anchor event, regardless of policy — the
+/// observer gate rides on `is_anchor`, unchanged.
+#[test]
+fn test_snapshot_policy_observer_delta_never_anchors() {
+    let mut storage = HistoricalStorage::with_config(AnchorConfig {
+        anchor_interval: 100, // deltas after the first version
+        max_delta_chain: 200,
+    });
+    let observer = Arc::new(RecordingObserver::new());
+    storage.add_observer(observer.clone());
+
+    let node_id = NodeId::new(1).unwrap();
+    let label = GLOBAL_INTERNER.intern("Test").unwrap();
+    // Snapshot policy (default) — proves deltas are excluded by is_anchor, not policy.
+    for v in 1..=4u64 {
+        storage
+            .add_node_version(
+                node_id,
+                VersionId::new(v).unwrap(),
+                (1000 * v as i64).into(),
+                (1000 * v as i64).into(),
+                label,
+                PropertyMapBuilder::new().insert("v", v as i64).build(),
+                false,
+            )
+            .unwrap();
+    }
+
+    // Only the first version is an anchor.
+    assert_eq!(
+        *observer.node_anchors.lock().unwrap(),
+        vec![1],
+        "only the anchor version delivers a NodeAnchorCreated"
+    );
+    assert_eq!(
+        observer.node_versions.lock().unwrap().len(),
+        4,
+        "every version delivers a general NodeVersionCreated"
+    );
+}
+
+/// Lock-order / no-deadlock smoke: a mixed-policy anchor sequence with an
+/// observer registered completes and delivers anchor events for exactly the
+/// opted-in entities.
+#[test]
+fn test_snapshot_policy_observer_mixed_sequence_completes() {
+    let mut storage = HistoricalStorage::new();
+    let observer = Arc::new(RecordingObserver::new());
+    storage.add_observer(observer.clone());
+
+    for id in 1..=20u64 {
+        if id % 2 == 0 {
+            storage.set_node_snapshot_policy(NodeId::new(id).unwrap(), SnapshotPolicy::Skip);
+        }
+    }
+    for id in 1..=20u64 {
+        add_first_node_anchor(&mut storage, id);
+    }
+
+    let expected: Vec<u64> = (1..=20u64).filter(|id| id % 2 == 1).collect();
+    assert_eq!(*observer.node_anchors.lock().unwrap(), expected);
+}


### PR DESCRIPTION
## Before / After
Before: the per-entity SnapshotPolicy (#3544) gated only the pre-anchor hook. The
second temporal-vector snapshot trigger — the VectorIndexObserver, which reacts to
NodeAnchorCreated / EdgeAnchorCreated by calling create_snapshot_for_anchor — ignored
the policy, so a `Skip` entity still captured a snapshot via the observer.
After: both entity-attributable, anchor-driven snapshot triggers (hook + observer) honor
the same per-entity policy. A `Skip` entity captures no snapshot via either path; default
`Snapshot` is byte-identical to prior behavior.

## How
Gate the NodeAnchorCreated / EdgeAnchorCreated event emission in
add_node_version / add_edge_version on the SAME node/edge_snapshot_policies registry as the
hook, via two shared helpers (node_anchor_triggers_vector_snapshot /
edge_anchor_triggers_vector_snapshot) used at both the hook site and the observer-event site,
so the two paths share one decision and cannot diverge. The general *VersionCreated events
stay ungated, so metrics/audit observers are unaffected. Single source of truth — no second
policy store. The interval-based on_transaction (SnapshotStrategy) whole-index trigger is not
entity-attributable and is out of scope by construction (documented).

## Locking analysis
The gate is one map read consulted while the `historical` write lock is already held (same
critical section as the hook and the existing notify_observers call). It acquires no new
primitive, never calls back into wal / current_timestamp / temporal_indexes / id-gens /
adjacency, and only ever reduces work under the lock (a Skip skips the observer's HNSW
snapshot build). Lock order (current_timestamp → wal → historical → temporal_indexes →
id gens → outgoing → incoming) and #3525 bounded-hook guarantees are preserved.

## Tests
Observer-path tests mirror the hook tests, incl. one asserting both paths agree for the same
entity; Skip suppresses the anchor event on both node and edge paths while the general version
event still fires; deltas never emit an anchor event; mixed-policy sequence smoke.
clippy (feature-set + all-features) clean; cargo test --lib: 3808 passed / 0 failed.

Depends on #3544 (now merged). Refs #383.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEiTkeBP9LYFteGKaE5GMH)_