### PR TITLE
feat(server): autumn-web 0.5 production server crate skeleton + node-read proof slice (PR1, #3524)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "aletheia-server"
+version = "0.1.0"
+dependencies = [
+ "aletheiadb",
+ "autumn-web 0.5.0",
+ "axum",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower",
+ "tower-http",
+]
+
+[[package]]
 name = "aletheiadb"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,12 @@ categories = ["database-implementations", "data-structures"]
 # the existing CI gates are entirely unaffected; the spike gets its own gates
 # (`cargo … -p aletheia-autumn-spike`, `just spike-check`).
 [workspace]
-members = ["crates/autumn-spike"]
+# `aletheia-server` is the production autumn-web 0.5 server crate (Issue #3524,
+# PR1 skeleton) — an isolated member for the same reason as the spike: autumn
+# 0.5's proc-macros hard-code `::autumn_web`, so the 0.5 surface must live in a
+# crate whose extern prelude binds `autumn_web` to 0.5. It requires an explicit
+# `-p aletheia-server`; bare cargo stays root-scoped via `default-members`.
+members = ["crates/autumn-spike", "crates/aletheia-server"]
 default-members = ["."]
 # `python/` and `fuzz/` are independent crates with their own manifests (the
 # Python wheels + cargo-fuzz workflows build them standalone); keep them OUT of

--- a/crates/aletheia-server/Cargo.toml
+++ b/crates/aletheia-server/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "aletheia-server"
+version = "0.1.0"
+edition = "2024"
+# autumn-web 0.5.0 is edition 2024 / rust-version 1.88.0.
+rust-version = "1.88"
+authors = ["AletheiaDB Contributors"]
+description = "Production autumn-web 0.5.0 server for AletheiaDB (HTTP + MCP + OpenAPI) — Issue #3524 PR1 skeleton"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lints.rust]
+missing_docs = "warn"
+
+[dependencies]
+# autumn-web 0.5.0 — UNRENAMED so its proc-macros' hard-coded `::autumn_web`
+# paths resolve (see docs/spikes/autumn-web-migration-spike.md §1). `mcp`
+# implies `openapi`; `default-features = false` keeps diesel/db out of the graph.
+autumn-web = { version = "0.5.0", default-features = false, features = ["maud", "mcp"] }
+# The shared AletheiaDB core: the HTTP serializers/envelope/error type
+# (`ApiResponse`, `node_to_query_json`, `AletheiaHttpError`), the constant-time
+# `AuthStore`/`AccessClass`/`Role` RBAC model, and the MCP typed node-read
+# request/response methods (`AletheiaMcpServer::get_node`/`list_nodes`/`count_nodes`).
+aletheiadb = { path = "../..", features = ["http-server", "mcp-server"] }
+axum = { version = "0.8" }
+tower-http = { version = "0.6", features = ["set-header"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = { version = "1.52", features = ["rt-multi-thread", "macros"] }
+
+[dev-dependencies]
+tokio = { version = "1.52", features = ["rt-multi-thread", "macros"] }
+# `tower::ServiceExt::oneshot` drives the legacy 0.4 router in parity tests.
+tower = { version = "0.5", features = ["util"] }

--- a/crates/aletheia-server/src/app.rs
+++ b/crates/aletheia-server/src/app.rs
@@ -1,0 +1,71 @@
+//! App assembly for the production autumn-web 0.5 server (Issue #3524 PR1).
+//!
+//! [`build_server_testapp`] wires the ported HTTP routes + the node-read proof
+//! slice into one autumn app that projects them to HTTP, OpenAPI
+//! (`/openapi.json`), and MCP-over-HTTP (`/mcp`) from single handler
+//! definitions, installs the shared DB + auth state, and applies the Lane-B
+//! security seam ([`apply_security`], [`init_state`], [`validate_startup`]).
+//!
+//! It builds a [`TestApp`] (the 0.5 type the parity harness drives via
+//! [`TestClient`]); the production `AppBuilder` shares the same method surface
+//! (`routes`/`openapi`/`mount_mcp`/`secure_mcp`/`state_initializer`), so Lane B
+//! can lift this into a `run_server` with minimal change.
+
+use crate::http_routes;
+use crate::node_tools;
+use crate::security::{self, SecurityConfig};
+use crate::state::ServerState;
+use aletheiadb::AletheiaDB;
+use aletheiadb::auth::{AuthMode, AuthStore};
+use autumn_web::openapi::OpenApiConfig;
+use autumn_web::prelude::routes;
+use autumn_web::test::{TestApp, TestClient};
+use std::sync::Arc;
+
+/// Build the unwired-but-assembled [`TestApp`]: all ported routes + the three
+/// node tools, `/openapi.json`, `/mcp`, the security seam applied, and the
+/// shared `db`/auth state installed. Returned unbuilt so callers can tweak.
+///
+/// Startup is validated ([`security::validate_startup`]) before assembly;
+/// **panics** on a refused config (required mode with zero credentials), which
+/// is the intended fail-fast behavior for a misconfigured server. Tests that
+/// need a keyless required-mode client should insert a bootstrap key first.
+#[must_use]
+pub fn build_server_testapp(db: Arc<AletheiaDB>, store: Arc<AuthStore>, mode: AuthMode) -> TestApp {
+    let cfg = SecurityConfig::new(store, mode);
+    security::validate_startup(&cfg).expect("security startup validation");
+
+    let server_state = ServerState::new(db);
+    let init_cfg = cfg.clone();
+
+    let app = TestApp::new()
+        .routes(routes![
+            http_routes::health_check,
+            http_routes::create_key,
+            http_routes::list_keys,
+            http_routes::revoke_key,
+            node_tools::get_node,
+            node_tools::list_nodes,
+            node_tools::count_nodes,
+        ])
+        .openapi(OpenApiConfig::new("AletheiaDB", env!("CARGO_PKG_VERSION")))
+        .mount_mcp("/mcp");
+
+    // Lane-B security seam: `/mcp` gate (Required mode), etc.
+    let app = security::apply_security(app, &cfg);
+
+    app.state_initializer(move |app_state| {
+        app_state.insert_extension(server_state);
+        security::init_state(app_state, &init_cfg);
+    })
+}
+
+/// Convenience: [`build_server_testapp`] then `.build()` into a [`TestClient`].
+#[must_use]
+pub fn build_server_client(
+    db: Arc<AletheiaDB>,
+    store: Arc<AuthStore>,
+    mode: AuthMode,
+) -> TestClient {
+    build_server_testapp(db, store, mode).build()
+}

--- a/crates/aletheia-server/src/http_routes.rs
+++ b/crates/aletheia-server/src/http_routes.rs
@@ -1,0 +1,131 @@
+//! The faithfully-ported HTTP routes (Issue #3524 PR1).
+//!
+//! Four of the legacy surface's five routes are ported here as autumn 0.5
+//! `#[get]`/`#[post]` + `#[api_doc]` handlers producing **byte-identical**
+//! bodies/status codes to `src/http/handlers.rs` + `src/http/admin.rs`, by
+//! reusing the exact same public serializers/envelope/error type
+//! ([`aletheiadb::http::ApiResponse`], [`aletheiadb::http::AletheiaHttpError`])
+//! and the same [`AuthStore`](aletheiadb::auth::AuthStore) methods.
+//!
+//! The fifth route — the polymorphic `POST /query` (10 operations, per-query
+//! resource limits, in-flight DoS guard, provenance filtering) — is a large,
+//! stateful port and is **deferred to a follow-up PR** (see the crate docs); it
+//! is intentionally NOT mounted in PR1's skeleton.
+
+use crate::security::{AdminClass, ApiKeyStore, Authorized, MetricsClass};
+use aletheiadb::auth::{AuthError, Role};
+use aletheiadb::http::{AletheiaHttpError, ApiResponse};
+use autumn_web::prelude::{Json, get, post};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+/// Health check response — serializes to `{"status":"healthy"}`, byte-identical
+/// to the legacy `health_check` (`src/http/handlers.rs`).
+#[derive(Debug, Serialize)]
+pub struct HealthResponse {
+    status: String,
+}
+
+/// `GET /status` — liveness probe. Classified [`MetricsClass`]: every role may
+/// probe, but (in required-auth mode) only with a valid credential.
+#[get("/status")]
+#[api_doc(description = "Liveness probe; returns {\"status\":\"healthy\"}")]
+pub async fn health_check(
+    _auth: Authorized<MetricsClass>,
+) -> Result<Json<HealthResponse>, AletheiaHttpError> {
+    Ok(Json(HealthResponse {
+        status: "healthy".to_string(),
+    }))
+}
+
+/// Request body for `POST /admin/keys`.
+#[derive(Debug, Deserialize)]
+pub struct CreateKeyRequest {
+    /// Operator-chosen display name for the new key's principal.
+    pub name: String,
+    /// Role granted to the new key.
+    pub role: Role,
+}
+
+/// Request body for `POST /admin/keys/revoke`.
+#[derive(Debug, Deserialize)]
+pub struct RevokeKeyRequest {
+    /// Principal id (as returned by create/list) to revoke.
+    pub id: String,
+}
+
+/// `POST /admin/keys` — create a key; returns the plaintext exactly once.
+#[post("/admin/keys")]
+#[api_doc(description = "Create an API key (admin); returns the plaintext key once")]
+pub async fn create_key(
+    _auth: Authorized<AdminClass>,
+    store: ApiKeyStore,
+    Json(req): Json<CreateKeyRequest>,
+) -> Result<Json<ApiResponse>, AletheiaHttpError> {
+    let (principal, key) = store
+        .0
+        .create_key(&req.name, req.role)
+        .map_err(|e| match e {
+            // Caller-fault input (empty/overlong name) is a 400, not a 500.
+            AuthError::InvalidInput(msg) => AletheiaHttpError::BadRequest(msg),
+            other => AletheiaHttpError::Internal(other.to_string()),
+        })?;
+
+    Ok(Json(ApiResponse::success(json!({
+        "id": principal.id,
+        "name": principal.name,
+        "role": principal.role,
+        "key_prefix": principal.key_prefix,
+        "created_at": principal.created_at,
+        // Plaintext, exactly once.
+        "key": &*key,
+    }))))
+}
+
+/// `GET /admin/keys` — masked principal list (never key material).
+#[get("/admin/keys")]
+#[api_doc(description = "List API-key principals (admin); masked, never key material")]
+pub async fn list_keys(
+    _auth: Authorized<AdminClass>,
+    store: ApiKeyStore,
+) -> Result<Json<ApiResponse>, AletheiaHttpError> {
+    let keys = store.0.list();
+    let items: Vec<serde_json::Value> = keys
+        .iter()
+        .map(|p| {
+            json!({
+                "id": p.id,
+                "name": p.name,
+                "role": p.role,
+                "key_prefix": p.key_prefix,
+                "created_at": p.created_at,
+            })
+        })
+        .collect();
+
+    Ok(Json(ApiResponse::success(json!({ "keys": items }))))
+}
+
+/// `POST /admin/keys/revoke` — revoke a key by principal id (immediate effect).
+#[post("/admin/keys/revoke")]
+#[api_doc(description = "Revoke an API key by principal id (admin); takes effect immediately")]
+pub async fn revoke_key(
+    _auth: Authorized<AdminClass>,
+    store: ApiKeyStore,
+    Json(req): Json<RevokeKeyRequest>,
+) -> Result<Json<ApiResponse>, AletheiaHttpError> {
+    let existed = store
+        .0
+        .revoke(&req.id)
+        .map_err(|e| AletheiaHttpError::Internal(e.to_string()))?;
+    if !existed {
+        return Err(AletheiaHttpError::NotFound(format!(
+            "no key with id '{}'",
+            req.id
+        )));
+    }
+
+    Ok(Json(ApiResponse::success(
+        json!({ "revoked": true, "id": req.id }),
+    )))
+}

--- a/crates/aletheia-server/src/lib.rs
+++ b/crates/aletheia-server/src/lib.rs
@@ -1,0 +1,38 @@
+//! Production autumn-web 0.5.0 server for AletheiaDB (Issue #3524, PR1 skeleton).
+//!
+//! This crate is the crate-boundary-staged (§5.0 of the migration design) home
+//! for AletheiaDB's unified HTTP + MCP + OpenAPI surface on autumn-web **0.5**.
+//! It depends on autumn-web 0.5 **unrenamed** (so the 0.5 proc-macros'
+//! hard-coded `::autumn_web` paths resolve) plus a path-dep on `aletheiadb`,
+//! keeping the main crate's 0.4 surface and gates entirely untouched.
+//!
+//! # PR1 scope
+//!
+//! - The production crate skeleton + app assembly ([`app`]): `routes` +
+//!   `.openapi(...)` (`/openapi.json`) + `.mount_mcp("/mcp")`.
+//! - The Lane-B-owned [`security`] seam (scaffolds Lane A stands up and Lane B
+//!   fills in): the class-parameterized [`security::Authorized`] extractor, the
+//!   `apply_security`/`init_state`/`validate_startup` seam functions, and empty
+//!   `rate_limit`/`resource_limits`/`cursor` modules.
+//! - Four of the five HTTP routes ported byte-identically ([`http_routes`]):
+//!   `/status`, `POST/GET /admin/keys`, `POST /admin/keys/revoke`. The
+//!   polymorphic `POST /query` is a larger, stateful port deferred to a
+//!   follow-up.
+//! - The node-read proof slice ([`node_tools`]): `get_node` / `list_nodes` /
+//!   `count_nodes` on HTTP **and** `/mcp`, reusing the main crate's MCP typed
+//!   methods so output is byte-identical to the legacy MCP surface.
+//!
+//! Behavior is pinned by the parity suite in `tests/`, which asserts
+//! byte-equality against the legacy 0.4 HTTP router and the legacy MCP server.
+
+#![warn(missing_docs)]
+
+pub mod app;
+pub mod http_routes;
+pub mod node_tools;
+pub mod security;
+pub mod state;
+
+pub use app::{build_server_client, build_server_testapp};
+pub use security::SecurityConfig;
+pub use state::ServerState;

--- a/crates/aletheia-server/src/node_tools.rs
+++ b/crates/aletheia-server/src/node_tools.rs
@@ -1,0 +1,122 @@
+//! Node-read proof slice: `get_node` / `list_nodes` / `count_nodes` (Issue #3524).
+//!
+//! Each is a single `#[get(...)]` + `#[api_doc(description=..., mcp)]` handler,
+//! so one definition surfaces on **HTTP**, **MCP-over-HTTP** (`/mcp`), and
+//! **OpenAPI** at once. The response body is produced by the *exact* main-crate
+//! MCP typed method ([`AletheiaMcpServer::get_node`]/`list_nodes`/`count_nodes`),
+//! so it is byte-identical to the legacy MCP surface (bare entity JSON + the
+//! `temporal` block, #3220 vector elision) — asserted in the parity suite
+//! against a fresh [`AletheiaMcpServer`] over the same `Arc<AletheiaDB>`.
+//!
+//! These reuse **already-public** symbols
+//! (`aletheiadb::mcp::{AletheiaMcpServer, GetNodeRequest, ListNodesRequest,
+//! CountNodesRequest}`), so PR1 requires **no** main-crate visibility widening.
+//!
+//! The MCP tool result carries in-band errors (e.g. a missing node →
+//! `{"error":{"code":"NOT_FOUND",...}}`); PR1 returns that JSON verbatim with a
+//! 200, matching the MCP method's `String` return exactly (unifying HTTP status
+//! semantics with the legacy HTTP envelope is Lane B / a follow-up).
+
+use crate::security::{Authorized, ReadClass};
+use crate::state::ServerState;
+use aletheiadb::mcp::{AletheiaMcpServer, CountNodesRequest, GetNodeRequest, ListNodesRequest};
+use autumn_web::prelude::{Json, Path, Query, get};
+use serde::Deserialize;
+use serde_json::Value;
+
+/// Parse an MCP tool method's JSON string result into a [`Value`] for the HTTP
+/// response. A non-JSON result (should not happen) degrades to a JSON string.
+fn tool_json(s: String) -> Json<Value> {
+    Json(serde_json::from_str::<Value>(&s).unwrap_or(Value::String(s)))
+}
+
+/// Query options for [`get_node`].
+#[derive(Debug, Default, Deserialize)]
+pub struct GetNodeQuery {
+    /// Return full vector/embedding arrays instead of the elided descriptor.
+    pub include_vectors: Option<bool>,
+}
+
+/// `get_node` — fetch a node by id, with bi-temporal bounds. HTTP + MCP tool.
+#[get("/nodes/{id}")]
+#[api_doc(
+    description = "Fetch a node by id, returning its properties and bi-temporal bounds",
+    mcp
+)]
+pub async fn get_node(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Path(id): Path<u64>,
+    Query(opts): Query<GetNodeQuery>,
+) -> Json<Value> {
+    let server = AletheiaMcpServer::new(state.db_arc());
+    let out = server.get_node(GetNodeRequest {
+        node_id: id,
+        include_vectors: opts.include_vectors,
+    });
+    tool_json(out)
+}
+
+/// Query options for [`list_nodes`].
+#[derive(Debug, Default, Deserialize)]
+pub struct ListNodesQuery {
+    /// Filter by node label.
+    pub label: Option<String>,
+    /// Filter by property key (with `label` + `property_value`).
+    pub property_key: Option<String>,
+    /// Filter by property value (string form on the HTTP query surface).
+    pub property_value: Option<String>,
+    /// Maximum number of nodes to return.
+    pub limit: Option<usize>,
+    /// Number of nodes to skip.
+    pub offset: Option<usize>,
+    /// Return full vector/embedding arrays instead of the elided descriptor.
+    pub include_vectors: Option<bool>,
+}
+
+/// `list_nodes` — list nodes with optional label/property filtering + paging.
+/// HTTP + MCP tool.
+#[get("/nodes")]
+#[api_doc(
+    description = "List nodes with optional label/property filtering and pagination",
+    mcp
+)]
+pub async fn list_nodes(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Query(opts): Query<ListNodesQuery>,
+) -> Json<Value> {
+    let server = AletheiaMcpServer::new(state.db_arc());
+    let out = server.list_nodes(ListNodesRequest {
+        label: opts.label,
+        property_key: opts.property_key,
+        property_value: opts.property_value.map(Value::String),
+        limit: opts.limit,
+        offset: opts.offset,
+        include_vectors: opts.include_vectors,
+    });
+    tool_json(out)
+}
+
+/// Query options for [`count_nodes`].
+#[derive(Debug, Default, Deserialize)]
+pub struct CountNodesQuery {
+    /// Count only nodes with this label (else all nodes).
+    pub label: Option<String>,
+}
+
+/// `count_nodes` — total node count, or count matching a label. HTTP + MCP tool.
+#[get("/nodes/count")]
+#[api_doc(
+    description = "Count nodes in the graph, or nodes matching a specific label",
+    mcp
+)]
+pub async fn count_nodes(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Query(opts): Query<CountNodesQuery>,
+) -> Json<Value> {
+    let server = AletheiaMcpServer::new(state.db_arc());
+    let out = server.count_nodes(CountNodesRequest { label: opts.label });
+    tool_json(out)
+}

