### PR TITLE
Fix VectorRank doctest compile error (missing metric/threshold/score_alias)

### DIFF
--- a/src/query/planner/rules/limit_pushdown.rs
+++ b/src/query/planner/rules/limit_pushdown.rs
@@ -50,6 +50,9 @@ use super::{OptimizationRule, Statistics};
 ///         embedding: vec![0.1, 0.2].into(),
 ///         top_k: None, // Missing limit!
 ///         property_key: None,
+///         metric: aletheiadb::core::vector::DistanceMetric::Cosine,
+///         threshold: None,
+///         score_alias: None,
 ///     },
 ///     scan
 /// );


### PR DESCRIPTION
## Before / After

**Before:** `cargo test --doc` failed to **compile** on trunk (and every PR branched off it):

```
error[E0063]: missing fields `metric`, `score_alias` and `threshold` in initializer of `UnaryOp`
  --> src/query/planner/rules/limit_pushdown.rs:50:5
```

**After:** the doctest compiles and the full doctest suite passes (`test result: ok. 414 passed; 0 failed`).

## Cause

Commit bce08e0 (#3543) added `metric` / `threshold` / `score_alias` fields to `UnaryOp::VectorRank` in `src/query/plan.rs`, but the `LimitPushdown` rustdoc example at `src/query/planner/rules/limit_pushdown.rs` still constructed the variant with only `embedding` / `top_k` / `property_key`. Doctests compile as an external crate, so the stale initializer broke the `Test Suite` doctest step for trunk and all branched PRs.

## How

Added the three fields introduced by #3543 to the doctest's `UnaryOp::VectorRank { .. }` initializer, using the external-crate path (`aletheiadb::core::vector::DistanceMetric::Cosine`, `threshold: None`, `score_alias: None`) to match the working construction at `src/query/plan.rs:633`. Doctest intent is unchanged.

A full `rg "VectorRank"` sweep across the repo confirmed this doctest was the **only** stale construction site — every compiled construction site (in `predicate_pushdown.rs`, `limit_pushdown.rs` unit tests, and `planner/mod.rs`) already carries the new fields.

## Impact

Unblocks the `Test Suite` doctest step on trunk and every PR branched off it.

## Files / sites touched

- `src/query/planner/rules/limit_pushdown.rs` — `LimitPushdown` doctest `UnaryOp::VectorRank` initializer (the only stale site)

Refs #3543

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEiTkeBP9LYFteGKaE5GMH)_