### PR TITLE
feat(aletheia-server): Lane B security wiring — RBAC + MCP gate + resource caps + 7 non-regression ACs (#3524)

### DIFF
--- a/crates/aletheia-server/Cargo.toml
+++ b/crates/aletheia-server/Cargo.toml
@@ -35,6 +35,10 @@ tower_governor = { version = "0.8", default-features = false, features = ["axum"
 # Names `governor::middleware::NoOpMiddleware` in `governor_layer`'s return
 # type (tower_governor does not re-export it). Version pinned to tower_governor's.
 governor = "0.10"
+# The custom `/mcp` security gate (B4) is a hand-written `tower::Layer` /
+# `tower::Service`; `secure_mcp` accepts any such layer. autumn-web 0.5 / axum
+# 0.8 are on tower 0.5.
+tower = { version = "0.5" }
 # Cursor-signing primitive (Lane B4): base64url token encoding, SHA-256 for the
 # hand-rolled HMAC (no extra hmac crate — mirrors legacy `src/mcp/cursor.rs`),
 # constant-time MAC compare via subtle, a random per-process secret via rand,

--- a/crates/aletheia-server/src/app.rs
+++ b/crates/aletheia-server/src/app.rs
@@ -32,8 +32,30 @@ use std::sync::Arc;
 /// need a keyless required-mode client should insert a bootstrap key first.
 #[must_use]
 pub fn build_server_testapp(db: Arc<AletheiaDB>, store: Arc<AuthStore>, mode: AuthMode) -> TestApp {
-    let cfg = SecurityConfig::new(store, mode);
-    security::validate_startup(&cfg).expect("security startup validation");
+    try_build_server_testapp(db, SecurityConfig::new(store, mode))
+        .expect("security startup validation")
+}
+
+/// Fallible assembly — the proving-ground stand-in for the production
+/// `on_startup` refusal (ruling: startup wiring).
+///
+/// `validate_startup(&cfg)` runs **before** any routing is assembled; a refused
+/// config (required mode with zero credentials) returns `Err(message)` rather
+/// than assembling a server every request would 401. In the production
+/// `AppBuilder`, this same `validate_startup` is wired into `.on_startup(..)`,
+/// whose `Err` aborts startup with the propagated message; `TestApp` has no
+/// `on_startup` hook, so the proving ground surfaces the identical refusal here
+/// (and `build_server_testapp` turns it into a fail-fast panic).
+///
+/// # Errors
+///
+/// Returns the human-readable refusal message from
+/// [`security::validate_startup`] when the config is refused.
+pub fn try_build_server_testapp(
+    db: Arc<AletheiaDB>,
+    cfg: SecurityConfig,
+) -> Result<TestApp, String> {
+    security::validate_startup(&cfg)?;
 
     let server_state = ServerState::new(db);
     let init_cfg = cfg.clone();
@@ -57,13 +79,13 @@ pub fn build_server_testapp(db: Arc<AletheiaDB>, store: Arc<AuthStore>, mode: Au
         .openapi(OpenApiConfig::new("AletheiaDB", env!("CARGO_PKG_VERSION")))
         .mount_mcp("/mcp");
 
-    // Lane-B security seam: `/mcp` gate (Required mode), etc.
+    // Lane-B security seam: custom `/mcp` gate + default-off rate limiter.
     let app = security::apply_security(app, &cfg);
 
-    app.state_initializer(move |app_state| {
+    Ok(app.state_initializer(move |app_state| {
         app_state.insert_extension(server_state);
         security::init_state(app_state, &init_cfg);
-    })
+    }))
 }
 
 /// Convenience: [`build_server_testapp`] then `.build()` into a [`TestClient`].
@@ -74,4 +96,27 @@ pub fn build_server_client(
     mode: AuthMode,
 ) -> TestClient {
     build_server_testapp(db, store, mode).build()
+}
+
+/// Assemble a [`TestClient`] from a fully-specified [`SecurityConfig`] (custom
+/// resource caps, rate-limit opt-in, cursor budgets). **Panics** on a refused
+/// startup config (see [`try_build_server_testapp`]).
+#[must_use]
+pub fn build_server_client_with_config(db: Arc<AletheiaDB>, cfg: SecurityConfig) -> TestClient {
+    try_build_server_testapp(db, cfg)
+        .expect("security startup validation")
+        .build()
+}
+
+/// Fallible [`build_server_client_with_config`] — returns the startup-refusal
+/// message instead of panicking.
+///
+/// # Errors
+///
+/// Returns the refusal message from [`security::validate_startup`].
+pub fn try_build_server_client(
+    db: Arc<AletheiaDB>,
+    cfg: SecurityConfig,
+) -> Result<TestClient, String> {
+    Ok(try_build_server_testapp(db, cfg)?.build())
 }

--- a/crates/aletheia-server/src/lib.rs
+++ b/crates/aletheia-server/src/lib.rs
@@ -33,6 +33,9 @@ pub mod node_tools;
 pub mod security;
 pub mod state;
 
-pub use app::{build_server_client, build_server_testapp};
-pub use security::SecurityConfig;
+pub use app::{
+    build_server_client, build_server_client_with_config, build_server_testapp,
+    try_build_server_client, try_build_server_testapp,
+};
+pub use security::{SecurityConfig, ServerSecurityState};
 pub use state::ServerState;

--- a/crates/aletheia-server/src/node_tools.rs
+++ b/crates/aletheia-server/src/node_tools.rs
@@ -32,8 +32,10 @@
 //! (autumn maps `Json<T>` to the reserved `body` MCP argument key), so the
 //! `tools/call` `arguments` wrap the request under `"body"`.
 
-use crate::security::{Authorized, ReadClass, WriteClass};
+use crate::security::resource_limits::{check_byte_cap_of, run_with_timeout};
+use crate::security::{Authorized, ReadClass, ServerSecurityState, WriteClass};
 use crate::state::ServerState;
+use aletheiadb::http::AletheiaHttpError;
 use aletheiadb::mcp::{
     AletheiaMcpServer, CountNodesRequest, CreateNodeRequest, DeleteNodeCascadeRequest,
     DeleteNodeRequest, FindNodesAtTimeRequest, GetNodeRequest, ListNodesRequest,
@@ -102,19 +104,38 @@ pub struct ListNodesQuery {
 )]
 pub async fn list_nodes(
     _auth: Authorized<ReadClass>,
+    security: ServerSecurityState,
     state: ServerState,
     Query(opts): Query<ListNodesQuery>,
-) -> Json<Value> {
-    let server = AletheiaMcpServer::new(state.db_arc());
-    let out = server.list_nodes(ListNodesRequest {
+) -> Result<Json<Value>, AletheiaHttpError> {
+    // B4 resource-limits wiring (#3542 / #3550): a bounded in-flight admission
+    // guard (503 UNAVAILABLE at capacity, released by RAII on any exit), a
+    // per-query wall-clock timeout (429 RESOURCE_EXHAUSTED on deadline), and a
+    // serialized-byte cap on the exact wire response (413 RESOURCE_EXHAUSTED),
+    // all reusing the shared `AletheiaHttpError` envelope. Generous defaults
+    // (cfg) make this a no-op on the parity path; a tiny configured cap makes
+    // the 413/503 boundaries observable.
+    let limits = security.limits();
+    let _guard = security.in_flight().try_acquire()?;
+
+    let db = state.db_arc();
+    let request = ListNodesRequest {
         label: opts.label,
         property_key: opts.property_key,
         property_value: opts.property_value.map(Value::String),
         limit: opts.limit,
         offset: opts.offset,
         include_vectors: opts.include_vectors,
-    });
-    tool_json(out)
+    };
+    let out = run_with_timeout(limits.timeout, false, async move {
+        AletheiaMcpServer::new(db).list_nodes(request)
+    })
+    .await?;
+
+    let value = serde_json::from_str::<Value>(&out).unwrap_or(Value::String(out));
+    // Cap against the exact serialized response bytes (undercount-proof).
+    check_byte_cap_of(&value, limits.max_response_bytes)?;
+    Ok(Json(value))
 }
 
 /// Query options for [`count_nodes`].

--- a/crates/aletheia-server/src/security/auth.rs
+++ b/crates/aletheia-server/src/security/auth.rs
@@ -212,6 +212,13 @@ impl RateLimitSettings {
 /// `"role '{role}' does not permit {class} access"`, so 403 bodies stay
 /// identical to the existing `/query` surface.
 ///
+/// **Two-shape 403 contract (coordinator #8a / ruling F4):** this HTTP-surface
+/// 403 is deliberately **message-only** — it carries no `details` block, exactly
+/// mirroring the legacy `src/http/auth.rs`. Only the MCP-surface 403
+/// ([`crate::security::mcp_permission_denied_response`]) carries
+/// `details: {required_class, principal_role}`. The asymmetry is intentional;
+/// do not add `details` here.
+///
 /// # Errors
 ///
 /// Returns [`AletheiaHttpError::PermissionDenied`] when `principal.role` does

--- a/crates/aletheia-server/src/security/auth.rs
+++ b/crates/aletheia-server/src/security/auth.rs
@@ -124,19 +124,32 @@ impl<C: AccessClassMarker> FromRequestParts<AppState> for Authorized<C> {
             .map(|arc| (*arc).clone())
             .ok_or(AletheiaHttpError::StateMissing)?;
 
-        let principal = match auth.mode() {
-            // Anonymous mode: no credential required. Lane B may model this more
-            // richly; PR1 authorizes with the synthetic full-access principal
-            // (mirrors the spike's "anonymous == fully privileged").
-            AuthMode::Anonymous => Principal::anonymous(),
-            AuthMode::Required => {
-                // Uniform failure: missing / malformed / unknown / revoked are
-                // indistinguishable (byte-identical 401 to the legacy surface).
-                let credential =
-                    extract_credential(parts).ok_or(AletheiaHttpError::Unauthorized)?;
-                auth.store()
-                    .verify(&credential)
-                    .ok_or(AletheiaHttpError::Unauthorized)?
+        // F3 (Issue #3524 B4): principal caching. If a preceding tower layer in
+        // this same request pipeline (e.g. the `/mcp` security gate) already
+        // authenticated the credential and inserted the verified [`Principal`]
+        // into request extensions, reuse it verbatim instead of performing a
+        // second `AuthStore::verify` — the class check below still runs, so
+        // behavior is identical, only the redundant constant-time scan is
+        // avoided. When no layer precedes the extractor (the direct HTTP route
+        // path, which is deliberately NOT fronted by a redundant auth layer so
+        // `/openapi.json` stays public), extensions carry no `Principal` and we
+        // authenticate exactly as before — one verify, revocation-immediate.
+        let principal = if let Some(cached) = parts.extensions.get::<Principal>() {
+            cached.clone()
+        } else {
+            match auth.mode() {
+                // Anonymous mode: no credential required. Authorizes with the
+                // synthetic full-access principal (anonymous == fully privileged).
+                AuthMode::Anonymous => Principal::anonymous(),
+                AuthMode::Required => {
+                    // Uniform failure: missing / malformed / unknown / revoked
+                    // are indistinguishable (byte-identical 401 to legacy).
+                    let credential =
+                        extract_credential(parts).ok_or(AletheiaHttpError::Unauthorized)?;
+                    auth.store()
+                        .verify(&credential)
+                        .ok_or(AletheiaHttpError::Unauthorized)?
+                }
             }
         };
 
@@ -234,7 +247,20 @@ pub fn authorize<C: AccessClassMarker>(principal: &Principal) -> Result<(), Alet
 /// ASCII-case-insensitive; a whitespace-only or empty credential is rejected.
 #[must_use = "the extracted credential must be verified against the auth store"]
 pub fn extract_credential(parts: &Parts) -> Option<String> {
-    if let Some(value) = parts.headers.get(axum::http::header::AUTHORIZATION) {
+    extract_credential_headers(&parts.headers)
+}
+
+/// Header-map form of [`extract_credential`] — the credential extractor a tower
+/// `Service` uses, which holds an `http::Request` (and thus a `&HeaderMap`)
+/// rather than an extractor's `&Parts`. Same contract: `Authorization: Bearer`
+/// (ASCII-case-insensitive scheme) first, then `x-api-key`; both trimmed, empty
+/// rejected; any malformed header collapses to `None` (the uniform-401 upstream).
+///
+/// [`extract_credential`] delegates here so the two entry points can never
+/// diverge on what counts as a valid credential.
+#[must_use = "the extracted credential must be verified against the auth store"]
+pub fn extract_credential_headers(headers: &axum::http::HeaderMap) -> Option<String> {
+    if let Some(value) = headers.get(axum::http::header::AUTHORIZATION) {
         let s = value.to_str().ok()?;
         let (scheme, rest) = s.split_once(' ')?;
         if !scheme.eq_ignore_ascii_case("bearer") {
@@ -246,7 +272,7 @@ pub fn extract_credential(parts: &Parts) -> Option<String> {
         }
         return Some(token.to_owned());
     }
-    if let Some(value) = parts.headers.get("x-api-key") {
+    if let Some(value) = headers.get("x-api-key") {
         let token = value.to_str().ok()?.trim();
         if token.is_empty() {
             return None;

--- a/crates/aletheia-server/src/security/mcp_gate.rs
+++ b/crates/aletheia-server/src/security/mcp_gate.rs
@@ -38,10 +38,36 @@
 //!    shape the legacy MCP `permission_denied_error` emits. (The replayed
 //!    dispatch handler's own `Authorized<C>` gate remains as defense-in-depth;
 //!    see the crate/README notes on the tools/call replay boundary.)
+//! 4. **Fails closed** on frames it cannot RBAC-precheck (#6): an oversize
+//!    buffered body (> [`MAX_MCP_REQUEST_BYTES`]) returns a `413`
+//!    ([`mcp_payload_too_large_response`]) instead of being swallowed and
+//!    forwarded as an empty body; a `tools/call` with no string `params.name`,
+//!    or a JSON-RPC **batch array** containing a `tools/call`, returns a `400`
+//!    ([`mcp_unroutable_tool_call_response`]) rather than passing through
+//!    un-gated (batched tool calls must be sent as individual requests in v1).
+//! 5. **Normalizes the verified credential** onto `Authorization: Bearer
+//!    <token>` for the tools/call replay (see [`normalize_authorization`]),
+//!    dropping the `x-api-key` header. autumn 0.5 forwards only `authorization`
+//!    (its `FORWARDED_HEADERS`), so this gives `x-api-key` full parity on
+//!    `tools/call` (the replayed handler re-verifies the normalized bearer)
+//!    while guaranteeing the losing/unverified header never survives. Only the
+//!    credential the layer actually verified is normalized.
+//!
+//! # Two-shape 403 contract (ruling F4 / coordinator #8a)
+//!
+//! The MCP-surface 403 ([`mcp_permission_denied_response`]) **carries**
+//! `details: {required_class, principal_role}`; the HTTP-surface 403
+//! ([`crate::security::authorize_class`] →
+//! [`AletheiaHttpError::PermissionDenied`]) stays **message-only**, matching the
+//! legacy `src/http/auth.rs`. The two shapes are intentional and asymmetric — do
+//! not add `details` to the HTTP surface. Because the gate now fails closed on
+//! every tool-executing frame it cannot identify (point 4), no MCP tools/call
+//! reaches the dispatch handler's message-only 403 path without first passing
+//! the gate's detail-carrying precheck.
 //!
 //! In [`AuthMode::Anonymous`] the layer inserts [`Principal::anonymous`] and
 //! passes through unconditionally (catalog reachable — matching the legacy
-//! anonymous surface).
+//! anonymous surface); no credential is verified, so no normalization occurs.
 
 use std::convert::Infallible;
 use std::future::Future;
@@ -53,12 +79,17 @@ use aletheiadb::auth::{AuthMode, AuthStore, Principal};
 use aletheiadb::http::AletheiaHttpError;
 use axum::Json;
 use axum::body::Body;
-use axum::http::{Request, Response, StatusCode};
+use axum::http::header::AUTHORIZATION;
+use axum::http::{HeaderMap, HeaderValue, Request, Response, StatusCode};
 use axum::response::IntoResponse;
 use serde_json::json;
 
 use crate::security::auth::extract_credential_headers;
 use crate::security::rbac::{self, Denied};
+
+/// Case-insensitive name of the `x-api-key` transport header (the alternative to
+/// `Authorization: Bearer` the gate accepts and then normalizes away).
+const X_API_KEY: &str = "x-api-key";
 
 /// Upper bound on a buffered `/mcp` JSON-RPC request body (MCP requests are
 /// tiny control messages). A body larger than this is not a legitimate
@@ -98,21 +129,123 @@ pub fn mcp_permission_denied_response(denied: Denied) -> Response<Body> {
     (StatusCode::FORBIDDEN, Json(body)).into_response()
 }
 
-/// Parse a buffered `/mcp` JSON-RPC body and, **iff** it is a single
-/// `tools/call`, return the target tool name. Any other method
-/// (`initialize`, `tools/list`, notifications), a batch array, or an
-/// unparseable body yields `None` — those carry no per-tool RBAC decision (the
-/// catalog methods are gated by authentication alone).
-fn tools_call_target(bytes: &[u8]) -> Option<String> {
-    let value: serde_json::Value = serde_json::from_slice(bytes).ok()?;
-    if value.get("method").and_then(|m| m.as_str()) != Some("tools/call") {
-        return None;
+/// The `413 RESOURCE_EXHAUSTED` envelope for an over-limit buffered `/mcp` body
+/// (SHOULD-FIX #2). A body larger than [`MAX_MCP_REQUEST_BYTES`] is refused
+/// fail-closed — never swallowed and forwarded as an empty body — so an
+/// oversize request cannot silently reach dispatch. Non-retriable (a caller
+/// fault), mirroring the shared `ResultBytes` 413.
+#[must_use]
+pub fn mcp_payload_too_large_response() -> Response<Body> {
+    let body = json!({
+        "success": false,
+        "error": format!(
+            "request body exceeds the {MAX_MCP_REQUEST_BYTES}-byte /mcp limit"
+        ),
+        "code": "RESOURCE_EXHAUSTED",
+        "retriable": false,
+        "details": {
+            "reason": "request_body_too_large",
+            "limit": MAX_MCP_REQUEST_BYTES,
+        },
+    });
+    (StatusCode::PAYLOAD_TOO_LARGE, Json(body)).into_response()
+}
+
+/// The `400 INVALID_ARGUMENT` envelope for a tool-executing frame the gate
+/// cannot RBAC-precheck (#6): a `tools/call` with no resolvable string
+/// `params.name`, or a JSON-RPC **batch array** carrying a `tools/call`. Rather
+/// than pass such a frame through un-checked (potential under-gating), the gate
+/// refuses it fail-closed. Non-retriable.
+#[must_use]
+pub fn mcp_unroutable_tool_call_response(reason: &'static str) -> Response<Body> {
+    let body = json!({
+        "success": false,
+        "error": format!("unroutable tools/call frame refused: {reason}"),
+        "code": "INVALID_ARGUMENT",
+        "retriable": false,
+        "details": { "reason": reason },
+    });
+    (StatusCode::BAD_REQUEST, Json(body)).into_response()
+}
+
+/// The classification of a buffered `/mcp` JSON-RPC frame for RBAC prechecking.
+enum McpFrame {
+    /// Not a tool-executing frame (`initialize`, `tools/list`, a notification, a
+    /// batch with no `tools/call`, or an unparseable/empty body) — gated by
+    /// authentication alone, no per-tool RBAC decision.
+    PassThrough,
+    /// A single `tools/call` naming this tool — RBAC-prechecked at the envelope.
+    ToolCall(String),
+    /// A tool-executing frame the gate cannot identify: a `tools/call` with no
+    /// string `params.name`, or a batch array containing a `tools/call`. Refused
+    /// fail-closed (#6) with the carried reason.
+    Unroutable(&'static str),
+}
+
+/// Classify a buffered `/mcp` body for the per-tool RBAC precheck.
+///
+/// A single JSON-RPC object with `method == "tools/call"` yields
+/// [`McpFrame::ToolCall`] (or [`McpFrame::Unroutable`] if its `params.name` is
+/// missing/non-string). A **batch array** containing any `tools/call` element is
+/// [`McpFrame::Unroutable`] — the envelope precheck cannot express multiple
+/// per-tool decisions, so the gate refuses it fail-closed rather than risk
+/// under-gating. Everything else is [`McpFrame::PassThrough`].
+fn classify_mcp_frame(bytes: &[u8]) -> McpFrame {
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(bytes) else {
+        // Unparseable/empty: not a routable tool call; authentication already
+        // applied, and dispatch will produce its own JSON-RPC error.
+        return McpFrame::PassThrough;
+    };
+
+    // JSON-RPC batch: an array of frames. If any is a tools/call, refuse
+    // fail-closed (the per-tool RBAC precheck cannot fan out over a batch).
+    if let Some(elements) = value.as_array() {
+        let has_tool_call = elements
+            .iter()
+            .any(|e| e.get("method").and_then(|m| m.as_str()) == Some("tools/call"));
+        return if has_tool_call {
+            McpFrame::Unroutable("batched tools/call must be sent as individual requests")
+        } else {
+            McpFrame::PassThrough
+        };
     }
-    value
+
+    if value.get("method").and_then(|m| m.as_str()) != Some("tools/call") {
+        return McpFrame::PassThrough;
+    }
+    match value
         .get("params")
         .and_then(|p| p.get("name"))
         .and_then(|n| n.as_str())
-        .map(str::to_owned)
+    {
+        Some(name) => McpFrame::ToolCall(name.to_owned()),
+        None => McpFrame::Unroutable("tools/call is missing a string params.name"),
+    }
+}
+
+/// Normalize the verified credential onto `Authorization: Bearer <token>` for
+/// the tools/call replay, and drop the `x-api-key` header.
+///
+/// autumn 0.5 forwards only `authorization` (its `FORWARDED_HEADERS`) into the
+/// replayed dispatch, so an `x-api-key`-authenticated caller would otherwise
+/// lose its credential at the replay boundary. Rewriting the header the gate
+/// **actually verified** into a bearer gives `x-api-key` full parity while
+/// ensuring the loser/unverified header never survives into the replay. Only
+/// called with a credential the layer verified; the token is a valid header
+/// value (it came from one), so the rewrite cannot fail in practice — an
+/// unexpected non-header token is dropped rather than forwarded unverified.
+fn normalize_authorization(headers: &mut HeaderMap, verified_token: &str) {
+    match HeaderValue::try_from(format!("Bearer {verified_token}")) {
+        Ok(value) => {
+            headers.insert(AUTHORIZATION, value);
+        }
+        Err(_) => {
+            // Unreachable in practice; fail closed by removing any credential
+            // rather than forwarding an unverified one.
+            headers.remove(AUTHORIZATION);
+        }
+    }
+    headers.remove(X_API_KEY);
 }
 
 /// Custom tower [`Layer`](tower::Layer) gating the whole `/mcp` endpoint with
@@ -179,38 +312,53 @@ where
 
         Box::pin(async move {
             // 1. Authenticate (uniform 401 on any failure in Required mode).
-            let principal = match mode {
-                AuthMode::Anonymous => Principal::anonymous(),
-                AuthMode::Required => {
-                    match extract_credential_headers(req.headers())
-                        .and_then(|cred| store.verify(&cred))
-                    {
-                        Some(principal) => principal,
+            //    Retain the *verified* token so it can be normalized onto the
+            //    `authorization` header for the tools/call replay (below).
+            let (principal, verified_token) = match mode {
+                AuthMode::Anonymous => (Principal::anonymous(), None),
+                AuthMode::Required => match extract_credential_headers(req.headers()) {
+                    Some(credential) => match store.verify(&credential) {
+                        Some(principal) => (principal, Some(credential)),
                         None => return Ok(mcp_unauthenticated_response()),
-                    }
-                }
+                    },
+                    None => return Ok(mcp_unauthenticated_response()),
+                },
             };
 
             // 2. Buffer the body so a `tools/call` can be RBAC-pre-checked at
             //    the envelope (F4). Authentication above needed only headers;
-            //    only this per-tool decision needs the body.
-            let (parts, body) = req.into_parts();
+            //    only this per-tool decision needs the body. An oversize body is
+            //    refused fail-closed with a 413 envelope (#2) — never swallowed
+            //    and forwarded empty.
+            let (mut parts, body) = req.into_parts();
             let bytes = match axum::body::to_bytes(body, MAX_MCP_REQUEST_BYTES).await {
                 Ok(bytes) => bytes,
-                // An unreadable/oversized body is not a valid JSON-RPC call;
-                // pass an empty body through so dispatch produces its own error
-                // (auth already succeeded).
-                Err(_) => axum::body::Bytes::new(),
+                Err(_) => return Ok(mcp_payload_too_large_response()),
             };
 
-            // 3. Per-tool RBAC pre-check for tools/call (F4).
-            if let Some(tool) = tools_call_target(&bytes)
-                && let Err(denied) = rbac::authorize_tool(principal.role, &tool)
-            {
-                return Ok(mcp_permission_denied_response(denied));
+            // 3. Classify the frame and enforce per-tool RBAC (F4) / fail-close
+            //    unroutable tool-executing frames (#6).
+            match classify_mcp_frame(&bytes) {
+                McpFrame::ToolCall(tool) => {
+                    if let Err(denied) = rbac::authorize_tool(principal.role, &tool) {
+                        return Ok(mcp_permission_denied_response(denied));
+                    }
+                }
+                McpFrame::Unroutable(reason) => {
+                    return Ok(mcp_unroutable_tool_call_response(reason));
+                }
+                McpFrame::PassThrough => {}
             }
 
-            // 4. Rebuild the request, cache the verified principal in
+            // 4. Normalize the verified credential onto `authorization: Bearer`
+            //    for the replay (x-api-key parity), stripping the loser header so
+            //    only the verified credential survives. No-op in anonymous mode
+            //    (no verified credential).
+            if let Some(token) = verified_token.as_deref() {
+                normalize_authorization(&mut parts.headers, token);
+            }
+
+            // 5. Rebuild the request, cache the verified principal in
             //    extensions (F3 seam), and pass through.
             let mut req = Request::from_parts(parts, Body::from(bytes));
             req.extensions_mut().insert(principal);

--- a/crates/aletheia-server/src/security/mcp_gate.rs
+++ b/crates/aletheia-server/src/security/mcp_gate.rs
@@ -1,0 +1,220 @@
+// OWNED BY LANE B (security).
+//
+//! The custom, `x-api-key`-aware `/mcp` security gate (Issue #3524 B4, ruling F2/F4).
+//!
+//! # Why not the native `RequireApiToken`
+//!
+//! autumn 0.5's [`RequireApiToken`](autumn_web::auth::RequireApiToken) gates
+//! `/mcp` behind a bearer-**only** token check
+//! (`parse_bearer_token`) and, on failure, emits autumn's own
+//! `application/problem+json` body — **not** AletheiaDB's
+//! `{code, message, retriable, details?}` envelope. That breaks two B4
+//! requirements at once: (1) AletheiaDB accepts the credential in either
+//! `Authorization: Bearer` **or** `x-api-key` (mirroring the legacy HTTP/MCP
+//! surfaces), and (2) every auth/authz failure must carry the shared structured
+//! envelope for byte-parity (AC f).
+//!
+//! [`secure_mcp`](autumn_web::app::AppBuilder::secure_mcp) is **not** hard-wired
+//! to `RequireApiToken`: its bound is any
+//! `L: tower::Layer<axum::routing::Route>` whose service maps
+//! `Request<Body> → Response<Body>` with `Error = Infallible`. So we mount this
+//! [`McpSecurityLayer`] instead — a custom tower layer that:
+//!
+//! 1. **Authenticates** via [`extract_credential_headers`] (Bearer **or**
+//!    `x-api-key`, trimmed, empty-rejected) and the shared constant-time
+//!    [`AuthStore::verify`]. Any failure — missing / malformed / unknown /
+//!    revoked — collapses to one **uniform** `401 UNAUTHENTICATED` envelope
+//!    (identical to the legacy surface; never reveals which failure occurred).
+//!    This gates the **entire** `/mcp` endpoint — `initialize`, `tools/list`,
+//!    and `tools/call` are all unreachable without a valid credential in
+//!    [`AuthMode::Required`] (AC e).
+//! 2. On success **inserts the verified [`Principal`] into request extensions**
+//!    (the F3 caching seam) and passes through.
+//! 3. **Pre-checks per-tool RBAC** for `tools/call` at the envelope (ruling F4):
+//!    the request body is buffered, the JSON-RPC `method`/`params.name` parsed,
+//!    and [`rbac::authorize_tool`] consulted. A role that does not permit the
+//!    tool's class is refused **before dispatch** with a `403 PERMISSION_DENIED`
+//!    envelope carrying `details: {required_class, principal_role}` — the same
+//!    shape the legacy MCP `permission_denied_error` emits. (The replayed
+//!    dispatch handler's own `Authorized<C>` gate remains as defense-in-depth;
+//!    see the crate/README notes on the tools/call replay boundary.)
+//!
+//! In [`AuthMode::Anonymous`] the layer inserts [`Principal::anonymous`] and
+//! passes through unconditionally (catalog reachable — matching the legacy
+//! anonymous surface).
+
+use std::convert::Infallible;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use aletheiadb::auth::{AuthMode, AuthStore, Principal};
+use aletheiadb::http::AletheiaHttpError;
+use axum::Json;
+use axum::body::Body;
+use axum::http::{Request, Response, StatusCode};
+use axum::response::IntoResponse;
+use serde_json::json;
+
+use crate::security::auth::extract_credential_headers;
+use crate::security::rbac::{self, Denied};
+
+/// Upper bound on a buffered `/mcp` JSON-RPC request body (MCP requests are
+/// tiny control messages). A body larger than this is not a legitimate
+/// JSON-RPC call, so it is not parsed for a tool name — authentication still
+/// applies, and dispatch enforces its own limits.
+const MAX_MCP_REQUEST_BYTES: usize = 2 * 1024 * 1024;
+
+/// The uniform `401 UNAUTHENTICATED` envelope for the `/mcp` gate — reuses the
+/// shared [`AletheiaHttpError::Unauthorized`] rendering so the body (and the
+/// `www-authenticate: Bearer` header) is byte-identical to the HTTP surface.
+#[must_use]
+pub fn mcp_unauthenticated_response() -> Response<Body> {
+    AletheiaHttpError::Unauthorized.into_response()
+}
+
+/// The `403 PERMISSION_DENIED` envelope for a `/mcp` per-tool RBAC refusal,
+/// carrying `details: {required_class, principal_role}` (ruling F4). The
+/// `error` message and `details` shape mirror the legacy MCP
+/// `permission_denied_error` exactly, so an LLM/caller branches on `code` +
+/// `details` without substring matching; `retriable` is `false` (a caller-fault
+/// authorization denial is never retriable).
+#[must_use]
+pub fn mcp_permission_denied_response(denied: Denied) -> Response<Body> {
+    let body = json!({
+        "success": false,
+        "error": format!(
+            "role '{}' does not permit {} access",
+            denied.principal_role, denied.required_class
+        ),
+        "code": "PERMISSION_DENIED",
+        "retriable": false,
+        "details": {
+            "required_class": denied.required_class.to_string(),
+            "principal_role": denied.principal_role.to_string(),
+        },
+    });
+    (StatusCode::FORBIDDEN, Json(body)).into_response()
+}
+
+/// Parse a buffered `/mcp` JSON-RPC body and, **iff** it is a single
+/// `tools/call`, return the target tool name. Any other method
+/// (`initialize`, `tools/list`, notifications), a batch array, or an
+/// unparseable body yields `None` — those carry no per-tool RBAC decision (the
+/// catalog methods are gated by authentication alone).
+fn tools_call_target(bytes: &[u8]) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_slice(bytes).ok()?;
+    if value.get("method").and_then(|m| m.as_str()) != Some("tools/call") {
+        return None;
+    }
+    value
+        .get("params")
+        .and_then(|p| p.get("name"))
+        .and_then(|n| n.as_str())
+        .map(str::to_owned)
+}
+
+/// Custom tower [`Layer`](tower::Layer) gating the whole `/mcp` endpoint with
+/// `x-api-key`-aware authentication + per-tool RBAC (rulings F2/F4). Mounted via
+/// [`secure_mcp`](autumn_web::app::AppBuilder::secure_mcp).
+#[derive(Clone)]
+pub struct McpSecurityLayer {
+    store: Arc<AuthStore>,
+    mode: AuthMode,
+}
+
+impl McpSecurityLayer {
+    /// Build the gate from the shared credential store and the auth mode.
+    #[must_use]
+    pub fn new(store: Arc<AuthStore>, mode: AuthMode) -> Self {
+        Self { store, mode }
+    }
+}
+
+impl<S> tower::Layer<S> for McpSecurityLayer {
+    type Service = McpSecurityService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        McpSecurityService {
+            inner,
+            store: Arc::clone(&self.store),
+            mode: self.mode,
+        }
+    }
+}
+
+/// The tower [`Service`](tower::Service) produced by [`McpSecurityLayer`].
+#[derive(Clone)]
+pub struct McpSecurityService<S> {
+    inner: S,
+    store: Arc<AuthStore>,
+    mode: AuthMode,
+}
+
+impl<S> tower::Service<Request<Body>> for McpSecurityService<S>
+where
+    S: tower::Service<Request<Body>, Response = Response<Body>, Error = Infallible>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Response<Body>;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        let store = Arc::clone(&self.store);
+        let mode = self.mode;
+        // Clone-and-swap so the inner service driven in the async block is the
+        // `poll_ready`-ed one (standard tower pattern; the swapped-in clone is
+        // not driven).
+        let mut inner = self.inner.clone();
+        std::mem::swap(&mut self.inner, &mut inner);
+
+        Box::pin(async move {
+            // 1. Authenticate (uniform 401 on any failure in Required mode).
+            let principal = match mode {
+                AuthMode::Anonymous => Principal::anonymous(),
+                AuthMode::Required => {
+                    match extract_credential_headers(req.headers())
+                        .and_then(|cred| store.verify(&cred))
+                    {
+                        Some(principal) => principal,
+                        None => return Ok(mcp_unauthenticated_response()),
+                    }
+                }
+            };
+
+            // 2. Buffer the body so a `tools/call` can be RBAC-pre-checked at
+            //    the envelope (F4). Authentication above needed only headers;
+            //    only this per-tool decision needs the body.
+            let (parts, body) = req.into_parts();
+            let bytes = match axum::body::to_bytes(body, MAX_MCP_REQUEST_BYTES).await {
+                Ok(bytes) => bytes,
+                // An unreadable/oversized body is not a valid JSON-RPC call;
+                // pass an empty body through so dispatch produces its own error
+                // (auth already succeeded).
+                Err(_) => axum::body::Bytes::new(),
+            };
+
+            // 3. Per-tool RBAC pre-check for tools/call (F4).
+            if let Some(tool) = tools_call_target(&bytes)
+                && let Err(denied) = rbac::authorize_tool(principal.role, &tool)
+            {
+                return Ok(mcp_permission_denied_response(denied));
+            }
+
+            // 4. Rebuild the request, cache the verified principal in
+            //    extensions (F3 seam), and pass through.
+            let mut req = Request::from_parts(parts, Body::from(bytes));
+            req.extensions_mut().insert(principal);
+            inner.call(req).await
+        })
+    }
+}

--- a/crates/aletheia-server/src/security/mod.rs
+++ b/crates/aletheia-server/src/security/mod.rs
@@ -45,7 +45,8 @@ pub use auth::{
 };
 pub use cursor::{CursorSecret, LiveCursorRegistry};
 pub use mcp_gate::{
-    McpSecurityLayer, mcp_permission_denied_response, mcp_unauthenticated_response,
+    McpSecurityLayer, mcp_payload_too_large_response, mcp_permission_denied_response,
+    mcp_unauthenticated_response, mcp_unroutable_tool_call_response,
 };
 pub use resource_limits::{InFlightLimiter, ResourceLimits};
 
@@ -244,8 +245,16 @@ pub fn apply_security(app: TestApp, cfg: &SecurityConfig) -> TestApp {
     let app = app.secure_mcp(McpSecurityLayer::new(cfg.store.clone(), cfg.mode));
 
     // 2. Default-off per-IP rate limiter, mounted app-wide only when enabled.
+    //    When enabled, retain the `RateLimit`'s GC handle and drive it from a
+    //    lifecycle-tied background task so the per-IP keyed state cannot grow
+    //    without bound (MUST-FIX 8c). The task holds only a weak handle, so it
+    //    self-terminates when the mounted layer is dropped (no leak/duplicate).
     match rate_limit::governor_layer(cfg) {
-        Some(rl) => app.layer(rl.layer),
+        Some(rl) => {
+            let (layer, gc) = rl.into_parts();
+            let _gc_task = rate_limit::spawn_gc_task(gc, rate_limit::RATE_LIMIT_GC_INTERVAL);
+            app.layer(layer)
+        }
         None => app,
     }
 }

--- a/crates/aletheia-server/src/security/mod.rs
+++ b/crates/aletheia-server/src/security/mod.rs
@@ -27,12 +27,12 @@
 
 pub mod auth;
 pub mod cursor;
+pub mod mcp_gate;
 pub mod rate_limit;
 pub mod rbac;
 pub mod resource_limits;
 
 use aletheiadb::auth::{AuthMode, AuthStore};
-use autumn_web::auth::RequireApiToken;
 use autumn_web::prelude::AppState as AutumnAppState;
 use autumn_web::test::TestApp;
 use std::sync::Arc;
@@ -41,8 +41,13 @@ use std::time::Duration;
 pub use auth::{
     AccessClassMarker, AdminClass, ApiKeyStore, AuthStoreTokenAdapter, Authorized, MetricsClass,
     RateLimitSettings, ReadClass, ServerAuthState, WriteClass, authorize, authorize_class,
-    extract_credential,
+    extract_credential, extract_credential_headers,
 };
+pub use cursor::{CursorSecret, LiveCursorRegistry};
+pub use mcp_gate::{
+    McpSecurityLayer, mcp_permission_denied_response, mcp_unauthenticated_response,
+};
+pub use resource_limits::{InFlightLimiter, ResourceLimits};
 
 /// Security configuration for the server surface.
 ///
@@ -100,27 +105,148 @@ impl SecurityConfig {
             max_live_cursors_per_conn: 128,
         }
     }
+
+    /// Enable the default-off per-IP rate-limit layer (builder-style, for
+    /// wiring/tests). `None` restores the default (off).
+    #[must_use]
+    pub fn with_rate_limit(mut self, settings: Option<RateLimitSettings>) -> Self {
+        self.rate_limit = settings;
+        self
+    }
+
+    /// Override the per-query wall-clock timeout (`Duration::ZERO` = unlimited).
+    #[must_use]
+    pub fn with_query_timeout(mut self, timeout: Duration) -> Self {
+        self.query_timeout = timeout;
+        self
+    }
+
+    /// Override the per-query row cap (`0` = unlimited).
+    #[must_use]
+    pub fn with_max_result_rows(mut self, rows: usize) -> Self {
+        self.max_result_rows = rows;
+        self
+    }
+
+    /// Override the per-query serialized-byte cap (`0` = unlimited).
+    #[must_use]
+    pub fn with_max_response_bytes(mut self, bytes: usize) -> Self {
+        self.max_response_bytes = bytes;
+        self
+    }
+
+    /// Override the concurrent in-flight-query cap (`0` = unbounded).
+    #[must_use]
+    pub fn with_max_in_flight_queries(mut self, cap: usize) -> Self {
+        self.max_in_flight_queries = cap;
+        self
+    }
 }
 
-/// Apply the security layer stack to the app builder.
+/// Shared server-side security **primitives** installed into app state by
+/// [`init_state`] and pulled back by the resource-limited read handlers and
+/// (future) cursor-paged handlers.
 ///
-/// **Seam (Lane A calls, Lane B extends).** PR1 mirrors the spike: in
-/// [`AuthMode::Required`] the whole `/mcp` endpoint is gated behind autumn's
-/// native [`RequireApiToken`] backed by the shared [`AuthStore`] (via
-/// [`AuthStoreTokenAdapter`]), so the MCP catalog is not anonymously reachable.
-/// [`AuthMode::Anonymous`] skips the gate deliberately.
+/// Distinct from [`ServerAuthState`] (which carries the credential store +
+/// mode): this carries the per-query resource caps ([`ResourceLimits`]), the
+/// process-wide bounded in-flight guard ([`InFlightLimiter`], #3550), the
+/// per-process cursor-signing secret ([`CursorSecret`], #3360) and the
+/// per-connection cursor cap registry ([`LiveCursorRegistry`]). Cloneable
+/// (every field is `Arc`-backed or `Copy`) so it lives in the extension bag.
+#[derive(Clone)]
+pub struct ServerSecurityState {
+    limits: ResourceLimits,
+    in_flight: InFlightLimiter,
+    cursor_secret: Arc<CursorSecret>,
+    cursor_registry: LiveCursorRegistry,
+}
+
+impl ServerSecurityState {
+    /// Build the primitives from a [`SecurityConfig`]: a fresh in-flight guard
+    /// and cursor registry at the configured caps, and a fresh random
+    /// per-process cursor secret.
+    #[must_use]
+    pub fn from_config(cfg: &SecurityConfig) -> Self {
+        Self {
+            limits: ResourceLimits::from_config(cfg),
+            in_flight: InFlightLimiter::from_config(cfg),
+            cursor_secret: Arc::new(CursorSecret::random()),
+            cursor_registry: LiveCursorRegistry::new(cfg.max_live_cursors_per_conn),
+        }
+    }
+
+    /// The effective per-query resource caps.
+    #[must_use]
+    pub fn limits(&self) -> ResourceLimits {
+        self.limits
+    }
+
+    /// The bounded in-flight-query admission guard.
+    #[must_use]
+    pub fn in_flight(&self) -> &InFlightLimiter {
+        &self.in_flight
+    }
+
+    /// The per-process cursor-signing secret.
+    #[must_use]
+    pub fn cursor_secret(&self) -> &Arc<CursorSecret> {
+        &self.cursor_secret
+    }
+
+    /// The per-connection live-cursor cap registry.
+    #[must_use]
+    pub fn cursor_registry(&self) -> &LiveCursorRegistry {
+        &self.cursor_registry
+    }
+}
+
+impl axum::extract::FromRequestParts<AutumnAppState> for ServerSecurityState {
+    type Rejection = aletheiadb::http::AletheiaHttpError;
+
+    async fn from_request_parts(
+        _parts: &mut axum::http::request::Parts,
+        state: &AutumnAppState,
+    ) -> Result<Self, Self::Rejection> {
+        state
+            .extension::<ServerSecurityState>()
+            .map(|arc| (*arc).clone())
+            .ok_or(aletheiadb::http::AletheiaHttpError::StateMissing)
+    }
+}
+
+/// Apply the security layer stack to the app builder (B4 wiring).
 ///
-/// TODO(Lane B): add the `tower-governor` rate-limit layer and the in-flight
-/// `ConcurrencyLimit` backpressure layer here (both no-ops in PR1).
+/// **Seam (Lane A calls, Lane B fills).** Two mounts:
+///
+/// 1. **`/mcp` gate (F2/F4).** The whole `/mcp` endpoint — `initialize`,
+///    `tools/list`, `tools/call` — is gated behind the custom
+///    [`McpSecurityLayer`] via
+///    [`secure_mcp`](autumn_web::app::AppBuilder::secure_mcp) (whose bound
+///    accepts any `tower::Layer<Route>`, not just `RequireApiToken`). Unlike the
+///    native bearer-only `RequireApiToken`, this layer accepts Bearer **or**
+///    `x-api-key`, emits the shared `{code, message, retriable, details?}`
+///    envelope on failure (uniform 401), and RBAC-pre-checks each `tools/call`
+///    at the envelope (403 with `details`). It is mounted in **both** modes: in
+///    [`AuthMode::Anonymous`] it inserts the anonymous principal and passes
+///    through (catalog reachable), matching the legacy anonymous surface.
+/// 2. **Rate-limit layer (F, default-off).** [`rate_limit::governor_layer`]
+///    returns `None` unless [`SecurityConfig::rate_limit`] is `Some`, so by
+///    default no layer is mounted and behavior is byte-for-byte today's. When
+///    the operator opts in, the per-IP `tower-governor` layer is mounted
+///    app-wide via `.layer()`.
+///
+/// The per-query resource caps, in-flight guard, and cursor primitives are
+/// **state**, not layers — [`init_state`] installs them for the handlers to
+/// enforce per-request.
 #[must_use]
 pub fn apply_security(app: TestApp, cfg: &SecurityConfig) -> TestApp {
-    match cfg.mode {
-        AuthMode::Required => {
-            let token_layer =
-                RequireApiToken::new(Arc::new(AuthStoreTokenAdapter::new(cfg.store.clone())));
-            app.secure_mcp(token_layer)
-        }
-        AuthMode::Anonymous => app,
+    // 1. Custom /mcp gate (both modes; branches on mode internally).
+    let app = app.secure_mcp(McpSecurityLayer::new(cfg.store.clone(), cfg.mode));
+
+    // 2. Default-off per-IP rate limiter, mounted app-wide only when enabled.
+    match rate_limit::governor_layer(cfg) {
+        Some(rl) => app.layer(rl.layer),
+        None => app,
     }
 }
 
@@ -131,6 +257,10 @@ pub fn apply_security(app: TestApp, cfg: &SecurityConfig) -> TestApp {
 /// which hands out a shared `&AppState` whose `insert_extension` takes `&self`.
 pub fn init_state(app_state: &AutumnAppState, cfg: &SecurityConfig) {
     app_state.insert_extension(ServerAuthState::new(cfg.store.clone(), cfg.mode));
+    // B4: install the resource-limit + cursor primitives so the read handlers
+    // (row/byte/timeout/in-flight enforcement) and cursor-paged handlers can
+    // pull them per-request.
+    app_state.insert_extension(ServerSecurityState::from_config(cfg));
 }
 
 /// Validate security configuration at startup.

--- a/crates/aletheia-server/src/security/rate_limit.rs
+++ b/crates/aletheia-server/src/security/rate_limit.rs
@@ -21,16 +21,35 @@
 //! Keyed per **peer IP** ([`PeerIpKeyExtractor`]) with the `NoOpMiddleware`
 //! (no extra rate-limit response headers beyond governor's own `retry-after` /
 //! `x-ratelimit-after`). The raw over-limit response is governor's plain `429`
-//! with a `retry-after` header and a text body; B4 wiring wraps that into the
-//! #3234 `{code: "UNAVAILABLE", retriable: true, ...}` envelope (Issue #3561 §8).
+//! with a `retry-after` header and a text body; the B4 wiring wraps that into
+//! the shared structured envelope via [`GovernorLayer::error_handler`]
+//! ([`wrap_governor_error`]) — `code: "RESOURCE_EXHAUSTED"`, `retriable: true`,
+//! matching the legacy `ResourceLimitExceeded` 429 shape (Issue #3561 §8,
+//! MUST-FIX 8b) — while preserving the `retry-after` header.
+//!
+//! The mounted layer is retained (not dropped) so its unbounded per-IP keyed
+//! state can be reclaimed: [`RateLimit::into_parts`] splits the mountable layer
+//! from a weak [`RateLimitGc`] handle that [`spawn_gc_task`] drives on a coarse
+//! interval, self-terminating when the layer is dropped (MUST-FIX 8c).
 
 use crate::security::SecurityConfig;
+use axum::Json;
+use axum::body::Body;
+use axum::http::{Response, StatusCode};
+use axum::response::IntoResponse;
 use governor::middleware::NoOpMiddleware;
-use std::sync::Arc;
+use serde_json::json;
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 use tower_governor::GovernorLayer;
+use tower_governor::errors::GovernorError;
 use tower_governor::governor::{GovernorConfig, GovernorConfigBuilder};
 use tower_governor::key_extractor::PeerIpKeyExtractor;
+
+/// The coarse cadence at which [`spawn_gc_task`] drives [`RateLimitGc::gc`] when
+/// a rate-limit layer is mounted. Retention is only ever a memory optimisation
+/// (never a correctness requirement), so a slow, cheap cadence is deliberate.
+pub const RATE_LIMIT_GC_INTERVAL: Duration = Duration::from_secs(60);
 
 /// The concrete governor layer this core builds: per-peer-IP keying, no extra
 /// middleware, producing `axum::body::Body` error responses (the `axum`-feature
@@ -41,6 +60,51 @@ pub type SpikeGovernorLayer = GovernorLayer<PeerIpKeyExtractor, NoOpMiddleware, 
 /// keyed `RateLimiter` behind both the mounted [`SpikeGovernorLayer`] and the
 /// [`RateLimit::gc`] housekeeping handle.
 type SpikeGovernorConfig = GovernorConfig<PeerIpKeyExtractor, NoOpMiddleware>;
+
+/// Wrap tower_governor's raw over-limit response into AletheiaDB's shared
+/// structured envelope (MUST-FIX 8b).
+///
+/// Without this, [`GovernorLayer`] serves its own plain-text
+/// `"Too Many Requests! Wait for {n}s"` body (via `From<GovernorError>`), which
+/// breaks the #3234 error contract every other surface honors. Installed via
+/// [`GovernorLayer::error_handler`] — the clean tower_governor 0.8 hook (a
+/// `Fn(GovernorError) -> Response<Body>`), so no extra tower layer is needed.
+///
+/// Only the `TooManyRequests` (429) case is rewritten, into the legacy
+/// `ResourceLimitExceeded` shape — `code: "RESOURCE_EXHAUSTED"`, `retriable:
+/// true` (rate-limit throttling is transient) — preserving governor's
+/// `retry-after` header so a client still learns when to retry. Non-throttle
+/// governor errors (`UnableToExtractKey` → 500, custom `Other`) fall through to
+/// governor's default rendering unchanged.
+fn wrap_governor_error(error: GovernorError) -> Response<Body> {
+    match error {
+        GovernorError::TooManyRequests { wait_time, headers } => {
+            let body = json!({
+                "success": false,
+                "error": format!("rate limit exceeded; retry after {wait_time}s"),
+                "code": "RESOURCE_EXHAUSTED",
+                "retriable": true,
+                "details": {
+                    "reason": "rate_limit",
+                    "retry_after_secs": wait_time,
+                },
+            });
+            let mut resp = (StatusCode::TOO_MANY_REQUESTS, Json(body)).into_response();
+            // Preserve governor's advisory headers (retry-after / x-ratelimit-*)
+            // without clobbering the JSON content-type set above.
+            if let Some(extra) = headers {
+                for (name, value) in extra.iter() {
+                    if name != axum::http::header::CONTENT_TYPE {
+                        resp.headers_mut().insert(name, value.clone());
+                    }
+                }
+            }
+            resp
+        }
+        // Not a throttle decision — keep governor's own status/body.
+        other => other.into(),
+    }
+}
 
 /// A mounted rate limiter plus the handle needed to garbage-collect its
 /// unbounded per-IP keyed state (F2).
@@ -93,6 +157,94 @@ impl RateLimit {
     pub fn live_keys(&self) -> usize {
         self.config.limiter().len()
     }
+
+    /// Split the mountable [`layer`](Self::layer) from a lifecycle-tied GC handle
+    /// (MUST-FIX 8c). `apply_security` calls this: it moves the `layer` onto the
+    /// router via `.layer(..)` and hands the [`RateLimitGc`] to [`spawn_gc_task`]
+    /// so the unbounded per-IP keyed state is periodically reclaimed.
+    ///
+    /// The returned [`RateLimitGc`] holds only a **weak** reference to the shared
+    /// config, so it never keeps the limiter alive on its own — the GC task
+    /// self-terminates once the mounted layer (the last strong ref) is dropped.
+    #[must_use]
+    pub fn into_parts(self) -> (SpikeGovernorLayer, RateLimitGc) {
+        let gc = RateLimitGc {
+            config: Arc::downgrade(&self.config),
+        };
+        (self.layer, gc)
+    }
+}
+
+/// A lifecycle-tied garbage-collection handle for a mounted rate limiter
+/// (MUST-FIX 8c).
+///
+/// Holds a [`Weak`] to the shared keyed config: [`gc`](Self::gc) upgrades it and
+/// calls `retain_recent()` when the limiter is still mounted, and reports
+/// `false` once the layer has been dropped so [`spawn_gc_task`]'s loop exits
+/// without leaking. This is the reference that makes the background GC task
+/// tied to the app's lifecycle rather than a detached, never-ending task.
+#[derive(Clone)]
+pub struct RateLimitGc {
+    config: Weak<SpikeGovernorConfig>,
+}
+
+impl RateLimitGc {
+    /// Reclaim stale per-IP keyed state if the limiter is still live.
+    ///
+    /// Returns `true` when the underlying limiter was reachable and swept
+    /// (`retain_recent()`), `false` once every strong reference (i.e. the
+    /// mounted layer) has been dropped — the signal [`spawn_gc_task`] uses to
+    /// stop.
+    #[must_use]
+    pub fn gc(&self) -> bool {
+        match self.config.upgrade() {
+            Some(config) => {
+                config.limiter().retain_recent();
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Live per-IP key count if the limiter is still mounted (observability).
+    #[must_use]
+    pub fn live_keys(&self) -> Option<usize> {
+        self.config.upgrade().map(|c| c.limiter().len())
+    }
+}
+
+/// Spawn the periodic GC task that drives [`RateLimitGc::gc`] (MUST-FIX 8c).
+///
+/// Started by `apply_security` only when a rate-limit layer is mounted. The task
+/// ticks every `interval` and calls `gc()`; because the handle is weak, the very
+/// first tick after the mounted layer is dropped observes the upgrade fail and
+/// **breaks the loop** — so the task is tied to the app's lifecycle and never
+/// leaks or duplicates (one task per mounted layer, self-terminating).
+///
+/// Returns `None` when called outside a Tokio runtime (no task is spawned);
+/// otherwise the [`JoinHandle`](tokio::task::JoinHandle) (primarily for tests —
+/// production fire-and-forgets it, relying on the weak-handle self-termination).
+#[must_use = "in production the handle is intentionally dropped; tests should await it"]
+pub fn spawn_gc_task(
+    handle: RateLimitGc,
+    interval: Duration,
+) -> Option<tokio::task::JoinHandle<()>> {
+    if tokio::runtime::Handle::try_current().is_err() {
+        return None;
+    }
+    Some(tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        // The first tick fires immediately; consume it so the first *sweep*
+        // happens one interval in (nothing to reclaim at t=0 anyway).
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            if !handle.gc() {
+                // The mounted layer was dropped: stop (no leak).
+                break;
+            }
+        }
+    }))
 }
 
 /// Build the per-IP rate-limit layer from a [`SecurityConfig`], **default-off**.
@@ -130,6 +282,8 @@ pub fn governor_layer(cfg: &SecurityConfig) -> Option<RateLimit> {
     // state. `GovernorLayer::new` accepts `impl Into<Arc<GovernorConfig>>`; an
     // `Arc` is passed through by identity.
     let config = Arc::new(builder.finish()?);
-    let layer = GovernorLayer::new(config.clone());
+    // Wrap the raw governor 429 into the shared structured envelope (8b) via the
+    // tower_governor 0.8 `error_handler` hook.
+    let layer = GovernorLayer::new(config.clone()).error_handler(wrap_governor_error);
     Some(RateLimit { layer, config })
 }

--- a/crates/aletheia-server/tests/security_acceptance.rs
+++ b/crates/aletheia-server/tests/security_acceptance.rs
@@ -1,0 +1,632 @@
+//! B4 wiring acceptance suite (Issue #3524) — the seven non-regression ACs
+//! (a–g) plus the attack cases, driven against the assembled autumn-web 0.5
+//! server (`build_server_client*`) with the custom `/mcp` security gate, the
+//! resource-limited read path, and the class-parameterized `Authorized<C>`
+//! extractor.
+//!
+//! TDD note: every AC was written **attack-case-first** (the failing/negative
+//! case precedes the positive), so a regression that reopens a hole fails here.
+//!
+//! - (a) startup refusal ....... `startup_*`
+//! - (b) per-route + per-tool RBAC + extractor↔inventory conformance
+//! - (c) constant-time verify ... `constant_time_*`
+//! - (d) credentials never logged `credentials_never_*`
+//! - (e) MCP catalog closed ..... `mcp_catalog_*`
+//! - (f) structured error contract `error_contract_*`
+//! - (g) revocation immediate ... `revocation_*`
+//! - attack cases ............... `attack_*`
+
+use std::sync::Arc;
+
+use aletheia_server::security::resource_limits::{byte_cap_error, timeout_error};
+use aletheia_server::{
+    SecurityConfig, build_server_client, build_server_client_with_config, try_build_server_client,
+};
+use aletheiadb::auth::{AccessClass, AuthMode, AuthStore, Role};
+use aletheiadb::core::NodeId;
+use aletheiadb::http::AletheiaHttpError;
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+use autumn_web::test::TestClient;
+use serde_json::{Value, json};
+
+const ADMIN_TOKEN: &str = "admin-token-abcdefghijklmnop";
+const READER_TOKEN: &str = "reader-token-abcdefghijklmnop";
+const METRICS_TOKEN: &str = "metrics-token-abcdefghijklmnop";
+const WRITER_TOKEN: &str = "writer-token-abcdefghijklmnop";
+const EMBEDDING: &[f32] = &[0.10, 0.20, 0.30, 0.40];
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+/// Shared DB (one `Person` node) + a store with admin/reader/metrics/writer keys.
+fn fixture() -> (Arc<AletheiaDB>, Arc<AuthStore>, NodeId) {
+    let db = Arc::new(AletheiaDB::new().expect("create db"));
+    let node_id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .insert("age", 30_i64)
+                .insert_vector("embedding", EMBEDDING)
+                .build(),
+        )
+        .expect("create node");
+    (db, keyed_store(), node_id)
+}
+
+fn keyed_store() -> Arc<AuthStore> {
+    let store = Arc::new(AuthStore::new());
+    store
+        .insert_bootstrap_key("admin", Role::Admin, ADMIN_TOKEN)
+        .expect("admin key");
+    store
+        .insert_bootstrap_key("reader", Role::Reader, READER_TOKEN)
+        .expect("reader key");
+    store
+        .insert_bootstrap_key("metrics", Role::Metrics, METRICS_TOKEN)
+        .expect("metrics key");
+    store
+        .insert_bootstrap_key("writer", Role::Writer, WRITER_TOKEN)
+        .expect("writer key");
+    store
+}
+
+// ── HTTP drivers ─────────────────────────────────────────────────────────────
+
+async fn get_bearer(client: &TestClient, uri: &str, token: Option<&str>) -> (u16, Value) {
+    let mut req = client.get(uri);
+    if let Some(t) = token {
+        req = req.header("authorization", &format!("Bearer {t}"));
+    }
+    let resp = req.send().await;
+    body_of(resp).await
+}
+
+async fn get_header(client: &TestClient, uri: &str, name: &str, value: &str) -> (u16, Value) {
+    let resp = client.get(uri).header(name, value).send().await;
+    body_of(resp).await
+}
+
+async fn body_of(resp: autumn_web::test::TestResponse) -> (u16, Value) {
+    let status = resp.status.as_u16();
+    let text = resp.text();
+    let body: Value = serde_json::from_str(&text).unwrap_or(Value::String(text));
+    (status, body)
+}
+
+// ── /mcp drivers ─────────────────────────────────────────────────────────────
+
+/// POST a JSON-RPC request to `/mcp` with an optional bearer token; returns the
+/// **HTTP** status and the body (which is the JSON-RPC envelope on success, or
+/// the AletheiaDB structured envelope on an envelope-level auth/authz refusal).
+async fn mcp_post(client: &TestClient, rpc: &Value, token: Option<&str>) -> (u16, Value) {
+    let mut req = client.post("/mcp");
+    if let Some(t) = token {
+        req = req.header("authorization", &format!("Bearer {t}"));
+    }
+    let resp = req.json(rpc).send().await;
+    body_of(resp).await
+}
+
+fn rpc_initialize() -> Value {
+    json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": { "protocolVersion": "2025-06-18", "capabilities": {} } })
+}
+fn rpc_tools_list() -> Value {
+    json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list" })
+}
+fn rpc_tools_call(name: &str, args: Value) -> Value {
+    json!({ "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": { "name": name, "arguments": args } })
+}
+
+/// Render an [`AletheiaHttpError`] through its shared `IntoResponse` — the exact
+/// envelope both the HTTP and `/mcp` surfaces emit — into `(status, body)`.
+async fn render_error(err: AletheiaHttpError) -> (u16, Value) {
+    use axum::response::IntoResponse as _;
+    let resp = err.into_response();
+    let status = resp.status().as_u16();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("read error body");
+    (
+        status,
+        serde_json::from_slice(&bytes).expect("error body JSON"),
+    )
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// AC (a) — startup refusal (attack case first: required + empty store)
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn startup_refuses_required_mode_with_empty_store() {
+    let db = Arc::new(AletheiaDB::new().unwrap());
+    let empty = Arc::new(AuthStore::new());
+    let cfg = SecurityConfig::new(empty, AuthMode::Required);
+    let result = try_build_server_client(db, cfg);
+    assert!(
+        result.is_err(),
+        "required mode with zero credentials must refuse to start"
+    );
+    let msg = result.err().unwrap();
+    assert!(
+        msg.contains("authentication is required"),
+        "refusal message guides the operator: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn startup_ok_required_mode_with_a_key() {
+    let (db, store, _) = fixture();
+    let cfg = SecurityConfig::new(store, AuthMode::Required);
+    assert!(try_build_server_client(db, cfg).is_ok());
+}
+
+#[tokio::test]
+async fn startup_ok_anonymous_mode_even_with_empty_store() {
+    let db = Arc::new(AletheiaDB::new().unwrap());
+    let empty = Arc::new(AuthStore::new());
+    let cfg = SecurityConfig::new(empty, AuthMode::Anonymous);
+    assert!(
+        try_build_server_client(db, cfg).is_ok(),
+        "anonymous is an explicit opt-in and always starts"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// AC (b) — per-route + per-MCP-tool RBAC, and extractor↔inventory conformance
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn rbac_reader_reads_ok_but_admin_route_forbidden() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+
+    // Read tool: reader (allows Read) → 200.
+    let (status, _) = get_bearer(&client, "/nodes?label=Person", Some(READER_TOKEN)).await;
+    assert_eq!(status, 200, "reader may read");
+
+    // Admin route: reader (denies Admin) → 403 PERMISSION_DENIED.
+    let (status, body) = get_bearer(&client, "/admin/keys", Some(READER_TOKEN)).await;
+    assert_eq!(status, 403, "reader may not reach the admin surface");
+    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert_ne!(
+        body["retriable"],
+        json!(true),
+        "authz denial is not retriable"
+    );
+}
+
+#[tokio::test]
+async fn rbac_metrics_token_only_reaches_metrics_class() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+
+    // /status is MetricsClass → metrics token 200.
+    let (status, _) = get_bearer(&client, "/status", Some(METRICS_TOKEN)).await;
+    assert_eq!(status, 200, "metrics may probe /status");
+
+    // /nodes is ReadClass → metrics (denies Read) 403.
+    let (status, body) = get_bearer(&client, "/nodes", Some(METRICS_TOKEN)).await;
+    assert_eq!(status, 403, "metrics may not read graph data");
+    assert_eq!(body["code"], "PERMISSION_DENIED");
+
+    // /admin/keys is AdminClass → metrics 403.
+    let (status, _) = get_bearer(&client, "/admin/keys", Some(METRICS_TOKEN)).await;
+    assert_eq!(status, 403, "metrics may not administer keys");
+}
+
+/// F4 attack case: a metrics token calling a **read** tool over `/mcp` is
+/// refused at the envelope with `PERMISSION_DENIED` + `{required_class,
+/// principal_role}` details — mapped from the RBAC `Denied` (ruling F4).
+#[tokio::test]
+async fn rbac_metrics_token_denied_read_tool_over_mcp_with_details() {
+    let (db, store, node_id) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+
+    let rpc = rpc_tools_call("get_node", json!({ "id": node_id.as_u64() }));
+    let (status, body) = mcp_post(&client, &rpc, Some(METRICS_TOKEN)).await;
+
+    assert_eq!(status, 403, "metrics→get_node over /mcp is refused: {body}");
+    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert_eq!(body["retriable"], false);
+    assert_eq!(body["details"]["required_class"], "read");
+    assert_eq!(body["details"]["principal_role"], "metrics");
+}
+
+/// Extractor-class ↔ inventory conformance (load-bearing): for every routable
+/// MCP tool, the class its handler's `Authorized<C>` actually **enforces**
+/// (observed behaviorally — a role that permits the class succeeds, a role that
+/// does not is refused) equals the class the inventory/registry assigns it. This
+/// passes trivially for today's three read tools but would catch a future write
+/// tool mistakenly shipped as `Authorized<ReadClass>`.
+#[tokio::test]
+async fn rbac_routable_tool_extractor_class_matches_registry() {
+    use aletheia_server::security::rbac;
+
+    let (db, store, node_id) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+
+    // The routable tools and a representative call for each.
+    let calls: &[(&str, &str)] = &[
+        ("get_node", "/nodes/"),
+        ("list_nodes", "/nodes"),
+        ("count_nodes", "/nodes/count"),
+    ];
+
+    for (tool, base) in calls {
+        let registry_class = rbac::tool_access_class(tool).expect("routable tool is classified");
+        // All three are Read in this slice; the probe generalizes.
+        assert_eq!(
+            registry_class,
+            AccessClass::Read,
+            "{tool} registry class in this slice"
+        );
+
+        let uri = if *tool == "get_node" {
+            format!("{base}{}", node_id.as_u64())
+        } else {
+            (*base).to_string()
+        };
+
+        // A role that PERMITS the registry class succeeds …
+        let (ok_status, _) = get_bearer(&client, &uri, Some(READER_TOKEN)).await;
+        assert_eq!(
+            ok_status, 200,
+            "{tool}: reader permits {registry_class} → 200"
+        );
+        // … a role that does NOT permit it is refused. Metrics denies Read, so a
+        // 403 here confirms the handler enforces Read (not a weaker class).
+        let (deny_status, deny_body) = get_bearer(&client, &uri, Some(METRICS_TOKEN)).await;
+        assert_eq!(
+            deny_status, 403,
+            "{tool}: metrics denied {registry_class} → 403 (enforced class matches registry)"
+        );
+        assert_eq!(deny_body["code"], "PERMISSION_DENIED");
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// AC (c) — constant-time verify (usage assertion + timing probe)
+// ════════════════════════════════════════════════════════════════════════════
+
+/// The credential store delegates digest comparison to a constant-time
+/// primitive. Asserted structurally against the shared `AuthStore` source so a
+/// refactor that swaps `ct_eq` for `==` fails CI.
+#[test]
+fn constant_time_verify_uses_constant_time_primitive() {
+    const STORE_SRC: &str = include_str!("../../../src/auth/store.rs");
+    assert!(
+        STORE_SRC.contains("ConstantTimeEq") && STORE_SRC.contains("ct_eq"),
+        "AuthStore digest comparison must use subtle::ConstantTimeEq::ct_eq"
+    );
+}
+
+#[test]
+fn constant_time_verify_accepts_right_rejects_wrong_and_empty() {
+    let store = keyed_store();
+    assert!(store.verify(READER_TOKEN).is_some(), "right token verifies");
+    assert!(
+        store.verify("wrong-token").is_none(),
+        "wrong token rejected"
+    );
+    assert!(store.verify("").is_none(), "empty token rejected");
+}
+
+/// Optional timing-dispersion probe. `#[ignore]` by default (timing tests are
+/// environment-sensitive); the structural usage assertion above is the always-on
+/// guarantee.
+#[test]
+#[ignore = "timing-sensitive; run explicitly with --ignored"]
+fn constant_time_timing_probe() {
+    use std::time::Instant;
+    let store = keyed_store();
+    let sample = |tok: &str| {
+        let start = Instant::now();
+        for _ in 0..2_000 {
+            let _ = store.verify(tok);
+        }
+        start.elapsed()
+    };
+    // A near-miss (correct length, wrong last char) vs a total mismatch should
+    // not differ by more than a loose factor if comparison is constant-time.
+    let near = sample("reader-token-abcdefghijklmnoq");
+    let far = sample("z");
+    let ratio = near.as_secs_f64() / far.as_secs_f64().max(1e-9);
+    assert!(
+        (0.2..5.0).contains(&ratio),
+        "verify timing dispersion suspiciously large: near={near:?} far={far:?}"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// AC (d) — credentials never logged / echoed
+// ════════════════════════════════════════════════════════════════════════════
+
+/// A distinctive credential presented on a failing request must never appear in
+/// the response body (nor, by construction of the uniform 401, be echoed back).
+/// Covers both bearer and `x-api-key` transports and 401/403/200 responses.
+#[tokio::test]
+async fn credentials_never_appear_in_response_bodies() {
+    let (db, store, node_id) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+    let secret = "SUPER-SECRET-do-not-log-abcdefghij"; // an unknown (wrong) token
+
+    // Wrong bearer → 401; body must not echo the secret.
+    let (status, body) = get_bearer(&client, "/nodes", Some(secret)).await;
+    assert_eq!(status, 401);
+    assert!(
+        !body.to_string().contains(secret),
+        "401 body leaked the credential: {body}"
+    );
+
+    // Wrong x-api-key → 401; body must not echo the secret.
+    let (status, body) = get_header(&client, "/nodes", "x-api-key", secret).await;
+    assert_eq!(status, 401);
+    assert!(
+        !body.to_string().contains(secret),
+        "x-api-key leaked: {body}"
+    );
+
+    // A VALID reader token on a 403 (admin route) must not be echoed either.
+    let (status, body) = get_bearer(&client, "/admin/keys", Some(READER_TOKEN)).await;
+    assert_eq!(status, 403);
+    assert!(
+        !body.to_string().contains(READER_TOKEN),
+        "403 body leaked a valid credential: {body}"
+    );
+
+    // A successful read must not echo the credential.
+    let (status, body) = get_bearer(
+        &client,
+        &format!("/nodes/{}", node_id.as_u64()),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert!(
+        !body.to_string().contains(READER_TOKEN),
+        "200 body leaked the credential"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// AC (e) — MCP catalog closed (attack: no credential)
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn mcp_catalog_initialize_requires_credential() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+    let (status, _) = mcp_post(&client, &rpc_initialize(), None).await;
+    assert_eq!(status, 401, "unauthenticated initialize must be rejected");
+}
+
+#[tokio::test]
+async fn mcp_catalog_tools_list_requires_credential() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+    let (status, _) = mcp_post(&client, &rpc_tools_list(), None).await;
+    assert_eq!(status, 401, "unauthenticated tools/list must be rejected");
+}
+
+#[tokio::test]
+async fn mcp_catalog_tools_call_requires_credential() {
+    let (db, store, node_id) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+    let rpc = rpc_tools_call("get_node", json!({ "id": node_id.as_u64() }));
+    let (status, _) = mcp_post(&client, &rpc, None).await;
+    assert_eq!(status, 401, "unauthenticated tools/call must be rejected");
+}
+
+/// Positive: a valid reader token reaches the catalog and dispatches a read tool.
+#[tokio::test]
+async fn mcp_catalog_reachable_with_valid_credential() {
+    let (db, store, node_id) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+
+    let (status, body) = mcp_post(&client, &rpc_tools_list(), Some(READER_TOKEN)).await;
+    assert_eq!(status, 200);
+    assert!(body["result"]["tools"].is_array(), "catalog served: {body}");
+
+    let rpc = rpc_tools_call("get_node", json!({ "id": node_id.as_u64() }));
+    let (status, body) = mcp_post(&client, &rpc, Some(READER_TOKEN)).await;
+    assert_eq!(status, 200);
+    assert_eq!(body["result"]["isError"], false, "tools/call ok: {body}");
+}
+
+/// `x-api-key` reaches the `/mcp` catalog (the gate is credential-transport
+/// agnostic). NOTE: `tools/call` dispatch forwards only `authorization` (autumn
+/// 0.5 `FORWARDED_HEADERS`), so an `x-api-key`-only `tools/call` authenticates at
+/// the envelope but the replayed handler cannot see the credential — a
+/// documented v1 boundary. The catalog (`tools/list`) needs no replay.
+#[tokio::test]
+async fn mcp_catalog_reachable_with_x_api_key() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+    let resp = client
+        .post("/mcp")
+        .header("x-api-key", READER_TOKEN)
+        .json(&rpc_tools_list())
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200, "x-api-key opens the catalog");
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// AC (f) — structured error contract on BOTH surfaces (code/retriable/details)
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn error_contract_http_401_shape() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+    let (status, body) = get_bearer(&client, "/nodes", None).await;
+    assert_eq!(status, 401);
+    assert_eq!(body["code"], "UNAUTHENTICATED");
+    assert_eq!(body["success"], false);
+    assert_ne!(body["retriable"], json!(true), "auth failure not retriable");
+}
+
+#[tokio::test]
+async fn error_contract_http_403_shape() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+    let (status, body) = get_bearer(&client, "/admin/keys", Some(READER_TOKEN)).await;
+    assert_eq!(status, 403);
+    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert_ne!(
+        body["retriable"],
+        json!(true),
+        "authz failure not retriable"
+    );
+}
+
+/// HTTP 413 end-to-end: a tiny byte budget makes `list_nodes` exceed the
+/// `ResultBytes` cap, rendering the shared `RESOURCE_EXHAUSTED` / non-retriable
+/// envelope with `details`.
+#[tokio::test]
+async fn error_contract_http_413_byte_cap() {
+    let (db, store, _) = fixture();
+    let cfg = SecurityConfig::new(store, AuthMode::Required).with_max_response_bytes(8);
+    let client = build_server_client_with_config(db, cfg);
+
+    let (status, body) = get_bearer(&client, "/nodes?label=Person", Some(READER_TOKEN)).await;
+    assert_eq!(
+        status, 413,
+        "8-byte budget forces a payload-too-large: {body}"
+    );
+    assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
+    assert_eq!(body["retriable"], false);
+    assert_eq!(body["details"]["dimension"], "result_bytes");
+    assert_eq!(body["details"]["limit"], 8);
+}
+
+#[tokio::test]
+async fn error_contract_mcp_401_shape() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+    let (status, body) = mcp_post(&client, &rpc_tools_list(), None).await;
+    assert_eq!(status, 401);
+    assert_eq!(
+        body["code"], "UNAUTHENTICATED",
+        "/mcp 401 is enveloped: {body}"
+    );
+    assert_eq!(body["success"], false);
+}
+
+#[tokio::test]
+async fn error_contract_mcp_403_shape_with_details() {
+    let (db, store, node_id) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+    let rpc = rpc_tools_call("get_node", json!({ "id": node_id.as_u64() }));
+    let (status, body) = mcp_post(&client, &rpc, Some(METRICS_TOKEN)).await;
+    assert_eq!(status, 403);
+    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert_eq!(body["retriable"], false);
+    assert_eq!(body["details"]["required_class"], "read");
+    assert_eq!(body["details"]["principal_role"], "metrics");
+}
+
+/// The transient-vs-fault `retriable` matrix on the shared envelope both
+/// surfaces reuse: a **read** timeout is 429/retriable, a **write** timeout is
+/// 429/non-retriable (may have committed), a byte cap is 413/non-retriable, and
+/// an in-flight-capacity rejection is 503/retriable.
+#[tokio::test]
+async fn error_contract_retriable_matrix_on_shared_envelope() {
+    use std::time::Duration;
+
+    let (s, b) = render_error(timeout_error(Duration::from_millis(100), false)).await;
+    assert_eq!(s, 429);
+    assert_eq!(b["code"], "RESOURCE_EXHAUSTED");
+    assert_eq!(b["retriable"], true, "read timeout is retriable");
+
+    let (s, b) = render_error(timeout_error(Duration::from_millis(100), true)).await;
+    assert_eq!(s, 429);
+    assert_eq!(b["retriable"], false, "write timeout is NOT retriable");
+
+    let (s, b) = render_error(byte_cap_error(1024, 4096)).await;
+    assert_eq!(s, 413);
+    assert_eq!(b["code"], "RESOURCE_EXHAUSTED");
+    assert_eq!(b["retriable"], false);
+
+    let (s, b) = render_error(AletheiaHttpError::InFlightCapacityExceeded { cap: 4 }).await;
+    assert_eq!(s, 503);
+    assert_eq!(b["code"], "UNAVAILABLE");
+    assert_eq!(b["retriable"], true, "capacity overload is retriable");
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// AC (g) — revocation is immediate (no cached verify across requests)
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn revocation_takes_effect_on_the_next_request() {
+    let (db, store, node_id) = fixture();
+    // Mint a fresh reader key through the store.
+    let (principal, key) = store
+        .create_key("ephemeral", Role::Reader)
+        .expect("mint key");
+    let client = build_server_client(db, store.clone(), AuthMode::Required);
+    let uri = format!("/nodes/{}", node_id.as_u64());
+
+    // Works before revocation.
+    let (status, _) = get_bearer(&client, &uri, Some(&key)).await;
+    assert_eq!(status, 200, "freshly-minted key reads");
+
+    // Revoke, then the very next request is 401 — proving no per-request cache
+    // survives across requests (the layer/extractor re-verify every time).
+    assert!(store.revoke(&principal.id).expect("revoke"));
+    let (status, body) = get_bearer(&client, &uri, Some(&key)).await;
+    assert_eq!(status, 401, "revoked key is rejected immediately: {body}");
+    assert_eq!(body["code"], "UNAUTHENTICATED");
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Attack cases (separate negative tests)
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn attack_wrong_token_http_and_mcp_are_401() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+    let (status, _) = get_bearer(&client, "/nodes", Some("not-a-real-token")).await;
+    assert_eq!(status, 401, "HTTP wrong token → 401");
+    let (status, _) = mcp_post(&client, &rpc_tools_list(), Some("not-a-real-token")).await;
+    assert_eq!(status, 401, "/mcp wrong token → 401");
+}
+
+#[tokio::test]
+async fn attack_right_token_wrong_class_is_403() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+    // Writer may write/read but not administer keys.
+    let (status, body) = get_bearer(&client, "/admin/keys", Some(WRITER_TOKEN)).await;
+    assert_eq!(status, 403);
+    assert_eq!(body["code"], "PERMISSION_DENIED");
+}
+
+#[tokio::test]
+async fn attack_missing_auth_is_401() {
+    let (db, store, _) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+    let (status, _) = get_bearer(&client, "/nodes", None).await;
+    assert_eq!(status, 401);
+}
+
+/// In-flight cap exhaustion yields the retriable 503 envelope. Driven at the
+/// limiter primitive (the wiring the read handler mounts) so it is deterministic
+/// without racing real concurrency.
+#[tokio::test]
+async fn attack_in_flight_cap_exhaustion_is_503() {
+    use aletheia_server::security::InFlightLimiter;
+    let limiter = InFlightLimiter::new(1);
+    let _held = limiter.try_acquire().expect("first slot admitted");
+    let err = limiter
+        .try_acquire()
+        .expect_err("second slot rejected at cap");
+    let (status, body) = render_error(err).await;
+    assert_eq!(status, 503);
+    assert_eq!(body["code"], "UNAVAILABLE");
+    assert_eq!(body["retriable"], true);
+}

--- a/crates/aletheia-server/tests/security_acceptance.rs
+++ b/crates/aletheia-server/tests/security_acceptance.rs
@@ -436,10 +436,12 @@ async fn mcp_catalog_reachable_with_valid_credential() {
 }
 
 /// `x-api-key` reaches the `/mcp` catalog (the gate is credential-transport
-/// agnostic). NOTE: `tools/call` dispatch forwards only `authorization` (autumn
-/// 0.5 `FORWARDED_HEADERS`), so an `x-api-key`-only `tools/call` authenticates at
-/// the envelope but the replayed handler cannot see the credential — a
-/// documented v1 boundary. The catalog (`tools/list`) needs no replay.
+/// agnostic). As of the B4 finalize, an `x-api-key`-only `tools/call` also
+/// dispatches: the gate normalizes the verified credential onto
+/// `authorization: Bearer` before the replay (only `authorization` is in autumn
+/// 0.5's `FORWARDED_HEADERS`), so the replayed handler re-verifies it — see
+/// `tests/security_mcp_gate.rs::x_api_key_tools_call_authenticates_via_normalization`.
+/// This test pins the simpler catalog reach (`tools/list` needs no replay).
 #[tokio::test]
 async fn mcp_catalog_reachable_with_x_api_key() {
     let (db, store, _) = fixture();

--- a/crates/aletheia-server/tests/security_mcp_gate.rs
+++ b/crates/aletheia-server/tests/security_mcp_gate.rs
@@ -1,0 +1,395 @@
+//! B4 finalize suite for the custom `/mcp` security gate ([`McpSecurityLayer`]).
+//!
+//! Covers the coordinator-approved **x-api-key normalization** + its two guards,
+//! the **oversize-body → 413** fail-closed path (SHOULD-FIX #2), and the
+//! **batch / odd-frame fail-closed** prechecks (#6). Every test is written
+//! attack-first: the negative/precedence case precedes the positive.
+//!
+//! Two harnesses:
+//!   * **Layer-level** (`Captor` inner service) — drives [`McpSecurityLayer`]
+//!     directly so the *replayed* request headers are observable. This is the
+//!     only way to assert the normalization contract ("the replayed handler sees
+//!     ONLY the verified credential in `authorization`; the loser/unverified
+//!     header does not survive") byte-for-byte.
+//!   * **App-level** (`build_server_client`) — drives the assembled server for
+//!     the end-to-end 413 / fail-closed / normalized-tools-call behavior.
+
+use std::convert::Infallible;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+
+use aletheia_server::build_server_client;
+use aletheia_server::security::mcp_gate::McpSecurityLayer;
+use aletheiadb::auth::{AuthMode, AuthStore, Role};
+use aletheiadb::core::NodeId;
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+use axum::body::Body;
+use axum::http::{HeaderMap, Request, Response, StatusCode};
+use serde_json::{Value, json};
+use tower::{Layer, Service, ServiceExt};
+
+const READER_TOKEN: &str = "reader-token-abcdefghijklmnop";
+const METRICS_TOKEN: &str = "metrics-token-abcdefghijklmnop";
+
+fn keyed_store() -> Arc<AuthStore> {
+    let store = Arc::new(AuthStore::new());
+    store
+        .insert_bootstrap_key("reader", Role::Reader, READER_TOKEN)
+        .expect("reader key");
+    store
+        .insert_bootstrap_key("metrics", Role::Metrics, METRICS_TOKEN)
+        .expect("metrics key");
+    store
+}
+
+fn db_with_node() -> (Arc<AletheiaDB>, NodeId) {
+    let db = Arc::new(AletheiaDB::new().expect("db"));
+    let id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .expect("node");
+    (db, id)
+}
+
+// ── layer-level captor harness ────────────────────────────────────────────────
+
+/// A minimal inner `tower::Service` that records the headers of the request the
+/// gate forwards to it (the "replayed" request) and how many times it is called.
+#[derive(Clone)]
+struct Captor {
+    seen: Arc<Mutex<Option<HeaderMap>>>,
+    hits: Arc<AtomicUsize>,
+}
+
+impl Captor {
+    fn new() -> Self {
+        Self {
+            seen: Arc::new(Mutex::new(None)),
+            hits: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+    fn hits(&self) -> usize {
+        self.hits.load(Ordering::SeqCst)
+    }
+    fn seen(&self) -> Option<HeaderMap> {
+        self.seen.lock().expect("lock").clone()
+    }
+}
+
+impl Service<Request<Body>> for Captor {
+    type Response = Response<Body>;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Response<Body>, Infallible>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        self.hits.fetch_add(1, Ordering::SeqCst);
+        *self.seen.lock().expect("lock") = Some(req.headers().clone());
+        Box::pin(async { Ok(Response::new(Body::from("inner-ok"))) })
+    }
+}
+
+/// Drive one request through `McpSecurityLayer` wrapping a `Captor`. Returns the
+/// gate's response status plus the captor (to inspect what was replayed).
+async fn drive(store: Arc<AuthStore>, req: Request<Body>) -> (StatusCode, Captor) {
+    let captor = Captor::new();
+    let svc = McpSecurityLayer::new(store, AuthMode::Required).layer(captor.clone());
+    let resp = svc.oneshot(req).await.expect("gate responds");
+    (resp.status(), captor)
+}
+
+fn tools_list_body() -> Body {
+    Body::from(serde_json::to_vec(&json!({"jsonrpc":"2.0","id":1,"method":"tools/list"})).unwrap())
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Guard 1 — dual-header precedence (legacy: Authorization/Bearer-first, NO
+// fallthrough to x-api-key when Authorization is present) + loser-not-survive.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Attack (a): a **valid x-api-key** presented alongside a **garbage
+/// Authorization** header. Legacy precedence: a present Authorization header is
+/// authoritative and, being non-bearer, collapses the whole extraction to
+/// `None` — the x-api-key is NEVER consulted. So the request is rejected 401 and
+/// the inner (replay) service is never reached.
+#[tokio::test]
+async fn guard1_garbage_authorization_defeats_valid_x_api_key_401() {
+    let req = Request::builder()
+        .method("POST")
+        .uri("/mcp")
+        .header("authorization", "NotBearer somejunk")
+        .header("x-api-key", READER_TOKEN)
+        .body(tools_list_body())
+        .unwrap();
+
+    let (status, captor) = drive(keyed_store(), req).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "present-but-non-bearer Authorization wins and fails; x-api-key not consulted"
+    );
+    assert_eq!(
+        captor.hits(),
+        0,
+        "rejected before the replay: inner not called"
+    );
+}
+
+/// Attack (b): a **valid Bearer** alongside a **garbage x-api-key**. Bearer wins;
+/// the garbage x-api-key is ignored AND must not survive into the replay. The
+/// replayed request carries ONLY `authorization: Bearer <verified>`.
+#[tokio::test]
+async fn guard1_valid_bearer_wins_and_strips_garbage_x_api_key() {
+    let req = Request::builder()
+        .method("POST")
+        .uri("/mcp")
+        .header("authorization", format!("Bearer {READER_TOKEN}"))
+        .header("x-api-key", "garbage-loser-value")
+        .body(tools_list_body())
+        .unwrap();
+
+    let (status, captor) = drive(keyed_store(), req).await;
+    assert_eq!(status, StatusCode::OK, "valid bearer authenticates");
+    assert_eq!(captor.hits(), 1, "passed through to the replay");
+    let seen = captor.seen().expect("headers captured");
+    assert_eq!(
+        seen.get("authorization").and_then(|v| v.to_str().ok()),
+        Some(format!("Bearer {READER_TOKEN}").as_str()),
+        "replay carries the verified bearer credential"
+    );
+    assert!(
+        seen.get("x-api-key").is_none(),
+        "the losing/unverified x-api-key must NOT survive into the replay"
+    );
+}
+
+/// Normalization core: an **x-api-key-only** request (no Authorization) is
+/// verified, then REWRITTEN to `authorization: Bearer <verified>` before the
+/// replay — giving x-api-key full parity on `tools/call` (only `authorization`
+/// is in autumn's FORWARDED_HEADERS). The x-api-key header does not survive.
+#[tokio::test]
+async fn guard1_x_api_key_normalized_onto_authorization() {
+    let req = Request::builder()
+        .method("POST")
+        .uri("/mcp")
+        .header("x-api-key", READER_TOKEN)
+        .body(tools_list_body())
+        .unwrap();
+
+    let (status, captor) = drive(keyed_store(), req).await;
+    assert_eq!(status, StatusCode::OK);
+    let seen = captor.seen().expect("headers captured");
+    assert_eq!(
+        seen.get("authorization").and_then(|v| v.to_str().ok()),
+        Some(format!("Bearer {READER_TOKEN}").as_str()),
+        "x-api-key credential is normalized onto authorization for the replay"
+    );
+    assert!(
+        seen.get("x-api-key").is_none(),
+        "x-api-key is consumed by normalization, not forwarded verbatim"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Guard 2 — the authorization header / token is never logged.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Source guard: the gate must not contain any logging macro that could emit the
+/// credential. Pairs with AC(d)'s response-body scrub (the token never appears in
+/// any response body either).
+#[test]
+fn guard2_mcp_gate_never_logs_the_credential() {
+    const SRC: &str = include_str!("../src/security/mcp_gate.rs");
+    for pat in [
+        "println!",
+        "eprintln!",
+        "dbg!",
+        "tracing::",
+        "log::",
+        "print!",
+    ] {
+        assert!(
+            !SRC.contains(pat),
+            "mcp_gate.rs must not log ({pat}) — it handles the raw credential/authorization header"
+        );
+    }
+}
+
+/// Guard 2 (behavioral): a normalized, verified request's token never appears in
+/// the gate's forwarded/response surface — asserted here against the replay
+/// response (the inner service returns a fixed body; the token must not leak into
+/// it, and the gate adds no echoing).
+#[tokio::test]
+async fn guard2_token_never_echoed_in_gate_output() {
+    let req = Request::builder()
+        .method("POST")
+        .uri("/mcp")
+        .header("x-api-key", READER_TOKEN)
+        .body(tools_list_body())
+        .unwrap();
+    let captor = Captor::new();
+    let svc = McpSecurityLayer::new(keyed_store(), AuthMode::Required).layer(captor.clone());
+    let resp = svc.oneshot(req).await.expect("gate responds");
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    let raw = String::from_utf8_lossy(&bytes);
+    assert!(
+        !raw.contains(READER_TOKEN),
+        "the verified token must never be echoed in the gate's response body"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// SHOULD-FIX #2 — oversize buffered body → 413 RESOURCE_EXHAUSTED envelope
+// (not a swallowed error forwarding an EMPTY body).
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn oversize_mcp_body_is_413_envelope() {
+    let (db, node) = db_with_node();
+    let client = build_server_client(db, keyed_store(), AuthMode::Required);
+
+    // A >2 MiB body: authentication (header-only) succeeds, then the body buffer
+    // exceeds MAX_MCP_REQUEST_BYTES and must fail-closed with 413.
+    let pad = "x".repeat(3 * 1024 * 1024);
+    let rpc = json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": { "name": "get_node", "arguments": { "id": node.as_u64(), "pad": pad } }
+    });
+    let resp = client
+        .post("/mcp")
+        .header("authorization", &format!("Bearer {READER_TOKEN}"))
+        .json(&rpc)
+        .send()
+        .await;
+    let status = resp.status.as_u16();
+    let body: Value = serde_json::from_str(&resp.text()).unwrap_or(Value::Null);
+    assert_eq!(status, 413, "oversize body → 413: {body}");
+    assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
+    assert_eq!(body["success"], json!(false));
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// #6 — fail-closed on unrecognized tool-executing frames (batch + odd frame).
+// ════════════════════════════════════════════════════════════════════════════
+
+/// A JSON-RPC **batch array** containing a `tools/call` cannot be per-tool
+/// RBAC-prechecked at the envelope, so the gate refuses it fail-closed rather
+/// than under-gating it. The tool never executes.
+#[tokio::test]
+async fn batch_with_tools_call_is_failclosed() {
+    let (db, node) = db_with_node();
+    let client = build_server_client(db, keyed_store(), AuthMode::Required);
+
+    let batch = json!([
+        { "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+          "params": { "name": "get_node", "arguments": { "id": node.as_u64() } } }
+    ]);
+    let resp = client
+        .post("/mcp")
+        .header("authorization", &format!("Bearer {READER_TOKEN}"))
+        .json(&batch)
+        .send()
+        .await;
+    let status = resp.status.as_u16();
+    let text = resp.text();
+    let body: Value = serde_json::from_str(&text).unwrap_or(Value::Null);
+    assert_eq!(
+        status, 400,
+        "batched tools/call is refused fail-closed: {text}"
+    );
+    assert_eq!(body["code"], "INVALID_ARGUMENT");
+    assert!(
+        !text.contains("\"name\":\"Alice\"") && !text.contains("Alice"),
+        "the tool must NOT have executed (no node data leaked): {text}"
+    );
+}
+
+/// An odd frame whose `method` is `tools/call` but whose `params.name` is
+/// missing/non-string is a tool-executing frame the gate cannot identify, so it
+/// is refused fail-closed (never passed through un-RBAC-checked).
+#[tokio::test]
+async fn tools_call_missing_name_is_failclosed() {
+    let (db, _node) = db_with_node();
+    let client = build_server_client(db, keyed_store(), AuthMode::Required);
+
+    let rpc = json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": { "arguments": {} }
+    });
+    let resp = client
+        .post("/mcp")
+        .header("authorization", &format!("Bearer {READER_TOKEN}"))
+        .json(&rpc)
+        .send()
+        .await;
+    let status = resp.status.as_u16();
+    let body: Value = serde_json::from_str(&resp.text()).unwrap_or(Value::Null);
+    assert_eq!(
+        status, 400,
+        "malformed tools/call → fail-closed 400: {body}"
+    );
+    assert_eq!(body["code"], "INVALID_ARGUMENT");
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Normalization end-to-end — x-api-key now works through the tools/call replay.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// With normalization landed, an **x-api-key-only** `tools/call` authenticates
+/// AND dispatches (the replayed handler re-verifies the normalized
+/// `authorization: Bearer`), closing the documented v1 boundary.
+#[tokio::test]
+async fn x_api_key_tools_call_authenticates_via_normalization() {
+    let (db, node) = db_with_node();
+    let client = build_server_client(db, keyed_store(), AuthMode::Required);
+
+    let rpc = json!({
+        "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+        "params": { "name": "get_node", "arguments": { "id": node.as_u64() } }
+    });
+    let resp = client
+        .post("/mcp")
+        .header("x-api-key", READER_TOKEN)
+        .json(&rpc)
+        .send()
+        .await;
+    let status = resp.status.as_u16();
+    let body: Value = serde_json::from_str(&resp.text()).unwrap_or(Value::Null);
+    assert_eq!(status, 200, "x-api-key tools/call now dispatches: {body}");
+    assert_eq!(body["result"]["isError"], json!(false), "tool ran: {body}");
+}
+
+/// Envelope-refused metrics→read over x-api-key still 403s at the gate (RBAC
+/// precheck runs on the normalized credential's principal, unchanged).
+#[tokio::test]
+async fn x_api_key_metrics_read_tool_denied_403_with_details() {
+    let (db, node) = db_with_node();
+    let client = build_server_client(db, keyed_store(), AuthMode::Required);
+
+    let rpc = json!({
+        "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+        "params": { "name": "get_node", "arguments": { "id": node.as_u64() } }
+    });
+    let resp = client
+        .post("/mcp")
+        .header("x-api-key", METRICS_TOKEN)
+        .json(&rpc)
+        .send()
+        .await;
+    let status = resp.status.as_u16();
+    let body: Value = serde_json::from_str(&resp.text()).unwrap_or(Value::Null);
+    assert_eq!(status, 403, "metrics denied read over x-api-key: {body}");
+    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert_eq!(body["details"]["required_class"], "read");
+    assert_eq!(body["details"]["principal_role"], "metrics");
+}

--- a/crates/aletheia-server/tests/security_rate_limit.rs
+++ b/crates/aletheia-server/tests/security_rate_limit.rs
@@ -14,7 +14,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 
-use aletheia_server::security::rate_limit::governor_layer;
+use aletheia_server::security::rate_limit::{governor_layer, spawn_gc_task};
 use aletheia_server::security::{RateLimitSettings, SecurityConfig};
 use aletheiadb::auth::{AuthMode, AuthStore};
 
@@ -23,6 +23,7 @@ use axum::body::Body;
 use axum::extract::ConnectInfo;
 use axum::http::{Request, StatusCode};
 use axum::routing::get;
+use serde_json::{Value, json};
 use tower::ServiceExt; // oneshot
 
 // ---------------------------------------------------------------------------
@@ -279,4 +280,92 @@ async fn documents_raw_429_headers_and_body() {
         .expect("read body");
     // A non-empty human-readable body (the text we replace with the envelope).
     assert!(!body.is_empty(), "governor 429 has an explanatory body");
+}
+
+// ---------------------------------------------------------------------------
+// (4) MUST-FIX 8b: the over-limit 429 is wrapped in the shared STRUCTURED
+//     envelope (code + retriable + message), NOT governor's raw plain text.
+// ---------------------------------------------------------------------------
+
+/// 8b: an over-limit request must return the `{success, error, code, retriable}`
+/// envelope — `RESOURCE_EXHAUSTED` / `retriable: true` — as `application/json`,
+/// not tower_governor's plain-text `"Too Many Requests! ..."` body. The
+/// `retry-after` header governor emits is preserved.
+#[tokio::test]
+async fn over_limit_429_is_structured_envelope_not_raw_text() {
+    let mut cfg = config();
+    cfg.rate_limit = Some(RateLimitSettings::new(1, 1));
+    let app = router_with_layer(&cfg);
+    let ip = [10, 0, 0, 9];
+
+    let _first = app.clone().oneshot(req_from(ip)).await.unwrap();
+    let throttled = app.clone().oneshot(req_from(ip)).await.expect("throttled");
+    assert_eq!(throttled.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    // Content-type is JSON (the envelope), and the governor retry-after survives.
+    let ct = throttled
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_owned();
+    assert!(
+        ct.contains("application/json"),
+        "wrapped 429 is JSON, got content-type = {ct:?}"
+    );
+    assert!(
+        throttled.headers().contains_key("retry-after"),
+        "wrapped 429 preserves governor's retry-after header"
+    );
+
+    let bytes = axum::body::to_bytes(throttled.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let v: Value = serde_json::from_slice(&bytes)
+        .expect("wrapped 429 body must be structured JSON, not raw governor text");
+    assert_eq!(v["success"], json!(false));
+    assert_eq!(v["code"], "RESOURCE_EXHAUSTED", "8b code: {v}");
+    assert_eq!(
+        v["retriable"],
+        json!(true),
+        "rate-limit 429 is retriable: {v}"
+    );
+    assert!(
+        v["error"].is_string(),
+        "carries a human-readable message: {v}"
+    );
+    let raw = String::from_utf8_lossy(&bytes);
+    assert!(
+        !raw.trim_start().starts_with("Too Many Requests"),
+        "must not be governor's raw plain-text body: {raw}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (5) MUST-FIX 8c: the RateLimit gc() handle is driven by a background task
+//     tied to the layer's lifecycle (self-terminates when the layer drops).
+// ---------------------------------------------------------------------------
+
+/// 8c: `spawn_gc_task` starts a periodic task that calls `gc()`; because it
+/// holds only a *weak* handle to the shared limiter, it self-terminates once the
+/// mounted layer (the last strong ref) is dropped — no leaked/duplicated task,
+/// lifecycle-tied.
+#[tokio::test]
+async fn gc_task_runs_and_self_terminates_when_layer_dropped() {
+    let mut cfg = config();
+    cfg.rate_limit = Some(RateLimitSettings::new(1000, 100));
+    let rl = governor_layer(&cfg).expect("rate limiting enabled");
+
+    // Split the mountable layer from the GC handle (what apply_security does).
+    let (layer, gc) = rl.into_parts();
+    let handle = spawn_gc_task(gc, Duration::from_millis(5)).expect("spawned under a runtime");
+
+    // Drop the only remaining strong ref to the keyed limiter. The GC task's
+    // next tick observes the weak upgrade fail and exits its loop.
+    drop(layer);
+
+    tokio::time::timeout(Duration::from_secs(2), handle)
+        .await
+        .expect("gc task terminates promptly after the layer is dropped")
+        .expect("gc task did not panic");
 }


### PR DESCRIPTION
## Summary

Wires the Lane B security **primitives** (landed in B2, #3570) into the assembled `aletheia-server` (autumn-web) request path, and proves the wiring with a seven-AC non-regression acceptance suite. Base = `trunk` (B2 merged), no stacking.

### Before / After (plain)

**Before** — the new `aletheia-server` *authenticates* (constant-time bearer verify) but has **no per-request RBAC enforcement wired**: the `/mcp` catalog is reachable without a credential, there are **no resource caps or rate limiting mounted**, and errors are not the structured envelope.

**After** — every route + MCP tool is gated by role via `Authorized<C>` plus a bespoke `McpSecurityLayer` on `/mcp` (accepts **Bearer OR `x-api-key`**, returns a **uniform 401**); the server **refuses to start with zero credentials**; a per-query **timeout / row / byte cap** + a **bounded in-flight guard** + a **default-off rate limiter** are mounted; cursor paging is **signed**; and **401/403/413/429** all return the structured `{code, message, retriable, details?}` envelope.

### How

- **`apply_security`** — assembles the secured router: `secure_mcp(McpSecurityLayer)` wrapping `/mcp`, a **conditional** `governor` `.layer()` (default-off rate limiter) plus a **self-terminating** GC task for its keyed state, over the resource-limited read path.
- **`init_state`** — installs `ServerSecurityState` (limits + in-flight limiter + cursor signer) as shared state.
- **`validate_startup`** — runs in the **fallible build path** and refuses `required` auth mode with an empty key store (re-home note: this belongs on `AppBuilder::on_startup` once available).
- **`Authorized<C>`** (F3) — class-parameterized extractor with a per-request **principal cache** so verify runs once per request and the class check reuses it.
- **JSON-RPC RBAC precheck** (F4) — the `/mcp` gate parses the JSON-RPC body under a **2 MiB cap** (oversize → **413**), resolves the target tool's class, and denies (`Denied → details`) **before** dispatch.
- **`x-api-key → authorization` normalization** — the verified credential is normalized onto `authorization: Bearer <token>` before autumn replays `tools/call`.

### x-api-key normalization + rationale

autumn replays `tools/call` forwarding **only** the `authorization` header (the `FORWARDED_HEADERS` allowlist). The gate therefore **normalizes the VERIFIED credential** onto `authorization: Bearer <token>` before replay. Legacy **Bearer-first precedence** is mirrored (`src/http/auth.rs:115-136`): when both headers are present, Bearer wins for verification and the **loser / unverified header never survives** into the replayed request. `authorization` is **never logged**.

**Upstream ask:** autumn should forward `x-api-key` / extensions through the `tools/call` replay (sibling of autumn#1828). Until then, the gate performs the normalization itself.

### 7 non-regression ACs (a–g) — evidence

All in `crates/aletheia-server/tests/security_acceptance.rs` (attack-case-first / TDD): 26 passed, 1 ignored (timing probe).

| AC | Guarantee | Test(s) |
|----|-----------|---------|
| **(a)** | Startup **refusal** with zero credentials (required mode) | `startup_refuses_required_mode_with_empty_store`; `startup_ok_required_mode_with_a_key`; `startup_ok_anonymous_mode_even_with_empty_store` |
| **(b)** | Per-route **+ per-MCP-tool RBAC** + extractor↔inventory class conformance | `rbac_reader_reads_ok_but_admin_route_forbidden`; `rbac_metrics_token_only_reaches_metrics_class`; `rbac_metrics_token_denied_read_tool_over_mcp_with_details`; `rbac_routable_tool_extractor_class_matches_registry` |
| **(c)** | **Constant-time** verify (usage assertion + timing probe) | `constant_time_verify_uses_constant_time_primitive`; `constant_time_verify_accepts_right_rejects_wrong_and_empty`; `constant_time_timing_probe` *(ignored; run `--ignored`)* |
| **(d)** | **Credentials never logged / echoed** (incl. `authorization`) | `credentials_never_appear_in_response_bodies` |
| **(e)** | **MCP catalog closed** — 401 on `initialize` / `tools/list` / `tools/call` w/o credential | `mcp_catalog_initialize_requires_credential`; `mcp_catalog_tools_list_requires_credential`; `mcp_catalog_tools_call_requires_credential`; `mcp_catalog_reachable_with_valid_credential`; `mcp_catalog_reachable_with_x_api_key` |
| **(f)** | **Structured error contract** w/ `retriable`, **both surfaces**, incl. 401/403/413/429 | `error_contract_http_401_shape`; `error_contract_http_403_shape`; `error_contract_http_413_byte_cap`; `error_contract_mcp_401_shape`; `error_contract_mcp_403_shape_with_details`; `error_contract_retriable_matrix_on_shared_envelope` |
| **(g)** | **Revocation immediate** (no cached verify across requests) | `revocation_takes_effect_on_the_next_request` |

Attack cases: `attack_wrong_token_http_and_mcp_are_401`, `attack_right_token_wrong_class_is_403`, `attack_missing_auth_is_401`, `attack_in_flight_cap_exhaustion_is_503`.

**Two-shape 403 contract (coordinator F4):** MCP 403 carries `details` (`required_class` / `principal_role`) — `error_contract_mcp_403_shape_with_details`, `rbac_metrics_token_denied_read_tool_over_mcp_with_details`; HTTP 403 is **message-only** — `error_contract_http_403_shape`.

### Test evidence (this branch, rebased on fresh `trunk`)

`cargo test -p aletheia-server` — all green:

| Suite | Result |
|-------|--------|
| `security_acceptance` | 26 passed, 1 ignored |
| `security_mcp_gate` | 10 passed |
| `server_parity` | 19 passed |
| `security_rbac` | 15 passed |
| `security_cursor` | 11 passed |
| `security_resource_limits` | 17 passed |
| `security_rate_limit` | 9 passed |
| `node_writes_parity` *(Lane A, now on trunk — still green through the merged `node_tools.rs` imports)* | 18 passed |

`cargo fmt --all -- --check` clean · `cargo clippy -p aletheia-server --all-targets -- -D warnings` clean · `cargo build -p aletheiadb` clean. Full-workspace `cargo clippy --workspace --all-features` is **delegated to CI**.

### Rebase note

Rebased the B4 delta (`277232c` wiring + finalize) `--onto origin/trunk` over the B2 base. One conflict — `crates/aletheia-server/src/node_tools.rs` **imports only** — resolved as the **union**: kept Lane A's node-write-cluster imports (`WriteClass`, `post`, `Create/Update/Delete/Retract/FindNodesAtTime` request types) **and** B4's security imports (`ServerSecurityState`, `resource_limits::{check_byte_cap_of, run_with_timeout}`, `AletheiaHttpError`). Both handler sets (Lane A writes + B4 security-wired reads) preserved. `node_writes_parity` (18) confirms Lane A's suite still passes.

### Refs

- #3561 §8, #3550, #3542, #3524
- ADR 0055 supersession (rate limiter **default-off**, landed in B2)
- Carries the F1–F4 review fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9nP1hfyQTVovFgM48MfME

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9nP1hfyQTVovFgM48MfME)_