--- a/crates/aletheia-server/src/security/auth.rs
+++ b/crates/aletheia-server/src/security/auth.rs
@@ -1,0 +1,248 @@
+// OWNED BY LANE B (security). Scaffold only — do not implement here.
+//
+//! Authentication + RBAC scaffolding for the production server.
+//!
+//! Generalizes the spike's `SpikeAuth` into a **class-parameterized**
+//! [`Authorized<C>`] extractor and a marker-type RBAC vocabulary
+//! ([`AccessClassMarker`] + [`ReadClass`]/[`WriteClass`]/[`MetricsClass`]/
+//! [`AdminClass`]). PR1 wires the *authentication* half (verify the
+//! bearer/`x-api-key` credential against the shared constant-time
+//! [`AuthStore`]); **RBAC-class enforcement is a marked TODO for Lane B**.
+//!
+//! Also provides [`AuthStoreTokenAdapter`] (autumn's native
+//! [`ApiTokenStore`](autumn_web::auth::ApiTokenStore) backed by the shared
+//! store, for `secure_mcp`) and the [`ApiKeyStore`] extractor the admin
+//! key-lifecycle handlers use to reach the store.
+
+use aletheiadb::auth::{AccessClass, AuthMode, AuthStore, Principal};
+use aletheiadb::http::AletheiaHttpError;
+use autumn_web::prelude::AppState;
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// Shared authentication state: the key store plus the configured mode.
+///
+/// Installed once into the app's extension bag by
+/// [`init_state`](crate::security::init_state) and pulled back out by the
+/// [`Authorized`] and [`ApiKeyStore`] extractors.
+#[derive(Clone)]
+pub struct ServerAuthState {
+    store: Arc<AuthStore>,
+    mode: AuthMode,
+}
+
+impl ServerAuthState {
+    /// Build auth state from a shared store and mode.
+    #[must_use]
+    pub fn new(store: Arc<AuthStore>, mode: AuthMode) -> Self {
+        Self { store, mode }
+    }
+
+    /// The shared key store.
+    #[must_use]
+    pub fn store(&self) -> &Arc<AuthStore> {
+        &self.store
+    }
+
+    /// The configured authentication mode.
+    #[must_use]
+    pub fn mode(&self) -> AuthMode {
+        self.mode
+    }
+}
+
+/// Compile-time marker binding a zero-size type to an [`AccessClass`].
+///
+/// Lets a handler declare the class it needs in the type system —
+/// `Authorized<ReadClass>` — so the schema surfacing and (Lane B's) RBAC gate
+/// key off one source. Generalizes the spike's fixed `AccessClass::Read`.
+pub trait AccessClassMarker {
+    /// The access class this marker denotes.
+    const CLASS: AccessClass;
+}
+
+/// Marker: [`AccessClass::Read`].
+#[derive(Debug, Clone, Copy)]
+pub struct ReadClass;
+impl AccessClassMarker for ReadClass {
+    const CLASS: AccessClass = AccessClass::Read;
+}
+
+/// Marker: [`AccessClass::Write`].
+#[derive(Debug, Clone, Copy)]
+pub struct WriteClass;
+impl AccessClassMarker for WriteClass {
+    const CLASS: AccessClass = AccessClass::Write;
+}
+
+/// Marker: [`AccessClass::Metrics`].
+#[derive(Debug, Clone, Copy)]
+pub struct MetricsClass;
+impl AccessClassMarker for MetricsClass {
+    const CLASS: AccessClass = AccessClass::Metrics;
+}
+
+/// Marker: [`AccessClass::Admin`].
+#[derive(Debug, Clone, Copy)]
+pub struct AdminClass;
+impl AccessClassMarker for AdminClass {
+    const CLASS: AccessClass = AccessClass::Admin;
+}
+
+/// Class-parameterized auth extractor: the verified [`Principal`] gated by the
+/// [`AccessClass`] denoted by `C`.
+///
+/// Field `0` is the verified principal (public, mirroring the requested shape);
+/// the [`PhantomData`] carries the class marker `C` in the type only.
+///
+/// PR1 performs **authentication** (uniform 401 on a missing/invalid credential
+/// in required mode; anonymous mode yields a synthetic anonymous principal via
+/// the store). RBAC-class enforcement is NOT yet done here.
+pub struct Authorized<C>(pub Principal, PhantomData<fn() -> C>);
+
+impl<C> Authorized<C> {
+    /// The verified principal.
+    #[must_use]
+    pub fn principal(&self) -> &Principal {
+        &self.0
+    }
+}
+
+impl<C: AccessClassMarker> FromRequestParts<AppState> for Authorized<C> {
+    type Rejection = AletheiaHttpError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let auth = state
+            .extension::<ServerAuthState>()
+            .map(|arc| (*arc).clone())
+            .ok_or(AletheiaHttpError::StateMissing)?;
+
+        let principal = match auth.mode() {
+            // Anonymous mode: no credential required. Lane B may model this more
+            // richly; PR1 authorizes with the synthetic full-access principal
+            // (mirrors the spike's "anonymous == fully privileged").
+            AuthMode::Anonymous => Principal::anonymous(),
+            AuthMode::Required => {
+                // Uniform failure: missing / malformed / unknown / revoked are
+                // indistinguishable (byte-identical 401 to the legacy surface).
+                let credential =
+                    extract_credential(parts).ok_or(AletheiaHttpError::Unauthorized)?;
+                auth.store()
+                    .verify(&credential)
+                    .ok_or(AletheiaHttpError::Unauthorized)?
+            }
+        };
+
+        // TODO(Lane B): enforce the RBAC class here —
+        //   `principal.role.allows(C::CLASS)` → else
+        //   `AletheiaHttpError::PermissionDenied(..)` (403), with
+        //   `details.{required_class, principal_role}` per Issue #3234/#3350.
+        // PR1 authenticates only; class enforcement is Lane B's.
+        Ok(Self(principal, PhantomData))
+    }
+}
+
+/// Extractor handing out the shared [`AuthStore`] for the admin key-lifecycle
+/// handlers (create/list/revoke), which operate on the store directly rather
+/// than a principal. Reads the same [`ServerAuthState`] extension.
+pub struct ApiKeyStore(pub Arc<AuthStore>);
+
+impl FromRequestParts<AppState> for ApiKeyStore {
+    type Rejection = AletheiaHttpError;
+
+    async fn from_request_parts(
+        _parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let auth = state
+            .extension::<ServerAuthState>()
+            .map(|arc| (*arc).clone())
+            .ok_or(AletheiaHttpError::StateMissing)?;
+        Ok(Self(auth.store().clone()))
+    }
+}
+
+/// Extract the bearer/`x-api-key` credential from request headers.
+///
+/// Returns `None` for missing or malformed headers — every failure collapses
+/// into the same uniform 401 upstream, deliberately.
+fn extract_credential(parts: &Parts) -> Option<String> {
+    if let Some(value) = parts.headers.get(axum::http::header::AUTHORIZATION) {
+        let s = value.to_str().ok()?;
+        let (scheme, rest) = s.split_once(' ')?;
+        if !scheme.eq_ignore_ascii_case("bearer") {
+            return None;
+        }
+        let token = rest.trim();
+        if token.is_empty() {
+            return None;
+        }
+        return Some(token.to_owned());
+    }
+    if let Some(value) = parts.headers.get("x-api-key") {
+        let token = value.to_str().ok()?.trim();
+        if token.is_empty() {
+            return None;
+        }
+        return Some(token.to_owned());
+    }
+    None
+}
+
+/// Adapts AletheiaDB's [`AuthStore`] to autumn's
+/// [`ApiTokenStore`](autumn_web::auth::ApiTokenStore) so autumn's native
+/// [`RequireApiToken`](autumn_web::auth::RequireApiToken) layer (used by
+/// `secure_mcp`) verifies tokens against the same constant-time-verified store
+/// the extractors use. Only `verify` is meaningful; key lifecycle is owned by
+/// the `/admin/keys*` endpoints, so `issue`/`revoke` return an "unsupported"
+/// error.
+pub struct AuthStoreTokenAdapter {
+    store: Arc<AuthStore>,
+}
+
+impl AuthStoreTokenAdapter {
+    /// Wrap a shared [`AuthStore`].
+    #[must_use]
+    pub fn new(store: Arc<AuthStore>) -> Self {
+        Self { store }
+    }
+}
+
+impl autumn_web::auth::ApiTokenStore for AuthStoreTokenAdapter {
+    fn issue<'a>(
+        &'a self,
+        _principal_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = autumn_web::AutumnResult<String>> + Send + 'a>> {
+        Box::pin(async move {
+            Err(autumn_web::AutumnError::internal_server_error_msg(
+                "token issuance is owned by AletheiaDB's /admin/keys endpoints",
+            ))
+        })
+    }
+
+    fn verify<'a>(
+        &'a self,
+        raw_token: &'a str,
+    ) -> Pin<Box<dyn Future<Output = autumn_web::AutumnResult<Option<String>>> + Send + 'a>> {
+        // Constant-time verify via the shared store; return the principal id.
+        Box::pin(async move { Ok(self.store.verify(raw_token).map(|p| p.id)) })
+    }
+
+    fn revoke<'a>(
+        &'a self,
+        _raw_token: &'a str,
+    ) -> Pin<Box<dyn Future<Output = autumn_web::AutumnResult<()>> + Send + 'a>> {
+        Box::pin(async move {
+            Err(autumn_web::AutumnError::internal_server_error_msg(
+                "token revocation is owned by AletheiaDB's /admin/keys endpoints",
+            ))
+        })
+    }
+}

