### PR TITLE
feat(query): AQL WHERE-clause provenance predicates (#3354a)

### DIFF
--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -95,6 +95,55 @@ extend them. Advertised, supported constructs:
 Mutating clauses (`CREATE`, `MERGE`, `SET`, `DELETE`, `REMOVE`, `DETACH`,
 `DROP`, `CALL`, `FOREACH`, `LOAD`) are rejected **before execution**.
 
+## Querying provenance (Issue #3354a)
+
+Write-time provenance (source / confidence / reason, Issue #3224 — the same
+metadata the structured read tools filter on in Issue #3348) is queryable
+directly from an **AQL** `WHERE` clause through the `query` tool, so an LLM can
+express a trust-thresholded, temporally-scoped question as one declarative
+statement instead of a fetch-all-then-filter chain.
+
+Read-only accessors (usable in `WHERE` only in v1):
+
+- `source(x)` — the version's `source` (string; `=`, `<>`)
+- `confidence(x)` — the version's `confidence` (number in `[0,1]`; `=`, `<>`,
+  `<`, `<=`, `>`, `>=`)
+- `reason(x)` — the version's `reason` (string; `=`, `<>`)
+- `provenance(x) IS [NOT] NULL` — select (or exclude) versions with no bundle
+
+`x` is a bound variable. A property literally named `source` is still
+`n.source` (property access) and is unaffected — the accessors resolve only in
+function-call position.
+
+**Semantics match the #3348 structured filter exactly.** Provenance is
+evaluated per-version at the query's bi-temporal coordinate (an `AS OF` query
+reads the bundle on the version visible at that coordinate, not the latest);
+unattributed versions (or a bundle missing the queried field) are **excluded**
+by any comparison and selectable only via `provenance(x) IS NULL`.
+
+```jsonc
+// tools/call -> "query": trusted HR facts as of a coordinate, one call
+{
+  "language": "aql",
+  "query": "AS OF '1704067200000000' MATCH (n:Person) WHERE source(n) = 'hr-system' AND confidence(n) >= 0.9 RETURN n",
+  "limit": 20
+}
+```
+
+Misuse fails closed with the tool's structured error payload, never a silent
+empty result: a `confidence` literal outside `[0,1]` (or NaN) → `invalid_params`
+naming `min_confidence`; an accessor compared to the wrong type
+(`confidence(n) = 'high'`, `source(n) = 5`) → `invalid_params`
+(`Type mismatch: …`); a malformed accessor argument (`source(n.foo)`,
+`confidence(n, m)`, `source()`) → `parse_error`. The accessors introduce no
+mutating clause, so the tool's read-only guarantee is unchanged, and the query
+tool stays `reader`-class.
+
+> **Deferred (v1):** provenance in `RETURN`/`ORDER BY` projections (needs the
+> scalar-projection-into-row lowering) and the Cypher surface (#3354b). Like
+> ordinary property predicates, an accessor reads the row's bound entity rather
+> than resolving per-variable.
+
 ## End-to-end example (LLM-style)
 
 **Question:** *"As of June 2026, which Products does Alice's KNOWS-network view

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -134,10 +134,17 @@ Misuse fails closed with the tool's structured error payload, never a silent
 empty result: a `confidence` literal outside `[0,1]` (or NaN) → `invalid_params`
 naming `min_confidence`; an accessor compared to the wrong type
 (`confidence(n) = 'high'`, `source(n) = 5`) → `invalid_params`
-(`Type mismatch: …`); a malformed accessor argument (`source(n.foo)`,
-`confidence(n, m)`, `source()`) → `parse_error`. The accessors introduce no
-mutating clause, so the tool's read-only guarantee is unchanged, and the query
-tool stays `reader`-class.
+(`Type mismatch: …`); an **ordering operator on a string accessor**
+(`source(n) < 'x'`, `reason(n) >= 'y'`) → `parse_error` (the string accessors
+support only `=`/`<>`, and ordering ops are rejected at convert time rather than
+silently accepted as lexicographic comparisons); a malformed accessor argument
+(`source(n.foo)`, `confidence(n, m)`, `source()`) → `parse_error`. The accessors
+introduce no mutating clause, so the tool's read-only guarantee is unchanged, and
+the query tool stays `reader`-class.
+
+In the single-entity pipeline, a non-provenance property leaf on an **edge** row
+is a pass-through (evaluates `true`); only provenance leaves actually filter edge
+rows, so a mixed edge predicate filters **only on its provenance clause**.
 
 > **Deferred (v1):** provenance in `RETURN`/`ORDER BY` projections (needs the
 > scalar-projection-into-row lowering) and the Cypher surface (#3354b). Like

--- a/docs/query-language-design.md
+++ b/docs/query-language-design.md
@@ -208,6 +208,62 @@ ORDER BY score DESC
 LIMIT 10
 ```
 
+### Querying Provenance (Issue #3354a)
+
+Write-time provenance (source / confidence / reason, Issue #3224) is queryable
+from an AQL `WHERE` clause through three read-only accessor functions plus a
+null check. This is the AQL half of Issue #3354; the Cypher surface (#3354b) and
+`RETURN`/`ORDER BY` provenance projection are tracked as follow-ups.
+
+| Accessor | Reads | Operand type | Operators |
+|----------|-------|--------------|-----------|
+| `source(x)` | version's `source` | string | `=`, `<>` |
+| `confidence(x)` | version's `confidence` | number `[0,1]` | `=`, `<>`, `<`, `<=`, `>`, `>=` |
+| `reason(x)` | version's `reason` | string | `=`, `<>` |
+| `provenance(x) IS [NOT] NULL` | whole bundle | — | — |
+
+`x` is a bound node/relationship variable. The accessors resolve **only** in
+function-call position, so a property literally named `source` (`n.source`) is
+unaffected.
+
+**Semantics (identical to the #3348 structured filter):**
+
+- Provenance is evaluated **per-version at the query's bi-temporal coordinate**:
+  under `AS OF`, the accessors read the bundle recorded on the version visible
+  at that coordinate, not the latest version.
+- A version with **no recorded provenance** (or a bundle missing the queried
+  field) makes the accessor null, so **every comparison is false** and the row
+  is excluded — matching #3348's exclude-unattributed default. Select the
+  unattributed rows deliberately with `provenance(x) IS NULL`.
+- `confidence` bounds are validated against `[0.0, 1.0]` (NaN rejected); an
+  out-of-range literal is a structured error, never a silent empty result.
+- Comparing an accessor to the wrong type (`confidence(n) = 'high'`,
+  `source(n) = 5`) is a type error, never a silent empty result.
+
+```cypher
+-- Only facts sourced from HR with high confidence
+MATCH (n:Person)
+WHERE source(n) = 'hr-system' AND confidence(n) >= 0.9
+RETURN n
+
+-- Deliberately select unattributed facts
+MATCH (n:Person)
+WHERE provenance(n) IS NULL
+RETURN n
+
+-- AS OF + graph pattern + confidence threshold in one statement
+AS OF '1704067200000000'
+MATCH (n:Person)
+WHERE confidence(n) >= 0.8 AND n.name = 'Alice'
+RETURN n
+```
+
+> **v1 limitation.** Like ordinary property predicates, an AQL provenance
+> accessor is evaluated against the row's bound entity, not resolved
+> per-variable (`confidence(r)` and `confidence(n)` both read the row entity's
+> provenance). Provenance in `RETURN`/`ORDER BY` projections is a deferred
+> follow-up (needs scalar-projection-into-row lowering).
+
 ## Semantic Mapping
 
 ### Query to Internal IR Mapping

--- a/docs/query-language-design.md
+++ b/docs/query-language-design.md
@@ -239,6 +239,10 @@ unaffected.
   out-of-range literal is a structured error, never a silent empty result.
 - Comparing an accessor to the wrong type (`confidence(n) = 'high'`,
   `source(n) = 5`) is a type error, never a silent empty result.
+- The string accessors `source`/`reason` accept only `=`/`<>`. An **ordering
+  operator** on them (`source(n) < 'x'`, `reason(n) >= 'y'`) is **rejected at
+  convert time** (fail-closed), never silently accepted as a lexicographic
+  comparison. `confidence` accepts the full numeric ordering set.
 
 ```cypher
 -- Only facts sourced from HR with high confidence
@@ -263,6 +267,14 @@ RETURN n
 > per-variable (`confidence(r)` and `confidence(n)` both read the row entity's
 > provenance). Provenance in `RETURN`/`ORDER BY` projections is a deferred
 > follow-up (needs scalar-projection-into-row lowering).
+>
+> **Edge rows.** In the single-entity pipeline, a non-provenance property leaf
+> on an **edge** row is a pass-through (it evaluates `true`); only provenance
+> leaves actually filter edge rows. So a mixed predicate over an edge filters
+> **only on its provenance clause** (e.g. the provenance leaf of
+> `foo = 'x' AND confidence(e) >= 0.9` decides the edge; the `foo` leaf passes
+> through). Note that AQL `RETURN e` currently projects the traversal node, so
+> this edge behavior is reached only where edge rows exist in the pipeline.
 
 ## Semantic Mapping
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -5552,6 +5552,17 @@ impl AletheiaMcpServer {
                 None,
                 Some(language),
             ),
+            // A type mismatch is a caller-repairable argument fault (e.g. a
+            // provenance accessor compared to the wrong type, `confidence(r) =
+            // 'high'`, Issue #3354a) -- surface it as `invalid_params` per the
+            // query tool's structured-error contract, never a silent empty
+            // result.
+            Error::Query(QueryError::TypeMismatch { expected, actual }) => self.query_error(
+                "invalid_params",
+                &format!("Type mismatch: expected {expected}, got {actual}"),
+                None,
+                Some(language),
+            ),
             Error::Query(QueryError::ExecutionError { message }) => {
                 self.query_error("runtime_error", &message, None, Some(language))
             }
@@ -6885,6 +6896,11 @@ fn tool_definitions() -> Vec<Tool> {
              (->, <-, -), WHERE, RETURN [DISTINCT] / AS aliases, ORDER BY, SKIP/LIMIT, WITH \
              chaining, vector similarity ranking, and bi-temporal scoping \
              (AS OF TIMESTAMP/VALID_TIME/SYSTEM_TIME, FOR SYSTEM_TIME AS OF, BETWEEN ... AND ...). \
+             AQL WHERE clauses can filter on write-time provenance (Issue #3354a) via the \
+             read-only accessors source(x)/confidence(x)/reason(x) (e.g. \
+             WHERE confidence(n) >= 0.9 AND source(n) = 'hr-system') and provenance(x) IS [NOT] NULL; \
+             provenance is evaluated on the version visible at the query's AS OF coordinate, \
+             unattributed versions are excluded (select them with provenance(x) IS NULL). \
              Mutating statements (CREATE/MERGE/SET/DELETE/REMOVE/DETACH/DROP/CALL/FOREACH/LOAD) \
              are rejected before execution and never write. Results are capped (default 100, \
              max 10000 rows; `truncated` indicates a cap hit). Per-query resource limits \
@@ -7580,6 +7596,19 @@ mod server_unit_tests {
             message: "boom".to_string(),
         });
         assert_eq!(error_kind(&server, err), "runtime_error");
+    }
+
+    #[test]
+    fn map_query_error_type_mismatch_yields_invalid_params() {
+        // A provenance accessor compared to the wrong type (e.g.
+        // `confidence(r) = 'high'`, Issue #3354a) surfaces as `invalid_params`,
+        // never a silent empty result (AC5).
+        let server = make_server();
+        let err = Error::Query(QueryError::TypeMismatch {
+            expected: "number".to_string(),
+            actual: "string".to_string(),
+        });
+        assert_eq!(error_kind(&server, err), "invalid_params");
     }
 
     #[test]

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -461,6 +461,18 @@ pub enum PredicateExpr {
     IsNull(PropertyAccess),
     /// NOT NULL check: n.prop IS NOT NULL
     IsNotNull(PropertyAccess),
+    /// Provenance null check: `provenance(x) IS [NOT] NULL` (Issue #3354a).
+    ///
+    /// Distinct from [`IsNull`](PredicateExpr::IsNull)/[`IsNotNull`](PredicateExpr::IsNotNull),
+    /// which take a property access; this addresses the whole provenance bundle
+    /// of the bound entity `x` (a bare variable), selecting versions with no
+    /// recorded provenance (`negated == false`) or with any (`negated == true`).
+    ProvenanceIsNull {
+        /// The bound entity variable whose provenance bundle is checked.
+        variable: String,
+        /// `true` for `IS NOT NULL`, `false` for `IS NULL`.
+        negated: bool,
+    },
     /// String contains: n.prop CONTAINS 'str'
     Contains {
         property: PropertyAccess,

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -935,7 +935,12 @@ impl AstConverter {
     /// [`ProvenanceFilter::validated`](crate::core::provenance::ProvenanceFilter::validated)
     /// rules. The two foldable positive shapes (`source(x) = 'S'`,
     /// `confidence(x) >= t`) are lowered to a `ProvenanceFilter` evaluated via
-    /// its shared `matches`; all other operators use the general accessor form.
+    /// its shared `matches`; other operators use the general accessor form.
+    ///
+    /// Ordering operators (`<`, `<=`, `>`, `>=`) are **rejected at convert
+    /// time** for the string accessors (`source`/`reason`), which support only
+    /// `=`/`<>` (fail-closed: they are never silently accepted as lexicographic
+    /// comparisons). `confidence` accepts the full numeric ordering set.
     fn build_provenance_comparison(
         &self,
         field: ProvenanceField,
@@ -947,9 +952,9 @@ impl AstConverter {
 
         match (field, operand) {
             (ProvenanceField::Confidence, ProvenanceOperand::Num(n)) => {
-                // Validate the confidence literal (range + NaN) once, reusing
-                // the core rules and the offending-field name; the resulting
-                // filter is only used by the foldable `>=` shape below.
+                // Validate the confidence literal (range + NaN) once for every
+                // operator, reusing the core rules and the offending-field name;
+                // the resulting filter is only folded for the `>=` shape below.
                 let filter = crate::core::provenance::ProvenanceFilter::validated(
                     None,
                     None,
@@ -961,18 +966,22 @@ impl AstConverter {
                         parameter: e.field().to_string(),
                         reason: format!("confidence(x) must be between 0.0 and 1.0, got {n}"),
                     })
-                })?
-                .expect("min_confidence yields an active filter");
+                })?;
                 // Foldable positive shape: `confidence(x) >= t` reuses the core
-                // filter's inclusive min-confidence semantics via matches().
-                if matches!(cmp, ProvenanceCmp::Ge) {
-                    Ok(Predicate::Provenance(ProvenancePredicate::Filter(filter)))
-                } else {
-                    Ok(Predicate::Provenance(ProvenancePredicate::Accessor {
+                // filter's inclusive min-confidence semantics via matches(). If
+                // the validated filter is inactive (defensive: a set
+                // min_confidence always yields an active filter), fall back to
+                // the general accessor form rather than panicking (coding
+                // standard: no expect/unwrap on the production path).
+                match (matches!(cmp, ProvenanceCmp::Ge), filter) {
+                    (true, Some(filter)) => {
+                        Ok(Predicate::Provenance(ProvenancePredicate::Filter(filter)))
+                    }
+                    _ => Ok(Predicate::Provenance(ProvenancePredicate::Accessor {
                         field,
                         op: cmp,
                         operand: ProvenanceOperand::Num(n),
-                    }))
+                    })),
                 }
             }
             (ProvenanceField::Confidence, ProvenanceOperand::Str(_)) => {
@@ -982,8 +991,28 @@ impl AstConverter {
                 }))
             }
             (ProvenanceField::Source | ProvenanceField::Reason, ProvenanceOperand::Str(s)) => {
+                // `source`/`reason` are string accessors: only equality and
+                // inequality are supported (documented `=`/`<>`). Ordering
+                // operators are rejected at convert time (fail-closed) rather
+                // than being silently accepted as lexicographic comparisons.
+                if matches!(
+                    cmp,
+                    ProvenanceCmp::Lt | ProvenanceCmp::Le | ProvenanceCmp::Gt | ProvenanceCmp::Ge
+                ) {
+                    return Err(Error::Query(QueryError::SyntaxError {
+                        message: format!(
+                            "ordering operators (<, <=, >, >=) are not supported for \
+                             {}(x); only = and <> are supported for source/reason",
+                            field.accessor_name()
+                        ),
+                    }));
+                }
                 // Foldable positive shape: `source(x) = 'S'` reuses the core
-                // filter's any-of exact-match semantics via matches().
+                // filter's any-of exact-match semantics via matches(). `reason`
+                // and the `<>` operator use the general accessor form. If the
+                // validated filter is inactive (defensive), fall back to the
+                // accessor form rather than panicking (coding standard: no
+                // expect/unwrap on the production path).
                 if field == ProvenanceField::Source && matches!(cmp, ProvenanceCmp::Eq) {
                     let filter = crate::core::provenance::ProvenanceFilter::validated(
                         Some(s.clone()),
@@ -996,9 +1025,16 @@ impl AstConverter {
                             parameter: e.field().to_string(),
                             reason: e.to_string(),
                         })
-                    })?
-                    .expect("active source filter");
-                    Ok(Predicate::Provenance(ProvenancePredicate::Filter(filter)))
+                    })?;
+                    if let Some(filter) = filter {
+                        Ok(Predicate::Provenance(ProvenancePredicate::Filter(filter)))
+                    } else {
+                        Ok(Predicate::Provenance(ProvenancePredicate::Accessor {
+                            field,
+                            op: cmp,
+                            operand: ProvenanceOperand::Str(s),
+                        }))
+                    }
                 } else {
                     Ok(Predicate::Provenance(ProvenancePredicate::Accessor {
                         field,

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -181,8 +181,50 @@ use super::ast::{
     RelationshipPattern, ReturnClause, SourceClause, TemporalClause, TimestampLiteral,
 };
 use super::builder::Query;
-use super::ir::{Predicate, PredicateValue, QueryOp, SortKey, TraversalDepth};
+use super::ir::{
+    Predicate, PredicateValue, ProvenanceCmp, ProvenanceField, ProvenanceOperand,
+    ProvenancePredicate, QueryOp, SortKey, TraversalDepth,
+};
 use super::plan::{QueryHints, TemporalContext};
+
+/// Map an AQL provenance accessor function name to its [`ProvenanceField`]
+/// (case-insensitive), or `None` if the name is not a provenance accessor
+/// (Issue #3354a).
+fn provenance_field_name(name: &str) -> Option<ProvenanceField> {
+    match name.to_ascii_lowercase().as_str() {
+        "source" => Some(ProvenanceField::Source),
+        "confidence" => Some(ProvenanceField::Confidence),
+        "reason" => Some(ProvenanceField::Reason),
+        _ => None,
+    }
+}
+
+/// Map an AST [`ComparisonOp`] to the IR [`ProvenanceCmp`] (Issue #3354a).
+fn provenance_cmp_from_ast(op: ComparisonOp) -> ProvenanceCmp {
+    match op {
+        ComparisonOp::Eq => ProvenanceCmp::Eq,
+        ComparisonOp::Ne => ProvenanceCmp::Ne,
+        ComparisonOp::Lt => ProvenanceCmp::Lt,
+        ComparisonOp::Le => ProvenanceCmp::Le,
+        ComparisonOp::Gt => ProvenanceCmp::Gt,
+        ComparisonOp::Ge => ProvenanceCmp::Ge,
+    }
+}
+
+/// Flip a comparison operator when its operands are swapped, so an accessor on
+/// the right-hand side (`0.9 <= confidence(x)`) lowers identically to the
+/// accessor-on-left form (`confidence(x) >= 0.9`). Equality/inequality are
+/// symmetric (Issue #3354a).
+fn flip_comparison_op(op: ComparisonOp) -> ComparisonOp {
+    match op {
+        ComparisonOp::Eq => ComparisonOp::Eq,
+        ComparisonOp::Ne => ComparisonOp::Ne,
+        ComparisonOp::Lt => ComparisonOp::Gt,
+        ComparisonOp::Le => ComparisonOp::Ge,
+        ComparisonOp::Gt => ComparisonOp::Lt,
+        ComparisonOp::Ge => ComparisonOp::Le,
+    }
+}
 
 /// Converts a parsed [`QueryAst`] into a [`Query`] that can be executed.
 ///
@@ -711,6 +753,11 @@ impl AstConverter {
             PredicateExpr::Exists(prop) => Ok(Predicate::Exists(prop.property.clone())),
             PredicateExpr::IsNull(prop) => Ok(Predicate::NotExists(prop.property.clone())),
             PredicateExpr::IsNotNull(prop) => Ok(Predicate::Exists(prop.property.clone())),
+            PredicateExpr::ProvenanceIsNull { negated, .. } => {
+                Ok(Predicate::Provenance(ProvenancePredicate::IsNull {
+                    negated: *negated,
+                }))
+            }
             PredicateExpr::Contains { .. }
             | PredicateExpr::StartsWith { .. }
             | PredicateExpr::EndsWith { .. } => self.convert_string_predicate(expr),
@@ -788,6 +835,30 @@ impl AstConverter {
         op: ComparisonOp,
         right: &Expression,
     ) -> Result<Predicate> {
+        // Provenance accessors (Issue #3354a): `source(x)`/`confidence(x)`/
+        // `reason(x)` appear as function calls, never property accesses, so a
+        // property named `source` (`n.source`) is unaffected. Recognize an
+        // accessor on either side and lower to a provenance predicate before
+        // the property-access handling below.
+        let left_accessor = self.as_provenance_accessor(left)?;
+        let right_accessor = self.as_provenance_accessor(right)?;
+        match (left_accessor, right_accessor) {
+            (Some(_), Some(_)) => {
+                return Err(Error::Query(QueryError::SyntaxError {
+                    message: "comparing two provenance accessors is not supported".to_string(),
+                }));
+            }
+            (Some(field), None) => {
+                return self.build_provenance_comparison(field, op, right);
+            }
+            (None, Some(field)) => {
+                // Accessor on the right: flip the comparison so the accessor is
+                // the logical left-hand side.
+                return self.build_provenance_comparison(field, flip_comparison_op(op), left);
+            }
+            (None, None) => {}
+        }
+
         // Try left side as property
         if let Expression::Property(prop) = left {
             let key = prop.property.clone();
@@ -822,6 +893,156 @@ impl AstConverter {
         Err(Error::Query(QueryError::SyntaxError {
             message: "Comparison must involve a property access (e.g., n.age)".to_string(),
         }))
+    }
+
+    /// Recognize a provenance accessor expression `source(x)`/`confidence(x)`/
+    /// `reason(x)` (Issue #3354a).
+    ///
+    /// Returns:
+    /// - `Ok(Some(field))` for a well-formed accessor over a single bound
+    ///   variable,
+    /// - `Ok(None)` for any other expression (including unknown function calls,
+    ///   which fall through to the ordinary comparison path),
+    /// - `Err(..)` for a provenance-named accessor with a malformed argument
+    ///   (e.g. `source(n.foo)`, `confidence('x')`, `confidence(r, s)`,
+    ///   `source()`), so the mistake surfaces as a structured error rather than
+    ///   silently degrading.
+    fn as_provenance_accessor(&self, expr: &Expression) -> Result<Option<ProvenanceField>> {
+        let Expression::FunctionCall { name, args } = expr else {
+            return Ok(None);
+        };
+        let Some(field) = provenance_field_name(name) else {
+            return Ok(None);
+        };
+        match args.as_slice() {
+            [Expression::Identifier(_)] => Ok(Some(field)),
+            _ => Err(Error::Query(QueryError::SyntaxError {
+                message: format!(
+                    "{}(x) provenance accessor requires exactly one bound variable argument",
+                    field.accessor_name()
+                ),
+            })),
+        }
+    }
+
+    /// Lower a provenance accessor comparison `field(x) <op> operand` (with the
+    /// accessor already normalized to the left) into a [`Predicate::Provenance`]
+    /// (Issue #3354a).
+    ///
+    /// Type-checks the operand (`confidence` compares only to a number;
+    /// `source`/`reason` only to a string) and validates a `confidence`
+    /// operand's range/NaN via the reusable
+    /// [`ProvenanceFilter::validated`](crate::core::provenance::ProvenanceFilter::validated)
+    /// rules. The two foldable positive shapes (`source(x) = 'S'`,
+    /// `confidence(x) >= t`) are lowered to a `ProvenanceFilter` evaluated via
+    /// its shared `matches`; all other operators use the general accessor form.
+    fn build_provenance_comparison(
+        &self,
+        field: ProvenanceField,
+        op: ComparisonOp,
+        operand_expr: &Expression,
+    ) -> Result<Predicate> {
+        let operand = self.expression_to_provenance_operand(operand_expr)?;
+        let cmp = provenance_cmp_from_ast(op);
+
+        match (field, operand) {
+            (ProvenanceField::Confidence, ProvenanceOperand::Num(n)) => {
+                // Validate the confidence literal (range + NaN) once, reusing
+                // the core rules and the offending-field name; the resulting
+                // filter is only used by the foldable `>=` shape below.
+                let filter = crate::core::provenance::ProvenanceFilter::validated(
+                    None,
+                    None,
+                    Some(n),
+                    false,
+                )
+                .map_err(|e| {
+                    Error::Query(QueryError::InvalidParameter {
+                        parameter: e.field().to_string(),
+                        reason: format!("confidence(x) must be between 0.0 and 1.0, got {n}"),
+                    })
+                })?
+                .expect("min_confidence yields an active filter");
+                // Foldable positive shape: `confidence(x) >= t` reuses the core
+                // filter's inclusive min-confidence semantics via matches().
+                if matches!(cmp, ProvenanceCmp::Ge) {
+                    Ok(Predicate::Provenance(ProvenancePredicate::Filter(filter)))
+                } else {
+                    Ok(Predicate::Provenance(ProvenancePredicate::Accessor {
+                        field,
+                        op: cmp,
+                        operand: ProvenanceOperand::Num(n),
+                    }))
+                }
+            }
+            (ProvenanceField::Confidence, ProvenanceOperand::Str(_)) => {
+                Err(Error::Query(QueryError::TypeMismatch {
+                    expected: "number".to_string(),
+                    actual: "string (confidence(x) compares only to a numeric value)".to_string(),
+                }))
+            }
+            (ProvenanceField::Source | ProvenanceField::Reason, ProvenanceOperand::Str(s)) => {
+                // Foldable positive shape: `source(x) = 'S'` reuses the core
+                // filter's any-of exact-match semantics via matches().
+                if field == ProvenanceField::Source && matches!(cmp, ProvenanceCmp::Eq) {
+                    let filter = crate::core::provenance::ProvenanceFilter::validated(
+                        Some(s.clone()),
+                        None,
+                        None,
+                        false,
+                    )
+                    .map_err(|e| {
+                        Error::Query(QueryError::InvalidParameter {
+                            parameter: e.field().to_string(),
+                            reason: e.to_string(),
+                        })
+                    })?
+                    .expect("active source filter");
+                    Ok(Predicate::Provenance(ProvenancePredicate::Filter(filter)))
+                } else {
+                    Ok(Predicate::Provenance(ProvenancePredicate::Accessor {
+                        field,
+                        op: cmp,
+                        operand: ProvenanceOperand::Str(s),
+                    }))
+                }
+            }
+            (ProvenanceField::Source | ProvenanceField::Reason, ProvenanceOperand::Num(_)) => {
+                Err(Error::Query(QueryError::TypeMismatch {
+                    expected: "string".to_string(),
+                    actual: format!(
+                        "number ({}(x) compares only to a string value)",
+                        field.accessor_name()
+                    ),
+                }))
+            }
+        }
+    }
+
+    /// Resolve the right-hand literal/parameter of a provenance comparison to a
+    /// typed operand (Issue #3354a).
+    fn expression_to_provenance_operand(&self, expr: &Expression) -> Result<ProvenanceOperand> {
+        let value = match expr {
+            Expression::Literal(pv) => self.convert_property_value(pv)?,
+            Expression::Parameter(name) => self.resolve_value_param(name)?,
+            _ => {
+                return Err(Error::Query(QueryError::SyntaxError {
+                    message: "a provenance accessor must be compared to a literal or parameter"
+                        .to_string(),
+                }));
+            }
+        };
+        match value {
+            PredicateValue::String(s) => Ok(ProvenanceOperand::Str(s)),
+            PredicateValue::Int(i) => Ok(ProvenanceOperand::Num(i as f64)),
+            PredicateValue::Float(f) => Ok(ProvenanceOperand::Num(f)),
+            PredicateValue::Bool(_) | PredicateValue::Null => {
+                Err(Error::Query(QueryError::TypeMismatch {
+                    expected: "string or number".to_string(),
+                    actual: "boolean or null (unsupported provenance operand)".to_string(),
+                }))
+            }
+        }
     }
 
     /// Convert an expression to a predicate value.
@@ -1122,6 +1343,106 @@ mod tests {
                 label: Some(l)
             } if l == "Person"
         ));
+    }
+
+    fn filter_predicate(aql: &str) -> Predicate {
+        let ast = Parser::parse(aql).unwrap();
+        let query = AstConverter::new().convert(&ast).unwrap();
+        query
+            .ops
+            .into_iter()
+            .find_map(|op| match op {
+                QueryOp::Filter(p) => Some(p),
+                _ => None,
+            })
+            .expect("a Filter op")
+    }
+
+    #[test]
+    fn test_convert_provenance_source_eq_folds_to_filter() {
+        // `source(x) = 'S'` reuses the core ProvenanceFilter (foldable shape).
+        let pred = filter_predicate("MATCH (n:Person) WHERE source(n) = 'hr' RETURN n");
+        assert!(
+            matches!(pred, Predicate::Provenance(ProvenancePredicate::Filter(_))),
+            "expected folded Filter, got {pred:?}"
+        );
+    }
+
+    #[test]
+    fn test_convert_provenance_confidence_ge_folds_to_filter() {
+        let pred = filter_predicate("MATCH (n:Person) WHERE confidence(n) >= 0.9 RETURN n");
+        assert!(
+            matches!(pred, Predicate::Provenance(ProvenancePredicate::Filter(_))),
+            "expected folded Filter, got {pred:?}"
+        );
+    }
+
+    #[test]
+    fn test_convert_provenance_confidence_lt_uses_accessor() {
+        // `<` is not expressible as a ProvenanceFilter -> general accessor path.
+        let pred = filter_predicate("MATCH (n:Person) WHERE confidence(n) < 0.5 RETURN n");
+        match pred {
+            Predicate::Provenance(ProvenancePredicate::Accessor { field, op, operand }) => {
+                assert_eq!(field, ProvenanceField::Confidence);
+                assert_eq!(op, ProvenanceCmp::Lt);
+                assert_eq!(operand, ProvenanceOperand::Num(0.5));
+            }
+            other => panic!("expected Accessor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_convert_provenance_accessor_on_right_flips() {
+        // `0.9 <= confidence(n)` lowers identically to `confidence(n) >= 0.9`
+        // (folded Filter).
+        let pred = filter_predicate("MATCH (n:Person) WHERE 0.9 <= confidence(n) RETURN n");
+        assert!(
+            matches!(pred, Predicate::Provenance(ProvenancePredicate::Filter(_))),
+            "expected folded Filter after flip, got {pred:?}"
+        );
+    }
+
+    #[test]
+    fn test_convert_provenance_is_null() {
+        let pred = filter_predicate("MATCH (n:Person) WHERE provenance(n) IS NULL RETURN n");
+        assert!(matches!(
+            pred,
+            Predicate::Provenance(ProvenancePredicate::IsNull { negated: false })
+        ));
+    }
+
+    #[test]
+    fn test_convert_provenance_confidence_out_of_range_rejected() {
+        let ast = Parser::parse("MATCH (n:Person) WHERE confidence(n) >= 1.5 RETURN n").unwrap();
+        let err = AstConverter::new().convert(&ast).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                Error::Query(QueryError::InvalidParameter { parameter, .. })
+                    if parameter == "min_confidence"
+            ),
+            "expected InvalidParameter(min_confidence), got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_convert_provenance_type_mismatch_rejected() {
+        let ast = Parser::parse("MATCH (n:Person) WHERE confidence(n) = 'high' RETURN n").unwrap();
+        let err = AstConverter::new().convert(&ast).unwrap_err();
+        assert!(
+            matches!(&err, Error::Query(QueryError::TypeMismatch { .. })),
+            "expected TypeMismatch, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_convert_property_named_source_is_not_accessor() {
+        // `n.source` must remain an ordinary property predicate.
+        let pred = filter_predicate("MATCH (n:Person) WHERE n.source = 'manual' RETURN n");
+        assert!(
+            matches!(pred, Predicate::Eq { ref key, .. } if key == "source"),
+            "expected property Eq, got {pred:?}"
+        );
     }
 
     #[test]

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -20,10 +20,11 @@ use crate::core::vector::DistanceMetric as VectorMetric;
 use crate::core::{NodeId, Timestamp};
 use crate::query::ir::{
     AggregateArg, AggregateFunc, AggregateGroupKey, AggregateSpec, Direction, Predicate,
-    PredicateValue, ScoreThreshold, SortKey,
+    PredicateValue, ProvenancePredicate, ScoreThreshold, SortKey,
 };
 use crate::storage::current::CurrentStorage;
 use crate::storage::historical::HistoricalStorage;
+use std::cell::RefCell;
 
 use super::results::{EntityId, EntityResult, QueryRow};
 
@@ -1737,15 +1738,47 @@ impl FilterIterator {
             .flatten()
     }
 
+    /// Evaluate a provenance leaf lazily: resolve the row entity's provenance
+    /// bundle **on demand** the first time a [`Predicate::Provenance`] leaf is
+    /// reached, memoizing it in `cache` for the rest of this row's evaluation
+    /// (Issue #3354a, DoS perf follow-up). Because resolution happens at the
+    /// leaf rather than eagerly per scanned row, an AND whose cheaper conjunct
+    /// already rejected the row never pays the `historical.read()` lock +
+    /// version lookup (short-circuit skips this call entirely). At most one
+    /// resolution per row is performed; the result is identical to the prior
+    /// eager scheme.
+    fn eval_provenance_leaf(
+        p: &ProvenancePredicate,
+        cache: &RefCell<Option<Option<Provenance>>>,
+        resolve: impl FnOnce() -> Option<Provenance>,
+    ) -> bool {
+        if cache.borrow().is_none() {
+            let resolved = resolve();
+            *cache.borrow_mut() = Some(resolved);
+        }
+        let guard = cache.borrow();
+        // Outer `Option` = "resolved yet?"; inner `Option<Provenance>` = the
+        // bundle (or `None` for an unattributed version).
+        p.evaluate(guard.as_ref().and_then(|inner| inner.as_ref()))
+    }
+
+    /// Evaluate the full predicate tree against a node with a caller-supplied
+    /// provenance bundle. The bundle is seeded into the memo cache so
+    /// provenance leaves evaluate against it directly without a historical
+    /// lookup; the streaming [`next`](ResultIterator::next) path resolves
+    /// provenance lazily instead. Test-facing convenience: the production path
+    /// resolves lazily in [`evaluate_predicate`](Self::evaluate_predicate).
+    #[cfg(test)]
     fn evaluate(&self, node: &Node, prov: Option<&Provenance>) -> bool {
-        self.evaluate_predicate(&self.predicate, node, prov)
+        let prov_cache: RefCell<Option<Option<Provenance>>> = RefCell::new(Some(prov.cloned()));
+        self.evaluate_predicate(&self.predicate, node, &prov_cache)
     }
 
     fn evaluate_predicate(
         &self,
         predicate: &Predicate,
         node: &Node,
-        prov: Option<&Provenance>,
+        prov_cache: &RefCell<Option<Option<Provenance>>>,
     ) -> bool {
         match predicate {
             Predicate::True => true,
@@ -1762,10 +1795,18 @@ impl FilterIterator {
             Predicate::StartsWith { key, prefix } => self.evaluate_starts_with(node, key, prefix),
             Predicate::EndsWith { key, suffix } => self.evaluate_ends_with(node, key, suffix),
             Predicate::In { key, values } => self.evaluate_in(node, key, values),
-            Predicate::Provenance(p) => p.evaluate(prov),
-            Predicate::And(preds) => preds.iter().all(|p| self.evaluate_predicate(p, node, prov)),
-            Predicate::Or(preds) => preds.iter().any(|p| self.evaluate_predicate(p, node, prov)),
-            Predicate::Not(pred) => !self.evaluate_predicate(pred, node, prov),
+            // Resolve provenance lazily so a cheaper conjunct that already
+            // rejected the row short-circuits before any historical read.
+            Predicate::Provenance(p) => {
+                Self::eval_provenance_leaf(p, prov_cache, || self.resolve_node_provenance(node))
+            }
+            Predicate::And(preds) => preds
+                .iter()
+                .all(|p| self.evaluate_predicate(p, node, prov_cache)),
+            Predicate::Or(preds) => preds
+                .iter()
+                .any(|p| self.evaluate_predicate(p, node, prov_cache)),
+            Predicate::Not(pred) => !self.evaluate_predicate(pred, node, prov_cache),
         }
     }
 
@@ -1776,13 +1817,26 @@ impl FilterIterator {
     /// evaluate to `true`, i.e. pass-through) while honoring
     /// [`Predicate::Provenance`] leaves against the edge's own provenance
     /// bundle (Issue #3354a). Only invoked when the predicate contains a
-    /// provenance leaf.
-    fn evaluate_edge_predicate(&self, predicate: &Predicate, prov: Option<&Provenance>) -> bool {
+    /// provenance leaf. Provenance is resolved lazily (memoized in `prov_cache`)
+    /// so an AND short-circuit skips the historical read for a row already
+    /// rejected by a cheaper leaf.
+    fn evaluate_edge_predicate(
+        &self,
+        predicate: &Predicate,
+        edge: Option<&crate::core::graph::Edge>,
+        prov_cache: &RefCell<Option<Option<Provenance>>>,
+    ) -> bool {
         match predicate {
-            Predicate::Provenance(p) => p.evaluate(prov),
-            Predicate::And(preds) => preds.iter().all(|p| self.evaluate_edge_predicate(p, prov)),
-            Predicate::Or(preds) => preds.iter().any(|p| self.evaluate_edge_predicate(p, prov)),
-            Predicate::Not(pred) => !self.evaluate_edge_predicate(pred, prov),
+            Predicate::Provenance(p) => Self::eval_provenance_leaf(p, prov_cache, || {
+                edge.and_then(|e| self.resolve_edge_provenance(e))
+            }),
+            Predicate::And(preds) => preds
+                .iter()
+                .all(|p| self.evaluate_edge_predicate(p, edge, prov_cache)),
+            Predicate::Or(preds) => preds
+                .iter()
+                .any(|p| self.evaluate_edge_predicate(p, edge, prov_cache)),
+            Predicate::Not(pred) => !self.evaluate_edge_predicate(pred, edge, prov_cache),
             Predicate::False => false,
             // Non-provenance leaves retain the pre-existing edge pass-through.
             _ => true,
@@ -1966,16 +2020,13 @@ impl ResultIterator for FilterIterator {
             match self.input.next() {
                 Some(Ok(row)) => {
                     if let Some(node) = row.entity.as_node() {
-                        // Resolve the row entity's provenance once (only when the
-                        // predicate actually references it), so an AND/OR of a
-                        // property filter and a provenance filter shares one
-                        // lookup (Issue #3354a).
-                        let prov = if self.needs_provenance {
-                            self.resolve_node_provenance(node)
-                        } else {
-                            None
-                        };
-                        if self.evaluate(node, prov.as_ref()) {
+                        // Provenance is resolved lazily at the provenance leaf
+                        // and memoized per row, so an AND/OR of a property
+                        // filter and a provenance filter shares one lookup and a
+                        // cheaper conjunct's rejection skips the historical read
+                        // entirely (Issue #3354a).
+                        let prov_cache: RefCell<Option<Option<Provenance>>> = RefCell::new(None);
+                        if self.evaluate_predicate(&self.predicate, node, &prov_cache) {
                             return Some(Ok(row));
                         }
                         // Filter didn't pass, continue to next
@@ -1990,13 +2041,14 @@ impl ResultIterator for FilterIterator {
                     } else if self.needs_provenance {
                         // Edge rows historically pass through the filter. When
                         // the predicate carries a provenance leaf, evaluate that
-                        // leaf against the edge's own provenance (Issue #3354a);
-                        // non-provenance leaves keep the pass-through behavior.
-                        let prov = row
-                            .entity
-                            .as_edge()
-                            .and_then(|edge| self.resolve_edge_provenance(edge));
-                        if self.evaluate_edge_predicate(&self.predicate, prov.as_ref()) {
+                        // leaf against the edge's own provenance (resolved lazily
+                        // and memoized); non-provenance leaves keep the
+                        // pass-through behavior. A non-edge entity resolves to no
+                        // provenance bundle, preserving the prior semantics
+                        // (Issue #3354a).
+                        let edge = row.entity.as_edge();
+                        let prov_cache: RefCell<Option<Option<Provenance>>> = RefCell::new(None);
+                        if self.evaluate_edge_predicate(&self.predicate, edge, &prov_cache) {
                             return Some(Ok(row));
                         }
                         // Filter didn't pass, continue to next
@@ -3353,6 +3405,153 @@ mod tests {
         fn size_hint(&self) -> (usize, Option<usize>) {
             self.items.size_hint()
         }
+    }
+
+    // ==================== Edge provenance-accessor tests (Issue #3354a) ====
+
+    /// Build an edge whose `current_version` is `version`, plus register that
+    /// version in `historical` with the given optional provenance bundle.
+    /// Returns the edge for feeding into a [`FilterIterator`].
+    fn edge_with_provenance(
+        historical: &Arc<RwLock<HistoricalStorage>>,
+        edge_id: u64,
+        version: u64,
+        provenance: Option<Provenance>,
+    ) -> crate::core::graph::Edge {
+        use crate::core::temporal::time;
+        let label = GLOBAL_INTERNER.intern("KNOWS").unwrap();
+        let src = NodeId::new(1).unwrap();
+        let tgt = NodeId::new(2).unwrap();
+        let props = PropertyMapBuilder::new().build();
+        let version_id = VersionId::new(version).unwrap();
+        let now = time::now();
+        historical
+            .write()
+            .add_edge_version_with_provenance(
+                crate::core::id::EdgeId::new(edge_id).unwrap(),
+                version_id,
+                now,
+                now,
+                label,
+                src,
+                tgt,
+                props.clone(),
+                false,
+                provenance.map(std::sync::Arc::new),
+            )
+            .unwrap();
+        crate::core::graph::Edge::new(
+            crate::core::id::EdgeId::new(edge_id).unwrap(),
+            label,
+            src,
+            tgt,
+            props,
+            version_id,
+        )
+    }
+
+    /// Collect the ids of edge rows that survive `predicate` through a
+    /// `FilterIterator` fed only edge rows (the pass-through / provenance-leaf
+    /// path exercised by `evaluate_edge_predicate`).
+    fn filter_edge_ids(
+        historical: &Arc<RwLock<HistoricalStorage>>,
+        edges: Vec<crate::core::graph::Edge>,
+        predicate: Predicate,
+    ) -> Vec<u64> {
+        let rows: Vec<Result<QueryRow>> = edges
+            .into_iter()
+            .map(|e| Ok(QueryRow::from_entity(EntityResult::Edge(e))))
+            .collect();
+        let input = Box::new(MockIterator::from_results(rows));
+        let mut filter = FilterIterator::with_historical(input, predicate, Arc::clone(historical));
+        let mut ids = Vec::new();
+        while let Some(row) = filter.next() {
+            if let EntityResult::Edge(e) = row.unwrap().entity {
+                ids.push(e.id.as_u64());
+            }
+        }
+        ids.sort_unstable();
+        ids
+    }
+
+    #[test]
+    fn edge_confidence_accessor_filters_edge_rows() {
+        // FIX 5 (Issue #3354a): a provenance accessor on EDGE rows filters by the
+        // edge's own write-time provenance. `RETURN e` in AQL projects the
+        // traversal node rather than the edge, so this path is covered here at
+        // the FilterIterator level where edge rows exist.
+        let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
+        let attributed = edge_with_provenance(
+            &historical,
+            1,
+            10,
+            Some(
+                Provenance::builder()
+                    .source("hr-system")
+                    .confidence(0.95)
+                    .build()
+                    .unwrap(),
+            ),
+        );
+        let unattributed = edge_with_provenance(&historical, 2, 11, None);
+
+        let predicate = Predicate::Provenance(ProvenancePredicate::Accessor {
+            field: crate::query::ir::ProvenanceField::Confidence,
+            op: crate::query::ir::ProvenanceCmp::Ge,
+            operand: crate::query::ir::ProvenanceOperand::Num(0.9),
+        });
+        let kept = filter_edge_ids(&historical, vec![attributed, unattributed], predicate);
+        assert_eq!(kept, vec![1], "only the >=0.9-confidence edge survives");
+    }
+
+    #[test]
+    fn edge_provenance_is_null_selects_unattributed_edges() {
+        // FIX 5 (Issue #3354a): `provenance(e) IS NULL` selects the edge rows
+        // with no recorded provenance bundle (mirroring the node semantics).
+        let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
+        let attributed = edge_with_provenance(
+            &historical,
+            1,
+            10,
+            Some(Provenance::builder().source("hr-system").build().unwrap()),
+        );
+        let unattributed = edge_with_provenance(&historical, 2, 11, None);
+
+        let predicate = Predicate::Provenance(ProvenancePredicate::IsNull { negated: false });
+        let kept = filter_edge_ids(&historical, vec![attributed, unattributed], predicate);
+        assert_eq!(kept, vec![2], "only the unattributed edge is IS NULL");
+    }
+
+    #[test]
+    fn edge_non_provenance_leaf_is_pass_through() {
+        // FIX 5 (Issue #3354a): in the single-entity pipeline a non-provenance
+        // property leaf on an EDGE row is pass-through (evaluates true), so a
+        // mixed `AND` filters an edge only on its provenance clause. Here the
+        // property leaf `foo = 'x'` (never present on the edge) passes through,
+        // and the confidence leaf decides the result.
+        let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
+        let attributed = edge_with_provenance(
+            &historical,
+            1,
+            10,
+            Some(Provenance::builder().confidence(0.95).build().unwrap()),
+        );
+        let unattributed = edge_with_provenance(&historical, 2, 11, None);
+
+        let predicate = Predicate::And(vec![
+            Predicate::eq("foo", "x"),
+            Predicate::Provenance(ProvenancePredicate::Accessor {
+                field: crate::query::ir::ProvenanceField::Confidence,
+                op: crate::query::ir::ProvenanceCmp::Ge,
+                operand: crate::query::ir::ProvenanceOperand::Num(0.9),
+            }),
+        ]);
+        let kept = filter_edge_ids(&historical, vec![attributed, unattributed], predicate);
+        assert_eq!(
+            kept,
+            vec![1],
+            "non-provenance leaf passes through; only the provenance clause filters edges"
+        );
     }
 
     // ==================== EmptyIterator Tests ====================

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -15,6 +15,7 @@ use crate::core::error::Result;
 use crate::core::graph::Node;
 use crate::core::interning::GLOBAL_INTERNER;
 use crate::core::property::PropertyValue;
+use crate::core::provenance::Provenance;
 use crate::core::vector::DistanceMetric as VectorMetric;
 use crate::core::{NodeId, Timestamp};
 use crate::query::ir::{
@@ -1651,19 +1652,101 @@ impl ResultIterator for TraversalIterator {
 pub struct FilterIterator {
     input: Box<dyn ResultIterator>,
     predicate: Predicate,
+    /// Historical storage, needed only to resolve a row entity's write-time
+    /// provenance for [`Predicate::Provenance`] leaves (Issue #3354a). `None`
+    /// when the predicate carries no provenance leaf (the overwhelming common
+    /// case), so a plain property filter never touches historical storage.
+    historical: Option<Arc<RwLock<HistoricalStorage>>>,
+    /// Cached: does the predicate tree contain any provenance leaf? Computed
+    /// once so `next()` avoids resolving provenance for property-only filters.
+    needs_provenance: bool,
 }
 
 impl FilterIterator {
     /// Create a new FilterIterator that filters results based on the predicate.
+    ///
+    /// This constructor carries no historical-storage handle, so a
+    /// [`Predicate::Provenance`] leaf would have no bundle to resolve and be
+    /// evaluated as absent (excluded). Use
+    /// [`with_historical`](Self::with_historical) when the predicate may
+    /// reference provenance.
     pub fn new(input: Box<dyn ResultIterator>, predicate: Predicate) -> Self {
-        FilterIterator { input, predicate }
+        let needs_provenance = Self::predicate_needs_provenance(&predicate);
+        FilterIterator {
+            input,
+            predicate,
+            historical: None,
+            needs_provenance,
+        }
     }
 
-    fn evaluate(&self, node: &Node) -> bool {
-        self.evaluate_predicate(&self.predicate, node)
+    /// Create a FilterIterator with access to historical storage so
+    /// [`Predicate::Provenance`] leaves (Issue #3354a) can resolve each row
+    /// entity's write-time provenance bundle at the version the row represents.
+    pub fn with_historical(
+        input: Box<dyn ResultIterator>,
+        predicate: Predicate,
+        historical: Arc<RwLock<HistoricalStorage>>,
+    ) -> Self {
+        let needs_provenance = Self::predicate_needs_provenance(&predicate);
+        FilterIterator {
+            input,
+            predicate,
+            historical: Some(historical),
+            needs_provenance,
+        }
     }
 
-    fn evaluate_predicate(&self, predicate: &Predicate, node: &Node) -> bool {
+    /// Returns `true` if the predicate tree contains any provenance leaf.
+    fn predicate_needs_provenance(predicate: &Predicate) -> bool {
+        match predicate {
+            Predicate::Provenance(_) => true,
+            Predicate::And(preds) | Predicate::Or(preds) => {
+                preds.iter().any(Self::predicate_needs_provenance)
+            }
+            Predicate::Not(pred) => Self::predicate_needs_provenance(pred),
+            _ => false,
+        }
+    }
+
+    /// Resolve the write-time provenance bundle recorded on the version a node
+    /// row represents (Issue #3354a).
+    ///
+    /// Uses the node's `current_version` — which, for a point-in-time (`AS OF`)
+    /// reconstructed node, is the historical version at that coordinate — so
+    /// provenance is evaluated as recorded at the query's bi-temporal
+    /// coordinate (AC3). A missing handle or a lookup error resolves to `None`
+    /// (treated as unattributed, i.e. excluded by any provenance comparison).
+    fn resolve_node_provenance(&self, node: &Node) -> Option<Provenance> {
+        let historical = self.historical.as_ref()?;
+        historical
+            .read()
+            .get_node_version_provenance(node.current_version)
+            .ok()
+            .flatten()
+    }
+
+    /// Resolve the write-time provenance bundle recorded on the version an edge
+    /// row represents (Issue #3354a). See [`resolve_node_provenance`](Self::resolve_node_provenance).
+    fn resolve_edge_provenance(&self, edge: &crate::core::graph::Edge) -> Option<Provenance> {
+        let historical = self.historical.as_ref()?;
+        historical
+            .read()
+            .get_edge_version_provenance(edge.current_version)
+            .ok()
+            .flatten()
+    }
+
+    fn evaluate(&self, node: &Node, prov: Option<&Provenance>) -> bool {
+        self.evaluate_predicate(&self.predicate, node, prov)
+    }
+
+    fn evaluate_predicate(
+        &self,
+        predicate: &Predicate,
+        node: &Node,
+        prov: Option<&Provenance>,
+    ) -> bool {
         match predicate {
             Predicate::True => true,
             Predicate::False => false,
@@ -1679,9 +1762,30 @@ impl FilterIterator {
             Predicate::StartsWith { key, prefix } => self.evaluate_starts_with(node, key, prefix),
             Predicate::EndsWith { key, suffix } => self.evaluate_ends_with(node, key, suffix),
             Predicate::In { key, values } => self.evaluate_in(node, key, values),
-            Predicate::And(preds) => preds.iter().all(|p| self.evaluate_predicate(p, node)),
-            Predicate::Or(preds) => preds.iter().any(|p| self.evaluate_predicate(p, node)),
-            Predicate::Not(pred) => !self.evaluate_predicate(pred, node),
+            Predicate::Provenance(p) => p.evaluate(prov),
+            Predicate::And(preds) => preds.iter().all(|p| self.evaluate_predicate(p, node, prov)),
+            Predicate::Or(preds) => preds.iter().any(|p| self.evaluate_predicate(p, node, prov)),
+            Predicate::Not(pred) => !self.evaluate_predicate(pred, node, prov),
+        }
+    }
+
+    /// Evaluate a predicate against an edge row for the provenance leaves only.
+    ///
+    /// The AQL single-entity pipeline historically passes edge rows through the
+    /// filter untouched; this preserves that for non-provenance leaves (which
+    /// evaluate to `true`, i.e. pass-through) while honoring
+    /// [`Predicate::Provenance`] leaves against the edge's own provenance
+    /// bundle (Issue #3354a). Only invoked when the predicate contains a
+    /// provenance leaf.
+    fn evaluate_edge_predicate(&self, predicate: &Predicate, prov: Option<&Provenance>) -> bool {
+        match predicate {
+            Predicate::Provenance(p) => p.evaluate(prov),
+            Predicate::And(preds) => preds.iter().all(|p| self.evaluate_edge_predicate(p, prov)),
+            Predicate::Or(preds) => preds.iter().any(|p| self.evaluate_edge_predicate(p, prov)),
+            Predicate::Not(pred) => !self.evaluate_edge_predicate(pred, prov),
+            Predicate::False => false,
+            // Non-provenance leaves retain the pre-existing edge pass-through.
+            _ => true,
         }
     }
 
@@ -1845,6 +1949,10 @@ impl FilterIterator {
             | Predicate::Contains { .. }
             | Predicate::StartsWith { .. }
             | Predicate::EndsWith { .. } => false,
+            // A null OPTIONAL MATCH binding carries no entity and therefore no
+            // provenance bundle: `provenance(x) IS NULL` is true, every other
+            // provenance comparison is not-true (Issue #3354a).
+            Predicate::Provenance(p) => p.evaluate(None),
             Predicate::And(preds) => preds.iter().all(|p| self.evaluate_null(p)),
             Predicate::Or(preds) => preds.iter().any(|p| self.evaluate_null(p)),
             Predicate::Not(pred) => !self.evaluate_null(pred),
@@ -1858,7 +1966,16 @@ impl ResultIterator for FilterIterator {
             match self.input.next() {
                 Some(Ok(row)) => {
                     if let Some(node) = row.entity.as_node() {
-                        if self.evaluate(node) {
+                        // Resolve the row entity's provenance once (only when the
+                        // predicate actually references it), so an AND/OR of a
+                        // property filter and a provenance filter shares one
+                        // lookup (Issue #3354a).
+                        let prov = if self.needs_provenance {
+                            self.resolve_node_provenance(node)
+                        } else {
+                            None
+                        };
+                        if self.evaluate(node, prov.as_ref()) {
                             return Some(Ok(row));
                         }
                         // Filter didn't pass, continue to next
@@ -1870,8 +1987,21 @@ impl ResultIterator for FilterIterator {
                             return Some(Ok(row));
                         }
                         // Filter didn't pass, continue to next
+                    } else if self.needs_provenance {
+                        // Edge rows historically pass through the filter. When
+                        // the predicate carries a provenance leaf, evaluate that
+                        // leaf against the edge's own provenance (Issue #3354a);
+                        // non-provenance leaves keep the pass-through behavior.
+                        let prov = row
+                            .entity
+                            .as_edge()
+                            .and_then(|edge| self.resolve_edge_provenance(edge));
+                        if self.evaluate_edge_predicate(&self.predicate, prov.as_ref()) {
+                            return Some(Ok(row));
+                        }
+                        // Filter didn't pass, continue to next
                     } else {
-                        // Non-node entities pass through
+                        // Non-node entities pass through (no provenance leaf).
                         return Some(Ok(row));
                     }
                 }
@@ -2005,7 +2135,11 @@ impl OptionalApplyIterator {
                     *temporal_context,
                 )),
                 OptionalPhysicalStep::Filter(predicate) => {
-                    Box::new(FilterIterator::new(iter, predicate.clone()))
+                    Box::new(FilterIterator::with_historical(
+                        iter,
+                        predicate.clone(),
+                        Arc::clone(&self.historical),
+                    ))
                 }
             };
         }
@@ -3246,7 +3380,7 @@ mod tests {
         let predicate = Predicate::eq("name", "Alice");
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3255,7 +3389,7 @@ mod tests {
         let predicate = Predicate::eq("name", "Bob");
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3264,7 +3398,7 @@ mod tests {
         let predicate = Predicate::eq("missing", "value");
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3273,7 +3407,7 @@ mod tests {
         let predicate = Predicate::ne("name", "Bob");
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3282,7 +3416,7 @@ mod tests {
         let predicate = Predicate::ne("name", "Alice");
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3292,7 +3426,7 @@ mod tests {
         let predicate = Predicate::ne("missing", "value");
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3301,7 +3435,7 @@ mod tests {
         let predicate = Predicate::gt("age", 18i64);
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3310,7 +3444,7 @@ mod tests {
         let predicate = Predicate::gt("age", 18i64);
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3319,7 +3453,7 @@ mod tests {
         let predicate = Predicate::gt("age", 18i64);
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3328,7 +3462,7 @@ mod tests {
         let predicate = Predicate::lt("age", 18i64);
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3337,7 +3471,7 @@ mod tests {
         let predicate = Predicate::lt("age", 18i64);
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3349,7 +3483,7 @@ mod tests {
         };
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3361,7 +3495,7 @@ mod tests {
         };
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3373,7 +3507,7 @@ mod tests {
         };
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3385,7 +3519,7 @@ mod tests {
         };
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3397,7 +3531,7 @@ mod tests {
         };
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3409,7 +3543,7 @@ mod tests {
         };
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3418,7 +3552,7 @@ mod tests {
         let predicate = Predicate::exists("name");
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3427,7 +3561,7 @@ mod tests {
         let predicate = Predicate::exists("missing");
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3436,7 +3570,7 @@ mod tests {
         let predicate = Predicate::NotExists("missing".to_string());
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3445,7 +3579,7 @@ mod tests {
         let predicate = Predicate::NotExists("name".to_string());
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3454,7 +3588,7 @@ mod tests {
         let predicate = Predicate::contains("name", "John");
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3463,7 +3597,7 @@ mod tests {
         let predicate = Predicate::contains("name", "Bob");
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3475,7 +3609,7 @@ mod tests {
         };
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3487,7 +3621,7 @@ mod tests {
         };
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3499,7 +3633,7 @@ mod tests {
         };
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3511,7 +3645,7 @@ mod tests {
         };
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3527,7 +3661,7 @@ mod tests {
         };
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3542,7 +3676,7 @@ mod tests {
         };
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3563,7 +3697,7 @@ mod tests {
         let predicate = Predicate::eq("name", "Alice").and(Predicate::gt("age", 18i64));
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3572,7 +3706,7 @@ mod tests {
         let predicate = Predicate::eq("name", "Alice").and(Predicate::gt("age", 18i64));
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3581,7 +3715,7 @@ mod tests {
         let predicate = Predicate::eq("name", "Alice").or(Predicate::eq("name", "Bob"));
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3590,7 +3724,7 @@ mod tests {
         let predicate = Predicate::eq("name", "Alice").or(Predicate::eq("name", "Bob"));
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3599,7 +3733,7 @@ mod tests {
         let predicate = Predicate::eq("name", "Alice").or(Predicate::eq("name", "Bob"));
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3608,7 +3742,7 @@ mod tests {
         let predicate = Predicate::Not(Box::new(Predicate::eq("name", "Bob")));
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3617,7 +3751,7 @@ mod tests {
         let predicate = Predicate::Not(Box::new(Predicate::eq("name", "Alice")));
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3626,7 +3760,7 @@ mod tests {
         let predicate = Predicate::True;
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3635,7 +3769,7 @@ mod tests {
         let predicate = Predicate::False;
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3651,11 +3785,11 @@ mod tests {
 
         let predicate = Predicate::gt("score", 3.0f64);
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
 
         let predicate = Predicate::lt("score", 4.0f64);
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -3671,11 +3805,11 @@ mod tests {
 
         let predicate = Predicate::eq("active", true);
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
 
         let predicate = Predicate::eq("active", false);
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     // ==================== FilterIterator Integration Tests ====================
@@ -4087,7 +4221,7 @@ mod tests {
         let predicate = Predicate::gt("name", 10i64); // Comparing String to Int
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node)); // Type mismatch returns false
+        assert!(!filter.evaluate(&node, None)); // Type mismatch returns false
     }
 
     #[test]
@@ -4096,7 +4230,7 @@ mod tests {
         let predicate = Predicate::contains("age", "30"); // age is Int, not String
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -4108,7 +4242,7 @@ mod tests {
         };
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     #[test]
@@ -4120,7 +4254,7 @@ mod tests {
         };
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     // ==================== Null handling ====================
@@ -4145,7 +4279,7 @@ mod tests {
             value: PredicateValue::Null,
         };
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     // ==================== Complex nested predicates ====================
@@ -4164,7 +4298,7 @@ mod tests {
         ]);
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -4174,7 +4308,7 @@ mod tests {
         let predicate = Predicate::And(vec![]);
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(filter.evaluate(&node));
+        assert!(filter.evaluate(&node, None));
     }
 
     #[test]
@@ -4184,7 +4318,7 @@ mod tests {
         let predicate = Predicate::Or(vec![]);
 
         let filter = FilterIterator::new(Box::new(EmptyIterator), predicate);
-        assert!(!filter.evaluate(&node));
+        assert!(!filter.evaluate(&node, None));
     }
 
     // ==================== NodeLookupIterator Tests ====================

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -443,9 +443,13 @@ impl QueryExecutor {
 
             PhysicalOp::Filter { input, predicate } => {
                 let input_iter = self.build_op(input, profile, child_depth)?;
-                Box::new(iterators::FilterIterator::new(
+                // Pass historical storage so a `Predicate::Provenance` leaf
+                // (Issue #3354a) can resolve each row entity's write-time
+                // provenance; property-only filters never touch it.
+                Box::new(iterators::FilterIterator::with_historical(
                     input_iter,
                     predicate.clone(),
+                    Arc::clone(&self.historical),
                 ))
             }
 

--- a/src/query/ir.rs
+++ b/src/query/ir.rs
@@ -706,10 +706,12 @@ impl ProvenanceCmp {
 
     /// Apply this comparator to two strings (for `source`/`reason`).
     ///
-    /// Only equality/inequality are meaningful for strings; ordering
-    /// comparators fall back to lexicographic order for completeness but are
-    /// not reachable through the AQL surface (only `=`/`<>` are accepted for
-    /// string accessors at convert time).
+    /// Only equality/inequality are meaningful for strings. The ordering
+    /// comparators (`Lt`/`Le`/`Gt`/`Ge`) are **rejected at convert time** for
+    /// the string accessors (see `build_provenance_comparison` in
+    /// `src/query/converter.rs`), so they are unreachable through the AQL
+    /// surface; the lexicographic arms below exist only for total-match
+    /// completeness and are never exercised by a converted query.
     #[must_use]
     pub fn compare_str(self, lhs: &str, rhs: &str) -> bool {
         match self {

--- a/src/query/ir.rs
+++ b/src/query/ir.rs
@@ -523,11 +523,204 @@ pub enum Predicate {
     /// Logical NOT of a predicate
     Not(Box<Predicate>),
 
+    /// Filter on a version's write-time provenance (Issue #3354a).
+    ///
+    /// Unlike every other [`Predicate`] variant (which reads a stored *property*
+    /// of the row entity), this reads the [`Provenance`](crate::core::provenance::Provenance)
+    /// bundle recorded on the version the row represents — resolved from the
+    /// entity's version id at the query's bi-temporal coordinate, so an `AS OF`
+    /// query filters on the provenance recorded on the version visible at that
+    /// coordinate (matching Issue #3348 semantics, AC3).
+    Provenance(ProvenancePredicate),
+
     /// Always true (identity for AND)
     True,
 
     /// Always false (identity for OR)
     False,
+}
+
+/// A write-time provenance predicate over a single version, lowered from an AQL
+/// `WHERE` provenance accessor (Issue #3354a).
+///
+/// Evaluated per-row against the `Option<Provenance>` recorded on the version
+/// the row represents. Absent provenance (no bundle, or a bundle missing the
+/// queried field) makes every accessor evaluate to null, so any comparison is
+/// false and the row is excluded — deliberately mirroring
+/// [`ProvenanceFilter::matches`](crate::core::provenance::ProvenanceFilter::matches)'s
+/// exclude-unattributed default. The [`ProvenancePredicate::Filter`] arm reuses
+/// that exact `matches` implementation for the foldable positive shapes.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProvenancePredicate {
+    /// The foldable positive shapes that the reusable core
+    /// [`ProvenanceFilter`](crate::core::provenance::ProvenanceFilter) already
+    /// expresses, evaluated per-version via its `matches`:
+    /// - `source(x) = 'S'`    → `sources = [S]` (any-of exact match)
+    /// - `confidence(x) >= t` → `min_confidence = t` (inclusive lower bound)
+    ///
+    /// Correctness rides on the shared `matches` implementation, so the AQL
+    /// accessor and the #3348 structured filter return identical result sets.
+    Filter(crate::core::provenance::ProvenanceFilter),
+
+    /// A general per-row accessor comparison for the operators the reusable
+    /// `ProvenanceFilter` cannot express (`<`, `<=`, `>`, `<>`, and `=` on
+    /// confidence/reason). Semantics for absent provenance still match
+    /// `ProvenanceFilter::matches` (excluded).
+    Accessor {
+        /// Which provenance field the accessor reads.
+        field: ProvenanceField,
+        /// The comparison operator.
+        op: ProvenanceCmp,
+        /// The right-hand literal to compare against.
+        operand: ProvenanceOperand,
+    },
+
+    /// `provenance(x) IS [NOT] NULL` — deliberately selects (or excludes) the
+    /// versions with **no** provenance bundle at all. `negated == false` keeps
+    /// rows whose bundle is absent (`IS NULL`); `negated == true` keeps rows
+    /// whose bundle is present (`IS NOT NULL`).
+    IsNull {
+        /// `true` for `IS NOT NULL`, `false` for `IS NULL`.
+        negated: bool,
+    },
+}
+
+/// A provenance field addressable by an AQL accessor (Issue #3354a).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProvenanceField {
+    /// `source(x)` → [`Provenance::source`](crate::core::provenance::Provenance::source).
+    Source,
+    /// `confidence(x)` → [`Provenance::confidence`](crate::core::provenance::Provenance::confidence).
+    Confidence,
+    /// `reason(x)` → [`Provenance::note`](crate::core::provenance::Provenance::note)
+    /// (the user-facing name for the internal `note` field).
+    Reason,
+}
+
+impl ProvenanceField {
+    /// The user-facing accessor name (`"source"`/`"confidence"`/`"reason"`).
+    #[must_use]
+    pub fn accessor_name(self) -> &'static str {
+        match self {
+            ProvenanceField::Source => "source",
+            ProvenanceField::Confidence => "confidence",
+            ProvenanceField::Reason => "reason",
+        }
+    }
+}
+
+/// Comparison operator for a [`ProvenancePredicate::Accessor`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProvenanceCmp {
+    /// `=`
+    Eq,
+    /// `<>` / `!=`
+    Ne,
+    /// `<`
+    Lt,
+    /// `<=`
+    Le,
+    /// `>`
+    Gt,
+    /// `>=`
+    Ge,
+}
+
+/// The right-hand literal of a [`ProvenancePredicate::Accessor`] comparison.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProvenanceOperand {
+    /// A string operand (for `source`/`reason`).
+    Str(String),
+    /// A numeric operand (for `confidence`, already validated to `[0,1]`).
+    Num(f64),
+}
+
+impl ProvenancePredicate {
+    /// Evaluate this predicate against the provenance bundle recorded on the
+    /// version a row represents.
+    ///
+    /// `prov` is the `Option<Provenance>` for the exact version being
+    /// considered (the historical version at the query's bi-temporal
+    /// coordinate for an `AS OF` query), so the decision reflects provenance as
+    /// recorded at that coordinate (Issue #3348 AC3).
+    ///
+    /// Absent provenance handling deliberately mirrors
+    /// [`ProvenanceFilter::matches`](crate::core::provenance::ProvenanceFilter::matches):
+    /// a missing bundle (or a bundle missing the queried field) fails every
+    /// accessor comparison; only [`ProvenancePredicate::IsNull`] can select the
+    /// no-bundle rows.
+    #[must_use]
+    pub fn evaluate(&self, prov: Option<&crate::core::provenance::Provenance>) -> bool {
+        match self {
+            // Reuse the shared core semantics for the foldable positive shapes.
+            ProvenancePredicate::Filter(filter) => filter.matches(prov),
+            ProvenancePredicate::IsNull { negated } => {
+                if *negated {
+                    prov.is_some()
+                } else {
+                    prov.is_none()
+                }
+            }
+            ProvenancePredicate::Accessor { field, op, operand } => {
+                match (field, operand) {
+                    (ProvenanceField::Confidence, ProvenanceOperand::Num(rhs)) => {
+                        match prov.and_then(crate::core::provenance::Provenance::confidence) {
+                            Some(lhs) => op.compare_num(lhs, *rhs),
+                            None => false, // absent field => excluded (matches semantics)
+                        }
+                    }
+                    (ProvenanceField::Source, ProvenanceOperand::Str(rhs)) => {
+                        match prov.and_then(crate::core::provenance::Provenance::source) {
+                            Some(lhs) => op.compare_str(lhs, rhs),
+                            None => false,
+                        }
+                    }
+                    (ProvenanceField::Reason, ProvenanceOperand::Str(rhs)) => {
+                        match prov.and_then(crate::core::provenance::Provenance::note) {
+                            Some(lhs) => op.compare_str(lhs, rhs),
+                            None => false,
+                        }
+                    }
+                    // Field/operand type mismatches are rejected at convert time,
+                    // so this arm is unreachable in practice; fail closed.
+                    _ => false,
+                }
+            }
+        }
+    }
+}
+
+impl ProvenanceCmp {
+    /// Apply this comparator to two numbers (for `confidence`).
+    #[must_use]
+    pub fn compare_num(self, lhs: f64, rhs: f64) -> bool {
+        match self {
+            ProvenanceCmp::Eq => lhs == rhs,
+            ProvenanceCmp::Ne => lhs != rhs,
+            ProvenanceCmp::Lt => lhs < rhs,
+            ProvenanceCmp::Le => lhs <= rhs,
+            ProvenanceCmp::Gt => lhs > rhs,
+            ProvenanceCmp::Ge => lhs >= rhs,
+        }
+    }
+
+    /// Apply this comparator to two strings (for `source`/`reason`).
+    ///
+    /// Only equality/inequality are meaningful for strings; ordering
+    /// comparators fall back to lexicographic order for completeness but are
+    /// not reachable through the AQL surface (only `=`/`<>` are accepted for
+    /// string accessors at convert time).
+    #[must_use]
+    pub fn compare_str(self, lhs: &str, rhs: &str) -> bool {
+        match self {
+            ProvenanceCmp::Eq => lhs == rhs,
+            ProvenanceCmp::Ne => lhs != rhs,
+            ProvenanceCmp::Lt => lhs < rhs,
+            ProvenanceCmp::Le => lhs <= rhs,
+            ProvenanceCmp::Gt => lhs > rhs,
+            ProvenanceCmp::Ge => lhs >= rhs,
+        }
+    }
 }
 
 impl Predicate {
@@ -802,6 +995,148 @@ mod tests {
 
         let v: PredicateValue = "hello".into();
         assert_eq!(v, PredicateValue::String("hello".to_string()));
+    }
+}
+
+#[cfg(test)]
+mod provenance_predicate_tests {
+    use super::*;
+    use crate::core::provenance::{Provenance, ProvenanceFilter};
+
+    fn prov(source: Option<&str>, confidence: Option<f64>, reason: Option<&str>) -> Provenance {
+        Provenance::from_parts(
+            source.map(String::from),
+            confidence,
+            reason.map(String::from),
+            None,
+            None,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn is_null_selects_no_bundle_only() {
+        let is_null = ProvenancePredicate::IsNull { negated: false };
+        let is_not_null = ProvenancePredicate::IsNull { negated: true };
+        assert!(is_null.evaluate(None));
+        assert!(!is_null.evaluate(Some(&prov(Some("crm"), None, None))));
+        assert!(!is_not_null.evaluate(None));
+        assert!(is_not_null.evaluate(Some(&prov(Some("crm"), None, None))));
+    }
+
+    #[test]
+    fn absent_provenance_fails_every_accessor() {
+        let cases = [
+            ProvenancePredicate::Accessor {
+                field: ProvenanceField::Confidence,
+                op: ProvenanceCmp::Ge,
+                operand: ProvenanceOperand::Num(0.5),
+            },
+            ProvenancePredicate::Accessor {
+                field: ProvenanceField::Confidence,
+                op: ProvenanceCmp::Lt,
+                operand: ProvenanceOperand::Num(0.5),
+            },
+            ProvenancePredicate::Accessor {
+                field: ProvenanceField::Source,
+                op: ProvenanceCmp::Ne,
+                operand: ProvenanceOperand::Str("x".into()),
+            },
+        ];
+        for c in cases {
+            assert!(!c.evaluate(None), "absent bundle must fail {c:?}");
+        }
+    }
+
+    #[test]
+    fn confidence_operators() {
+        let p = prov(None, Some(0.8), None);
+        let mk = |op| ProvenancePredicate::Accessor {
+            field: ProvenanceField::Confidence,
+            op,
+            operand: ProvenanceOperand::Num(0.8),
+        };
+        assert!(mk(ProvenanceCmp::Ge).evaluate(Some(&p)));
+        assert!(mk(ProvenanceCmp::Le).evaluate(Some(&p)));
+        assert!(mk(ProvenanceCmp::Eq).evaluate(Some(&p)));
+        assert!(!mk(ProvenanceCmp::Gt).evaluate(Some(&p)));
+        assert!(!mk(ProvenanceCmp::Lt).evaluate(Some(&p)));
+        assert!(!mk(ProvenanceCmp::Ne).evaluate(Some(&p)));
+    }
+
+    /// The foldable `Filter` arm and the shared `ProvenanceFilter::matches` must
+    /// agree exactly on every bundle shape (AC3 parity).
+    #[test]
+    fn filter_arm_matches_core_provenance_filter() {
+        let filter = ProvenanceFilter::validated(Some("hr".into()), None, Some(0.9), false)
+            .unwrap()
+            .unwrap();
+        let pred = ProvenancePredicate::Filter(filter.clone());
+        let bundles = [
+            None,
+            Some(prov(Some("hr"), Some(0.95), None)),
+            Some(prov(Some("hr"), Some(0.5), None)),
+            Some(prov(Some("crm"), Some(0.95), None)),
+            Some(prov(None, Some(0.95), None)),
+            Some(prov(Some("hr"), None, None)),
+        ];
+        for b in &bundles {
+            assert_eq!(
+                pred.evaluate(b.as_ref()),
+                filter.matches(b.as_ref()),
+                "Filter arm must equal ProvenanceFilter::matches for {b:?}"
+            );
+        }
+    }
+
+    /// The general `Accessor` arm for the foldable positive shapes must equal
+    /// the equivalent `ProvenanceFilter::matches` result (source exact match,
+    /// inclusive min-confidence).
+    #[test]
+    fn accessor_arm_parity_with_filter_on_foldable_shapes() {
+        // confidence(x) >= 0.9  ==  min_confidence 0.9
+        let acc = ProvenancePredicate::Accessor {
+            field: ProvenanceField::Confidence,
+            op: ProvenanceCmp::Ge,
+            operand: ProvenanceOperand::Num(0.9),
+        };
+        let filter = ProvenanceFilter::validated(None, None, Some(0.9), false)
+            .unwrap()
+            .unwrap();
+        for b in [
+            None,
+            Some(prov(None, Some(0.95), None)),
+            Some(prov(None, Some(0.9), None)),
+            Some(prov(None, Some(0.5), None)),
+            Some(prov(Some("crm"), None, None)),
+        ] {
+            assert_eq!(
+                acc.evaluate(b.as_ref()),
+                filter.matches(b.as_ref()),
+                "{b:?}"
+            );
+        }
+
+        // source(x) = 'crm'  ==  sources [crm]
+        let acc = ProvenancePredicate::Accessor {
+            field: ProvenanceField::Source,
+            op: ProvenanceCmp::Eq,
+            operand: ProvenanceOperand::Str("crm".into()),
+        };
+        let filter = ProvenanceFilter::validated(Some("crm".into()), None, None, false)
+            .unwrap()
+            .unwrap();
+        for b in [
+            None,
+            Some(prov(Some("crm"), None, None)),
+            Some(prov(Some("hr"), None, None)),
+        ] {
+            assert_eq!(
+                acc.evaluate(b.as_ref()),
+                filter.matches(b.as_ref()),
+                "{b:?}"
+            );
+        }
     }
 }
 

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1013,19 +1013,20 @@ impl Parser {
         // it to the dedicated provenance variant; any other function-call head
         // (or a non-property expression) falls through to the property path,
         // which reports a structured error.
-        if let Expression::FunctionCall { name, args } = &expr
-            && name.eq_ignore_ascii_case("provenance")
-        {
-            if let [Expression::Identifier(var)] = args.as_slice() {
-                return Ok(PredicateExpr::ProvenanceIsNull {
-                    variable: var.clone(),
-                    negated: is_not,
-                });
+        match &expr {
+            Expression::FunctionCall { name, args } if name.eq_ignore_ascii_case("provenance") => {
+                if let [Expression::Identifier(var)] = args.as_slice() {
+                    return Ok(PredicateExpr::ProvenanceIsNull {
+                        variable: var.clone(),
+                        negated: is_not,
+                    });
+                }
+                return Err(self.error(
+                    "provenance(x) IS NULL requires a single bound variable argument".to_string(),
+                    Some("provenance(n) IS NULL".to_string()),
+                ));
             }
-            return Err(self.error(
-                "provenance(x) IS NULL requires a single bound variable argument".to_string(),
-                Some("provenance(n) IS NULL".to_string()),
-            ));
+            _ => {}
         }
 
         let prop = self.require_property_expr(expr, "IS NULL")?;

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1008,6 +1008,26 @@ impl Parser {
         };
         self.expect(&Token::Null)?;
 
+        // `provenance(x) IS [NOT] NULL` (Issue #3354a): the head is a
+        // `provenance(var)` function call rather than a property access. Route
+        // it to the dedicated provenance variant; any other function-call head
+        // (or a non-property expression) falls through to the property path,
+        // which reports a structured error.
+        if let Expression::FunctionCall { name, args } = &expr
+            && name.eq_ignore_ascii_case("provenance")
+        {
+            if let [Expression::Identifier(var)] = args.as_slice() {
+                return Ok(PredicateExpr::ProvenanceIsNull {
+                    variable: var.clone(),
+                    negated: is_not,
+                });
+            }
+            return Err(self.error(
+                "provenance(x) IS NULL requires a single bound variable argument".to_string(),
+                Some("provenance(n) IS NULL".to_string()),
+            ));
+        }
+
         let prop = self.require_property_expr(expr, "IS NULL")?;
         Ok(if is_not {
             PredicateExpr::IsNotNull(prop)
@@ -1096,7 +1116,9 @@ impl Parser {
     fn parse_expression(&mut self) -> Result<Expression, ParseError> {
         match self.current() {
             Some(Token::Identifier(_)) => {
-                // Could be property access (n.prop) or just identifier (n)
+                // Could be property access (n.prop), a function call (func(args),
+                // e.g. the provenance accessors source(x)/confidence(x)/reason(x)
+                // and provenance(x), Issue #3354a), or just an identifier (n).
                 let ident = self.parse_identifier()?;
                 if self.check(&Token::Dot) {
                     self.advance();
@@ -1105,6 +1127,12 @@ impl Parser {
                         variable: ident,
                         property: prop,
                     }))
+                } else if self.check(&Token::LeftParen) {
+                    // Function call: name(arg, ...). Arguments are general
+                    // expressions; provenance-accessor arity/shape is validated
+                    // later at convert time so an unknown function or a malformed
+                    // argument yields a structured error, not a parse panic.
+                    self.parse_function_call(ident)
                 } else {
                     // Just an identifier - a variable reference
                     Ok(Expression::Identifier(ident))
@@ -1117,6 +1145,30 @@ impl Parser {
             }
             _ => self.parse_literal_expression(),
         }
+    }
+
+    /// Parse the argument list of a function call `name(arg, ...)`, given the
+    /// already-consumed function `name`. The opening `(` is the current token.
+    ///
+    /// Arguments are parsed as general expressions and returned verbatim; the
+    /// converter validates whether `name` is a known accessor and whether its
+    /// arguments have the expected shape (Issue #3354a). An empty argument list
+    /// `name()` is permitted syntactically and rejected (if invalid) at convert
+    /// time.
+    fn parse_function_call(&mut self, name: String) -> Result<Expression, ParseError> {
+        self.expect(&Token::LeftParen)?;
+        let mut args = Vec::new();
+        if !self.check(&Token::RightParen) {
+            loop {
+                args.push(self.parse_expression()?);
+                if !self.check(&Token::Comma) {
+                    break;
+                }
+                self.advance();
+            }
+        }
+        self.expect(&Token::RightParen)?;
+        Ok(Expression::FunctionCall { name, args })
     }
 
     fn parse_literal_expression(&mut self) -> Result<Expression, ParseError> {
@@ -1720,6 +1772,50 @@ mod tests {
         if let Some(WhereClause { predicate }) = &query.where_clause {
             assert!(matches!(predicate, PredicateExpr::IsNotNull(_)));
         }
+    }
+
+    #[test]
+    fn test_parse_where_provenance_accessor_call() {
+        // Issue #3354a: `confidence(n)` parses as a function call in WHERE.
+        let query = Parser::parse("MATCH (n) WHERE confidence(n) >= 0.9 RETURN n").unwrap();
+        let Some(WhereClause { predicate }) = &query.where_clause else {
+            panic!("expected WHERE");
+        };
+        let PredicateExpr::Comparison { left, .. } = predicate else {
+            panic!("expected comparison, got {predicate:?}");
+        };
+        match left {
+            Expression::FunctionCall { name, args } => {
+                assert_eq!(name, "confidence");
+                assert_eq!(args.len(), 1);
+                assert!(matches!(&args[0], Expression::Identifier(v) if v == "n"));
+            }
+            other => panic!("expected FunctionCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_where_provenance_is_null() {
+        let query = Parser::parse("MATCH (n) WHERE provenance(n) IS NULL RETURN n").unwrap();
+        let Some(WhereClause { predicate }) = &query.where_clause else {
+            panic!("expected WHERE");
+        };
+        assert!(matches!(
+            predicate,
+            PredicateExpr::ProvenanceIsNull { variable, negated: false } if variable == "n"
+        ));
+    }
+
+    #[test]
+    fn test_parse_where_provenance_is_not_null() {
+        let query = Parser::parse("MATCH (n) WHERE provenance(n) IS NOT NULL RETURN n").unwrap();
+        let Some(WhereClause { predicate }) = &query.where_clause else {
+            panic!("expected WHERE");
+        };
+        assert!(matches!(
+            predicate,
+            PredicateExpr::ProvenanceIsNull { variable, negated: true } if variable == "n"
+        ));
     }
 
     #[test]

--- a/src/query/planner/rules/operation_reordering.rs
+++ b/src/query/planner/rules/operation_reordering.rs
@@ -373,6 +373,11 @@ impl OperationReordering {
             Predicate::Ne { .. } => NOT_EQUALS_SELECTIVITY,
             Predicate::In { .. } => IN_PREDICATE_SELECTIVITY,
             Predicate::Exists(_) | Predicate::NotExists(_) => EXISTENCE_CHECK_SELECTIVITY,
+            // Provenance predicates (Issue #3354a) require a per-version
+            // metadata lookup with no column statistics available; treat them
+            // like a range predicate for ordering purposes (moderately
+            // selective, so they run after cheap equality filters).
+            Predicate::Provenance(_) => RANGE_PREDICATE_SELECTIVITY,
             Predicate::True => TRUE_SELECTIVITY,
             Predicate::False => FALSE_SELECTIVITY,
         }

--- a/tests/aql_provenance_where.rs
+++ b/tests/aql_provenance_where.rs
@@ -50,9 +50,10 @@ fn names(db: &AletheiaDB, aql: &str) -> Vec<String> {
     let results = db.execute_aql(aql).expect("query executes");
     let mut out = Vec::new();
     for row in results.collect_all().expect("collect rows") {
-        if let EntityResult::Node(n) = row.entity
-            && let Some(v) = n.get_property("name")
-        {
+        let EntityResult::Node(n) = row.entity else {
+            continue;
+        };
+        if let Some(v) = n.get_property("name") {
             out.push(format!("{v:?}"));
         }
     }
@@ -322,4 +323,49 @@ fn as_of_evaluates_provenance_at_that_coordinate() {
         &format!("AS OF '{t3}' MATCH (n:Person) WHERE confidence(n) >= 0.90 RETURN n"),
     );
     assert_eq!(after, vec!["String(\"alice\")"]);
+}
+
+#[test]
+fn ordering_operator_on_source_is_rejected() {
+    // FIX 1 (Issue #3354a): the string accessors `source`/`reason` support only
+    // `=`/`<>`. An ordering operator must be rejected at convert time with a
+    // structured error, never silently accepted as a lexicographic comparison.
+    let db = make_db();
+    let msg = err_msg(&db, "MATCH (n:Person) WHERE source(n) < 'x' RETURN n");
+    let lower = msg.to_lowercase();
+    assert!(
+        lower.contains("source") && (lower.contains("ordering") || lower.contains("= and <>")),
+        "expected a structured rejection naming source and the allowed operators, got: {msg}"
+    );
+}
+
+#[test]
+fn ordering_operator_on_reason_is_rejected() {
+    // FIX 1 (Issue #3354a): `reason(n) >= 'y'` must be rejected, not accepted as
+    // a lexicographic comparison.
+    let db = make_db();
+    let msg = err_msg(&db, "MATCH (n:Person) WHERE reason(n) >= 'y' RETURN n");
+    let lower = msg.to_lowercase();
+    assert!(
+        lower.contains("reason") && (lower.contains("ordering") || lower.contains("= and <>")),
+        "expected a structured rejection naming reason and the allowed operators, got: {msg}"
+    );
+}
+
+#[test]
+fn provenance_and_always_false_cheap_predicate_is_empty() {
+    // FIX 4 (Issue #3354a, DoS perf follow-up): a provenance leaf AND-combined
+    // with an always-false cheap property predicate must return no rows.
+    // Correctness first -- with lazy provenance resolution the cheap conjunct
+    // rejects every row before any historical read, but the result set is the
+    // same empty set either way.
+    let db = make_db();
+    let got = names(
+        &db,
+        "MATCH (n:Person) WHERE n.name = '__no_such_person__' AND source(n) = 'hr-system' RETURN n",
+    );
+    assert!(
+        got.is_empty(),
+        "an always-false cheap conjunct must yield an empty result, got: {got:?}"
+    );
 }

--- a/tests/aql_provenance_where.rs
+++ b/tests/aql_provenance_where.rs
@@ -1,0 +1,325 @@
+//! Integration tests for AQL `WHERE`-clause provenance predicates (Issue #3354a).
+//!
+//! Covers the read-only provenance accessors `source(x)` / `confidence(x)` /
+//! `reason(x)` and `provenance(x) IS [NOT] NULL` end-to-end through
+//! `execute_aql`, including absent-provenance exclusion, composition with an
+//! ordinary property `WHERE`, and per-version (`AS OF`) evaluation.
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::PropertyMapBuilder;
+use aletheiadb::api::transaction::WriteRequestOptions;
+use aletheiadb::core::NodeId;
+use aletheiadb::core::provenance::Provenance;
+use aletheiadb::query::executor::EntityResult;
+
+fn prov(source: Option<&str>, confidence: Option<f64>, reason: Option<&str>) -> Provenance {
+    let mut b = Provenance::builder();
+    if let Some(s) = source {
+        b = b.source(s);
+    }
+    if let Some(c) = confidence {
+        b = b.confidence(c);
+    }
+    if let Some(r) = reason {
+        b = b.note(r);
+    }
+    b.build().expect("valid provenance")
+}
+
+fn create_person(db: &AletheiaDB, name: &str, provenance: Option<Provenance>) -> NodeId {
+    let props = PropertyMapBuilder::new().insert("name", name).build();
+    let mut opts = WriteRequestOptions::new();
+    if let Some(p) = provenance {
+        opts = opts.with_provenance(p);
+    }
+    db.create_node_with_options("Person", props, opts)
+        .expect("create person")
+}
+
+/// Run an AQL query expected to fail, returning the error message.
+/// (`QueryResults` is not `Debug`, so `Result::expect_err` cannot be used.)
+fn err_msg(db: &AletheiaDB, aql: &str) -> String {
+    match db.execute_aql(aql) {
+        Ok(_) => panic!("expected error for query: {aql}"),
+        Err(e) => e.to_string(),
+    }
+}
+
+/// Collect the `name` property of every node row returned by an AQL query.
+fn names(db: &AletheiaDB, aql: &str) -> Vec<String> {
+    let results = db.execute_aql(aql).expect("query executes");
+    let mut out = Vec::new();
+    for row in results.collect_all().expect("collect rows") {
+        if let EntityResult::Node(n) = row.entity
+            && let Some(v) = n.get_property("name")
+        {
+            out.push(format!("{v:?}"));
+        }
+    }
+    out.sort();
+    out
+}
+
+fn make_db() -> AletheiaDB {
+    let db = AletheiaDB::new().expect("db");
+    create_person(
+        &db,
+        "alice",
+        Some(prov(Some("hr-system"), Some(0.95), Some("verified"))),
+    );
+    create_person(
+        &db,
+        "bob",
+        Some(prov(Some("crm-sync"), Some(0.60), Some("imported"))),
+    );
+    create_person(
+        &db,
+        "carol",
+        Some(prov(Some("hr-system"), Some(0.80), None)),
+    );
+    create_person(&db, "dave", None); // unattributed
+    db
+}
+
+#[test]
+fn source_exact_match_filters_rows() {
+    let db = make_db();
+    let got = names(
+        &db,
+        "MATCH (n:Person) WHERE source(n) = 'hr-system' RETURN n",
+    );
+    assert_eq!(got, vec!["String(\"alice\")", "String(\"carol\")"]);
+}
+
+#[test]
+fn source_inequality_excludes_and_absent() {
+    let db = make_db();
+    // `<>` keeps attributed rows whose source differs; unattributed (dave) is
+    // excluded because its accessor is null.
+    let got = names(
+        &db,
+        "MATCH (n:Person) WHERE source(n) <> 'hr-system' RETURN n",
+    );
+    assert_eq!(got, vec!["String(\"bob\")"]);
+}
+
+#[test]
+fn confidence_inclusive_lower_bound() {
+    let db = make_db();
+    // >= 0.80 keeps alice (0.95) and carol (0.80, inclusive), not bob (0.60).
+    let got = names(&db, "MATCH (n:Person) WHERE confidence(n) >= 0.80 RETURN n");
+    assert_eq!(got, vec!["String(\"alice\")", "String(\"carol\")"]);
+}
+
+#[test]
+fn confidence_strict_greater_is_exclusive() {
+    let db = make_db();
+    // > 0.80 excludes carol (== bound), keeps only alice.
+    let got = names(&db, "MATCH (n:Person) WHERE confidence(n) > 0.80 RETURN n");
+    assert_eq!(got, vec!["String(\"alice\")"]);
+}
+
+#[test]
+fn confidence_less_than_general_path() {
+    let db = make_db();
+    // `<` is a non-foldable shape (general accessor path).
+    let got = names(&db, "MATCH (n:Person) WHERE confidence(n) < 0.80 RETURN n");
+    assert_eq!(got, vec!["String(\"bob\")"]);
+}
+
+#[test]
+fn reason_equality() {
+    let db = make_db();
+    let got = names(
+        &db,
+        "MATCH (n:Person) WHERE reason(n) = 'verified' RETURN n",
+    );
+    assert_eq!(got, vec!["String(\"alice\")"]);
+}
+
+#[test]
+fn absent_provenance_excluded_by_confidence() {
+    let db = make_db();
+    // dave (no bundle) and carol (no reason field) both excluded by a reason
+    // filter; a confidence filter excludes only dave among attributed rows.
+    let got = names(&db, "MATCH (n:Person) WHERE confidence(n) >= 0.0 RETURN n");
+    assert_eq!(
+        got,
+        vec!["String(\"alice\")", "String(\"bob\")", "String(\"carol\")"]
+    );
+}
+
+#[test]
+fn partial_bundle_missing_field_excluded() {
+    let db = make_db();
+    // carol has a bundle but no `reason`; a reason predicate excludes her.
+    let got = names(
+        &db,
+        "MATCH (n:Person) WHERE reason(n) = 'imported' RETURN n",
+    );
+    assert_eq!(got, vec!["String(\"bob\")"]);
+}
+
+#[test]
+fn provenance_is_null_selects_unattributed() {
+    let db = make_db();
+    let got = names(&db, "MATCH (n:Person) WHERE provenance(n) IS NULL RETURN n");
+    assert_eq!(got, vec!["String(\"dave\")"]);
+}
+
+#[test]
+fn provenance_is_not_null_selects_attributed() {
+    let db = make_db();
+    // carol has a (partial) bundle => IS NOT NULL is true for her.
+    let got = names(
+        &db,
+        "MATCH (n:Person) WHERE provenance(n) IS NOT NULL RETURN n",
+    );
+    assert_eq!(
+        got,
+        vec!["String(\"alice\")", "String(\"bob\")", "String(\"carol\")"]
+    );
+}
+
+#[test]
+fn combined_source_and_confidence_is_and() {
+    let db = make_db();
+    let got = names(
+        &db,
+        "MATCH (n:Person) WHERE source(n) = 'hr-system' AND confidence(n) >= 0.90 RETURN n",
+    );
+    assert_eq!(got, vec!["String(\"alice\")"]);
+}
+
+#[test]
+fn combined_property_and_provenance() {
+    let db = make_db();
+    // Property predicate ANDed with a provenance predicate.
+    let got = names(
+        &db,
+        "MATCH (n:Person) WHERE n.name = 'carol' AND confidence(n) >= 0.5 RETURN n",
+    );
+    assert_eq!(got, vec!["String(\"carol\")"]);
+}
+
+#[test]
+fn combined_property_or_provenance() {
+    let db = make_db();
+    // OR mixing forces the general (non-folded) evaluation path.
+    let got = names(
+        &db,
+        "MATCH (n:Person) WHERE n.name = 'dave' OR confidence(n) >= 0.90 RETURN n",
+    );
+    assert_eq!(got, vec!["String(\"alice\")", "String(\"dave\")"]);
+}
+
+#[test]
+fn accessor_on_right_hand_side() {
+    let db = make_db();
+    // `0.90 <= confidence(n)` must lower identically to `confidence(n) >= 0.90`.
+    let got = names(&db, "MATCH (n:Person) WHERE 0.90 <= confidence(n) RETURN n");
+    assert_eq!(got, vec!["String(\"alice\")"]);
+}
+
+#[test]
+fn property_named_source_is_not_a_provenance_accessor() {
+    // A property literally named `source` (accessed as `n.source`) must remain
+    // an ordinary property filter, not a provenance accessor.
+    let db = AletheiaDB::new().expect("db");
+    let props = PropertyMapBuilder::new()
+        .insert("name", "eve")
+        .insert("source", "manual")
+        .build();
+    db.create_node_with_options("Person", props, WriteRequestOptions::new())
+        .expect("create");
+    let got = names(&db, "MATCH (n:Person) WHERE n.source = 'manual' RETURN n");
+    assert_eq!(got, vec!["String(\"eve\")"]);
+}
+
+#[test]
+fn confidence_out_of_range_is_rejected() {
+    let db = make_db();
+    let msg = err_msg(&db, "MATCH (n:Person) WHERE confidence(n) >= 1.5 RETURN n");
+    assert!(
+        msg.contains("min_confidence") || msg.contains("1.5"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn confidence_compared_to_string_is_type_error() {
+    let db = make_db();
+    let msg = err_msg(
+        &db,
+        "MATCH (n:Person) WHERE confidence(n) = 'high' RETURN n",
+    );
+    assert!(msg.to_lowercase().contains("type mismatch"), "got: {msg}");
+}
+
+#[test]
+fn source_compared_to_number_is_type_error() {
+    let db = make_db();
+    let msg = err_msg(&db, "MATCH (n:Person) WHERE source(n) = 5 RETURN n");
+    assert!(msg.to_lowercase().contains("type mismatch"), "got: {msg}");
+}
+
+#[test]
+fn malformed_accessor_argument_is_parse_or_convert_error() {
+    let db = make_db();
+    for q in [
+        "MATCH (n:Person) WHERE source(n.foo) = 'x' RETURN n",
+        "MATCH (n:Person) WHERE confidence(n, m) >= 0.5 RETURN n",
+        "MATCH (n:Person) WHERE source() = 'x' RETURN n",
+    ] {
+        assert!(db.execute_aql(q).is_err(), "expected error for: {q}");
+    }
+}
+
+#[test]
+fn as_of_evaluates_provenance_at_that_coordinate() {
+    // AC3: an `AS OF` query filters on the provenance recorded on the version
+    // visible at that coordinate, not the latest version. Build a node whose
+    // confidence rose from 0.50 (valid [T1, T2)) to 0.95 (valid [T2, ..)).
+    let db = AletheiaDB::new().expect("db");
+    let t1: i64 = 1_000_000_000_000; // microseconds
+    let t2: i64 = 2_000_000_000_000;
+    let t3: i64 = 3_000_000_000_000;
+
+    let props = PropertyMapBuilder::new().insert("name", "alice").build();
+    let node_id = db
+        .create_node_with_options(
+            "Person",
+            props,
+            WriteRequestOptions::new()
+                .with_valid_from(aletheiadb::core::temporal::Timestamp::from(t1))
+                .with_provenance(prov(Some("hr-system"), Some(0.50), None)),
+        )
+        .expect("create v1");
+
+    let props2 = PropertyMapBuilder::new().insert("name", "alice").build();
+    db.update_node_with_options(
+        node_id,
+        props2,
+        WriteRequestOptions::new()
+            .with_valid_from(aletheiadb::core::temporal::Timestamp::from(t2))
+            .with_provenance(prov(Some("hr-system"), Some(0.95), None)),
+    )
+    .expect("update v2");
+
+    // AS OF valid_time within [T1, T2): confidence was 0.50 -> excluded by >= 0.9.
+    let before = names(
+        &db,
+        &format!("AS OF '{t1}' MATCH (n:Person) WHERE confidence(n) >= 0.90 RETURN n"),
+    );
+    assert!(
+        before.is_empty(),
+        "at T1 confidence was 0.50, got: {before:?}"
+    );
+
+    // AS OF valid_time >= T2: confidence is 0.95 -> included by >= 0.9.
+    let after = names(
+        &db,
+        &format!("AS OF '{t3}' MATCH (n:Person) WHERE confidence(n) >= 0.90 RETURN n"),
+    );
+    assert_eq!(after, vec!["String(\"alice\")"]);
+}

--- a/tests/http_provenance_where.rs
+++ b/tests/http_provenance_where.rs
@@ -1,0 +1,128 @@
+//! Integration test for AQL `WHERE`-clause provenance predicates over the HTTP
+//! `/query` surface (Issue #3354a).
+//!
+//! Confirms the read-only provenance accessors flow through the HTTP
+//! `execute_query` path unchanged (reader-class, no handler change) and that a
+//! type-misused accessor fails closed with a structured error rather than a
+//! silent empty result.
+//!
+//! Run with: `cargo test --test http_provenance_where --features http-server`
+
+#![cfg(feature = "http-server")]
+
+use std::sync::Arc;
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::api::transaction::WriteRequestOptions;
+use aletheiadb::auth::AuthMode;
+use aletheiadb::core::PropertyMapBuilder;
+use aletheiadb::core::provenance::Provenance;
+use aletheiadb::http::{AppState, ServerConfig, build_test_router};
+use autumn_web::test::{TestApp, TestClient};
+use serde_json::{Value, json};
+
+fn client() -> (TestClient, Arc<AletheiaDB>) {
+    let db = Arc::new(AletheiaDB::new().expect("create DB"));
+    let state = AppState::new(db.clone());
+    let config = ServerConfig::builder()
+        .auth_mode(AuthMode::Anonymous)
+        .build();
+    let router = build_test_router(state, &config).expect("build router");
+    (TestApp::from_router(router), db)
+}
+
+fn seed(db: &AletheiaDB, name: &str, source: &str, confidence: f64) {
+    let props = PropertyMapBuilder::new().insert("name", name).build();
+    let prov = Provenance::builder()
+        .source(source)
+        .confidence(confidence)
+        .build()
+        .expect("valid provenance");
+    db.create_node_with_options(
+        "Person",
+        props,
+        WriteRequestOptions::new().with_provenance(prov),
+    )
+    .expect("seed");
+}
+
+async fn post_query(client: &TestClient, body: &Value) -> (u16, Value) {
+    let resp = client.post("/query").json(body).send().await;
+    let status = resp.status.as_u16();
+    let json = serde_json::from_slice::<Value>(&resp.body).unwrap_or(Value::Null);
+    (status, json)
+}
+
+#[tokio::test]
+async fn provenance_where_filters_over_http() {
+    let (client, db) = client();
+    seed(&db, "alice", "hr-system", 0.95);
+    seed(&db, "bob", "crm-sync", 0.60);
+    seed(&db, "carol", "hr-system", 0.80);
+
+    let (status, body) = post_query(
+        &client,
+        &json!({
+            "operation": "execute_query",
+            "query": "MATCH (n:Person) WHERE source(n) = 'hr-system' AND confidence(n) >= 0.9 RETURN n"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, 200, "provenance query should succeed: {body}");
+    assert_eq!(body["success"], true, "{body}");
+    let rows = body["data"].as_array().expect("data array");
+    assert_eq!(
+        rows.len(),
+        1,
+        "only alice matches source+confidence: {body}"
+    );
+}
+
+#[tokio::test]
+async fn provenance_is_null_over_http() {
+    let (client, db) = client();
+    seed(&db, "alice", "hr-system", 0.95);
+    // dave has no provenance bundle.
+    db.create_node(
+        "Person",
+        PropertyMapBuilder::new().insert("name", "dave").build(),
+    )
+    .expect("seed dave");
+
+    let (status, body) = post_query(
+        &client,
+        &json!({
+            "operation": "execute_query",
+            "query": "MATCH (n:Person) WHERE provenance(n) IS NULL RETURN n"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, 200, "{body}");
+    let rows = body["data"].as_array().expect("data array");
+    assert_eq!(rows.len(), 1, "only the unattributed node matches: {body}");
+}
+
+#[tokio::test]
+async fn provenance_type_mismatch_fails_closed_over_http() {
+    let (client, db) = client();
+    seed(&db, "alice", "hr-system", 0.95);
+
+    let (status, body) = post_query(
+        &client,
+        &json!({
+            "operation": "execute_query",
+            "query": "MATCH (n:Person) WHERE confidence(n) = 'high' RETURN n"
+        }),
+    )
+    .await;
+
+    // Fails closed with a client error, never a silent empty 200 success.
+    assert!(
+        status >= 400,
+        "type-misused accessor must be a structured error, not a silent empty result: \
+         status={status} body={body}"
+    );
+    assert_eq!(body["success"], false, "{body}");
+}


### PR DESCRIPTION
## Summary

Implements **Issue #3354 Part A (v1)** — provenance predicates in the **`WHERE` clause of AQL only** — reusing the existing `core::provenance::ProvenanceFilter` seam (merged via #3348/#3545). An AQL `WHERE` clause can now filter on write-time provenance through read-only accessors:

- `source(x) = 'S'` / `source(x) <> 'S'`
- `confidence(x)` compared to `t` (`=`, `<>`, `<`, `<=`, `>`, `>=`; `t` validated to `[0,1]`, NaN rejected)
- `reason(x) = 'R'` / `reason(x) <> 'R'`
- `provenance(x) IS [NOT] NULL`

`x` is a bound variable; accessors resolve only in function-call position, so a property named `source` (`n.source`) is unaffected. Semantics match #3348 exactly: provenance is evaluated **per-version at the query's bi-temporal coordinate** (an `AS OF` query reads the version visible at that coordinate); unattributed versions (or a bundle missing the queried field) are **excluded**, selectable only via `provenance(x) IS NULL`. Malformed / mis-typed / out-of-range predicates **fail closed** with the existing structured error vocabulary (`parse_error` / `invalid_params`), never a silent empty result. The `query` tool stays read-only and `reader`-class.

### Reuse of the `ProvenanceFilter` seam
- The two foldable positive shapes (`source(x) = 'S'`, `confidence(x) >= t`) lower to a `core::provenance::ProvenanceFilter` and are evaluated **per-row via `ProvenanceFilter::matches`** — no duplicated semantics.
- Confidence literals are validated via `ProvenanceFilter::validated` (range/NaN rules + `ProvenanceFilterError::field()` naming) — genuine reuse.
- A parity test proves the general accessor path equals `ProvenanceFilter::matches` on the foldable shapes; absent-provenance handling mirrors `matches` exactly.

## Review fixes (Wave-5 Lane 4)

Applied on top of the initial implementation:

| Fix | What | Evidence |
|---|---|---|
| **FIX 1 (correctness)** | `source()`/`reason()` are `=`/`<>` only; ordering operators (`<`,`<=`,`>`,`>=`) are now **rejected at convert time** (fail-closed `SyntaxError` → `parse_error`) instead of silently accepted as lexicographic comparisons. `confidence` numeric ordering unchanged. `ir.rs` `compare_str` doc corrected. | `ordering_operator_on_source_is_rejected`, `ordering_operator_on_reason_is_rejected` |
| **FIX 2 (Gemini high)** | Removed unstable `let`-chains: parser `provenance(x) IS [NOT] NULL` branch → guarded `match`; test helper → `let`-else. Compiles on the pinned stable toolchain; clippy-clean (no `collapsible_if`). | clippy subset + all-features exit 0 |
| **FIX 3 (Gemini medium ×2)** | Replaced `.expect(...)` on `ProvenanceFilter::validated` (confidence + source folds) with `Ok(None)` → accessor fallback; no `expect`/`unwrap` on the production path. Folding for valid inputs unchanged. | `test_convert_provenance_source_eq_folds_to_filter`, `accessor_arm_parity_with_filter_on_foldable_shapes` (fold behavior unchanged) |
| **FIX 4 (DoS perf)** | Provenance is now resolved **lazily at the `Predicate::Provenance` leaf**, memoized once per row (`RefCell` cache), so an `AND` short-circuit skips the per-row `historical.read()` for rows a cheaper conjunct already rejected. Same semantics (≤1 resolution/row); node + edge paths. | `provenance_and_always_false_cheap_predicate_is_empty` (correctness) |
| **FIX 5 (coverage + docs)** | AQL `RETURN e` projects the traversal **node**, not an edge row, so the edge-accessor path is covered by unit tests driving `evaluate_edge_predicate` over real edge rows; doc note on edge pass-through added to both guides. | `edge_confidence_accessor_filters_edge_rows`, `edge_provenance_is_null_selects_unattributed_edges`, `edge_non_provenance_leaf_is_pass_through` |
| **FIX 6 (PR-body accuracy)** | Verified `tests/parity/inventory.json` `mcp_tools` on this branch = **46** (trunk merged #3540). This PR adds no tool, so the golden is unchanged at 46 (inventory.json untouched). | — |

## Deferred (out of scope for #3354a, noted per coordinator ruling)
- **RETURN / ORDER BY provenance projection** — needs Lane 3's scalar-projection-into-row lowering (the same blocker the CLAUDE.md aggregation notes describe). v1 is `WHERE`-only.
- **Cypher provenance predicates (#3354b)** — `src/cypher/**` deliberately untouched; held for Lane 3's PR B.
- Like ordinary AQL property predicates, an accessor reads the row's bound entity rather than resolving per-variable (documented v1 limitation).
- **AQL edge rows** — `RETURN e` currently projects the traversal node, so provenance accessors on edge rows are exercised at the `FilterIterator` level (unit tests) rather than through `execute_aql`.

## Files touched (all within lane)
- `src/query/ast.rs` — `PredicateExpr::ProvenanceIsNull`; reuses `Expression::FunctionCall`.
- `src/query/parser.rs` — function-call parsing in `parse_expression`; `provenance(x) IS [NOT] NULL` (guarded `match`, no let-chain).
- `src/query/converter.rs` — accessor detection/lowering + type-check + `ProvenanceFilter::validated`; ordering-op rejection for string accessors; `expect`-free folds.
- `src/query/ir.rs` — `Predicate::Provenance(ProvenancePredicate)` + per-version `evaluate` (reuses `matches`); `compare_str` doc.
- `src/query/planner/rules/operation_reordering.rs` — selectivity arm.
- `src/query/executor/{iterators,mod}.rs` — lazy, memoized per-row provenance resolution in `FilterIterator` (AS OF via entity `current_version`).
- `src/mcp/server.rs` — `map_query_error`: `TypeMismatch → invalid_params`; additive `query` tool description.
- `docs/query-language-design.md`, `docs/guides/mcp-query-tool.md` — "Querying provenance" (AQL) + ordering-op / edge pass-through notes.
- `tests/aql_provenance_where.rs`, `tests/http_provenance_where.rs` — new integration tests.

No new MCP tool or HTTP route, so `tests/parity/inventory.json` needs no additive row (the tool-inventory golden count is unchanged at 46).

## AC evidence

| AC (#3354a) | Satisfied by | Evidence (test) |
|---|---|---|
| AC1 accessor syntax (source/confidence/reason) | parser + converter | `test_parse_where_provenance_accessor_call`, `test_convert_provenance_source_eq_folds_to_filter`, `test_convert_provenance_confidence_lt_uses_accessor` |
| AC2 usable in WHERE (eq/neq source, numeric confidence) | executor | `source_exact_match_filters_rows`, `confidence_inclusive_lower_bound`, `confidence_strict_greater_is_exclusive`, `confidence_less_than_general_path`, `reason_equality` |
| AC3 per-version at bi-temporal coordinate | `FilterIterator` resolves `entity.current_version` | `as_of_evaluates_provenance_at_that_coordinate` |
| AC4 unattributed → null → excluded; `IS NULL` selects them | ir `evaluate` mirrors `matches` | `absent_provenance_excluded_by_confidence`, `provenance_is_null_selects_unattributed`, `provenance_is_not_null_selects_attributed`, `partial_bundle_missing_field_excluded` |
| AC5 mis-type → structured error, never silent empty | converter + `map_query_error` | `confidence_compared_to_string_is_type_error`, `source_compared_to_number_is_type_error`, `confidence_out_of_range_is_rejected`, `ordering_operator_on_source_is_rejected`, `ordering_operator_on_reason_is_rejected`, `map_query_error_type_mismatch_yields_invalid_params`, `provenance_type_mismatch_fails_closed_over_http` |
| AC6 read-only unchanged (reader-class) | no mutating clause added | `provenance_where_filters_over_http`, `provenance_is_null_over_http` (reader path); read-only guard untouched |
| AC7 docs | query-language + MCP guide "Querying provenance" | `docs/query-language-design.md`, `docs/guides/mcp-query-tool.md` |
| Parity (#3348 semantics) | reuse `ProvenanceFilter::matches` | `filter_arm_matches_core_provenance_filter`, `accessor_arm_parity_with_filter_on_foldable_shapes` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01US9RGTLAzSymm8eMtqdt3T

---
_Generated by [Claude Code](https://claude.ai/code/session_01US9RGTLAzSymm8eMtqdt3T)_