### PR TITLE
feat(aletheia-server): Lane B security primitives — resource limits, rate limiter, cursor signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,11 +97,18 @@ dependencies = [
  "aletheiadb",
  "autumn-web 0.5.0",
  "axum",
+ "base64 0.22.1",
+ "governor",
+ "rand 0.8.6",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
+ "subtle",
  "tokio",
  "tower",
  "tower-http",
+ "tower_governor",
+ "zeroize",
 ]
 
 [[package]]
@@ -3146,6 +3153,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,6 +3254,12 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -3702,6 +3725,29 @@ name = "glam"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+
+[[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.4",
+ "smallvec 1.15.1",
+ "spinning_top",
+ "web-time",
+]
 
 [[package]]
 name = "group"
@@ -5195,6 +5241,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6257,6 +6315,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid 11.6.0",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -7587,6 +7660,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8314,6 +8396,22 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower_governor"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44de9b94d849d3c46e06a883d72d408c2de6403367b39df2b1c9d9e7b6736fe6"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "governor",
+ "http 1.4.0",
+ "pin-project",
+ "thiserror 2.0.18",
+ "tower",
+ "tracing",
+]
 
 [[package]]
 name = "tracing"

--- a/crates/aletheia-server/Cargo.toml
+++ b/crates/aletheia-server/Cargo.toml
@@ -26,9 +26,26 @@ axum = { version = "0.8" }
 tower-http = { version = "0.6", features = ["set-header"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.52", features = ["rt-multi-thread", "macros"] }
+# `time` feature: resource_limits' `run_with_timeout` uses `tokio::time::timeout`.
+tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "time"] }
+# Rate-limit primitive (Lane B3). `default-features = false` drops the `tonic`
+# default so only the axum body conversion is compiled in; autumn-web 0.5 /
+# axum 0.8 / tower 0.5 compatible.
+tower_governor = { version = "0.8", default-features = false, features = ["axum"] }
+# Names `governor::middleware::NoOpMiddleware` in `governor_layer`'s return
+# type (tower_governor does not re-export it). Version pinned to tower_governor's.
+governor = "0.10"
+# Cursor-signing primitive (Lane B4): base64url token encoding, SHA-256 for the
+# hand-rolled HMAC (no extra hmac crate — mirrors legacy `src/mcp/cursor.rs`),
+# constant-time MAC compare via subtle, a random per-process secret via rand,
+# and zeroize to wipe the secret on drop. Versions match the main crate.
+base64 = "0.22"
+sha2 = "0.11"
+subtle = "2.6"
+rand = "0.8"
+zeroize = "1"
 
 [dev-dependencies]
-tokio = { version = "1.52", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "time"] }
 # `tower::ServiceExt::oneshot` drives the legacy 0.4 router in parity tests.
 tower = { version = "0.5", features = ["util"] }

--- a/crates/aletheia-server/src/security/auth.rs
+++ b/crates/aletheia-server/src/security/auth.rs
@@ -169,6 +169,28 @@ impl FromRequestParts<AppState> for ApiKeyStore {
     }
 }
 
+/// Per-IP rate-limit settings for the default-**off** `tower-governor` layer
+/// (Lane B3). Present (`Some`) on [`SecurityConfig`](crate::security::SecurityConfig)
+/// only when the operator opts in; the effective switch for
+/// [`governor_layer`](crate::security::rate_limit::governor_layer) is
+/// `SecurityConfig::rate_limit.is_some()`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RateLimitSettings {
+    /// Sustained requests per second replenished per key (per peer IP).
+    pub rps: u64,
+    /// Burst bucket size — the number of requests allowed to arrive at once
+    /// before the per-second replenishment throttles them.
+    pub burst: u32,
+}
+
+impl RateLimitSettings {
+    /// Build settings from a sustained rate and a burst allowance.
+    #[must_use]
+    pub fn new(rps: u64, burst: u32) -> Self {
+        Self { rps, burst }
+    }
+}
+
 /// Authorize an authenticated `principal` for an [`AccessClass`].
 ///
 /// The per-request RBAC decision. On refusal returns

--- a/crates/aletheia-server/src/security/cursor.rs
+++ b/crates/aletheia-server/src/security/cursor.rs
@@ -1,6 +1,450 @@
-// OWNED BY LANE B (security). Scaffold only — do not implement here.
-//
-//! Opaque cursor signing / TTL / per-connection cap (Issue #3360).
+//! Cursor-signing core (Lane B4 / Issue #3360).
 //!
