### PR TITLE
Operator CLI: `aletheia keys status/generate/verify` (#490)

### DIFF
--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -57,6 +57,10 @@ fn run() -> Result<(), String> {
         Some("backup") => handle_backup(args.collect()),
         Some("restore") => handle_restore(args.collect()),
         Some("verify") => handle_verify(args.collect()),
+        // Encryption key operator commands (Issue #490): the independent,
+        // non-rotation slice. `keys rotate` depends on the rotation engine
+        // (Issue #488) and is intentionally not implemented here.
+        Some("keys") => handle_keys(args.collect()),
         // A single `import` verb serves both formats; `handle_import` reads `--format`
         // and dispatches to the neo4j-csv (Issue #3356) or parquet (Issue #3364) path.
         // `handle_import` is always defined (a stub when the `import` feature is off).
@@ -96,7 +100,10 @@ Usage:\n\
   aletheia backup <output_path>\n\
   aletheia restore <input_path>\n\
   aletheia restore <input_path> --wal-archive <dir> [--as-of <iso8601|micros> | --lsn <n> | --latest] [--dry-run]\n\
-  aletheia verify [--entity <node|edge>:<id>] [--export-head PATH] [--against PATH] [--json]"
+  aletheia verify [--entity <node|edge>:<id>] [--export-head PATH] [--against PATH] [--json]\n\
+  aletheia keys generate --output <PATH> [--force]\n\
+  aletheia keys status [--key-file PATH | --env-var NAME]   (alias: keys info)\n\
+  aletheia keys verify --key-file <PATH>"
     );
     // The neo4j-csv import verb is gated behind the `import` feature; only advertise it
     // when it is compiled in.
@@ -165,7 +172,14 @@ Usage:\n\
   audit-keygen — Generate an Ed25519 signing key (0600) and print its public key.\n\
   audit-export — Sign an entity's full bi-temporal history into a portable artifact.\n\
   audit-verify — Verify an artifact OFFLINE (no database) with the signer's public key.\n\
-  audit-render — Render an artifact as a human-readable chronology.\n"
+  audit-render — Render an artifact as a human-readable chronology.\n\
+\nEncryption keys (Issue #490):\n\
+  keys generate — Provision a new 32-byte master key file (0600 on Unix).\n\
+                  Refuses to overwrite unless --force. Key bytes are never printed.\n\
+  keys status   — Show the key configuration (provider, algorithm, version)\n\
+                  without reading or printing key material. Alias: keys info.\n\
+                  Not configured is reported informationally (exit 0).\n\
+  keys verify   — Verify the named key file loads and is valid (health check).\n"
     );
 }
 
