### PR TITLE
Silence RUSTSEC-2023-0071 (rsa Marvin timing sidechannel) in Security Audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -14,4 +14,16 @@ ignore = [
     # to the optional embedding pipeline, which is not deployed in production.
     # Track: upgrade embed_anything when it supports lopdf >= 0.42.
     "RUSTSEC-2026-0187",
+
+    # rsa 0.9.10 "Marvin Attack" key-recovery timing sidechannel (CVSS 5.9
+    # Medium). No patched release exists upstream. Pulled in TRANSITIVELY (not a
+    # direct dependency): rsa <- jsonwebtoken <- autumn-web 0.5 (via its `mcp`
+    # feature) <- the unpublished `crates/autumn-spike` crate ONLY. It is ABSENT
+    # from the default / CI / all-features builds, and no AletheiaDB code
+    # exercises RSA private-key operations, so exposure in shipped builds is nil.
+    # The `rsa` pull originates in the upstream `autumn-web 0.5` crate, so we
+    # cannot drop the feature from our own Cargo.toml; the durable fix is the
+    # upstream bump to autumn 0.6.0 (tracked via autumn#1828). This ignore is the
+    # interim unblock. Mirrors the lopdf RUSTSEC-2026-0187 precedent above.
+    "RUSTSEC-2023-0071",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,16 @@ jobs:
         uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: "RUSTSEC-2026-0104, RUSTSEC-2024-0436"
+          # RUSTSEC-2023-0071: rsa 0.9.10 "Marvin Attack" timing sidechannel
+          # (CVSS 5.9 Medium, no patched release). Transitive-only via
+          # jsonwebtoken <- autumn-web 0.5 (mcp feature) <- unpublished
+          # crates/autumn-spike; absent from default/CI/all-features builds and
+          # no RSA private-key ops are exercised, so shipped-build exposure is
+          # nil. Durable fix is upstream in autumn 0.6.0. Mirrors the audit.toml
+          # RUSTSEC-2026-0187 (lopdf) precedent. rustsec/audit-check@v2 honors
+          # only this `ignore:` input, so the advisory is listed here as well as
+          # in .cargo/audit.toml.
+          ignore: "RUSTSEC-2026-0104, RUSTSEC-2024-0436, RUSTSEC-2023-0071"
 
   feature-matrix:
     name: Feature Matrix


### PR DESCRIPTION
## Status: DRAFT — silences a real security advisory; merge is the user's call

This is a coordinator-sanctioned CI/audit-config hotfix. It stays **DRAFT** pending the user's decision because it suppresses a genuine (if unreachable) advisory.

## What
Adds `RUSTSEC-2023-0071` to the audit ignore list so the `security:` ("Security Audit") CI job passes. Exact edits:

- **`.cargo/audit.toml`** — added `"RUSTSEC-2023-0071"` to the `[advisories] ignore` array with a justification comment block (mirrors the existing lopdf `RUSTSEC-2026-0187` entry directly above it). **This is the load-bearing change** (see "Effective mechanism" below).
- **`.github/workflows/ci.yml`** — appended `RUSTSEC-2023-0071` to the `security` job's `rustsec/audit-check@v2` `ignore:` input (`"RUSTSEC-2026-0104, RUSTSEC-2024-0436, RUSTSEC-2023-0071"`) with an inline comment. Belt-and-suspenders.

## Why
`RUSTSEC-2023-0071` = the **"Marvin Attack"** — a potential RSA key-recovery **timing sidechannel** in `rsa@0.9.10`. **CVSS 5.9 Medium. There is NO patched release** (`Solution: No fixed upgrade is available!`). It is pulled in **transitively** (it is not in our `Cargo.toml`).

## Reachability trace (verbatim, from Lane 2)
`rsa` &larr; `jsonwebtoken` &larr; `autumn-web 0.5` &larr; unpublished `crates/autumn-spike` only; ABSENT from default / CI / all-features builds; no code exercises RSA private-key ops. So exposure is nil in shipped builds.

## Effective mechanism (verified)
`rustsec/audit-check@v2` **does honor `.cargo/audit.toml`** (it runs cargo-audit, which loads the config), in addition to its own `ignore:` input. Proof: the four other real vulnerabilities in `Cargo.lock` (`RUSTSEC-2026-0187`, `-0099`, `-0104`, `-0098`) are silenced today, yet three of them (`-0187`, `-0099`, `-0098`) appear **only** in `.cargo/audit.toml` and not in ci.yml's `ignore:` input — so if the config file were ignored those would also fail the check, but the check fails on `RUSTSEC-2023-0071` **alone**. Hence `.cargo/audit.toml` is authoritative; the entry was added there (and additionally to ci.yml for safety).

Local `cargo audit` verification against `./Cargo.lock` (879 deps):
- **Before** (no ignore): `error: 5 vulnerabilities found!` — including `RUSTSEC-2023-0071  rsa 0.9.10  Marvin Attack  Severity: 5.9 (medium)  Solution: No fixed upgrade is available!`
- **After** (this branch's `.cargo/audit.toml`): `exit 0`, no `vulnerabilities found`, only `warning: 6 allowed warnings found` (unmaintained/unsound — non-blocking). `RUSTSEC-2023-0071` fully silenced.

## Precedent
Mirrors the existing `lopdf` `RUSTSEC-2026-0187` ignore in `.cargo/audit.toml` (same comment structure: advisory, severity, transitive chain, why-unreachable, durable-fix tracking).

## The real / durable fix (option 2)
The `rsa` pull is via `autumn-web 0.5`'s `mcp` feature — an **upstream** crate — so we **cannot** drop `jsonwebtoken`'s feature from our own `Cargo.toml`. The durable fix is upstream in **autumn 0.6.0** (flagged to the user re: autumn#1828's sibling). This ignore is the interim unblock.

## Required-check status
"Security Audit" is **red-but-mergeable, NOT a required/blocking status check** on `trunk`. Evidence: PRs **#3538** (merged 2026-07-13 01:19Z) and **#3544** (merged 2026-07-13 06:55Z) both merged while their **Security Audit** check conclusion was `failure` (alongside other red checks — Code Coverage, Test Suite, Mutants). A required status check would have blocked those merges. So the swarm is **not** hard-blocked by this advisory — the red check is an advisory signal, not a gate.

Because this PR silences a real advisory, it remains **DRAFT** pending the user's explicit decision to merge.

## Scope
CI/audit configuration only — no Rust source changes. Verified: `.cargo/audit.toml` parses as valid TOML, `.github/workflows/ci.yml` parses as valid YAML, and `cargo audit` now reports 0 vulnerabilities against `Cargo.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01US9RGTLAzSymm8eMtqdt3T

---
_Generated by [Claude Code](https://claude.ai/code/session_01US9RGTLAzSymm8eMtqdt3T)_