--- a/crates/aletheia-server/src/security/cursor.rs
+++ b/crates/aletheia-server/src/security/cursor.rs
@@ -1,0 +1,6 @@
+// OWNED BY LANE B (security). Scaffold only — do not implement here.
+//
+//! Opaque cursor signing / TTL / per-connection cap (Issue #3360).
+//!
+//! TODO(Lane B): carry the per-process cursor signing secret + TTL/cap registry
+//! in app state and validate resumed cursors here. No cursor support in PR1.

--- a/crates/aletheia-server/src/security/mod.rs
+++ b/crates/aletheia-server/src/security/mod.rs
@@ -1,0 +1,112 @@
+// OWNED BY LANE B (security). Scaffold only — do not implement here.
+//
+//! Security seam for the production autumn-web 0.5 server (Issue #3524).
+//!
+//! This module tree is the **security boundary** Lane A stands up as a set of
+//! compiling, minimally-behaving scaffolds and Lane B fills in. Lane A's
+//! [`crate::app`] calls exactly three seam functions from here —
+//! [`apply_security`], [`init_state`], and [`validate_startup`] — so Lane B can
+//! flesh out authentication, RBAC-class enforcement, rate limiting, resource
+//! limits, and cursor signing behind those signatures without touching the app
+//! assembly again.
+//!
+//! Current PR1 behavior (deliberately minimal):
+//! - [`apply_security`] gates `/mcp` with the native `RequireApiToken` layer in
+//!   [`AuthMode::Required`] (auth-on-by-default parity), pass-through otherwise.
+//! - [`init_state`] installs the shared [`ServerAuthState`] extension.
+//! - [`validate_startup`] refuses required-mode startup with zero credentials.
+//! - [`auth::Authorized`] **authenticates** but does NOT yet enforce the RBAC
+//!   class — that enforcement is Lane B's (see the TODO there).
+//! - [`rate_limit`], [`resource_limits`], [`cursor`] are empty `TODO(Lane B)`.
+
+pub mod auth;
+pub mod cursor;
+pub mod rate_limit;
+pub mod rbac;
+pub mod resource_limits;
+
+use aletheiadb::auth::{AuthMode, AuthStore};
+use autumn_web::auth::RequireApiToken;
+use autumn_web::prelude::AppState as AutumnAppState;
+use autumn_web::test::TestApp;
+use std::sync::Arc;
+
+pub use auth::{
+    AccessClassMarker, AdminClass, ApiKeyStore, AuthStoreTokenAdapter, Authorized, MetricsClass,
+    ReadClass, ServerAuthState, WriteClass,
+};
+
+/// Security configuration for the server surface.
+///
+/// **Lane-B-owned.** PR1 carries only the auth essentials (the shared
+/// credential store and the auth mode) — enough for the three seam functions to
+/// compile and for the node-read proof slice + parity to run. Lane B extends
+/// this with rate-limit, in-flight/resource, and cursor-signing configuration.
+#[derive(Clone)]
+pub struct SecurityConfig {
+    /// The shared, constant-time-verified API-key store.
+    pub store: Arc<AuthStore>,
+    /// Whether authentication is required or explicitly anonymous.
+    pub mode: AuthMode,
+}
+
+impl SecurityConfig {
+    /// Build a config from a shared store and mode.
+    #[must_use]
+    pub fn new(store: Arc<AuthStore>, mode: AuthMode) -> Self {
+        Self { store, mode }
+    }
+}
+
+/// Apply the security layer stack to the app builder.
+///
+/// **Seam (Lane A calls, Lane B extends).** PR1 mirrors the spike: in
+/// [`AuthMode::Required`] the whole `/mcp` endpoint is gated behind autumn's
+/// native [`RequireApiToken`] backed by the shared [`AuthStore`] (via
+/// [`AuthStoreTokenAdapter`]), so the MCP catalog is not anonymously reachable.
+/// [`AuthMode::Anonymous`] skips the gate deliberately.
+///
+/// TODO(Lane B): add the `tower-governor` rate-limit layer and the in-flight
+/// `ConcurrencyLimit` backpressure layer here (both no-ops in PR1).
+#[must_use]
+pub fn apply_security(app: TestApp, cfg: &SecurityConfig) -> TestApp {
+    match cfg.mode {
+        AuthMode::Required => {
+            let token_layer =
+                RequireApiToken::new(Arc::new(AuthStoreTokenAdapter::new(cfg.store.clone())));
+            app.secure_mcp(token_layer)
+        }
+        AuthMode::Anonymous => app,
+    }
+}
+
+/// Insert security-related app state (the auth extension).
+///
+/// **Seam (Lane A calls, Lane B extends).** Mirrors the spike's
+/// `insert_extension(auth_state)`. Called from the app's `state_initializer`,
+/// which hands out a shared `&AppState` whose `insert_extension` takes `&self`.
+pub fn init_state(app_state: &AutumnAppState, cfg: &SecurityConfig) {
+    app_state.insert_extension(ServerAuthState::new(cfg.store.clone(), cfg.mode));
+}
+
+/// Validate security configuration at startup.
+///
+/// **Seam (Lane A calls, Lane B extends).** Refuse to start in
+/// [`AuthMode::Required`] with zero credentials — every request would be
+/// rejected — mirroring `validate_mcp_auth_startup` / `validate_auth_startup`.
+///
+/// # Errors
+///
+/// Returns a human-readable message when `mode` is `Required` and the store is
+/// empty.
+pub fn validate_startup(cfg: &SecurityConfig) -> Result<(), String> {
+    match cfg.mode {
+        AuthMode::Anonymous => Ok(()),
+        AuthMode::Required if cfg.store.is_empty() => Err(
+            "authentication is required (the default) but no credentials are available: \
+             provide a bootstrap key or explicitly opt into anonymous mode"
+                .to_string(),
+        ),
+        AuthMode::Required => Ok(()),
+    }
+}