@@ -407,6 +421,150 @@ fn handle_verify(args: Vec<String>) -> Result<(), String> {
     // Default: full-chain verify.
     let result = db.verify_chain().map_err(chain_error_hint)?;
     finish_verification(&result, "full", json)
+}
+
+/// `aletheia keys <generate|status|verify>` — encryption key operator commands
+/// (Issue #490).
+///
+/// This is the independent, non-rotation slice of the encryption CLI:
+/// - `generate` provisions a new 32-byte master key file.
+/// - `status` (alias `info`) reports the key configuration without ever
+///   reading or printing key material.
+/// - `verify` confirms the configured/named key loads and is valid.
+///
+/// `keys rotate` is intentionally NOT implemented: it depends on the key
+/// rotation engine (Issue #488), which is not yet on trunk.
+fn handle_keys(args: Vec<String>) -> Result<(), String> {
+    match args.first().map(String::as_str) {
+        Some("generate") => keys_generate(&args[1..]),
+        // `info` is accepted as an alias for `status`.
+        Some("status") | Some("info") => keys_status(&args[1..]),
+        Some("verify") => keys_verify(&args[1..]),
+        Some(sub) => Err(format!("unknown keys subcommand '{sub}'")),
+        None => Err("usage: aletheia keys <generate|status|verify> ...".to_string()),
+    }
+}
+
+/// `aletheia keys generate --output <PATH> [--force]` — generate a new 32-byte
+/// master key file.
+///
+/// Refuses to overwrite an existing file unless `--force` is passed, so a live
+/// key is never clobbered by accident. The generated key bytes are NEVER
+/// printed. On Unix the file is tightened to `0600` (owner read/write only).
+fn keys_generate(args: &[String]) -> Result<(), String> {
+    let output = arg_value(args, "--output")
+        .ok_or_else(|| "usage: aletheia keys generate --output <PATH> [--force]".to_string())?;
+    let force = args.iter().any(|a| a == "--force");
+    let path = Path::new(&output);
+
+    if path.exists() && !force {
+        return Err(format!(
+            "refusing to overwrite existing key file '{output}' (pass --force to replace it)"
+        ));
+    }
+
+    let result = aletheiadb::encryption::cli::generate_key(path)
+        .map_err(|e| format!("failed to generate key: {e}"))?;
+
+    // A master key must never be world-readable; tighten to owner-only on Unix.
+    // (`generate_key_file` writes with the process umask, so we set the mode
+    // explicitly here rather than relying on it.)
+    restrict_key_permissions(path)?;
+
+    println!(
+        "Generated a new {}-byte master key at {}\n  algorithm: {}\n  (key bytes are not printed)",
+        result.key_length, result.path, result.algorithm
+    );
+    Ok(())
+}
+
+/// `aletheia keys status` (alias `info`) — report the encryption key
+/// configuration WITHOUT reading or printing key material.
+///
+/// Configuration is resolved from `--key-file`/`--env-var` flags, else from an
+/// `ALETHEIADB_CONFIG` TOML (when the `config-toml` feature is compiled in),
+/// else reported as not configured (exit 0, informational). Only non-secret
+/// facts are shown: provider type, provider detail (path/var name — not
+/// secret), algorithm, and the key version (always 1 until rotation lands).
+fn keys_status(args: &[String]) -> Result<(), String> {
+    let config = resolve_encryption_config(args)?;
+    let status = aletheiadb::encryption::cli::get_encryption_status(&config);
+    let mut out = aletheiadb::encryption::cli::format_encryption_status(&status);
+    if status.enabled {
+        // There is no rotation yet (Issue #488), so the key version is always
+        // 1 today. Surface it explicitly rather than implying multi-version.
+        out.push_str("Key version:    1 (rotation not yet enabled)\n");
+    }
+    print!("{out}");
+    Ok(())
+}
+
+/// `aletheia keys verify --key-file <PATH>` — verify the named key is usable.
+///
+/// Constructs the file key provider and runs its health check (which loads and
+/// parses the MEK). This is the scoped v1 of the issue's `encryption verify`:
+/// it verifies the KEY is loadable/valid, NOT that all encrypted data across
+/// all storage layers decrypts (that broader check depends on index encryption,
+/// Issue #481, which is not yet on trunk). On failure a safe error category is
+/// reported (never key bytes) and the process exits non-zero.
+fn keys_verify(args: &[String]) -> Result<(), String> {
+    let key_file = arg_value(args, "--key-file")
+        .ok_or_else(|| "usage: aletheia keys verify --key-file <PATH>".to_string())?;
+    let path = Path::new(&key_file);
+    match aletheiadb::encryption::cli::validate_key_file(path) {
+        Ok(()) => {
+            println!("Key at {key_file} loads and is valid.");
+            Ok(())
+        }
+        // `KeyProviderError`'s Display never contains key bytes (only a
+        // category and, for a length mismatch, a byte count), so it is safe to
+        // surface directly.
+        Err(e) => Err(format!("key verification failed: {e}")),
+    }
+}
+
+/// Resolve the [`EncryptionConfig`](aletheiadb::encryption::config::EncryptionConfig)
+/// for `keys status` from CLI flags or ambient config.
+///
+/// Precedence: `--key-file` > `--env-var` > `ALETHEIADB_CONFIG` (TOML, when
+/// `config-toml` is compiled in) > disabled/not-configured.
+fn resolve_encryption_config(
+    args: &[String],
+) -> Result<aletheiadb::encryption::config::EncryptionConfig, String> {
+    use aletheiadb::encryption::config::EncryptionConfig;
+
+    if let Some(path) = arg_value(args, "--key-file") {
+        return Ok(EncryptionConfig::file_based(path));
+    }
+    if let Some(var) = arg_value(args, "--env-var") {
+        return Ok(EncryptionConfig::env_based(var));
+    }
+    #[cfg(feature = "config-toml")]
+    if let Ok(cfg_path) = env::var(aletheiadb::config::CONFIG_ENV) {
+        let cfg = aletheiadb::config::AletheiaDBConfig::from_toml_file(&cfg_path)
+            .map_err(|e| format!("failed to load config '{cfg_path}': {e}"))?;
+        return Ok(cfg.encryption);
+    }
+    Ok(EncryptionConfig::disabled())
+}
+
+/// Tighten a freshly written key file to owner-only permissions (`0600`) on
+/// Unix. A no-op on non-Unix platforms (which lack POSIX mode bits).
+#[cfg(unix)]
+fn restrict_key_permissions(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|e| {
+        format!(
+            "failed to set owner-only permissions on key file '{}': {e}",
+            path.display()
+        )
+    })
+}
+
+/// Non-Unix no-op for [`restrict_key_permissions`].
+#[cfg(not(unix))]
+fn restrict_key_permissions(_path: &Path) -> Result<(), String> {
+    Ok(())
 }
 
 /// Turn a chain API error (notably "chain not enabled") into a CLI-friendly

