### PR TITLE
feat(aletheia-server): Lane B RBAC + constant-time bearer auth (46-tool registry, Authorized<C> class gate)

### DIFF
--- a/crates/aletheia-server/src/security/auth.rs
+++ b/crates/aletheia-server/src/security/auth.rs
@@ -210,7 +210,7 @@ pub fn authorize<C: AccessClassMarker>(principal: &Principal) -> Result<(), Alet
 /// Returns `None` for missing or malformed headers — every failure collapses
 /// into the same uniform 401 upstream, deliberately. The bearer scheme match is
 /// ASCII-case-insensitive; a whitespace-only or empty credential is rejected.
-#[must_use]
+#[must_use = "the extracted credential must be verified against the auth store"]
 pub fn extract_credential(parts: &Parts) -> Option<String> {
     if let Some(value) = parts.headers.get(axum::http::header::AUTHORIZATION) {
         let s = value.to_str().ok()?;

--- a/crates/aletheia-server/src/security/auth.rs
+++ b/crates/aletheia-server/src/security/auth.rs
@@ -1,4 +1,4 @@
-// OWNED BY LANE B (security). Scaffold only — do not implement here.
+// OWNED BY LANE B (security).
 //
 //! Authentication + RBAC scaffolding for the production server.
 //!
@@ -140,11 +140,11 @@ impl<C: AccessClassMarker> FromRequestParts<AppState> for Authorized<C> {
             }
         };
 
-        // TODO(Lane B): enforce the RBAC class here —
-        //   `principal.role.allows(C::CLASS)` → else
-        //   `AletheiaHttpError::PermissionDenied(..)` (403), with
-        //   `details.{required_class, principal_role}` per Issue #3234/#3350.
-        // PR1 authenticates only; class enforcement is Lane B's.
+        // RBAC-class enforcement: reject with a byte-identical 403 unless the
+        // authenticated principal's role permits `C::CLASS`. In anonymous mode
+        // `Principal::anonymous()` carries `Role::Admin`, so every class passes —
+        // matching anonymous mode's documented full access.
+        authorize::<C>(&principal)?;
         Ok(Self(principal, PhantomData))
     }
 }
@@ -169,11 +169,49 @@ impl FromRequestParts<AppState> for ApiKeyStore {
     }
 }
 
+/// Authorize an authenticated `principal` for an [`AccessClass`].
+///
+/// The per-request RBAC decision. On refusal returns
+/// [`AletheiaHttpError::PermissionDenied`] (HTTP 403 / `PERMISSION_DENIED`,
+/// non-retriable) with the **byte-identical** legacy message
+/// `"role '{role}' does not permit {class} access"`, so 403 bodies stay
+/// identical to the existing `/query` surface.
+///
+/// # Errors
+///
+/// Returns [`AletheiaHttpError::PermissionDenied`] when `principal.role` does
+/// not permit `class`.
+pub fn authorize_class(principal: &Principal, class: AccessClass) -> Result<(), AletheiaHttpError> {
+    if principal.role.allows(class) {
+        Ok(())
+    } else {
+        Err(AletheiaHttpError::PermissionDenied(format!(
+            "role '{}' does not permit {} access",
+            principal.role, class
+        )))
+    }
+}
+
+/// Marker-generic wrapper over [`authorize_class`] — the shape the
+/// [`Authorized<C>`] extractor calls. Reads the required class from the type
+/// parameter's [`AccessClassMarker::CLASS`], so a handler's declared class
+/// (`Authorized<WriteClass>`) is the one enforced.
+///
+/// # Errors
+///
+/// Returns [`AletheiaHttpError::PermissionDenied`] when `principal.role` does
+/// not permit `C::CLASS`.
+pub fn authorize<C: AccessClassMarker>(principal: &Principal) -> Result<(), AletheiaHttpError> {
+    authorize_class(principal, C::CLASS)
+}
+
 /// Extract the bearer/`x-api-key` credential from request headers.
 ///
 /// Returns `None` for missing or malformed headers — every failure collapses