--- a/crates/aletheia-server/src/security/rate_limit.rs
+++ b/crates/aletheia-server/src/security/rate_limit.rs
@@ -1,0 +1,7 @@
+// OWNED BY LANE B (security). Scaffold only — do not implement here.
+//
+//! Per-IP / per-principal rate limiting.
+//!
+//! TODO(Lane B): mount a `tower-governor` `GovernorLayer` (confirmed to satisfy
+//! autumn 0.5's relaxed `IntoAppLayer`) via `apply_security`. No rate limiting
+//! in PR1.

--- a/crates/aletheia-server/src/security/rbac.rs
+++ b/crates/aletheia-server/src/security/rbac.rs
@@ -1,0 +1,30 @@
+// OWNED BY LANE B (security). Scaffold only — do not implement here.
+//
+//! Per-MCP-tool access-class table (stub).
+//!
+//! Maps an MCP tool name to the [`AccessClass`] it requires. PR1 provides a
+//! small self-contained map covering the node-read proof slice; Lane B owns the
+//! full table **and** its enforcement.
+//!
+//! Lane B: anchor this on tests/parity/inventory.json (do not widen legacy
+//! TOOL_ACCESS_CLASSES) — the inventory's `mcp.tools[].access_class` is the
+//! shared source of truth, checked bidirectionally + for totality against the
+//! live registry, so this table must be derived from / verified against
+//! inventory.json rather than the main crate's `pub(crate)` constant.
+
+use aletheiadb::auth::AccessClass;
+
+/// The access class required by an MCP tool, or `None` if unknown to this stub.
+///
+/// PR1 scope: the three node-read tools surfaced on `/mcp`. Lane B replaces this
+/// with the full inventory-anchored table and wires enforcement into the
+/// dispatch/replay path.
+#[must_use]
+pub fn tool_access_class(name: &str) -> Option<AccessClass> {
+    match name {
+        // Node-read proof slice (Issue #3524 PR1).
+        "get_node" | "list_nodes" | "count_nodes" => Some(AccessClass::Read),
+        // TODO(Lane B): complete this from tests/parity/inventory.json.
+        _ => None,
+    }
+}

--- a/crates/aletheia-server/src/security/rbac.rs
+++ b/crates/aletheia-server/src/security/rbac.rs
@@ -1,30 +1,67 @@
 // OWNED BY LANE B (security). Scaffold only — do not implement here.
 //
-//! Per-MCP-tool access-class table (stub).
+//! Per-MCP-tool access-class table (bypass-proof-by-construction stub).
 //!
-//! Maps an MCP tool name to the [`AccessClass`] it requires. PR1 provides a
-//! small self-contained map covering the node-read proof slice; Lane B owns the
-//! full table **and** its enforcement.
+//! # Why a single source list (Lane B adversarial-review requirement)
 //!
-//! Lane B: anchor this on tests/parity/inventory.json (do not widen legacy
-//! TOOL_ACCESS_CLASSES) — the inventory's `mcp.tools[].access_class` is the
-//! shared source of truth, checked bidirectionally + for totality against the
-//! live registry, so this table must be derived from / verified against
-//! inventory.json rather than the main crate's `pub(crate)` constant.
+//! On the legacy MCP surface `authorize_tool` returns `Ok` for **unknown** tool
+//! names (safe there only because the string dispatcher then errors on unknown).
+//! On the autumn surface any dispatcher-routable tool name missing from the RBAC
+//! class table would **bypass the class gate** — a privilege-escalation hole. We
+//! close it two ways:
+//!
+//! 1. **The class lives ON the handler.** Every MCP-exposed handler declares its
+//!    required class in its own signature as `Authorized<ReadClass>` /
+//!    `Authorized<WriteClass>` / … — the one place a tool is defined. autumn
+//!    replays `/mcp tools/call` through that same handler, so the per-request
+//!    class gate (Lane B's enforcement in `Authorized<C>`) is carried by the
+//!    routable handler itself and cannot be forgotten without deleting the
+//!    extractor. This is the "unrepresentable, not just tested-for" half.
+//!
+//! 2. **One source list drives the class map.** autumn 0.5 derives the routable
+//!    `/mcp` tool set from the `#[api_doc(mcp)]` handlers registered in
+//!    `routes![..]` — a macro-expansion set we cannot *literally* fuse with a
+//!    Rust data table. So we take the **documented fallback**: [`MCP_TOOL_CLASSES`]
+//!    is the single list from which [`tool_access_class`] is derived, and the
+//!    PR1 conformance test `mcp_routable_tools_are_all_classified`
+//!    (`tests/server_parity.rs`) asserts the **live** routable set (from `/mcp`
+//!    `tools/list`) equals this registry — so a routable tool that is not
+//!    classified fails CI. Lane B asserts the same bidirectionally against
+//!    `tests/parity/inventory.json`.
+//!
+//! Lane B: anchor this registry on tests/parity/inventory.json (do not widen
+//! legacy TOOL_ACCESS_CLASSES) — the inventory's `mcp.tools[].access_class` is
+//! the shared source of truth, checked bidirectionally + for totality against
+//! the live registry, so this table must be derived from / verified against
+//! inventory.json rather than the main crate's `pub(crate)` constant. Extend the
+//! list below as slices 2–8 add handlers; the conformance test keeps it honest.
 
 use aletheiadb::auth::AccessClass;
 
-/// The access class required by an MCP tool, or `None` if unknown to this stub.
+/// The single source of truth pairing every MCP-exposed handler name with the
+/// [`AccessClass`] it requires. Both [`tool_access_class`] and the PR1
+/// conformance test derive from THIS list, so the routable-name set and the
+/// class-table set are one list by construction (they cannot silently drift
+/// into two independently-maintained lists).
 ///
