### PR TITLE
feat(cypher): WHERE-clause provenance predicates (#3354b)

### DIFF
--- a/src/cypher/converter.rs
+++ b/src/cypher/converter.rs
@@ -1268,8 +1268,8 @@ impl CypherConverter {
     ///   which fall through to the ordinary comparison path),
     /// - `Err(..)` for a provenance-named accessor with a malformed argument
     ///   (e.g. `source(n.foo)`, `confidence('x')`, `confidence(r, s)`,
-    ///   `source()`, `source(DISTINCT n)`), so the mistake surfaces as a
-    ///   structured error rather than silently degrading.
+    ///   `source()`), so the mistake surfaces as a structured error rather than
+    ///   silently degrading.
     fn as_provenance_accessor(
         &self,
         expr: &CypherExpr,

--- a/src/cypher/converter.rs
+++ b/src/cypher/converter.rs
@@ -42,9 +42,13 @@ use super::parser::CypherParser;
 use crate::core::temporal::{TimeRange, Timestamp};
 use crate::core::vector::DistanceMetric as VectorMetric;
 use crate::query::builder::Query;
+use crate::query::converter::{
+    ProvenanceLoweringError, lower_provenance_comparison, provenance_field_name,
+};
 use crate::query::ir::{
     AggregateArg, AggregateFunc, AggregateGroupKey, AggregateSpec, Predicate, PredicateValue,
-    QueryOp, ScoreComparison, ScoreThreshold, SortKey, TraversalDepth,
+    ProvenanceCmp, ProvenanceField, ProvenanceOperand, ProvenancePredicate, QueryOp,
+    ScoreComparison, ScoreThreshold, SortKey, TraversalDepth,
 };
 use crate::query::plan::{QueryHints, TemporalContext};
 
@@ -57,6 +61,68 @@ use crate::query::plan::{QueryHints, TemporalContext};
 /// Kept clearly above the parser's cap so it only ever rejects such hand-built
 /// pathological input, never a legitimately parsed query.
 const MAX_CONVERT_DEPTH: usize = 256;
+
+/// Map a Cypher [`CypherCompOp`] to the IR [`ProvenanceCmp`] (Issue #3354b).
+fn cypher_comp_to_provenance_cmp(op: CypherCompOp) -> ProvenanceCmp {
+    match op {
+        CypherCompOp::Eq => ProvenanceCmp::Eq,
+        CypherCompOp::Ne => ProvenanceCmp::Ne,
+        CypherCompOp::Lt => ProvenanceCmp::Lt,
+        CypherCompOp::Le => ProvenanceCmp::Le,
+        CypherCompOp::Gt => ProvenanceCmp::Gt,
+        CypherCompOp::Ge => ProvenanceCmp::Ge,
+    }
+}
+
+/// Flip a Cypher comparison operator when its operands are swapped, so an
+/// accessor on the right-hand side (`0.9 <= confidence(x)`) lowers identically
+/// to the accessor-on-left form (`confidence(x) >= 0.9`). Equality/inequality
+/// are symmetric (Issue #3354b).
+fn flip_cypher_comp_op(op: CypherCompOp) -> CypherCompOp {
+    match op {
+        CypherCompOp::Eq => CypherCompOp::Eq,
+        CypherCompOp::Ne => CypherCompOp::Ne,
+        CypherCompOp::Lt => CypherCompOp::Gt,
+        CypherCompOp::Le => CypherCompOp::Ge,
+        CypherCompOp::Gt => CypherCompOp::Lt,
+        CypherCompOp::Ge => CypherCompOp::Le,
+    }
+}
+
+/// Map the surface-agnostic [`ProvenanceLoweringError`] into the Cypher error
+/// vocabulary (Issue #3354b).
+///
+/// Chosen so the MCP `query` tool surfaces the same structured kinds as the AQL
+/// side (via [`CypherError`] → `crate::core::error::Error` → `map_query_error`):
+/// type mismatches and out-of-range confidence become
+/// [`CypherError::ParameterError`] (→ `invalid_params`); the ordering-op-on-
+/// string rejection becomes [`CypherError::SemanticError`] (→ `parse_error`).
+fn map_provenance_lowering_error(e: ProvenanceLoweringError) -> CypherError {
+    match e {
+        ProvenanceLoweringError::ConfidenceOutOfRange { value, .. } => CypherError::ParameterError(
+            format!("confidence(x) must be between 0.0 and 1.0, got {value}"),
+        ),
+        ProvenanceLoweringError::ConfidenceNotNumeric => CypherError::ParameterError(
+            "type mismatch: confidence(x) compares only to a numeric value".to_string(),
+        ),
+        ProvenanceLoweringError::OrderingOpOnStringField { field } => {
+            CypherError::SemanticError(format!(
+                "ordering operators (<, <=, >, >=) are not supported for {}(x); \
+                 only = and <> are supported for source/reason",
+                field.accessor_name()
+            ))
+        }
+        ProvenanceLoweringError::StringFieldNotString { field } => {
+            CypherError::ParameterError(format!(
+                "type mismatch: {}(x) compares only to a string value",
+                field.accessor_name()
+            ))
+        }
+        ProvenanceLoweringError::FilterValidation { message, .. } => {
+            CypherError::ParameterError(message)
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Parameter values
@@ -1040,6 +1106,13 @@ impl CypherConverter {
                 Ok(Predicate::Not(Box::new(inner_pred)))
             }
             CypherExpr::IsNull(inner) => {
+                // `provenance(x) IS NULL` (Issue #3354b): selects the versions
+                // with no provenance bundle at all (unattributed rows).
+                if self.is_provenance_bundle_accessor(inner)? {
+                    return Ok(Predicate::Provenance(ProvenancePredicate::IsNull {
+                        negated: false,
+                    }));
+                }
                 match inner.as_ref() {
                     // Property access (`n.email IS NULL`): openCypher treats a
                     // property as null when it is ABSENT *or* present with an
@@ -1069,6 +1142,13 @@ impl CypherConverter {
                 }
             }
             CypherExpr::IsNotNull(inner) => {
+                // `provenance(x) IS NOT NULL` (Issue #3354b): selects the
+                // versions that carry a provenance bundle (attributed rows).
+                if self.is_provenance_bundle_accessor(inner)? {
+                    return Ok(Predicate::Provenance(ProvenancePredicate::IsNull {
+                        negated: true,
+                    }));
+                }
                 match inner.as_ref() {
                     // Property access (`n.email IS NOT NULL`): openCypher requires
                     // the property to be PRESENT with a non-null value. Lower to
@@ -1141,6 +1221,30 @@ impl CypherConverter {
         op: CypherCompOp,
         right: &CypherExpr,
     ) -> Result<Predicate, CypherError> {
+        // Provenance accessors (Issue #3354b): `source(x)`/`confidence(x)`/
+        // `reason(x)` appear as function calls, never property accesses, so a
+        // property literally named `source` (`n.source`) is unaffected.
+        // Recognize an accessor on either side and lower to a provenance
+        // predicate before the ordinary property-access handling below.
+        let left_accessor = self.as_provenance_accessor(left)?;
+        let right_accessor = self.as_provenance_accessor(right)?;
+        match (left_accessor, right_accessor) {
+            (Some(_), Some(_)) => {
+                return Err(CypherError::SemanticError(
+                    "comparing two provenance accessors is not supported".to_string(),
+                ));
+            }
+            (Some(field), None) => {
+                return self.build_provenance_comparison(field, op, right);
+            }
+            (None, Some(field)) => {
+                // Accessor on the right (`0.9 <= confidence(n)`): flip the
+                // comparison so the accessor is the logical left-hand side.
+                return self.build_provenance_comparison(field, flip_cypher_comp_op(op), left);
+            }
+            (None, None) => {}
+        }
+
         let key = self.extract_property_key(left)?;
         let value = self.convert_expr_to_predicate_value(right)?;
 
@@ -1152,6 +1256,127 @@ impl CypherConverter {
             CypherCompOp::Lt => Predicate::Lt { key, value },
             CypherCompOp::Le => Predicate::Lte { key, value },
         })
+    }
+
+    /// Recognize a provenance accessor expression `source(x)`/`confidence(x)`/
+    /// `reason(x)` (Issue #3354b).
+    ///
+    /// Returns:
+    /// - `Ok(Some(field))` for a well-formed accessor over a single bound
+    ///   variable,
+    /// - `Ok(None)` for any other expression (including unknown function calls,
+    ///   which fall through to the ordinary comparison path),
+    /// - `Err(..)` for a provenance-named accessor with a malformed argument
+    ///   (e.g. `source(n.foo)`, `confidence('x')`, `confidence(r, s)`,
+    ///   `source()`, `source(DISTINCT n)`), so the mistake surfaces as a
+    ///   structured error rather than silently degrading.
+    fn as_provenance_accessor(
+        &self,
+        expr: &CypherExpr,
+    ) -> Result<Option<ProvenanceField>, CypherError> {
+        let CypherExpr::FunctionCall {
+            name,
+            args,
+            distinct,
+        } = expr
+        else {
+            return Ok(None);
+        };
+        let Some(field) = provenance_field_name(name) else {
+            return Ok(None);
+        };
+        // `DISTINCT` is only meaningful for aggregates; reject it here rather
+        // than silently ignoring it.
+        if *distinct {
+            return Err(CypherError::SemanticError(format!(
+                "{}(x) provenance accessor does not accept DISTINCT",
+                field.accessor_name()
+            )));
+        }
+        match args.as_slice() {
+            [CypherExpr::Variable(_)] => Ok(Some(field)),
+            _ => Err(CypherError::SemanticError(format!(
+                "{}(x) provenance accessor requires exactly one bound variable argument",
+                field.accessor_name()
+            ))),
+        }
+    }
+
+    /// Recognize a `provenance(x)` bundle accessor for the `IS [NOT] NULL` form
+    /// (Issue #3354b).
+    ///
+    /// Returns `Ok(true)` for a well-formed `provenance(<bound variable>)` call,
+    /// `Ok(false)` for any other expression, and `Err(..)` for a
+    /// `provenance(...)` call with a malformed argument. Unlike the field
+    /// accessors, `provenance` addresses the whole bundle and is only valid in
+    /// the `IS [NOT] NULL` position.
+    fn is_provenance_bundle_accessor(&self, expr: &CypherExpr) -> Result<bool, CypherError> {
+        let CypherExpr::FunctionCall {
+            name,
+            args,
+            distinct,
+        } = expr
+        else {
+            return Ok(false);
+        };
+        if !name.eq_ignore_ascii_case("provenance") {
+            return Ok(false);
+        }
+        if *distinct {
+            return Err(CypherError::SemanticError(
+                "provenance(x) does not accept DISTINCT".to_string(),
+            ));
+        }
+        match args.as_slice() {
+            [CypherExpr::Variable(_)] => Ok(true),
+            _ => Err(CypherError::SemanticError(
+                "provenance(x) IS NULL requires a single bound variable argument".to_string(),
+            )),
+        }
+    }
+
+    /// Lower a provenance accessor comparison `field(x) <op> operand` (accessor
+    /// already normalized to the left) into a [`Predicate::Provenance`], reusing
+    /// the shared surface-agnostic lowering (Issue #3354b).
+    ///
+    /// The type-check / folding / ordering-op rejection / `[0,1]`-NaN validation
+    /// semantics live once in [`lower_provenance_comparison`]; this method only
+    /// adapts the Cypher operand/operator into the IR triple and maps the
+    /// neutral error into the Cypher error vocabulary.
+    fn build_provenance_comparison(
+        &self,
+        field: ProvenanceField,
+        op: CypherCompOp,
+        operand_expr: &CypherExpr,
+    ) -> Result<Predicate, CypherError> {
+        let operand = self.expr_to_provenance_operand(operand_expr)?;
+        let cmp = cypher_comp_to_provenance_cmp(op);
+        lower_provenance_comparison(field, cmp, operand).map_err(map_provenance_lowering_error)
+    }
+
+    /// Resolve the right-hand literal/parameter of a provenance comparison to a
+    /// typed operand (Issue #3354b).
+    fn expr_to_provenance_operand(
+        &self,
+        expr: &CypherExpr,
+    ) -> Result<ProvenanceOperand, CypherError> {
+        let value = match expr {
+            CypherExpr::Value(v) => self.convert_value_to_predicate_value(v)?,
+            _ => {
+                return Err(CypherError::SemanticError(
+                    "a provenance accessor must be compared to a literal or parameter".to_string(),
+                ));
+            }
+        };
+        match value {
+            PredicateValue::String(s) => Ok(ProvenanceOperand::Str(s)),
+            PredicateValue::Int(i) => Ok(ProvenanceOperand::Num(i as f64)),
+            PredicateValue::Float(f) => Ok(ProvenanceOperand::Num(f)),
+            PredicateValue::Bool(_) | PredicateValue::Null => Err(CypherError::ParameterError(
+                "type mismatch: a provenance accessor operand must be a string or number"
+                    .to_string(),
+            )),
+        }
     }
 
     /// Extract a property key from an expression.

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -7570,6 +7570,135 @@ mod server_unit_tests {
         );
     }
 
+    /// End-to-end (Issue #3354b): a Cypher provenance `WHERE` accessor filters
+    /// rows through the MCP `query` tool exactly like the AQL side, using the
+    /// shared executor evaluation. Alice (source `hr-system`) is kept; Bob
+    /// (source `crm-sync`) is excluded.
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn handle_query_cypher_provenance_where_filters() {
+        use crate::api::transaction::WriteRequestOptions;
+        use crate::core::property::PropertyMapBuilder;
+        use crate::core::provenance::Provenance;
+
+        let db = Arc::new(AletheiaDB::new().expect("db init"));
+        let alice_prov = Provenance::builder()
+            .source("hr-system")
+            .build()
+            .expect("prov");
+        db.create_node_with_options(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "alice").build(),
+            WriteRequestOptions::new().with_provenance(alice_prov),
+        )
+        .expect("create alice");
+        let bob_prov = Provenance::builder()
+            .source("crm-sync")
+            .build()
+            .expect("prov");
+        db.create_node_with_options(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "bob").build(),
+            WriteRequestOptions::new().with_provenance(bob_prov),
+        )
+        .expect("create bob");
+        let server = AletheiaMcpServer::new(db);
+
+        let result = server.handle_query(serde_json::json!({
+            "language": "cypher",
+            "query": "MATCH (n:Person) WHERE source(n) = 'hr-system' RETURN n",
+        }));
+        let val: serde_json::Value =
+            serde_json::from_str(&AletheiaMcpServer::extract_text(result)).unwrap();
+        assert!(
+            val.get("error").is_none(),
+            "provenance WHERE must not error: {val}"
+        );
+        assert_eq!(val["row_count"], 1, "only alice matches: {val}");
+        let rows = val["rows"].as_array().expect("rows array");
+        assert_eq!(
+            rows[0]["entity"]["properties"]["name"], "alice",
+            "the kept row is alice: {val}"
+        );
+    }
+
+    /// A Cypher provenance accessor compared to the wrong type surfaces as the
+    /// structured `invalid_params` kind (never a silent empty result), mirroring
+    /// the AQL side (Issue #3354b).
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn handle_query_cypher_provenance_type_mismatch_is_invalid_params() {
+        let db = Arc::new(AletheiaDB::new().expect("db init"));
+        let server = AletheiaMcpServer::new(db);
+        let result = server.handle_query(serde_json::json!({
+            "language": "cypher",
+            "query": "MATCH (n:Person) WHERE confidence(n) = 'high' RETURN n",
+        }));
+        let val: serde_json::Value =
+            serde_json::from_str(&AletheiaMcpServer::extract_text(result)).unwrap();
+        assert_eq!(
+            val["error"]["kind"].as_str(),
+            Some("invalid_params"),
+            "type mismatch is a caller-repairable argument fault: {val}"
+        );
+    }
+
+    /// The ordering-op-on-string rejection (fail-closed) surfaces as a
+    /// structured `parse_error` through the MCP `query` tool (Issue #3354b).
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn handle_query_cypher_provenance_ordering_op_rejected() {
+        let db = Arc::new(AletheiaDB::new().expect("db init"));
+        let server = AletheiaMcpServer::new(db);
+        let result = server.handle_query(serde_json::json!({
+            "language": "cypher",
+            "query": "MATCH (n:Person) WHERE source(n) < 'x' RETURN n",
+        }));
+        let val: serde_json::Value =
+            serde_json::from_str(&AletheiaMcpServer::extract_text(result)).unwrap();
+        assert_eq!(
+            val["error"]["kind"].as_str(),
+            Some("parse_error"),
+            "ordering op on a string accessor is rejected: {val}"
+        );
+    }
+
+    /// Read-only invariant (Issue #3354b): a provenance predicate cannot smuggle
+    /// a write. A pure provenance-`WHERE` read is accepted, but the same query
+    /// with an appended mutating clause is rejected `read_only_violation`
+    /// *before* execution by the existing statement guard.
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn handle_query_cypher_provenance_stays_read_only() {
+        let db = Arc::new(AletheiaDB::new().expect("db init"));
+        let server = AletheiaMcpServer::new(db);
+
+        // Pure provenance read: not a mutating clause, accepted.
+        let ok = server.handle_query(serde_json::json!({
+            "language": "cypher",
+            "query": "MATCH (n:Person) WHERE provenance(n) IS NOT NULL RETURN n",
+        }));
+        let ok_val: serde_json::Value =
+            serde_json::from_str(&AletheiaMcpServer::extract_text(ok)).unwrap();
+        assert!(
+            ok_val.get("error").is_none(),
+            "a read-only provenance query must not be rejected: {ok_val}"
+        );
+
+        // Provenance WHERE with an appended write is rejected before execution.
+        let bad = server.handle_query(serde_json::json!({
+            "language": "cypher",
+            "query": "MATCH (n:Person) WHERE source(n) = 'hr-system' DELETE n",
+        }));
+        let bad_val: serde_json::Value =
+            serde_json::from_str(&AletheiaMcpServer::extract_text(bad)).unwrap();
+        assert_eq!(
+            bad_val["error"]["kind"].as_str(),
+            Some("read_only_violation"),
+            "a smuggled write is rejected read-only: {bad_val}"
+        );
+    }
+
     #[test]
     fn map_query_error_unsupported_feature_yields_unsupported_construct() {
         let server = make_server();

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -187,10 +187,14 @@ use super::ir::{
 };
 use super::plan::{QueryHints, TemporalContext};
 
-/// Map an AQL provenance accessor function name to its [`ProvenanceField`]
+/// Map a provenance accessor function name to its [`ProvenanceField`]
 /// (case-insensitive), or `None` if the name is not a provenance accessor
 /// (Issue #3354a).
-fn provenance_field_name(name: &str) -> Option<ProvenanceField> {
+///
+/// Shared by the AQL converter and the Cypher converter
+/// (`src/cypher/converter.rs`, Issue #3354b) so both surfaces recognize exactly
+/// the same accessor names.
+pub(crate) fn provenance_field_name(name: &str) -> Option<ProvenanceField> {
     match name.to_ascii_lowercase().as_str() {
         "source" => Some(ProvenanceField::Source),
         "confidence" => Some(ProvenanceField::Confidence),
@@ -223,6 +227,155 @@ fn flip_comparison_op(op: ComparisonOp) -> ComparisonOp {
         ComparisonOp::Le => ComparisonOp::Ge,
         ComparisonOp::Gt => ComparisonOp::Lt,
         ComparisonOp::Ge => ComparisonOp::Le,
+    }
+}
+
+/// AST-agnostic reason a provenance accessor comparison could not be lowered
+/// (Issue #3354a / #3354b).
+///
+/// Both the AQL converter ([`AstConverter::build_provenance_comparison`]) and
+/// the Cypher converter (`src/cypher/converter.rs`) convert their own
+/// operand/operator into the surface-neutral IR triple
+/// `(ProvenanceField, ProvenanceCmp, ProvenanceOperand)`, call
+/// [`lower_provenance_comparison`], and then map this neutral error into their
+/// own error vocabulary. Sharing the lowering keeps the folding, type-check,
+/// ordering-op rejection, and `[0,1]`/NaN validation semantics identical across
+/// both surfaces (no copy-pasted semantics to drift).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum ProvenanceLoweringError {
+    /// An ordering operator (`<`, `<=`, `>`, `>=`) was applied to a string
+    /// accessor (`source`/`reason`), which supports only `=`/`<>`. Rejected
+    /// fail-closed rather than silently accepted as a lexicographic comparison.
+    OrderingOpOnStringField {
+        /// The offending string accessor.
+        field: ProvenanceField,
+    },
+    /// `confidence(x)` was compared to a non-numeric operand.
+    ConfidenceNotNumeric,
+    /// `source(x)`/`reason(x)` was compared to a non-string operand.
+    StringFieldNotString {
+        /// The offending string accessor.
+        field: ProvenanceField,
+    },
+    /// A `confidence(x)` numeric operand was NaN or outside `[0.0, 1.0]`.
+    ConfidenceOutOfRange {
+        /// The reusable-filter field name that rejected the value (for the
+        /// structured-error `parameter`/`details` payload).
+        field: &'static str,
+        /// The rejected value (may be NaN).
+        value: f64,
+    },
+    /// Defensive: the reusable [`ProvenanceFilter::validated`] rejected the
+    /// folded positive shape. Unreachable through either surface today (the
+    /// source `=` fold passes a single non-empty scalar), retained so the
+    /// production path never `unwrap`s.
+    FilterValidation {
+        /// The reusable-filter field name that rejected the input.
+        field: &'static str,
+        /// The rejection message.
+        message: String,
+    },
+}
+
+/// Lower a provenance accessor comparison `field(x) <cmp> operand` (with the
+/// accessor already normalized to the left) into a [`Predicate::Provenance`]
+/// (Issue #3354a / #3354b).
+///
+/// This is the single, surface-agnostic home of the provenance-comparison
+/// semantics:
+///
+/// - `confidence(x)` accepts only a numeric operand, validated to `[0,1]`/non-NaN
+///   via [`ProvenanceFilter::validated`](crate::core::provenance::ProvenanceFilter::validated);
+///   the foldable positive shape `confidence(x) >= t` reuses the core filter's
+///   inclusive min-confidence semantics via `matches`, other operators use the
+///   general accessor form.
+/// - `source(x)`/`reason(x)` accept only a string operand and only `=`/`<>`
+///   (ordering operators are rejected fail-closed). The foldable positive shape
+///   `source(x) = 'S'` reuses the core filter's any-of exact-match semantics.
+///
+/// Absent-provenance handling is delegated to
+/// [`ProvenancePredicate::evaluate`], which mirrors `ProvenanceFilter::matches`
+/// (unattributed rows excluded).
+pub(crate) fn lower_provenance_comparison(
+    field: ProvenanceField,
+    cmp: ProvenanceCmp,
+    operand: ProvenanceOperand,
+) -> std::result::Result<Predicate, ProvenanceLoweringError> {
+    match (field, operand) {
+        (ProvenanceField::Confidence, ProvenanceOperand::Num(n)) => {
+            // Validate the confidence literal (range + NaN) once for every
+            // operator, reusing the core rules; the filter is only folded for
+            // the `>=` shape below.
+            let filter =
+                crate::core::provenance::ProvenanceFilter::validated(None, None, Some(n), false)
+                    .map_err(|e| ProvenanceLoweringError::ConfidenceOutOfRange {
+                        field: e.field(),
+                        value: n,
+                    })?;
+            // Foldable positive shape: `confidence(x) >= t`. If the validated
+            // filter is inactive (defensive: a set min_confidence always yields
+            // an active filter), fall back to the general accessor form rather
+            // than panicking (coding standard: no expect/unwrap on the
+            // production path).
+            match (matches!(cmp, ProvenanceCmp::Ge), filter) {
+                (true, Some(filter)) => {
+                    Ok(Predicate::Provenance(ProvenancePredicate::Filter(filter)))
+                }
+                _ => Ok(Predicate::Provenance(ProvenancePredicate::Accessor {
+                    field,
+                    op: cmp,
+                    operand: ProvenanceOperand::Num(n),
+                })),
+            }
+        }
+        (ProvenanceField::Confidence, ProvenanceOperand::Str(_)) => {
+            Err(ProvenanceLoweringError::ConfidenceNotNumeric)
+        }
+        (ProvenanceField::Source | ProvenanceField::Reason, ProvenanceOperand::Str(s)) => {
+            // `source`/`reason` are string accessors: only equality and
+            // inequality are supported. Ordering operators are rejected here
+            // (fail-closed) rather than silently accepted as lexicographic
+            // comparisons.
+            if matches!(
+                cmp,
+                ProvenanceCmp::Lt | ProvenanceCmp::Le | ProvenanceCmp::Gt | ProvenanceCmp::Ge
+            ) {
+                return Err(ProvenanceLoweringError::OrderingOpOnStringField { field });
+            }
+            // Foldable positive shape: `source(x) = 'S'` reuses the core
+            // filter's any-of exact-match semantics via `matches`. `reason` and
+            // the `<>` operator use the general accessor form.
+            if field == ProvenanceField::Source && matches!(cmp, ProvenanceCmp::Eq) {
+                let filter = crate::core::provenance::ProvenanceFilter::validated(
+                    Some(s.clone()),
+                    None,
+                    None,
+                    false,
+                )
+                .map_err(|e| ProvenanceLoweringError::FilterValidation {
+                    field: e.field(),
+                    message: e.to_string(),
+                })?;
+                if let Some(filter) = filter {
+                    Ok(Predicate::Provenance(ProvenancePredicate::Filter(filter)))
+                } else {
+                    Ok(Predicate::Provenance(ProvenancePredicate::Accessor {
+                        field,
+                        op: cmp,
+                        operand: ProvenanceOperand::Str(s),
+                    }))
+                }
+            } else {
+                Ok(Predicate::Provenance(ProvenancePredicate::Accessor {
+                    field,
+                    op: cmp,
+                    operand: ProvenanceOperand::Str(s),
+                }))
+            }
+        }
+        (ProvenanceField::Source | ProvenanceField::Reason, ProvenanceOperand::Num(_)) => {
+            Err(ProvenanceLoweringError::StringFieldNotString { field })
+        }
     }
 }
 
@@ -950,109 +1103,50 @@ impl AstConverter {
         let operand = self.expression_to_provenance_operand(operand_expr)?;
         let cmp = provenance_cmp_from_ast(op);
 
-        match (field, operand) {
-            (ProvenanceField::Confidence, ProvenanceOperand::Num(n)) => {
-                // Validate the confidence literal (range + NaN) once for every
-                // operator, reusing the core rules and the offending-field name;
-                // the resulting filter is only folded for the `>=` shape below.
-                let filter = crate::core::provenance::ProvenanceFilter::validated(
-                    None,
-                    None,
-                    Some(n),
-                    false,
-                )
-                .map_err(|e| {
-                    Error::Query(QueryError::InvalidParameter {
-                        parameter: e.field().to_string(),
-                        reason: format!("confidence(x) must be between 0.0 and 1.0, got {n}"),
-                    })
-                })?;
-                // Foldable positive shape: `confidence(x) >= t` reuses the core
-                // filter's inclusive min-confidence semantics via matches(). If
-                // the validated filter is inactive (defensive: a set
-                // min_confidence always yields an active filter), fall back to
-                // the general accessor form rather than panicking (coding
-                // standard: no expect/unwrap on the production path).
-                match (matches!(cmp, ProvenanceCmp::Ge), filter) {
-                    (true, Some(filter)) => {
-                        Ok(Predicate::Provenance(ProvenancePredicate::Filter(filter)))
-                    }
-                    _ => Ok(Predicate::Provenance(ProvenancePredicate::Accessor {
-                        field,
-                        op: cmp,
-                        operand: ProvenanceOperand::Num(n),
-                    })),
-                }
-            }
-            (ProvenanceField::Confidence, ProvenanceOperand::Str(_)) => {
-                Err(Error::Query(QueryError::TypeMismatch {
+        // Delegate the surface-agnostic semantics (folding, type checks,
+        // ordering-op rejection, [0,1]/NaN validation) to the shared lowering,
+        // then map its neutral error into the AQL error vocabulary (unchanged
+        // wording, so behavior is byte-identical to the pre-refactor path).
+        lower_provenance_comparison(field, cmp, operand).map_err(|e| match e {
+            ProvenanceLoweringError::ConfidenceOutOfRange {
+                field: param,
+                value,
+            } => Error::Query(QueryError::InvalidParameter {
+                parameter: param.to_string(),
+                reason: format!("confidence(x) must be between 0.0 and 1.0, got {value}"),
+            }),
+            ProvenanceLoweringError::ConfidenceNotNumeric => {
+                Error::Query(QueryError::TypeMismatch {
                     expected: "number".to_string(),
                     actual: "string (confidence(x) compares only to a numeric value)".to_string(),
-                }))
+                })
             }
-            (ProvenanceField::Source | ProvenanceField::Reason, ProvenanceOperand::Str(s)) => {
-                // `source`/`reason` are string accessors: only equality and
-                // inequality are supported (documented `=`/`<>`). Ordering
-                // operators are rejected at convert time (fail-closed) rather
-                // than being silently accepted as lexicographic comparisons.
-                if matches!(
-                    cmp,
-                    ProvenanceCmp::Lt | ProvenanceCmp::Le | ProvenanceCmp::Gt | ProvenanceCmp::Ge
-                ) {
-                    return Err(Error::Query(QueryError::SyntaxError {
-                        message: format!(
-                            "ordering operators (<, <=, >, >=) are not supported for \
-                             {}(x); only = and <> are supported for source/reason",
-                            field.accessor_name()
-                        ),
-                    }));
-                }
-                // Foldable positive shape: `source(x) = 'S'` reuses the core
-                // filter's any-of exact-match semantics via matches(). `reason`
-                // and the `<>` operator use the general accessor form. If the
-                // validated filter is inactive (defensive), fall back to the
-                // accessor form rather than panicking (coding standard: no
-                // expect/unwrap on the production path).
-                if field == ProvenanceField::Source && matches!(cmp, ProvenanceCmp::Eq) {
-                    let filter = crate::core::provenance::ProvenanceFilter::validated(
-                        Some(s.clone()),
-                        None,
-                        None,
-                        false,
-                    )
-                    .map_err(|e| {
-                        Error::Query(QueryError::InvalidParameter {
-                            parameter: e.field().to_string(),
-                            reason: e.to_string(),
-                        })
-                    })?;
-                    if let Some(filter) = filter {
-                        Ok(Predicate::Provenance(ProvenancePredicate::Filter(filter)))
-                    } else {
-                        Ok(Predicate::Provenance(ProvenancePredicate::Accessor {
-                            field,
-                            op: cmp,
-                            operand: ProvenanceOperand::Str(s),
-                        }))
-                    }
-                } else {
-                    Ok(Predicate::Provenance(ProvenancePredicate::Accessor {
-                        field,
-                        op: cmp,
-                        operand: ProvenanceOperand::Str(s),
-                    }))
-                }
+            ProvenanceLoweringError::OrderingOpOnStringField { field } => {
+                Error::Query(QueryError::SyntaxError {
+                    message: format!(
+                        "ordering operators (<, <=, >, >=) are not supported for \
+                         {}(x); only = and <> are supported for source/reason",
+                        field.accessor_name()
+                    ),
+                })
             }
-            (ProvenanceField::Source | ProvenanceField::Reason, ProvenanceOperand::Num(_)) => {
-                Err(Error::Query(QueryError::TypeMismatch {
+            ProvenanceLoweringError::StringFieldNotString { field } => {
+                Error::Query(QueryError::TypeMismatch {
                     expected: "string".to_string(),
                     actual: format!(
                         "number ({}(x) compares only to a string value)",
                         field.accessor_name()
                     ),
-                }))
+                })
             }
-        }
+            ProvenanceLoweringError::FilterValidation {
+                field: param,
+                message,
+            } => Error::Query(QueryError::InvalidParameter {
+                parameter: param.to_string(),
+                reason: message,
+            }),
+        })
     }
 
     /// Resolve the right-hand literal/parameter of a provenance comparison to a

--- a/tests/cypher_provenance_where.rs
+++ b/tests/cypher_provenance_where.rs
@@ -1,0 +1,464 @@
+//! Integration tests for Cypher `WHERE`-clause provenance predicates
+//! (Issue #3354b).
+//!
+//! Mirrors the AQL suite (`tests/aql_provenance_where.rs`, Issue #3354a) for the
+//! Cypher surface: the read-only provenance accessors `source(x)` /
+//! `confidence(x)` / `reason(x)` and `provenance(x) IS [NOT] NULL` end-to-end
+//! through `execute_cypher`, including absent-provenance exclusion, composition
+//! with an ordinary property `WHERE`, per-version (`AS OF`) evaluation, and
+//! parity with the AQL lowering (both surfaces share
+//! `crate::query::converter::lower_provenance_comparison`).
+
+#![cfg(feature = "cypher")]
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::PropertyMapBuilder;
+use aletheiadb::api::transaction::WriteRequestOptions;
+use aletheiadb::core::NodeId;
+use aletheiadb::core::provenance::Provenance;
+use aletheiadb::query::executor::EntityResult;
+
+fn prov(source: Option<&str>, confidence: Option<f64>, reason: Option<&str>) -> Provenance {
+    let mut b = Provenance::builder();
+    if let Some(s) = source {
+        b = b.source(s);
+    }
+    if let Some(c) = confidence {
+        b = b.confidence(c);
+    }
+    if let Some(r) = reason {
+        b = b.note(r);
+    }
+    b.build().expect("valid provenance")
+}
+
+fn create_person(db: &AletheiaDB, name: &str, provenance: Option<Provenance>) -> NodeId {
+    let props = PropertyMapBuilder::new().insert("name", name).build();
+    let mut opts = WriteRequestOptions::new();
+    if let Some(p) = provenance {
+        opts = opts.with_provenance(p);
+    }
+    db.create_node_with_options("Person", props, opts)
+        .expect("create person")
+}
+
+/// Run a Cypher query expected to fail, returning the error message.
+/// (`QueryResults` is not `Debug`, so `Result::expect_err` cannot be used.)
+fn err_msg(db: &AletheiaDB, cypher: &str) -> String {
+    match db.execute_cypher(cypher) {
+        Ok(_) => panic!("expected error for query: {cypher}"),
+        Err(e) => e.to_string(),
+    }
+}
+
+/// Collect the `name` property of every node row returned by a Cypher query.
+fn names(db: &AletheiaDB, cypher: &str) -> Vec<String> {
+    let results = db.execute_cypher(cypher).expect("query executes");
+    let mut out = Vec::new();
+    for row in results.collect_all().expect("collect rows") {
+        let EntityResult::Node(n) = row.entity else {
+            continue;
+        };
+        if let Some(v) = n.get_property("name") {
+            out.push(format!("{v:?}"));
+        }
+    }
+    out.sort();
+    out
+}
+
+fn make_db() -> AletheiaDB {
+    let db = AletheiaDB::new().expect("db");
+    create_person(
+        &db,
+        "alice",
+        Some(prov(Some("hr-system"), Some(0.95), Some("verified"))),
+    );
+    create_person(
+        &db,
+        "bob",
+        Some(prov(Some("crm-sync"), Some(0.60), Some("imported"))),
+    );
+    create_person(
+        &db,
+        "carol",
+        Some(prov(Some("hr-system"), Some(0.80), None)),
+    );
+    create_person(&db, "dave", None); // unattributed
+    db
+}
+
+#[test]
+fn source_exact_match_filters_rows() {
+    let db = make_db();
+    let got = names(
+        &db,
+        "MATCH (n:Person) WHERE source(n) = 'hr-system' RETURN n",
+    );
+    assert_eq!(got, vec!["String(\"alice\")", "String(\"carol\")"]);
+}
+
+#[test]
+fn source_inequality_excludes_and_absent() {
+    let db = make_db();
+    // `<>` keeps attributed rows whose source differs; unattributed (dave) is
+    // excluded because its accessor is null.
+    let got = names(
+        &db,
+        "MATCH (n:Person) WHERE source(n) <> 'hr-system' RETURN n",
+    );
+    assert_eq!(got, vec!["String(\"bob\")"]);
+}
+
+#[test]
+fn confidence_inclusive_lower_bound() {
+    let db = make_db();
+    // >= 0.80 keeps alice (0.95) and carol (0.80, inclusive), not bob (0.60).
+    let got = names(&db, "MATCH (n:Person) WHERE confidence(n) >= 0.80 RETURN n");
+    assert_eq!(got, vec!["String(\"alice\")", "String(\"carol\")"]);
+}
+
+#[test]
+fn confidence_strict_greater_is_exclusive() {
+    let db = make_db();
+    // > 0.80 excludes carol (== bound), keeps only alice.
+    let got = names(&db, "MATCH (n:Person) WHERE confidence(n) > 0.80 RETURN n");
+    assert_eq!(got, vec!["String(\"alice\")"]);
+}
+
+#[test]
+fn confidence_less_than_general_path() {
+    let db = make_db();
+    // `<` is a non-foldable shape (general accessor path).
+    let got = names(&db, "MATCH (n:Person) WHERE confidence(n) < 0.80 RETURN n");
+    assert_eq!(got, vec!["String(\"bob\")"]);
+}
+
+#[test]
+fn reason_equality() {
+    let db = make_db();
+    let got = names(
+        &db,
+        "MATCH (n:Person) WHERE reason(n) = 'verified' RETURN n",
+    );
+    assert_eq!(got, vec!["String(\"alice\")"]);
+}
+
+#[test]
+fn absent_provenance_excluded_by_confidence() {
+    let db = make_db();
+    // dave (no bundle) excluded; the other three attributed rows kept.
+    let got = names(&db, "MATCH (n:Person) WHERE confidence(n) >= 0.0 RETURN n");
+    assert_eq!(
+        got,
+        vec!["String(\"alice\")", "String(\"bob\")", "String(\"carol\")"]
+    );
+}
+
+#[test]
+fn partial_bundle_missing_field_excluded() {
+    let db = make_db();
+    // carol has a bundle but no `reason`; a reason predicate excludes her.
+    let got = names(
+        &db,
+        "MATCH (n:Person) WHERE reason(n) = 'imported' RETURN n",
+    );
+    assert_eq!(got, vec!["String(\"bob\")"]);
+}
+
+#[test]
+fn provenance_is_null_selects_unattributed() {
+    let db = make_db();
+    let got = names(&db, "MATCH (n:Person) WHERE provenance(n) IS NULL RETURN n");
+    assert_eq!(got, vec!["String(\"dave\")"]);
+}
+
+#[test]
+fn provenance_is_not_null_selects_attributed() {
+    let db = make_db();
+    // carol has a (partial) bundle => IS NOT NULL is true for her.
+    let got = names(
+        &db,
+        "MATCH (n:Person) WHERE provenance(n) IS NOT NULL RETURN n",
+    );
+    assert_eq!(
+        got,
+        vec!["String(\"alice\")", "String(\"bob\")", "String(\"carol\")"]
+    );
+}
+
+#[test]
+fn combined_source_and_confidence_is_and() {
+    let db = make_db();
+    let got = names(
+        &db,
+        "MATCH (n:Person) WHERE source(n) = 'hr-system' AND confidence(n) >= 0.90 RETURN n",
+    );
+    assert_eq!(got, vec!["String(\"alice\")"]);
+}
+
+#[test]
+fn combined_property_and_provenance() {
+    let db = make_db();
+    // Property predicate ANDed with a provenance predicate.
+    let got = names(
+        &db,
+        "MATCH (n:Person) WHERE n.name = 'carol' AND confidence(n) >= 0.5 RETURN n",
+    );
+    assert_eq!(got, vec!["String(\"carol\")"]);
+}
+
+#[test]
+fn combined_property_or_provenance() {
+    let db = make_db();
+    // OR mixing forces the general (non-folded) evaluation path.
+    let got = names(
+        &db,
+        "MATCH (n:Person) WHERE n.name = 'dave' OR confidence(n) >= 0.90 RETURN n",
+    );
+    assert_eq!(got, vec!["String(\"alice\")", "String(\"dave\")"]);
+}
+
+#[test]
+fn accessor_on_right_hand_side() {
+    let db = make_db();
+    // `0.90 <= confidence(n)` must lower identically to `confidence(n) >= 0.90`.
+    let got = names(&db, "MATCH (n:Person) WHERE 0.90 <= confidence(n) RETURN n");
+    assert_eq!(got, vec!["String(\"alice\")"]);
+}
+
+#[test]
+fn property_named_source_is_not_a_provenance_accessor() {
+    // A property literally named `source` (accessed as `n.source`) must remain
+    // an ordinary property filter, not a provenance accessor.
+    let db = AletheiaDB::new().expect("db");
+    let props = PropertyMapBuilder::new()
+        .insert("name", "eve")
+        .insert("source", "manual")
+        .build();
+    db.create_node_with_options("Person", props, WriteRequestOptions::new())
+        .expect("create");
+    let got = names(&db, "MATCH (n:Person) WHERE n.source = 'manual' RETURN n");
+    assert_eq!(got, vec!["String(\"eve\")"]);
+}
+
+#[test]
+fn confidence_out_of_range_is_rejected() {
+    let db = make_db();
+    let msg = err_msg(&db, "MATCH (n:Person) WHERE confidence(n) >= 1.5 RETURN n");
+    assert!(
+        msg.contains("0.0 and 1.0") || msg.contains("1.5"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn confidence_nan_via_parameter_is_rejected() {
+    use aletheiadb::cypher::CypherParameterValue;
+    use std::collections::HashMap;
+    let db = make_db();
+    // NaN is rejected by the same [0,1]/NaN validation as an out-of-range value.
+    // NaN cannot be written as a literal, so the user-facing path is a bound
+    // parameter.
+    let mut params = HashMap::new();
+    params.insert("c".to_string(), CypherParameterValue::Float(f64::NAN));
+    let res = db.execute_cypher_with_params(
+        "MATCH (n:Person) WHERE confidence(n) >= $c RETURN n",
+        params,
+    );
+    assert!(res.is_err(), "NaN confidence must be rejected");
+}
+
+#[test]
+fn confidence_via_parameter_folds() {
+    use aletheiadb::cypher::CypherParameterValue;
+    use std::collections::HashMap;
+    let db = make_db();
+    // A valid confidence bound supplied as a parameter behaves like the literal.
+    let mut params = HashMap::new();
+    params.insert("c".to_string(), CypherParameterValue::Float(0.80));
+    let results = db
+        .execute_cypher_with_params(
+            "MATCH (n:Person) WHERE confidence(n) >= $c RETURN n",
+            params,
+        )
+        .expect("query executes");
+    let mut got = Vec::new();
+    for row in results.collect_all().expect("collect rows") {
+        if let EntityResult::Node(n) = row.entity
+            && let Some(v) = n.get_property("name")
+        {
+            got.push(format!("{v:?}"));
+        }
+    }
+    got.sort();
+    assert_eq!(got, vec!["String(\"alice\")", "String(\"carol\")"]);
+}
+
+#[test]
+fn confidence_compared_to_string_is_type_error() {
+    let db = make_db();
+    let msg = err_msg(
+        &db,
+        "MATCH (n:Person) WHERE confidence(n) = 'high' RETURN n",
+    );
+    assert!(msg.to_lowercase().contains("type mismatch"), "got: {msg}");
+}
+
+#[test]
+fn source_compared_to_number_is_type_error() {
+    let db = make_db();
+    let msg = err_msg(&db, "MATCH (n:Person) WHERE source(n) = 5 RETURN n");
+    assert!(msg.to_lowercase().contains("type mismatch"), "got: {msg}");
+}
+
+#[test]
+fn malformed_accessor_argument_is_parse_or_convert_error() {
+    let db = make_db();
+    for q in [
+        "MATCH (n:Person) WHERE source(n.foo) = 'x' RETURN n",
+        "MATCH (n:Person) WHERE confidence(n, m) >= 0.5 RETURN n",
+        "MATCH (n:Person) WHERE source() = 'x' RETURN n",
+        "MATCH (n:Person) WHERE provenance(n.foo) IS NULL RETURN n",
+    ] {
+        assert!(db.execute_cypher(q).is_err(), "expected error for: {q}");
+    }
+}
+
+#[test]
+fn ordering_operator_on_source_is_rejected() {
+    // The string accessors `source`/`reason` support only `=`/`<>`. An ordering
+    // operator must be rejected at convert time with a structured error, never
+    // silently accepted as a lexicographic comparison (mirrors #3354a FIX 1).
+    let db = make_db();
+    for q in [
+        "MATCH (n:Person) WHERE source(n) < 'x' RETURN n",
+        "MATCH (n:Person) WHERE reason(n) >= 'x' RETURN n",
+    ] {
+        let msg = err_msg(&db, q);
+        let lower = msg.to_lowercase();
+        assert!(
+            (lower.contains("source") || lower.contains("reason"))
+                && (lower.contains("ordering") || lower.contains("= and <>")),
+            "expected a structured rejection naming the accessor and allowed operators, got: {msg}"
+        );
+    }
+}
+
+#[test]
+fn as_of_evaluates_provenance_at_that_coordinate() {
+    // AC3: an `AS OF` query filters on the provenance recorded on the version
+    // visible at that coordinate, not the latest version. Build a node whose
+    // confidence rose from 0.50 (valid [T1, T2)) to 0.95 (valid [T2, ..)).
+    let db = AletheiaDB::new().expect("db");
+    let t1: i64 = 1_000_000_000_000; // microseconds
+    let t2: i64 = 2_000_000_000_000;
+    let t3: i64 = 3_000_000_000_000;
+
+    let props = PropertyMapBuilder::new().insert("name", "alice").build();
+    let node_id = db
+        .create_node_with_options(
+            "Person",
+            props,
+            WriteRequestOptions::new()
+                .with_valid_from(aletheiadb::core::temporal::Timestamp::from(t1))
+                .with_provenance(prov(Some("hr-system"), Some(0.50), None)),
+        )
+        .expect("create v1");
+
+    let props2 = PropertyMapBuilder::new().insert("name", "alice").build();
+    db.update_node_with_options(
+        node_id,
+        props2,
+        WriteRequestOptions::new()
+            .with_valid_from(aletheiadb::core::temporal::Timestamp::from(t2))
+            .with_provenance(prov(Some("hr-system"), Some(0.95), None)),
+    )
+    .expect("update v2");
+
+    // AS OF valid_time within [T1, T2): confidence was 0.50 -> excluded by >= 0.9.
+    // VALID_TIME sets valid time only (transaction time defaults to now), so the
+    // 2026 writes are visible; only the valid-time coordinate selects the
+    // version.
+    let before = names(
+        &db,
+        &format!("MATCH (n:Person) WHERE confidence(n) >= 0.90 AS OF VALID_TIME '{t1}' RETURN n"),
+    );
+    assert!(
+        before.is_empty(),
+        "at T1 confidence was 0.50, got: {before:?}"
+    );
+
+    // AS OF valid_time >= T2: confidence is 0.95 -> included by >= 0.9.
+    let after = names(
+        &db,
+        &format!("MATCH (n:Person) WHERE confidence(n) >= 0.90 AS OF VALID_TIME '{t3}' RETURN n"),
+    );
+    assert_eq!(after, vec!["String(\"alice\")"]);
+}
+
+#[test]
+fn as_of_system_time_and_provenance_composition() {
+    // The provenance predicate composes with an explicit SYSTEM_TIME AS OF: at a
+    // transaction-time before any write, nothing is visible; at now, the current
+    // version's provenance is evaluated.
+    let db = make_db();
+    // Far-future system time: current versions are visible; predicate applies.
+    let got = names(
+        &db,
+        "MATCH (n:Person) WHERE source(n) = 'hr-system' AS OF SYSTEM_TIME '2999-01-01T00:00:00Z' RETURN n",
+    );
+    assert_eq!(got, vec!["String(\"alice\")", "String(\"carol\")"]);
+}
+
+/// Parity: the Cypher and AQL surfaces share
+/// `crate::query::converter::lower_provenance_comparison`, so for the same data
+/// and equivalent queries they must return identical result sets. This proves
+/// the two agree (the task's foldable-vs-accessor / cross-surface parity gate).
+#[test]
+fn cypher_aql_parity_over_representative_queries() {
+    let db = make_db();
+    let pairs = [
+        (
+            "MATCH (n:Person) WHERE source(n) = 'hr-system' RETURN n",
+            "MATCH (n:Person) WHERE source(n) = 'hr-system' RETURN n",
+        ),
+        (
+            "MATCH (n:Person) WHERE confidence(n) >= 0.80 RETURN n",
+            "MATCH (n:Person) WHERE confidence(n) >= 0.80 RETURN n",
+        ),
+        (
+            "MATCH (n:Person) WHERE confidence(n) < 0.80 RETURN n",
+            "MATCH (n:Person) WHERE confidence(n) < 0.80 RETURN n",
+        ),
+        (
+            "MATCH (n:Person) WHERE reason(n) <> 'verified' RETURN n",
+            "MATCH (n:Person) WHERE reason(n) <> 'verified' RETURN n",
+        ),
+        (
+            "MATCH (n:Person) WHERE provenance(n) IS NULL RETURN n",
+            "MATCH (n:Person) WHERE provenance(n) IS NULL RETURN n",
+        ),
+        (
+            "MATCH (n:Person) WHERE provenance(n) IS NOT NULL RETURN n",
+            "MATCH (n:Person) WHERE provenance(n) IS NOT NULL RETURN n",
+        ),
+    ];
+    for (cypher, aql) in pairs {
+        let via_cypher = names(&db, cypher);
+        let via_aql = {
+            let results = db.execute_aql(aql).expect("aql executes");
+            let mut out = Vec::new();
+            for row in results.collect_all().expect("collect rows") {
+                if let EntityResult::Node(n) = row.entity
+                    && let Some(v) = n.get_property("name")
+                {
+                    out.push(format!("{v:?}"));
+                }
+            }
+            out.sort();
+            out
+        };
+        assert_eq!(via_cypher, via_aql, "parity mismatch for: {cypher}");
+    }
+}

--- a/tests/cypher_provenance_where.rs
+++ b/tests/cypher_provenance_where.rs
@@ -285,14 +285,39 @@ fn confidence_via_parameter_folds() {
         .expect("query executes");
     let mut got = Vec::new();
     for row in results.collect_all().expect("collect rows") {
-        if let EntityResult::Node(n) = row.entity
-            && let Some(v) = n.get_property("name")
-        {
+        if let Some(v) = match &row.entity {
+            EntityResult::Node(n) => n.get_property("name"),
+            _ => None,
+        } {
             got.push(format!("{v:?}"));
         }
     }
     got.sort();
     assert_eq!(got, vec!["String(\"alice\")", "String(\"carol\")"]);
+}
+
+#[test]
+fn count_star_reflects_provenance_filter_before_aggregation() {
+    use aletheiadb::core::property::PropertyValue;
+    let db = make_db();
+    // The provenance `WHERE` runs BEFORE aggregation: only alice (0.95) clears
+    // `>= 0.9`, so `count(*)` is 1 -- not the 4-row unfiltered total. This locks
+    // the filter-then-aggregate ordering.
+    let results = db
+        .execute_cypher("MATCH (n:Person) WHERE confidence(n) >= 0.9 RETURN count(*)")
+        .expect("query executes");
+    let rows = results.collect_all().expect("collect rows");
+    assert_eq!(rows.len(), 1, "keyless count(*) yields a single global row");
+    let cols = rows[0]
+        .columns
+        .as_ref()
+        .expect("aggregate row carries columns");
+    assert_eq!(cols.len(), 1, "one projected aggregate column");
+    assert_eq!(
+        cols[0].1,
+        PropertyValue::Int(1),
+        "only the provenance-filtered rows are counted"
+    );
 }
 
 #[test]
@@ -450,9 +475,10 @@ fn cypher_aql_parity_over_representative_queries() {
             let results = db.execute_aql(aql).expect("aql executes");
             let mut out = Vec::new();
             for row in results.collect_all().expect("collect rows") {
-                if let EntityResult::Node(n) = row.entity
-                    && let Some(v) = n.get_property("name")
-                {
+                if let Some(v) = match &row.entity {
+                    EntityResult::Node(n) => n.get_property("name"),
+                    _ => None,
+                } {
                     out.push(format!("{v:?}"));
                 }
             }


### PR DESCRIPTION
## Summary

Completes issue **#3354**'s declarative side by exposing write-time
**provenance predicates in the Cypher `WHERE` clause** (v1 — WHERE only, no
RETURN/ORDER-BY projection). Mirrors the AQL side (**#3354a** / **#3562**) and
reuses the **same** shared `Predicate::Provenance` IR + executor evaluation now
on trunk, so this is a small additive `src/cypher` change.

### Final Cypher syntax
```cypher
MATCH (n:Person) WHERE source(n) = 'hr-system' RETURN n
MATCH (n:Person) WHERE confidence(n) >= 0.9 RETURN n
MATCH (n:Person) WHERE reason(n) = 'imported' RETURN n
MATCH (n:Person) WHERE provenance(n) IS NULL RETURN n
MATCH (n:Person) WHERE provenance(n) IS NOT NULL RETURN n
MATCH (n:Person) WHERE 0.9 <= confidence(n) RETURN n           -- accessor on RHS
AS OF VALID_TIME '...' MATCH (n) WHERE confidence(n) >= 0.9 RETURN n  -- per-version
```
Accessors resolve **only** in function-call position (a property `n.source`
stays a property); there is **no** `principal(x)` accessor.

### How the shared #3562 lowering is reused
The surface-agnostic core
`(ProvenanceField, ProvenanceCmp, ProvenanceOperand) -> Predicate` — folding via
`ProvenanceFilter::validated`/`matches`, ordering-op-on-string rejection
(fail-closed), confidence `[0,1]`/NaN validation, type checks — is **factored
into `crate::query::converter::lower_provenance_comparison`** (a shared
`pub(crate)` helper, not a copy). The **AQL** converter is refactored to
delegate to it (byte-identical error wording; the 23-test AQL suite is
unchanged), and the **Cypher** converter calls the same helper. One source of
truth ⇒ the two surfaces cannot drift. A cross-surface **parity** test proves
AQL and Cypher return identical result sets over representative queries.

No parser changes were needed: `source(n)`, `confidence(n) >= 0.9`, and
`provenance(n) IS NULL` already parse as `FunctionCall` / `IsNull(FunctionCall)`.

### Files
- `src/query/converter.rs` — shared `lower_provenance_comparison` +
  `ProvenanceLoweringError`; `provenance_field_name` made `pub(crate)`; AQL
  `build_provenance_comparison` refactored to delegate.
- `src/cypher/converter.rs` — accessor recognition (`as_provenance_accessor`,
  `is_provenance_bundle_accessor`), `build_provenance_comparison`, operand/cmp
  adapters, error mapping; `convert_comparison` + `IsNull`/`IsNotNull` arms.
- `src/mcp/server.rs` — 4 end-to-end/read-only unit tests (no routing change).
- `tests/cypher_provenance_where.rs` — 25 integration tests.

### MCP surface
No routing change: Cypher already routes through the shared executor. Provenance
errors surface via the existing structured vocabulary (type mismatch →
`invalid_params`, ordering-op rejection → `parse_error`), the tool stays
**read-only** (mutating clauses rejected pre-execution), and the tool inventory
golden is unchanged (**46**).

## AC evidence (#3354b)

| Acceptance criterion | Evidence |
|---|---|
| `source(n) = 'x'` filters rows | `source_exact_match_filters_rows` |
| `confidence(n) >= t` inclusive fold | `confidence_inclusive_lower_bound`, `confidence_strict_greater_is_exclusive` |
| `reason(n) = 'r'` | `reason_equality`, `partial_bundle_missing_field_excluded` |
| `provenance(n) IS [NOT] NULL` | `provenance_is_null_selects_unattributed`, `provenance_is_not_null_selects_attributed` |
| Absent/partial provenance excluded | `absent_provenance_excluded_by_confidence`, `partial_bundle_missing_field_excluded` |
| Reject `source(n) < 'x'` (fail-closed) | `ordering_operator_on_source_is_rejected`, `handle_query_cypher_provenance_ordering_op_rejected` |
| confidence NaN / out-of-range rejected | `confidence_out_of_range_is_rejected`, `confidence_nan_via_parameter_is_rejected` |
| Provenance AND/OR-composed with property | `combined_property_and_provenance`, `combined_property_or_provenance` |
| Property `n.source` still a property | `property_named_source_is_not_a_provenance_accessor` |
| AS OF (valid/system-time) per-version | `as_of_evaluates_provenance_at_that_coordinate`, `as_of_system_time_and_provenance_composition` |
| MCP end-to-end via `language:"cypher"` | `handle_query_cypher_provenance_where_filters`, `..._type_mismatch_is_invalid_params` |
| Read-only (no smuggled write) | `handle_query_cypher_provenance_stays_read_only` |
| Foldable-vs-accessor / cross-surface parity | `cypher_aql_parity_over_representative_queries` |
| `cypher` feature off → `language_unavailable` | unchanged (existing behavior) |

## Deferred
- RETURN / ORDER-BY provenance **projection** (v1 is WHERE-only), matching the
  AQL scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01US9RGTLAzSymm8eMtqdt3T

---
_Generated by [Claude Code](https://claude.ai/code/session_01US9RGTLAzSymm8eMtqdt3T)_