-//! TODO(Lane B): carry the per-process cursor signing secret + TTL/cap registry
-//! in app state and validate resumed cursors here. No cursor support in PR1.
+//! Fills `aletheia-server::security::cursor`. A self-contained mirror of the
+//! legacy #3360 contract (`src/mcp/cursor.rs`): opaque, printable, bounded
+//! **base64url** continuation tokens, **HMAC-SHA256**-signed with a per-process
+//! secret, binding the originating tool identity + the pinned snapshot
+//! bi-temporal coordinate + the keyset/offset position + issued-at/expiry. A
+//! mangled, wrong-secret, or wrong-tool token is rejected with a structured
+//! error and never served wrong data.
+//!
+//! # Cross-connection resume within TTL is by design (#3360)
+//!
+//! The signing secret is **per process**, not per connection: any connection
+//! that presents a valid, unexpired, correct-tool token resumes the scan,
+//! regardless of which connection minted it. This is the documented #3360
+//! property (tokens are stateless bearer continuations bounded only by TTL and
+//! the per-connection live cap), **not** an authorization bypass — every
+//! resumed read is still RBAC-gated by the surface's `Authorized<C>` extractor,
+//! and a token grants no data its bearer could not already read. Binding a
+//! cursor to a single connection is a deliberate non-goal in v1.
+//!
+//! # Error mapping (Issue #3234 codes, at the future MCP/HTTP boundary)
+//!
+//! [`verify_cursor`](CursorSecret::verify_cursor) and
+//! [`LiveCursorRegistry::register`] return a [`CursorError`] the surface layer
+//! maps: [`CursorError::Invalid`] → `INVALID_ARGUMENT` (a caller/tamper fault:
+//! re-issue the original query); [`CursorError::Expired`] and
+//! [`CursorError::CapExceeded`] → `FAILED_PRECONDITION` with remediation
+//! guidance. [`CursorError::class`] names the boundary class so the mapping is
+//! not a substring match. See Issue #3561 §8 (cursor TTL/cap budgets).
+//!
+//! # Lifecycle & statelessness
+//!
+//! The token is **stateless**: everything needed to resume — tool, snapshot,
+//! keyset position, page size, issued-at, expiry, filters — is signed *inside*
+//! the token, so a resume needs no server-side session and no other request
+//! parameters. The expiry is baked in at mint time (`exp = iat + ttl`), so
+//! [`verify_cursor`](CursorSecret::verify_cursor) needs only `now` — TTL is
+//! self-describing. The [`LiveCursorRegistry`] is the *only* in-process state: a
+//! tiny per-connection live-lease count enforcing the concurrency cap, released
+//! by RAII ([`CursorLease`]'s `Drop`) even on panic. Expired cursors pin no
+//! storage — TTL lives in the token, not the registry.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
+use zeroize::Zeroizing;
+
+/// Opaque token prefix and version tag. Bumping the version invalidates old
+/// tokens (they parse-fail cleanly with a structured error). Matches legacy.
+pub const TOKEN_PREFIX: &str = "aletheiadb.cursor.v1.";
+
+/// Hard ceiling on an accepted token's length. A cursor payload is tiny; a
+/// token far larger than this is malformed (or hostile) and is rejected before
+/// any allocation-heavy decode. Matches legacy.
+pub const MAX_TOKEN_LEN: usize = 8 * 1024;
+
+/// The boundary error class a [`CursorError`] maps to (Issue #3234). The future
+/// MCP/HTTP surface reads this instead of matching on the message text.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CursorErrorClass {
+    /// Caller/tamper fault — maps to `INVALID_ARGUMENT` (non-retriable).
+    InvalidArgument,
+    /// Lifecycle fault (expiry / cap) — maps to `FAILED_PRECONDITION`
+    /// (non-retriable) with remediation guidance.
+    FailedPrecondition,
+}
+
+/// A cursor verification / registration failure, structured so the surface
+/// layer maps it to a #3234 code without substring matching.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CursorError {
+    /// Malformed / wrong-prefix / bad base64 / bad signature / wrong version /
+    /// wrong tool. The message names the cause; the class is
+    /// [`CursorErrorClass::InvalidArgument`].
+    Invalid(String),
+    /// The token's embedded TTL has elapsed. Class
+    /// [`CursorErrorClass::FailedPrecondition`]; remediation: re-issue the query.
+    Expired,
+    /// The per-connection live-cursor cap is reached. Class
+    /// [`CursorErrorClass::FailedPrecondition`]; remediation: finish or abandon
+    /// an open scan, or re-issue without a cursor.
+    CapExceeded {
+        /// The configured cap that was hit.
+        max_live_cursors: usize,
+    },
+}
+
+impl CursorError {
+    /// The boundary class this error maps to at the MCP/HTTP surface.
+    #[must_use]
+    pub fn class(&self) -> CursorErrorClass {
+        match self {
+            CursorError::Invalid(_) => CursorErrorClass::InvalidArgument,
+            CursorError::Expired | CursorError::CapExceeded { .. } => {
+                CursorErrorClass::FailedPrecondition
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for CursorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CursorError::Invalid(msg) => write!(f, "{msg}"),
+            CursorError::Expired => write!(
+                f,
+                "cursor has expired; re-issue the original query to start a new scan"
+            ),
+            CursorError::CapExceeded { max_live_cursors } => write!(
+                f,
+                "too many live cursors (cap {max_live_cursors}); finish or abandon an \
+                 open scan, or re-issue the query without a cursor"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CursorError {}
+
+/// The self-describing, signed contents of a cursor token.
+///
+/// Field names are kept terse because the struct is serialized into every token
+/// the client round-trips. Mirrors legacy `super::CursorPayload`, plus an
+/// explicit `exp` so verification is TTL-self-describing (needs only `now`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CursorPayload {
+    /// Payload schema version (matches [`TOKEN_PREFIX`]'s tag).
+    pub v: u8,
+    /// The originating tool name (e.g. `"list_nodes"`). A token minted by one
+    /// tool is rejected if replayed against another.
+    pub tool: String,
+    /// Pinned snapshot valid-time (microseconds since epoch).
+    pub svt: i64,
+    /// Pinned snapshot transaction-time (microseconds since epoch).
+    pub stt: i64,
+    /// Exclusive keyset lower bound: the last id returned on the prior page.
+    /// `None` means "from the beginning" — kept distinct from `Some(0)` because
+    /// ids are 0-based.
+    pub after: Option<u64>,
+    /// Offset fallback for tools whose result order is not a simple id keyset
+    /// (e.g. `traverse`'s DFS order). Snapshot-anchored, so still consistent.
+    pub off: u64,
+    /// Page size carried across the whole scan so every page is the same size.
+    pub limit: usize,
+    /// Issued-at (microseconds since epoch).
+    pub iat: i64,
+    /// Expiry (microseconds since epoch) = `iat + ttl`; authoritative for TTL.
+    pub exp: i64,
+    /// Random per-cursor id; the registry key for cap + reclamation.
+    pub cid: String,
+    /// The discriminating request parameters (label, property filter, edge
+    /// label, direction, ...) so continuation needs no other arguments.
+    pub filters: serde_json::Value,
+}
+
+impl CursorPayload {
+    /// Build the seed of a first-page cursor. `tool`/`iat`/`exp`/`cid` are
+    /// stamped by [`CursorSecret::mint_cursor`]; the keyset position starts at
+    /// the beginning (`after = None`, `off = 0`).
+    #[must_use]
+    pub fn seed(snapshot: (i64, i64), limit: usize, filters: serde_json::Value) -> Self {
+        Self {
+            v: 1,
+            tool: String::new(),
+            svt: snapshot.0,
+            stt: snapshot.1,
+            after: None,
+            off: 0,
+            limit,
+            iat: 0,
+            exp: 0,
+            cid: String::new(),
+            filters,
+        }
+    }
+}
+
+/// Per-process HMAC secret for cursor tokens. Randomized at construction (or
+/// supplied explicitly for deterministic tests), never exposed and never
+/// logged: [`Debug`] is redacted, the bytes are held in a [`Zeroizing`] buffer
+/// (wiped on drop), and there is no accessor for them. Makes tokens unforgeable
+/// and — deliberately — non-durable across a restart (a new process gets a new
+/// secret, so old tokens fail verification and the caller re-issues).
+#[derive(Clone)]
+pub struct CursorSecret {
+    secret: Zeroizing<[u8; 32]>,
+}
+
+impl std::fmt::Debug for CursorSecret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never reveal key material.
+        f.write_str("CursorSecret(<redacted>)")
+    }
+}
+
+impl CursorSecret {
+    /// A fresh secret from the OS CSPRNG. Use in production (one per process).
+    /// This is the **only** production constructor.
+    #[must_use]
+    pub fn random() -> Self {
+        let mut secret = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut secret);
+        Self {
+            secret: Zeroizing::new(secret),
+        }
+    }
+
+    /// Build a secret from explicit bytes. Intended **only** for deterministic
+    /// tests and for callers that derive the secret from an external key
+    /// source; never hard-code a secret in production — use [`random`](Self::random)
+    /// there. `#[doc(hidden)]` so it does not advertise itself as a general
+    /// constructor, while staying `pub` for the crate's integration tests.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn from_bytes(secret: [u8; 32]) -> Self {
+        Self {
+            secret: Zeroizing::new(secret),
+        }
+    }
+
+    /// Mint a signed, opaque token from a seed `payload`, binding `tool_name`,
+    /// stamping `iat = now` and `exp = now + ttl`, and generating a random
+    /// cursor id when the seed does not carry one (a continuation reuses its
+    /// existing `cid`). The returned string is base64url-printable and bounded.
+    #[must_use]
+    pub fn mint_cursor(
+        &self,
+        mut payload: CursorPayload,
+        tool_name: &str,
+        now: i64,
+        ttl: Duration,
+    ) -> String {
+        payload.v = 1;
+        payload.tool = tool_name.to_string();
+        payload.iat = now;
+        let ttl_micros = i64::try_from(ttl.as_micros()).unwrap_or(i64::MAX);
+        payload.exp = now.saturating_add(ttl_micros);
+        if payload.cid.is_empty() {
+            payload.cid = Self::random_id();
+        }
+        self.encode(&payload)
+    }
+
+    /// Decode, verify the signature (constant-time), and lifecycle-check a token
+    /// presented for `expected_tool` at `now`.
+    ///
+    /// # Errors
+    ///
+    /// - [`CursorError::Invalid`] for a malformed / wrong-prefix / bad-base64 /
+    ///   bad-signature (tampered or wrong-secret) / wrong-version / wrong-tool
+    ///   token — a caller/tamper fault (`INVALID_ARGUMENT`);
+    /// - [`CursorError::Expired`] when `now >= exp` (`FAILED_PRECONDITION`).
+    ///
+    /// A verification failure never returns a (wrong) payload.
+    pub fn verify_cursor(
+        &self,
+        token: &str,
+        expected_tool: &str,
+        now: i64,
+    ) -> Result<CursorPayload, CursorError> {
+        if token.len() > MAX_TOKEN_LEN {
+            return Err(Self::invalid("cursor token is too long to be valid"));
+        }
+        let body = token
+            .strip_prefix(TOKEN_PREFIX)
+            .ok_or_else(|| Self::invalid("cursor token has an unrecognized format"))?;
+        let (payload_b64, sig_b64) = body
+            .split_once('.')
+            .ok_or_else(|| Self::invalid("cursor token is malformed (missing signature)"))?;
+
+        let payload_bytes = B64
+            .decode(payload_b64)
+            .map_err(|_| Self::invalid("cursor token payload is not valid base64url"))?;
+        let presented_sig = B64
+            .decode(sig_b64)
+            .map_err(|_| Self::invalid("cursor token signature is not valid base64url"))?;
+
+        // Verify the signature over the exact encoded payload bytes before
+        // trusting anything inside it (reject tampering up front). Constant-time
+        // compare via subtle::ConstantTimeEq so a match/mismatch position is not
+        // timing-observable; unequal lengths yield a `0` Choice.
+        let expected_tag = self.sign(payload_b64.as_bytes());
+        if presented_sig.ct_eq(&expected_tag[..]).unwrap_u8() != 1 {
+            return Err(Self::invalid(
+                "cursor token signature is invalid (tampered or issued by another server)",
+            ));
+        }
+
+        let payload: CursorPayload = serde_json::from_slice(&payload_bytes)
+            .map_err(|_| Self::invalid("cursor token payload is not decodable"))?;
+
+        if payload.v != 1 {
+            return Err(Self::invalid("cursor token version is unsupported"));
+        }
+        if payload.tool != expected_tool {
+            return Err(Self::invalid(&format!(
+                "cursor was issued for tool '{}', not '{}'; re-issue the query with this tool",
+                payload.tool, expected_tool
+            )));
+        }
+        // TTL is authoritative from the embedded expiry, so an expired token is
+        // rejected regardless of any registry state (stateless-safe).
+        if now >= payload.exp {
+            return Err(CursorError::Expired);
+        }
+
+        Ok(payload)
+    }
+
+    /// Encode + sign a fully-stamped payload into an opaque token string.
+    fn encode(&self, payload: &CursorPayload) -> String {
+        let json = serde_json::to_vec(payload).expect("cursor payload serialization is infallible");
+        let payload_b64 = B64.encode(json);
+        let tag = self.sign(payload_b64.as_bytes());
+        let sig_b64 = B64.encode(tag);
+        format!("{TOKEN_PREFIX}{payload_b64}.{sig_b64}")
+    }
+
+    /// HMAC-SHA256 of `msg` under the per-process secret.
+    fn sign(&self, msg: &[u8]) -> [u8; 32] {
+        hmac_sha256(&self.secret, msg)
+    }
+
+    fn random_id() -> String {
+        let mut bytes = [0u8; 12];
+        rand::thread_rng().fill_bytes(&mut bytes);
+        B64.encode(bytes)
+    }
+
+    fn invalid(msg: &str) -> CursorError {
+        CursorError::Invalid(msg.to_string())
+    }
+}
+
+/// HMAC-SHA256 (RFC 2104) using `sha2`. The key is 32 bytes, shorter than
+/// SHA-256's 64-byte block, so it is zero-padded rather than hashed. Mirrors
+/// legacy `src/mcp/cursor.rs::hmac_sha256` (no extra `hmac` crate).
+fn hmac_sha256(key: &[u8; 32], msg: &[u8]) -> [u8; 32] {
+    const BLOCK: usize = 64;
+    let mut ipad = [0x36u8; BLOCK];
+    let mut opad = [0x5cu8; BLOCK];
+    for i in 0..key.len() {
+        ipad[i] ^= key[i];
+        opad[i] ^= key[i];
+    }
+    let mut inner = Sha256::new();
+    inner.update(ipad);
+    inner.update(msg);
+    let inner_digest = inner.finalize();
+
+    let mut outer = Sha256::new();
+    outer.update(opad);
+    outer.update(inner_digest);
+    outer.finalize().into()
+}
+
+/// Shared per-connection live-lease counts. `conn_id -> live lease count`.
+type LiveCounts = Arc<Mutex<HashMap<u64, usize>>>;
+
+/// Per-connection cap on concurrently live cursors (#3360 default 128).
+///
+/// The *only* in-process cursor state: a tiny per-connection count, not any
+/// token or snapshot storage. [`register`](Self::register) admits a scan when
+/// the connection is under the cap and hands back a RAII [`CursorLease`]; the
+/// lease's `Drop` releases the slot — guaranteed even on an early return or a
+/// panic (Rust runs `Drop` as the stack unwinds). A `cap` of `0` means
+/// unbounded (slots are still counted so [`live_count`](Self::live_count) is
+/// observable). Expired cursors pin no storage: TTL is enforced by the token's
+/// embedded expiry, not by this registry.
+#[derive(Clone)]
+pub struct LiveCursorRegistry {
+    cap: usize,
+    live: LiveCounts,
+}
+
+/// RAII lease for one live cursor scan on a connection. Decrements the
+/// connection's live count on drop; hold it for exactly as long as the scan is
+/// resumable.
+#[derive(Debug)]
+pub struct CursorLease {
+    conn_id: u64,
+    live: LiveCounts,
+}
+
+impl Drop for CursorLease {
+    fn drop(&mut self) {
+        let mut live = self.live.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(count) = live.get_mut(&self.conn_id) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                // Reclaim the map slot so an idle connection pins nothing.
+                live.remove(&self.conn_id);
+            }
+        }
+    }
+}
+
+impl LiveCursorRegistry {
+    /// A fresh registry with the given per-connection cap (`0` = unbounded),
+    /// starting empty.
+    #[must_use]
+    pub fn new(cap: usize) -> Self {
+        Self {
+            cap,
+            live: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// The configured per-connection cap.
+    #[must_use]
+    pub fn cap(&self) -> usize {
+        self.cap
+    }
+
+    /// Admit a new live cursor on `conn_id`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CursorError::CapExceeded`] (→ `FAILED_PRECONDITION`) when the
+    /// connection already holds `cap` live cursors.
+    pub fn register(&self, conn_id: u64) -> Result<CursorLease, CursorError> {
+        let mut live = self.live.lock().unwrap_or_else(|e| e.into_inner());
+        let count = live.entry(conn_id).or_insert(0);
+        if self.cap != 0 && *count >= self.cap {
+            return Err(CursorError::CapExceeded {
+                max_live_cursors: self.cap,
+            });
+        }
+        *count += 1;
+        Ok(CursorLease {
+            conn_id,
+            live: self.live.clone(),
+        })
+    }
+
+    /// Number of currently-live leases on `conn_id` (for observability/tests).
+    #[must_use]
+    pub fn live_count(&self, conn_id: u64) -> usize {
+        let live = self.live.lock().unwrap_or_else(|e| e.into_inner());
+        live.get(&conn_id).copied().unwrap_or(0)
+    }
+}

--- a/crates/aletheia-server/src/security/mod.rs
+++ b/crates/aletheia-server/src/security/mod.rs
@@ -16,9 +16,14 @@
 //! - [`init_state`] installs the shared [`ServerAuthState`] extension.
 //! - [`validate_startup`] refuses required-mode startup with zero credentials.
 //! - [`auth::Authorized`] **authenticates and enforces the RBAC class** via
-//!   [`authorize`] (Lane B, this PR): a role that does not permit the handler's
+//!   [`authorize`] (Lane B): a role that does not permit the handler's
 //!   declared `C::CLASS` gets a byte-identical 403.
-//! - [`rate_limit`], [`resource_limits`], [`cursor`] are empty `TODO(Lane B)`.
+//! - [`resource_limits`], [`rate_limit`], [`cursor`] carry the Lane B security
+//!   **primitives** — per-query timeout/row/byte caps + bounded in-flight guard
+//!   (#3542 / #3550), the default-off `tower-governor` rate-limit layer (#3561
+//!   §8), and signed opaque cursor tokens (#3360). They are the building blocks
+//!   the B4 wiring PR mounts via [`apply_security`]; PR1 behavior is unchanged
+//!   until then (rate limiting off, generous caps, no cursor validation wired).
 
 pub mod auth;
 pub mod cursor;
@@ -31,10 +36,12 @@ use autumn_web::auth::RequireApiToken;
 use autumn_web::prelude::AppState as AutumnAppState;
 use autumn_web::test::TestApp;
 use std::sync::Arc;
+use std::time::Duration;
 
 pub use auth::{
     AccessClassMarker, AdminClass, ApiKeyStore, AuthStoreTokenAdapter, Authorized, MetricsClass,
-    ReadClass, ServerAuthState, WriteClass, authorize, authorize_class, extract_credential,
+    RateLimitSettings, ReadClass, ServerAuthState, WriteClass, authorize, authorize_class,
+    extract_credential,
 };
 
 /// Security configuration for the server surface.
@@ -49,13 +56,49 @@ pub struct SecurityConfig {
     pub store: Arc<AuthStore>,
     /// Whether authentication is required or explicitly anonymous.
     pub mode: AuthMode,
+    /// Per-IP rate-limit settings (Lane B3). `None` = **off** (default, parity
+    /// with today). `Some` builds the default-off `tower-governor` layer via
+    /// [`rate_limit::governor_layer`]. The B4 wiring PR mounts the layer.
+    pub rate_limit: Option<RateLimitSettings>,
+    /// Per-query wall-clock timeout (Lane B2, #3542). Generous default (30 s)
+    /// so no existing behavior changes; `Duration::ZERO` = unlimited.
+    pub query_timeout: Duration,
+    /// Cap on rows/entities returned by a single query (Lane B2, #3542). `0` =
+    /// unlimited. Generous default (10_000) mirroring the HTTP `/query`
+    /// surface's `DEFAULT_MAX_RESULT_ROWS`.
+    pub max_result_rows: usize,
+    /// Cap on serialized response bytes of a single query (Lane B2, #3542).
+    /// `0` = unlimited. Generous default (8 MiB) mirroring
+    /// `DEFAULT_MAX_RESPONSE_BYTES`.
+    pub max_response_bytes: usize,
+    /// Max concurrent in-flight timed queries (Lane B2 DoS guard, #3550). `0` =
+    /// unbounded. The cap the [`resource_limits`] in-flight limiter enforces.
+    pub max_in_flight_queries: usize,
+    /// Cursor time-to-live (Lane B4, #3360 default 300 s). Wired at B4.
+    pub cursor_ttl: Duration,
+    /// Max concurrently-live cursors per connection (Lane B4, #3360 default
+    /// 128). Wired at B4.
+    pub max_live_cursors_per_conn: usize,
 }
 
 impl SecurityConfig {
-    /// Build a config from a shared store and mode.
+    /// Build a config from a shared store and mode, with the not-yet-wired
+    /// security primitives at their conservative defaults (rate limiting off,
+    /// 30 s query timeout, 10_000-row / 8-MiB caps, in-flight cap 64, cursor
+    /// TTL 300 s, cursor cap 128).
     #[must_use]
     pub fn new(store: Arc<AuthStore>, mode: AuthMode) -> Self {
-        Self { store, mode }
+        Self {
+            store,
+            mode,
+            rate_limit: None,
+            query_timeout: Duration::from_millis(30_000),
+            max_result_rows: 10_000,
+            max_response_bytes: 8 * 1024 * 1024,
+            max_in_flight_queries: 64,
+            cursor_ttl: Duration::from_secs(300),
+            max_live_cursors_per_conn: 128,
+        }
     }
 }
 

--- a/crates/aletheia-server/src/security/rate_limit.rs
+++ b/crates/aletheia-server/src/security/rate_limit.rs
@@ -1,7 +1,135 @@
-// OWNED BY LANE B (security). Scaffold only — do not implement here.
-//
-//! Per-IP / per-principal rate limiting.
+//! Per-IP rate-limit core (Lane B3).
 //!
-//! TODO(Lane B): mount a `tower-governor` `GovernorLayer` (confirmed to satisfy
-//! autumn 0.5's relaxed `IntoAppLayer`) via `apply_security`. No rate limiting
-//! in PR1.
+//! Fills `aletheia-server::security::rate_limit`. A single, **default-off**
+//! constructor, [`governor_layer`], that turns a [`SecurityConfig`] into an
+//! optional [`tower_governor::GovernorLayer`] — a real `tower::Layer` that
+//! mounts on an autumn-0.5 / axum-0.8 router via `.layer()`.
+//!
+//! # ADR-0055 supersession
+//!
+//! ADR-0055 concluded that a custom tower/middleware rate limiter was
+//! impractical under autumn 0.4, whose sealed `IntoAppLayer` rejected arbitrary
+//! `tower::Layer`s. Under autumn 0.5 that bound is lifted: an arbitrary
+//! `tower::Layer` — including `tower_governor::GovernorLayer` — mounts through
+//! `.layer()`. Rate limiting therefore returns as a **default-off** governor
+//! layer: `governor_layer` yields `None` unless the operator opts in via
+//! [`SecurityConfig::rate_limit`], so default behavior is byte-for-byte today's
+//! (no layer, no `429`s).
+//!
+//! # v1 shape
+//!
+//! Keyed per **peer IP** ([`PeerIpKeyExtractor`]) with the `NoOpMiddleware`
+//! (no extra rate-limit response headers beyond governor's own `retry-after` /
+//! `x-ratelimit-after`). The raw over-limit response is governor's plain `429`
+//! with a `retry-after` header and a text body; B4 wiring wraps that into the
+//! #3234 `{code: "UNAVAILABLE", retriable: true, ...}` envelope (Issue #3561 §8).
+
+use crate::security::SecurityConfig;
+use governor::middleware::NoOpMiddleware;
+use std::sync::Arc;
+use std::time::Duration;
+use tower_governor::GovernorLayer;
+use tower_governor::governor::{GovernorConfig, GovernorConfigBuilder};
+use tower_governor::key_extractor::PeerIpKeyExtractor;
+
+/// The concrete governor layer this core builds: per-peer-IP keying, no extra
+/// middleware, producing `axum::body::Body` error responses (the `axum`-feature
+/// `From<GovernorError> for Response<axum::body::Body>` conversion).
+pub type SpikeGovernorLayer = GovernorLayer<PeerIpKeyExtractor, NoOpMiddleware, axum::body::Body>;
+
+/// The concrete governor config this core builds — the shared, per-peer-IP
+/// keyed `RateLimiter` behind both the mounted [`SpikeGovernorLayer`] and the
+/// [`RateLimit::gc`] housekeeping handle.
+type SpikeGovernorConfig = GovernorConfig<PeerIpKeyExtractor, NoOpMiddleware>;
+
+/// A mounted rate limiter plus the handle needed to garbage-collect its
+/// unbounded per-IP keyed state (F2).
+///
+/// `tower_governor` keys rate-limit state per peer IP in an internal keyed map
+/// that **grows without bound**: every distinct source IP ever seen leaves a
+/// residual entry, and the raw [`GovernorLayer`] exposes no way to reclaim
+/// them. A long-running server keyed on attacker-controlled source IPs would
+/// leak memory indefinitely. This struct pairs the [`layer`](Self::layer) with
+/// [`gc`](Self::gc), which calls the underlying limiter's `retain_recent()` to
+/// evict keys whose state is indistinguishable from fresh (i.e. idle long
+/// enough to no longer affect any decision).
+///
+/// # B4 wiring contract
+///
+/// The [`layer`](Self::layer) is `move`d onto the router via `.layer(...)`, but
+/// the `RateLimit` (holding the shared config `Arc`) must be **retained** by
+/// `apply_security` so it can drive GC. B4 must call [`gc`](Self::gc)
+/// periodically — e.g. from a guarded background task on a coarse interval
+/// (retention is only ever a memory optimisation, never a correctness
+/// requirement, so a slow cadence such as once per minute is fine). GC shares
+/// the limiter with the live layer (same `Arc`), so eviction is immediately
+/// reflected by in-flight requests.
+pub struct RateLimit {
+    /// The mounted `tower::Layer`. Move this onto the router via `.layer(..)`.
+    pub layer: SpikeGovernorLayer,
+    /// The shared config behind the layer, retained so [`gc`](Self::gc) can
+    /// reach the same keyed limiter the mounted layer uses.
+    config: Arc<SpikeGovernorConfig>,
+}
+
+impl RateLimit {
+    /// Garbage-collect stale per-IP keyed state (the F2 unbounded-growth fix).
+    ///
+    /// Delegates to the underlying keyed `RateLimiter::retain_recent()`, which
+    /// drops every key whose rate-limit state is indistinguishable from a fresh
+    /// (never-seen) key — i.e. IPs idle long enough that retaining them changes
+    /// no future decision. Safe to call at any time and **idempotent**: calling
+    /// it again with no intervening traffic is a no-op. B4 should call this on
+    /// a periodic schedule (see the type-level "B4 wiring contract").
+    pub fn gc(&self) {
+        self.config.limiter().retain_recent();
+    }
+
+    /// The number of "live" per-IP keys currently retained in the limiter's
+    /// state store. Primarily an observability/testing hook for [`gc`](Self::gc)
+    /// (this is the count that shrinks after eviction). May be an estimate under
+    /// concurrent traffic, per governor's own `RateLimiter::len` contract.
+    #[must_use]
+    pub fn live_keys(&self) -> usize {
+        self.config.limiter().len()
+    }
+}
+
+/// Build the per-IP rate-limit layer from a [`SecurityConfig`], **default-off**.
+///
+/// Returns `None` (no layer, today's behavior) unless
+/// [`SecurityConfig::rate_limit`] is `Some`. When enabled it builds a
+/// [`GovernorConfigBuilder`] with the configured sustained rate
+/// ([`RateLimitSettings::rps`](crate::security::RateLimitSettings::rps)) and
+/// burst allowance
+/// ([`RateLimitSettings::burst`](crate::security::RateLimitSettings::burst)),
+/// returning `None` if the resulting quota is invalid (e.g. a zero rate).
+///
+/// The returned [`RateLimit`] carries both the mountable [`RateLimit::layer`]
+/// and the [`RateLimit::gc`] handle B4 must drive to bound the per-IP keyed
+/// state (F2). Default-off is preserved: this is still `Option`, still `None`
+/// unless the operator opts in.
+#[must_use]
+pub fn governor_layer(cfg: &SecurityConfig) -> Option<RateLimit> {
+    let settings = cfg.rate_limit?;
+    // Map the sustained rate `rps` (requests/second) onto governor's per-cell
+    // *replenishment period* correctly. `GovernorConfigBuilder::per_second(n)`
+    // is a misnomer: it sets the period to `n` SECONDS (rate = 1/n req/s), so
+    // `per_second(rps)` inverts the intent — `rps=100` would mean one request
+    // every 100s. The correct period between replenished cells is `1/rps`
+    // seconds = `1_000_000_000 / rps` nanoseconds. `rps == 0` is an invalid
+    // (zero) rate → no layer.
+    if settings.rps == 0 {
+        return None;
+    }
+    let period = Duration::from_nanos(1_000_000_000 / settings.rps);
+    let mut builder = GovernorConfigBuilder::default();
+    builder.period(period).burst_size(settings.burst);
+    // Retain the config `Arc` alongside the layer: the mounted layer and the
+    // `gc()` handle share the SAME keyed limiter, so eviction reaches the live
+    // state. `GovernorLayer::new` accepts `impl Into<Arc<GovernorConfig>>`; an
+    // `Arc` is passed through by identity.
+    let config = Arc::new(builder.finish()?);
+    let layer = GovernorLayer::new(config.clone());
+    Some(RateLimit { layer, config })
+}

--- a/crates/aletheia-server/src/security/resource_limits.rs
+++ b/crates/aletheia-server/src/security/resource_limits.rs
@@ -1,7 +1,305 @@
-// OWNED BY LANE B (security). Scaffold only — do not implement here.
-//
-//! In-flight-query cap and per-query resource limits.
+//! Per-query resource-limits core (Lane B2).
 //!
-//! TODO(Lane B): port the in-flight worker cap (`ConcurrencyLimit`) and the
-//! per-query timeout/row/byte limits (Issue #3368) into the shared handler
-//! path. No resource limiting in PR1.
+//! Fills `aletheia-server::security::resource_limits`. Four pieces, all reusing
+//! AletheiaDB's shared [`AletheiaHttpError`] envelope — so the wire mapping
+//! (429 timeout / 413 too-large / 503 at-capacity) is inherited verbatim from
+//! the HTTP `/query` surface (Issue #3542 / #3550), not reinvented:
+//!
+//! 1. [`ResourceLimits`] — the per-query caps view (timeout, row cap, byte cap,
+//!    in-flight cap) sourced from [`SecurityConfig`].
+//! 2. [`run_with_timeout`] — the async per-query wall-clock timeout wrapper.
+//!    On deadline it returns the reused `429 RESOURCE_EXHAUSTED`
+//!    (`WallClockTimeout`) error, mirroring `src/http` and #3542. The
+//!    `retriable` flag is `!is_write` (#3368 MUST-FIX-1): a read-class timeout
+//!    is transient/retriable, a write-class timeout is non-retriable (the write
+//!    may already have committed). (The MCP surface labels the same condition
+//!    `UNAVAILABLE`; here we reuse the HTTP envelope, whose timeout dimension is
+//!    429, as the source of truth.)
+//! 3. [`check_row_cap`] / [`check_byte_cap`] — the too-large `413` helpers,
+//!    matching `src/http`'s `ResultRows` / `ResultBytes` dimensions.
+//! 4. [`InFlightLimiter`] + [`InFlightGuard`] — the bounded in-flight-query DoS
+//!    guard, an `Arc<AtomicUsize>` + RAII guard mirroring
+//!    `src/http/state.rs::InFlightCounter` (#3550) exactly: a CAS-loop acquire
+//!    that can never leak a slot, and a `Drop` that releases the slot even on
+//!    an early return or a panic (RAII survives unwind).
+
+use crate::security::SecurityConfig;
+use aletheiadb::http::{AletheiaHttpError, LimitDimension, ResourceLimitExceeded};
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+/// The concrete per-query caps in force for one surface, sourced from
+/// [`SecurityConfig`]. A `0`/`Duration::ZERO` value on any dimension means
+/// "unlimited", consistent with the HTTP `EffectiveQueryLimits` convention.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ResourceLimits {
+    /// Per-query wall-clock timeout (`Duration::ZERO` = unlimited).
+    pub timeout: Duration,
+    /// Cap on rows/entities in a result (`0` = unlimited).
+    pub max_result_rows: usize,
+    /// Cap on serialized response bytes (`0` = unlimited).
+    pub max_response_bytes: usize,
+    /// Cap on concurrently-live timed-query workers (`0` = unbounded).
+    pub in_flight_cap: usize,
+}
+
+impl ResourceLimits {
+    /// Read the caps from a [`SecurityConfig`].
+    #[must_use]
+    pub fn from_config(cfg: &SecurityConfig) -> Self {
+        Self {
+            timeout: cfg.query_timeout,
+            max_result_rows: cfg.max_result_rows,
+            max_response_bytes: cfg.max_response_bytes,
+            in_flight_cap: cfg.max_in_flight_queries,
+        }
+    }
+
+    /// Build the [`InFlightLimiter`] this config's in-flight cap implies.
+    #[must_use]
+    pub fn in_flight_limiter(&self) -> InFlightLimiter {
+        InFlightLimiter::new(self.in_flight_cap)
+    }
+}
+
+/// Construct the reused wall-clock-timeout error: a `429 RESOURCE_EXHAUSTED`
+/// carrying the effective timeout (in ms) in the `WallClockTimeout` dimension.
+/// `retriable` is `!is_write`: a read-class timeout is transient (retriable), a
+/// write-class timeout is non-retriable (it may already have committed — the
+/// same classification `src/http::enforce_query_limits` uses, #3368 MUST-FIX-1).
+#[must_use]
+pub fn timeout_error(timeout: Duration, is_write: bool) -> AletheiaHttpError {
+    AletheiaHttpError::ResourceLimitExceeded(ResourceLimitExceeded {
+        dimension: LimitDimension::WallClockTimeout,
+        limit: u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX),
+        consumed: None,
+        // #3368 MUST-FIX-1: a read-class timeout is transient (retriable), but a
+        // write-class timeout may already have committed — retrying risks a
+        // duplicate write, so it must be non-retriable. Mirrors legacy
+        // `src/http/handlers.rs::enforce_query_limits` (`retriable: !is_write`).
+        retriable: !is_write,
+    })
+}
+
+/// Construct the reused row-cap error: a **non-retriable** `413` in the
+/// `ResultRows` dimension. `limit` is the effective cap, `consumed` the row
+/// count that exceeded it.
+#[must_use]
+pub fn row_cap_error(limit: usize, consumed: usize) -> AletheiaHttpError {
+    AletheiaHttpError::ResourceLimitExceeded(ResourceLimitExceeded {
+        dimension: LimitDimension::ResultRows,
+        limit: limit as u64,
+        consumed: Some(consumed as u64),
+        retriable: false,
+    })
+}
+
+/// Construct the reused byte-cap error: a **non-retriable** `413` in the
+/// `ResultBytes` dimension. `limit` is the effective cap, `consumed` the
+/// serialized byte size that exceeded it.
+#[must_use]
+pub fn byte_cap_error(limit: usize, consumed: usize) -> AletheiaHttpError {
+    AletheiaHttpError::ResourceLimitExceeded(ResourceLimitExceeded {
+        dimension: LimitDimension::ResultBytes,
+        limit: limit as u64,
+        consumed: Some(consumed as u64),
+        retriable: false,
+    })
+}
+
+/// Run `fut` under a per-query wall-clock deadline.
+///
+/// A `Duration::ZERO` timeout means **unlimited**: `fut` runs inline with no
+/// deadline (no timer task is armed). Otherwise the future races the deadline;
+/// on the deadline it resolves to the reused [`timeout_error`], whose
+/// `retriable` flag is `!is_write` (read-class retriable, write-class not).
+///
+/// `is_write` classifies the guarded op: pass `true` for a write-path query so
+/// a deadline that fires after a possible commit is reported non-retriable
+/// (#3368 MUST-FIX-1), `false` for a read-path query.
+///
+/// Note the deadline bounds only the *await*; a synchronous, non-cancellable
+/// body is not interrupted (mirroring the HTTP/MCP surfaces, which pair this
+/// with the [`InFlightLimiter`] to bound the still-running worker count).
+///
+/// # Errors
+///
+/// Returns [`AletheiaHttpError::ResourceLimitExceeded`] (`WallClockTimeout`;
+/// `retriable = !is_write`) when the deadline elapses before `fut` resolves.
+pub async fn run_with_timeout<F, T>(
+    timeout: Duration,
+    is_write: bool,
+    fut: F,
+) -> Result<T, AletheiaHttpError>
+where
+    F: Future<Output = T>,
+{
+    if timeout.is_zero() {
+        return Ok(fut.await);
+    }
+    match tokio::time::timeout(timeout, fut).await {
+        Ok(value) => Ok(value),
+        Err(_elapsed) => Err(timeout_error(timeout, is_write)),
+    }
+}
+
+/// Enforce the row cap: `Ok` when `count <= max` (or `max == 0`, unlimited),
+/// else the reused non-retriable `413` [`row_cap_error`]. The boundary is
+/// inclusive — a result of exactly `max` rows is within budget.
+///
+/// # Errors
+///
+/// Returns [`AletheiaHttpError::ResourceLimitExceeded`] (`ResultRows`) when
+/// `count` exceeds a finite `max`.
+pub fn check_row_cap(count: usize, max: usize) -> Result<(), AletheiaHttpError> {
+    if max != 0 && count > max {
+        Err(row_cap_error(max, count))
+    } else {
+        Ok(())
+    }
+}
+
+/// Enforce the byte cap against a **caller-supplied** byte count: `Ok` when
+/// `bytes <= max` (or `max == 0`, unlimited), else the reused non-retriable
+/// `413` [`byte_cap_error`]. The boundary is inclusive.
+///
+/// **This helper trusts `bytes`.** If the caller measures anything other than
+/// the exact serialized response (e.g. a partial payload, a pre-envelope body,
+/// or a `count` field), it undercounts and an over-cap response slips through.
+/// Prefer [`check_byte_cap_of`], which serializes and measures the full value
+/// itself, whenever you hold the value to be returned.
+///
+/// # Errors
+///
+/// Returns [`AletheiaHttpError::ResourceLimitExceeded`] (`ResultBytes`) when
+/// `bytes` exceeds a finite `max`.
+pub fn check_byte_cap(bytes: usize, max: usize) -> Result<(), AletheiaHttpError> {
+    if max != 0 && bytes > max {
+        Err(byte_cap_error(max, bytes))
+    } else {
+        Ok(())
+    }
+}
+
+/// Enforce the byte cap by serializing the **full** `value` and measuring the
+/// real serialized length — the undercount-proof counterpart to
+/// [`check_byte_cap`] (F4). Mirrors `src/http/handlers.rs`, which caps against
+/// `serde_json::to_vec(&body)` (the exact wire bytes), never a caller estimate.
+///
+/// Returns the true serialized byte length on success (`Ok(len)`, useful when
+/// the caller then writes those same bytes), or the reused non-retriable `413`
+/// [`byte_cap_error`] (`ResultBytes`, `consumed` = the full serialized length)
+/// when it exceeds a finite `max`. A `max` of `0` means unlimited (the value is
+/// still serialized to report its length). The boundary is inclusive.
+///
+/// # Errors
+///
+/// Returns [`AletheiaHttpError::ResourceLimitExceeded`] (`ResultBytes`) when the
+/// serialized length exceeds a finite `max`, or [`AletheiaHttpError::Internal`]
+/// if `value` fails to serialize (mirroring the HTTP surface's serialize-error
+/// path).
+pub fn check_byte_cap_of<T: serde::Serialize>(
+    value: &T,
+    max: usize,
+) -> Result<usize, AletheiaHttpError> {
+    let len = serde_json::to_vec(value)
+        .map_err(|e| AletheiaHttpError::Internal(format!("failed to serialize response: {e}")))?
+        .len();
+    if max != 0 && len > max {
+        Err(byte_cap_error(max, len))
+    } else {
+        Ok(len)
+    }
+}
+
+/// Bounded in-flight-query admission control (Issue #3550 DoS guard).
+///
+/// An `Arc<AtomicUsize>` of live workers plus a `cap`, mirroring
+/// `src/http/state.rs::InFlightCounter` (#3550): a CAS-loop acquire that at the
+/// cap rejects with a retriable `503 UNAVAILABLE` rather than admitting another
+/// worker, and an RAII [`InFlightGuard`] that releases the slot on drop — which
+/// is guaranteed even on an early return or a panic (Rust runs `Drop` as the
+/// stack unwinds). A `cap` of `0` means unbounded (slots are still counted so
+/// [`live`](Self::live) is observable).
+#[derive(Clone)]
+pub struct InFlightLimiter {
+    count: Arc<AtomicUsize>,
+    cap: usize,
+}
+
+/// RAII slot in the bounded in-flight pool. Decrements the shared counter on
+/// drop; hold it for exactly as long as the work it guards is live.
+#[derive(Debug)]
+pub struct InFlightGuard {
+    count: Arc<AtomicUsize>,
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        self.count.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+impl InFlightLimiter {
+    /// A fresh limiter with the given cap (`0` = unbounded), starting empty.
+    #[must_use]
+    pub fn new(cap: usize) -> Self {
+        Self {
+            count: Arc::new(AtomicUsize::new(0)),
+            cap,
+        }
+    }
+
+    /// Build a limiter from a [`SecurityConfig`]'s in-flight cap.
+    #[must_use]
+    pub fn from_config(cfg: &SecurityConfig) -> Self {
+        Self::new(cfg.max_in_flight_queries)
+    }
+
+    /// Try to reserve a slot.
+    ///
+    /// Returns `Ok(guard)` on success (the guard releases the slot on drop), or
+    /// the reused [`AletheiaHttpError::InFlightCapacityExceeded`] (retriable
+    /// `503`) when the pool is already at `cap`. A `cap` of `0` always admits.
+    /// Uses a CAS loop so a spurious over-count can never leak a slot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AletheiaHttpError::InFlightCapacityExceeded`] when the pool is
+    /// full.
+    pub fn try_acquire(&self) -> Result<InFlightGuard, AletheiaHttpError> {
+        let mut current = self.count.load(Ordering::Acquire);
+        loop {
+            if self.cap != 0 && current >= self.cap {
+                return Err(AletheiaHttpError::InFlightCapacityExceeded { cap: self.cap });
+            }
+            match self.count.compare_exchange_weak(
+                current,
+                current + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    return Ok(InFlightGuard {
+                        count: Arc::clone(&self.count),
+                    });
+                }
+                Err(actual) => current = actual,
+            }
+        }
+    }
+
+    /// Current number of live in-flight slots.
+    #[must_use]
+    pub fn live(&self) -> usize {
+        self.count.load(Ordering::Acquire)
+    }
+
+    /// The configured cap (`0` = unbounded).
+    #[must_use]
+    pub fn cap(&self) -> usize {
+        self.cap
+    }
+}