--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -440,6 +440,12 @@ fn handle_keys(args: Vec<String>) -> Result<(), String> {
         // `info` is accepted as an alias for `status`.
         Some("status") | Some("info") => keys_status(&args[1..]),
         Some("verify") => keys_verify(&args[1..]),
+        // `rotate` is a known-but-deferred verb: give an honest, specific
+        // message (not a generic "unknown subcommand") so operators know it is
+        // planned, not a typo. Still exits non-zero.
+        Some("rotate") => {
+            Err("keys rotate is not yet available (key rotation engine, Issue #488)".to_string())
+        }
         Some(sub) => Err(format!("unknown keys subcommand '{sub}'")),
         None => Err("usage: aletheia keys <generate|status|verify> ...".to_string()),
     }
@@ -463,12 +469,19 @@ fn keys_generate(args: &[String]) -> Result<(), String> {
         ));
     }
 
-    let result = aletheiadb::encryption::cli::generate_key(path)
+    // Pass `force` as the overwrite flag: when `--force` is absent the file is
+    // created atomically with `O_EXCL`, so a file racing into existence between
+    // the check above and the write below fails closed rather than being
+    // silently clobbered (closes the check-then-write TOCTOU). The key file is
+    // created with mode 0600 *before* any key bytes are written on Unix, so it
+    // is never world-readable at any instant.
+    let result = aletheiadb::encryption::cli::generate_key_with_overwrite(path, force)
         .map_err(|e| format!("failed to generate key: {e}"))?;
 