-/// PR1 scope: the three node-read tools surfaced on `/mcp`. Lane B replaces this
-/// with the full inventory-anchored table and wires enforcement into the
-/// dispatch/replay path.
+/// PR1 scope: the three node-read tools surfaced on `/mcp`.
+pub const MCP_TOOL_CLASSES: &[(&str, AccessClass)] = &[
+    ("get_node", AccessClass::Read),
+    ("list_nodes", AccessClass::Read),
+    ("count_nodes", AccessClass::Read),
+    // TODO(Lane B): extend from tests/parity/inventory.json as slices 2–8 land;
+    // the conformance test asserts this stays == the live routable set.
+];
+
+/// The access class required by an MCP tool, or `None` if the name is not a
+/// registered (routable + classified) tool. Derived from [`MCP_TOOL_CLASSES`].
+///
+/// A `None` here at the dispatch gate MUST be treated as "reject" (not "allow"),
+/// so an unregistered/unknown routable name can never bypass the class gate.
 #[must_use]
 pub fn tool_access_class(name: &str) -> Option<AccessClass> {
-    match name {
-        // Node-read proof slice (Issue #3524 PR1).
-        "get_node" | "list_nodes" | "count_nodes" => Some(AccessClass::Read),
-        // TODO(Lane B): complete this from tests/parity/inventory.json.
-        _ => None,
-    }
+    MCP_TOOL_CLASSES
+        .iter()
+        .find(|(n, _)| *n == name)
+        .map(|(_, class)| *class)
 }

--- a/crates/aletheia-server/src/security/resource_limits.rs
+++ b/crates/aletheia-server/src/security/resource_limits.rs
@@ -1,0 +1,7 @@
+// OWNED BY LANE B (security). Scaffold only — do not implement here.
+//
+//! In-flight-query cap and per-query resource limits.
+//!
+//! TODO(Lane B): port the in-flight worker cap (`ConcurrencyLimit`) and the
+//! per-query timeout/row/byte limits (Issue #3368) into the shared handler
+//! path. No resource limiting in PR1.

--- a/crates/aletheia-server/src/state.rs
+++ b/crates/aletheia-server/src/state.rs
@@ -1,0 +1,48 @@
+//! Shared database state, delivered as an autumn-web 0.5 extension.
+//!
+//! Mirrors `src/http/state.rs` / the spike's `SpikeState`, bound to autumn
+//! **0.5**'s `AppState`. The `Arc<AletheiaDB>` is installed once at startup and
+//! pulled back per-request through the [`ServerState`] extractor.
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::http::AletheiaHttpError;
+use autumn_web::prelude::AppState;
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use std::sync::Arc;
+
+/// Per-request handle to the shared database.
+#[derive(Clone)]
+pub struct ServerState {
+    db: Arc<AletheiaDB>,
+}
+
+impl ServerState {
+    /// Wrap a shared database for installation into the app's extension bag.
+    #[must_use]
+    pub fn new(db: Arc<AletheiaDB>) -> Self {
+        Self { db }
+    }
+
+    /// Clone the `Arc<AletheiaDB>` for moving into a blocking task.
+    #[must_use]
+    pub fn db_arc(&self) -> Arc<AletheiaDB> {
+        self.db.clone()
+    }
+}
+
+impl FromRequestParts<AppState> for ServerState {
+    type Rejection = AletheiaHttpError;
+
+    async fn from_request_parts(
+        _parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        // `StateMissing` (HTTP 500) is exactly what the existing server returns
+        // for an uninstalled extension — a boot-time invariant.
+        state
+            .extension::<ServerState>()
+            .map(|arc| (*arc).clone())
+            .ok_or(AletheiaHttpError::StateMissing)
+    }
+}