--- a/crates/aletheia-server/tests/security_cursor.rs
+++ b/crates/aletheia-server/tests/security_cursor.rs
@@ -1,0 +1,234 @@
+//! RED→GREEN tests for the seam-independent cursor-signing core (Lane B4 /
+//! Issue #3360).
+//!
+//! Mirrors the legacy #3360 contract (`src/mcp/cursor.rs`): an opaque, printable,
+//! bounded base64url token, HMAC-SHA256-signed with a per-process secret, binding
+//! the tool identity + snapshot bi-temporal coordinate + keyset/offset +
+//! issued-at/expiry. Tampered / wrong-secret / wrong-tool tokens map to
+//! `INVALID_ARGUMENT`; expiry and the per-connection live-cursor cap map to
+//! `FAILED_PRECONDITION` (see Issue #3561 §8: cursor TTL/cap budgets).
+
+use std::time::Duration;
+
+use aletheia_server::security::cursor::{
+    CursorError, CursorErrorClass, CursorPayload, CursorSecret, LiveCursorRegistry, MAX_TOKEN_LEN,
+    TOKEN_PREFIX,
+};
+
+const NOW: i64 = 1_000_000;
+const TTL: Duration = Duration::from_secs(300);
+
+fn secret() -> CursorSecret {
+    // Deterministic, explicit secret bytes — never a time/RNG-derived value in
+    // tests, so round-trips are reproducible.
+    CursorSecret::from_bytes([7u8; 32])
+}
+
+fn seed() -> CursorPayload {
+    CursorPayload::seed((1_000, 2_000), 10, serde_json::json!({ "label": "Person" }))
+}
+
+// 1. Round-trip: mint then verify with same tool/secret/within-TTL → Ok, matches.
+#[test]
+fn round_trips_a_valid_token() {
+    let s = secret();
+    let token = s.mint_cursor(seed(), "list_nodes", NOW, TTL);
+    let p = s
+        .verify_cursor(&token, "list_nodes", NOW + 1_000_000)
+        .expect("verify within TTL");
+    assert_eq!(p.tool, "list_nodes");
+    assert_eq!(p.svt, 1_000);
+    assert_eq!(p.stt, 2_000);
+    assert_eq!(p.limit, 10);
+    assert_eq!(p.filters["label"], "Person");
+    assert!(!p.cid.is_empty(), "mint stamps a cursor id");
+    assert_eq!(p.iat, NOW, "mint stamps issued-at");
+    assert_eq!(
+        p.exp,
+        NOW + TTL.as_micros() as i64,
+        "mint stamps expiry = iat + ttl"
+    );
+}
+
+// 2. Tamper / garbage / truncated / non-base64 → Invalid (INVALID_ARGUMENT), never panic.
+#[test]
+fn tampered_payload_is_invalid_argument() {
+    let s = secret();
+    let token = s.mint_cursor(seed(), "list_nodes", NOW, TTL);
+    let body = token.strip_prefix(TOKEN_PREFIX).unwrap();
+    let (payload_b64, sig_b64) = body.split_once('.').unwrap();
+    let mut chars: Vec<char> = payload_b64.chars().collect();
+    let idx = chars.len() / 2;
+    chars[idx] = if chars[idx] == 'A' { 'B' } else { 'A' };
+    let mutated: String = chars.into_iter().collect();
+    let tampered = format!("{TOKEN_PREFIX}{mutated}.{sig_b64}");
+
+    let err = s
+        .verify_cursor(&tampered, "list_nodes", NOW)
+        .expect_err("tampered token must be rejected");
+    assert!(matches!(err, CursorError::Invalid(_)));
+    assert_eq!(err.class(), CursorErrorClass::InvalidArgument);
+}
+
+#[test]
+fn garbage_tokens_are_invalid_argument_never_panic() {
+    let s = secret();
+    for bad in [
+        "",
+        "not-a-cursor",
+        "aletheiadb.cursor.v1.@@@.@@@",
+        "aletheiadb.cursor.v1.onlyonesegment",
+        TOKEN_PREFIX,
+        "aletheiadb.cursor.v1.", // prefix with empty body
+    ] {
+        let err = s
+            .verify_cursor(bad, "list_nodes", NOW)
+            .expect_err("garbage must be rejected");
+        assert_eq!(
+            err.class(),
+            CursorErrorClass::InvalidArgument,
+            "token {bad:?} should be INVALID_ARGUMENT"
+        );
+    }
+}
+
+// 3. Wrong tool: minted for A, verified for B → Invalid.
+#[test]
+fn cross_tool_replay_is_invalid_argument() {
+    let s = secret();
+    let token = s.mint_cursor(seed(), "list_nodes", NOW, TTL);
+    let err = s
+        .verify_cursor(&token, "find_nodes_at_time", NOW)
+        .expect_err("cross-tool replay must be rejected");
+    assert_eq!(err.class(), CursorErrorClass::InvalidArgument);
+}
+
+// 4. Wrong secret / restart: a different secret cannot verify the token.
+#[test]
+fn token_does_not_survive_a_secret_change() {
+    let a = secret();
+    let b = CursorSecret::from_bytes([9u8; 32]);
+    let token = a.mint_cursor(seed(), "list_nodes", NOW, TTL);
+    let err = b
+        .verify_cursor(&token, "list_nodes", NOW)
+        .expect_err("a different secret must not verify");
+    assert_eq!(err.class(), CursorErrorClass::InvalidArgument);
+}
+
+// 5. Expiry: now past issued_at+ttl → Expired (FAILED_PRECONDITION).
+#[test]
+fn expired_cursor_is_failed_precondition() {
+    let s = secret();
+    let token = s.mint_cursor(seed(), "list_nodes", NOW, TTL);
+    let past_ttl = NOW + TTL.as_micros() as i64 + 1;
+    let err = s
+        .verify_cursor(&token, "list_nodes", past_ttl)
+        .expect_err("expired token must be rejected");
+    assert!(matches!(err, CursorError::Expired));
+    assert_eq!(err.class(), CursorErrorClass::FailedPrecondition);
+
+    // Exactly at expiry is expired (exclusive TTL boundary).
+    let at_exp = NOW + TTL.as_micros() as i64;
+    assert!(matches!(
+        s.verify_cursor(&token, "list_nodes", at_exp),
+        Err(CursorError::Expired)
+    ));
+}
+
+// 6. Constant-time MAC: assert the comparison uses subtle::ConstantTimeEq
+//    (usage test; a naive `==` on the tag would be a timing leak).
+#[test]
+fn mac_comparison_uses_constant_time_eq() {
+    let src = include_str!("../src/security/cursor.rs");
+    assert!(
+        src.contains("use subtle::") && src.contains(".ct_eq("),
+        "MAC tag comparison must go through subtle::ConstantTimeEq (.ct_eq)"
+    );
+    assert!(
+        !src.contains("sig == expected") && !src.contains("expected == sig"),
+        "MAC tag must not be compared with a variable-time `==`"
+    );
+}
+
+// 7. Registry cap: register up to N ok; N+1 → FAILED_PRECONDITION; RAII release
+//    frees a slot; release survives a panic.
+#[test]
+fn registry_enforces_per_connection_cap() {
+    let reg = LiveCursorRegistry::new(2);
+    let conn = 42u64;
+    let a = reg.register(conn).expect("first lease");
+    let _b = reg.register(conn).expect("second lease");
+    assert_eq!(reg.live_count(conn), 2);
+
+    let err = reg.register(conn).expect_err("cap exceeded");
+    assert!(matches!(
+        err,
+        CursorError::CapExceeded {
+            max_live_cursors: 2
+        }
+    ));
+    assert_eq!(err.class(), CursorErrorClass::FailedPrecondition);
+
+    // A different connection has its own budget.
+    let _other = reg.register(7).expect("separate connection unaffected");
+
+    // RAII release frees a slot.
+    drop(a);
+    assert_eq!(reg.live_count(conn), 1);
+    let _c = reg.register(conn).expect("slot freed by drop");
+    assert_eq!(reg.live_count(conn), 2);
+}
+
+#[test]
+fn registry_releases_the_slot_on_panic() {
+    let reg = std::sync::Arc::new(LiveCursorRegistry::new(1));
+    let conn = 5u64;
+    let reg2 = reg.clone();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _lease = reg2.register(conn).expect("lease before panic");
+        assert_eq!(reg2.live_count(conn), 1);
+        panic!("boom while holding a lease");
+    }));
+    assert!(result.is_err(), "the closure panicked");
+    // The lease's Drop ran during unwind, so the slot is free again.
+    assert_eq!(reg.live_count(conn), 0);
+    let _fresh = reg.register(conn).expect("slot reclaimed after panic");
+}
+
+// 8. Bounded / printable: minted token is base64url-printable and under the bound.
+#[test]
+fn token_is_printable_and_bounded() {
+    let s = secret();
+    let token = s.mint_cursor(seed(), "list_nodes", NOW, TTL);
+    assert!(token.starts_with(TOKEN_PREFIX));
+    assert!(token.len() < MAX_TOKEN_LEN, "token must be bounded");
+    assert!(
+        token
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.')),
+        "token must be printable + escape-free, got {token}"
+    );
+}
+
+// 9. Secret never logged / never Debug-leaked.
+#[test]
+fn secret_is_never_logged_or_debug_leaked() {
+    let src = include_str!("../src/security/cursor.rs");
+    for banned in ["println!", "eprintln!", "dbg!", "print!", "eprint!"] {
+        assert!(
+            !src.contains(banned),
+            "cursor core must not contain `{banned}` (secret-leak risk)"
+        );
+    }
+    // Debug is redacted: printing the secret reveals no key bytes.
+    let s = CursorSecret::from_bytes([0xABu8; 32]);
+    let dbg = format!("{s:?}");
+    assert!(
+        dbg.contains("redacted"),
+        "CursorSecret Debug must be redacted, got {dbg}"
+    );
+    assert!(
+        !dbg.contains("171") && !dbg.contains("ab") && !dbg.contains("AB"),
+        "CursorSecret Debug must not print key bytes, got {dbg}"
+    );
+}