-    // A master key must never be world-readable; tighten to owner-only on Unix.
-    // (`generate_key_file` writes with the process umask, so we set the mode
-    // explicitly here rather than relying on it.)
+    // Defense-in-depth: re-assert owner-only permissions. `generate_key_with_overwrite`
+    // already creates the file 0600 at creation time on Unix, so this is a
+    // belt-and-suspenders check that introduces no new window (it only ever
+    // tightens, never loosens, and the file is already 0600 by here).
     restrict_key_permissions(path)?;
 
     println!(

--- a/src/encryption/cli.rs
+++ b/src/encryption/cli.rs
@@ -50,7 +50,28 @@ pub struct KeyGenResult {
 ///
 /// Returns [`KeyProviderError`] if directory creation or file writing fails.
 pub fn generate_key(output_path: &Path) -> Result<KeyGenResult, KeyProviderError> {
-    let _key = FileKeyProvider::generate_key_file(output_path)?;
+    generate_key_with_overwrite(output_path, true)
+}
+
+/// Generate a new master key file, refusing to overwrite an existing file when
+/// `overwrite` is `false`.
+///
+/// When `overwrite` is `false` the file is created atomically with `O_EXCL`, so
+/// a file racing into existence between an external existence check and this
+/// call cannot be silently clobbered (fail-closed). When `overwrite` is `true`
+/// any existing file is re-created fresh. On Unix the file is created with mode
+/// `0600` before any key bytes are written -- the key is never world-readable at
+/// any instant.
+///
+/// # Errors
+///
+/// Returns [`KeyProviderError`] if directory creation or file writing fails, or
+/// (when `overwrite` is `false`) if a file already exists at `output_path`.
+pub fn generate_key_with_overwrite(
+    output_path: &Path,
+    overwrite: bool,
+) -> Result<KeyGenResult, KeyProviderError> {
+    let _key = FileKeyProvider::generate_key_file_with_overwrite(output_path, overwrite)?;
     Ok(KeyGenResult {
         path: output_path.display().to_string(),
         algorithm: "AES-256-GCM / ChaCha20-Poly1305".into(),

--- a/src/encryption/key_provider.rs
+++ b/src/encryption/key_provider.rs
@@ -72,11 +72,45 @@ impl FileKeyProvider {
         Self { path: path.into() }
     }
 
-    /// Generate a new random key file at the given path.
+    /// Generate a new random key file at the given path, overwriting any
+    /// existing file.
     ///
     /// Creates parent directories if they don't exist. The key is written as
     /// 64 hex characters followed by a newline.
+    ///
+    /// # Security
+    /// On Unix the file is created with mode `0600` (owner read/write only)
+    /// *before* any key bytes are written, so the master key is **never**
+    /// world- or group-readable at any instant -- there is no window between
+    /// creation and a subsequent `chmod` during which the real key sits in a
+    /// `0644` file. See [`generate_key_file_with_overwrite`] for the
+    /// non-overwriting (atomic `O_EXCL`) variant.
+    ///
+    /// [`generate_key_file_with_overwrite`]: Self::generate_key_file_with_overwrite
     pub fn generate_key_file(path: &Path) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+        Self::generate_key_file_with_overwrite(path, true)
+    }
+
+    /// Generate a new random key file, refusing to overwrite an existing file
+    /// when `overwrite` is `false`.
+    ///
+    /// When `overwrite` is `false`, the file is created atomically with
+    /// `O_EXCL` (`create_new`): if a file already exists at `path` the call
+    /// fails (fail-closed) rather than clobbering it, closing the
+    /// check-then-write TOCTOU. When `overwrite` is `true`, any existing file
+    /// is first removed so the key file is always (re-)created fresh with the
+    /// correct mode (a momentary absence exposes no key material).
+    ///
+    /// # Security
+    /// On Unix the file is created with mode `0600` (owner read/write only)
+    /// *before* any key bytes are written, so the master key is **never**
+    /// world- or group-readable at any instant.
+    pub fn generate_key_file_with_overwrite(
+        path: &Path,
+        overwrite: bool,
+    ) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+        use std::io::Write;
+
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -84,8 +118,36 @@ impl FileKeyProvider {
         let mut key = Zeroizing::new([0u8; 32]);
         rand::thread_rng().fill_bytes(key.as_mut());
 
-        let hex = bytes_to_hex(key.as_ref());
-        std::fs::write(path, format!("{hex}\n"))?;
+        // Keep the hex representation in a zeroizing buffer so the key never
+        // lingers in a plain heap `String`.
+        let key_hex = Zeroizing::new(format!("{}\n", bytes_to_hex(key.as_ref())));
+
+        if overwrite {
+            // Opening an existing file with `truncate` does NOT reset its mode,
+            // which could leave a stale (possibly world-readable) file's
+            // permissions in place. Remove it first, then re-create fresh with
+            // `0600`. A brief absence exposes no key material.
+            match std::fs::remove_file(path) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e.into()),
+            }
+        }
+
+        // Create with `O_EXCL` in both paths (the overwrite path just removed
+        // any prior file). This makes creation atomic and guarantees the mode
+        // is applied at creation time on Unix -- the key bytes are only ever
+        // written into a `0600` file.
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let mut f = opts.open(path)?;
+        f.write_all(key_hex.as_bytes())?;
+        f.flush()?;
 
         Ok(key)
     }
@@ -303,6 +365,47 @@ mod tests {
         let provider = FileKeyProvider::new(&path);
         let loaded = provider.get_mek().unwrap();
         assert_eq!(generated.as_ref(), loaded.as_ref());
+    }
+
+    /// The key file must be `0600` the instant `generate_key_file` returns --
+    /// proving the mode is applied at creation time and does NOT depend on any
+    /// post-hoc `chmod` by the caller. If it did, this test would observe the
+    /// looser default-umask mode.
+    #[cfg(unix)]
+    #[test]
+    fn generate_key_file_is_0600_immediately() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("created_0600.hex");
+
+        let _key = FileKeyProvider::generate_key_file(&path).unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "key file must be 0600 at creation time (no post-hoc chmod), got {mode:o}"
+        );
+    }
+
+    /// The non-overwriting variant must fail (fail-closed) if a file already
+    /// exists at the path, and must leave that file's contents untouched.
+    #[test]
+    fn generate_key_file_no_overwrite_refuses_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("existing.hex");
+        std::fs::write(&path, b"pre-existing contents").unwrap();
+
+        let err = FileKeyProvider::generate_key_file_with_overwrite(&path, false).unwrap_err();
+        assert!(
+            matches!(err, KeyProviderError::Io(_)),
+            "expected an Io (AlreadyExists) error, got: {err}"
+        );
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            b"pre-existing contents",
+            "existing file must be left untouched when overwrite is refused"
+        );
     }
 
     #[test]

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -30,8 +30,8 @@ pub use cipher::{
     AES_256_GCM_ID, Aes256GcmCipher, CHACHA20_POLY1305_ID, ChaCha20Poly1305Cipher, Cipher,
 };
 pub use cli::{
-    EncryptionStatus, KeyGenResult, format_encryption_status, generate_key, get_encryption_status,
-    validate_key_file,
+    EncryptionStatus, KeyGenResult, format_encryption_status, generate_key,
+    generate_key_with_overwrite, get_encryption_status, validate_key_file,
 };
 pub use config::{EncryptionConfig, KeyProviderConfig};
 pub use error::{EncryptionError, KeyDerivationError, KeyProviderError};

