### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -37,3 +37,6 @@
 **[Fix `execute_traversal` target shards bug]**
 **Learning:** `plan.steps` from `route_traversal` returns empty list, and we need `involved_shards`
 **Action:** Replace `steps` with `involved_shards` and update the test.
+**f32::partial_cmp panics on NaN when unwrap() is used**
+**Learning:** Sorting vectors of floats using `.partial_cmp(...).unwrap()` panics if any of the float values are `NaN` because `partial_cmp` returns `None` for `NaN` comparisons.
+**Action:** Always use `.total_cmp(...)` instead when sorting floats to safely handle `NaN` and `Infinity` according to IEEE 754 total ordering rules.

--- a/src/experimental/characterization/archetype.rs
+++ b/src/experimental/characterization/archetype.rs
@@ -104,7 +104,7 @@ impl<'a> Archetype<'a> {
         }
 
         // Sort by purity descending
-        node_results.sort_by(|a, b| b.purity_score.partial_cmp(&a.purity_score).unwrap());
+        node_results.sort_by(|a, b| b.purity_score.total_cmp(&a.purity_score));
 
         Ok(ArchetypeResult {
             centroid,
@@ -262,5 +262,40 @@ mod tests {
 
         // Nodes should be sorted by purity (highest first)
         assert_eq!(result.nodes[2].node_id, outlier);
+    }
+
+    #[test]
+    fn test_archetype_nan_vectors_do_not_panic() {
+        let db = AletheiaDB::new().unwrap();
+
+        let mut n1 = NodeId::new(0).unwrap();
+        let mut n2 = NodeId::new(0).unwrap();
+
+        db.write(|tx| {
+            n1 = tx
+                .create_node(
+                    "Node",
+                    PropertyMapBuilder::new()
+                        .insert_vector("embedding", &[1.0, f32::NAN])
+                        .build(),
+                )
+                .unwrap();
+
+            n2 = tx
+                .create_node(
+                    "Node",
+                    PropertyMapBuilder::new()
+                        .insert_vector("embedding", &[f32::NAN, 1.0])
+                        .build(),
+                )
+                .unwrap();
+            Ok::<(), Error>(())
+        })
+        .unwrap();
+
+        let archetype = Archetype::new(&db);
+        let result = archetype.analyze(&[n1, n2], "embedding").unwrap();
+
+        assert_eq!(result.nodes.len(), 2);
     }
 }


### PR DESCRIPTION
🎯 Target: src/experimental/characterization/archetype.rs
💣 Risk: Prevents panic on NaN input when sorting node purity scores
🧪 Strategy: Added test cases with NaN vectors and replaced partial_cmp.unwrap() with total_cmp()
🔬 Verification: cargo test --lib --features "nova" archetype

---
*PR created automatically by Jules for task [11679831531939351573](https://jules.google.com/task/11679831531939351573) started by @madmax983*