-/// into the same uniform 401 upstream, deliberately.
-fn extract_credential(parts: &Parts) -> Option<String> {
+/// into the same uniform 401 upstream, deliberately. The bearer scheme match is
+/// ASCII-case-insensitive; a whitespace-only or empty credential is rejected.
+#[must_use]
+pub fn extract_credential(parts: &Parts) -> Option<String> {
     if let Some(value) = parts.headers.get(axum::http::header::AUTHORIZATION) {
         let s = value.to_str().ok()?;
         let (scheme, rest) = s.split_once(' ')?;

--- a/crates/aletheia-server/src/security/mod.rs
+++ b/crates/aletheia-server/src/security/mod.rs
@@ -15,8 +15,9 @@
 //!   [`AuthMode::Required`] (auth-on-by-default parity), pass-through otherwise.
 //! - [`init_state`] installs the shared [`ServerAuthState`] extension.
 //! - [`validate_startup`] refuses required-mode startup with zero credentials.
-//! - [`auth::Authorized`] **authenticates** but does NOT yet enforce the RBAC
-//!   class — that enforcement is Lane B's (see the TODO there).
+//! - [`auth::Authorized`] **authenticates and enforces the RBAC class** via
+//!   [`authorize`] (Lane B, this PR): a role that does not permit the handler's
+//!   declared `C::CLASS` gets a byte-identical 403.
 //! - [`rate_limit`], [`resource_limits`], [`cursor`] are empty `TODO(Lane B)`.
 
 pub mod auth;
@@ -33,7 +34,7 @@ use std::sync::Arc;
 
 pub use auth::{
     AccessClassMarker, AdminClass, ApiKeyStore, AuthStoreTokenAdapter, Authorized, MetricsClass,
-    ReadClass, ServerAuthState, WriteClass,
+    ReadClass, ServerAuthState, WriteClass, authorize, authorize_class, extract_credential,
 };
 
 /// Security configuration for the server surface.

--- a/crates/aletheia-server/src/security/rbac.rs
+++ b/crates/aletheia-server/src/security/rbac.rs
@@ -1,6 +1,6 @@
-// OWNED BY LANE B (security). Scaffold only — do not implement here.
+// OWNED BY LANE B (security).
 //
-//! Per-MCP-tool access-class table (bypass-proof-by-construction stub).
+//! Per-MCP-tool access-class table (bypass-proof-by-construction).
 //!
 //! # Why a single source list (Lane B adversarial-review requirement)
 //!
@@ -29,32 +29,88 @@
 //!    classified fails CI. Lane B asserts the same bidirectionally against
 //!    `tests/parity/inventory.json`.
 //!
-//! Lane B: anchor this registry on tests/parity/inventory.json (do not widen
-//! legacy TOOL_ACCESS_CLASSES) — the inventory's `mcp.tools[].access_class` is
-//! the shared source of truth, checked bidirectionally + for totality against
-//! the live registry, so this table must be derived from / verified against
-//! inventory.json rather than the main crate's `pub(crate)` constant. Extend the
-//! list below as slices 2–8 add handlers; the conformance test keeps it honest.
+//! This registry is anchored on `tests/parity/inventory.json` — the inventory's
+//! `mcp.tools[].access_class` is the shared source of truth. It enumerates all
+//! 46 tools upfront (coordinator-directed): `registry_matches_inventory_exactly`
+//! checks it bidirectionally against the inventory, and
+//! `mcp_routable_tools_are_all_classified` checks the live routable set is a
+//! subset (every routable tool classified). Handlers become routable one slice
+//! at a time during the port; the subset invariant keeps that honest.
 
-use aletheiadb::auth::AccessClass;
+use aletheiadb::auth::{AccessClass, Role};
 
 /// The single source of truth pairing every MCP-exposed handler name with the
-/// [`AccessClass`] it requires. Both [`tool_access_class`] and the PR1
-/// conformance test derive from THIS list, so the routable-name set and the
-/// class-table set are one list by construction (they cannot silently drift
-/// into two independently-maintained lists).
+/// [`AccessClass`] it requires. Both [`tool_access_class`] and the conformance
+/// tests derive from THIS list, so the routable-name set and the class-table
+/// set cannot silently drift into two independently-maintained lists.
 ///
-/// PR1 scope: the three node-read tools surfaced on `/mcp`.
+/// This registry is **inventory-anchored**: it enumerates all 46 tools from
+/// `tests/parity/inventory.json` (`mcp.tools[].access_class`) upfront, mirroring
+/// the legacy `src/mcp/auth.rs::TOOL_ACCESS_CLASSES` verbatim. The conformance
+/// test `registry_matches_inventory_exactly` (`tests/security_rbac.rs`) proves
+/// the registry equals the inventory exactly (both directions, name + class),
+/// and `mcp_routable_tools_are_all_classified` (`tests/server_parity.rs`) proves
+/// the **live** routable set is a subset of this registry (every routable tool
+/// is classified — a routable-but-unclassified tool would bypass the class gate).
+/// During the port the registry may legitimately hold entries whose handlers are
+/// not yet routable; it never holds a routable tool that is unclassified.
 pub const MCP_TOOL_CLASSES: &[(&str, AccessClass)] = &[
+    // ---- Read: lookups, traversals, history, schema/extent discovery, and the
+    // read-only declarative `query` tool.
     ("get_node", AccessClass::Read),
     ("list_nodes", AccessClass::Read),
     ("count_nodes", AccessClass::Read),
-    // TODO(Lane B): extend from tests/parity/inventory.json as slices 2–8 land;
-    // the conformance test asserts this stays == the live routable set.
+    ("get_edge", AccessClass::Read),
+    ("list_edges", AccessClass::Read),
+    ("count_edges", AccessClass::Read),
+    ("get_outgoing_edges", AccessClass::Read),
+    ("get_incoming_edges", AccessClass::Read),
+    ("traverse", AccessClass::Read),
+    ("find_similar", AccessClass::Read),
+    ("list_vector_indexes", AccessClass::Read),
+    ("list_unique_constraints", AccessClass::Read),
+    ("get_node_at_time", AccessClass::Read),
+    ("get_edge_at_time", AccessClass::Read),
+    ("find_nodes_at_time", AccessClass::Read),
+    ("list_changes", AccessClass::Read),
+    ("get_node_at_valid_time", AccessClass::Read),
+    ("get_node_at_transaction_time", AccessClass::Read),
+    ("get_node_history", AccessClass::Read),
+    ("diff_node_versions", AccessClass::Read),
+    ("get_edge_at_valid_time", AccessClass::Read),
+    ("get_edge_at_transaction_time", AccessClass::Read),
+    ("get_edge_history", AccessClass::Read),
+    ("diff_edge_versions", AccessClass::Read),
+    ("hybrid_query", AccessClass::Read),
+    ("query", AccessClass::Read),
+    ("get_schema", AccessClass::Read),
+    ("temporal_extent", AccessClass::Read),
+    ("lineage_upstream", AccessClass::Read),
+    ("lineage_downstream", AccessClass::Read),
+    ("audit_export", AccessClass::Read),
+    ("verify_chain", AccessClass::Read),
+    ("export_chain_head", AccessClass::Read),
+    // ---- Metrics: operational health/stats.
+    ("database_stats", AccessClass::Metrics),
+    // ---- Write: graph mutations plus index/constraint state changes.
+    ("create_node", AccessClass::Write),
+    ("update_node", AccessClass::Write),
+    ("delete_node", AccessClass::Write),
+    ("delete_node_cascade", AccessClass::Write),
+    ("retract_node", AccessClass::Write),
+    ("create_edge", AccessClass::Write),
+    ("update_edge", AccessClass::Write),
+    ("delete_edge", AccessClass::Write),
+    ("retract_edge", AccessClass::Write),
+    ("apply_batch", AccessClass::Write),
+    ("enable_vector_index", AccessClass::Write),
+    ("enable_unique_constraint", AccessClass::Write),
+    // ---- Admin: none yet. Key lifecycle is served by the HTTP admin surface
+    // over the shared persisted store (no Admin-class MCP tools).
 ];
 
 /// The access class required by an MCP tool, or `None` if the name is not a
-/// registered (routable + classified) tool. Derived from [`MCP_TOOL_CLASSES`].
+/// registered (classified) tool. Derived from [`MCP_TOOL_CLASSES`].
 ///
 /// A `None` here at the dispatch gate MUST be treated as "reject" (not "allow"),
 /// so an unregistered/unknown routable name can never bypass the class gate.
@@ -64,4 +120,51 @@ pub fn tool_access_class(name: &str) -> Option<AccessClass> {
         .iter()
         .find(|(n, _)| *n == name)
         .map(|(_, class)| *class)
+}
+
+/// A role-vs-tool authorization denial: the class the tool requires and the
+/// role that was refused. Pure data (no transport coupling); the extractor
+/// layer maps this into an [`AletheiaHttpError::PermissionDenied`] with the
+/// byte-identical legacy message.
+///
+/// [`AletheiaHttpError::PermissionDenied`]: aletheiadb::http::AletheiaHttpError::PermissionDenied
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Denied {
+    /// The access class the tool requires.
+    pub required_class: AccessClass,
+    /// The role that was refused.
+    pub principal_role: Role,
+}
+
+/// Authorize a `role` to invoke `tool` by name (the MCP name-based decision).
+///
+/// Adapted to the autumn surface's **"unknown == reject"** contract (unlike the
+/// legacy `SessionAuth::authorize_tool`, which returned `Ok` for unknown names
+/// and relied on the string dispatcher to error afterwards): an unregistered
+/// routable name has no class, so it can never bypass the class gate. Known
+/// tools are `Ok` iff `role.allows(class)`.
+///
+/// The primary per-request enforcement is carried by the `Authorized<C>`
+/// extractor (which reads the class from the handler's own type parameter, so a
+/// handler cannot ship class-ungated); this name-based helper is the decision
+/// for any dispatcher that pre-checks by tool name.
+///
+/// # Errors
+///
+/// Returns [`Denied`] when the role does not permit the tool's class, or when
+/// the tool is unknown (rejected as the most-restrictive [`AccessClass::Admin`]).
+pub fn authorize_tool(role: Role, tool: &str) -> Result<(), Denied> {
+    match tool_access_class(tool) {
+        Some(class) if role.allows(class) => Ok(()),
+        Some(class) => Err(Denied {
+            required_class: class,
+            principal_role: role,
+        }),
+        // Unknown/unregistered routable name: reject (never allow). No concrete
+        // class exists, so report the most-restrictive class as the requirement.
+        None => Err(Denied {
+            required_class: AccessClass::Admin,
+            principal_role: role,
+        }),
+    }
 }

--- a/crates/aletheia-server/tests/security_rbac.rs
+++ b/crates/aletheia-server/tests/security_rbac.rs
@@ -1,0 +1,397 @@
+//! Lane B security tests: RBAC registry + constant-time bearer auth
+//! (Issue #3563 fill; design doc §6 ACs a/b/c/g).
+//!
+//! These cover the pure role/class decision layer and the credential/verify
+//! plumbing without standing up the full server (the live `/mcp` gate is proven
+//! by `tests/server_parity.rs`). Structure:
+//!
+//! - **AC (b) role×tool RBAC**: `registry_matches_inventory_exactly`,
+//!   `role_access_class_matrix_matches_role_allows`, `reader_denied_write_tool`,
+//!   `metrics_role_permits_only_database_stats`, `unknown_tool_has_no_class`.
+//! - **AC (c) constant-time verify**: `adapter_verify_delegates_to_constant_time_store`,
+//!   `store_verify_rejects_wrong_and_empty_token`.
+//! - **AC (g) 403-message parity**: `permission_denied_message_is_byte_identical`.
+//! - **AC (a) startup refusal**: `validate_startup_*`.
+//! - credential extraction: `extract_credential_*`.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use aletheia_server::SecurityConfig;
+use aletheia_server::security::rbac::{self, Denied};
+use aletheia_server::security::{
+    AuthStoreTokenAdapter, MetricsClass, ReadClass, WriteClass, authorize, authorize_class,
+    extract_credential, validate_startup,
+};
+use aletheiadb::auth::{AccessClass, AuthMode, AuthStore, Principal, Role};
+use aletheiadb::http::AletheiaHttpError;
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+/// Map an inventory `access_class` string to the typed [`AccessClass`],
+/// panicking on any value outside the known four (so an unexpected class in
+/// `inventory.json` fails the conformance test loudly rather than silently).
+fn class_from_inventory(s: &str) -> AccessClass {
+    match s {
+        "read" => AccessClass::Read,
+        "write" => AccessClass::Write,
+        "metrics" => AccessClass::Metrics,
+        "admin" => AccessClass::Admin,
+        other => panic!("unexpected access_class {other:?} in inventory.json"),
+    }
+}
+
+/// Obtain a real [`Principal`] carrying `role` (the type is `#[non_exhaustive]`,
+/// so it can only be produced by the store or `anonymous()`).
+fn principal_with_role(role: Role) -> Principal {
+    let store = AuthStore::new();
+    let token = "role-fixture-token-abcdefghijklmnop";
+    store
+        .insert_bootstrap_key("fixture", role, token)
+        .expect("insert key");
+    store.verify(token).expect("verify fixture key")
+}
+
+// ── AC (b): registry / inventory conformance ────────────────────────────────
+
+/// The RBAC registry equals `tests/parity/inventory.json`'s `mcp.tools[]`
+/// EXACTLY — same 46 names, same class per name, in both directions. The
+/// inventory is the cross-lane source of truth; this pins the registry to it so
+/// neither can drift silently.
+#[test]
+fn registry_matches_inventory_exactly() {
+    // Repo-root inventory, located relative to this crate's manifest dir so the
+    // test is CWD-independent.
+    let raw = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../tests/parity/inventory.json"
+    ));
+    let doc: serde_json::Value = serde_json::from_str(raw).expect("inventory.json parses");
+    let tools = doc["mcp"]["tools"].as_array().expect("mcp.tools array");
+
+    let inventory: BTreeMap<String, AccessClass> = tools
+        .iter()
+        .map(|t| {
+            let name = t["name"].as_str().expect("tool name").to_string();
+            let class = class_from_inventory(t["access_class"].as_str().expect("access_class"));
+            (name, class)
+        })
+        .collect();
+
+    let registry: BTreeMap<String, AccessClass> = rbac::MCP_TOOL_CLASSES
+        .iter()
+        .map(|(n, c)| ((*n).to_string(), *c))
+        .collect();
+
+    assert_eq!(
+        registry.len(),
+        rbac::MCP_TOOL_CLASSES.len(),
+        "registry has duplicate tool names"
+    );
+    assert_eq!(inventory.len(), 46, "inventory advertises 46 MCP tools");
+    assert_eq!(
+        registry, inventory,
+        "MCP_TOOL_CLASSES must equal inventory.json mcp.tools[] exactly \
+         (name + class, both directions)"
+    );
+}
+
+/// The 4×4 role/class matrix the server enforces equals `Role::allows`
+/// (Admin ⊇ all; Writer = {Read, Write, Metrics}; Reader = {Read, Metrics};
+/// Metrics = {Metrics}).
+#[test]
+fn role_access_class_matrix_matches_role_allows() {
+    use AccessClass::{Admin, Metrics, Read, Write};
+
+    // The full 4×4 truth table the server enforces.
+    let table: &[(Role, AccessClass, bool)] = &[
+        (Role::Admin, Read, true),
+        (Role::Admin, Write, true),
+        (Role::Admin, Admin, true),
+        (Role::Admin, Metrics, true),
+        (Role::Writer, Read, true),
+        (Role::Writer, Write, true),
+        (Role::Writer, Admin, false),
+        (Role::Writer, Metrics, true),
+        (Role::Reader, Read, true),
+        (Role::Reader, Write, false),
+        (Role::Reader, Admin, false),
+        (Role::Reader, Metrics, true),
+        (Role::Metrics, Read, false),
+        (Role::Metrics, Write, false),
+        (Role::Metrics, Admin, false),
+        (Role::Metrics, Metrics, true),
+    ];
+    for &(role, class, expected) in table {
+        assert_eq!(
+            role.allows(class),
+            expected,
+            "{role}.allows({class}) should be {expected}"
+        );
+    }
+}
+
+/// A reader is denied a write-class tool: `authorize_tool` returns the pure
+/// [`Denied`] carrying `required_class = Write` / `principal_role = Reader`
+/// (the `details` an error surface would attach). PERMISSION_DENIED is
+/// non-retriable by contract (see the message-parity test for the HTTP shape).
+#[test]
+fn reader_denied_write_tool() {
+    assert_eq!(
+        rbac::authorize_tool(Role::Reader, "create_node"),
+        Err(Denied {
+            required_class: AccessClass::Write,
+            principal_role: Role::Reader,
+        }),
+    );
+    // A reader IS allowed a read-class tool.
+    assert_eq!(rbac::authorize_tool(Role::Reader, "get_node"), Ok(()));
+}
+
+/// The `metrics` role permits only `database_stats` (the sole Metrics tool) and
+/// is denied a sample read tool and a sample write tool.
+#[test]
+fn metrics_role_permits_only_database_stats() {
+    assert_eq!(
+        rbac::authorize_tool(Role::Metrics, "database_stats"),
+        Ok(())
+    );
+
+    // Denied a read tool.
+    assert_eq!(
+        rbac::authorize_tool(Role::Metrics, "get_node"),
+        Err(Denied {
+            required_class: AccessClass::Read,
+            principal_role: Role::Metrics,
+        }),
+    );
+    // Denied a write tool.
+    assert_eq!(
+        rbac::authorize_tool(Role::Metrics, "create_node"),
+        Err(Denied {
+            required_class: AccessClass::Write,
+            principal_role: Role::Metrics,
+        }),
+    );
+
+    // database_stats is the ONLY tool a metrics role may invoke across the whole
+    // registry.
+    for (tool, _) in rbac::MCP_TOOL_CLASSES {
+        let ok = rbac::authorize_tool(Role::Metrics, tool).is_ok();
+        assert_eq!(
+            ok,
+            *tool == "database_stats",
+            "metrics role: {tool} should be {}",
+            if *tool == "database_stats" {
+                "allowed"
+            } else {
+                "denied"
+            }
+        );
+    }
+}
+
+/// An unknown/unregistered tool name has no class (`tool_access_class` → `None`,
+/// which the dispatch gate MUST treat as reject) and `authorize_tool` rejects it
+/// even for an admin — an unroutable name can never bypass the gate.
+#[test]
+fn unknown_tool_has_no_class() {
+    assert_eq!(rbac::tool_access_class("nonexistent_tool"), None);
+    assert!(rbac::authorize_tool(Role::Admin, "nonexistent_tool").is_err());
+}
+
+// ── AC (c): constant-time verify ────────────────────────────────────────────
+
+/// The autumn `ApiTokenStore` adapter verifies **by delegation** to
+/// `AuthStore::verify`, which compares SHA-256 digests with
+/// `subtle::ConstantTimeEq` and never early-exits on a mismatch
+/// (`src/auth/store.rs:319-330`). The adapter adds no timing-observable
+/// comparison of its own: a correct token resolves to the principal id, a
+/// wrong/empty token resolves to `None` (→ uniform 401 upstream).
+#[tokio::test]
+async fn adapter_verify_delegates_to_constant_time_store() {
+    use autumn_web::auth::ApiTokenStore;
+
+    let store = Arc::new(AuthStore::new());
+    let token = "adapter-token-abcdefghijklmnop";
+    store
+        .insert_bootstrap_key("svc", Role::Reader, token)
+        .expect("insert key");
+    let principal_id = store.verify(token).expect("principal").id;
+
+    let adapter = AuthStoreTokenAdapter::new(store);
+
+    assert_eq!(
+        adapter.verify(token).await.expect("verify ok"),
+        Some(principal_id),
+        "correct token resolves to the principal id via the constant-time store"
+    );
+    assert_eq!(
+        adapter
+            .verify("wrong-token-abcdefghijklmnop")
+            .await
+            .expect("verify ok"),
+        None,
+        "wrong token → None (uniform 401 upstream)"
+    );
+    assert_eq!(
+        adapter.verify("").await.expect("verify ok"),
+        None,
+        "empty token → None"
+    );
+}
+
+/// Direct constant-time-store negative test (`src/auth/store.rs:319-330`): a
+/// wrong or empty presented key never verifies.
+#[test]
+fn store_verify_rejects_wrong_and_empty_token() {
+    let store = AuthStore::new();
+    let token = "store-token-abcdefghijklmnop";
+    store
+        .insert_bootstrap_key("svc", Role::Admin, token)
+        .expect("insert key");
+
+    assert!(store.verify(token).is_some(), "correct token verifies");
+    assert!(store.verify("nope").is_none(), "wrong token rejected");
+    assert!(store.verify("").is_none(), "empty token rejected");
+}
+
+// ── AC (g): 403-message parity ──────────────────────────────────────────────
+
+/// The 403 body is byte-identical to the legacy surface:
+/// `"role '{role}' does not permit {class} access"`.
+#[test]
+fn permission_denied_message_is_byte_identical() {
+    let reader = principal_with_role(Role::Reader);
+
+    // via authorize_class
+    let err = authorize_class(&reader, AccessClass::Write).expect_err("reader denied write");
+    let AletheiaHttpError::PermissionDenied(msg) = err else {
+        panic!("expected PermissionDenied");
+    };
+    assert_eq!(msg, "role 'reader' does not permit write access");
+
+    // via the marker-generic authorize::<C> (the shape Authorized<C> calls)
+    let err = authorize::<WriteClass>(&reader).expect_err("reader denied write class");
+    let AletheiaHttpError::PermissionDenied(msg) = err else {
+        panic!("expected PermissionDenied");
+    };
+    assert_eq!(msg, "role 'reader' does not permit write access");
+
+    // A permitted class does not error.
+    assert!(authorize::<ReadClass>(&reader).is_ok());
+
+    // metrics role denied metrics? no — metrics IS permitted; check a denial the
+    // matrix guarantees: metrics role denied read.
+    let metrics = principal_with_role(Role::Metrics);
+    let err = authorize::<ReadClass>(&metrics).expect_err("metrics denied read");
+    let AletheiaHttpError::PermissionDenied(msg) = err else {
+        panic!("expected PermissionDenied");
+    };
+    assert_eq!(msg, "role 'metrics' does not permit read access");
+    assert!(authorize::<MetricsClass>(&metrics).is_ok());
+}
+
+/// Anonymous principals carry `Role::Admin`, so `authorize::<C>` passes every
+/// class — anonymous mode's documented full access.
+#[test]
+fn anonymous_principal_passes_every_class() {
+    let anon = Principal::anonymous();
+    assert!(authorize::<ReadClass>(&anon).is_ok());
+    assert!(authorize::<WriteClass>(&anon).is_ok());
+    assert!(authorize::<MetricsClass>(&anon).is_ok());
+    assert!(authorize_class(&anon, AccessClass::Admin).is_ok());
+}
+
+// ── AC (a): startup refusal ─────────────────────────────────────────────────
+
+/// `validate_startup` refuses `Required` mode with an empty store (every request
+/// would be rejected — fail closed at boot instead), allows `Required` with at
+/// least one key, and always allows `Anonymous`.
+#[test]
+fn validate_startup_required_empty_store_is_refused() {
+    let store = Arc::new(AuthStore::new());
+    let cfg = SecurityConfig::new(store, AuthMode::Required);
+    assert!(validate_startup(&cfg).is_err());
+}
+
+#[test]
+fn validate_startup_required_with_key_is_ok() {
+    let store = Arc::new(AuthStore::new());
+    store
+        .insert_bootstrap_key("admin", Role::Admin, "startup-token-abcdefghijklmnop")
+        .expect("insert key");
+    let cfg = SecurityConfig::new(store, AuthMode::Required);
+    assert!(validate_startup(&cfg).is_ok());
+}
+
+#[test]
+fn validate_startup_anonymous_is_ok() {
+    let store = Arc::new(AuthStore::new());
+    let cfg = SecurityConfig::new(store, AuthMode::Anonymous);
+    assert!(validate_startup(&cfg).is_ok());
+}
+
+// ── credential extraction ───────────────────────────────────────────────────
+
+/// Build request `Parts` carrying the given headers.
+fn parts_with(headers: &[(&str, &str)]) -> axum::http::request::Parts {
+    let mut builder = axum::http::Request::builder();
+    for (k, v) in headers {
+        builder = builder.header(*k, *v);
+    }
+    builder.body(()).expect("build request").into_parts().0
+}
+
+#[test]
+fn extract_credential_bearer_is_case_insensitive() {
+    for scheme in ["Bearer", "bearer", "BEARER", "BeArEr"] {
+        let parts = parts_with(&[("authorization", &format!("{scheme} tok123"))]);
+        assert_eq!(
+            extract_credential(&parts).as_deref(),
+            Some("tok123"),
+            "scheme {scheme} should extract the token"
+        );
+    }
+}
+
+#[test]
+fn extract_credential_x_api_key_is_accepted() {
+    let parts = parts_with(&[("x-api-key", "tok456")]);
+    assert_eq!(extract_credential(&parts).as_deref(), Some("tok456"));
+}
+
+#[test]
+fn extract_credential_rejects_basic_missing_empty_and_whitespace() {
+    // Non-bearer scheme.
+    let basic = parts_with(&[("authorization", "Basic dXNlcjpwYXNz")]);
+    assert_eq!(extract_credential(&basic), None, "Basic scheme rejected");
+
+    // No credential header at all.
+    let missing = parts_with(&[]);
+    assert_eq!(extract_credential(&missing), None, "missing header → None");
+
+    // Empty bearer token.
+    let empty_bearer = parts_with(&[("authorization", "Bearer ")]);
+    assert_eq!(
+        extract_credential(&empty_bearer),
+        None,
+        "empty bearer token → None"
+    );
+
+    // Whitespace-only bearer token (trimmed to empty).
+    let ws_bearer = parts_with(&[("authorization", "Bearer     ")]);
+    assert_eq!(
+        extract_credential(&ws_bearer),
+        None,
+        "whitespace-only bearer token → None"
+    );
+
+    // Whitespace-only x-api-key (trimmed to empty).
+    let ws_key = parts_with(&[("x-api-key", "   ")]);
+    assert_eq!(
+        extract_credential(&ws_key),
+        None,
+        "whitespace-only x-api-key → None"
+    );
+}

--- a/crates/aletheia-server/tests/server_parity.rs
+++ b/crates/aletheia-server/tests/server_parity.rs
@@ -489,12 +489,21 @@ async fn mcp_tools_list_advertises_three_node_tools_with_read_class() {
     );
 }
 