--- a/tests/cli_keys.rs
+++ b/tests/cli_keys.rs
@@ -286,7 +286,8 @@ fn keys_verify_garbage_key_fails_without_leak() {
     let dir = TempDir::new().unwrap();
     let key_path = dir.path().join("garbage.key");
     // 17 bytes: neither 64 hex chars nor 32 raw bytes -> invalid format.
-    std::fs::write(&key_path, [0xABu8; 17]).unwrap();
+    let garbage = [0xABu8; 17];
+    std::fs::write(&key_path, garbage).unwrap();
 
     let r = run(&["keys", "verify", "--key-file", key_path.to_str().unwrap()]);
     assert_ne!(r.code, 0, "verify of a malformed key must fail");
@@ -295,6 +296,22 @@ fn keys_verify_garbage_key_fails_without_leak() {
         "verify must fail cleanly, not panic; stderr={:?}",
         r.stderr
     );
+
+    // No-leak contract: the file's raw bytes must never appear in output, in
+    // any encoding a future error message might use (a hex dump or the literal
+    // bytes), so the guarantee is airtight against error-message changes.
+    let hex: String = garbage.iter().map(|b| format!("{b:02x}")).collect();
+    let byte_string = String::from_utf8_lossy(&garbage).into_owned();
+    for out in [&r.stdout, &r.stderr] {
+        assert!(
+            !out.contains(&hex),
+            "verify output must NEVER contain the file's hex bytes; got={out:?}"
+        );
+        assert!(
+            !out.contains(&byte_string),
+            "verify output must NEVER contain the file's raw bytes; got={out:?}"
+        );
+    }
 }
 
 #[test]
