### PR TITLE
ci: stop broken nightly rustc from cancelling the Test Suite matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,14 @@ jobs:
   test:
     name: Test Suite
     runs-on: ${{ matrix.os }}
+    # Nightly rustc is an advisory canary for upcoming compiler releases, not a
+    # merge gate. An ICE or breakage in a nightly cell must never cancel or
+    # redden the required stable cells: the matrix runs fail-fast: false so a
+    # broken cell cannot cancel its siblings, and nightly cells are
+    # continue-on-error so their failures stay visible without failing the run.
+    continue-on-error: ${{ matrix.rust == 'nightly' }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         rust: [stable, nightly]


### PR DESCRIPTION
## Before / After

**Before:** Every open PR showed a cancelled / red **Test Suite** run. Today's nightly rustc (`1.99.0`, commit `daf2e5e18`, 2026-07-13) hits an internal compiler error (ICE) in `rustc_ast/attr/mod.rs` on a test-entrypoint attribute, crashing before any test runs. Because the `test` matrix ran with the default `fail-fast: true`, the ICE-ing nightly cell (windows/macos + nightly) cancelled the still-running **stable** cells — destroying the signal from the stable cells that are the actual required gate. Seen on PR #3578 and others on 2026-07-14.

**After:** A broken nightly cell no longer affects the stable cells. Stable cells gate the PR; nightly cells are advisory canaries that stay visible without ever reddening or cancelling the run.

## How

In `.github/workflows/ci.yml`, the `test` job (`Test Suite`):
- `strategy.fail-fast: false` — a failure/ICE in any one matrix cell can no longer cancel its siblings. This is the essential change.
- `continue-on-error: ${{ matrix.rust == 'nightly' }}` — the two nightly cells report their status but a failure does not fail the job.

Semantics: nightly = advisory (informational canary for upcoming rustc), stable = gating (required), and matrix cells are now independent. No nightly pin was added — a pinned date rots; the structural fix is preferred.

## Scope check

Other workflows with a nightly rustc toolchain were checked: `fuzz.yml` already sets `fail-fast: false`; `nightly.yml` has no matrix (uses step-level `continue-on-error`). No further changes needed.

## Verification

- YAML parses (`python3 yaml.safe_load` → OK).

## Note: this change unmasked a pre-existing trunk break

`fail-fast: false` also surfaced a compile error that trunk's previous `fail-fast: true` was hiding as a "cancelled" cell:

    error[E0599]: no method named `index_cipher` found for `&Arc<IndexPersistenceManager>`
      src/storage/index_persistence/operations.rs:652 and :1035

This is from the recent index-at-rest encryption / key-rotation work — unrelated to this workflow change — and is fixed separately by #3578. It is not a regression introduced here: previously the macOS stable cell was cancelled by fail-fast before it could compile, so the break was invisible. Making cells independent means real failures now show up instead of being masked. Once #3578 merges, re-running this PR's checks should go fully green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHypdqT4ML1gmPD9DohhV6)_