### PR TITLE
Key rotation: sync re-encryption engine for the index layer (#488)

### DIFF
--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -377,6 +377,15 @@ impl AletheiaDB {
                 None
             };
 
+            // Retain the encryption config for key rotation (Issue #488): the
+            // current MEK must be re-sourceable to guard against rotating to the
+            // same key. Only stored when encryption is enabled; never the key.
+            let encryption_config_stored = if config.encryption.enabled {
+                Some(config.encryption.clone())
+            } else {
+                None
+            };
+
             // Extract WAL cipher from encryption manager (if enabled)
             let wal_cipher = encryption_manager
                 .as_ref()
@@ -490,11 +499,22 @@ impl AletheiaDB {
                 persistence_thread_stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
                 persistence_thread_handle: None,
                 encryption_manager: encryption_manager.clone(),
+                encryption_config: encryption_config_stored,
                 constraint_registry: Arc::new(crate::core::constraint::ConstraintRegistry::new()),
                 lineage: Arc::new(crate::core::lineage::LineageStore::new()),
                 chain: None,
                 _tempdir: None,
             };
+
+            // Issue #488: resume an interrupted index key rotation BEFORE
+            // loading indexes, so the index directory is a single, uniform key
+            // generation by the time it is read back (a crash mid-rotation left
+            // a mix of old/new key files plus a `rotation.state` breadcrumb).
+            if let Some(ref manager) = persistence_manager
+                && config.encryption.enabled
+            {
+                crate::db::rotation::resume_pending_rotation(manager, &config.encryption)?;
+            }
 
             // Load indexes on startup if enabled
             if let Some(ref manager) = persistence_manager
@@ -852,6 +872,7 @@ impl AletheiaDB {
                 persistence_thread_stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
                 persistence_thread_handle: None,
                 encryption_manager: None,
+                encryption_config: None,
                 constraint_registry: Arc::new(crate::core::constraint::ConstraintRegistry::new()),
                 lineage: Arc::new(crate::core::lineage::LineageStore::new()),
                 chain: None,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -42,6 +42,8 @@ pub mod ops;
 pub mod pitr;
 /// Query builder and executor hooks.
 pub mod query;
+/// Index-layer key rotation orchestration (Issue #488).
+pub mod rotation;
 /// Graph schema discovery (labels, edge types, property keys).
 pub mod schema;
 /// Unified vector similarity query builder.
@@ -189,6 +191,10 @@ pub struct AletheiaDB {
     pub(crate) persistence_thread_handle: Option<std::thread::JoinHandle<()>>,
     /// Encryption manager (if encryption at rest is enabled)
     pub(crate) encryption_manager: Option<Arc<crate::encryption::EncryptionManager>>,
+    /// Encryption configuration used at startup (retained for key rotation,
+    /// Issue #488: re-sourcing the current MEK to guard against rotating to the
+    /// same key). `None` when encryption is disabled.
+    pub(crate) encryption_config: Option<crate::encryption::config::EncryptionConfig>,
     /// Uniqueness constraint registry (declarations + reservation index).
     pub(crate) constraint_registry: Arc<crate::core::constraint::ConstraintRegistry>,
     /// Fact-to-fact derivation lineage index (Issue #3371).

--- a/src/db/rotation.rs
+++ b/src/db/rotation.rs
@@ -1,0 +1,696 @@
+//! Index-layer key rotation orchestration (Issue #488).
+//!
+//! Wires the index re-encryption engine
+//! ([`IndexKeyRotation`](crate::storage::index_persistence::IndexKeyRotation))
+//! into [`AletheiaDB`] behind a synchronous API. A rotation:
+//!
+//! 1. sources the current MEK (from the retained startup config) and the new
+//!    MEK (from the caller-supplied key source), derives both index DEKs, and
+//!    refuses if they are equal (rotating to the same key is a no-op that risks
+//!    nonce reuse) or if encryption / index persistence is not configured;
+//! 2. adds the new generation to the persistence manager's live keyring — so
+//!    reads immediately dispatch on each file's header `key_version` and writes
+//!    stamp the new version — and records a durable `rotation.state` breadcrumb;
+//! 3. re-encrypts every old-key index file to the new key, atomically per file;
+//! 4. verifies zero old-key files remain, retires the old generation, and
+//!    removes the breadcrumb.
+//!
+//! A crash mid-rotation leaves the breadcrumb and a mix of old/new files;
+//! [`resume_pending_rotation`] re-runs the idempotent pass on the next startup.
+//!
+//! ## v1 scope / limitations
+//!
+//! * Only the **index** layer is rotated. WAL, cold-storage, and checkpoint
+//!   re-encryption are owned by those modules and are tracked as follow-ups.
+//! * The rotation is driven synchronously and expects the caller to quiesce
+//!   heavy index persistence for its duration; live reads stay correct
+//!   throughout (keyring dispatch), and any concurrent index write uses the new
+//!   generation (the manager's keyring is already switched).
+//! * After a successful rotation the operator MUST point the database's
+//!   `key_provider` config at the new key source for subsequent restarts; the
+//!   `rotation.state` breadcrumb lets an *interrupted* rotation resume against
+//!   the still-current old config.
+//! * Audit events are emitted to a locally-constructed key-events logger; the
+//!   shared audit sink is wired with Issue #489.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use subtle::ConstantTimeEq;
+use zeroize::Zeroizing;
+
+use crate::core::error::{Error, Result, StorageError};
+use crate::db::AletheiaDB;
+use crate::encryption::audit::{AuditEvent, AuditLevel, EncryptionAuditLogger};
+use crate::encryption::cipher::Cipher;
+use crate::encryption::config::{EncryptionConfig, KeyProviderConfig};
+use crate::encryption::factory::create_cipher;
+use crate::encryption::key_derivation::KeyDerivation;
+use crate::encryption::key_provider::{EnvKeyProvider, FileKeyProvider, KeyProvider};
+use crate::storage::index_persistence::{
+    IndexKeyRotation, IndexPersistenceManager, RotationError, RotationStatus,
+};
+
+/// Summary of a completed index key rotation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RotationReport {
+    /// Previous (retired) key version.
+    pub old_version: u32,
+    /// New (now current) key version.
+    pub new_version: u32,
+    /// Encrypted index files considered.
+    pub files_total: usize,
+    /// Files re-encrypted to the new key.
+    pub files_reencrypted: usize,
+    /// Files skipped (already at the new key).
+    pub files_skipped: usize,
+    /// Wall-clock duration of the rotation, in milliseconds.
+    pub duration_ms: u64,
+}
+
+fn rotation_err(e: RotationError) -> Error {
+    match e {
+        RotationError::NotConfigured => StorageError::InconsistentState {
+            reason: "index encryption is not configured; cannot rotate keys".to_string(),
+        }
+        .into(),
+        RotationError::KeyProvider(msg) => StorageError::KeyProvider(msg).into(),
+        other => StorageError::PersistenceError(other.to_string()).into(),
+    }
+}
+
+/// Source an MEK from a key-provider config (no key material is logged).
+fn load_mek(cfg: &KeyProviderConfig) -> std::result::Result<Zeroizing<[u8; 32]>, RotationError> {
+    let provider: Box<dyn KeyProvider> = match cfg {
+        KeyProviderConfig::File { path } => Box::new(FileKeyProvider::new(path)),
+        KeyProviderConfig::Env { variable } => Box::new(EnvKeyProvider::new(variable)),
+    };
+    provider
+        .get_mek()
+        .map_err(|e| RotationError::KeyProvider(e.to_string()))
+}
+
+/// Derive the index DEK for a MEK using the shared HKDF context.
+fn derive_index_dek(
+    mek: Zeroizing<[u8; 32]>,
+) -> std::result::Result<Zeroizing<[u8; 32]>, RotationError> {
+    KeyDerivation::new(mek)
+        .derive_index_dek()
+        .map_err(|e| RotationError::KeyProvider(e.to_string()))
+}
+
+impl AletheiaDB {
+    /// Classify the on-disk index files by key generation (read-only probe).
+    ///
+    /// Returns counts of files at the current key, at an old key, at an unknown
+    /// key, and plaintext. Useful before/after a rotation and as the operator
+    /// "how far along am I?" probe.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if index persistence or encryption is not configured, or
+    /// if the index directory cannot be scanned.
+    pub fn index_rotation_status(&self) -> Result<RotationStatus> {
+        let manager = self.require_rotation_prereqs()?;
+        let keyring = manager
+            .keyring()
+            .cloned()
+            .ok_or_else(|| rotation_err(RotationError::NotConfigured))?;
+        let cipher = keyring
+            .current_cipher()
+            .ok_or_else(|| rotation_err(RotationError::NotConfigured))?;
+        let version = keyring.current_version();
+        // Status only reads headers; a single-generation engine suffices.
+        let engine = IndexKeyRotation::new(
+            manager.indexes_path(),
+            keyring,
+            version,
+            cipher.clone(),
+            version,
+            cipher,
+        );
+        engine.status().map_err(rotation_err)
+    }
+
+    /// Rotate the index-encryption key to a new key source, re-encrypting every
+    /// persisted index file from the current key to the new one.
+    ///
+    /// Synchronous: performs begin → re-encrypt → complete in one call. Both key
+    /// generations are held for the duration so live reads stay correct, and the
+    /// old generation is retired only after a verified full pass (so the old key
+    /// can be safely dropped afterward).
+    ///
+    /// # Errors
+    ///
+    /// * index persistence or encryption is not configured;
+    /// * the new key derives the same index DEK as the current key;
+    /// * a key provider cannot source an MEK;
+    /// * a filesystem or decryption error occurs during re-encryption.
+    pub fn rotate_index_keys(&self, new_key_source: KeyProviderConfig) -> Result<RotationReport> {
+        let manager = self.require_rotation_prereqs()?;
+        let enc_cfg = self
+            .encryption_config
+            .clone()
+            .ok_or_else(|| rotation_err(RotationError::NotConfigured))?;
+
+        let started = Instant::now();
+        let report = self.run_rotation(&manager, &enc_cfg, &new_key_source, started);
+
+        let logger = EncryptionAuditLogger::new(AuditLevel::KeyEvents, "aletheiadb");
+        match &report {
+            Ok(r) => {
+                // NOTE: emitted to a local key-events logger; the shared audit
+                // sink is wired with Issue #489. Never logs key material.
+                logger.log(&AuditEvent::RotationCompleted {
+                    new_version: r.new_version,
+                    duration_ms: r.duration_ms,
+                });
+            }
+            Err(e) => {
+                logger.log(&AuditEvent::RotationFailed {
+                    version: manager.keyring().map(|k| k.current_version()).unwrap_or(0),
+                    error: e.to_string(),
+                });
+            }
+        }
+        report
+    }
+
+    /// Prerequisite check shared by status and rotate: index persistence must be
+    /// enabled and encryption configured.
+    fn require_rotation_prereqs(&self) -> Result<Arc<IndexPersistenceManager>> {
+        let manager =
+            self.persistence_manager
+                .as_ref()
+                .ok_or_else(|| StorageError::InconsistentState {
+                    reason: "index persistence is not enabled; cannot rotate keys".to_string(),
+                })?;
+        if manager.keyring().is_none() {
+            return Err(rotation_err(RotationError::NotConfigured));
+        }
+        Ok(Arc::clone(manager))
+    }
+
+    fn run_rotation(
+        &self,
+        manager: &Arc<IndexPersistenceManager>,
+        enc_cfg: &EncryptionConfig,
+        new_key_source: &KeyProviderConfig,
+        started: Instant,
+    ) -> Result<RotationReport> {
+        // Shared, mutable keyring handle (mutations are observed by the manager).
+        let keyring = manager
+            .keyring()
+            .cloned()
+            .ok_or_else(|| rotation_err(RotationError::NotConfigured))?;
+        let old_cipher = keyring
+            .current_cipher()
+            .ok_or_else(|| rotation_err(RotationError::NotConfigured))?;
+        let old_version = keyring.current_version();
+        let new_version = old_version + 1;
+
+        // Derive both index DEKs and refuse a same-key rotation (constant time).
+        let old_dek = derive_index_dek(load_mek(&enc_cfg.key_provider).map_err(rotation_err)?)
+            .map_err(rotation_err)?;
+        let new_dek = derive_index_dek(load_mek(new_key_source).map_err(rotation_err)?)
+            .map_err(rotation_err)?;
+        if bool::from(old_dek.as_ref().ct_eq(new_dek.as_ref())) {
+            return Err(rotation_err(RotationError::SameKey));
+        }
+
+        let new_cipher: Arc<dyn Cipher> = Arc::from(create_cipher(enc_cfg.algorithm, &new_dek));
+
+        // Begin: switch the live keyring to two generations and record the
+        // durable breadcrumb, then emit the audit event.
+        keyring.add_generation(new_version, Arc::clone(&new_cipher));
+        write_rotation_state(manager, new_version, new_key_source)?;
+        EncryptionAuditLogger::new(AuditLevel::KeyEvents, "aletheiadb").log(
+            &AuditEvent::RotationStarted {
+                old_version,
+                new_version,
+            },
+        );
+
+        let engine = IndexKeyRotation::new(
+            manager.indexes_path(),
+            keyring.clone(),
+            old_version,
+            old_cipher,
+            new_version,
+            new_cipher,
+        );
+
+        let progress = engine.re_encrypt(&mut |_| true).map_err(rotation_err)?;
+        engine.complete().map_err(rotation_err)?;
+        clear_rotation_state(manager);
+
+        Ok(RotationReport {
+            old_version,
+            new_version,
+            files_total: progress.files_total,
+            files_reencrypted: progress.files_reencrypted,
+            files_skipped: progress.files_skipped,
+            duration_ms: started.elapsed().as_millis() as u64,
+        })
+    }
+}
+
+// ── Durable rotation-state breadcrumb (crash-resume) ─────────────────
+//
+// A tiny line-based file under the data dir recording that a rotation is in
+// flight and the new key source needed to reconstruct the new cipher on
+// resume. No key material is written — only the source *reference* (a file path
+// or env var name) and the version numbers.
+
+fn rotation_state_path(manager: &IndexPersistenceManager) -> std::path::PathBuf {
+    manager.base_path().join("rotation.state")
+}
+
+fn write_rotation_state(
+    manager: &IndexPersistenceManager,
+    new_version: u32,
+    new_source: &KeyProviderConfig,
+) -> Result<()> {
+    let (kind, value) = match new_source {
+        KeyProviderConfig::File { path } => ("file", path.to_string_lossy().into_owned()),
+        KeyProviderConfig::Env { variable } => ("env", variable.clone()),
+    };
+    let body = format!(
+        "version=1\nnew_version={new_version}\nnew_source_kind={kind}\nnew_source_value={value}\n"
+    );
+    std::fs::create_dir_all(manager.base_path())
+        .map_err(|e| StorageError::io_error(format!("Failed to create data dir: {e}")))?;
+    std::fs::write(rotation_state_path(manager), body)
+        .map_err(|e| StorageError::io_error(format!("Failed to write rotation.state: {e}")))?;
+    Ok(())
+}
+
+fn clear_rotation_state(manager: &IndexPersistenceManager) {
+    let _ = std::fs::remove_file(rotation_state_path(manager));
+}
+
+/// Parsed rotation breadcrumb.
+struct PendingRotation {
+    new_version: u32,
+    new_source: KeyProviderConfig,
+}
+
+fn read_rotation_state(manager: &IndexPersistenceManager) -> Option<PendingRotation> {
+    let body = std::fs::read_to_string(rotation_state_path(manager)).ok()?;
+    let mut new_version = None;
+    let mut kind = None;
+    let mut value = None;
+    for line in body.lines() {
+        let (k, v) = line.split_once('=')?;
+        match k {
+            "new_version" => new_version = v.parse::<u32>().ok(),
+            "new_source_kind" => kind = Some(v.to_string()),
+            "new_source_value" => value = Some(v.to_string()),
+            _ => {}
+        }
+    }
+    let new_source = match kind.as_deref()? {
+        "file" => KeyProviderConfig::File {
+            path: value?.into(),
+        },
+        "env" => KeyProviderConfig::Env { variable: value? },
+        _ => return None,
+    };
+    Some(PendingRotation {
+        new_version: new_version?,
+        new_source,
+    })
+}
+
+/// Resume an interrupted index key rotation on startup (Issue #488).
+///
+/// If a `rotation.state` breadcrumb is present, reconstruct the new generation
+/// from the recorded source (the current `enc_cfg` supplies the old key),
+/// add it to the manager's keyring, re-run the idempotent re-encryption pass
+/// (skipping already-migrated files by header), complete, and clear the
+/// breadcrumb. A no-op when no rotation was in flight.
+///
+/// # Errors
+///
+/// Returns an error if the recorded new key source cannot be sourced or the
+/// re-encryption pass fails.
+pub fn resume_pending_rotation(
+    manager: &Arc<IndexPersistenceManager>,
+    enc_cfg: &EncryptionConfig,
+) -> Result<Option<RotationReport>> {
+    let Some(pending) = read_rotation_state(manager) else {
+        return Ok(None);
+    };
+    let Some(keyring) = manager.keyring().cloned() else {
+        // Encryption not configured on this startup; leave the breadcrumb.
+        return Ok(None);
+    };
+    let started = Instant::now();
+    let old_cipher = keyring
+        .current_cipher()
+        .ok_or_else(|| rotation_err(RotationError::NotConfigured))?;
+    let old_version = keyring.current_version();
+
+    let new_dek = derive_index_dek(load_mek(&pending.new_source).map_err(rotation_err)?)
+        .map_err(rotation_err)?;
+    let new_cipher: Arc<dyn Cipher> = Arc::from(create_cipher(enc_cfg.algorithm, &new_dek));
+
+    keyring.add_generation(pending.new_version, Arc::clone(&new_cipher));
+
+    let engine = IndexKeyRotation::new(
+        manager.indexes_path(),
+        keyring,
+        old_version,
+        old_cipher,
+        pending.new_version,
+        new_cipher,
+    );
+    let progress = engine.re_encrypt(&mut |_| true).map_err(rotation_err)?;
+    engine.complete().map_err(rotation_err)?;
+    clear_rotation_state(manager);
+
+    EncryptionAuditLogger::new(AuditLevel::KeyEvents, "aletheiadb").log(
+        &AuditEvent::RotationCompleted {
+            new_version: pending.new_version,
+            duration_ms: started.elapsed().as_millis() as u64,
+        },
+    );
+
+    Ok(Some(RotationReport {
+        old_version,
+        new_version: pending.new_version,
+        files_total: progress.files_total,
+        files_reencrypted: progress.files_reencrypted,
+        files_skipped: progress.files_skipped,
+        duration_ms: started.elapsed().as_millis() as u64,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{AletheiaDBConfig, WalConfigBuilder};
+    use crate::core::property::PropertyMapBuilder;
+    use crate::encryption::EncryptionManager;
+    use crate::index::vector::{DistanceMetric, HnswConfig};
+    use crate::storage::index_persistence::IndexPersistenceManager;
+    use crate::storage::index_persistence::common::index_file_key_version;
+    use crate::storage::wal::DurabilityMode;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    /// Build an encrypted, persistent DB rooted at `root`, keyed by `key_file`.
+    fn build_db(root: &Path, key_file: &Path) -> AletheiaDB {
+        let config = AletheiaDBConfig::builder()
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(root.join("wal"))
+                    .durability_mode(DurabilityMode::GroupCommit {
+                        max_delay_ms: 5,
+                        max_batch_size: 64,
+                    })
+                    .build(),
+            )
+            .persistence(crate::storage::index_persistence::PersistenceConfig {
+                enabled: true,
+                data_dir: root.join("data"),
+                load_on_startup: true,
+                ..Default::default()
+            })
+            .encryption(EncryptionConfig::file_based(key_file))
+            .build();
+        AletheiaDB::with_unified_config(config).unwrap()
+    }
+
+    /// Guard against silent plaintext bypass: EVERY persisted index file under
+    /// `indexes_dir` — bitcode files AND the native usearch files + sidecars —
+    /// must begin with the AEIX header when a cipher is configured. Returns the
+    /// number of files checked. (Coordinator-requested cross-path guard.)
+    fn assert_all_index_files_encrypted(indexes_dir: &Path) -> usize {
+        use crate::storage::index_persistence::common::is_encrypted_index;
+        fn is_scratch(name: &str) -> bool {
+            name.ends_with(".tmp")
+                || name.contains(".tmp.")
+                || name.starts_with(".aeix-usearch-tmp-")
+        }
+        fn walk(dir: &Path, count: &mut usize) {
+            for e in std::fs::read_dir(dir).unwrap() {
+                let p = e.unwrap().path();
+                if p.is_dir() {
+                    walk(&p, count);
+                    continue;
+                }
+                let name = p.file_name().unwrap().to_string_lossy().into_owned();
+                if is_scratch(&name) {
+                    continue;
+                }
+                let bytes = std::fs::read(&p).unwrap();
+                assert!(
+                    is_encrypted_index(&bytes),
+                    "index file {p:?} is NOT encrypted (missing AEIX header) — plaintext bypass!"
+                );
+                *count += 1;
+            }
+        }
+        let mut count = 0;
+        walk(indexes_dir, &mut count);
+        count
+    }
+
+    /// Every AEIX index file under `data/indexes` carries `expected` key_version.
+    fn assert_all_at_version(indexes_dir: &Path, expected: u32) -> usize {
+        fn walk(dir: &Path, expected: u32, count: &mut usize) {
+            for e in std::fs::read_dir(dir).unwrap() {
+                let p = e.unwrap().path();
+                if p.is_dir() {
+                    walk(&p, expected, count);
+                } else if let Ok(bytes) = std::fs::read(&p)
+                    && let Some(v) = index_file_key_version(&bytes)
+                {
+                    assert_eq!(v, expected, "file {p:?} not at key_version {expected}");
+                    *count += 1;
+                }
+            }
+        }
+        let mut count = 0;
+        walk(indexes_dir, expected, &mut count);
+        count
+    }
+
+    fn seed(db: &AletheiaDB) -> (crate::core::NodeId, crate::core::NodeId) {
+        db.enable_vector_index("embedding", HnswConfig::new(4, DistanceMetric::Cosine))
+            .unwrap();
+        let alice = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("name", "Alice")
+                    .insert_vector("embedding", &[1.0f32, 0.0, 0.0, 0.0])
+                    .build(),
+            )
+            .unwrap();
+        let bob = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("name", "Bob")
+                    .insert_vector("embedding", &[0.9f32, 0.1, 0.0, 0.0])
+                    .build(),
+            )
+            .unwrap();
+        db.create_edge(alice, bob, "KNOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+        db.persist_indexes().unwrap();
+        (alice, bob)
+    }
+
+    #[test]
+    fn full_cycle_reencrypts_index_files_and_data_intact() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let old_key = root.join("old.key");
+        let new_key = root.join("new.key");
+        crate::encryption::FileKeyProvider::generate_key_file(&old_key).unwrap();
+        crate::encryption::FileKeyProvider::generate_key_file(&new_key).unwrap();
+
+        let indexes_dir = root.join("data").join("indexes");
+        let db = build_db(root, &old_key);
+        let (alice, bob) = seed(&db);
+        // Pre-rotation: files are at key_version 1 AND every file is encrypted
+        // (no silent plaintext bypass on the normal persist path).
+        assert!(assert_all_at_version(&indexes_dir, 1) > 0);
+        assert!(assert_all_index_files_encrypted(&indexes_dir) > 0);
+
+        let report = db
+            .rotate_index_keys(KeyProviderConfig::File {
+                path: new_key.clone(),
+            })
+            .unwrap();
+        assert_eq!(report.old_version, 1);
+        assert_eq!(report.new_version, 2);
+        assert!(report.files_reencrypted > 0);
+
+        // Every persisted index file advanced to key_version 2 AND every file
+        // is still encrypted (rotation must never emit a plaintext file).
+        let n = assert_all_at_version(&indexes_dir, 2);
+        assert!(n > 0, "expected re-encrypted files at v2");
+        assert_eq!(
+            assert_all_index_files_encrypted(&indexes_dir),
+            n,
+            "some index file lost its AEIX header during rotation"
+        );
+
+        // Live instance: in-memory graph + vector search still work.
+        assert!(db.get_node(alice).is_ok(), "node must still be readable");
+        let similar = db
+            .similarity_search(crate::db::similarity_query::SimilarityQuery::from_node(alice).k(5))
+            .unwrap();
+        assert!(similar.iter().any(|(id, _)| *id == bob));
+        assert!(db.index_rotation_status().unwrap().is_fully_rotated());
+
+        // Prove the re-encrypted manifest round-trips under the NEW index key.
+        let new_index_cipher = std::sync::Arc::clone(
+            EncryptionManager::from_config(&EncryptionConfig::file_based(&new_key))
+                .unwrap()
+                .index_cipher(),
+        );
+        let reader =
+            IndexPersistenceManager::with_cipher(root.join("data"), Some(new_index_cipher.clone()));
+        crate::storage::index_persistence::manifest::load_manifest_with_cipher(
+            &reader.manifest_path(),
+            Some(&new_index_cipher),
+        )
+        .expect("manifest must decrypt under the new key after rotation");
+    }
+
+    #[test]
+    fn encrypted_persist_writes_no_plaintext_index_files() {
+        // Cross-path guard: a plain encrypted persist (no rotation) must write
+        // EVERY index file — bitcode files AND native usearch + sidecar — with
+        // the AEIX header. Catches any write path that silently bypasses the
+        // cipher (the compiler does not catch a plaintext bypass).
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let key = root.join("k.key");
+        crate::encryption::FileKeyProvider::generate_key_file(&key).unwrap();
+        let indexes_dir = root.join("data").join("indexes");
+        let db = build_db(root, &key);
+        seed(&db);
+        let checked = assert_all_index_files_encrypted(&indexes_dir);
+        assert!(
+            checked >= 4,
+            "expected the manifest/interner/graph/temporal/vector files to be present, got {checked}"
+        );
+    }
+
+    #[test]
+    fn rotate_rejects_same_key() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let key = root.join("k.key");
+        crate::encryption::FileKeyProvider::generate_key_file(&key).unwrap();
+        let db = build_db(root, &key);
+        seed(&db);
+        let err = db
+            .rotate_index_keys(KeyProviderConfig::File { path: key.clone() })
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("same key") || err.to_string().contains("equals"),
+            "expected same-key rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rotate_rejects_without_encryption() {
+        let db = AletheiaDB::new().unwrap();
+        let err = db
+            .rotate_index_keys(KeyProviderConfig::Env {
+                variable: "NOPE".to_string(),
+            })
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("persistence") || err.to_string().contains("encryption"),
+            "expected not-configured rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn crash_resume_completes_from_state_file() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let old_key = root.join("old.key");
+        let new_key = root.join("new.key");
+        crate::encryption::FileKeyProvider::generate_key_file(&old_key).unwrap();
+        crate::encryption::FileKeyProvider::generate_key_file(&new_key).unwrap();
+        let indexes_dir = root.join("data").join("indexes");
+
+        {
+            let db = build_db(root, &old_key);
+            seed(&db);
+        }
+
+        // Simulate a crash mid-rotation: add the new generation, write the
+        // breadcrumb, and re-encrypt only PART of the files.
+        let enc_cfg = EncryptionConfig::file_based(&old_key);
+        let manager = std::sync::Arc::new(IndexPersistenceManager::with_cipher(
+            root.join("data"),
+            Some(std::sync::Arc::clone(
+                EncryptionManager::from_config(&enc_cfg)
+                    .unwrap()
+                    .index_cipher(),
+            )),
+        ));
+        let keyring = manager.keyring().cloned().unwrap();
+        let new_index_cipher = std::sync::Arc::clone(
+            EncryptionManager::from_config(&EncryptionConfig::file_based(&new_key))
+                .unwrap()
+                .index_cipher(),
+        );
+        keyring.add_generation(2, new_index_cipher.clone());
+        super::write_rotation_state(
+            &manager,
+            2,
+            &KeyProviderConfig::File {
+                path: new_key.clone(),
+            },
+        )
+        .unwrap();
+        let engine = IndexKeyRotation::new(
+            manager.indexes_path(),
+            keyring,
+            1,
+            std::sync::Arc::clone(
+                EncryptionManager::from_config(&enc_cfg)
+                    .unwrap()
+                    .index_cipher(),
+            ),
+            2,
+            new_index_cipher,
+        );
+        let mut n = 0;
+        engine
+            .re_encrypt(&mut |_| {
+                n += 1;
+                n < 2
+            })
+            .unwrap();
+        // Mixed state + breadcrumb present.
+        assert!(root.join("data").join("rotation.state").exists());
+
+        // Resume finishes the rotation and clears the breadcrumb.
+        let resume_mgr = std::sync::Arc::new(IndexPersistenceManager::with_cipher(
+            root.join("data"),
+            Some(std::sync::Arc::clone(
+                EncryptionManager::from_config(&enc_cfg)
+                    .unwrap()
+                    .index_cipher(),
+            )),
+        ));
+        let report = resume_pending_rotation(&resume_mgr, &enc_cfg)
+            .unwrap()
+            .expect("a pending rotation should resume");
+        assert_eq!(report.new_version, 2);
+        assert!(!root.join("data").join("rotation.state").exists());
+        assert!(assert_all_at_version(&indexes_dir, 2) > 0);
+    }
+}

--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -506,20 +506,20 @@ impl CheckpointManager {
         // Encrypt checkpoint index files at rest when a cipher is configured
         // (Issue #481): a checkpoint in an encryption-enabled DB must not write
         // cleartext, and `recover` must read these files back encrypted.
-        let cipher = self.persistence_manager.index_cipher();
+        let keyring = self.persistence_manager.keyring();
         if self.config.enable_compression {
-            crate::storage::index_persistence::graph::save_graph_index_compressed_with_cipher(
+            crate::storage::index_persistence::graph::save_graph_index_compressed_with_keyring(
                 &graph_data,
                 &graph_path,
                 self.config.compression_level,
-                cipher,
+                keyring,
             )
             .map_err(persistence_err)?;
         } else {
-            crate::storage::index_persistence::graph::save_graph_index_with_cipher(
+            crate::storage::index_persistence::graph::save_graph_index_with_keyring(
                 &graph_data,
                 &graph_path,
-                cipher,
+                keyring,
             )
             .map_err(persistence_err)?;
         }
@@ -530,10 +530,10 @@ impl CheckpointManager {
             .persistence_manager
             .temporal_path()
             .join("versions.idx");
-        crate::storage::index_persistence::temporal::save_temporal_index_with_cipher(
+        crate::storage::index_persistence::temporal::save_temporal_index_with_keyring(
             &temporal_data,
             &temporal_path,
-            self.persistence_manager.index_cipher(),
+            self.persistence_manager.keyring(),
         )
         .map_err(persistence_err)?;
         bytes_written += std::fs::metadata(&temporal_path)
@@ -1039,9 +1039,9 @@ impl CheckpointManager {
             // ids to live ids (Issue #3490) before the raw resolution sites
             // below touch them; an identity remap is a no-op.
             let mut graph_data =
-                crate::storage::index_persistence::graph::load_graph_index_with_cipher(
+                crate::storage::index_persistence::graph::load_graph_index_with_keyring(
                     &graph_path,
-                    self.persistence_manager.index_cipher(),
+                    self.persistence_manager.keyring(),
                 )
                 .map_err(persistence_err)?;
             remap.remap_graph_index_data(&mut graph_data);
@@ -1116,9 +1116,9 @@ impl CheckpointManager {
             // `restore_into_historical_storage` resolves them; an identity remap
             // is a no-op.
             let mut temporal_data =
-                crate::storage::index_persistence::temporal::load_temporal_index_with_cipher(
+                crate::storage::index_persistence::temporal::load_temporal_index_with_keyring(
                     &temporal_path,
-                    self.persistence_manager.index_cipher(),
+                    self.persistence_manager.keyring(),
                 )
                 .map_err(persistence_err)?;
             remap.remap_temporal_index_data(&mut temporal_data);

--- a/src/storage/index_persistence/common.rs
+++ b/src/storage/index_persistence/common.rs
@@ -7,11 +7,174 @@ use bitcode::{Decode, Encode};
 use crc32fast::Hasher;
 use std::fs;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use super::atomic_write;
 use super::error::{IndexPersistenceError, Result};
 use crate::encryption::cipher::Cipher;
+
+// ── Key-version-addressable index cipher keyring (Issue #488) ─────────
+//
+// Before key rotation there is exactly one index generation. During a
+// rotation the data dir holds a MIX of files encrypted under the old and the
+// new key, distinguished only by the plaintext header `key_version` (Issue
+// #481). The keyring maps `key_version -> cipher` so the read path can decrypt
+// each file with the generation that actually wrote it, while writes always
+// use the CURRENT (newest) generation and stamp its `key_version` into the
+// header. A single-generation keyring reproduces the pre-rotation behavior
+// exactly (it decrypts any header with its one cipher and writes `key_version`
+// == 1), so the non-rotation path is unchanged.
+
+/// One key generation: a `key_version` and the cipher derived from that
+/// generation's index DEK.
+#[derive(Clone)]
+struct KeyGeneration {
+    key_version: u32,
+    cipher: Arc<dyn Cipher>,
+}
+
+#[derive(Clone)]
+struct KeyringInner {
+    /// All live generations (1 before rotation, 2 during, 1 after). Small.
+    generations: Vec<KeyGeneration>,
+    /// Version stamped into freshly written files (the newest generation).
+    current_version: u32,
+    /// Back-compat mode: a lone generation created from a single cipher with
+    /// no explicit version decrypts ANY header `key_version` with that cipher,
+    /// matching #481's version-agnostic single-cipher read exactly.
+    match_any: bool,
+}
+
+/// A cheaply-cloneable, shared-mutable set of index ciphers addressed by
+/// `key_version` (Issue #488).
+///
+/// Clones share the same underlying state, so a rotation engine can add the
+/// new generation (making live reads dispatch on the header and live writes
+/// stamp the new version) and later retire the old generation while the
+/// persistence manager holding a clone observes the change immediately.
+#[derive(Clone)]
+pub(crate) struct IndexKeyring {
+    inner: Arc<RwLock<KeyringInner>>,
+}
+
+impl IndexKeyring {
+    /// A single-generation keyring from one cipher (the non-rotation path).
+    ///
+    /// Reads decrypt any header `key_version` with this cipher and writes stamp
+    /// `ENC_INDEX_KEY_VERSION_V1` — byte-for-byte identical to #481.
+    pub(crate) fn single(cipher: Arc<dyn Cipher>) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(KeyringInner {
+                generations: vec![KeyGeneration {
+                    key_version: ENC_INDEX_KEY_VERSION_V1,
+                    cipher,
+                }],
+                current_version: ENC_INDEX_KEY_VERSION_V1,
+                match_any: true,
+            })),
+        }
+    }
+
+    /// A single-generation keyring pinned to an explicit `key_version` (strict
+    /// dispatch). Used by rotation tests to construct pinned/mixed keyrings.
+    #[cfg(test)]
+    pub(crate) fn single_versioned(cipher: Arc<dyn Cipher>, key_version: u32) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(KeyringInner {
+                generations: vec![KeyGeneration {
+                    key_version,
+                    cipher,
+                }],
+                current_version: key_version,
+                match_any: false,
+            })),
+        }
+    }
+
+    /// Read (decrypt) cipher for a header `key_version`, or `None` if no
+    /// generation matches. A `match_any` single keyring returns its only
+    /// cipher for every version (back-compat).
+    fn cipher_for_version(&self, key_version: u32) -> Option<Arc<dyn Cipher>> {
+        let inner = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        if inner.match_any {
+            return inner.generations.first().map(|g| g.cipher.clone());
+        }
+        inner
+            .generations
+            .iter()
+            .find(|g| g.key_version == key_version)
+            .map(|g| g.cipher.clone())
+    }
+
+    /// Current (write) cipher and the `key_version` it stamps.
+    pub(crate) fn current(&self) -> Option<(Arc<dyn Cipher>, u32)> {
+        let inner = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        let v = inner.current_version;
+        inner
+            .generations
+            .iter()
+            .find(|g| g.key_version == v)
+            .map(|g| (g.cipher.clone(), v))
+    }
+
+    /// The version freshly written files are stamped with.
+    pub(crate) fn current_version(&self) -> u32 {
+        self.inner
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .current_version
+    }
+
+    /// Whether a generation with `key_version` is currently held (i.e. reads of
+    /// files stamped with it can be decrypted). A `match_any` single keyring
+    /// holds every version.
+    #[cfg(test)]
+    pub(crate) fn has_version(&self, key_version: u32) -> bool {
+        let inner = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        inner.match_any
+            || inner
+                .generations
+                .iter()
+                .any(|g| g.key_version == key_version)
+    }
+
+    /// The current (write) cipher, if any (for callers that only need the
+    /// cipher, e.g. checkpoint's single-generation writes).
+    pub(crate) fn current_cipher(&self) -> Option<Arc<dyn Cipher>> {
+        self.current().map(|(c, _)| c)
+    }
+
+    /// Add a new generation, making it current. Switches the keyring to strict
+    /// per-version dispatch. Used by the rotation engine at `begin`.
+    pub(crate) fn add_generation(&self, key_version: u32, cipher: Arc<dyn Cipher>) {
+        let mut inner = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        inner.match_any = false;
+        inner.generations.retain(|g| g.key_version != key_version);
+        inner.generations.push(KeyGeneration {
+            key_version,
+            cipher,
+        });
+        inner.current_version = key_version;
+    }
+
+    /// Retire every generation except `key_version`, which becomes the sole,
+    /// current generation. Used by the rotation engine at `complete`/`cancel`.
+    pub(crate) fn retain_only(&self, key_version: u32) {
+        let mut inner = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        inner.generations.retain(|g| g.key_version == key_version);
+        inner.current_version = key_version;
+        inner.match_any = false;
+    }
+}
+
+/// Read the header `key_version` of an encrypted index buffer without
+/// decrypting. Returns `None` if `bytes` is not an encrypted index file.
+pub(crate) fn index_file_key_version(bytes: &[u8]) -> Option<u32> {
+    if !is_encrypted_index(bytes) {
+        return None;
+    }
+    Some(u32::from_le_bytes([bytes[6], bytes[7], bytes[8], bytes[9]]))
+}
 
 // ── Encrypted index file header (Issue #481) ─────────────────────────
 //
@@ -70,7 +233,18 @@ fn build_enc_header(algorithm_id: u8, key_version: u32) -> [u8; ENC_HEADER_LEN] 
 ///
 /// The header is passed as AAD so it is authenticated (but not encrypted).
 pub(crate) fn encrypt_index_bytes(plaintext: &[u8], cipher: &Arc<dyn Cipher>) -> Result<Vec<u8>> {
-    let header = build_enc_header(cipher.algorithm_id(), ENC_INDEX_KEY_VERSION_V1);
+    encrypt_index_bytes_versioned(plaintext, cipher, ENC_INDEX_KEY_VERSION_V1)
+}
+
+/// Like [`encrypt_index_bytes`] but stamps an explicit `key_version` into the
+/// header (Issue #488 key rotation). `encrypt_index_bytes` is exactly this with
+/// `key_version == ENC_INDEX_KEY_VERSION_V1`.
+pub(crate) fn encrypt_index_bytes_versioned(
+    plaintext: &[u8],
+    cipher: &Arc<dyn Cipher>,
+    key_version: u32,
+) -> Result<Vec<u8>> {
+    let header = build_enc_header(cipher.algorithm_id(), key_version);
     let ciphertext = cipher
         .encrypt(plaintext, &header)
         .map_err(|e| IndexPersistenceError::Serialization(format!("Encryption failed: {e}")))?;
@@ -392,6 +566,113 @@ pub(crate) fn save_encoded_encrypted<T: Encode>(
     // Encrypt the whole thing (data + CRC) with the header as AAD.
     let encrypted = encrypt_index_bytes(&plaintext, cipher)?;
 
+    atomic_write(path, &encrypted)
+}
+
+// ── Keyring-aware read/write path (Issue #488) ───────────────────────
+//
+// These mirror the single-cipher helpers above but dispatch the decrypt
+// cipher on the file's header `key_version` via an [`IndexKeyring`], and stamp
+// the keyring's current version on writes. A single-generation keyring makes
+// them behave exactly like the single-cipher path.
+
+/// Decrypt an encrypted index buffer, selecting the cipher by the header's
+/// `key_version` from `keyring` (Issue #488). `bytes` MUST satisfy
+/// [`is_encrypted_index`].
+pub(crate) fn decrypt_index_bytes_with_keyring(
+    bytes: &[u8],
+    path: &Path,
+    keyring: Option<&IndexKeyring>,
+) -> Result<Vec<u8>> {
+    debug_assert!(is_encrypted_index(bytes));
+    let key_version = u32::from_le_bytes([bytes[6], bytes[7], bytes[8], bytes[9]]);
+    let cipher = keyring.and_then(|k| k.cipher_for_version(key_version));
+    decrypt_index_bytes(bytes, path, cipher.as_ref())
+}
+
+/// Like [`read_index_file`] but decrypts via a keyring (Issue #488).
+pub(crate) fn read_index_file_with_keyring(
+    path: &Path,
+    max_size: u64,
+    context: &str,
+    keyring: Option<&IndexKeyring>,
+) -> Result<Vec<u8>> {
+    let metadata = fs::metadata(path)?;
+    if metadata.len() > max_size {
+        return Err(IndexPersistenceError::SizeLimitExceeded {
+            message: format!(
+                "{} file size {} exceeds limit {}",
+                context,
+                metadata.len(),
+                max_size
+            ),
+        });
+    }
+
+    let bytes = fs::read(path)?;
+    if is_encrypted_index(&bytes) {
+        decrypt_index_bytes_with_keyring(&bytes, path, keyring)
+    } else {
+        Ok(bytes)
+    }
+}
+
+/// Like [`read_and_verify_crc_maybe_encrypted`] but decrypts via a keyring.
+pub(crate) fn read_and_verify_crc_maybe_encrypted_with_keyring(
+    path: &Path,
+    max_size: u64,
+    context: &str,
+    keyring: Option<&IndexKeyring>,
+) -> Result<Vec<u8>> {
+    let content = read_index_file_with_keyring(path, max_size, context, keyring)?;
+    verify_and_strip_crc(content, path)
+}
+
+/// Like [`load_encoded_maybe_encrypted`] but decrypts via a keyring.
+pub(crate) fn load_encoded_maybe_encrypted_with_keyring<T: for<'a> Decode<'a>>(
+    path: &Path,
+    max_size: u64,
+    context: &str,
+    keyring: Option<&IndexKeyring>,
+) -> Result<T> {
+    let data = read_and_verify_crc_maybe_encrypted_with_keyring(path, max_size, context, keyring)?;
+    let decoded: T = bitcode::decode(&data)?;
+    Ok(decoded)
+}
+
+/// Like [`save_encoded_maybe_encrypted`] but encrypts with the keyring's
+/// current generation, stamping its `key_version` into the header (Issue #488).
+/// A `None` keyring writes plaintext.
+pub(crate) fn save_encoded_maybe_encrypted_with_keyring<T: Encode>(
+    data: &T,
+    path: &Path,
+    keyring: Option<&IndexKeyring>,
+) -> Result<()> {
+    match keyring.and_then(IndexKeyring::current) {
+        Some((cipher, key_version)) => {
+            save_encoded_encrypted_versioned(data, path, &cipher, key_version)
+        }
+        None => save_encoded_with_crc(data, path),
+    }
+}
+
+/// Like [`save_encoded_encrypted`] but stamps an explicit `key_version`.
+pub(crate) fn save_encoded_encrypted_versioned<T: Encode>(
+    data: &T,
+    path: &Path,
+    cipher: &Arc<dyn Cipher>,
+    key_version: u32,
+) -> Result<()> {
+    let encoded = bitcode::encode(data);
+
+    let mut hasher = Hasher::new();
+    hasher.update(&encoded);
+    let checksum = hasher.finalize();
+
+    let mut plaintext = encoded;
+    plaintext.extend_from_slice(&checksum.to_le_bytes());
+
+    let encrypted = encrypt_index_bytes_versioned(&plaintext, cipher, key_version)?;
     atomic_write(path, &encrypted)
 }
 

--- a/src/storage/index_persistence/graph.rs
+++ b/src/storage/index_persistence/graph.rs
@@ -38,6 +38,24 @@ fn write_graph_buffer_maybe_encrypted(
     }
 }
 
+/// Write a graph-file buffer, encrypting with the current generation of an
+/// [`IndexKeyring`](super::common::IndexKeyring) and stamping its `key_version`
+/// (Issue #488 key rotation). A `None` keyring writes plaintext.
+fn write_graph_buffer_with_keyring(
+    path: &Path,
+    plaintext: &[u8],
+    keyring: Option<&super::common::IndexKeyring>,
+) -> Result<()> {
+    match keyring.and_then(super::common::IndexKeyring::current) {
+        Some((cipher, key_version)) => {
+            let encrypted =
+                super::common::encrypt_index_bytes_versioned(plaintext, &cipher, key_version)?;
+            super::atomic_write(path, &encrypted)
+        }
+        None => super::atomic_write(path, plaintext),
+    }
+}
+
 /// Map decompression errors to `IndexPersistenceError`, preserving the
 /// specific `SizeLimitExceeded` variant for capacity violations.
 fn map_decompress_error(e: crate::core::error::Error) -> IndexPersistenceError {
@@ -263,6 +281,17 @@ pub fn save_graph_index_with_cipher(
     write_graph_buffer_maybe_encrypted(path, &plaintext, cipher)
 }
 
+/// Save graph index data (uncompressed), encrypting with an
+/// [`IndexKeyring`](super::common::IndexKeyring) (Issue #488 key rotation).
+pub(crate) fn save_graph_index_with_keyring(
+    data: &GraphIndexData,
+    path: &Path,
+    keyring: Option<&super::common::IndexKeyring>,
+) -> Result<()> {
+    let plaintext = build_graph_plaintext(data);
+    write_graph_buffer_with_keyring(path, &plaintext, keyring)
+}
+
 /// Load graph index data from disk and validate CRC32 checksum.
 ///
 /// Automatically detects zstd compression by checking for magic bytes.
@@ -364,6 +393,22 @@ pub fn load_graph_index_with_cipher(
     decode_graph_bytes(&buffer, path)
 }
 
+/// Load graph index data, decrypting via an
+/// [`IndexKeyring`](super::common::IndexKeyring) that dispatches on the header
+/// `key_version` (Issue #488 key rotation).
+pub(crate) fn load_graph_index_with_keyring(
+    path: &Path,
+    keyring: Option<&super::common::IndexKeyring>,
+) -> Result<GraphIndexData> {
+    let buffer = super::common::read_index_file_with_keyring(
+        path,
+        super::MAX_GRAPH_INDEX_FILE_SIZE,
+        "Graph index",
+        keyring,
+    )?;
+    decode_graph_bytes(&buffer, path)
+}
+
 /// Create a new empty GraphIndexData.
 pub fn new_graph_index_data() -> GraphIndexData {
     GraphIndexData {
@@ -443,6 +488,18 @@ pub fn save_graph_index_compressed_with_cipher(
 ) -> Result<()> {
     let plaintext = build_graph_plaintext_compressed(data, compression_level)?;
     write_graph_buffer_maybe_encrypted(path, &plaintext, cipher)
+}
+
+/// Save graph index data (zstd-compressed), encrypting with an
+/// [`IndexKeyring`](super::common::IndexKeyring) (Issue #488 key rotation).
+pub(crate) fn save_graph_index_compressed_with_keyring(
+    data: &GraphIndexData,
+    path: &Path,
+    compression_level: i32,
+    keyring: Option<&super::common::IndexKeyring>,
+) -> Result<()> {
+    let plaintext = build_graph_plaintext_compressed(data, compression_level)?;
+    write_graph_buffer_with_keyring(path, &plaintext, keyring)
 }
 
 /// Load graph index data using memory-mapped file for efficient large file handling.

--- a/src/storage/index_persistence/loader.rs
+++ b/src/storage/index_persistence/loader.rs
@@ -4,12 +4,13 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use super::common::IndexKeyring;
 use super::error::Result;
 use super::formats::IndexManifest;
-use super::manifest::{load_manifest_with_cipher, save_manifest_with_cipher};
+use super::manifest::{load_manifest_with_keyring, save_manifest_with_keyring};
 use super::strings::{
-    InternerRemap, load_string_interner_with_cipher, restore_string_interner,
-    save_string_interner_with_cipher,
+    InternerRemap, load_string_interner_with_keyring, restore_string_interner,
+    save_string_interner_with_keyring,
 };
 use crate::encryption::cipher::Cipher;
 
@@ -17,12 +18,15 @@ use crate::encryption::cipher::Cipher;
 pub struct IndexPersistenceManager {
     /// Base directory for all index files
     base_path: PathBuf,
-    /// Optional cipher for encryption-at-rest of index files (Issue #481).
+    /// Optional key-version-addressable cipher set for encryption-at-rest of
+    /// index files (Issue #481 single-generation; Issue #488 rotation).
     /// `None` means indexes are persisted/read as plaintext (default,
     /// back-compatible). When `Some`, files are written with the encrypted
-    /// index header and read back transparently (a legacy plaintext file is
-    /// still read correctly via header sniffing).
-    index_cipher: Option<Arc<dyn Cipher>>,
+    /// index header stamped with the keyring's current `key_version`, and read
+    /// back by dispatching on each file's header `key_version` (so a mix of
+    /// old- and new-key files during a rotation reads correctly). A legacy
+    /// plaintext file is still read correctly via header sniffing.
+    keyring: Option<IndexKeyring>,
 }
 
 impl IndexPersistenceManager {
@@ -30,26 +34,43 @@ impl IndexPersistenceManager {
     pub fn new(base_path: impl Into<PathBuf>) -> Self {
         Self {
             base_path: base_path.into(),
-            index_cipher: None,
+            keyring: None,
         }
     }
 
     /// Create a new persistence manager with an optional index cipher.
     ///
-    /// Passing `None` is equivalent to [`IndexPersistenceManager::new`].
+    /// Passing `None` is equivalent to [`IndexPersistenceManager::new`]. A
+    /// `Some(cipher)` builds a single-generation keyring (the non-rotation
+    /// path), byte-for-byte identical to Issue #481.
     pub fn with_cipher(
         base_path: impl Into<PathBuf>,
         index_cipher: Option<Arc<dyn Cipher>>,
     ) -> Self {
         Self {
             base_path: base_path.into(),
-            index_cipher,
+            keyring: index_cipher.map(IndexKeyring::single),
         }
     }
 
-    /// The index cipher, if encryption-at-rest is enabled.
-    pub(crate) fn index_cipher(&self) -> Option<&Arc<dyn Cipher>> {
-        self.index_cipher.as_ref()
+    /// Create a new persistence manager with an explicit
+    /// [`IndexKeyring`](super::common::IndexKeyring) (Issue #488 key rotation).
+    /// Test-only: production builds the manager via [`Self::with_cipher`] and
+    /// mutates the shared keyring in place during rotation.
+    #[cfg(test)]
+    pub(crate) fn with_keyring(
+        base_path: impl Into<PathBuf>,
+        keyring: Option<IndexKeyring>,
+    ) -> Self {
+        Self {
+            base_path: base_path.into(),
+            keyring,
+        }
+    }
+
+    /// The index keyring, if encryption-at-rest is enabled.
+    pub(crate) fn keyring(&self) -> Option<&IndexKeyring> {
+        self.keyring.as_ref()
     }
 
     /// Get the base path.
@@ -152,8 +173,7 @@ impl IndexPersistenceManager {
             // (Issue #481); `restore_string_interner` returns the file-id ->
             // live-id remap (Issue #3490) the caller threads through the graph /
             // temporal index data.
-            let interner_data =
-                load_string_interner_with_cipher(&interner_path, self.index_cipher())?;
+            let interner_data = load_string_interner_with_keyring(&interner_path, self.keyring())?;
             let remap = restore_string_interner(&interner_data)?;
             (true, remap)
         } else {
@@ -180,7 +200,7 @@ impl IndexPersistenceManager {
         }
 
         // 3. Load manifest
-        let manifest = load_manifest_with_cipher(&manifest_path, self.index_cipher())?;
+        let manifest = load_manifest_with_keyring(&manifest_path, self.keyring())?;
 
         Ok((manifest, remap))
     }
@@ -188,13 +208,13 @@ impl IndexPersistenceManager {
     /// Save the manifest.
     pub fn save_manifest(&self, manifest: &IndexManifest) -> Result<()> {
         self.ensure_directories()?;
-        save_manifest_with_cipher(manifest, &self.manifest_path(), self.index_cipher())
+        save_manifest_with_keyring(manifest, &self.manifest_path(), self.keyring())
     }
 
     /// Save the string interner.
     pub fn save_string_interner(&self) -> Result<()> {
         self.ensure_directories()?;
-        save_string_interner_with_cipher(&self.interner_path(), self.index_cipher())
+        save_string_interner_with_keyring(&self.interner_path(), self.keyring())
     }
 }
 
@@ -203,6 +223,54 @@ mod tests {
     use super::*;
     use crate::core::GLOBAL_INTERNER;
     use tempfile::tempdir;
+
+    fn enc_cipher(seed: u8) -> Arc<dyn Cipher> {
+        use crate::encryption::Aes256GcmCipher;
+        use zeroize::Zeroizing;
+        let mut key = Zeroizing::new([0u8; 32]);
+        key[0] = seed;
+        Arc::new(Aes256GcmCipher::new(&key))
+    }
+
+    #[test]
+    fn manager_load_path_dispatches_on_key_version_in_mixed_dir() {
+        // Issue #488: the manager's load path must read a MIX of old-key and
+        // new-key index files via keyring dispatch. We write the interner under
+        // the OLD key (v1) and the manifest under the NEW key (v2), then load
+        // both through a two-generation keyring manager.
+        let dir = tempdir().unwrap();
+        let (old, new) = (enc_cipher(0xE1), enc_cipher(0xE2));
+
+        GLOBAL_INTERNER.intern("mixed_dir_label").unwrap();
+
+        // Interner: OLD key, key_version 1.
+        let mgr_old = IndexPersistenceManager::with_cipher(dir.path(), Some(old.clone()));
+        mgr_old.save_string_interner().unwrap();
+
+        // Manifest: NEW key, key_version 2 (strict single-gen keyring at v2).
+        let ring_new = IndexKeyring::single_versioned(new.clone(), 2);
+        let mgr_new = IndexPersistenceManager::with_keyring(dir.path(), Some(ring_new));
+        mgr_new.save_manifest(&IndexManifest::new(4242)).unwrap();
+
+        // Sanity: the two files really are stamped with different key_versions.
+        let manifest_raw = std::fs::read(mgr_old.manifest_path()).unwrap();
+        let interner_raw = std::fs::read(mgr_old.interner_path()).unwrap();
+        assert_eq!(
+            super::super::common::index_file_key_version(&manifest_raw),
+            Some(2)
+        );
+        assert_eq!(
+            super::super::common::index_file_key_version(&interner_raw),
+            Some(1)
+        );
+
+        // A two-generation keyring (old v1 + new v2, current v2) loads BOTH.
+        let ring_mixed = IndexKeyring::single_versioned(old, 1);
+        ring_mixed.add_generation(2, new);
+        let mgr_mixed = IndexPersistenceManager::with_keyring(dir.path(), Some(ring_mixed));
+        let manifest = mgr_mixed.load_manifest_and_strings().unwrap();
+        assert_eq!(manifest.lsn, 4242, "new-key manifest read via dispatch");
+    }
 
     #[test]
     fn test_persistence_manager_paths() {

--- a/src/storage/index_persistence/manifest.rs
+++ b/src/storage/index_persistence/manifest.rs
@@ -117,6 +117,16 @@ pub fn save_manifest_with_cipher(
     super::common::save_encoded_maybe_encrypted(manifest, path, cipher)
 }
 
+/// Save the manifest, encrypting with the current generation of an
+/// [`IndexKeyring`](super::common::IndexKeyring) (Issue #488 key rotation).
+pub(crate) fn save_manifest_with_keyring(
+    manifest: &IndexManifest,
+    path: &Path,
+    keyring: Option<&super::common::IndexKeyring>,
+) -> Result<()> {
+    super::common::save_encoded_maybe_encrypted_with_keyring(manifest, path, keyring)
+}
+
 /// Load manifest from disk and validate CRC32 checksum.
 ///
 /// # Examples
@@ -172,7 +182,26 @@ pub fn load_manifest_with_cipher(
         "Manifest",
         cipher,
     )?;
+    decode_and_validate_manifest(data, path)
+}
 
+/// Load the manifest, decrypting via an [`IndexKeyring`](super::common::IndexKeyring)
+/// that dispatches on the header `key_version` (Issue #488 key rotation).
+pub(crate) fn load_manifest_with_keyring(
+    path: &Path,
+    keyring: Option<&super::common::IndexKeyring>,
+) -> Result<IndexManifest> {
+    let data = super::common::read_and_verify_crc_maybe_encrypted_with_keyring(
+        path,
+        super::MAX_MANIFEST_FILE_SIZE,
+        "Manifest",
+        keyring,
+    )?;
+    decode_and_validate_manifest(data, path)
+}
+
+/// Decode + validate the bitcode manifest payload (magic + version check).
+fn decode_and_validate_manifest(data: Vec<u8>, path: &Path) -> Result<IndexManifest> {
     // Decode and validate
     let manifest: IndexManifest = bitcode::decode(&data)?;
 

--- a/src/storage/index_persistence/mod.rs
+++ b/src/storage/index_persistence/mod.rs
@@ -87,6 +87,8 @@ pub mod loader;
 pub mod manifest;
 /// Persistence operations implementation.
 pub mod operations;
+/// Index-layer key-rotation re-encryption engine (Issue #488).
+pub mod reencrypt;
 pub mod strings;
 pub mod temporal;
 pub mod temporal_adjacency;
@@ -108,6 +110,7 @@ pub use error::{IndexPersistenceError, Result};
 pub use formats::*;
 pub use loader::IndexPersistenceManager;
 use rayon::prelude::*;
+pub use reencrypt::{IndexKeyRotation, RotationError, RotationProgress, RotationStatus};
 
 /// Current manifest format version.
 ///

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -64,11 +64,11 @@ pub(crate) fn persist_vector_indexes(
 ) -> Result<()> {
     use crate::storage::index_persistence::formats::PersistedHnswConfig;
     use crate::storage::index_persistence::vector::{
-        new_vector_mappings, new_vector_meta, save_vector_mappings_with_cipher,
-        save_vector_meta_with_cipher,
+        new_vector_mappings, new_vector_meta, save_vector_mappings_with_keyring,
+        save_vector_meta_with_keyring,
     };
 
-    let cipher = manager.index_cipher();
+    let keyring = manager.keyring();
 
     // Save string interner first (required by all indexes)
     manager.save_string_interner().map_err(|e| {
@@ -106,10 +106,10 @@ pub(crate) fn persist_vector_indexes(
         // a cipher is configured (Issue #481, closes AC #1).
         let usearch_path = vec_path.join("current.usearch");
 
-        crate::storage::index_persistence::vector::save_hnsw_index_maybe_encrypted(
+        crate::storage::index_persistence::vector::save_hnsw_index_with_keyring(
             index.as_ref(),
             &usearch_path,
-            cipher,
+            keyring,
         )
         .map_err(|e| {
             StorageError::PersistenceError(format!("Failed to save usearch index: {}", e))
@@ -132,7 +132,7 @@ pub(crate) fn persist_vector_indexes(
         // Set the actual vector count
         vector_meta.vector_count = vector_count as u64;
 
-        save_vector_meta_with_cipher(&vector_meta, &vec_path.join("meta.idx"), cipher).map_err(
+        save_vector_meta_with_keyring(&vector_meta, &vec_path.join("meta.idx"), keyring).map_err(
             |e| {
                 StorageError::PersistenceError(format!(
                     "Failed to save vector metadata for {}: {}",
@@ -153,13 +153,17 @@ pub(crate) fn persist_vector_indexes(
             })
             .collect();
 
-        save_vector_mappings_with_cipher(&vector_mappings, &vec_path.join("mappings.idx"), cipher)
-            .map_err(|e| {
-                StorageError::PersistenceError(format!(
-                    "Failed to save vector mappings for {}: {}",
-                    property_name, e
-                ))
-            })?;
+        save_vector_mappings_with_keyring(
+            &vector_mappings,
+            &vec_path.join("mappings.idx"),
+            keyring,
+        )
+        .map_err(|e| {
+            StorageError::PersistenceError(format!(
+                "Failed to save vector mappings for {}: {}",
+                property_name, e
+            ))
+        })?;
     }
 
     if let Some(tracker) = tracker {
@@ -217,12 +221,12 @@ struct SkippedVectorIndex {
 /// so output stays deterministic even though loads run in parallel.
 fn load_single_vector_index(
     vec_path: &std::path::Path,
-    cipher: Option<&Arc<dyn crate::encryption::cipher::Cipher>>,
+    keyring: Option<&crate::storage::index_persistence::common::IndexKeyring>,
 ) -> std::result::Result<LoadedVectorIndex, SkippedVectorIndex> {
     use crate::index::vector::{DistanceMetric, HnswConfig, HnswIndex};
     use crate::storage::index_persistence::vector::{
-        load_hnsw_index_maybe_encrypted, load_vector_mappings_with_cipher,
-        load_vector_meta_with_cipher,
+        load_hnsw_index_with_keyring, load_vector_mappings_with_keyring,
+        load_vector_meta_with_keyring,
     };
 
     let skipped = |property_name: &str, reason: String| SkippedVectorIndex {
@@ -263,7 +267,7 @@ fn load_single_vector_index(
         return Err(skipped(&property_name, "metadata not found".to_string()));
     }
 
-    let meta = match load_vector_meta_with_cipher(&meta_path, cipher) {
+    let meta = match load_vector_meta_with_keyring(&meta_path, keyring) {
         Ok(meta) => meta,
         Err(e) => {
             return Err(skipped(
@@ -296,7 +300,7 @@ fn load_single_vector_index(
     let usearch_path = vec_path.join("current.usearch");
     let index_result = if usearch_path.exists() {
         // Load existing index (decrypting first if encrypted at rest)
-        load_hnsw_index_maybe_encrypted(&usearch_path, config.clone(), cipher)
+        load_hnsw_index_with_keyring(&usearch_path, config.clone(), keyring)
     } else {
         // Create new empty index
         HnswIndex::new(config.clone())
@@ -315,7 +319,7 @@ fn load_single_vector_index(
     let mut warnings = Vec::new();
     let mappings_path = vec_path.join("mappings.idx");
     if mappings_path.exists() {
-        let mappings_data = match load_vector_mappings_with_cipher(&mappings_path, cipher) {
+        let mappings_data = match load_vector_mappings_with_keyring(&mappings_path, keyring) {
             Ok(data) => data,
             Err(e) => {
                 return Err(skipped(
@@ -420,12 +424,12 @@ pub(crate) fn load_vector_indexes(
     // otherwise propagate the panic through `collect`).
     // Clone the index cipher (cheap Arc clone) so each parallel task can decrypt
     // encrypted vector meta/mappings files (Issue #481).
-    let cipher = manager.index_cipher().cloned();
+    let keyring = manager.keyring().cloned();
     let staged: Vec<std::result::Result<LoadedVectorIndex, SkippedVectorIndex>> = index_dirs
         .par_iter()
         .map(|path| {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                load_single_vector_index(path, cipher.as_ref())
+                load_single_vector_index(path, keyring.as_ref())
             }))
             .unwrap_or_else(|payload| {
                 let panic_msg = if let Some(s) = payload.downcast_ref::<&str>() {
@@ -524,7 +528,7 @@ pub(crate) fn persist_graph_index(
     current_lsn: u64,
 ) -> Result<(u64, u64)> {
     use crate::storage::index_persistence::graph::{
-        new_graph_index_data, persist_property_map, save_graph_index_with_cipher,
+        new_graph_index_data, persist_property_map, save_graph_index_with_keyring,
     };
     use crate::storage::index_persistence::{PersistedEdge, PersistedNode};
 
@@ -588,9 +592,9 @@ pub(crate) fn persist_graph_index(
         StorageError::PersistenceError(format!("Failed to create graph directory: {}", e))
     })?;
 
-    save_graph_index_with_cipher(&graph_data, &graph_path, manager.index_cipher()).map_err(
-        |e| StorageError::PersistenceError(format!("Failed to save graph index: {}", e)),
-    )?;
+    save_graph_index_with_keyring(&graph_data, &graph_path, manager.keyring()).map_err(|e| {
+        StorageError::PersistenceError(format!("Failed to save graph index: {}", e))
+    })?;
 
     if let Some(tracker) = tracker {
         tracker.reset_graph_mutations();
@@ -619,7 +623,7 @@ pub(crate) fn persist_temporal_index(
     use crate::storage::index_persistence::temporal::{
         convert_edge_version, convert_node_version, materialize_version_data_for_persistence,
         needs_sparse_vector_materialization, new_temporal_index_data,
-        save_temporal_index_with_cipher,
+        save_temporal_index_with_keyring,
     };
 
     // Get read lock on historical storage
@@ -736,10 +740,9 @@ pub(crate) fn persist_temporal_index(
 
     // Save to disk
     let temporal_path = manager.indexes_path().join("temporal").join("versions.idx");
-    save_temporal_index_with_cipher(&temporal_data, &temporal_path, manager.index_cipher())
-        .map_err(|e| {
-            StorageError::PersistenceError(format!("Failed to save temporal index: {}", e))
-        })?;
+    save_temporal_index_with_keyring(&temporal_data, &temporal_path, manager.keyring()).map_err(
+        |e| StorageError::PersistenceError(format!("Failed to save temporal index: {}", e)),
+    )?;
 
     tracker.reset_temporal_mutations();
     tracker.update_temporal_lsn(current_lsn);
@@ -780,15 +783,15 @@ pub(crate) fn persist_temporal_adjacency_index(
     historical: &Arc<RwLock<HistoricalStorage>>,
     manager: &Arc<IndexPersistenceManager>,
 ) -> Result<()> {
-    use crate::storage::index_persistence::temporal_adjacency::save_temporal_adjacency_index_with_cipher;
+    use crate::storage::index_persistence::temporal_adjacency::save_temporal_adjacency_index_with_keyring;
 
     // Get the temporal adjacency index from historical storage
     let historical_read = historical.read();
     if let Some(adj_index) = historical_read.get_temporal_adjacency_index() {
-        save_temporal_adjacency_index_with_cipher(
+        save_temporal_adjacency_index_with_keyring(
             adj_index,
             manager.base_path(),
-            manager.index_cipher(),
+            manager.keyring(),
         )
         .map_err(|e| {
             StorageError::PersistenceError(format!(
@@ -964,10 +967,10 @@ pub(crate) fn load_indexes_startup(
     let graph_path = manager.graph_path().join("adjacency.idx");
     if graph_path.exists() {
         use crate::storage::index_persistence::graph::{
-            load_graph_index_with_cipher, restore_property_map,
+            load_graph_index_with_keyring, restore_property_map,
         };
 
-        match load_graph_index_with_cipher(&graph_path, manager.index_cipher()) {
+        match load_graph_index_with_keyring(&graph_path, manager.keyring()) {
             Ok(mut graph_data) => {
                 // Issue #3490: translate persisted (file-space) interner ids
                 // (node/edge labels, property keys, and string property values)
@@ -1199,10 +1202,10 @@ pub(crate) fn load_indexes_startup(
     let temporal_path = manager.temporal_path().join("versions.idx");
     if temporal_path.exists() {
         use crate::storage::index_persistence::temporal::{
-            load_temporal_index_with_cipher, restore_into_historical_storage,
+            load_temporal_index_with_keyring, restore_into_historical_storage,
         };
 
-        match load_temporal_index_with_cipher(&temporal_path, manager.index_cipher()) {
+        match load_temporal_index_with_keyring(&temporal_path, manager.keyring()) {
             Ok(mut temporal_data) => {
                 // Issue #3490: translate persisted (file-space) interner ids in
                 // the historical versions/anchors (labels, property keys, string
@@ -1320,16 +1323,16 @@ pub(crate) fn load_indexes_startup(
     // filtering silently matches the wrong edge type after a reload whose
     // interner order diverged from the saved file. The combined loader decrypts
     // first, then applies the remap to the decoded data.
-    use crate::storage::index_persistence::temporal_adjacency::load_temporal_adjacency_index_with_cipher_and_remap;
+    use crate::storage::index_persistence::temporal_adjacency::load_temporal_adjacency_index_with_keyring_and_remap;
 
     let adjacency_file = manager
         .base_path()
         .join("temporal_adjacency")
         .join("adjacency.idx");
     if adjacency_file.exists() {
-        match load_temporal_adjacency_index_with_cipher_and_remap(
+        match load_temporal_adjacency_index_with_keyring_and_remap(
             manager.base_path(),
-            manager.index_cipher(),
+            manager.keyring(),
             &interner_remap,
         ) {
             Ok(adj_index) => {

--- a/src/storage/index_persistence/reencrypt.rs
+++ b/src/storage/index_persistence/reencrypt.rs
@@ -1,0 +1,629 @@
+//! Index-layer key-rotation re-encryption engine (Issue #488).
+//!
+//! Rebuilds every encrypted index file under a data directory from an old key
+//! generation to a new one, in place, crash-safely, and resumably. It is the
+//! real work behind key rotation: the counter-only
+//! [`KeyRotationManager`](crate::encryption::KeyRotationManager) tracks the
+//! version state machine, while this engine actually rewrites persisted bytes.
+//!
+//! # How it works
+//!
+//! Every encrypted index file is self-describing: Issue #481's 10-byte plaintext
+//! header carries the `key_version` that wrote it. During a rotation the data
+//! dir holds a MIX of old- and new-key files; the engine:
+//!
+//! 1. Holds BOTH generations in an [`IndexKeyring`](super::common::IndexKeyring)
+//!    (so live reads dispatch on the header `key_version`).
+//! 2. Walks the `indexes/` tree and, for each file still tagged with the OLD
+//!    `key_version`, decrypts it with the old generation and re-encrypts it with
+//!    the NEW generation, publishing atomically via temp-write + rename
+//!    (a crash mid-file leaves either the intact old or the intact new file,
+//!    never a torn one).
+//! 3. Skips files already at the new `key_version` — the per-file header IS the
+//!    progress marker, so a resumed pass converges idempotently.
+//!
+//! `complete` refuses while any old-key file remains; only then is the old
+//! generation retired. `cancel` re-encrypts any already-migrated file back to
+//! the old generation (a reverse pass) and retires the new generation, leaving
+//! a uniform old-key dataset identical to the pre-`begin` state. Both
+//! generations stay live for the whole operation, so reads never fail.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use super::atomic_write;
+use super::common::{
+    ENC_HEADER_LEN, IndexKeyring, decrypt_index_bytes_with_keyring, encrypt_index_bytes_versioned,
+    index_file_key_version, is_encrypted_index,
+};
+use crate::encryption::cipher::Cipher;
+
+/// Errors from the index key-rotation engine.
+#[derive(Debug, thiserror::Error)]
+pub enum RotationError {
+    /// Encryption is not configured (no cipher), so there is nothing to rotate.
+    #[error("index encryption is not configured; cannot rotate keys")]
+    NotConfigured,
+    /// The new key derives the same index DEK as the old key.
+    #[error("new key equals the current key; rotation would be a no-op and risk nonce reuse")]
+    SameKey,
+    /// A rotation is already in progress.
+    #[error("a key rotation is already in progress")]
+    AlreadyInProgress,
+    /// No rotation is in progress.
+    #[error("no key rotation is in progress")]
+    NotInProgress,
+    /// `complete` was called while old-key files remain.
+    #[error("cannot complete rotation: {remaining} index file(s) still hold the old key")]
+    OldKeyFilesRemain {
+        /// How many files are still tagged with a non-current key_version.
+        remaining: usize,
+    },
+    /// A key provider failed while sourcing an MEK.
+    #[error("key provider error: {0}")]
+    KeyProvider(String),
+    /// Filesystem error.
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    /// Index persistence error (decrypt/encrypt/serialize).
+    #[error("index error: {0}")]
+    Index(#[from] super::error::IndexPersistenceError),
+}
+
+/// Progress of a re-encryption pass.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RotationProgress {
+    /// Total encrypted index files considered in this pass.
+    pub files_total: usize,
+    /// Files processed so far (re-encrypted + skipped).
+    pub files_done: usize,
+    /// Files re-encrypted to the new key so far.
+    pub files_reencrypted: usize,
+    /// Files skipped because they were already at the new key.
+    pub files_skipped: usize,
+}
+
+/// Read-only classification of the on-disk index files by key generation.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RotationStatus {
+    /// Encrypted files stamped with the current (new) `key_version`.
+    pub at_current: usize,
+    /// Encrypted files stamped with a non-current (old) `key_version`.
+    pub at_old: usize,
+    /// Encrypted files whose `key_version` matches no held generation.
+    pub unknown: usize,
+    /// Plaintext (non-encrypted) files encountered.
+    pub plaintext: usize,
+}
+
+impl RotationStatus {
+    /// True when no old-key or unknown-key encrypted files remain.
+    #[must_use]
+    pub fn is_fully_rotated(&self) -> bool {
+        self.at_old == 0 && self.unknown == 0
+    }
+}
+
+/// Per-file outcome of the byte-level re-encryption primitive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FileOutcome {
+    Reencrypted,
+    SkippedAlreadyNew,
+    SkippedPlaintext,
+}
+
+/// The index re-encryption engine. Holds both key generations for the duration
+/// of a rotation and rewrites files from the old generation to the new.
+pub struct IndexKeyRotation {
+    /// The `indexes/` directory whose encrypted files are rotated.
+    indexes_dir: PathBuf,
+    /// Shared keyring holding both generations (dispatches live reads/writes).
+    keyring: IndexKeyring,
+    /// Old (retiring) generation.
+    old_version: u32,
+    old_cipher: Arc<dyn Cipher>,
+    /// New (current) generation.
+    new_version: u32,
+    new_cipher: Arc<dyn Cipher>,
+}
+
+impl IndexKeyRotation {
+    /// Construct an engine over `indexes_dir` for a rotation from `old` to
+    /// `new`. The `keyring` MUST already hold both generations (the new one
+    /// current); the engine mutates it only at `complete`/`cancel` to retire a
+    /// generation.
+    pub(crate) fn new(
+        indexes_dir: impl Into<PathBuf>,
+        keyring: IndexKeyring,
+        old_version: u32,
+        old_cipher: Arc<dyn Cipher>,
+        new_version: u32,
+        new_cipher: Arc<dyn Cipher>,
+    ) -> Self {
+        Self {
+            indexes_dir: indexes_dir.into(),
+            keyring,
+            old_version,
+            old_cipher,
+            new_version,
+            new_cipher,
+        }
+    }
+
+    /// The `key_version` new files are stamped with.
+    #[must_use]
+    pub fn new_version(&self) -> u32 {
+        self.new_version
+    }
+
+    /// The retiring `key_version`.
+    #[must_use]
+    pub fn old_version(&self) -> u32 {
+        self.old_version
+    }
+
+    /// Scan the index files and classify them by key generation without
+    /// rewriting anything (dry-run / verify probe).
+    pub fn status(&self) -> Result<RotationStatus, RotationError> {
+        let mut status = RotationStatus::default();
+        for path in self.enumerate_index_files()? {
+            match peek_key_version(&path)? {
+                None => status.plaintext += 1,
+                Some(v) if v == self.new_version => status.at_current += 1,
+                Some(v) if v == self.old_version => status.at_old += 1,
+                Some(_) => status.unknown += 1,
+            }
+        }
+        Ok(status)
+    }
+
+    /// Re-encrypt every old-key file to the new key (forward pass).
+    ///
+    /// Idempotent and resumable: files already at the new key are skipped, so a
+    /// crash-interrupted pass converges when re-run. `progress` is invoked after
+    /// each file; returning `false` stops the pass early (used to simulate a
+    /// crash mid-rotation in tests), leaving a valid mix that a later call
+    /// finishes.
+    pub fn re_encrypt(
+        &self,
+        progress: &mut dyn FnMut(RotationProgress) -> bool,
+    ) -> Result<RotationProgress, RotationError> {
+        let files = self.enumerate_index_files()?;
+        let mut p = RotationProgress {
+            files_total: files.len(),
+            ..Default::default()
+        };
+        for path in files {
+            match self.reencrypt_one(&path, self.new_version, &self.new_cipher)? {
+                FileOutcome::Reencrypted => p.files_reencrypted += 1,
+                FileOutcome::SkippedAlreadyNew | FileOutcome::SkippedPlaintext => {
+                    p.files_skipped += 1
+                }
+            }
+            p.files_done += 1;
+            if !progress(p) {
+                break;
+            }
+        }
+        Ok(p)
+    }
+
+    /// Verify a full pass completed (zero old/unknown encrypted files remain).
+    pub fn verify_complete(&self) -> Result<(), RotationError> {
+        let status = self.status()?;
+        let remaining = status.at_old + status.unknown;
+        if remaining > 0 {
+            return Err(RotationError::OldKeyFilesRemain { remaining });
+        }
+        Ok(())
+    }
+
+    /// Finish the rotation: require a fully-rotated dataset, then retire the old
+    /// generation from the keyring so the old key can be dropped.
+    pub fn complete(&self) -> Result<(), RotationError> {
+        self.verify_complete()?;
+        self.keyring.retain_only(self.new_version);
+        Ok(())
+    }
+
+    /// Roll back: re-encrypt any already-migrated files back to the OLD key,
+    /// then retire the new generation. Leaves a uniform old-key dataset. Both
+    /// generations remain live until the reverse pass finishes, so reads stay
+    /// correct throughout.
+    pub fn cancel(&self) -> Result<(), RotationError> {
+        for path in self.enumerate_index_files()? {
+            // Reverse: rewrite files currently at the new key back to old.
+            self.reencrypt_one(&path, self.old_version, &self.old_cipher)?;
+        }
+        self.keyring.retain_only(self.old_version);
+        Ok(())
+    }
+
+    /// Byte-level, format-agnostic re-encryption of a single file to
+    /// `target_version` using `target_cipher`. Reads the whole file, dispatches
+    /// the decrypt cipher on the header `key_version` via the keyring, and
+    /// publishes atomically. Files already at `target_version`, and plaintext
+    /// files, are left untouched.
+    fn reencrypt_one(
+        &self,
+        path: &Path,
+        target_version: u32,
+        target_cipher: &Arc<dyn Cipher>,
+    ) -> Result<FileOutcome, RotationError> {
+        let bytes = std::fs::read(path)?;
+        if !is_encrypted_index(&bytes) {
+            return Ok(FileOutcome::SkippedPlaintext);
+        }
+        let current = index_file_key_version(&bytes).unwrap_or(0);
+        if current == target_version {
+            return Ok(FileOutcome::SkippedAlreadyNew);
+        }
+        // Decrypt with whichever generation wrote this file (keyring dispatch).
+        let plaintext = decrypt_index_bytes_with_keyring(&bytes, path, Some(&self.keyring))?;
+        let reencrypted = encrypt_index_bytes_versioned(&plaintext, target_cipher, target_version)?;
+        atomic_write(path, &reencrypted)?;
+        Ok(FileOutcome::Reencrypted)
+    }
+
+    /// Recursively collect every regular file under `indexes_dir` that carries
+    /// the encrypted-index header. Temp files (atomic-write scratch and the
+    /// native-index decrypt scratch) are skipped by name.
+    fn enumerate_index_files(&self) -> Result<Vec<PathBuf>, RotationError> {
+        let mut out = Vec::new();
+        if self.indexes_dir.exists() {
+            collect_index_files(&self.indexes_dir, &mut out)?;
+        }
+        out.sort();
+        Ok(out)
+    }
+}
+
+/// Read only the header bytes of `path` and return its `key_version`, or `None`
+/// for a plaintext file or a file too short to carry a header.
+fn peek_key_version(path: &Path) -> Result<Option<u32>, RotationError> {
+    use std::io::Read;
+    let mut header = [0u8; ENC_HEADER_LEN];
+    let mut file = std::fs::File::open(path)?;
+    let mut filled = 0usize;
+    loop {
+        match file.read(&mut header[filled..]) {
+            Ok(0) => break,
+            Ok(n) => {
+                filled += n;
+                if filled == header.len() {
+                    break;
+                }
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e.into()),
+        }
+    }
+    Ok(index_file_key_version(&header[..filled]))
+}
+
+/// A temp/scratch file the rotation engine must never treat as an index file.
+fn is_scratch_file(name: &str) -> bool {
+    name.ends_with(".tmp") || name.contains(".tmp.") || name.starts_with(".aeix-usearch-tmp-")
+}
+
+fn collect_index_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), RotationError> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_index_files(&path, out)?;
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if is_scratch_file(&name) {
+            continue;
+        }
+        // Only files that are actually encrypted-index files participate.
+        if peek_key_version(&path)?.is_some() {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encryption::Aes256GcmCipher;
+    use zeroize::Zeroizing;
+
+    const OLD_V: u32 = 1;
+    const NEW_V: u32 = 2;
+
+    fn cipher_from_seed(seed: u8) -> Arc<dyn Cipher> {
+        let mut key = Zeroizing::new([0u8; 32]);
+        key[0] = seed;
+        key[1] = seed.wrapping_add(7);
+        Arc::new(Aes256GcmCipher::new(&key))
+    }
+
+    /// A strict (per-version dispatch) keyring holding both generations.
+    fn rotating_keyring(old: &Arc<dyn Cipher>, new: &Arc<dyn Cipher>) -> IndexKeyring {
+        let ring = IndexKeyring::single_versioned(old.clone(), OLD_V);
+        ring.add_generation(NEW_V, new.clone());
+        ring
+    }
+
+    fn engine(dir: &Path, old: &Arc<dyn Cipher>, new: &Arc<dyn Cipher>) -> IndexKeyRotation {
+        let keyring = rotating_keyring(old, new);
+        IndexKeyRotation::new(dir, keyring, OLD_V, old.clone(), NEW_V, new.clone())
+    }
+
+    /// Write an encrypted index file at `path` with `key_version`, containing
+    /// `plaintext` (CRC-appended so it round-trips like a real index file).
+    fn write_enc(path: &Path, cipher: &Arc<dyn Cipher>, key_version: u32, plaintext: &[u8]) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let bytes = encrypt_index_bytes_versioned(plaintext, cipher, key_version).unwrap();
+        atomic_write(path, &bytes).unwrap();
+    }
+
+    /// Decrypt an encrypted index file through a keyring (dispatch on header).
+    fn read_enc(path: &Path, keyring: &IndexKeyring) -> Vec<u8> {
+        let bytes = std::fs::read(path).unwrap();
+        decrypt_index_bytes_with_keyring(&bytes, path, Some(keyring)).unwrap()
+    }
+
+    /// Lay down a realistic set of old-key (v1) encrypted files under
+    /// `indexes/`, returning (path, plaintext) pairs.
+    fn seed_old_files(indexes: &Path, old: &Arc<dyn Cipher>) -> Vec<(PathBuf, Vec<u8>)> {
+        let files = vec![
+            (indexes.join("manifest.idx"), b"MANIFEST-payload-0".to_vec()),
+            (
+                indexes.join("strings").join("interner.idx"),
+                b"interner-payload-1".to_vec(),
+            ),
+            (
+                indexes.join("graph").join("adjacency.idx"),
+                b"graph-payload-2".to_vec(),
+            ),
+            (
+                indexes.join("temporal").join("versions.idx"),
+                b"temporal-payload-3".to_vec(),
+            ),
+            (
+                indexes.join("vector").join("emb").join("meta.idx"),
+                b"vector-meta-4".to_vec(),
+            ),
+            (
+                indexes.join("vector").join("emb").join("current.usearch"),
+                b"native-usearch-bytes-5".to_vec(),
+            ),
+        ];
+        for (p, pt) in &files {
+            write_enc(p, old, OLD_V, pt);
+        }
+        files
+    }
+
+    #[test]
+    fn re_encrypt_advances_all_headers_and_preserves_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let indexes = dir.path().join("indexes");
+        let (old, new) = (cipher_from_seed(0x11), cipher_from_seed(0x22));
+        let files = seed_old_files(&indexes, &old);
+
+        let eng = engine(&indexes, &old, &new);
+        let prog = eng.re_encrypt(&mut |_| true).unwrap();
+        assert_eq!(prog.files_total, files.len());
+        assert_eq!(prog.files_reencrypted, files.len());
+        assert_eq!(prog.files_skipped, 0);
+
+        // Every file now carries the new key_version and decrypts under new.
+        let new_ring = IndexKeyring::single_versioned(new.clone(), NEW_V);
+        for (p, pt) in &files {
+            assert_eq!(peek_key_version(p).unwrap(), Some(NEW_V));
+            assert_eq!(&read_enc(p, &new_ring), pt);
+        }
+        assert!(eng.status().unwrap().is_fully_rotated());
+    }
+
+    #[test]
+    fn live_reads_dispatch_on_key_version_in_mixed_state() {
+        // Rotate only SOME files, leaving a genuine mix, and assert reads via
+        // the keyring return correct data for BOTH old- and new-key files.
+        let dir = tempfile::tempdir().unwrap();
+        let indexes = dir.path().join("indexes");
+        let (old, new) = (cipher_from_seed(0x33), cipher_from_seed(0x44));
+        let files = seed_old_files(&indexes, &old);
+        let keyring = rotating_keyring(&old, &new);
+
+        // Stop after 3 files: a real mix of old and new on disk.
+        let eng = IndexKeyRotation::new(
+            &indexes,
+            keyring.clone(),
+            OLD_V,
+            old.clone(),
+            NEW_V,
+            new.clone(),
+        );
+        let mut done = 0;
+        eng.re_encrypt(&mut |_| {
+            done += 1;
+            done < 3
+        })
+        .unwrap();
+
+        let status = eng.status().unwrap();
+        assert!(
+            status.at_current > 0 && status.at_old > 0,
+            "expected a mix: {status:?}"
+        );
+
+        // Every file still reads correctly through the dispatching keyring,
+        // regardless of which key encrypted it.
+        for (p, pt) in &files {
+            assert_eq!(
+                &read_enc(p, &keyring),
+                pt,
+                "mixed-state read failed for {p:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn re_encrypt_is_idempotent_and_resumable() {
+        let dir = tempfile::tempdir().unwrap();
+        let indexes = dir.path().join("indexes");
+        let (old, new) = (cipher_from_seed(0x55), cipher_from_seed(0x66));
+        let files = seed_old_files(&indexes, &old);
+
+        let eng = engine(&indexes, &old, &new);
+        // First pass: stop after 2 files (simulated crash).
+        let mut n = 0;
+        eng.re_encrypt(&mut |_| {
+            n += 1;
+            n < 2
+        })
+        .unwrap();
+        assert!(!eng.status().unwrap().is_fully_rotated());
+
+        // Resume: re-run the same pass; it must finish and SKIP already-done.
+        let prog = eng.re_encrypt(&mut |_| true).unwrap();
+        assert!(
+            prog.files_skipped >= 1,
+            "resume must skip already-rotated files"
+        );
+        assert_eq!(prog.files_reencrypted + prog.files_skipped, files.len());
+        assert!(eng.status().unwrap().is_fully_rotated());
+        // A third pass is a pure no-op (all skipped) — idempotent.
+        let again = eng.re_encrypt(&mut |_| true).unwrap();
+        assert_eq!(again.files_reencrypted, 0);
+        assert_eq!(again.files_skipped, files.len());
+    }
+
+    #[test]
+    fn complete_refuses_until_full_pass_then_retires_old() {
+        let dir = tempfile::tempdir().unwrap();
+        let indexes = dir.path().join("indexes");
+        let (old, new) = (cipher_from_seed(0x77), cipher_from_seed(0x88));
+        seed_old_files(&indexes, &old);
+        let keyring = rotating_keyring(&old, &new);
+        let eng = IndexKeyRotation::new(
+            &indexes,
+            keyring.clone(),
+            OLD_V,
+            old.clone(),
+            NEW_V,
+            new.clone(),
+        );
+
+        // Partial: complete must refuse.
+        let mut n = 0;
+        eng.re_encrypt(&mut |_| {
+            n += 1;
+            n < 2
+        })
+        .unwrap();
+        assert!(matches!(
+            eng.complete().unwrap_err(),
+            RotationError::OldKeyFilesRemain { .. }
+        ));
+
+        // Full pass, then complete succeeds and the old generation is retired.
+        eng.re_encrypt(&mut |_| true).unwrap();
+        eng.complete().unwrap();
+        // After retiring old, the keyring no longer holds the old version.
+        assert_eq!(keyring.current_version(), NEW_V);
+        assert!(!keyring.has_version(OLD_V));
+    }
+
+    #[test]
+    fn cancel_rolls_back_to_old_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let indexes = dir.path().join("indexes");
+        let (old, new) = (cipher_from_seed(0x99), cipher_from_seed(0xAA));
+        let files = seed_old_files(&indexes, &old);
+        let keyring = rotating_keyring(&old, &new);
+        let eng = IndexKeyRotation::new(
+            &indexes,
+            keyring.clone(),
+            OLD_V,
+            old.clone(),
+            NEW_V,
+            new.clone(),
+        );
+
+        // Migrate a few, then cancel: all files return to the old key.
+        let mut n = 0;
+        eng.re_encrypt(&mut |_| {
+            n += 1;
+            n < 3
+        })
+        .unwrap();
+        eng.cancel().unwrap();
+
+        let old_ring = IndexKeyring::single_versioned(old.clone(), OLD_V);
+        for (p, pt) in &files {
+            assert_eq!(peek_key_version(p).unwrap(), Some(OLD_V));
+            assert_eq!(&read_enc(p, &old_ring), pt);
+        }
+        assert_eq!(keyring.current_version(), OLD_V);
+    }
+
+    #[test]
+    fn plaintext_files_are_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let indexes = dir.path().join("indexes");
+        let (old, new) = (cipher_from_seed(0x01), cipher_from_seed(0x02));
+        seed_old_files(&indexes, &old);
+        // A legacy plaintext file (no AEIX header) is not enumerated/rotated.
+        let plain = indexes.join("legacy.idx");
+        std::fs::write(&plain, b"\x00plaintext-not-encrypted").unwrap();
+
+        let eng = engine(&indexes, &old, &new);
+        let status_before = eng.status().unwrap();
+        assert_eq!(
+            status_before.plaintext, 0,
+            "plaintext file is not enumerated"
+        );
+        eng.re_encrypt(&mut |_| true).unwrap();
+        // The plaintext file is untouched.
+        assert_eq!(
+            std::fs::read(&plain).unwrap(),
+            b"\x00plaintext-not-encrypted"
+        );
+    }
+
+    #[test]
+    fn nonce_uniqueness_under_new_key() {
+        // Re-encrypting many files under the new key must produce distinct
+        // nonces (fresh per call); no nonce is copied from the old ciphertext.
+        let dir = tempfile::tempdir().unwrap();
+        let indexes = dir.path().join("indexes");
+        let (old, new) = (cipher_from_seed(0xC0), cipher_from_seed(0xC1));
+        // Many files with identical plaintext (worst case for nonce reuse).
+        let mut paths = Vec::new();
+        for i in 0..25 {
+            let p = indexes.join(format!("f{i}.idx"));
+            write_enc(&p, &old, OLD_V, b"identical-plaintext");
+            paths.push(p);
+        }
+        let eng = engine(&indexes, &old, &new);
+        eng.re_encrypt(&mut |_| true).unwrap();
+
+        // AES-256-GCM wire format after the 10-byte header is [nonce(12)]...
+        use std::collections::HashSet;
+        let mut nonces = HashSet::new();
+        for p in &paths {
+            let raw = std::fs::read(p).unwrap();
+            let nonce = raw[ENC_HEADER_LEN..ENC_HEADER_LEN + 12].to_vec();
+            assert!(
+                nonces.insert(nonce),
+                "duplicate nonce under new key for {p:?}"
+            );
+        }
+        assert_eq!(nonces.len(), paths.len());
+    }
+}

--- a/src/storage/index_persistence/strings.rs
+++ b/src/storage/index_persistence/strings.rs
@@ -284,6 +284,24 @@ pub fn save_string_interner_with_cipher(
     super::common::save_encoded_maybe_encrypted(&data, path, cipher)
 }
 
+/// Save the global string interner, encrypting with the current generation of
+/// an [`IndexKeyring`](super::common::IndexKeyring) (Issue #488 key rotation).
+pub(crate) fn save_string_interner_with_keyring(
+    path: &Path,
+    keyring: Option<&super::common::IndexKeyring>,
+) -> Result<()> {
+    let strings = GLOBAL_INTERNER.get_all_strings();
+
+    let data = StringInternerData {
+        magic: INTERNER_MAGIC,
+        version: MANIFEST_VERSION,
+        string_count: strings.len() as u64,
+        strings,
+    };
+
+    super::common::save_encoded_maybe_encrypted_with_keyring(&data, path, keyring)
+}
+
 /// Load the string interner from disk and validate CRC32 checksum.
 ///
 /// # Examples
@@ -331,7 +349,27 @@ pub fn load_string_interner_with_cipher(
         "String interner",
         cipher,
     )?;
+    validate_string_interner(data, path)
+}
 
+/// Load the string interner, decrypting via an
+/// [`IndexKeyring`](super::common::IndexKeyring) that dispatches on the header
+/// `key_version` (Issue #488 key rotation).
+pub(crate) fn load_string_interner_with_keyring(
+    path: &Path,
+    keyring: Option<&super::common::IndexKeyring>,
+) -> Result<StringInternerData> {
+    let data: StringInternerData = super::common::load_encoded_maybe_encrypted_with_keyring(
+        path,
+        super::MAX_STRING_INTERNER_FILE_SIZE,
+        "String interner",
+        keyring,
+    )?;
+    validate_string_interner(data, path)
+}
+
+/// Validate a decoded string-interner payload (magic, version, DoS limits).
+fn validate_string_interner(data: StringInternerData, path: &Path) -> Result<StringInternerData> {
     // Validate magic bytes
     if data.magic != INTERNER_MAGIC {
         return Err(IndexPersistenceError::InvalidMagic {

--- a/src/storage/index_persistence/temporal.rs
+++ b/src/storage/index_persistence/temporal.rs
@@ -723,6 +723,16 @@ pub fn save_temporal_index_with_cipher(
     super::common::save_encoded_maybe_encrypted(data, path, cipher)
 }
 
+/// Save temporal index data, encrypting with an
+/// [`IndexKeyring`](super::common::IndexKeyring) (Issue #488 key rotation).
+pub(crate) fn save_temporal_index_with_keyring(
+    data: &TemporalIndexData,
+    path: &Path,
+    keyring: Option<&super::common::IndexKeyring>,
+) -> Result<()> {
+    super::common::save_encoded_maybe_encrypted_with_keyring(data, path, keyring)
+}
+
 /// Load temporal index data from disk and validate CRC32 checksum.
 ///
 /// # Validation
@@ -758,7 +768,18 @@ pub fn load_temporal_index_with_cipher(
     path: &Path,
     cipher: Option<&Arc<dyn Cipher>>,
 ) -> Result<TemporalIndexData> {
-    decode_temporal_blob(path, cipher)
+    let ring = cipher.map(|c| super::common::IndexKeyring::single(c.clone()));
+    decode_temporal_blob(path, ring.as_ref())
+}
+
+/// Load temporal index data, decrypting via an
+/// [`IndexKeyring`](super::common::IndexKeyring) that dispatches on the header
+/// `key_version` (Issue #488 key rotation).
+pub(crate) fn load_temporal_index_with_keyring(
+    path: &Path,
+    keyring: Option<&super::common::IndexKeyring>,
+) -> Result<TemporalIndexData> {
+    decode_temporal_blob(path, keyring)
 }
 
 /// Decode temporal index bytes, transparently upgrading pre-fidelity
@@ -782,16 +803,16 @@ pub fn load_temporal_index_with_cipher(
 /// reads and checksum passes on the (common, cheap) legacy-fallback paths.
 fn decode_temporal_blob(
     path: &Path,
-    cipher: Option<&Arc<dyn Cipher>>,
+    keyring: Option<&super::common::IndexKeyring>,
 ) -> Result<TemporalIndexData> {
     use crate::storage::index_persistence::formats::legacy_v2::TemporalIndexDataV2;
     use crate::storage::index_persistence::formats::legacy_v3::TemporalIndexDataV3;
 
-    let bytes = super::common::read_and_verify_crc_maybe_encrypted(
+    let bytes = super::common::read_and_verify_crc_maybe_encrypted_with_keyring(
         path,
         super::MAX_TEMPORAL_INDEX_FILE_SIZE,
         "Temporal index",
-        cipher,
+        keyring,
     )?;
 
     if let Ok(data) = bitcode::decode::<TemporalIndexData>(&bytes)

--- a/src/storage/index_persistence/temporal_adjacency.rs
+++ b/src/storage/index_persistence/temporal_adjacency.rs
@@ -77,6 +77,36 @@ pub fn save_temporal_adjacency_index_with_cipher(
     Ok(())
 }
 
+/// Save the temporal adjacency index, encrypting with the current generation of
+/// an [`IndexKeyring`](super::common::IndexKeyring) (Issue #488 key rotation).
+pub(crate) fn save_temporal_adjacency_index_with_keyring(
+    index: &TemporalAdjacencyIndex,
+    data_dir: &Path,
+    keyring: Option<&super::common::IndexKeyring>,
+) -> Result<()> {
+    let adjacency_dir = data_dir.join("temporal_adjacency");
+    std::fs::create_dir_all(&adjacency_dir)?;
+
+    let outgoing = extract_outgoing_data(index);
+    let data = TemporalAdjacencyData {
+        magic: TEMPORAL_ADJACENCY_MAGIC,
+        version: MANIFEST_VERSION,
+        outgoing,
+    };
+    let bytes = bitcode::encode(&data);
+
+    let adjacency_file = adjacency_dir.join("adjacency.idx");
+    match keyring.and_then(super::common::IndexKeyring::current) {
+        Some((cipher, key_version)) => {
+            let encrypted =
+                super::common::encrypt_index_bytes_versioned(&bytes, &cipher, key_version)?;
+            super::atomic_write(&adjacency_file, &encrypted)?;
+        }
+        None => super::atomic_write(&adjacency_file, &bytes)?,
+    }
+    Ok(())
+}
+
 /// Maximum file size for temporal adjacency index (10 MB)
 ///
 /// With 64 bytes per entry, this allows ~163K entries total.
@@ -156,7 +186,19 @@ pub fn load_temporal_adjacency_index_with_cipher_and_remap(
     cipher: Option<&Arc<dyn Cipher>>,
     remap: &InternerRemap,
 ) -> Result<Arc<TemporalAdjacencyIndex>> {
-    let mut data = load_temporal_adjacency_data(data_dir, cipher)?;
+    let ring = cipher.map(|c| super::common::IndexKeyring::single(c.clone()));
+    load_temporal_adjacency_index_with_keyring_and_remap(data_dir, ring.as_ref(), remap)
+}
+
+/// Load the temporal adjacency index, decrypting via an
+/// [`IndexKeyring`](super::common::IndexKeyring) that dispatches on the header
+/// `key_version` (Issue #488 key rotation) and applying the interner `remap`.
+pub(crate) fn load_temporal_adjacency_index_with_keyring_and_remap(
+    data_dir: &Path,
+    keyring: Option<&super::common::IndexKeyring>,
+    remap: &InternerRemap,
+) -> Result<Arc<TemporalAdjacencyIndex>> {
+    let mut data = load_temporal_adjacency_data_with_keyring(data_dir, keyring)?;
     remap.remap_temporal_adjacency_data(&mut data);
     Ok(Arc::new(reconstruct_index(data)?))
 }
@@ -166,9 +208,9 @@ pub fn load_temporal_adjacency_index_with_cipher_and_remap(
 /// interner-id translation). Passing `cipher == None` reads a plaintext file;
 /// a legacy plaintext file is read even when a cipher is supplied (header
 /// sniffing).
-fn load_temporal_adjacency_data(
+fn load_temporal_adjacency_data_with_keyring(
     data_dir: &Path,
-    cipher: Option<&Arc<dyn Cipher>>,
+    keyring: Option<&super::common::IndexKeyring>,
 ) -> Result<TemporalAdjacencyData> {
     let adjacency_file = data_dir.join("temporal_adjacency").join("adjacency.idx");
 
@@ -185,7 +227,7 @@ fn load_temporal_adjacency_data(
     // Read file, decrypting transparently if it carries the encrypted header.
     let raw = std::fs::read(&adjacency_file)?;
     let bytes = if super::common::is_encrypted_index(&raw) {
-        super::common::decrypt_index_bytes(&raw, &adjacency_file, cipher)?
+        super::common::decrypt_index_bytes_with_keyring(&raw, &adjacency_file, keyring)?
     } else {
         raw
     };

--- a/src/storage/index_persistence/vector.rs
+++ b/src/storage/index_persistence/vector.rs
@@ -40,6 +40,16 @@ pub fn save_vector_meta_with_cipher(
     super::common::save_encoded_maybe_encrypted(meta, path, cipher)
 }
 
+/// Save vector index metadata, encrypting with the current generation of an
+/// [`IndexKeyring`](super::common::IndexKeyring) (Issue #488 key rotation).
+pub(crate) fn save_vector_meta_with_keyring(
+    meta: &VectorIndexMeta,
+    path: &Path,
+    keyring: Option<&super::common::IndexKeyring>,
+) -> Result<()> {
+    super::common::save_encoded_maybe_encrypted_with_keyring(meta, path, keyring)
+}
+
 /// Load vector index metadata and validate CRC32 checksum.
 ///
 /// Reads the encoded vector metadata and verifies its CRC32 checksum before decoding
@@ -64,12 +74,23 @@ pub fn load_vector_meta_with_cipher(
     path: &Path,
     cipher: Option<&Arc<dyn Cipher>>,
 ) -> Result<VectorIndexMeta> {
+    let ring = cipher.map(|c| super::common::IndexKeyring::single(c.clone()));
+    load_vector_meta_with_keyring(path, ring.as_ref())
+}
+
+/// Load vector index metadata, decrypting via an
+/// [`IndexKeyring`](super::common::IndexKeyring) that dispatches on the header
+/// `key_version` (Issue #488 key rotation).
+pub(crate) fn load_vector_meta_with_keyring(
+    path: &Path,
+    keyring: Option<&super::common::IndexKeyring>,
+) -> Result<VectorIndexMeta> {
     // Metadata should be small, but use standard limit for consistency
-    let meta: VectorIndexMeta = super::common::load_encoded_maybe_encrypted(
+    let meta: VectorIndexMeta = super::common::load_encoded_maybe_encrypted_with_keyring(
         path,
         super::MAX_VECTOR_INDEX_FILE_SIZE,
         "Vector index",
-        cipher,
+        keyring,
     )?;
 
     if meta.magic != VECTOR_META_MAGIC {
@@ -115,6 +136,16 @@ pub fn save_vector_mappings_with_cipher(
     super::common::save_encoded_maybe_encrypted(mappings, path, cipher)
 }
 
+/// Save vector ID mappings, encrypting with the current generation of an
+/// [`IndexKeyring`](super::common::IndexKeyring) (Issue #488 key rotation).
+pub(crate) fn save_vector_mappings_with_keyring(
+    mappings: &VectorMappingsData,
+    path: &Path,
+    keyring: Option<&super::common::IndexKeyring>,
+) -> Result<()> {
+    super::common::save_encoded_maybe_encrypted_with_keyring(mappings, path, keyring)
+}
+
 /// Load vector ID mappings and validate CRC32 checksum.
 ///
 /// Restores the `NodeId` <-> `u64` translation table into memory, verifying
@@ -138,11 +169,22 @@ pub fn load_vector_mappings_with_cipher(
     path: &Path,
     cipher: Option<&Arc<dyn Cipher>>,
 ) -> Result<VectorMappingsData> {
-    super::common::load_encoded_maybe_encrypted(
+    let ring = cipher.map(|c| super::common::IndexKeyring::single(c.clone()));
+    load_vector_mappings_with_keyring(path, ring.as_ref())
+}
+
+/// Load vector ID mappings, decrypting via an
+/// [`IndexKeyring`](super::common::IndexKeyring) that dispatches on the header
+/// `key_version` (Issue #488 key rotation).
+pub(crate) fn load_vector_mappings_with_keyring(
+    path: &Path,
+    keyring: Option<&super::common::IndexKeyring>,
+) -> Result<VectorMappingsData> {
+    super::common::load_encoded_maybe_encrypted_with_keyring(
         path,
         super::MAX_VECTOR_INDEX_FILE_SIZE,
         "Vector index",
-        cipher,
+        keyring,
     )
 }
 
@@ -306,56 +348,62 @@ fn native_temp_base(real_path: &Path) -> PathBuf {
     dir.join(format!(".aeix-usearch-tmp-{suffix}.usearch"))
 }
 
-/// Whole-file-encrypt the plaintext bytes at `src` and atomically write the
-/// `[AEIX header][ciphertext]` blob to `dst`.
-fn encrypt_file_whole(src: &Path, dst: &Path, cipher: &Arc<dyn Cipher>) -> Result<()> {
+/// Whole-file-encrypt the plaintext bytes at `src`, stamping `key_version` into
+/// the `[AEIX header]`, and atomically write the ciphertext blob to `dst`
+/// (Issue #488 key rotation; the native usearch write path).
+fn encrypt_file_whole_versioned(
+    src: &Path,
+    dst: &Path,
+    cipher: &Arc<dyn Cipher>,
+    key_version: u32,
+) -> Result<()> {
     let plaintext = std::fs::read(src)?;
-    let encrypted = super::common::encrypt_index_bytes(&plaintext, cipher)?;
+    let encrypted = super::common::encrypt_index_bytes_versioned(&plaintext, cipher, key_version)?;
     super::atomic_write(dst, &encrypted)
 }
 
 /// Read `src`, transparently decrypting if it carries the `AEIX` header (a
 /// legacy plaintext file is copied through unchanged, covering the upgrade /
-/// torn-write case), and atomically write the plaintext to `dst`.
-fn decrypt_file_to(
+/// torn-write case) via an [`IndexKeyring`](super::common::IndexKeyring) that
+/// dispatches on the header `key_version`, and atomically write the plaintext to
+/// `dst` (Issue #488 key rotation; the native usearch read path).
+fn decrypt_file_to_with_keyring(
     src: &Path,
     dst: &Path,
     max_size: u64,
     context: &str,
-    cipher: Option<&Arc<dyn Cipher>>,
+    keyring: Option<&super::common::IndexKeyring>,
 ) -> Result<()> {
-    let plaintext = super::common::read_index_file(src, max_size, context, cipher)?;
+    let plaintext = super::common::read_index_file_with_keyring(src, max_size, context, keyring)?;
     super::atomic_write(dst, &plaintext)
 }
 
-/// Save the native HNSW index (`current.usearch` + `.usearch.mappings`
-/// sidecar), encrypting both at rest when `cipher` is `Some` (Issue #481).
-///
-/// With `cipher == None` this is exactly `index.save(real_path)`.
-pub(crate) fn save_hnsw_index_maybe_encrypted(
+/// Save the native HNSW index, encrypting both files with the current
+/// generation of an [`IndexKeyring`](super::common::IndexKeyring) and stamping
+/// its `key_version` (Issue #488 key rotation). A `None`/empty keyring writes
+/// plaintext (identical to `index.save`).
+pub(crate) fn save_hnsw_index_with_keyring(
     index: &crate::index::vector::HnswIndex,
     real_path: &Path,
-    cipher: Option<&Arc<dyn Cipher>>,
+    keyring: Option<&super::common::IndexKeyring>,
 ) -> crate::core::error::Result<()> {
     use crate::index::vector::VectorIndex;
 
-    let Some(cipher) = cipher else {
-        // Plaintext path: byte-identical to the pre-encryption behavior.
+    let Some((cipher, key_version)) = keyring.and_then(super::common::IndexKeyring::current) else {
         return index.save(real_path);
     };
 
     let temp_base = native_temp_base(real_path);
     let temp_mappings = temp_base.with_extension("usearch.mappings");
-    // Clean up the plaintext temp files on every exit path.
     let _guard = TempFileGuard::new(vec![temp_base.clone(), temp_mappings.clone()]);
 
-    // Let usearch write its two plaintext files to the temp base.
     index.save(&temp_base)?;
 
-    // Encrypt each and atomically publish to the real paths.
     let real_mappings = real_path.with_extension("usearch.mappings");
-    encrypt_file_whole(&temp_base, real_path, cipher).map_err(native_enc_err)?;
-    encrypt_file_whole(&temp_mappings, &real_mappings, cipher).map_err(native_enc_err)?;
+    encrypt_file_whole_versioned(&temp_base, real_path, &cipher, key_version)
+        .map_err(native_enc_err)?;
+    encrypt_file_whole_versioned(&temp_mappings, &real_mappings, &cipher, key_version)
+        .map_err(native_enc_err)?;
     Ok(())
 }
 
@@ -364,46 +412,48 @@ pub(crate) fn save_hnsw_index_maybe_encrypted(
 ///
 /// A legacy plaintext file (no header) is handed straight to usearch with no
 /// temp shuffle, so the plaintext path is unchanged.
-pub(crate) fn load_hnsw_index_maybe_encrypted(
+/// Load the native HNSW index, decrypting via an
+/// [`IndexKeyring`](super::common::IndexKeyring) that dispatches on the header
+/// `key_version` (Issue #488 key rotation). A legacy plaintext file loads
+/// directly.
+pub(crate) fn load_hnsw_index_with_keyring(
     real_path: &Path,
     config: crate::index::vector::HnswConfig,
-    cipher: Option<&Arc<dyn Cipher>>,
+    keyring: Option<&super::common::IndexKeyring>,
 ) -> crate::core::error::Result<crate::index::vector::HnswIndex> {
     use crate::index::vector::HnswIndex;
 
     if !native_file_is_encrypted(real_path) {
-        // Legacy / plaintext index: load directly (unchanged path).
         return HnswIndex::load(real_path, config);
     }
 
-    // Encrypted on disk: decrypt both files to a temp base, load from there.
-    let cipher = cipher.ok_or_else(|| {
-        crate::core::error::Error::Vector(crate::core::error::VectorError::IndexError(
-            "usearch index is encrypted but no encryption key is configured".to_string(),
-        ))
-    })?;
+    if keyring.is_none() {
+        return Err(crate::core::error::Error::Vector(
+            crate::core::error::VectorError::IndexError(
+                "usearch index is encrypted but no encryption key is configured".to_string(),
+            ),
+        ));
+    }
 
     let temp_base = native_temp_base(real_path);
     let temp_mappings = temp_base.with_extension("usearch.mappings");
     let real_mappings = real_path.with_extension("usearch.mappings");
-    // Clean up the decrypted-plaintext temp files on every exit path (success,
-    // decrypt error, or usearch load error).
     let _guard = TempFileGuard::new(vec![temp_base.clone(), temp_mappings.clone()]);
 
-    decrypt_file_to(
+    decrypt_file_to_with_keyring(
         real_path,
         &temp_base,
         super::MAX_MMAP_FILE_SIZE,
         "usearch index",
-        Some(cipher),
+        keyring,
     )
     .map_err(native_enc_err)?;
-    decrypt_file_to(
+    decrypt_file_to_with_keyring(
         &real_mappings,
         &temp_mappings,
         super::MAX_VECTOR_INDEX_FILE_SIZE,
         "usearch mappings",
-        Some(cipher),
+        keyring,
     )
     .map_err(native_enc_err)?;
 
@@ -605,7 +655,8 @@ mod tests {
             .add(NodeId::new(2).unwrap(), &[0.0, 1.0, 0.0, 0.0])
             .unwrap();
 
-        save_hnsw_index_maybe_encrypted(&index, &path, Some(&cipher)).unwrap();
+        let ring = super::super::common::IndexKeyring::single(cipher.clone());
+        save_hnsw_index_with_keyring(&index, &path, Some(&ring)).unwrap();
 
         // Both the native index file and its mappings sidecar are encrypted at
         // rest (carry the AEIX header).
@@ -625,7 +676,7 @@ mod tests {
         );
 
         // Correct key => decrypts to a temp file, loads, and the vectors survive.
-        let loaded = load_hnsw_index_maybe_encrypted(&path, config.clone(), Some(&cipher)).unwrap();
+        let loaded = load_hnsw_index_with_keyring(&path, config.clone(), Some(&ring)).unwrap();
         assert_eq!(loaded.len(), 2);
         assert!(
             !any_aeix_temp_present(dir.path()),
@@ -634,7 +685,7 @@ mod tests {
 
         // Fails closed: encrypted on disk but no cipher supplied. The error
         // message names the missing key and leaks no plaintext / no temp file.
-        let err = load_hnsw_index_maybe_encrypted(&path, config.clone(), None).unwrap_err();
+        let err = load_hnsw_index_with_keyring(&path, config.clone(), None).unwrap_err();
         assert!(
             format!("{err}").contains("no encryption key"),
             "expected fail-closed missing-key error, got: {err}"
@@ -653,7 +704,8 @@ mod tests {
             k[7] = 0x5A;
             Arc::new(Aes256GcmCipher::new(&k)) as Arc<dyn Cipher>
         };
-        assert!(load_hnsw_index_maybe_encrypted(&path, config, Some(&wrong)).is_err());
+        let wrong_ring = super::super::common::IndexKeyring::single(wrong);
+        assert!(load_hnsw_index_with_keyring(&path, config, Some(&wrong_ring)).is_err());
         assert!(
             !any_aeix_temp_present(dir.path()),
             "temp leaked on wrong-key load"


### PR DESCRIPTION
## Before / After

**Before (#481, just merged):** every persisted index file is encrypted at rest with a single, immutable index key and carries a 10‑byte plaintext header `[AEIX | format | algorithm_id | key_version]` — but `key_version` was always the constant `1` and the reader ignored it. `KeyRotationManager` was a counter‑only state machine that touched no bytes. There was no way to change the index encryption key without losing the data encrypted under the old one.

**After (this PR, #488):** a real, synchronous re‑encryption engine rotates the index‑layer key. It rewrites every persisted index file from the old key generation to a new one — in place, atomically per file, idempotently, and resumably after a crash — while live reads stay correct throughout because each file is decrypted with the generation that actually wrote it (header `key_version` dispatch). The old key is retired only after a verified full pass, so it can then be safely dropped.

## How

- **Two‑generation keyring** (`IndexKeyring`, `common.rs`): a cheaply‑cloneable, shared‑mutable `key_version -> Arc<dyn Cipher>` map. A single‑generation keyring reproduces the #481 path **byte‑for‑byte** (writes stamp `key_version = 1`, reads decrypt any header). During rotation it holds **both** generations: reads dispatch on each file's header `key_version`, writes stamp the current (new) generation. The persistence manager holds one; the engine mutates the *same* shared handle, so a rotation is observed immediately by live reads/writes.
- **Key‑version‑aware read/write plumbing**: added `*_with_keyring` variants alongside the existing `*_with_cipher` functions across manifest / strings / graph / temporal / temporal_adjacency / vector meta+mappings / native usearch. The manager, `operations.rs`, and `checkpoint.rs` route through the keyring; `decrypt_index_bytes_with_keyring` selects the cipher by header. The `*_with_cipher` API and its on‑disk bytes are unchanged.
- **Atomic, resumable re‑encryption** (`IndexKeyRotation`, `reencrypt.rs`): a byte‑level, format‑agnostic pass over the `indexes/` tree. For each file still at the old `key_version`: decrypt with the matching generation, re‑encrypt with the new generation (stamping the new `key_version`), publish via the existing `atomic_write` temp+rename. Files already at the new version are skipped — the per‑file header **is** the progress marker, so a resumed pass converges. `status()` classifies files without rewriting; `complete()` refuses while any old‑key file remains, then retires the old generation; `cancel()` reverse‑re‑encrypts back to the old key.
- **Durable progress + crash‑resume**: a tiny `rotation.state` breadcrumb (no key material — only the new key *source* reference and version numbers) records an in‑flight rotation; startup runs the idempotent pass before loading indexes, so the directory is a single uniform generation by the time it's read back.
- **Sync DB API + audit** (`db/rotation.rs`): `AletheiaDB::rotate_index_keys(new_key_source)` / `index_rotation_status()`. Rejects a same‑key rotation (constant‑time `subtle` compare of the two derived index DEKs) and rejects when encryption/persistence isn't configured. Emits `AuditEvent::RotationStarted/Completed/Failed` (to a local key‑events logger; the shared sink lands with #489). No key material is ever logged, serialized, or placed in errors.

## Encryption‑bypass guard (coordinator request)

Every rotation write routes through the cipher plumbing — the byte‑level `reencrypt_one` always `encrypt_index_bytes_versioned`s with the new generation and stamps the header; the native‑usearch rewrite uses the same versioned whole‑file encrypt; plaintext (headerless) files are skipped, never rewritten. A directory‑scan guard test `assert_all_index_files_encrypted` asserts **every** persisted file (bitcode files **and** native `current.usearch` + sidecar) begins with the `AEIX` header, run after both a plain encrypted persist and a full rotation.

## AC → evidence

| #488 acceptance criterion | Test (evidence) |
|---|---|
| Full cycle begin→re‑encrypt→complete; all headers advance; data intact (nodes/edges/vector round‑trip) | `db::rotation::tests::full_cycle_reencrypts_index_files_and_data_intact`, `reencrypt::tests::re_encrypt_advances_all_headers_and_preserves_data` |
| Live reads during rotation with a MIX of old/new files (keyring dispatch) | `reencrypt::tests::live_reads_dispatch_on_key_version_in_mixed_state`; through the real manager load path: `loader::tests::manager_load_path_dispatches_on_key_version_in_mixed_dir` |
| Crash‑resume completes and skips already‑done files (idempotent) | `reencrypt::tests::re_encrypt_is_idempotent_and_resumable`, `db::rotation::tests::crash_resume_completes_from_state_file` |
| Crash mid‑file is atomic (no torn file) | atomic temp+rename via `atomic_write`; validated by the mixed‑state read + resume tests (every file always decrypts under exactly one key) |
| `complete` refuses while old‑key files remain; succeeds after full pass; old key retired | `reencrypt::tests::complete_refuses_until_full_pass_then_retires_old` |
| `cancel` rolls back cleanly | `reencrypt::tests::cancel_rolls_back_to_old_key` |
| Reject new == old key; reject when no cipher configured | `db::rotation::tests::rotate_rejects_same_key`, `rotate_rejects_without_encryption` |
| Nonce uniqueness under the new key (fresh DEK + fresh nonces) | `reencrypt::tests::nonce_uniqueness_under_new_key` |
| Non‑rotation path unchanged (regression guard) | single‑generation keyring is byte‑identical to #481; the pre‑existing #481 `*_with_cipher` encryption tests are untouched and pass |
| No silent plaintext bypass (coordinator guard) | `db::rotation::tests::encrypted_persist_writes_no_plaintext_index_files` + the guard call inside `full_cycle_*` |

## Cancel semantics (chosen)

`cancel_rotation` performs a **reverse re‑encryption pass**: any file already migrated to the new key is re‑encrypted back to the old key, then the new generation is retired — leaving a uniform old‑key dataset identical to the pre‑`begin` state. Both generations remain live for the whole reverse pass, so reads stay correct throughout.

## Out of scope / follow‑ups

- **WAL / cold‑storage / checkpoint re‑encryption** — owned by those modules (redb‑managed cold files need a redb‑aware pass); separate issues. A running instance keeps using the old MEK for those components; a full MEK switch across restarts needs them rotated too.
- **`aletheia keys rotate` CLI** — #490, built on this engine.
- **Durable audit for the destructive old‑key retirement** — mirrors the #3427 WAL‑payload caveat.
- **Shared audit sink wiring** — #489 (events are emitted here to a local key‑events logger meanwhile).

## Gates

- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all` — applied
- `cargo test --lib` for `storage::index_persistence`, `encryption`, `db::rotation`, `storage::checkpoint` — 290 passed / 0 failed / 1 ignored; durable‑DB modules (`db::config/backup/pitr/extent/chain`) 37 passed / 0 failed. No `unsafe` added (no Miri needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZLv4kocirF3n4AwKNdHoW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZLv4kocirF3n4AwKNdHoW)_