--- a/crates/aletheia-server/tests/security_rate_limit.rs
+++ b/crates/aletheia-server/tests/security_rate_limit.rs
@@ -1,0 +1,282 @@
+//! Seam-independent acceptance tests for the Lane B3 rate-limit core (autumn
+//! migration §8 / Issue #3561 AC: default-off per-IP `tower-governor` layer,
+//! 429 on over-limit).
+//!
+//! Proves two things the proving ground exists to prove:
+//!   1. **Default-off parity** — a conservative `SecurityConfig` yields no
+//!      layer (`governor_layer(..) == None`), so a router built without it
+//!      never 429s (today's behavior, unchanged).
+//!   2. **The real `GovernorLayer` mounts and runs** on an axum 0.8 / tower 0.5
+//!      `Router` via `.layer()` and enforces the configured rate — superseding
+//!      ADR-0055's "custom middleware impractical under autumn 0.4" finding.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use aletheia_server::security::rate_limit::governor_layer;
+use aletheia_server::security::{RateLimitSettings, SecurityConfig};
+use aletheiadb::auth::{AuthMode, AuthStore};
+
+use axum::Router;
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::{Request, StatusCode};
+use axum::routing::get;
+use tower::ServiceExt; // oneshot
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// A conservative-default `SecurityConfig` (store-first `new` in the re-homed
+/// crate).
+fn config() -> SecurityConfig {
+    SecurityConfig::new(Arc::new(AuthStore::new()), AuthMode::Required)
+}
+
+/// A `GET /` request carrying a `ConnectInfo` peer IP (what
+/// `PeerIpKeyExtractor` keys on). Driving via `oneshot` bypasses the server's
+/// `into_make_service_with_connect_info`, so the extension is inserted by hand.
+fn req_from(ip: [u8; 4]) -> Request<Body> {
+    let mut r = Request::builder()
+        .uri("/")
+        .body(Body::empty())
+        .expect("valid request");
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::from(ip)), 9999);
+    r.extensions_mut().insert(ConnectInfo(addr));
+    r
+}
+
+fn router_with_layer(cfg: &SecurityConfig) -> Router {
+    let rl = governor_layer(cfg).expect("rate limiting is enabled for this config");
+    Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(rl.layer)
+}
+
+// ---------------------------------------------------------------------------
+// (1) Default-OFF parity — always-on, never flaky
+// ---------------------------------------------------------------------------
+
+#[test]
+fn default_config_yields_no_layer() {
+    let cfg = config();
+    assert!(cfg.rate_limit.is_none(), "rate limiting is off by default");
+    assert!(
+        governor_layer(&cfg).is_none(),
+        "no layer is built unless the operator opts in"
+    );
+}
+
+#[tokio::test]
+async fn router_without_layer_never_rate_limits() {
+    // A router built the default way (no governor layer) serves every request
+    // 200, no matter how many arrive back-to-back from one IP.
+    let app = Router::new().route("/", get(|| async { "ok" }));
+    for _ in 0..25 {
+        let resp = app
+            .clone()
+            .oneshot(req_from([127, 0, 0, 1]))
+            .await
+            .expect("router responds");
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (2) Enabled: the real GovernorLayer mounts and enforces the rate
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn enabled_under_limit_request_succeeds() {
+    let mut cfg = config();
+    cfg.rate_limit = Some(RateLimitSettings::new(1, 1));
+    let app = router_with_layer(&cfg);
+
+    // The first (only) request from an IP is within the burst budget → 200.
+    let resp = app
+        .oneshot(req_from([10, 0, 0, 1]))
+        .await
+        .expect("layer passes the request through");
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+/// Over-limit → 429. Uses burst=1 + an immediate second request from the same
+/// IP. If the quanta clock proves flaky under the sandbox scheduler, `#[ignore]`
+/// this one — the default-off test above remains the always-on guarantee.
+#[tokio::test]
+async fn enabled_over_limit_request_is_rejected_429() {
+    let mut cfg = config();
+    cfg.rate_limit = Some(RateLimitSettings::new(1, 1));
+    let app = router_with_layer(&cfg);
+
+    // Burst budget of 1: the first request consumes the single cell.
+    let first = app
+        .clone()
+        .oneshot(req_from([10, 0, 0, 2]))
+        .await
+        .expect("first request served");
+    assert_eq!(first.status(), StatusCode::OK);
+
+    // The immediate second request from the same IP (no time for the 1/s
+    // replenishment) is throttled.
+    let second = app
+        .clone()
+        .oneshot(req_from([10, 0, 0, 2]))
+        .await
+        .expect("second request served");
+    assert_eq!(
+        second.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "over-limit request must be 429"
+    );
+}
+
+/// F1 regression (rate-mapping inversion): with `rps=5, burst=5` the layer must
+/// admit a burst of 5, reject the 6th immediate request (429), and — crucially —
+/// **replenish** a cell after roughly one period (1/rps = 200ms) so a later
+/// request passes again. The historical bug mapped `rps` onto the replenishment
+/// *period in seconds* (`per_second(rps)`), so `rps=5` meant "one cell every 5s":
+/// the burst/429 half coincidentally held, but no cell replenished within 220ms,
+/// so the post-sleep request stayed 429. This test pins the replenishment half
+/// the inversion breaks.
+#[tokio::test]
+async fn rps_5_allows_burst_then_429s() {
+    let mut cfg = config();
+    cfg.rate_limit = Some(RateLimitSettings::new(5, 5));
+    let app = router_with_layer(&cfg);
+    let ip = [10, 0, 0, 5];
+
+    // Burst budget of 5: the first five immediate requests all pass.
+    for i in 0..5 {
+        let resp = app
+            .clone()
+            .oneshot(req_from(ip))
+            .await
+            .expect("burst request served");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "request {i} within the burst of 5 must pass"
+        );
+    }
+
+    // The 6th immediate request (no time to replenish) is throttled.
+    let sixth = app
+        .clone()
+        .oneshot(req_from(ip))
+        .await
+        .expect("sixth request served");
+    assert_eq!(
+        sixth.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "6th immediate request exhausts the burst → 429"
+    );
+
+    // After ~1.1 periods (1/rps = 200ms) exactly one cell has replenished, so
+    // one more request passes. Under the inverted mapping (period = 5s) nothing
+    // replenishes in this window and this stays 429 — the RED assertion.
+    tokio::time::sleep(Duration::from_millis(220)).await;
+    let after_replenish = app
+        .clone()
+        .oneshot(req_from(ip))
+        .await
+        .expect("post-replenish request served");
+    assert_eq!(
+        after_replenish.status(),
+        StatusCode::OK,
+        "a cell replenishes within ~1 period (1/rps), so this must pass"
+    );
+}
+
+/// F2 regression (unbounded per-IP keyed state): the limiter accrues one keyed
+/// entry per distinct source IP and — without a GC handle — never reclaims them,
+/// leaking memory under attacker-controlled source IPs. `RateLimit::gc()` (the
+/// exposed `retain_recent()` handle) must evict keys once they are idle past the
+/// retention window. Drives several distinct IPs through the SHARED layer,
+/// asserts the keyed state grows, then asserts `gc()` after the window shrinks
+/// it back to empty (and is idempotent). A period of 20ms (`rps=50`) keeps the
+/// retention window tiny so the test is fast and non-flaky.
+#[tokio::test]
+async fn retain_recent_evicts_stale_keys() {
+    let mut cfg = config();
+    // rps=50 → 20ms replenishment period → ~tens-of-ms retention window.
+    cfg.rate_limit = Some(RateLimitSettings::new(50, 1));
+    let rl = governor_layer(&cfg).expect("rate limiting enabled");
+
+    // Mount a CLONE of the layer so `rl` stays owned for gc()/live_keys(); the
+    // clone shares the same keyed limiter Arc, so GC on `rl` reaches this layer.
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(rl.layer.clone());
+
+    // Empty before any traffic.
+    assert_eq!(rl.live_keys(), 0, "no keys before traffic");
+
+    // Register five distinct source IPs (one request each, all within burst=1).
+    let ips = [
+        [10, 2, 0, 1],
+        [10, 2, 0, 2],
+        [10, 2, 0, 3],
+        [10, 2, 0, 4],
+        [10, 2, 0, 5],
+    ];
+    for ip in ips {
+        let resp = app.clone().oneshot(req_from(ip)).await.expect("served");
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // Keyed state grew: one live key per distinct IP.
+    assert_eq!(rl.live_keys(), 5, "one keyed entry accrues per distinct IP");
+
+    // GC before the retention window is a safe no-op (keys still fresh).
+    rl.gc();
+    assert_eq!(rl.live_keys(), 5, "fresh keys survive an early gc()");
+
+    // After the retention window the keys are stale; gc() reclaims them.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    rl.gc();
+    assert_eq!(rl.live_keys(), 0, "gc() evicts stale per-IP keys");
+
+    // Idempotent: a second gc() with no intervening traffic stays at zero.
+    rl.gc();
+    assert_eq!(rl.live_keys(), 0, "gc() is idempotent");
+}
+
+// ---------------------------------------------------------------------------
+// (3) Document the raw 429 shape governor emits (wrapped into the retriable
+// envelope at B4).
+// ---------------------------------------------------------------------------
+
+/// The raw `GovernorLayer` 429 carries a `retry-after` header (seconds until a
+/// cell frees) and a plain-text body. B4 will wrap this into the #3234
+/// `{code: "UNAVAILABLE", retriable: true, ...}` envelope; this test pins the
+/// raw shape we are wrapping.
+#[tokio::test]
+async fn documents_raw_429_headers_and_body() {
+    let mut cfg = config();
+    cfg.rate_limit = Some(RateLimitSettings::new(1, 1));
+    let app = router_with_layer(&cfg);
+
+    let _first = app.clone().oneshot(req_from([10, 0, 0, 3])).await.unwrap();
+    let throttled = app
+        .clone()
+        .oneshot(req_from([10, 0, 0, 3]))
+        .await
+        .expect("throttled response");
+    assert_eq!(throttled.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    // Raw governor 429 advertises a `retry-after` header.
+    assert!(
+        throttled.headers().contains_key("retry-after"),
+        "governor 429 carries retry-after; headers = {:?}",
+        throttled.headers()
+    );
+
+    let body = axum::body::to_bytes(throttled.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    // A non-empty human-readable body (the text we replace with the envelope).
+    assert!(!body.is_empty(), "governor 429 has an explanatory body");
+}

--- a/crates/aletheia-server/tests/security_resource_limits.rs
+++ b/crates/aletheia-server/tests/security_resource_limits.rs
@@ -1,0 +1,368 @@
+//! Seam-independent acceptance tests for the Lane B2 resource-limits core
+//! (autumn migration §8 / Issue #3561 ACs: per-query timeout, row/byte caps,
+//! bounded in-flight guard; #3542 caps, #3550 in-flight bound).
+//!
+//! These pin the parts provable **without a running server**: the async
+//! per-query timeout wrapper, the row/byte cap helpers, and the RAII
+//! in-flight guard (acquire/release, release-on-drop, release-on-panic). Every
+//! error is the reused [`aletheiadb::http::AletheiaHttpError`] envelope — no
+//! new error shapes — so the wire mapping (429 timeout / 413 too-large / 503
+//! at-capacity) is inherited verbatim from the HTTP surface.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use aletheia_server::security::SecurityConfig;
+use aletheia_server::security::resource_limits::{
+    InFlightLimiter, ResourceLimits, byte_cap_error, check_byte_cap, check_byte_cap_of,
+    check_row_cap, row_cap_error, run_with_timeout, timeout_error,
+};
+use aletheiadb::auth::{AuthMode, AuthStore};
+use aletheiadb::http::{AletheiaHttpError, LimitDimension};
+
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// A conservative-default `SecurityConfig` (auth required, generous caps,
+/// rate-limit off). Note the re-homed crate's `new` is store-first.
+fn config() -> SecurityConfig {
+    SecurityConfig::new(Arc::new(AuthStore::new()), AuthMode::Required)
+}
+
+/// Render an error to its HTTP status (the reused envelope's wire mapping).
+fn status_of(err: AletheiaHttpError) -> StatusCode {
+    err.into_response().status()
+}
+
+// ---------------------------------------------------------------------------
+// ResourceLimits view sourced from SecurityConfig
+// ---------------------------------------------------------------------------
+
+#[test]
+fn resource_limits_are_sourced_from_config() {
+    let cfg = config();
+    let limits = ResourceLimits::from_config(&cfg);
+    assert_eq!(limits.timeout, cfg.query_timeout);
+    assert_eq!(limits.max_result_rows, cfg.max_result_rows);
+    assert_eq!(limits.max_response_bytes, cfg.max_response_bytes);
+    assert_eq!(limits.in_flight_cap, cfg.max_in_flight_queries);
+    // Conservative defaults: generous, non-zero caps.
+    assert_eq!(limits.timeout, Duration::from_millis(30_000));
+    assert_eq!(limits.max_result_rows, 10_000);
+    assert_eq!(limits.max_response_bytes, 8 * 1024 * 1024);
+    assert_eq!(limits.in_flight_cap, 64);
+}
+
+// ---------------------------------------------------------------------------
+// (1) Async per-query timeout wrapper
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn fast_op_under_timeout_completes_ok() {
+    let out = run_with_timeout(Duration::from_secs(5), false, async { 7_u32 }).await;
+    assert_eq!(out.expect("fast op is well within the deadline"), 7);
+}
+
+#[tokio::test]
+async fn slow_op_over_timeout_is_retriable_resource_exhausted() {
+    // Read-class (`is_write = false`): a timeout invites a retry (retriable).
+    let out: Result<(), _> = run_with_timeout(Duration::from_millis(20), false, async {
+        tokio::time::sleep(Duration::from_millis(400)).await;
+    })
+    .await;
+    let err = out.expect_err("the op overran its deadline");
+    // The reused HTTP envelope models a wall-clock timeout as a *retriable*
+    // 429 RESOURCE_EXHAUSTED (`WallClockTimeout` dimension). This is the
+    // src/http source of truth; the MCP surface (#3542) labels the same
+    // condition UNAVAILABLE, but here we reuse AletheiaHttpError verbatim.
+    match &err {
+        AletheiaHttpError::ResourceLimitExceeded(e) => {
+            assert_eq!(e.dimension, LimitDimension::WallClockTimeout);
+            assert!(e.retriable, "a read-class timeout invites a retry");
+            assert_eq!(e.limit, 20);
+        }
+        other => panic!("expected ResourceLimitExceeded timeout, got {other:?}"),
+    }
+    assert_eq!(status_of(err), StatusCode::TOO_MANY_REQUESTS);
+}
+
+#[tokio::test]
+async fn zero_timeout_means_unlimited_and_never_fires() {
+    // `Duration::ZERO` disables the deadline: the op runs inline to completion.
+    let out = run_with_timeout(Duration::ZERO, false, async {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        99_u32
+    })
+    .await;
+    assert_eq!(out.expect("zero timeout = unlimited, runs inline"), 99);
+}
+
+#[test]
+fn timeout_error_shape_is_the_reused_429_envelope() {
+    // Read-class constructor: retriable 429.
+    let err = timeout_error(Duration::from_millis(123), false);
+    match &err {
+        AletheiaHttpError::ResourceLimitExceeded(e) => {
+            assert_eq!(e.dimension, LimitDimension::WallClockTimeout);
+            assert_eq!(e.limit, 123);
+            assert!(e.retriable);
+        }
+        other => panic!("expected timeout envelope, got {other:?}"),
+    }
+    assert_eq!(status_of(err), StatusCode::TOO_MANY_REQUESTS);
+}
+
+/// F3 regression (#3368 MUST-FIX-1): a **write-class** timeout must be
+/// **non-retriable**. A write may already have committed by the time the
+/// deadline fires, so inviting a retry risks a duplicate write — legacy uses
+/// `retriable: !is_write` (`src/http/handlers.rs::enforce_query_limits`). The
+/// historical bug hardcoded `retriable: true` regardless of write-class. This
+/// pins both the `run_with_timeout(is_write=true)` path and the `timeout_error`
+/// constructor; the read-class TRUE case stays covered by
+/// `slow_op_over_timeout_is_retriable_resource_exhausted` and
+/// `timeout_error_shape_is_the_reused_429_envelope`.
+#[tokio::test]
+async fn write_timeout_is_not_retriable() {
+    // Write-class run_with_timeout: the deadline fires, the error is NOT
+    // retriable.
+    let out: Result<(), _> = run_with_timeout(Duration::from_millis(20), true, async {
+        tokio::time::sleep(Duration::from_millis(400)).await;
+    })
+    .await;
+    let err = out.expect_err("the write op overran its deadline");
+    match &err {
+        AletheiaHttpError::ResourceLimitExceeded(e) => {
+            assert_eq!(e.dimension, LimitDimension::WallClockTimeout);
+            assert_eq!(e.limit, 20);
+            assert!(
+                !e.retriable,
+                "a write-class timeout must NOT invite a retry (may double-commit)"
+            );
+        }
+        other => panic!("expected ResourceLimitExceeded timeout, got {other:?}"),
+    }
+    // Still the reused 429 wire mapping — only the retriable flag differs.
+    assert_eq!(status_of(err), StatusCode::TOO_MANY_REQUESTS);
+
+    // The constructor honors write-class directly, too.
+    let ctor = timeout_error(Duration::from_millis(123), true);
+    match &ctor {
+        AletheiaHttpError::ResourceLimitExceeded(e) => {
+            assert!(
+                !e.retriable,
+                "timeout_error(_, is_write=true) is non-retriable"
+            );
+        }
+        other => panic!("expected timeout envelope, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (2) Row cap + (3) Byte cap + (7) exact boundary
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rows_under_cap_ok_over_cap_rejected() {
+    // Under the cap: Ok.
+    assert!(check_row_cap(9, 10).is_ok());
+    // Over the cap: a non-retriable 413.
+    let err = check_row_cap(25, 10).expect_err("25 > 10");
+    match &err {
+        AletheiaHttpError::ResourceLimitExceeded(e) => {
+            assert_eq!(e.dimension, LimitDimension::ResultRows);
+            assert_eq!(e.limit, 10);
+            assert_eq!(e.consumed, Some(25));
+            assert!(!e.retriable, "a row cap is a caller-fault, not retriable");
+        }
+        other => panic!("expected ResultRows envelope, got {other:?}"),
+    }
+    assert_eq!(status_of(err), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[test]
+fn bytes_under_cap_ok_over_cap_rejected() {
+    assert!(check_byte_cap(1024, 4096).is_ok());
+    let err = check_byte_cap(8192, 4096).expect_err("8192 > 4096");
+    match &err {
+        AletheiaHttpError::ResourceLimitExceeded(e) => {
+            assert_eq!(e.dimension, LimitDimension::ResultBytes);
+            assert_eq!(e.limit, 4096);
+            assert_eq!(e.consumed, Some(8192));
+            assert!(!e.retriable);
+        }
+        other => panic!("expected ResultBytes envelope, got {other:?}"),
+    }
+    assert_eq!(status_of(err), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[test]
+fn cap_helpers_honor_the_exact_boundary() {
+    // Exactly at the cap is allowed; one over is rejected (both dimensions).
+    assert!(
+        check_row_cap(10, 10).is_ok(),
+        "count == cap is within budget"
+    );
+    assert!(check_row_cap(11, 10).is_err(), "count == cap + 1 is over");
+    assert!(check_byte_cap(4096, 4096).is_ok());
+    assert!(check_byte_cap(4097, 4096).is_err());
+}
+
+/// F4 regression (byte-cap undercount): `check_byte_cap` trusts a caller-supplied
+/// byte count, so a caller that measured only part of the response (e.g. a count
+/// field, or the pre-envelope payload) undercounts and wrongly passes a response
+/// that is actually over the cap. `check_byte_cap_of` removes the trust by
+/// serializing the FULL value itself (`serde_json::to_vec`) and measuring that —
+/// mirroring legacy `src/http/handlers.rs`, which caps against the real wire
+/// bytes. Under cap → `Ok(len)`; over cap → the non-retriable `413` with
+/// `consumed` = the true serialized length.
+#[test]
+fn check_byte_cap_of_measures_the_full_serialized_value() {
+    // Under the cap: returns the true serialized byte length.
+    let small = vec![1u32, 2, 3];
+    let true_len = serde_json::to_vec(&small).expect("serializes").len();
+    let ok = check_byte_cap_of(&small, 4096).expect("small value under cap");
+    assert_eq!(ok, true_len, "returns the real serialized byte length");
+
+    // Over the cap: the non-retriable 413, consumed = full serialized length.
+    let big: Vec<u32> = (0..1000).collect();
+    let serialized = serde_json::to_vec(&big).expect("serializes").len();
+    assert!(
+        serialized > 16,
+        "sanity: the big value is over the tiny cap"
+    );
+    let err = check_byte_cap_of(&big, 16).expect_err("serialized value over cap");
+    match &err {
+        AletheiaHttpError::ResourceLimitExceeded(e) => {
+            assert_eq!(e.dimension, LimitDimension::ResultBytes);
+            assert_eq!(e.limit, 16);
+            assert_eq!(
+                e.consumed,
+                Some(serialized as u64),
+                "consumed is the FULL serialized length, not a caller estimate"
+            );
+            assert!(!e.retriable);
+        }
+        other => panic!("expected ResultBytes envelope, got {other:?}"),
+    }
+    assert_eq!(status_of(err), StatusCode::PAYLOAD_TOO_LARGE);
+
+    // The exact undercount bug the helper fixes: a caller that miscounts the
+    // size (here, pretends the big value is only 10 bytes) would slip past the
+    // trusting `check_byte_cap`, but `check_byte_cap_of` measures the real value.
+    let caller_undercount = 10usize;
+    assert!(
+        check_byte_cap(caller_undercount, 16).is_ok(),
+        "raw check_byte_cap trusts the (wrong) caller count and passes"
+    );
+    assert!(
+        check_byte_cap_of(&big, 16).is_err(),
+        "check_byte_cap_of measures the full value and rejects it"
+    );
+}
+
+#[test]
+fn zero_cap_means_unlimited() {
+    // `0` = unlimited on either dimension (mirrors EffectiveQueryLimits).
+    assert!(check_row_cap(usize::MAX, 0).is_ok());
+    assert!(check_byte_cap(usize::MAX, 0).is_ok());
+}
+
+#[test]
+fn cap_error_constructors_carry_consumed() {
+    match row_cap_error(5, 9) {
+        AletheiaHttpError::ResourceLimitExceeded(e) => {
+            assert_eq!(e.dimension, LimitDimension::ResultRows);
+            assert_eq!(e.limit, 5);
+            assert_eq!(e.consumed, Some(9));
+        }
+        other => panic!("unexpected {other:?}"),
+    }
+    match byte_cap_error(5, 9) {
+        AletheiaHttpError::ResourceLimitExceeded(e) => {
+            assert_eq!(e.dimension, LimitDimension::ResultBytes);
+        }
+        other => panic!("unexpected {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (4) Bounded in-flight guard: acquire N ok, N+1 rejected
+// ---------------------------------------------------------------------------
+
+#[test]
+fn in_flight_acquires_up_to_cap_then_rejects() {
+    let limiter = InFlightLimiter::new(2);
+    let g1 = limiter.try_acquire().expect("1st slot");
+    let g2 = limiter.try_acquire().expect("2nd slot");
+    assert_eq!(limiter.live(), 2);
+
+    let err = limiter.try_acquire().expect_err("3rd over cap");
+    match &err {
+        AletheiaHttpError::InFlightCapacityExceeded { cap } => assert_eq!(*cap, 2),
+        other => panic!("expected InFlightCapacityExceeded, got {other:?}"),
+    }
+    // At-capacity is a retriable 503 UNAVAILABLE (back off and retry).
+    assert_eq!(status_of(err), StatusCode::SERVICE_UNAVAILABLE);
+
+    // Keep the guards live across the assertions above.
+    drop((g1, g2));
+}
+
+#[test]
+fn in_flight_cap_zero_is_unbounded() {
+    let limiter = InFlightLimiter::new(0);
+    let _a = limiter.try_acquire().expect("unbounded");
+    let _b = limiter.try_acquire().expect("unbounded");
+    let _c = limiter.try_acquire().expect("unbounded");
+    assert_eq!(limiter.live(), 3);
+}
+
+#[test]
+fn in_flight_limiter_from_config_reads_the_cap() {
+    let cfg = config();
+    let limiter = InFlightLimiter::from_config(&cfg);
+    // Default cap is 64; acquire one to prove it is live.
+    let _g = limiter.try_acquire().expect("slot within default cap");
+    assert_eq!(limiter.live(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// (5) Slot released after guard drop
+// ---------------------------------------------------------------------------
+
+#[test]
+fn slot_is_released_when_guard_drops() {
+    let limiter = InFlightLimiter::new(1);
+    {
+        let _g = limiter.try_acquire().expect("1st slot");
+        // The single slot is now exhausted.
+        assert!(limiter.try_acquire().is_err());
+        assert_eq!(limiter.live(), 1);
+    }
+    // Guard dropped at end of scope → slot returned.
+    assert_eq!(limiter.live(), 0);
+    assert!(limiter.try_acquire().is_ok(), "slot reusable after drop");
+}
+
+// ---------------------------------------------------------------------------
+// (6) Slot released even when the guarded scope PANICS
+// ---------------------------------------------------------------------------
+
+#[test]
+fn slot_is_released_on_panic_in_guarded_scope() {
+    let limiter = InFlightLimiter::new(1);
+    let in_thread = limiter.clone();
+    let handle = std::thread::spawn(move || {
+        let _g = in_thread.try_acquire().expect("slot in worker");
+        // RAII must survive unwind: Drop runs as the stack unwinds.
+        panic!("boom in guarded scope");
+    });
+    // The worker panicked; its guard dropped during unwind.
+    assert!(handle.join().is_err(), "worker panicked as expected");
+    assert_eq!(limiter.live(), 0, "panic must not leak the slot");
+    let _fresh = limiter.try_acquire().expect("fresh acquire after panic");
+}

--- a/docs/adr/0055-migrate-http-server-to-autumn.md
+++ b/docs/adr/0055-migrate-http-server-to-autumn.md
@@ -2,7 +2,44 @@
 
 ## Status
 
-Accepted — 2026-04-19.
+Accepted — 2026-04-19. **Partially superseded — 2026-07-13** (see
+[Supersession: rate limiting returns under autumn 0.5](#supersession-rate-limiting-returns-under-autumn-05) below).
+
+## Supersession: rate limiting returns under autumn 0.5
+
+The migration landed on autumn-web **0.5** (not the 0.2/0.3 line this ADR was
+drafted against), and the production server now lives in the dedicated
+`aletheia-server` crate (Issue #3524). Two of the deferrals recorded under
+[Decision](#decision) are lifted by that move:
+
+-   **Rate limiting is no longer deferred.** This ADR judged a custom
+    tower/middleware rate limiter impractical because autumn 0.4's sealed
+    `IntoAppLayer` rejected arbitrary `tower::Layer`s, and it bet on autumn
+    0.3 shipping native per-IP rate limiting. Neither held: autumn **0.5**
+    relaxes that bound so an arbitrary `tower::Layer` — including
+    `tower_governor::GovernorLayer` — mounts through `.layer()`, and no native
+    limiter shipped. Rate limiting therefore returns as a **default-off**
+    `tower-governor` layer built by
+    `aletheia_server::security::rate_limit::governor_layer`, which yields
+    `None` unless the operator opts in via `SecurityConfig::rate_limit`. Default
+    behavior is byte-for-byte unchanged (no layer, no `429`s), so this
+    supersedes the deferral without changing the shipped default. The
+    "[Retire `tower-governor`](#follow-up-work)" follow-up is likewise moot —
+    `tower-governor` is retained, not retired.
+-   **The `ConnectInfo` test-harness gap is unchanged.** The negative
+    consequence that `PeerIpKeyExtractor` needs `ConnectInfo<SocketAddr>` (only
+    populated by `axum::serve()` at the TCP layer) still stands; the new crate's
+    `security::rate_limit` acceptance tests insert `ConnectInfo` by hand when
+    driving the layer via `tower`'s `oneshot`, exactly as noted here.
+
+The rate limiter arrives alongside the other per-query security **primitives**
+in the `aletheia-server::security` module (per-query timeout / row / byte caps
+and a bounded in-flight guard, Issues #3542 / #3550; signed opaque cursor
+tokens, Issue #3360). These are the building blocks; the wiring PR that mounts
+them via `apply_security` (and wraps governor's raw `429` into the Issue #3234
+`{code, retriable, ...}` envelope) is tracked under the autumn migration §8 /
+Issue #3561 plan. This note records the reversal; it does not re-open the ADR's
+other decisions.
 
 ## Context
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -47,7 +47,7 @@ pub use config::{
     LimitOverrideError, QueryLimitsConfig, QueryLimitsOverride, RateLimitConfig, RowOverflowPolicy,
     ServerConfig, ServerConfigBuilder,
 };
-pub use error::AletheiaHttpError;
+pub use error::{AletheiaHttpError, ResourceLimitExceeded};
 // exposed for autumn-web migration spike (Issue #3524): the isolated
 // `aletheia-autumn-spike` crate reuses the exact node → JSON serializer the
 // `POST /query` GetNode path uses, so its parity assertion is a true


### PR DESCRIPTION
## Lane B security primitives for `aletheia-server` (autumn migration)

Fills the three PR1 security stubs in the merged `aletheia-server` crate with
the validated, seam-independent security **primitives** — the building blocks a
later wiring PR mounts. Base is fresh `origin/trunk` (includes merged B1 #3567);
no stacking.

### Before / After (plain language)

**Before:** the new production `aletheia-server` had authentication + RBAC-class
enforcement (B1), but **no per-query resource caps** (a single query could run
unbounded, return unbounded rows, or serialize an unbounded body), **no rate
limiting**, and **no cursor-paging security** (no signed continuation tokens,
no TTL, no per-connection cap). `resource_limits`, `rate_limit`, and `cursor`
were 2–6 line `TODO(Lane B)` placeholders.

**After:** those three modules carry real, tested primitives:

- **Per-query resource limits** — a wall-clock timeout wrapper, row/byte caps,
  and a bounded in-flight guard, all reusing the shared `AletheiaHttpError`
  envelope so the wire mapping (429 timeout / 413 too-large / 503 at-capacity)
  is inherited verbatim from the HTTP `/query` surface.
- **Default-off rate limiter** — a `tower-governor` `GovernorLayer` built only
  when the operator opts in; default behavior is byte-for-byte today's (no
  layer, no `429`s).
- **Signed opaque cursor tokens** — HMAC-SHA256-signed, base64url, TTL-bounded,
  per-connection-capped continuation tokens (#3360), with a constant-time MAC
  compare.

These are primitives only. The wiring PR (B4) mounts them via `apply_security`
and wraps governor's raw `429` into the #3234 `{code, retriable, …}` envelope —
**not in this PR**. Omitting the new `SecurityConfig` toggles reproduces prior
behavior exactly.

### How

- `src/security/resource_limits.rs` — `ResourceLimits` (config view),
  `run_with_timeout(timeout, is_write, fut)` (**F3**: `retriable = !is_write`),
  `timeout_error` / `row_cap_error` / `byte_cap_error`, `check_row_cap`,
  `check_byte_cap`, and the undercount-proof `check_byte_cap_of<T: Serialize>`
  (**F4**, serializes + measures the full value), plus the RAII
  `InFlightLimiter` / `InFlightGuard` (CAS-loop acquire, release-on-drop and
  release-on-panic).
- `src/security/rate_limit.rs` — `governor_layer(cfg) -> Option<RateLimit>`
  (default-off), keyed per peer IP. **F1**: correct `1/rps` replenishment
  period (not the inverted `per_second(rps)`). **F2**: `RateLimit { layer,
  config }` with `gc()` / `live_keys()` to bound the otherwise-unbounded per-IP
  keyed state.
- `src/security/cursor.rs` — `CursorSecret` (HMAC-SHA256 sign/verify,
  `subtle::ConstantTimeEq`), `CursorPayload`, `CursorError` + `class()`,
  `LiveCursorRegistry` / `CursorLease` (RAII per-connection cap). **Coordinator-
  approved hardenings:** the secret is held in `zeroize::Zeroizing` (wiped on
  drop) and `from_bytes` is `#[doc(hidden)]` (tests only) with `random()` the
  sole production constructor; a doc note records that the per-process-secret
  design permits cursor resume across connections within TTL (a documented
  #3360 property — reads stay RBAC-gated; not an authz bypass).
- `src/security/mod.rs` — additive `SecurityConfig` fields (`rate_limit`,
  `query_timeout` 30 s, `max_result_rows` 10_000, `max_response_bytes` 8 MiB,
  `max_in_flight_queries` 64, `cursor_ttl` 300 s, `max_live_cursors_per_conn`
  128) + `RateLimitSettings`; `pub mod` / `pub use` for the three modules. B1's
  re-exports untouched.
- **Main crate — `src/http/mod.rs` (one line):** additive
  `pub use error::ResourceLimitExceeded;` (already-public struct; mirrors the
  existing `AletheiaHttpError` / `LimitDimension` exports). The **only**
  main-crate change; no behavior change in `src/http` or `src/mcp`.
- `crates/aletheia-server/Cargo.toml` — `tower_governor` 0.8 (default-features
  off, `axum`), `governor` 0.10, `base64`/`sha2`/`subtle`/`rand`/`zeroize` and
  tokio `time`, versions matching the main crate (no lock churn).
- `docs/adr/0055-migrate-http-server-to-autumn.md` — supersession note.
- `crates/aletheia-server/tests/` — 35 ported acceptance tests
  (`security_resource_limits.rs` 17, `security_rate_limit.rs` 7,
  `security_cursor.rs` 11).

### ADR 0055 supersession

ADR 0055 deferred rate limiting because autumn 0.4's sealed `IntoAppLayer`
rejected arbitrary `tower::Layer`s and it bet on autumn 0.3 shipping a native
limiter (which never landed). Under autumn **0.5** that bound is lifted:
`tower_governor::GovernorLayer` mounts through `.layer()`. This PR adds a
supersession note recording that reversal — rate limiting returns as a
**default-off** governor layer, so the shipped default is unchanged. The
"retire `tower-governor`" follow-up is likewise moot.

### F1–F4 fixes carried

- **F1** — rate-mapping inversion fixed (`1/rps` period); pinned by
  `rps_5_allows_burst_then_429s`.
- **F2** — unbounded per-IP keyed state bounded via `gc()`; pinned by
  `retain_recent_evicts_stale_keys`.
- **F3** — write-class timeout is non-retriable; pinned by
  `write_timeout_is_not_retriable`.
- **F4** — byte-cap undercount closed by `check_byte_cap_of`; pinned by
  `check_byte_cap_of_measures_the_full_serialized_value`.

### AC / issue mapping

| Issue / AC | Where |
|---|---|
| **#3542** — per-query timeout + row/byte caps | `resource_limits::{run_with_timeout, check_row_cap, check_byte_cap, check_byte_cap_of}` |
| **#3550** — bounded in-flight guard | `resource_limits::{InFlightLimiter, InFlightGuard}` |
| **#3561 §8** — 429 / in-flight / cursor budgets | rate limiter (429), in-flight guard (503), cursor TTL/cap; **full 429-envelope wrapping + mounting are B4** |
| **#3360** — signed opaque cursor tokens, TTL, per-conn cap | `cursor::{CursorSecret, LiveCursorRegistry, CursorLease}` |
| ADR 0055 supersession (rate limiting under autumn 0.5) | `docs/adr/0055-migrate-http-server-to-autumn.md` |

### Gates

- `cargo fmt --all --check` — clean
- `cargo clippy -p aletheia-server --all-targets -- -D warnings` — GREEN (0 warnings)
- `cargo build -p aletheiadb` — GREEN (additive http re-export doesn't break the main crate)
- `cargo test -p aletheia-server` — GREEN (B1's 15 unit + 19 parity, plus 17 resource + 7 rate + 11 cursor = 69 tests)
- `cargo clippy --workspace --all-targets --all-features` — **delegated to CI** (long build; not run in this session)

Status: **Draft** — primitives only; the wiring PR (B4) mounts them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9nP1hfyQTVovFgM48MfME

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9nP1hfyQTVovFgM48MfME)_