--- a/crates/aletheia-server/tests/server_parity.rs
+++ b/crates/aletheia-server/tests/server_parity.rs
@@ -1,0 +1,541 @@
+//! Parity + surface tests for the production autumn-web 0.5 server (Issue #3524).
+//!
+//! Mirrors `crates/autumn-spike/tests/autumn_spike_parity.rs`: it drives the new
+//! crate's autumn [`TestClient`] and asserts behavior against the **legacy**
+//! surfaces sharing the same `Arc<AletheiaDB>` + `Arc<AuthStore>` —
+//!
+//! - the four ported HTTP routes vs the legacy 0.4 router
+//!   ([`aletheiadb::http::build_test_router_with_auth`]), and
+//! - the three node-read tools vs the legacy MCP server
+//!   ([`aletheiadb::mcp::AletheiaMcpServer`]) —
+//!
+//! plus `/openapi.json` and the `/mcp` catalog. Deterministic bodies are
+//! asserted byte-identical (parsed-JSON equality, `trace_id` stripped);
+//! non-deterministic admin bodies (random key/id/timestamp) are shape-asserted.
+
+use std::sync::Arc;
+
+use aletheia_server::build_server_client;
+use aletheia_server::security::rbac;
+use aletheiadb::auth::{AccessClass, AuthMode, AuthStore, Role};
+use aletheiadb::core::NodeId;
+use aletheiadb::mcp::{AletheiaMcpServer, CountNodesRequest, GetNodeRequest, ListNodesRequest};
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+use autumn_web::test::TestClient;
+use serde_json::{Value, json};
+
+const ADMIN_TOKEN: &str = "admin-token-abcdefghijklmnop";
+const READER_TOKEN: &str = "reader-token-abcdefghijklmnop";
+const METRICS_TOKEN: &str = "metrics-token-abcdefghijklmnop";
+const EMBEDDING: &[f32] = &[0.10, 0.20, 0.30, 0.40];
+
+/// A shared DB holding one `Person` node (with a vector property) and a shared
+/// auth store with admin / reader / metrics keys. Returns the node id.
+fn fixture() -> (Arc<AletheiaDB>, Arc<AuthStore>, NodeId) {
+    let db = Arc::new(AletheiaDB::new().expect("create db"));
+    let node_id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .insert("age", 30_i64)
+                .insert_vector("embedding", EMBEDDING)
+                .build(),
+        )
+        .expect("create node");
+
+    let store = Arc::new(AuthStore::new());
+    store
+        .insert_bootstrap_key("admin", Role::Admin, ADMIN_TOKEN)
+        .expect("insert admin key");
+    store
+        .insert_bootstrap_key("reader", Role::Reader, READER_TOKEN)
+        .expect("insert reader key");
+    store
+        .insert_bootstrap_key("metrics", Role::Metrics, METRICS_TOKEN)
+        .expect("insert metrics key");
+
+    (db, store, node_id)
+}
+
+/// Drop the per-request `trace_id` so two responses can be compared.
+fn strip_trace(mut v: Value) -> Value {
+    if let Some(obj) = v.as_object_mut() {
+        obj.remove("trace_id");
+    }
+    v
+}
+
+// ── legacy 0.4 HTTP router drivers ─────────────────────────────────────────
+
+async fn legacy_router(db: Arc<AletheiaDB>, store: Arc<AuthStore>, mode: AuthMode) -> axum::Router {
+    let app_state = aletheiadb::http::AppState::new(db);
+    let auth_state = aletheiadb::http::AuthState::new(store, mode);
+    let config = aletheiadb::http::ServerConfig::default();
+    aletheiadb::http::build_test_router_with_auth(app_state, auth_state, &config)
+        .expect("build 0.4 router")
+}
+
+async fn legacy_request(
+    router: axum::Router,
+    method: &str,
+    uri: &str,
+    body: Option<String>,
+    bearer: Option<&str>,
+) -> (u16, Value) {
+    use tower::ServiceExt as _;
+    let mut builder = axum::http::Request::builder().method(method).uri(uri);
+    if body.is_some() {
+        builder = builder.header("content-type", "application/json");
+    }
+    if let Some(token) = bearer {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+    let request = builder
+        .body(axum::body::Body::from(body.unwrap_or_default()))
+        .expect("build request");
+    let response = router.oneshot(request).await.expect("oneshot");
+    let status = response.status().as_u16();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let json: Value = serde_json::from_slice(&bytes).expect("legacy body is JSON");
+    (status, strip_trace(json))
+}
+
+// ── new-crate HTTP drivers ─────────────────────────────────────────────────
+
+async fn new_get(client: &TestClient, uri: &str, bearer: Option<&str>) -> (u16, Value) {
+    let mut req = client.get(uri);
+    if let Some(token) = bearer {
+        req = req.header("authorization", &format!("Bearer {token}"));
+    }
+    let resp = req.send().await;
+    let status = resp.status.as_u16();
+    let body: Value = serde_json::from_str(&resp.text()).expect("new body is JSON");
+    (status, strip_trace(body))
+}
+
+async fn new_post(
+    client: &TestClient,
+    uri: &str,
+    body: &Value,
+    bearer: Option<&str>,
+) -> (u16, Value) {
+    let mut req = client.post(uri);
+    if let Some(token) = bearer {
+        req = req.header("authorization", &format!("Bearer {token}"));
+    }
+    let resp = req.json(body).send().await;
+    let status = resp.status.as_u16();
+    let body: Value = serde_json::from_str(&resp.text()).expect("new body is JSON");
+    (status, strip_trace(body))
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// HTTP route parity: GET /status
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn status_success_byte_parity_required_mode() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db.clone(), store.clone(), AuthMode::Required);
+
+    let (s_status, s_body) = new_get(&client, "/status", Some(READER_TOKEN)).await;
+    let router = legacy_router(db, store, AuthMode::Required).await;
+    let (l_status, l_body) =
+        legacy_request(router, "GET", "/status", None, Some(READER_TOKEN)).await;
+
+    assert_eq!(s_status, 200);
+    assert_eq!(s_status, l_status);
+    assert_eq!(s_body, json!({ "status": "healthy" }));
+    assert_eq!(s_body, l_body, "/status body must equal legacy");
+}
+
+#[tokio::test]
+async fn status_unauthenticated_401_byte_parity() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db.clone(), store.clone(), AuthMode::Required);
+
+    let resp = client.get("/status").send().await;
+    assert_eq!(resp.status.as_u16(), 401);
+    assert_eq!(resp.header("www-authenticate"), Some("Bearer"));
+
+    let (s_status, s_body) = new_get(&client, "/status", None).await;
+    let router = legacy_router(db, store, AuthMode::Required).await;
+    let (l_status, l_body) = legacy_request(router, "GET", "/status", None, None).await;
+    assert_eq!(s_status, 401);
+    assert_eq!(s_status, l_status);
+    assert_eq!(s_body["code"], "UNAUTHENTICATED");
+    assert_eq!(s_body, l_body, "uniform 401 must equal legacy");
+}
+
+#[tokio::test]
+async fn status_success_anonymous_mode() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db, store, AuthMode::Anonymous);
+    // Anonymous: no credential needed.
+    let (status, body) = new_get(&client, "/status", None).await;
+    assert_eq!(status, 200);
+    assert_eq!(body, json!({ "status": "healthy" }));
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// HTTP route parity: /admin/keys (create, list, revoke)
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn admin_list_keys_byte_parity_with_shared_store() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db.clone(), store.clone(), AuthMode::Required);
+
+    let (s_status, s_body) = new_get(&client, "/admin/keys", Some(ADMIN_TOKEN)).await;
+    let router = legacy_router(db, store, AuthMode::Required).await;
+    let (l_status, l_body) =
+        legacy_request(router, "GET", "/admin/keys", None, Some(ADMIN_TOKEN)).await;
+
+    assert_eq!(s_status, 200);
+    assert_eq!(s_status, l_status);
+    assert_eq!(s_body["success"], true);
+    // Shared store → identical masked principal list (sorted by id).
+    assert_eq!(s_body, l_body, "masked key list must equal legacy");
+    // Never leak key material.
+    for k in s_body["data"]["keys"].as_array().unwrap() {
+        assert!(k.get("key").is_none(), "list must not contain key material");
+    }
+}
+
+#[tokio::test]
+async fn admin_list_keys_unauthenticated_401_byte_parity() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db.clone(), store.clone(), AuthMode::Required);
+
+    let (s_status, s_body) = new_get(&client, "/admin/keys", None).await;
+    let router = legacy_router(db, store, AuthMode::Required).await;
+    let (l_status, l_body) = legacy_request(router, "GET", "/admin/keys", None, None).await;
+    assert_eq!(s_status, 401);
+    assert_eq!(s_status, l_status);
+    assert_eq!(s_body, l_body, "admin 401 must equal legacy");
+}
+
+#[tokio::test]
+async fn admin_create_key_success_shape() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+
+    let (status, body) = new_post(
+        &client,
+        "/admin/keys",
+        &json!({ "name": "svc-1", "role": "reader" }),
+        Some(ADMIN_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert_eq!(body["success"], true);
+    let data = &body["data"];
+    assert!(data["id"].is_string());
+    assert_eq!(data["name"], "svc-1");
+    assert_eq!(data["role"], "reader");
+    assert!(data["key_prefix"].is_string());
+    assert!(data["created_at"].is_string());
+    // Plaintext key returned exactly once, prefixed by its masked prefix.
+    let key = data["key"].as_str().expect("plaintext key");
+    let prefix = data["key_prefix"].as_str().unwrap();
+    assert!(
+        key.starts_with(prefix),
+        "key {key} must extend prefix {prefix}"
+    );
+}
+
+#[tokio::test]
+async fn admin_create_key_unauthenticated_401_byte_parity() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db.clone(), store.clone(), AuthMode::Required);
+    let body = json!({ "name": "x", "role": "reader" });
+
+    let (s_status, s_body) = new_post(&client, "/admin/keys", &body, None).await;
+    let router = legacy_router(db, store, AuthMode::Required).await;
+    let (l_status, l_body) =
+        legacy_request(router, "POST", "/admin/keys", Some(body.to_string()), None).await;
+    assert_eq!(s_status, 401);
+    assert_eq!(s_status, l_status);
+    assert_eq!(s_body, l_body, "create-key 401 must equal legacy");
+}
+
+#[tokio::test]
+async fn admin_revoke_key_behavior() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db, store.clone(), AuthMode::Required);
+
+    // Mint a key to revoke via the store directly.
+    let (principal, _key) = store.create_key("to-revoke", Role::Reader).expect("mint");
+
+    let (status, body) = new_post(
+        &client,
+        "/admin/keys/revoke",
+        &json!({ "id": principal.id }),
+        Some(ADMIN_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert_eq!(
+        body,
+        json!({ "success": true, "data": { "revoked": true, "id": principal.id } })
+    );
+
+    // Revoking an unknown id → 404.
+    let (status, body) = new_post(
+        &client,
+        "/admin/keys/revoke",
+        &json!({ "id": "does-not-exist" }),
+        Some(ADMIN_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 404);
+    assert_eq!(body["success"], false);
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Node-read proof slice: get_node / list_nodes / count_nodes vs legacy MCP
+// ════════════════════════════════════════════════════════════════════════════
+
+fn mcp_server(db: &Arc<AletheiaDB>) -> AletheiaMcpServer {
+    AletheiaMcpServer::new(db.clone())
+}
+
+#[tokio::test]
+async fn get_node_byte_parity_with_legacy_mcp() {
+    let (db, store, node_id) = fixture();
+    let client = build_server_client(db.clone(), store, AuthMode::Required);
+
+    let (status, body) = new_get(
+        &client,
+        &format!("/nodes/{}", node_id.as_u64()),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+
+    let legacy: Value = serde_json::from_str(&mcp_server(&db).get_node(GetNodeRequest {
+        node_id: node_id.as_u64(),
+        include_vectors: None,
+    }))
+    .expect("legacy mcp json");
+    assert_eq!(
+        body, legacy,
+        "get_node HTTP body must equal legacy MCP method"
+    );
+    // Read responses carry a temporal block; the vector is elided by default.
+    assert!(
+        body["temporal"].is_object(),
+        "temporal block present: {body}"
+    );
+    assert_eq!(body["properties"]["embedding"]["elided"], true);
+}
+
+#[tokio::test]
+async fn get_node_include_vectors_parity() {
+    let (db, store, node_id) = fixture();
+    let client = build_server_client(db.clone(), store, AuthMode::Required);
+
+    let (_s, body) = new_get(
+        &client,
+        &format!("/nodes/{}?include_vectors=true", node_id.as_u64()),
+        Some(READER_TOKEN),
+    )
+    .await;
+    let legacy: Value = serde_json::from_str(&mcp_server(&db).get_node(GetNodeRequest {
+        node_id: node_id.as_u64(),
+        include_vectors: Some(true),
+    }))
+    .expect("legacy mcp json");
+    assert_eq!(body, legacy);
+    assert!(
+        body["properties"]["embedding"].is_array(),
+        "include_vectors=true returns the raw array"
+    );
+}
+
+#[tokio::test]
+async fn get_node_anonymous_mode_parity() {
+    let (db, store, node_id) = fixture();
+    let client = build_server_client(db.clone(), store, AuthMode::Anonymous);
+    // Anonymous: no credential.
+    let (status, body) = new_get(&client, &format!("/nodes/{}", node_id.as_u64()), None).await;
+    assert_eq!(status, 200);
+    let legacy: Value = serde_json::from_str(&mcp_server(&db).get_node(GetNodeRequest {
+        node_id: node_id.as_u64(),
+        include_vectors: None,
+    }))
+    .expect("legacy mcp json");
+    assert_eq!(body, legacy);
+}
+
+#[tokio::test]
+async fn get_node_unauthenticated_401() {
+    let (db, store, node_id) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+    let resp = client
+        .get(&format!("/nodes/{}", node_id.as_u64()))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 401);
+    assert_eq!(resp.header("www-authenticate"), Some("Bearer"));
+}
+
+#[tokio::test]
+async fn list_nodes_byte_parity_with_legacy_mcp() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db.clone(), store, AuthMode::Required);
+
+    let (status, body) = new_get(&client, "/nodes?label=Person", Some(READER_TOKEN)).await;
+    assert_eq!(status, 200);
+    let legacy: Value = serde_json::from_str(&mcp_server(&db).list_nodes(ListNodesRequest {
+        label: Some("Person".to_string()),
+        property_key: None,
+        property_value: None,
+        limit: None,
+        offset: None,
+        include_vectors: None,
+    }))
+    .expect("legacy mcp json");
+    assert_eq!(
+        body, legacy,
+        "list_nodes HTTP body must equal legacy MCP method"
+    );
+}
+
+#[tokio::test]
+async fn count_nodes_byte_parity_with_legacy_mcp() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db.clone(), store, AuthMode::Required);
+
+    let (status, body) = new_get(&client, "/nodes/count", Some(READER_TOKEN)).await;
+    assert_eq!(status, 200);
+    let legacy: Value =
+        serde_json::from_str(&mcp_server(&db).count_nodes(CountNodesRequest { label: None }))
+            .expect("legacy mcp json");
+    assert_eq!(
+        body, legacy,
+        "count_nodes HTTP body must equal legacy MCP method"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// OpenAPI + /mcp catalog
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn openapi_serves_and_documents_get_node() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+
+    let resp = client.get("/openapi.json").send().await;
+    assert_eq!(resp.status.as_u16(), 200);
+    let spec: Value = resp.json();
+    let op = &spec["paths"]["/nodes/{id}"]["get"];
+    assert!(
+        !op.is_null(),
+        "GET /nodes/{{id}} documented: {}",
+        spec["paths"]
+    );
+    let params = op["parameters"].as_array().expect("parameters");
+    let id_param = params
+        .iter()
+        .find(|p| p["name"] == "id" && p["in"] == "path")
+        .expect("id path param");
+    assert_eq!(id_param["required"], true);
+}
+
+#[tokio::test]
+async fn mcp_tools_list_advertises_three_node_tools_with_read_class() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+
+    let rpc = json!({ "jsonrpc": "2.0", "id": 1, "method": "tools/list" });
+    let resp = client
+        .post("/mcp")
+        .header("authorization", &format!("Bearer {READER_TOKEN}"))
+        .json(&rpc)
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200);
+    let body: Value = serde_json::from_str(&resp.text()).expect("json");
+    assert_eq!(body["id"], 1);
+    let tools = body["result"]["tools"].as_array().expect("tools array");
+
+    for name in ["get_node", "list_nodes", "count_nodes"] {
+        assert!(
+            tools.iter().any(|t| t["name"] == name),
+            "/mcp must advertise {name}: {body}"
+        );
+        // The RBAC stub classifies each node-read tool as Read.
+        assert_eq!(
+            rbac::tool_access_class(name),
+            Some(AccessClass::Read),
+            "{name} access class"
+        );
+    }
+
+    // get_node's inputSchema carries the `id` param, required.
+    let get_node = tools.iter().find(|t| t["name"] == "get_node").unwrap();
+    assert!(get_node["inputSchema"]["properties"]["id"].is_object());
+    assert!(
+        get_node["inputSchema"]["required"]
+            .as_array()
+            .expect("required")
+            .iter()
+            .any(|r| r == "id")
+    );
+}
+
+#[tokio::test]
+async fn mcp_tools_call_get_node_matches_http() {
+    let (db, store, node_id) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+
+    let http_body = client
+        .get(&format!("/nodes/{}", node_id.as_u64()))
+        .header("authorization", &format!("Bearer {READER_TOKEN}"))
+        .send()
+        .await
+        .text();
+
+    let rpc = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": { "name": "get_node", "arguments": { "id": node_id.as_u64() } }
+    });
+    let resp = client
+        .post("/mcp")
+        .header("authorization", &format!("Bearer {READER_TOKEN}"))
+        .json(&rpc)
+        .send()
+        .await;
+    let body: Value = serde_json::from_str(&resp.text()).expect("json");
+    assert_eq!(body["id"], 2);
+    let result = &body["result"];
+    assert_eq!(result["isError"], false, "tools/call must succeed: {body}");
+    let text = result["content"][0]["text"].as_str().expect("tool text");
+    let tool_json: Value = serde_json::from_str(text).expect("tool text JSON");
+    let http_json: Value = serde_json::from_str(&http_body).expect("http JSON");
+    assert_eq!(
+        tool_json, http_json,
+        "tools/call payload must equal HTTP GET"
+    );
+}
+
+#[tokio::test]
+async fn mcp_catalog_requires_token() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+    let rpc = json!({ "jsonrpc": "2.0", "id": 3, "method": "tools/list" });
+    let resp = client.post("/mcp").json(&rpc).send().await;
+    assert_eq!(
+        resp.status.as_u16(),
+        401,
+        "unauthenticated /mcp catalog must be rejected: {}",
+        resp.text()
+    );
+}

