### PR TITLE
mcp: widen public re-export surface for #3361 direct-call bench (26->37 tools)

### DIFF
--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -45,12 +45,15 @@ pub use server::AletheiaMcpServer;
 
 // Re-export tool request/response types for testing (alphabetically sorted)
 pub use tools::{
-    CountEdgesRequest, CountNodesRequest, CreateEdgeRequest, CreateNodeRequest, DeleteEdgeRequest,
-    DeleteNodeCascadeRequest, DeleteNodeRequest, EnableVectorIndexRequest, FindNodesAtTimeRequest,
-    FindSimilarRequest, GetEdgeAtTimeRequest, GetEdgeRequest, GetIncomingEdgesRequest,
-    GetNodeAtTimeRequest, GetNodeRequest, GetOutgoingEdgesRequest, HybridQueryRequest,
-    ListChangesRequest, ListEdgesRequest, ListNodesRequest, ListVectorIndexesRequest,
-    ProvenanceRequest, QueryRequest, TemporalBounds, TraverseRequest, UpdateEdgeRequest,
+    CountEdgesRequest, CountNodesRequest, CreateEdgeRequest, CreateNodeRequest,
+    DatabaseStatsRequest, DeleteEdgeRequest, DeleteNodeCascadeRequest, DeleteNodeRequest,
+    EnableUniqueConstraintRequest, EnableVectorIndexRequest, FindNodesAtTimeRequest,
+    FindSimilarRequest, GetEdgeAtTimeRequest, GetEdgeHistoryRequest, GetEdgeRequest,
+    GetIncomingEdgesRequest, GetNodeAtTimeRequest, GetNodeHistoryRequest, GetNodeRequest,
+    GetOutgoingEdgesRequest, GetSchemaRequest, HybridQueryRequest, LineageQueryRequest,
+    ListChangesRequest, ListEdgesRequest, ListNodesRequest, ListUniqueConstraintsRequest,
+    ListVectorIndexesRequest, ProvenanceRequest, QueryRequest, RetractEdgeRequest,
+    RetractNodeRequest, TemporalBounds, TemporalExtentRequest, TraverseRequest, UpdateEdgeRequest,
     UpdateNodeRequest,
 };
 


### PR DESCRIPTION
## Summary

Widens the public direct-call surface of the `mcp` module by re-exporting **10 already-public, already-existing** typed request structs from `src/mcp/tools.rs` through the module's `pub use tools::{…}` block. This is a **re-exports-only** change: no new types, no new methods, no behavior change, no tool-handler or access-class change.

## Why

Lane 5's #3361 MCP round-trip benchmark (PR #3553) computes an overhead sub-metric by invoking each tool through its **public** typed direct-call entry point (`server.get_node(GetNodeRequest{..}) -> String`, etc.). It currently covers **26/46** tools because only 26 request structs are re-exported from the module root. The typed method + `pub` request struct already exist for the following 11 tools; they were simply not re-exported, so the bench could not name their request type from an external crate.

Adding them to the re-export block makes these 11 tools coverable (**26 → 37**):

`get_node_history`, `get_edge_history`, `get_schema`, `database_stats`, `temporal_extent`, `list_unique_constraints`, `enable_unique_constraint`, `retract_node`, `retract_edge`, `lineage_upstream`, `lineage_downstream`.

`lineage_upstream` and `lineage_downstream` share `LineageQueryRequest`, so this adds **10 distinct struct names**.

Consumer: PR #3553 (Lane 5, #3361 bench).

## Scope / non-goals

- No tool is added and no inventory changes — the parity golden stays **46** (verified: `parity_mcp` 11/11, `parity_http` 23/23 pass).
- The remaining **9** tools that #3553 cannot yet cover need **new public typed methods** (not just a re-export) and are explicitly **out of scope** for this PR — a future wave.

## Gates

- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` — pass
- `cargo clippy --all-targets --all-features -- -D warnings` — pass
- `cargo fmt --all` — applied
- `cargo test` (mcp lib + `parity_mcp` + `parity_http`) — pass (mcp lib 495/495 single-threaded; the `in_flight_cap_rejects_then_releases` timing test is a pre-existing parallel-contention flake — passes in isolation and single-threaded — unrelated to this re-export-only diff)

---
_Generated by [Claude Code](https://claude.ai/code/session_01US9RGTLAzSymm8eMtqdt3T)_