-/// Bypass-proofing (Lane B adversarial-review requirement): the set of tools
-/// the dispatcher will actually route (the live `/mcp` `tools/list`) must equal
-/// the RBAC registry `MCP_TOOL_CLASSES`. A routable tool missing from the
-/// registry would bypass the class gate on the autumn surface; a stale registry
-/// entry would classify a non-existent tool. This test fails on either drift,
-/// so a new `#[api_doc(mcp)]` handler cannot ship routable-but-unclassified.
+/// Bypass-proofing (Lane B adversarial-review requirement): every tool the
+/// dispatcher will actually route (the live `/mcp` `tools/list`) must be
+/// classified in the RBAC registry `MCP_TOOL_CLASSES` — `routable ⊆ registry`,
+/// STRICT. A routable tool missing from the registry would bypass the class
+/// gate on the autumn surface (a privilege-escalation hole), so this test fails
+/// on any routable-but-unclassified tool: a new `#[api_doc(mcp)]` handler cannot
+/// ship class-ungated.
+///
+/// The reverse inclusion (registry ⊆ routable) is deliberately NOT asserted
+/// (coordinator-directed): the registry is inventory-anchored to all 46 tools
+/// upfront (`registry_matches_inventory_exactly` in `tests/security_rbac.rs`
+/// pins it to `tests/parity/inventory.json`), while handlers become routable one
+/// slice at a time during the autumn port. The registry legitimately contains
+/// not-yet-routable classified entries; it never contains a routable
+/// unclassified one.
 #[tokio::test]
 async fn mcp_routable_tools_are_all_classified() {
     use std::collections::BTreeSet;
@@ -524,12 +533,12 @@ async fn mcp_routable_tools_are_all_classified() {
         .collect();
 
     // routable ⊆ registry: no routable tool may lack a class (the escalation
-    // hole). registry ⊆ routable: no stale/phantom class entries.
-    assert_eq!(
-        routable, registered,
-        "the live /mcp routable tool set must equal the RBAC registry \
-         (routable-but-unclassified = class-gate bypass): routable={routable:?} \
-         registry={registered:?}"
+    // hole). Reported precisely so a drift names the offending tools.
+    let unclassified: BTreeSet<&String> = routable.difference(&registered).collect();
+    assert!(
+        unclassified.is_empty(),
+        "every live /mcp routable tool must be classified in the RBAC registry \
+         (routable-but-unclassified = class-gate bypass); unclassified={unclassified:?}"
     );
     // And every routable name resolves to a concrete class (defensive: None at
     // the dispatch gate must be treated as reject, never allow).


### PR DESCRIPTION
## Before / After

**Before (PR1 scaffold):** the new `aletheia-server` crate authenticated the
bearer/`x-api-key` credential against the shared constant-time `AuthStore`, but
the `Authorized<C>` extractor carried a `TODO` — it did **not** enforce the
token's role against the handler's required access class. The RBAC registry was
a 3-tool stub. An authenticated principal of any role could reach any routable
tool: the class gate was a no-op.

**After (this PR):** every MCP tool and route is gated by the token's role.
`Authorized<C>` now enforces `authorize::<C>(&principal)` — a role that does not
permit the handler's declared `C::CLASS` gets a byte-identical 403. The RBAC
registry is an **inventory-anchored 46-tool** map (the single source of truth is
`tests/parity/inventory.json`), so a routable tool cannot ship
class-ungated. Constant-time bearer verification is preserved by delegation to
`AuthStore::verify` (SHA-256 digests compared via `subtle::ConstantTimeEq`, no
early exit).

Scope is **rbac + auth only** (design doc §6 ACs a/b/c/g). The
`resource_limits` / `rate_limit` / `cursor` seams remain their PR1 stubs
(B2/B3/cursor). `SecurityConfig` is unchanged (`{store, mode}`). No new Cargo
deps (constant-time is delegated).

## How

`crates/aletheia-server/src/security/`:

- **`rbac.rs`** — `MCP_TOOL_CLASSES` widened to all 46 tools (copied from the
  inventory / validated spike table: 33 Read, 12 Write, 1 Metrics, 0 Admin).
  Added the pure decision layer: `Denied { required_class, principal_role }` and
  `authorize_tool(role, tool) -> Result<(), Denied>` (autumn "unknown == reject":
  an unregistered name has no class and cannot bypass the gate). `tool_access_class`
  unchanged (`None` = reject).
- **`auth.rs`** — added `authorize_class(&Principal, AccessClass)` and the
  marker-generic `authorize::<C: AccessClassMarker>(&Principal)`, both returning
  `AletheiaHttpError::PermissionDenied` with the byte-identical legacy message
  `"role '{role}' does not permit {class} access"`. Filled the `Authorized<C>`
  `from_request_parts` TODO with `authorize::<C>(&principal)?`. Made
  `extract_credential` `pub` (Bearer case-insensitive + `x-api-key` + trim +
  empty-reject). Anonymous principals carry `Role::Admin`, so anonymous mode
  passes every class (unchanged).
- **`mod.rs`** — re-exports `authorize`, `authorize_class`, `extract_credential`.
  `validate_startup` already refused Required+empty and allowed Anonymous (kept).

## Registry-sizing change (coordinator-directed — please note)

The scaffold's `mcp_routable_tools_are_all_classified` asserted
`routable == registry` (registry ⊆ routable **and** routable ⊆ registry). With
the registry widened to all 46 upfront while only the 3 node-read handlers are
routable today, that equality would fail. Per coordinator ruling it is
**relaxed to `routable ⊆ registry`, STRICT** — every routable tool must be
classified (the escalation hole is closed), but the registry may legitimately
hold not-yet-routable classified entries during the autumn port. The reverse
inclusion is intentionally dropped. To keep the registry honest, a new
conformance test `registry_matches_inventory_exactly` pins
`MCP_TOOL_CLASSES` to `tests/parity/inventory.json` **exactly** (46 tools, both
directions, name + class). This is the only scaffold test modified.

## AC-evidence table

| AC | Requirement | Test(s) proving it |
|----|-------------|--------------------|
| (a) | Startup refuses Required-mode + empty store; allows keys / anonymous | `validate_startup_required_empty_store_is_refused`, `validate_startup_required_with_key_is_ok`, `validate_startup_anonymous_is_ok` |
| (b) | Role×tool RBAC (46-tool registry, matrix, denials) | `registry_matches_inventory_exactly`, `mcp_routable_tools_are_all_classified` (relaxed subset), `role_access_class_matrix_matches_role_allows`, `reader_denied_write_tool`, `metrics_role_permits_only_database_stats`, `unknown_tool_has_no_class`, `anonymous_principal_passes_every_class` |
| (c) | Constant-time bearer verify (delegated) | `adapter_verify_delegates_to_constant_time_store`, `store_verify_rejects_wrong_and_empty_token` |
| (g) | 403 message byte-identical to legacy | `permission_denied_message_is_byte_identical` |
| — | Credential extraction (Bearer/x-api-key/reject) | `extract_credential_bearer_is_case_insensitive`, `extract_credential_x_api_key_is_accepted`, `extract_credential_rejects_basic_missing_empty_and_whitespace` |

## References

- Issue #3563 (autumn-server security fill; PR1 scaffold).
- Design doc §6 ACs (a) startup refusal / (b) role×tool RBAC / (c) constant-time
  verify / (g) 403-message parity.

## Notes / follow-ups (out of scope here)

- The 403 body currently carries only the message; populating
  `details.{required_class, principal_role}` needs `PermissionDenied` to grow a
  details channel (#3234/#3350). The `Denied` struct is the ready-made payload.
- `resource_limits` / `rate_limit` / `cursor` remain stubs (B2/B3/cursor PRs).

---
This PR is opened as a **draft** — the lane owner reviews before it goes
ready-for-review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9nP1hfyQTVovFgM48MfME)_