### PR TITLE
test(mcp): de-flake in_flight_cap_rejects_then_releases (#3542/#3368)

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6966,12 +6966,22 @@ mod server_unit_tests {
             serde_json::from_str(&AletheiaMcpServer::extract_text(ok)).unwrap();
         assert!(val.get("error").is_none(), "slot released, query ok: {val}");
         assert_eq!(val["row_count"].as_u64(), Some(1));
-        // No worker is left occupying a slot after completion.
-        assert_eq!(
-            server.in_flight_queries.load(super::Ordering::Acquire),
-            0,
-            "workers must release their slot on completion"
-        );
+        // No worker is left occupying a slot after completion. The worker
+        // releases its slot when its closure ends (the `InFlightGuard` drops),
+        // which is ordered strictly *after* it sends the result the caller
+        // already received above — so under parallel test load the guard-drop
+        // can lag the received result by a scheduling quantum. Wait
+        // deterministically (bounded) for the count to fall back to 0 rather
+        // than racing the worker with an immediate assert; a real slot leak
+        // still fails the test when the deadline elapses.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while server.in_flight_queries.load(super::Ordering::Acquire) != 0 {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "workers must release their slot on completion (still occupied after 5s)"
+            );
+            std::thread::yield_now();
+        }
     }
 
     /// FIX 2 (Issue #3368): the inline `timeout_ms == 0` path never spawns a

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6974,12 +6974,12 @@ mod server_unit_tests {
         // deterministically (bounded) for the count to fall back to 0 rather
         // than racing the worker with an immediate assert; a real slot leak
         // still fails the test when the deadline elapses.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let start = std::time::Instant::now();
+        let timeout = std::time::Duration::from_secs(5);
         while server.in_flight_queries.load(super::Ordering::Acquire) != 0 {
-            assert!(
-                std::time::Instant::now() < deadline,
-                "workers must release their slot on completion (still occupied after 5s)"
-            );
+            if start.elapsed() >= timeout {
+                panic!("workers must release their slot on completion (still occupied after 5s)");
+            }
             std::thread::yield_now();
         }
     }


### PR DESCRIPTION
## Summary

De-flakes the `in_flight_cap_rejects_then_releases` unit test in
`src/mcp/server.rs`, added by #3542 (Issue #3368, MCP per-query resource
limits + in-flight-query cap). The test passes in isolation but
**intermittently fails under full-parallel `cargo test`**, so since #3542
merged it has been intermittently reddening CI on every PR.

## Root cause — test-synchronization race (NOT a product bug)

The in-flight guard is an `Arc<AtomicUsize>` + RAII `InFlightGuard` moved into
the spawned timeout-race worker so the slot releases when the **worker**
finishes. In `race_deadline`, the worker does:

```rust
std::thread::spawn(move || {
    let _guard = guard;
    let _ = tx.send(f());   // (A) result sent → caller unblocks
    // (B) _guard drops here → counter decremented
});
```

The caller's `rx.recv_timeout` returns as soon as **(A)** lands. The test's
final assertion `assert_eq!(in_flight_queries == 0)` then ran immediately —
racing **(B)**, which happens strictly later in the worker thread. Under
parallel load the worker gets descheduled between (A) and (B), so the caller
observes the counter still at `1` and the assertion panics.

The product behavior (release-on-worker-finish) is exactly as documented and
**correct** — the counter is a per-instance `Arc<AtomicUsize>` (created fresh
in `new()`/`with_auth()`, only `query_limits` is swapped by
`with_query_limits`), so there is no process-global static and no cross-test
contention. The bug was purely in the test's immediate assert.

## Fix

Replace the immediate assert with a **deterministic, condition-based bounded
wait**: poll the counter (with `yield_now`) until it returns to `0`, failing
only if a 5s deadline elapses (so a genuine slot leak still fails the test).
No product code touched; in-flight-cap behavior (default 64, reject-at-cap
`UNAVAILABLE`/retriable, release-on-worker-finish) is unchanged. No
tool/inventory/parity-golden change.

## Verification

Isolated target dir; `src/mcp/**` only.

**Reproduced the flake pre-fix** (full default-parallel lib test binary):

```
run 2: in_flight_cap_rejects_then_releases ... FAILED
  panicked at src/mcp/server.rs:6970:9:
  assertion `left == right` failed: workers must release their slot on completion
    left: 1
PRE-FIX full-binary in_flight failures: 2 / 6   (runs 2 and 5)
```

**Post-fix, deterministic:**

- Full default-parallel lib test binary: **12/12 green** (4344 passed, 0 failed each run)
- `in_flight_cap_rejects_then_releases` isolated: **25/25 ok**
- 32-way concurrent stress (4 cores), 10 rounds: **320/320 ok**
- `parity_mcp`: 11 passed · `parity_http`: 23 passed
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --all`: clean

Refs #3542, #3368.

---
_Generated by [Claude Code](https://claude.ai/code/session_01US9RGTLAzSymm8eMtqdt3T)_