@@ -311,6 +328,28 @@ fn keys_verify_requires_key_file() {
 fn keys_unknown_subcommand_fails() {
     let r = run(&["keys", "frobnicate"]);
     assert_ne!(r.code, 0, "unknown keys subcommand must fail");
+}
+
+#[test]
+fn keys_rotate_reports_deferred_not_unknown() {
+    let r = run(&["keys", "rotate"]);
+    assert_ne!(
+        r.code, 0,
+        "keys rotate must exit non-zero (not yet available)"
+    );
+    let combined = format!("{}{}", r.stdout, r.stderr).to_lowercase();
+    // Must be an honest, specific deferred message -- NOT the generic
+    // "unknown keys subcommand" fallback.
+    assert!(
+        combined.contains("rotate") && combined.contains("not yet available"),
+        "keys rotate must give a specific deferred message; stdout={:?} stderr={:?}",
+        r.stdout,
+        r.stderr
+    );
+    assert!(
+        !combined.contains("unknown keys subcommand"),
+        "keys rotate must not use the generic unknown-subcommand message; got={combined:?}"
+    );
 }
 
 #[test]

--- a/tests/cli_keys.rs
+++ b/tests/cli_keys.rs
@@ -1,0 +1,325 @@
+//! End-to-end tests for the `aletheia keys` subcommand group (Issue #490).
+//!
+//! Covers the independent, non-rotation slice of the encryption operator CLI:
+//! `keys generate`, `keys status` (alias `info`), and `keys verify`. Each test
+//! invokes the real built binary via `env!("CARGO_BIN_EXE_aletheia")` in its own
+//! process, mirroring the harness in `tests/cli_aletheia.rs`.
+//!
+//! Security-critical assertions: generated/verified output must NEVER contain
+//! the raw key hex, and failures must not leak key material.
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+/// Result of running the CLI binary once.
+struct CliRun {
+    code: i32,
+    stdout: String,
+    stderr: String,
+}
+
+/// Run the `aletheia` binary with `args`, with `ALETHEIADB_CONFIG` and
+/// `ALETHEIADB_DATA_DIR` explicitly removed so the child sees no ambient
+/// database configuration (keeps `keys status` deterministic).
+fn run(args: &[&str]) -> CliRun {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_aletheia"));
+    cmd.args(args);
+    cmd.env_remove("ALETHEIADB_CONFIG");
+    cmd.env_remove("ALETHEIADB_DATA_DIR");
+    let output = cmd.output().expect("failed to spawn aletheia binary");
+    CliRun {
+        code: output.status.code().expect("process terminated by signal"),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    }
+}
+
+/// Read a generated key file's raw contents (the 64-char hex + newline).
+fn read_key(path: &Path) -> String {
+    std::fs::read_to_string(path).expect("key file should be readable")
+}
+
+/// The bare 64-char hex string of a key file (trimmed of the trailing newline).
+fn key_hex(path: &Path) -> String {
+    read_key(path).trim().to_string()
+}
+
+// ============================================================================
+// keys generate
+// ============================================================================
+
+#[test]
+fn keys_generate_creates_key_file() {
+    let dir = TempDir::new().unwrap();
+    let key_path = dir.path().join("master.key");
+
+    let r = run(&["keys", "generate", "--output", key_path.to_str().unwrap()]);
+    assert_eq!(
+        r.code, 0,
+        "keys generate must exit 0; stderr={:?}",
+        r.stderr
+    );
+    assert!(key_path.exists(), "key file must exist after generation");
+
+    // 64 hex chars + trailing newline.
+    let raw = read_key(&key_path);
+    assert_eq!(
+        raw.trim().len(),
+        64,
+        "key must be 64 hex chars; got {raw:?}"
+    );
+    assert!(
+        raw.trim().chars().all(|c| c.is_ascii_hexdigit()),
+        "key must be hex; got {raw:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn keys_generate_sets_0600_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().unwrap();
+    let key_path = dir.path().join("perm.key");
+
+    let r = run(&["keys", "generate", "--output", key_path.to_str().unwrap()]);
+    assert_eq!(
+        r.code, 0,
+        "keys generate must exit 0; stderr={:?}",
+        r.stderr
+    );
+
+    let mode = std::fs::metadata(&key_path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o600, "key file must be 0600, got {mode:o}");
+}
+
+#[test]
+fn keys_generate_refuses_overwrite_without_force() {
+    let dir = TempDir::new().unwrap();
+    let key_path = dir.path().join("existing.key");
+
+    let first = run(&["keys", "generate", "--output", key_path.to_str().unwrap()]);
+    assert_eq!(first.code, 0, "first generate must succeed");
+    let original = read_key(&key_path);
+
+    let second = run(&["keys", "generate", "--output", key_path.to_str().unwrap()]);
+    assert_ne!(second.code, 0, "second generate without --force must fail");
+    assert_eq!(
+        read_key(&key_path),
+        original,
+        "key file must be unchanged when overwrite is refused"
+    );
+}
+
+#[test]
+fn keys_generate_force_overwrites() {
+    let dir = TempDir::new().unwrap();
+    let key_path = dir.path().join("force.key");
+
+    let first = run(&["keys", "generate", "--output", key_path.to_str().unwrap()]);
+    assert_eq!(first.code, 0, "first generate must succeed");
+    let original = read_key(&key_path);
+
+    let second = run(&[
+        "keys",
+        "generate",
+        "--output",
+        key_path.to_str().unwrap(),
+        "--force",
+    ]);
+    assert_eq!(
+        second.code, 0,
+        "generate --force must succeed; stderr={:?}",
+        second.stderr
+    );
+    assert_ne!(
+        read_key(&key_path),
+        original,
+        "--force must write a fresh key (overwhelmingly likely to differ)"
+    );
+}
+
+#[test]
+fn keys_generate_output_never_leaks_key_bytes() {
+    let dir = TempDir::new().unwrap();
+    let key_path = dir.path().join("secret.key");
+
+    let r = run(&["keys", "generate", "--output", key_path.to_str().unwrap()]);
+    assert_eq!(
+        r.code, 0,
+        "keys generate must exit 0; stderr={:?}",
+        r.stderr
+    );
+
+    let hex = key_hex(&key_path);
+    assert!(
+        !r.stdout.contains(&hex) && !r.stderr.contains(&hex),
+        "generate output must NEVER contain the raw key hex"
+    );
+}
+
+#[test]
+fn keys_generate_requires_output() {
+    let r = run(&["keys", "generate"]);
+    assert_ne!(r.code, 0, "keys generate with no --output must fail");
+}
+
+// ============================================================================
+// keys status / info
+// ============================================================================
+
+#[test]
+fn keys_status_not_configured_is_informational() {
+    let r = run(&["keys", "status"]);
+    assert_eq!(
+        r.code, 0,
+        "keys status with no config must be informational (exit 0); stderr={:?}",
+        r.stderr
+    );
+    let lower = r.stdout.to_lowercase();
+    assert!(
+        lower.contains("disabled") || lower.contains("not configured"),
+        "status must clearly state encryption is not configured; stdout={:?}",
+        r.stdout
+    );
+}
+
+#[test]
+fn keys_status_with_key_file_shows_provider_version_algorithm() {
+    let dir = TempDir::new().unwrap();
+    let key_path = dir.path().join("status.key");
+    let g = run(&["keys", "generate", "--output", key_path.to_str().unwrap()]);
+    assert_eq!(g.code, 0, "generate must succeed");
+
+    let r = run(&["keys", "status", "--key-file", key_path.to_str().unwrap()]);
+    assert_eq!(r.code, 0, "keys status must exit 0; stderr={:?}", r.stderr);
+
+    let out = r.stdout.to_lowercase();
+    assert!(
+        out.contains("file"),
+        "status must name the provider type; stdout={:?}",
+        r.stdout
+    );
+    assert!(
+        out.contains("version"),
+        "status must show key version; stdout={:?}",
+        r.stdout
+    );
+    // Algorithm line (Auto/AES/ChaCha) must be present.
+    assert!(
+        out.contains("algorithm"),
+        "status must show algorithm; stdout={:?}",
+        r.stdout
+    );
+
+    // Path is not secret, but key bytes must never appear.
+    let hex = key_hex(&key_path);
+    assert!(
+        !r.stdout.contains(&hex),
+        "status must NEVER contain the raw key hex"
+    );
+}
+
+#[test]
+fn keys_info_is_an_alias_for_status() {
+    let r = run(&["keys", "info"]);
+    assert_eq!(r.code, 0, "keys info must exit 0; stderr={:?}", r.stderr);
+    let lower = r.stdout.to_lowercase();
+    assert!(
+        lower.contains("disabled") || lower.contains("not configured"),
+        "info alias must behave like status; stdout={:?}",
+        r.stdout
+    );
+}
+
+// ============================================================================
+// keys verify
+// ============================================================================
+
+#[test]
+fn keys_verify_valid_key_succeeds() {
+    let dir = TempDir::new().unwrap();
+    let key_path = dir.path().join("valid.key");
+    let g = run(&["keys", "generate", "--output", key_path.to_str().unwrap()]);
+    assert_eq!(g.code, 0, "generate must succeed");
+
+    let r = run(&["keys", "verify", "--key-file", key_path.to_str().unwrap()]);
+    assert_eq!(
+        r.code, 0,
+        "verify of a valid key must exit 0; stderr={:?}",
+        r.stderr
+    );
+    assert!(
+        r.stdout.to_lowercase().contains("valid") || r.stdout.to_lowercase().contains("ok"),
+        "verify must report success; stdout={:?}",
+        r.stdout
+    );
+
+    // Success output must not leak the key.
+    let hex = key_hex(&key_path);
+    assert!(
+        !r.stdout.contains(&hex),
+        "verify success output must NEVER contain the raw key hex"
+    );
+}
+
+#[test]
+fn keys_verify_missing_key_fails_safely() {
+    let dir = TempDir::new().unwrap();
+    let missing = dir.path().join("nope.key");
+
+    let r = run(&["keys", "verify", "--key-file", missing.to_str().unwrap()]);
+    assert_ne!(r.code, 0, "verify of a missing key must fail");
+    // No key material can leak from a file that does not exist; assert the
+    // error is a clean category message, not a panic.
+    assert!(
+        !r.stderr.contains("panicked"),
+        "verify must fail cleanly, not panic; stderr={:?}",
+        r.stderr
+    );
+}
+
+#[test]
+fn keys_verify_garbage_key_fails_without_leak() {
+    let dir = TempDir::new().unwrap();
+    let key_path = dir.path().join("garbage.key");
+    // 17 bytes: neither 64 hex chars nor 32 raw bytes -> invalid format.
+    std::fs::write(&key_path, [0xABu8; 17]).unwrap();
+
+    let r = run(&["keys", "verify", "--key-file", key_path.to_str().unwrap()]);
+    assert_ne!(r.code, 0, "verify of a malformed key must fail");
+    assert!(
+        !r.stderr.contains("panicked"),
+        "verify must fail cleanly, not panic; stderr={:?}",
+        r.stderr
+    );
+}
+
+#[test]
+fn keys_verify_requires_key_file() {
+    let r = run(&["keys", "verify"]);
+    assert_ne!(r.code, 0, "verify with no --key-file must fail");
+}
+
+// ============================================================================
+// keys routing
+// ============================================================================
+
+#[test]
+fn keys_unknown_subcommand_fails() {
+    let r = run(&["keys", "frobnicate"]);
+    assert_ne!(r.code, 0, "unknown keys subcommand must fail");
+}
+
+#[test]
+fn keys_no_subcommand_shows_usage() {
+    let r = run(&["keys"]);
+    assert_ne!(r.code, 0, "keys with no subcommand must fail with usage");
+    assert!(
+        r.stderr.to_lowercase().contains("usage") || r.stdout.to_lowercase().contains("usage"),
+        "keys with no subcommand must mention usage; stderr={:?}",
+        r.stderr
+    );
+}


### PR DESCRIPTION
## Summary

Adds a `keys` subcommand group to the `aletheia` binary (`src/bin/aletheia.rs`) for encryption-key operator tasks — the **independent, non-rotation slice** of #490:

- **`aletheia keys generate --output <PATH> [--force]`** — provision a new 32-byte master key file (via `encryption::cli::generate_key`). Refuses to overwrite an existing file unless `--force`; tightens the file to `0600` on Unix. Key bytes are **never** printed.
- **`aletheia keys status`** (alias `info`) — report provider type, provider detail, algorithm, and key version (always `1` — rotation not yet enabled) **without reading or printing key material**. Not-configured is reported informationally (exit 0). Config is resolved from `--key-file`/`--env-var` flags, else `ALETHEIADB_CONFIG` TOML, else disabled.
- **`aletheia keys verify --key-file <PATH>`** — health-check the key provider (loads and parses the MEK); clean non-zero exit with a safe error category on failure.

> Note: the issue text references a dead `gallifreydb` binary name — the real binary is `aletheia`. This PR targets that binary.

## Before / After

**Before:** no CLI surface for encryption keys; operators had to use `openssl rand` and hand-manage key files. The `encryption::cli` helpers existed in the library but weren't wired to any command.

**After:**
```
$ aletheia keys generate --output ./m.key
Generated a new 32-byte master key at ./m.key
  algorithm: AES-256-GCM / ChaCha20-Poly1305
  (key bytes are not printed)

$ aletheia keys status --key-file ./m.key
Encryption Status
─────────────────────────────────
Overall:        ENABLED
Algorithm:      Auto (AES-256-GCM if AES-NI, else ChaCha20-Poly1305)
Key Provider:   file (./m.key)
Key version:    1 (rotation not yet enabled)

$ aletheia keys verify --key-file ./m.key
Key at ./m.key loads and is valid.

$ aletheia keys verify --key-file ./missing.key   # exit 1
error: key verification failed: Key not found
```

## How

- One additive `Some("keys") => handle_keys(...)` dispatch arm in `run()`, plus self-contained handlers (`keys_generate`, `keys_status`, `keys_verify`, `resolve_encryption_config`, `restrict_key_permissions`). **No changes to existing subcommands** — the merge-conflict-prone binary stays additive/small (+160 lines).
- Reuses existing library helpers: `encryption::cli::{generate_key, get_encryption_status, format_encryption_status, validate_key_file}` and `EncryptionConfig::{file_based, env_based, disabled}`.
- `0600` is set explicitly in the CLI handler after generation (the underlying `generate_key_file` writes with the process umask and does **not** set mode itself — see Deferred).

## Security invariants

- Key bytes are never printed, logged, or echoed on any path (generate/status/verify), including error messages. Verified by dedicated tests that read the generated hex and assert it is absent from stdout/stderr.
- `status` prints only non-secret facts (provider type, path/var name, algorithm, version) and never reads the key file.
- Failures fail closed with a safe category (`KeyProviderError` Display carries no key material) and a non-zero exit.

## Acceptance-criteria evidence (this slice)

| AC (this slice) | Status | Evidence |
|---|---|---|
| `keys generate` creates a valid 32-byte key file | ✅ | `keys_generate_creates_key_file` |
| Refuse overwrite without `--force`; `--force` overwrites | ✅ | `keys_generate_refuses_overwrite_without_force`, `keys_generate_force_overwrites` |
| Key file is `0600` on Unix | ✅ | `keys_generate_sets_0600_permissions` |
| `keys status`/`info` shows provider + version + algorithm, no key bytes | ✅ | `keys_status_with_key_file_shows_provider_version_algorithm`, `keys_info_is_an_alias_for_status` |
| Not-configured is informational (exit 0) | ✅ | `keys_status_not_configured_is_informational` |
| `keys verify` valid → exit 0; invalid/missing → non-zero, no leak | ✅ | `keys_verify_valid_key_succeeds`, `keys_verify_missing_key_fails_safely`, `keys_verify_garbage_key_fails_without_leak` |
| Output never contains raw key hex (security) | ✅ | `keys_generate_output_never_leaks_key_bytes` + leak asserts in status/verify tests |

15 end-to-end tests in `tests/cli_keys.rs`, mirroring the `tests/cli_aletheia.rs` harness.

## Gates

- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all` — applied
- `cargo test --test cli_keys` — 15 passed; `--test cli_aletheia` — 25 passed; `--bin aletheia` — 60 passed

## Deferred (explicitly out of scope for this slice)

- **`keys rotate`** → depends on the key rotation engine (#488), not yet on trunk.
- **Full `encryption verify` / `encryption status` across all storage layers** → the broader "verify all encrypted data decrypts" check depends on index encryption (#481). This PR's `keys verify` verifies the KEY is loadable/valid only.
- **Pre-existing gap (noted, not expanded here):** `FileKeyProvider::generate_key_file` does not itself set `0600` — this PR compensates in the CLI handler. Hardening the library primitive is a follow-up.
- Shell completions and progress bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZLv4kocirF3n4AwKNdHoW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZLv4kocirF3n4AwKNdHoW)_