--- a/crates/aletheia-server/tests/server_parity.rs
+++ b/crates/aletheia-server/tests/server_parity.rs
@@ -489,6 +489,58 @@ async fn mcp_tools_list_advertises_three_node_tools_with_read_class() {
     );
 }
 
+/// Bypass-proofing (Lane B adversarial-review requirement): the set of tools
+/// the dispatcher will actually route (the live `/mcp` `tools/list`) must equal
+/// the RBAC registry `MCP_TOOL_CLASSES`. A routable tool missing from the
+/// registry would bypass the class gate on the autumn surface; a stale registry
+/// entry would classify a non-existent tool. This test fails on either drift,
+/// so a new `#[api_doc(mcp)]` handler cannot ship routable-but-unclassified.
+#[tokio::test]
+async fn mcp_routable_tools_are_all_classified() {
+    use std::collections::BTreeSet;
+
+    let (db, store, _) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+
+    let rpc = json!({ "jsonrpc": "2.0", "id": 42, "method": "tools/list" });
+    let resp = client
+        .post("/mcp")
+        .header("authorization", &format!("Bearer {READER_TOKEN}"))
+        .json(&rpc)
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200);
+    let body: Value = serde_json::from_str(&resp.text()).expect("json");
+
+    let routable: BTreeSet<String> = body["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .map(|t| t["name"].as_str().expect("tool name").to_string())
+        .collect();
+    let registered: BTreeSet<String> = rbac::MCP_TOOL_CLASSES
+        .iter()
+        .map(|(n, _)| (*n).to_string())
+        .collect();
+
+    // routable ⊆ registry: no routable tool may lack a class (the escalation
+    // hole). registry ⊆ routable: no stale/phantom class entries.
+    assert_eq!(
+        routable, registered,
+        "the live /mcp routable tool set must equal the RBAC registry \
+         (routable-but-unclassified = class-gate bypass): routable={routable:?} \
+         registry={registered:?}"
+    );
+    // And every routable name resolves to a concrete class (defensive: None at
+    // the dispatch gate must be treated as reject, never allow).
+    for name in &routable {
+        assert!(
+            rbac::tool_access_class(name).is_some(),
+            "routable tool {name} has no class"
+        );
+    }
+}
+
 #[tokio::test]
 async fn mcp_tools_call_get_node_matches_http() {
     let (db, store, node_id) = fixture();

--- a/src/auth/store.rs
+++ b/src/auth/store.rs
@@ -58,6 +58,29 @@ pub struct Principal {
     pub created_at: String,
 }
 
+impl Principal {
+    /// Construct a synthetic, fully-privileged **anonymous** principal for
+    /// surfaces running in explicit anonymous mode, where no credential is
+    /// presented but a [`Principal`] value is still required (e.g. the
+    /// autumn-web 0.5 server's class-parameterized auth extractor). Carries the
+    /// `admin` role so it may exercise every access class, matching anonymous
+    /// mode's documented "full, unauthenticated access". This is the only
+    /// out-of-crate way to obtain a principal not backed by a stored key, since
+    /// [`Principal`] is `#[non_exhaustive]`.
+    ///
+    // exposed for autumn-web migration (Issue #3524)
+    #[must_use]
+    pub fn anonymous() -> Self {
+        Self {
+            id: "anonymous".to_string(),
+            name: "anonymous".to_string(),
+            role: Role::Admin,
+            key_prefix: String::new(),
+            created_at: String::new(),
+        }
+    }
+}
+
 /// Errors from [`AuthStore`] operations.
 #[derive(Debug, thiserror::Error)]
 pub enum AuthError {


### PR DESCRIPTION
## Before / After (plain language)

**Before.** AletheiaDB's HTTP surface is on autumn-web **0.4** (used non-idiomatically), and the 44-tool MCP surface is an entirely separate `rmcp` stdio stack. autumn 0.4 and 0.5 cannot coexist in one crate (hardcoded `::autumn_web` macro paths), so the unified 0.5 surface has to live at a crate boundary. The only 0.5 code so far is the proof-of-concept `crates/autumn-spike`.

**After (this PR — PR1).** A real production server crate, `crates/aletheia-server`, is stood up as an isolated workspace member on autumn-web 0.5 (unrenamed) with a path-dep on `aletheiadb`. It assembles one autumn app that projects handlers to **HTTP + OpenAPI (`/openapi.json`) + MCP-over-HTTP (`/mcp`)**, carries the Lane-B security seam as compiling scaffolds, ports four of the five HTTP routes byte-identically, and lands a thin end-to-end **node-read proof slice** (`get_node`/`list_nodes`/`count_nodes`) on both HTTP and `/mcp`. The main crate's 0.4 surface and every existing gate are untouched. Additive; bare `cargo` stays root-scoped (`default-members = ["."]`), the crate requires `-p aletheia-server`.

### Scope delivered
- **App assembly** (`src/app.rs`): `.routes(routes[..])` + `.openapi(OpenApiConfig::new("AletheiaDB", <crate version>))` + `.mount_mcp("/mcp")` + security seam + shared state via `state_initializer`.
- **Lane-B security scaffold** (`src/security/`): class-parameterized `Authorized<C>` extractor, `AccessClassMarker` + markers, the three seam fns, `SecurityConfig`, a **single-source-of-truth** `rbac::MCP_TOOL_CLASSES` registry driving `tool_access_class`, and empty `rate_limit`/`resource_limits`/`cursor` `TODO(Lane B)` modules. Each Lane-B file carries the `// OWNED BY LANE B (security). Scaffold only` header.
- **HTTP routes ported byte-identically** (`src/http_routes.rs`): `GET /status`, `POST /admin/keys`, `GET /admin/keys`, `POST /admin/keys/revoke`, reusing `aletheiadb::http::{ApiResponse, AletheiaHttpError}` + `AuthStore`.
- **Node-read proof slice** (`src/node_tools.rs`): reuses the main crate's already-public MCP typed methods (`AletheiaMcpServer::get_node`/`list_nodes`/`count_nodes`).

### Deliberate deferral (out of PR1 scope)
`POST /query` (the 10-op polymorphic handler + per-query resource limits + in-flight DoS guard + provenance filtering, ~900 lines depending on several `pub(crate)` converters/limit internals) is **not** a "thin" port and is **deferred to a follow-up PR**. It is intentionally not mounted here. All other inventory rows in scope are covered.

---

## Scaffolded signatures for Lane B

Pinned **verbatim against the real autumn-web 0.5.0 API** so Lane B cannot drift. Types are fully qualified.

**RBAC vocabulary**
```rust
pub trait AccessClassMarker { const CLASS: aletheiadb::auth::AccessClass; }

pub struct ReadClass;    impl AccessClassMarker for ReadClass    { const CLASS: AccessClass = AccessClass::Read; }
pub struct WriteClass;   impl AccessClassMarker for WriteClass   { const CLASS: AccessClass = AccessClass::Write; }
pub struct MetricsClass; impl AccessClassMarker for MetricsClass { const CLASS: AccessClass = AccessClass::Metrics; }
pub struct AdminClass;   impl AccessClassMarker for AdminClass   { const CLASS: AccessClass = AccessClass::Admin; }
```

**(a) `Authorized<C>` + its `FromRequestParts` impl** — exact State bound + `type Rejection`:
```rust
// Note: PhantomData<fn() -> C> is required — a tuple struct with an otherwise-
// unused type param `C` does not compile. Field .0 remains `pub Principal`.
pub struct Authorized<C>(pub aletheiadb::auth::Principal, std::marker::PhantomData<fn() -> C>);

impl<C: AccessClassMarker> axum::extract::FromRequestParts<autumn_web::prelude::AppState>
    for Authorized<C>
{
    type Rejection = aletheiadb::http::AletheiaHttpError;   // HTTP-path parity (uniform 401, etc.)
    async fn from_request_parts(
        parts: &mut axum::http::request::Parts,
        state: &autumn_web::prelude::AppState,
    ) -> Result<Self, Self::Rejection>;
}
```
PR1 **authenticates** only (uniform 401 in required mode; `Principal::anonymous()` in anonymous mode). **RBAC-class enforcement is a marked `TODO(Lane B)`** in the impl body: `principal.role.allows(C::CLASS)` → else `AletheiaHttpError::PermissionDenied(..)`.

**(b) `apply_security`** — concrete app-builder type is autumn 0.5's **`TestApp`** (the type the parity harness drives; the production `AppBuilder` shares the same `secure_mcp`/`state_initializer`/`routes`/`openapi`/`mount_mcp` surface, so Lane B can lift it):
```rust
pub fn apply_security(app: autumn_web::test::TestApp, cfg: &SecurityConfig) -> autumn_web::test::TestApp
// In Required mode calls app.secure_mcp(RequireApiToken::new(Arc<AuthStoreTokenAdapter>)).
// secure_mcp bound (autumn 0.5): L: tower::Layer<axum::routing::Route> + Clone + Send + Sync + 'static,
//   L::Service: Service<Request<Body>, Response = Response<Body>, Error = Infallible> + ...
```

**(c) `init_state`** — app-state-builder param type + inserted extension types:
```rust
pub fn init_state(app_state: &autumn_web::prelude::AppState, cfg: &SecurityConfig)
// autumn's TestApp/AppBuilder::state_initializer closure is `FnOnce(&AppState)` and
// AppState::insert_extension takes `&self`, so the param is `&AppState` (NOT `&mut`).
// Inserts extension: ServerAuthState { store: Arc<AuthStore>, mode: AuthMode }.
// (Lane A's app.rs additionally inserts `ServerState { db: Arc<AletheiaDB> }`.)
```

**(d) `validate_startup`** — refuse-on-zero-credentials, and the exact hook it wires into:
```rust
pub fn validate_startup(cfg: &SecurityConfig) -> Result<(), String>
// PR1 calls it EAGERLY inside build_server_testapp (TestApp has no startup hook).
// Production wiring point (Lane B), exact autumn 0.5 shape:
//   AppBuilder::on_startup<F, Fut>(hook: F)
//     where F: Fn(autumn_web::prelude::AppState) -> Fut + Send + Sync + 'static,
//           Fut: Future<Output = autumn_web::AutumnResult<()>> + Send + 'static
```

**Config + RBAC table**
```rust
pub struct SecurityConfig { pub store: std::sync::Arc<aletheiadb::auth::AuthStore>, pub mode: aletheiadb::auth::AuthMode }
pub const MCP_TOOL_CLASSES: &[(&str, aletheiadb::auth::AccessClass)];       // single source of truth
pub fn tool_access_class(name: &str) -> Option<aletheiadb::auth::AccessClass>;  // derived from MCP_TOOL_CLASSES
```
Per Lane B's contract refinement, `tool_access_class` is **self-contained** (`get_node`/`list_nodes`/`count_nodes` → Read) with `// Lane B: anchor this on tests/parity/inventory.json (do not widen legacy TOOL_ACCESS_CLASSES)`. **The legacy `TOOL_ACCESS_CLASSES` was NOT widened.**

### MCP tool registration — bypass-proofing (Lane B adversarial-review requirement)

The escalation hole: a dispatcher-routable tool name missing from the RBAC class table would bypass the class gate. Chosen shape (both halves):

1. **The class lives ON the handler.** Every MCP-exposed handler declares its class in its own signature as `Authorized<ReadClass>` / `Authorized<WriteClass>` / … — the one place a tool is defined. autumn replays `/mcp tools/call` through that same handler, so the per-request class gate (Lane B's enforcement inside `Authorized<C>`) is carried by the routable handler itself and cannot be forgotten without deleting the extractor. *This is the "unrepresentable" half.*
2. **autumn 0.5's macro-routing forces the class table to be physically separate from `routes[..]`** (the routable `/mcp` set is a macro-expansion set over `#[api_doc(mcp)]` handlers; there is no `register_tool(app, handler, Class)` hook to fuse them). So I took **the documented fallback (b)**: one source list `rbac::MCP_TOOL_CLASSES` **derives** `tool_access_class`, and a PR1 conformance test **`mcp_routable_tools_are_all_classified`** asserts the **live** `/mcp` `tools/list` routable set **equals** the registry (routable ⊆ registry closes the hole; registry ⊆ routable rejects phantom entries). Lane B extends the registry from `tests/parity/inventory.json` and asserts the same bidirectionally. `tool_access_class` returning `None` at the dispatch gate **must be treated as reject**, documented on the fn.

---

## Main-crate widenings

Exactly **one**, additive, zero behavior change (verified below).

| File:line | Symbol | Change | Marker |
|---|---|---|---|
| `src/auth/store.rs:73` | `pub fn Principal::anonymous() -> Principal` | **New** pub constructor (not a visibility change): `Principal` is `#[non_exhaustive]`, so anonymous mode — which needs a `Principal` value with no backing key — cannot construct one out-of-crate. Returns a synthetic `admin`-role anonymous principal. | `// exposed for autumn-web migration (Issue #3524)` (`src/auth/store.rs:71`) |

The node-read proof slice needed **no** widening: `AletheiaMcpServer::{get_node,list_nodes,count_nodes}` and `aletheiadb::mcp::{GetNodeRequest,ListNodesRequest,CountNodesRequest}` are already public; `ApiResponse`/`node_to_query_json` were already public (spike). No `pub(crate)` module was opened.

---

## AC evidence — inventory rows → passing parity tests

Suite: `crates/aletheia-server/tests/server_parity.rs` (**19** tests). Deterministic bodies asserted byte-identical (parsed-JSON equality, `trace_id` stripped) vs the legacy 0.4 router (`build_test_router_with_auth`) / legacy MCP server (`AletheiaMcpServer`); non-deterministic admin bodies shape-asserted. Both anonymous and required modes covered.

| Inventory row | Surface | Pinning test(s) in this PR | Status |
|---|---|---|---|
| `GET /status` | HTTP | `status_success_byte_parity_required_mode`, `status_unauthenticated_401_byte_parity`, `status_success_anonymous_mode` | ✅ |
| `POST /admin/keys` | HTTP | `admin_create_key_success_shape`, `admin_create_key_unauthenticated_401_byte_parity` | ✅ |
| `GET /admin/keys` | HTTP | `admin_list_keys_byte_parity_with_shared_store`, `admin_list_keys_unauthenticated_401_byte_parity` | ✅ |
| `POST /admin/keys/revoke` | HTTP | `admin_revoke_key_behavior` | ✅ |
| `POST /query` | HTTP | **Deferred to follow-up PR** (see Scope) | ⏭️ |
| `get_node` | HTTP + `/mcp` | `get_node_byte_parity_with_legacy_mcp`, `get_node_include_vectors_parity`, `get_node_anonymous_mode_parity`, `get_node_unauthenticated_401`, `mcp_tools_call_get_node_matches_http` | ✅ |
| `list_nodes` | HTTP + `/mcp` | `list_nodes_byte_parity_with_legacy_mcp` | ✅ |
| `count_nodes` | HTTP + `/mcp` | `count_nodes_byte_parity_with_legacy_mcp` | ✅ |
| `/openapi.json` | — | `openapi_serves_and_documents_get_node` | ✅ |
| `/mcp` catalog + class gate | MCP | `mcp_tools_list_advertises_three_node_tools_with_read_class`, `mcp_catalog_requires_token`, `mcp_routable_tools_are_all_classified` | ✅ |

### Verbatim gate output (each gate ran in an isolated `CARGO_TARGET_DIR`)

`cargo clippy -p aletheia-server --all-targets -- -D warnings` → `Finished` (exit 0, no warnings).

`cargo test -p aletheia-server`
```
running 19 tests
test admin_create_key_unauthenticated_401_byte_parity ... ok
test admin_create_key_success_shape ... ok
test admin_list_keys_unauthenticated_401_byte_parity ... ok
test admin_list_keys_byte_parity_with_shared_store ... ok
test count_nodes_byte_parity_with_legacy_mcp ... ok
test admin_revoke_key_behavior ... ok
test get_node_anonymous_mode_parity ... ok
test get_node_byte_parity_with_legacy_mcp ... ok
test get_node_include_vectors_parity ... ok
test get_node_unauthenticated_401 ... ok
test mcp_catalog_requires_token ... ok
test list_nodes_byte_parity_with_legacy_mcp ... ok
test mcp_routable_tools_are_all_classified ... ok
test mcp_tools_call_get_node_matches_http ... ok
test mcp_tools_list_advertises_three_node_tools_with_read_class ... ok
test status_success_anonymous_mode ... ok
test openapi_serves_and_documents_get_node ... ok
test status_success_byte_parity_required_mode ... ok
test status_unauthenticated_401_byte_parity ... ok

test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.88s
```

`cargo fmt --all -- --check` → clean.

**Main-crate regression (widening safety):**
- `cargo check -p aletheiadb --no-default-features --tests --features http-server` → `Finished` (exit 0)
- `cargo clippy -p aletheiadb --features "config-toml,mcp-server,sharding-rpc,simulation" --all-targets -- -D warnings` → `Finished` (exit 0)
- `cargo test --features http-server,mcp-server --test parity_http --test parity_mcp` → `parity_http: 33 passed; 0 failed` · `parity_mcp: 11 passed; 0 failed`

### Threading note (spawn_blocking, grounded for parity)
Every handler matches its own legacy reference's threading: the node tools call the **synchronous** MCP typed methods (`src/mcp/server.rs` has **no** `spawn_blocking`), and `/status` + the admin routes match `src/http/admin.rs` / `health_check` which are also **synchronous** (no `spawn_blocking`). The `POST /query` read path (`handle_get_node` via `blocking()`) and the spike *do* wrap in `spawn_blocking`, but they mirror the HTTP `/query` surface, not the MCP one — so remaining faithful to the reference each handler is pinned against means matching synchronous here.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEwJg2bDPZ7DzcHebqwZVK