### PR TITLE
feat(aletheia-server): port EDGES cluster (9 MCP tools) to autumn-web (#3524 PR3)

### DIFF
--- a/crates/aletheia-server/src/app.rs
+++ b/crates/aletheia-server/src/app.rs
@@ -11,6 +11,7 @@
 //! (`routes`/`openapi`/`mount_mcp`/`secure_mcp`/`state_initializer`), so Lane B
 //! can lift this into a `run_server` with minimal change.
 
+use crate::edge_tools;
 use crate::http_routes;
 use crate::node_tools;
 use crate::security::{self, SecurityConfig};
@@ -75,6 +76,15 @@ pub fn try_build_server_testapp(
             node_tools::delete_node_cascade,
             node_tools::retract_node,
             node_tools::find_nodes_at_time,
+            edge_tools::get_edge,
+            edge_tools::list_edges,
+            edge_tools::count_edges,
+            edge_tools::get_outgoing_edges,
+            edge_tools::get_incoming_edges,
+            edge_tools::create_edge,
+            edge_tools::update_edge,
+            edge_tools::delete_edge,
+            edge_tools::retract_edge,
         ])
         .openapi(OpenApiConfig::new("AletheiaDB", env!("CARGO_PKG_VERSION")))
         .mount_mcp("/mcp");

--- a/crates/aletheia-server/src/edge_tools.rs
+++ b/crates/aletheia-server/src/edge_tools.rs
@@ -1,0 +1,422 @@
+//! Edge tools: the edge cluster — the reads `get_edge` / `list_edges` /
+//! `count_edges` / `get_outgoing_edges` / `get_incoming_edges` and the writes
+//! `create_edge` / `update_edge` / `delete_edge` / `retract_edge` (Issue #3524,
+//! PR3).
+//!
+//! Each is a single `#[get(...)]`/`#[post(...)]` + `#[api_doc(description=...,
+//! mcp)]` handler, so one definition surfaces on **HTTP**, **MCP-over-HTTP**
+//! (`/mcp`), and **OpenAPI** at once. The response body is produced by the
+//! *exact* main-crate MCP dispatch, so it is byte-identical to the legacy MCP
+//! surface (bare entity JSON + the `temporal` block #3232, #3220 vector elision
+//! on the edge read path, the #3416 concurrent-write orphan-abort on
+//! `create_edge`/`delete_edge`, the #3230 retraction contract, and #3221
+//! `valid_time`) — asserted in the parity suite against
+//! `aletheiadb::mcp::AletheiaMcpServer` over the same `Arc<AletheiaDB>`.
+//!
+//! # Forwarding: typed methods vs. raw-argument dispatch
+//!
+//! The **writes** (`create_edge`/`update_edge`/`delete_edge`/`retract_edge`) and
+//! `count_edges` forward through the main crate's typed per-tool methods
+//! (`AletheiaMcpServer::create_edge`, …). The **four budgetable reads**
+//! (`get_edge`/`list_edges`/`get_outgoing_edges`/`get_incoming_edges`) instead
+//! forward the raw JSON arguments through
+//! `AletheiaMcpServer::dispatch_tool_json`, because the Issue #3353 token budget
+//! (`max_response_tokens`/`max_response_bytes`/`priority_properties`) and the
+//! Issue #3360 cursor paging (`use_cursor`/`cursor`, adjacency tools only) are
+//! read off the raw arguments and applied in `dispatch_tool` — the typed
+//! per-tool methods bypass that pipeline and their request structs do not carry
+//! those params, so typed forwarding would silently drop them. With neither
+//! budget nor cursor present, `dispatch_tool_json` reproduces the typed method's
+//! output byte-for-byte (same `handle_*`; the shared server is anonymous, so its
+//! built-in tool authorization is a no-op — the autumn `Authorized<C>` extractor
+//! is the real gate).
+//!
+//! `dispatch_tool_json` is the one main-crate visibility widening PR3 adds
+//! (marked `// exposed for autumn-web migration (Issue #3524)`); every request
+//! type it needs was already public. Cursor tokens are validated against a
+//! per-instance secret, so these handlers use the process-lifetime shared
+//! [`ServerState::mcp_server`](crate::state::ServerState::mcp_server) rather than
+//! constructing a server per request.
+//!
+//! The MCP tool result carries in-band errors (e.g. a missing edge →
+//! `{"error":{"code":"NOT_FOUND",...}}`); we return that JSON verbatim with a
+//! 200, matching the MCP method's `String` return exactly (unifying HTTP status
+//! semantics with the legacy HTTP envelope is a follow-up).
+//!
+//! The four write tools are classified [`WriteClass`] and the five reads
+//! [`ReadClass`]; the marker rides in each handler's `Authorized<C>` signature
+//! (the one place the class is declared), which autumn replays for `/mcp
+//! tools/call`. The write handlers take their arguments as a JSON **body**
+//! (autumn maps `Json<T>` to the reserved `body` MCP argument key), so the
+//! `tools/call` `arguments` wrap the request under `"body"`.
+
+use crate::security::{Authorized, ReadClass, WriteClass};
+use crate::state::ServerState;
+use aletheiadb::auth::AccessClass;
+use aletheiadb::mcp::{
+    CountEdgesRequest, CreateEdgeRequest, DeleteEdgeRequest, RetractEdgeRequest, UpdateEdgeRequest,
+};
+use autumn_web::prelude::{Json, Path, Query, get, post};
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+/// The dispatch-routed budgetable edge reads, each paired with (a) the
+/// **hardcoded literal tool name** it pins in its `dispatch_tool_json(...)` call
+/// and (b) the [`AccessClass`] of its `Authorized<C>` gate (all
+/// [`ReadClass`](crate::security::ReadClass) → [`AccessClass::Read`]).
+///
+/// This is the single source of truth binding *pinned name* ↔ *routed name* ↔
+/// *registry class*. The `dispatch_pinned_names_match_routed_class` conformance
+/// test in `tests/server_parity.rs` asserts, for every entry, that the pinned
+/// name is routed on `/mcp` **and** that its RBAC-registry class equals the
+/// class declared here — so a read-gated handler can never pin a write tool's
+/// name (a privilege-escalation route through a gated handler). The names here
+/// are the exact literals passed at the call sites; keep them in lockstep.
+///
+/// `pub` (not `pub(crate)`) because the conformance test is an integration test
+/// — an external crate — exactly like the already-`pub`
+/// `security::rbac::MCP_TOOL_CLASSES` it cross-checks against.
+pub const DISPATCH_ROUTED_READ_TOOLS: &[(&str, AccessClass)] = &[
+    ("get_edge", AccessClass::Read),
+    ("list_edges", AccessClass::Read),
+    ("get_outgoing_edges", AccessClass::Read),
+    ("get_incoming_edges", AccessClass::Read),
+];
+
+/// Parse an MCP tool method's JSON string result into a [`Value`] for the HTTP
+/// response. A non-JSON result (should not happen) degrades to a JSON string.
+fn tool_json(s: String) -> Json<Value> {
+    Json(serde_json::from_str::<Value>(&s).unwrap_or(Value::String(s)))
+}
+
+/// Fold a present optional value into the raw MCP arguments object under `key`.
+fn insert_opt(args: &mut Map<String, Value>, key: &str, val: Option<Value>) {
+    if let Some(v) = val {
+        args.insert(key.to_string(), v);
+    }
+}
+
+/// Fold the Issue #3353 token-budget parameters (`max_response_tokens` /
+/// `max_response_bytes` / `priority_properties`) into the raw arguments object,
+/// each only when present. These ride raw arguments (the legacy typed request
+/// structs do not carry them; #3353 shaping is applied in
+/// `AletheiaMcpServer::dispatch_tool`), so budgetable edge read handlers forward
+/// them via `AletheiaMcpServer::dispatch_tool_json` rather than the typed
+/// per-tool methods (which would silently drop them).
+fn insert_budget(
+    args: &mut Map<String, Value>,
+    max_response_tokens: Option<u64>,
+    max_response_bytes: Option<u64>,
+    priority_properties: Option<Vec<String>>,
+) {
+    insert_opt(
+        args,
+        "max_response_tokens",
+        max_response_tokens.map(Value::from),
+    );
+    insert_opt(
+        args,
+        "max_response_bytes",
+        max_response_bytes.map(Value::from),
+    );
+    if let Some(props) = priority_properties {
+        args.insert("priority_properties".to_string(), Value::from(props));
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Edge reads: get_edge / list_edges / count_edges / get_outgoing_edges /
+// get_incoming_edges — all [`ReadClass`], #3220 vector elision default +
+// `include_vectors`, #3232 temporal block.
+//
+// The four **budgetable** reads (`get_edge`, `list_edges`, `get_outgoing_edges`,
+// `get_incoming_edges`) forward through [`AletheiaMcpServer::dispatch_tool_json`]
+// rather than the typed per-tool methods, because the Issue #3353 token budget
+// (`max_response_tokens` / `max_response_bytes` / `priority_properties`) and the
+// Issue #3360 cursor paging (`use_cursor` / `cursor`, adjacency tools only) are
+// read off the **raw arguments** and applied in `dispatch_tool` — the typed
+// methods bypass that pipeline and their request structs do not carry those
+// params, so typed forwarding would silently drop them. With neither budget nor
+// cursor present, `dispatch_tool_json` reproduces the typed method's output
+// byte-for-byte (same `handle_*`, anonymous auth is a no-op). `count_edges` is
+// not budgetable/cursorable, so it keeps the typed method.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Query options for [`get_edge`] — the entity flag plus the #3353 token-budget
+/// parameters.
+#[derive(Debug, Default, Deserialize)]
+pub struct GetEdgeQuery {
+    /// Return full vector/embedding arrays instead of the elided descriptor.
+    pub include_vectors: Option<bool>,
+    /// #3353: cap the response at roughly this many tokens (utf8_bytes / 4).
+    pub max_response_tokens: Option<u64>,
+    /// #3353: byte-exact response cap.
+    pub max_response_bytes: Option<u64>,
+    /// #3353: property keys to protect first as the response degrades.
+    pub priority_properties: Option<Vec<String>>,
+}
+
+/// `get_edge` — fetch an edge by id, with bi-temporal bounds. HTTP + MCP tool.
+#[get("/edges/{id}")]
+#[api_doc(
+    description = "Fetch an edge by id, returning its source, target, label, properties, and bi-temporal bounds",
+    mcp
+)]
+pub async fn get_edge(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Path(id): Path<u64>,
+    Query(opts): Query<GetEdgeQuery>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    let mut args = Map::new();
+    args.insert("edge_id".to_string(), Value::from(id));
+    insert_opt(
+        &mut args,
+        "include_vectors",
+        opts.include_vectors.map(Value::from),
+    );
+    insert_budget(
+        &mut args,
+        opts.max_response_tokens,
+        opts.max_response_bytes,
+        opts.priority_properties,
+    );
+    tool_json(server.dispatch_tool_json("get_edge", Value::Object(args)))
+}
+
+/// Query options for [`list_edges`] — label/paging plus the #3353 token budget.
+#[derive(Debug, Default, Deserialize)]
+pub struct ListEdgesQuery {
+    /// Filter by edge label.
+    pub label: Option<String>,
+    /// Maximum number of edges to return.
+    pub limit: Option<usize>,
+    /// Number of edges to skip.
+    pub offset: Option<usize>,
+    /// Return full vector/embedding arrays instead of the elided descriptor.
+    pub include_vectors: Option<bool>,
+    /// #3353: cap the response at roughly this many tokens (utf8_bytes / 4).
+    pub max_response_tokens: Option<u64>,
+    /// #3353: byte-exact response cap.
+    pub max_response_bytes: Option<u64>,
+    /// #3353: property keys to protect first as the response degrades.
+    pub priority_properties: Option<Vec<String>>,
+}
+
+/// `list_edges` — list edges with optional label filtering + paging. HTTP + MCP
+/// tool. Budgetable (#3353) but not cursorable (per the design doc, `list_edges`
+/// does not enumerate edges — use the adjacency tools).
+#[get("/edges")]
+#[api_doc(
+    description = "List edges with optional label filtering and pagination",
+    mcp
+)]
+pub async fn list_edges(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Query(opts): Query<ListEdgesQuery>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    let mut args = Map::new();
+    insert_opt(&mut args, "label", opts.label.map(Value::from));
+    insert_opt(&mut args, "limit", opts.limit.map(Value::from));
+    insert_opt(&mut args, "offset", opts.offset.map(Value::from));
+    insert_opt(
+        &mut args,
+        "include_vectors",
+        opts.include_vectors.map(Value::from),
+    );
+    insert_budget(
+        &mut args,
+        opts.max_response_tokens,
+        opts.max_response_bytes,
+        opts.priority_properties,
+    );
+    tool_json(server.dispatch_tool_json("list_edges", Value::Object(args)))
+}
+
+/// Query options for [`count_edges`].
+#[derive(Debug, Default, Deserialize)]
+pub struct CountEdgesQuery {
+    /// Count only edges with this label (else all edges).
+    pub label: Option<String>,
+}
+
+/// `count_edges` — total edge count, or count matching a label. HTTP + MCP tool.
+/// Not budgetable/cursorable, so it forwards through the typed method.
+#[get("/edges/count")]
+#[api_doc(
+    description = "Count edges in the graph, or edges matching a specific label",
+    mcp
+)]
+pub async fn count_edges(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Query(opts): Query<CountEdgesQuery>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    let out = server.count_edges(CountEdgesRequest { label: opts.label });
+    tool_json(out)
+}
+
+/// Query options for [`get_outgoing_edges`] / [`get_incoming_edges`] — the
+/// filter/flag plus the #3353 token budget and the #3360 cursor parameters.
+#[derive(Debug, Default, Deserialize)]
+pub struct AdjacencyQuery {
+    /// Filter by edge label.
+    pub label: Option<String>,
+    /// Return full vector/embedding arrays instead of the elided descriptor.
+    pub include_vectors: Option<bool>,
+    /// #3360: per-page size when cursor paging (ignored by the full-adjacency
+    /// non-cursor path, which returns every edge).
+    pub limit: Option<usize>,
+    /// #3353: cap the response at roughly this many tokens (utf8_bytes / 4).
+    pub max_response_tokens: Option<u64>,
+    /// #3353: byte-exact response cap.
+    pub max_response_bytes: Option<u64>,
+    /// #3353: property keys to protect first as the response degrades.
+    pub priority_properties: Option<Vec<String>>,
+    /// #3360: request a snapshot-anchored cursor on the first page.
+    pub use_cursor: Option<bool>,
+    /// #3360: opaque continuation token from a prior page. The token carries the
+    /// scan's `node_id`; the path `node_id` is still required by the route but
+    /// is superseded by the token on continuation.
+    pub cursor: Option<String>,
+}
+
+/// Build the raw adjacency arguments (node_id + filter/flag + #3353 budget +
+/// #3360 cursor), shared by the outgoing and incoming handlers.
+fn adjacency_args(node_id: u64, opts: AdjacencyQuery) -> Value {
+    let mut args = Map::new();
+    args.insert("node_id".to_string(), Value::from(node_id));
+    insert_opt(&mut args, "label", opts.label.map(Value::from));
+    insert_opt(
+        &mut args,
+        "include_vectors",
+        opts.include_vectors.map(Value::from),
+    );
+    insert_opt(&mut args, "limit", opts.limit.map(Value::from));
+    insert_budget(
+        &mut args,
+        opts.max_response_tokens,
+        opts.max_response_bytes,
+        opts.priority_properties,
+    );
+    insert_opt(&mut args, "use_cursor", opts.use_cursor.map(Value::from));
+    insert_opt(&mut args, "cursor", opts.cursor.map(Value::from));
+    Value::Object(args)
+}
+
+/// `get_outgoing_edges` — the edges starting at a node, optionally filtered by
+/// label. [`ReadClass`]; vectors elided by default (#3220); budgetable (#3353)
+/// and cursorable (#3360). HTTP + MCP tool.
+#[get("/nodes/{node_id}/edges/outgoing")]
+#[api_doc(
+    description = "Get outgoing edges from a node, optionally filtered by edge label",
+    mcp
+)]
+pub async fn get_outgoing_edges(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Path(node_id): Path<u64>,
+    Query(opts): Query<AdjacencyQuery>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    tool_json(server.dispatch_tool_json("get_outgoing_edges", adjacency_args(node_id, opts)))
+}
+
+/// `get_incoming_edges` — the edges ending at a node, optionally filtered by
+/// label. [`ReadClass`]; vectors elided by default (#3220); budgetable (#3353)
+/// and cursorable (#3360). HTTP + MCP tool.
+#[get("/nodes/{node_id}/edges/incoming")]
+#[api_doc(
+    description = "Get incoming edges to a node, optionally filtered by edge label",
+    mcp
+)]
+pub async fn get_incoming_edges(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Path(node_id): Path<u64>,
+    Query(opts): Query<AdjacencyQuery>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    tool_json(server.dispatch_tool_json("get_incoming_edges", adjacency_args(node_id, opts)))
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Edge-write cluster (Issue #3524, PR3): create / update / delete / retract —
+// all [`WriteClass`].
+//
+// Each handler forwards its request body to the exact legacy MCP typed method
+// and returns that method's `String` verbatim, so every contract those methods
+// implement — #3221 `valid_time`, #3416 concurrent-write orphan-abort on
+// create_edge/delete_edge, #3230 retraction idempotency, #3232 temporal block —
+// is preserved byte-for-byte with **zero** reserialization.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// `create_edge` — create an edge between two nodes with properties and optional
+/// bi-temporal `valid_time` (#3221), provenance, and derivation lineage (#3371).
+/// The response carries the new edge with its `temporal` block (#3232). HTTP +
+/// MCP tool.
+#[post("/edges")]
+#[api_doc(
+    description = "Create an edge between two nodes with properties and optional valid_time, provenance, and lineage",
+    mcp
+)]
+pub async fn create_edge(
+    _auth: Authorized<WriteClass>,
+    state: ServerState,
+    Json(req): Json<CreateEdgeRequest>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    tool_json(server.create_edge(req))
+}
+
+/// `update_edge` — replace an edge's properties, recording a new bi-temporal
+/// version (optional `valid_time` #3221, provenance, lineage). HTTP + MCP tool.
+#[post("/edges/update")]
+#[api_doc(
+    description = "Update an edge's properties, recording a new version with optional valid_time",
+    mcp
+)]
+pub async fn update_edge(
+    _auth: Authorized<WriteClass>,
+    state: ServerState,
+    Json(req): Json<UpdateEdgeRequest>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    tool_json(server.update_edge(req))
+}
+
+/// `delete_edge` — remove an edge, with optional `valid_time` (#3221). HTTP +
+/// MCP tool.
+#[post("/edges/delete")]
+#[api_doc(
+    description = "Delete an edge, removing the relationship between two nodes",
+    mcp
+)]
+pub async fn delete_edge(
+    _auth: Authorized<WriteClass>,
+    state: ServerState,
+    Json(req): Json<DeleteEdgeRequest>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    tool_json(server.delete_edge(req))
+}
+
+/// `retract_edge` — close an edge's valid-time interval without deleting history
+/// (#3230); re-retraction is an idempotent no-op. HTTP + MCP tool.
+#[post("/edges/retract")]
+#[api_doc(
+    description = "Retract an edge (close its valid-time interval) without deleting history",
+    mcp
+)]
+pub async fn retract_edge(
+    _auth: Authorized<WriteClass>,
+    state: ServerState,
+    Json(req): Json<RetractEdgeRequest>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    tool_json(server.retract_edge(req))
+}

--- a/crates/aletheia-server/src/lib.rs
+++ b/crates/aletheia-server/src/lib.rs
@@ -28,6 +28,7 @@
 #![warn(missing_docs)]
 
 pub mod app;
+pub mod edge_tools;
 pub mod http_routes;
 pub mod node_tools;
 pub mod security;

--- a/crates/aletheia-server/src/state.rs
+++ b/crates/aletheia-server/src/state.rs
@@ -6,28 +6,52 @@
 
 use aletheiadb::AletheiaDB;
 use aletheiadb::http::AletheiaHttpError;
+use aletheiadb::mcp::AletheiaMcpServer;
 use autumn_web::prelude::AppState;
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
 use std::sync::Arc;
 
 /// Per-request handle to the shared database.
+///
+/// Also carries a **single, process-lifetime** [`AletheiaMcpServer`] shared
+/// across every request. This matters for the Issue #3360 cursor tokens, which
+/// are signed with (and validated against) a per-instance secret and tracked in
+/// a per-instance live-cursor registry: a fresh `AletheiaMcpServer::new()` per
+/// request would mint a new secret each time, so a cursor issued on one request
+/// could never be resumed on the next. Holding one shared instance keeps the
+/// secret + registry stable so continuation works. The shared server is
+/// anonymous (its built-in tool authorization is a no-op); the autumn-web
+/// `Authorized<C>` extractor remains the real access-control gate.
 #[derive(Clone)]
 pub struct ServerState {
     db: Arc<AletheiaDB>,
+    mcp: Arc<AletheiaMcpServer>,
 }
 
 impl ServerState {
-    /// Wrap a shared database for installation into the app's extension bag.
+    /// Wrap a shared database for installation into the app's extension bag,
+    /// constructing the shared [`AletheiaMcpServer`] once.
     #[must_use]
     pub fn new(db: Arc<AletheiaDB>) -> Self {
-        Self { db }
+        let mcp = Arc::new(AletheiaMcpServer::new(db.clone()));
+        Self { db, mcp }
     }
 
     /// Clone the `Arc<AletheiaDB>` for moving into a blocking task.
     #[must_use]
     pub fn db_arc(&self) -> Arc<AletheiaDB> {
         self.db.clone()
+    }
+
+    /// The process-lifetime shared [`AletheiaMcpServer`]. Handlers that forward
+    /// raw arguments through `dispatch_tool_json` (for the Issue #3353 token
+    /// budget and Issue #3360 cursor paging) must use this shared instance so
+    /// the cursor signing secret and live-cursor registry persist across
+    /// requests.
+    #[must_use]
+    pub fn mcp_server(&self) -> Arc<AletheiaMcpServer> {
+        self.mcp.clone()
     }
 }
 

--- a/crates/aletheia-server/tests/edge_parity.rs
+++ b/crates/aletheia-server/tests/edge_parity.rs
@@ -1,0 +1,1181 @@
+//! Parity tests for the edge cluster (Issue #3524, PR3).
+//!
+//! Mirrors `tests/node_writes_parity.rs` (the PR2 write cluster) for the nine
+//! edge tools ported in PR3: the reads `get_edge`, `list_edges`, `count_edges`,
+//! `get_outgoing_edges`, `get_incoming_edges`, and the writes `create_edge`,
+//! `update_edge`, `delete_edge`, `retract_edge`. Each test drives the new
+//! crate's autumn [`TestClient`] (HTTP and/or `/mcp`) and asserts the response
+//! is byte-identical to the **legacy** MCP typed method ([`AletheiaMcpServer`])
+//! for the same operation.
+//!
+//! # Why two databases + volatile-field normalization
+//!
+//! A write mutates, so the autumn surface and the legacy method cannot share one
+//! `Arc<AletheiaDB>` without double-applying. Instead each write test runs the
+//! *same* logical operation against **two freshly-seeded, identical** databases
+//! (id generation is deterministic from a fresh `AletheiaDB::new()`, guarded by
+//! an explicit assertion where relevant) and compares after stripping the
+//! wall-clock-volatile fields (`trace_id` + the bi-temporal timestamps
+//! `valid_from`/`valid_to`/`transaction_from`/`transaction_to`, which differ by
+//! microseconds between two independent commits). The structural payload — ids,
+//! labels, properties, success flags, `deleted_edge_id`, `already_retracted`,
+//! `is_current`, row counts — is asserted byte-equal; the meaningful volatile
+//! values (`already_retracted`, `is_current`) get their own targeted assertions
+//! on the autumn response directly, where they are deterministic.
+//!
+//! Contracts covered: #3232 temporal block, #3220 vector elision (default +
+//! `include_vectors`), #3230 retraction (idempotent), #3221 `valid_time` on the
+//! write path — plus both auth modes and the `/mcp` catalog surfacing the nine
+//! tools with their access classes.
+
+use std::sync::Arc;
+
+use aletheia_server::build_server_client;
+use aletheiadb::AletheiaDB;
+use aletheiadb::PropertyMapBuilder;
+use aletheiadb::auth::{AuthMode, AuthStore, Role};
+use aletheiadb::core::{EdgeId, NodeId};
+use aletheiadb::mcp::{
+    AletheiaMcpServer, CountEdgesRequest, CreateEdgeRequest, DeleteEdgeRequest, GetEdgeRequest,
+    GetIncomingEdgesRequest, GetOutgoingEdgesRequest, ListEdgesRequest, RetractEdgeRequest,
+    UpdateEdgeRequest,
+};
+use autumn_web::test::TestClient;
+use serde_json::{Value, json};
+use std::collections::HashMap;
+
+const ADMIN_TOKEN: &str = "admin-token-abcdefghijklmnop";
+const READER_TOKEN: &str = "reader-token-abcdefghijklmnop";
+const EMBEDDING: &[f32] = &[0.10, 0.20, 0.30, 0.40];
+
+/// A shared auth store with admin + reader keys. Writes authenticate as admin
+/// (the `admin` role satisfies every access class); reads authenticate as
+/// reader (the `reader` role satisfies [`ReadClass`]).
+fn make_store() -> Arc<AuthStore> {
+    let store = Arc::new(AuthStore::new());
+    store
+        .insert_bootstrap_key("admin", Role::Admin, ADMIN_TOKEN)
+        .expect("insert admin key");
+    store
+        .insert_bootstrap_key("reader", Role::Reader, READER_TOKEN)
+        .expect("insert reader key");
+    store
+}
+
+/// A fresh, empty database.
+fn fresh_db() -> Arc<AletheiaDB> {
+    Arc::new(AletheiaDB::new().expect("create db"))
+}
+
+fn mcp_server(db: &Arc<AletheiaDB>) -> AletheiaMcpServer {
+    AletheiaMcpServer::new(db.clone())
+}
+
+/// Recursively drop the per-request `trace_id` and every wall-clock-volatile
+/// bi-temporal timestamp so two independent commits are comparable. Structural
+/// fields (ids, labels, properties, flags, counts, `is_current`) survive.
+fn normalize(v: Value) -> Value {
+    match v {
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .filter(|(k, _)| {
+                    !matches!(
+                        k.as_str(),
+                        "trace_id"
+                            | "valid_from"
+                            | "valid_to"
+                            | "transaction_from"
+                            | "transaction_to"
+                    )
+                })
+                .map(|(k, val)| (k, normalize(val)))
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(items.into_iter().map(normalize).collect()),
+        other => other,
+    }
+}
+
+async fn post(client: &TestClient, uri: &str, body: &Value, bearer: Option<&str>) -> (u16, Value) {
+    let mut req = client.post(uri);
+    if let Some(token) = bearer {
+        req = req.header("authorization", &format!("Bearer {token}"));
+    }
+    let resp = req.json(body).send().await;
+    let status = resp.status.as_u16();
+    let body: Value = serde_json::from_str(&resp.text()).expect("new body is JSON");
+    (status, body)
+}
+
+async fn get(client: &TestClient, uri: &str, bearer: Option<&str>) -> (u16, Value) {
+    let mut req = client.get(uri);
+    if let Some(token) = bearer {
+        req = req.header("authorization", &format!("Bearer {token}"));
+    }
+    let resp = req.send().await;
+    let status = resp.status.as_u16();
+    let body: Value = serde_json::from_str(&resp.text()).expect("new body is JSON");
+    (status, body)
+}
+
+fn props(pairs: &[(&str, Value)]) -> HashMap<String, Value> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), v.clone()))
+        .collect()
+}
+
+/// Seed `Alice --KNOWS--> Bob` on `db`, returning `(alice, bob, edge)`. Two
+/// fresh dbs seeded this way assign identical ids (deterministic generation).
+fn seed_edge(db: &Arc<AletheiaDB>) -> (NodeId, NodeId, EdgeId) {
+    let alice = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .expect("seed alice");
+    let bob = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+        )
+        .expect("seed bob");
+    let edge = db
+        .create_edge(
+            alice,
+            bob,
+            "KNOWS",
+            PropertyMapBuilder::new().insert("since", 2020_i64).build(),
+        )
+        .expect("seed edge");
+    (alice, bob, edge)
+}
+
+/// Seed `Alice --KNOWS[embedding]--> Bob`, returning `(alice, bob, edge)`.
+fn seed_edge_with_vector(db: &Arc<AletheiaDB>) -> (NodeId, NodeId, EdgeId) {
+    let alice = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .expect("seed alice");
+    let bob = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+        )
+        .expect("seed bob");
+    let edge = db
+        .create_edge(
+            alice,
+            bob,
+            "KNOWS",
+            PropertyMapBuilder::new()
+                .insert("since", 2020_i64)
+                .insert_vector("embedding", EMBEDDING)
+                .build(),
+        )
+        .expect("seed edge");
+    (alice, bob, edge)
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// create_edge (#3221 valid_time, #3232 temporal block)
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn create_edge_byte_parity_with_legacy_mcp() {
+    let db_http = fresh_db();
+    let db_mcp = fresh_db();
+    // Seed two identical nodes on both dbs so the edge endpoints exist.
+    let seed_nodes = |db: &Arc<AletheiaDB>| -> (NodeId, NodeId) {
+        let a = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Alice").build(),
+            )
+            .unwrap();
+        let b = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Bob").build(),
+            )
+            .unwrap();
+        (a, b)
+    };
+    let (a_http, b_http) = seed_nodes(&db_http);
+    let (a_mcp, b_mcp) = seed_nodes(&db_mcp);
+    assert_eq!((a_http, b_http), (a_mcp, b_mcp), "deterministic node ids");
+    let client = build_server_client(db_http, make_store(), AuthMode::Required);
+
+    let body = json!({
+        "source_id": a_http.as_u64(),
+        "target_id": b_http.as_u64(),
+        "label": "KNOWS",
+        "properties": { "since": 2020 }
+    });
+    let (status, http_body) = post(&client, "/edges", &body, Some(ADMIN_TOKEN)).await;
+    assert_eq!(status, 200);
+
+    let legacy: Value = serde_json::from_str(&mcp_server(&db_mcp).create_edge(CreateEdgeRequest {
+        source_id: a_mcp.as_u64(),
+        target_id: b_mcp.as_u64(),
+        label: "KNOWS".to_string(),
+        properties: Some(props(&[("since", json!(2020))])),
+        valid_time: None,
+        provenance: None,
+        derived_from: None,
+    }))
+    .expect("legacy mcp json");
+
+    assert_eq!(
+        normalize(http_body.clone()),
+        normalize(legacy),
+        "create_edge HTTP body must equal legacy MCP method"
+    );
+    // #3232: the created edge carries a temporal block, current at creation.
+    assert!(
+        http_body["temporal"].is_object(),
+        "temporal block: {http_body}"
+    );
+    assert_eq!(http_body["temporal"]["is_current"], true);
+    assert_eq!(http_body["label"], "KNOWS");
+    assert_eq!(http_body["source_id"], a_http.as_u64());
+    assert_eq!(http_body["target_id"], b_http.as_u64());
+    assert_eq!(http_body["properties"]["since"], 2020);
+}
+
+#[tokio::test]
+async fn create_edge_backdated_valid_time_honored() {
+    // #3221: an explicit valid_time backdates when the relationship became true.
+    let db_http = fresh_db();
+    let db_mcp = fresh_db();
+    let seed_nodes = |db: &Arc<AletheiaDB>| -> (NodeId, NodeId) {
+        let a = db
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let b = db
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        (a, b)
+    };
+    let (a_http, b_http) = seed_nodes(&db_http);
+    let (a_mcp, b_mcp) = seed_nodes(&db_mcp);
+    let client = build_server_client(db_http, make_store(), AuthMode::Required);
+
+    let vt = "2020-01-15T10:00:00Z";
+    let body = json!({
+        "source_id": a_http.as_u64(),
+        "target_id": b_http.as_u64(),
+        "label": "KNOWS",
+        "valid_time": vt
+    });
+    let (status, http_body) = post(&client, "/edges", &body, Some(ADMIN_TOKEN)).await;
+    assert_eq!(status, 200);
+    assert_eq!(
+        http_body["temporal"]["valid_from"], "2020-01-15T10:00:00.000000Z",
+        "backdated valid_from must be honored: {http_body}"
+    );
+
+    let legacy: Value = serde_json::from_str(&mcp_server(&db_mcp).create_edge(CreateEdgeRequest {
+        source_id: a_mcp.as_u64(),
+        target_id: b_mcp.as_u64(),
+        label: "KNOWS".to_string(),
+        properties: None,
+        valid_time: Some(vt.to_string()),
+        provenance: None,
+        derived_from: None,
+    }))
+    .expect("legacy mcp json");
+    assert_eq!(normalize(http_body), normalize(legacy));
+}
+
+#[tokio::test]
+async fn create_edge_anonymous_mode_parity() {
+    let db_http = fresh_db();
+    let db_mcp = fresh_db();
+    let seed_nodes = |db: &Arc<AletheiaDB>| -> (NodeId, NodeId) {
+        let a = db
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let b = db
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        (a, b)
+    };
+    let (a_http, b_http) = seed_nodes(&db_http);
+    let (a_mcp, b_mcp) = seed_nodes(&db_mcp);
+    let client = build_server_client(db_http, make_store(), AuthMode::Anonymous);
+
+    let body = json!({
+        "source_id": a_http.as_u64(),
+        "target_id": b_http.as_u64(),
+        "label": "KNOWS"
+    });
+    let (status, http_body) = post(&client, "/edges", &body, None).await;
+    assert_eq!(status, 200);
+
+    let legacy: Value = serde_json::from_str(&mcp_server(&db_mcp).create_edge(CreateEdgeRequest {
+        source_id: a_mcp.as_u64(),
+        target_id: b_mcp.as_u64(),
+        label: "KNOWS".to_string(),
+        properties: None,
+        valid_time: None,
+        provenance: None,
+        derived_from: None,
+    }))
+    .expect("legacy mcp json");
+    assert_eq!(normalize(http_body), normalize(legacy));
+}
+
+#[tokio::test]
+async fn create_edge_unauthenticated_401() {
+    let client = build_server_client(fresh_db(), make_store(), AuthMode::Required);
+    let resp = client
+        .post("/edges")
+        .json(&json!({ "source_id": 1, "target_id": 2, "label": "KNOWS" }))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 401);
+    assert_eq!(resp.header("www-authenticate"), Some("Bearer"));
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// get_edge — #3232 temporal block, #3220 vector elision (default + include)
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn get_edge_byte_parity_and_temporal_block() {
+    let db = fresh_db();
+    let (_a, _b, edge) = seed_edge(&db);
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    let (status, http_body) = get(
+        &client,
+        &format!("/edges/{}", edge.as_u64()),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert_eq!(http_body["id"], edge.as_u64());
+    assert_eq!(http_body["label"], "KNOWS");
+    assert!(http_body["temporal"].is_object(), "temporal: {http_body}");
+    assert_eq!(http_body["temporal"]["is_current"], true);
+
+    // Shared-db byte parity: get is a pure read, so both surfaces observe the
+    // same version and are byte-identical without normalization.
+    let legacy: Value = serde_json::from_str(&mcp_server(&db).get_edge(GetEdgeRequest {
+        edge_id: edge.as_u64(),
+        include_vectors: None,
+    }))
+    .expect("legacy mcp json");
+    assert_eq!(
+        normalize(http_body),
+        normalize(legacy),
+        "get_edge HTTP body must equal legacy MCP method"
+    );
+}
+
+#[tokio::test]
+async fn get_edge_vector_elided_by_default_and_full_with_flag() {
+    let db = fresh_db();
+    let (_a, _b, edge) = seed_edge_with_vector(&db);
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    // #3220: vectors elided by default on the read path.
+    let (status, elided) = get(
+        &client,
+        &format!("/edges/{}", edge.as_u64()),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert_eq!(
+        elided["properties"]["embedding"]["elided"], true,
+        "vector elided by default: {elided}"
+    );
+    let legacy_elided: Value = serde_json::from_str(&mcp_server(&db).get_edge(GetEdgeRequest {
+        edge_id: edge.as_u64(),
+        include_vectors: None,
+    }))
+    .expect("legacy mcp json");
+    assert_eq!(normalize(elided), normalize(legacy_elided));
+
+    // include_vectors=true returns the raw array.
+    let (status, full) = get(
+        &client,
+        &format!("/edges/{}?include_vectors=true", edge.as_u64()),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert!(
+        full["properties"]["embedding"].is_array(),
+        "include_vectors=true returns the raw array: {full}"
+    );
+    let legacy_full: Value = serde_json::from_str(&mcp_server(&db).get_edge(GetEdgeRequest {
+        edge_id: edge.as_u64(),
+        include_vectors: Some(true),
+    }))
+    .expect("legacy mcp json");
+    assert_eq!(normalize(full), normalize(legacy_full));
+}
+
+#[tokio::test]
+async fn get_edge_missing_returns_not_found_in_band() {
+    let db = fresh_db();
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+    let (status, http_body) = get(&client, "/edges/999", Some(READER_TOKEN)).await;
+    assert_eq!(status, 200, "MCP method returns 200 with in-band error");
+    assert_eq!(http_body["error"]["code"], "NOT_FOUND");
+
+    let legacy: Value = serde_json::from_str(&mcp_server(&db).get_edge(GetEdgeRequest {
+        edge_id: 999,
+        include_vectors: None,
+    }))
+    .expect("legacy mcp json");
+    assert_eq!(normalize(http_body), normalize(legacy));
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// update_edge
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn update_edge_byte_parity_with_legacy_mcp() {
+    let db_http = fresh_db();
+    let db_mcp = fresh_db();
+    let (_a_http, _b_http, e_http) = seed_edge(&db_http);
+    let (_a_mcp, _b_mcp, e_mcp) = seed_edge(&db_mcp);
+    assert_eq!(e_http, e_mcp, "fresh dbs must assign identical edge ids");
+    let client = build_server_client(db_http, make_store(), AuthMode::Required);
+
+    let body = json!({
+        "edge_id": e_http.as_u64(),
+        "properties": { "since": 2021 }
+    });
+    let (status, http_body) = post(&client, "/edges/update", &body, Some(ADMIN_TOKEN)).await;
+    assert_eq!(status, 200);
+
+    let legacy: Value = serde_json::from_str(&mcp_server(&db_mcp).update_edge(UpdateEdgeRequest {
+        edge_id: e_mcp.as_u64(),
+        properties: props(&[("since", json!(2021))]),
+        valid_time: None,
+        provenance: None,
+        derived_from: None,
+    }))
+    .expect("legacy mcp json");
+
+    assert_eq!(normalize(http_body.clone()), normalize(legacy));
+    assert_eq!(http_body["properties"]["since"], 2021);
+    assert!(http_body["temporal"].is_object());
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// delete_edge
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn delete_edge_byte_parity() {
+    let db_http = fresh_db();
+    let db_mcp = fresh_db();
+    let (_a_http, _b_http, e_http) = seed_edge(&db_http);
+    let (_a_mcp, _b_mcp, e_mcp) = seed_edge(&db_mcp);
+    let client = build_server_client(db_http.clone(), make_store(), AuthMode::Required);
+
+    let body = json!({ "edge_id": e_http.as_u64() });
+    let (status, http_body) = post(&client, "/edges/delete", &body, Some(ADMIN_TOKEN)).await;
+    assert_eq!(status, 200);
+    assert_eq!(http_body["success"], true);
+    assert_eq!(http_body["deleted_edge_id"], e_http.as_u64());
+
+    let legacy: Value = serde_json::from_str(&mcp_server(&db_mcp).delete_edge(DeleteEdgeRequest {
+        edge_id: e_mcp.as_u64(),
+        valid_time: None,
+    }))
+    .expect("legacy mcp json");
+    assert_eq!(normalize(http_body), normalize(legacy));
+    assert!(db_http.get_edge(e_http).is_err(), "edge deleted");
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// retract_edge — #3230 idempotent close of valid-time
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn retract_edge_idempotent_byte_parity() {
+    let db_http = fresh_db();
+    let db_mcp = fresh_db();
+    let (_a_http, _b_http, e_http) = seed_edge(&db_http);
+    let (_a_mcp, _b_mcp, e_mcp) = seed_edge(&db_mcp);
+    let client = build_server_client(db_http, make_store(), AuthMode::Required);
+
+    // Omit valid_time (defaults to now); valid_from/valid_to are wall-clock
+    // volatile and normalized away for the cross-db comparison.
+    let body = json!({ "edge_id": e_http.as_u64() });
+    let (status, first) = post(&client, "/edges/retract", &body, Some(ADMIN_TOKEN)).await;
+    assert_eq!(status, 200);
+    assert_eq!(first["success"], true);
+    assert_eq!(first["retracted"], true);
+    assert_eq!(first["already_retracted"], false);
+    assert!(first["valid_to"].is_string(), "valid_to present: {first}");
+
+    let legacy: Value =
+        serde_json::from_str(&mcp_server(&db_mcp).retract_edge(RetractEdgeRequest {
+            edge_id: e_mcp.as_u64(),
+            valid_time: None,
+        }))
+        .expect("legacy mcp json");
+    assert_eq!(normalize(first.clone()), normalize(legacy));
+
+    // Re-retract: idempotent no-op returning the EXISTING interval.
+    let (status, second) = post(&client, "/edges/retract", &body, Some(ADMIN_TOKEN)).await;
+    assert_eq!(status, 200);
+    assert_eq!(second["already_retracted"], true);
+    // The reported interval is stable across the two calls.
+    assert_eq!(first["valid_from"], second["valid_from"]);
+    assert_eq!(first["valid_to"], second["valid_to"]);
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// list_edges / count_edges
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn list_edges_byte_parity() {
+    let db = fresh_db();
+    seed_edge(&db);
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    let (status, http_body) = get(&client, "/edges", Some(READER_TOKEN)).await;
+    assert_eq!(status, 200);
+
+    let legacy: Value = serde_json::from_str(&mcp_server(&db).list_edges(ListEdgesRequest {
+        label: None,
+        limit: None,
+        offset: None,
+        include_vectors: None,
+    }))
+    .expect("legacy mcp json");
+    assert_eq!(
+        normalize(http_body),
+        normalize(legacy),
+        "list_edges HTTP body must equal legacy MCP method"
+    );
+}
+
+#[tokio::test]
+async fn count_edges_byte_parity() {
+    let db = fresh_db();
+    seed_edge(&db);
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    let (status, http_body) = get(&client, "/edges/count", Some(READER_TOKEN)).await;
+    assert_eq!(status, 200);
+    assert_eq!(http_body["count"], 1);
+
+    let legacy: Value =
+        serde_json::from_str(&mcp_server(&db).count_edges(CountEdgesRequest { label: None }))
+            .expect("legacy mcp json");
+    assert_eq!(normalize(http_body), normalize(legacy));
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// get_outgoing_edges / get_incoming_edges — #3220 elision, #3232 temporal
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn get_outgoing_edges_byte_parity_and_elision() {
+    let db = fresh_db();
+    let (alice, _bob, _edge) = seed_edge_with_vector(&db);
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    let (status, http_body) = get(
+        &client,
+        &format!("/nodes/{}/edges/outgoing", alice.as_u64()),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert_eq!(http_body["count"], 1, "one outgoing edge: {http_body}");
+    // #3220: vectors elided by default on the read path.
+    assert_eq!(
+        http_body["edges"][0]["properties"]["embedding"]["elided"], true,
+        "vector elided by default: {http_body}"
+    );
+
+    let legacy: Value = serde_json::from_str(&mcp_server(&db).get_outgoing_edges(
+        GetOutgoingEdgesRequest {
+            node_id: alice.as_u64(),
+            label: None,
+            include_vectors: None,
+        },
+    ))
+    .expect("legacy mcp json");
+    assert_eq!(
+        normalize(http_body),
+        normalize(legacy),
+        "get_outgoing_edges HTTP body must equal legacy MCP method"
+    );
+}
+
+#[tokio::test]
+async fn get_outgoing_edges_include_vectors() {
+    let db = fresh_db();
+    let (alice, _bob, _edge) = seed_edge_with_vector(&db);
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    let (status, http_body) = get(
+        &client,
+        &format!(
+            "/nodes/{}/edges/outgoing?include_vectors=true",
+            alice.as_u64()
+        ),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert!(
+        http_body["edges"][0]["properties"]["embedding"].is_array(),
+        "include_vectors=true returns the raw array: {http_body}"
+    );
+
+    let legacy: Value = serde_json::from_str(&mcp_server(&db).get_outgoing_edges(
+        GetOutgoingEdgesRequest {
+            node_id: alice.as_u64(),
+            label: None,
+            include_vectors: Some(true),
+        },
+    ))
+    .expect("legacy mcp json");
+    assert_eq!(normalize(http_body), normalize(legacy));
+}
+
+#[tokio::test]
+async fn get_incoming_edges_byte_parity() {
+    let db = fresh_db();
+    let (_alice, bob, _edge) = seed_edge(&db);
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    let (status, http_body) = get(
+        &client,
+        &format!("/nodes/{}/edges/incoming", bob.as_u64()),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert_eq!(http_body["count"], 1, "one incoming edge: {http_body}");
+
+    let legacy: Value = serde_json::from_str(&mcp_server(&db).get_incoming_edges(
+        GetIncomingEdgesRequest {
+            node_id: bob.as_u64(),
+            label: None,
+            include_vectors: None,
+        },
+    ))
+    .expect("legacy mcp json");
+    assert_eq!(
+        normalize(http_body),
+        normalize(legacy),
+        "get_incoming_edges HTTP body must equal legacy MCP method"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// #3353 token budget + #3360 cursor paging on the budgetable/cursorable edge
+// reads. These params ride the RAW arguments and are applied in
+// `AletheiaMcpServer::dispatch_tool` (the typed per-tool methods bypass that
+// pipeline), so the handlers forward through `dispatch_tool_json`. The tests
+// use that same public entry as the legacy reference.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Seed `count` outgoing `KNOWS` edges from a fresh source node, each carrying a
+/// long `note` property so the full response comfortably exceeds a small byte
+/// budget. Returns `(source, edge_ids)`.
+fn seed_fanout(db: &Arc<AletheiaDB>, count: usize) -> (NodeId, Vec<EdgeId>) {
+    let src = db
+        .create_node(
+            "Hub",
+            PropertyMapBuilder::new().insert("name", "Hub").build(),
+        )
+        .expect("seed hub");
+    let mut edges = Vec::new();
+    for i in 0..count {
+        let dst = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("idx", i as i64).build(),
+            )
+            .expect("seed dst");
+        let e = db
+            .create_edge(
+                src,
+                dst,
+                "KNOWS",
+                PropertyMapBuilder::new()
+                    .insert("idx", i as i64)
+                    .insert(
+                        "note",
+                        "a deliberately long note property, repeated so the full \
+                         serialized response comfortably exceeds a moderate byte budget \
+                         and the #3353 ladder must shape it down: lorem ipsum dolor sit \
+                         amet consectetur adipiscing elit sed do eiusmod tempor incididunt \
+                         ut labore et dolore magna aliqua ut enim ad minim veniam quis",
+                    )
+                    .build(),
+            )
+            .expect("seed fanout edge");
+        edges.push(e);
+    }
+    (src, edges)
+}
+
+#[tokio::test]
+async fn get_outgoing_edges_token_budget_shapes_response() {
+    // #3353: a small max_response_bytes shapes the response (disclosed `budget`
+    // block, emitted string within the cap) and the autumn surface matches the
+    // legacy dispatch byte-for-byte for the same budget; omitting the budget
+    // reproduces the full, unshaped response.
+    let db = fresh_db();
+    let (src, _edges) = seed_fanout(&db, 5);
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    // Full (no budget): larger than the cap, no `budget` block.
+    let (status, full) = get(
+        &client,
+        &format!("/nodes/{}/edges/outgoing", src.as_u64()),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert!(full.get("budget").is_none(), "no budget block: {full}");
+    assert_eq!(full["count"], 5);
+    let full_len = serde_json::to_string(&full).unwrap().len();
+    // The cap sits below the full response (so shaping is forced) and above the
+    // minimal-rung floor (so it shapes rather than returning the #3353
+    // too-small-budget error).
+    let cap: u64 = 2000;
+    assert!(
+        full_len as u64 > cap,
+        "full response should exceed the cap: {full_len}"
+    );
+
+    // Budgeted: the legacy dispatch is the reference; its emitted string is the
+    // exact bytes the #3353 contract bounds.
+    let budget_args = json!({ "node_id": src.as_u64(), "max_response_bytes": cap });
+    let legacy_text = mcp_server(&db).dispatch_tool_json("get_outgoing_edges", budget_args);
+    assert!(
+        legacy_text.len() as u64 <= cap,
+        "emitted string must fit the byte budget: {} > {cap}",
+        legacy_text.len()
+    );
+    let legacy: Value = serde_json::from_str(&legacy_text).expect("legacy json");
+    assert!(
+        legacy["budget"].is_object(),
+        "budget block discloses the applied rung: {legacy}"
+    );
+
+    // Autumn surface with the same budget must match the legacy dispatch.
+    let (status, budgeted) = get(
+        &client,
+        &format!(
+            "/nodes/{}/edges/outgoing?max_response_bytes={cap}",
+            src.as_u64()
+        ),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert!(budgeted["budget"].is_object(), "shaped: {budgeted}");
+    assert_eq!(
+        normalize(budgeted),
+        normalize(legacy),
+        "budgeted autumn response must equal the legacy dispatch for the same budget"
+    );
+}
+
+#[tokio::test]
+async fn get_edge_token_budget_parity() {
+    // The single-entity budgetable read also forwards the budget: a max token
+    // budget yields the same shaped result as the legacy dispatch.
+    let db = fresh_db();
+    let (_a, _b, edge) = seed_edge_with_vector(&db);
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    let tokens: u64 = 64;
+    let (status, budgeted) = get(
+        &client,
+        &format!("/edges/{}?max_response_tokens={tokens}", edge.as_u64()),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+
+    let legacy_text = mcp_server(&db).dispatch_tool_json(
+        "get_edge",
+        json!({ "edge_id": edge.as_u64(), "max_response_tokens": tokens }),
+    );
+    let legacy: Value = serde_json::from_str(&legacy_text).expect("legacy json");
+    assert_eq!(
+        normalize(budgeted),
+        normalize(legacy),
+        "get_edge budgeted autumn response must equal the legacy dispatch"
+    );
+}
+
+#[tokio::test]
+async fn get_outgoing_edges_cursor_paging_snapshot_anchored() {
+    // #3360: use_cursor:true opens a snapshot-anchored scan returning an opaque
+    // cursor + first page; passing the cursor back continues it, duplicate-free
+    // and gap-free, until exhausted — the union equals the full adjacency.
+    let db = fresh_db();
+    let (src, edge_ids) = seed_fanout(&db, 3);
+    let expected: std::collections::BTreeSet<u64> = edge_ids.iter().map(|e| e.as_u64()).collect();
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    // First page: opt in with a per-page size of 1 to force continuation.
+    let (status, page1) = get(
+        &client,
+        &format!(
+            "/nodes/{}/edges/outgoing?use_cursor=true&limit=1",
+            src.as_u64()
+        ),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert_eq!(
+        page1["paging"], "cursor",
+        "cursor paging disclosed: {page1}"
+    );
+    assert!(
+        page1["snapshot_valid_time"].is_string(),
+        "snapshot disclosed: {page1}"
+    );
+    assert!(
+        page1["cursor"].as_str().is_some(),
+        "first page returns a continuation token: {page1}"
+    );
+
+    // Collect all edge ids across pages, following the cursor via the autumn
+    // surface. The cursor secret lives on the process-lifetime shared server in
+    // `ServerState`, so a token issued on one request resumes on the next (a
+    // separate `AletheiaMcpServer` instance signs with a different secret and
+    // could not decode it — hence the drive is autumn-only, not cross-instance).
+    let mut seen: Vec<u64> = Vec::new();
+    let mut page = page1.clone();
+    let mut prev_snapshot = page1["snapshot_valid_time"].clone();
+    let mut guard = 0;
+    loop {
+        for e in page["edges"].as_array().expect("edges array") {
+            seen.push(e["id"].as_u64().expect("edge id"));
+        }
+        let Some(token) = page["cursor"].as_str() else {
+            break;
+        };
+        // Continuation: the token carries the scan's node_id; the route still
+        // requires a path node_id (superseded by the token). The base64url
+        // no-pad token is URL-safe, so it embeds in the query verbatim.
+        let token = token.to_string();
+        let (status, next) = get(
+            &client,
+            &format!("/nodes/{}/edges/outgoing?cursor={}", src.as_u64(), token),
+            Some(READER_TOKEN),
+        )
+        .await;
+        assert_eq!(status, 200, "continuation page: {next}");
+        // Snapshot-anchored: every page answers at the coordinate pinned on the
+        // first page.
+        assert_eq!(
+            next["snapshot_valid_time"], prev_snapshot,
+            "continuation stays on the pinned snapshot: {next}"
+        );
+        prev_snapshot = next["snapshot_valid_time"].clone();
+        page = next;
+        guard += 1;
+        assert!(guard < 10, "cursor scan did not terminate");
+    }
+
+    // Duplicate-free and complete: the union equals the full adjacency.
+    let seen_set: std::collections::BTreeSet<u64> = seen.iter().copied().collect();
+    assert_eq!(seen.len(), seen_set.len(), "no duplicates across pages");
+    assert_eq!(
+        seen_set, expected,
+        "union of pages equals the full adjacency"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// /mcp catalog + tools/call for the nine PR3 tools
+// ════════════════════════════════════════════════════════════════════════════
+
+/// The nine PR3 edge tools and their intended access class (sourced from
+/// `tests/parity/inventory.json`'s `mcp.tools[].access_class`). Lane B's
+/// inventory-anchored RBAC registry classifies each identically; the
+/// `mcp_routable_tools_are_all_classified` conformance test in
+/// `tests/server_parity.rs` enforces that binding.
+const PR3_TOOLS: &[(&str, &str)] = &[
+    ("get_edge", "read"),
+    ("list_edges", "read"),
+    ("count_edges", "read"),
+    ("get_outgoing_edges", "read"),
+    ("get_incoming_edges", "read"),
+    ("create_edge", "write"),
+    ("update_edge", "write"),
+    ("delete_edge", "write"),
+    ("retract_edge", "write"),
+];
+
+#[tokio::test]
+async fn mcp_catalog_advertises_the_nine_edge_tools() {
+    let client = build_server_client(fresh_db(), make_store(), AuthMode::Required);
+    let rpc = json!({ "jsonrpc": "2.0", "id": 1, "method": "tools/list" });
+    let resp = client
+        .post("/mcp")
+        .header("authorization", &format!("Bearer {ADMIN_TOKEN}"))
+        .json(&rpc)
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200);
+    let body: Value = serde_json::from_str(&resp.text()).expect("json");
+    let tools = body["result"]["tools"].as_array().expect("tools array");
+
+    for (name, class) in PR3_TOOLS {
+        let tool = tools
+            .iter()
+            .find(|t| t["name"] == *name)
+            .unwrap_or_else(|| panic!("/mcp must advertise {name}: {body}"));
+        assert!(
+            tool["inputSchema"].is_object(),
+            "{name} inputSchema present"
+        );
+        assert!(
+            matches!(*class, "write" | "read"),
+            "{name} class {class} is a known access class"
+        );
+    }
+}
+
+#[tokio::test]
+async fn mcp_tools_call_get_edge_matches_http() {
+    let db_http = fresh_db();
+    let db_call = fresh_db();
+    let (_a, _b, e_http) = seed_edge(&db_http);
+    let (_a2, _b2, e_call) = seed_edge(&db_call);
+    assert_eq!(e_http, e_call, "deterministic edge ids");
+    let client_http = build_server_client(db_http, make_store(), AuthMode::Required);
+    let client_call = build_server_client(db_call, make_store(), AuthMode::Required);
+
+    let (_s, http_body) = get(
+        &client_http,
+        &format!("/edges/{}", e_http.as_u64()),
+        Some(READER_TOKEN),
+    )
+    .await;
+
+    let rpc = json!({
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "tools/call",
+        "params": { "name": "get_edge", "arguments": { "id": e_call.as_u64() } }
+    });
+    let resp = client_call
+        .post("/mcp")
+        .header("authorization", &format!("Bearer {READER_TOKEN}"))
+        .json(&rpc)
+        .send()
+        .await;
+    let body: Value = serde_json::from_str(&resp.text()).expect("json");
+    assert_eq!(body["id"], 7);
+    assert_eq!(body["result"]["isError"], false, "tools/call ok: {body}");
+    let text = body["result"]["content"][0]["text"]
+        .as_str()
+        .expect("tool text");
+    let tool_json: Value = serde_json::from_str(text).expect("tool text JSON");
+    assert_eq!(
+        normalize(tool_json),
+        normalize(http_body),
+        "tools/call get_edge must equal HTTP GET"
+    );
+}
+
+#[tokio::test]
+async fn mcp_tools_call_create_edge_matches_http() {
+    let db_http = fresh_db();
+    let db_call = fresh_db();
+    let seed_nodes = |db: &Arc<AletheiaDB>| -> (NodeId, NodeId) {
+        let a = db
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let b = db
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        (a, b)
+    };
+    let (a_http, b_http) = seed_nodes(&db_http);
+    let (a_call, b_call) = seed_nodes(&db_call);
+    assert_eq!((a_http, b_http), (a_call, b_call));
+    let client_http = build_server_client(db_http, make_store(), AuthMode::Required);
+    let client_call = build_server_client(db_call, make_store(), AuthMode::Required);
+
+    let edge = json!({
+        "source_id": a_http.as_u64(),
+        "target_id": b_http.as_u64(),
+        "label": "KNOWS"
+    });
+    let (_s, http_body) = post(&client_http, "/edges", &edge, Some(ADMIN_TOKEN)).await;
+
+    let rpc = json!({
+        "jsonrpc": "2.0",
+        "id": 8,
+        "method": "tools/call",
+        "params": { "name": "create_edge", "arguments": { "body": edge } }
+    });
+    let resp = client_call
+        .post("/mcp")
+        .header("authorization", &format!("Bearer {ADMIN_TOKEN}"))
+        .json(&rpc)
+        .send()
+        .await;
+    let body: Value = serde_json::from_str(&resp.text()).expect("json");
+    assert_eq!(body["id"], 8);
+    assert_eq!(body["result"]["isError"], false, "tools/call ok: {body}");
+    let text = body["result"]["content"][0]["text"]
+        .as_str()
+        .expect("tool text");
+    let tool_json: Value = serde_json::from_str(text).expect("tool text JSON");
+    assert_eq!(
+        normalize(tool_json),
+        normalize(http_body),
+        "tools/call create_edge must equal HTTP POST"
+    );
+}
+
+#[tokio::test]
+async fn mcp_write_edge_tool_requires_token() {
+    let client = build_server_client(fresh_db(), make_store(), AuthMode::Required);
+    let rpc = json!({
+        "jsonrpc": "2.0",
+        "id": 9,
+        "method": "tools/call",
+        "params": {
+            "name": "create_edge",
+            "arguments": { "body": { "source_id": 1, "target_id": 2, "label": "KNOWS" } }
+        }
+    });
+    let resp = client.post("/mcp").json(&rpc).send().await;
+    assert_eq!(
+        resp.status.as_u16(),
+        401,
+        "unauthenticated /mcp write must be rejected: {}",
+        resp.text()
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Per-surface error-envelope parity.
+//
+// The 4 budgetable edge reads are exposed as flat-HTTP routes (`GET /edges/{id}`
+// etc.) AND as `/mcp` tools. The legacy flat-HTTP router (src/http) exposes ONLY
+// /status, /admin/keys[/revoke], /query — there is NO legacy flat `/edges/*` or
+// `/nodes/*` endpoint. So these routes are brand-new MCP projections whose
+// contract (established by PR2) is "return the MCP tool result verbatim with
+// HTTP 200, in-band errors and all". The flat `AletheiaHttpError` envelope
+// belongs to the ported legacy routes (PR1), not to these tools. The envelope is
+// therefore the MCP nested `{"error":{code,message,retriable,details}}` shape on
+// BOTH surfaces — so HTTP↔/mcp envelope parity HOLDS (they are identical). These
+// tests lock that in.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Extract the tool-result JSON text from a `/mcp` tools/call response body.
+fn mcp_tool_result(body: &Value) -> Value {
+    let text = body["result"]["content"][0]["text"]
+        .as_str()
+        .expect("tool text");
+    serde_json::from_str(text).expect("tool text JSON")
+}
+
+#[tokio::test]
+async fn get_edge_error_envelope_identical_across_http_and_mcp() {
+    // A NOT_FOUND on the read path returns the SAME MCP nested envelope on the
+    // flat-HTTP surface and the /mcp tools/call surface (no flat-vs-nested
+    // divergence, because there is no legacy flat `/edges/{id}` to match).
+    let db = fresh_db();
+    let client = build_server_client(db, make_store(), AuthMode::Required);
+
+    let (status, http_err) = get(&client, "/edges/999", Some(READER_TOKEN)).await;
+    assert_eq!(status, 200, "MCP method returns 200 with in-band error");
+    assert_eq!(http_err["error"]["code"], "NOT_FOUND");
+    // It is the MCP nested envelope, not a flat AletheiaHttpError body.
+    assert!(
+        http_err["error"]["retriable"].is_boolean(),
+        "nested MCP error envelope on HTTP: {http_err}"
+    );
+
+    let rpc = json!({
+        "jsonrpc": "2.0",
+        "id": 21,
+        "method": "tools/call",
+        "params": { "name": "get_edge", "arguments": { "id": 999 } }
+    });
+    let resp = client
+        .post("/mcp")
+        .header("authorization", &format!("Bearer {READER_TOKEN}"))
+        .json(&rpc)
+        .send()
+        .await;
+    let body: Value = serde_json::from_str(&resp.text()).expect("json");
+    let mcp_err = mcp_tool_result(&body);
+
+    assert_eq!(
+        normalize(http_err),
+        normalize(mcp_err),
+        "the error envelope must be identical on the HTTP and /mcp surfaces"
+    );
+}
+
+#[tokio::test]
+async fn too_small_budget_invalid_argument_envelope_across_surfaces() {
+    // The #3353 too-small-budget INVALID_ARGUMENT also rides the same MCP nested
+    // envelope on both surfaces (byte 1 is below any minimal rung).
+    let db = fresh_db();
+    let (src, _edges) = seed_fanout(&db, 3);
+    let client = build_server_client(db, make_store(), AuthMode::Required);
+
+    let (status, http_err) = get(
+        &client,
+        &format!(
+            "/nodes/{}/edges/outgoing?max_response_bytes=1",
+            src.as_u64()
+        ),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert_eq!(http_err["error"]["code"], "INVALID_ARGUMENT");
+    assert_eq!(http_err["error"]["retriable"], false);
+
+    let rpc = json!({
+        "jsonrpc": "2.0",
+        "id": 22,
+        "method": "tools/call",
+        "params": {
+            "name": "get_outgoing_edges",
+            "arguments": { "node_id": src.as_u64(), "query": { "max_response_bytes": 1 } }
+        }
+    });
+    let resp = client
+        .post("/mcp")
+        .header("authorization", &format!("Bearer {READER_TOKEN}"))
+        .json(&rpc)
+        .send()
+        .await;
+    let body: Value = serde_json::from_str(&resp.text()).expect("json");
+    let mcp_err = mcp_tool_result(&body);
+
+    assert_eq!(
+        normalize(http_err),
+        normalize(mcp_err),
+        "too-small-budget INVALID_ARGUMENT envelope must be identical on both surfaces"
+    );
+}

--- a/crates/aletheia-server/tests/server_parity.rs
+++ b/crates/aletheia-server/tests/server_parity.rs
@@ -550,6 +550,65 @@ async fn mcp_routable_tools_are_all_classified() {
     }
 }
 
+/// SECURITY. The budgetable edge reads forward RAW ARGUMENTS to
+/// `AletheiaMcpServer::dispatch_tool_json` with a **hardcoded literal** tool
+/// name pinned to the route (e.g. the `get_edge` handler pins `"get_edge"`). A
+/// read-gated (`Authorized<ReadClass>`) handler that pinned a WRITE tool's name
+/// would route a caller past a read gate into a write tool — privilege
+/// escalation. This test makes that impossible: for every pinned entry in
+/// `edge_tools::DISPATCH_ROUTED_READ_TOOLS`, the pinned name must (1) be a
+/// **routed** tool on `/mcp` (pinned ↔ routed) and (2) resolve in the RBAC
+/// registry to **exactly** the [`AccessClass`] of the handler's `Authorized<C>`
+/// gate (routed ↔ class). Since every dispatch-routed read is `ReadClass`, any
+/// drift to a non-Read (e.g. write) pinned name fails here.
+#[tokio::test]
+async fn dispatch_pinned_names_match_routed_class() {
+    use aletheia_server::edge_tools::DISPATCH_ROUTED_READ_TOOLS;
+    use std::collections::BTreeSet;
+
+    let (db, store, _) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+
+    // The set of tool names actually routed on `/mcp`.
+    let rpc = json!({ "jsonrpc": "2.0", "id": 77, "method": "tools/list" });
+    let resp = client
+        .post("/mcp")
+        .header("authorization", &format!("Bearer {READER_TOKEN}"))
+        .json(&rpc)
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200);
+    let body: Value = serde_json::from_str(&resp.text()).expect("json");
+    let routable: BTreeSet<String> = body["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .map(|t| t["name"].as_str().expect("tool name").to_string())
+        .collect();
+
+    assert!(
+        !DISPATCH_ROUTED_READ_TOOLS.is_empty(),
+        "the pinned-name table must not be empty"
+    );
+    for (pinned, class) in DISPATCH_ROUTED_READ_TOOLS {
+        // (1) pinned ↔ routed: the literal a handler forwards must be a real,
+        // routed tool name (never a typo or an off-surface name).
+        assert!(
+            routable.contains(*pinned),
+            "pinned dispatch name {pinned:?} is not routed on /mcp: {routable:?}"
+        );
+        // (2) routed ↔ class: the RBAC-registry class of the pinned name must
+        // equal the handler's declared Authorized<C> class. A read-gated
+        // handler pinning a write tool's name would trip this (Write != Read).
+        assert_eq!(
+            rbac::tool_access_class(pinned),
+            Some(*class),
+            "pinned dispatch name {pinned:?} registry class must equal the handler's \
+             Authorized<C> class ({class:?}) — a read handler pinning a write name is escalation"
+        );
+    }
+}
+
 #[tokio::test]
 async fn mcp_tools_call_get_node_matches_http() {
     let (db, store, node_id) = fixture();

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -612,6 +612,27 @@ impl AletheiaMcpServer {
         ))
     }
 
+    /// Dispatch a tool by name from a raw JSON arguments object, returning the
+    /// tool's JSON string result.
+    ///
+    /// Unlike the per-tool typed methods (e.g. [`get_edge`](Self::get_edge)),
+    /// which call their `handle_*` directly, this routes through
+    /// [`dispatch_tool`](Self::dispatch_tool) so the raw-argument-driven
+    /// cross-cutting read features apply: the Issue #3353 token-budget shaping
+    /// (`max_response_tokens` / `max_response_bytes` / `priority_properties`)
+    /// and the Issue #3360 snapshot-anchored cursor paging (`use_cursor` /
+    /// `cursor`), both of which are read off the raw arguments and are therefore
+    /// invisible to the typed request structs. On the embedded/anonymous
+    /// [`AletheiaMcpServer::new`] path the built-in tool authorization is a
+    /// no-op; a caller that has authorized the tool out-of-band (e.g. the
+    /// autumn-web HTTP surface's own RBAC gate) gets the same result a direct
+    /// `handle_*` would produce when neither budget nor cursor is present.
+    ///
+    // exposed for autumn-web migration (Issue #3524)
+    pub fn dispatch_tool_json(&self, name: &str, args: serde_json::Value) -> String {
+        Self::extract_text(self.dispatch_tool(name, args))
+    }
+
     /// Get an edge by its ID.
     ///
     /// Returns the edge's source, target, label, and properties.


### PR DESCRIPTION
## EDGES cluster (9 MCP tools) → autumn-web (Issue #3524, PR3)

Ports the edge cluster to the production autumn-web 0.5 `aletheia-server` crate, mirroring PR1/PR2: nine `#[get]`/`#[post]` + `#[api_doc(mcp)]` handlers surface on HTTP, MCP-over-HTTP (`/mcp`), and OpenAPI from single definitions, registered in `app.rs` `routes[]`.

### Before / After (plain language)
- **Before:** the 9 edge tools existed only on the legacy MCP surface. The new autumn crate had nodes (PR2) but no edges.
- **After:** all 9 edge tools are routable on both HTTP and `/mcp`, byte-identical to the legacy MCP methods, class-gated by the Lane-B RBAC seam. Budgetable/cursorable edge reads honor #3353 token budgets and #3360 cursor paging.

### ⚠️ Two architecture changes (please review)

**(a) New main-crate widening: `pub fn AletheiaMcpServer::dispatch_tool_json(name, args) -> String`** — the ONLY visibility widening in this PR, marked `// exposed for autumn-web migration (Issue #3524)` at `src/mcp/server.rs`.
- **Why:** #3353 token-budget shaping is applied in `dispatch_tool`, which the typed per-tool methods bypass; and #3353/#3360 params are read off **raw args** (`budget::parse_budget`; `cursor_requested`) — the legacy request structs do not carry them, so `serde_json::to_value(typed_req)` drops them. Routing the 4 budgetable edge reads through `dispatch_tool_json` reuses the **already-tested** legacy budget+cursor pipeline, giving **parity by construction**. With neither budget nor cursor present it reproduces the typed-method output byte-for-byte (all pre-existing parity tests stay green). Writes + `count_edges` keep the typed methods.
- **Security (tool-name pinning):** each budgetable-read handler passes a **hardcoded literal** tool name tied to its route (never derived from request contents/body/params), so a caller cannot route to a different tool through a gated handler:
  - `dispatch_tool_json(&#34;get_edge&#34;, Value::Object(args))`
  - `dispatch_tool_json(&#34;list_edges&#34;, Value::Object(args))`
  - `dispatch_tool_json(&#34;get_outgoing_edges&#34;, adjacency_args(node_id, opts))`
  - `dispatch_tool_json(&#34;get_incoming_edges&#34;, adjacency_args(node_id, opts))`

  A `pub const DISPATCH_ROUTED_READ_TOOLS: &amp;[(&amp;str, AccessClass)]` table in `edge_tools.rs` binds each pinned name to its handler&#39;s `Authorized` class (all `ReadClass`). The conformance test **`dispatch_pinned_names_match_routed_class`** (`tests/server_parity.rs`) asserts, per entry: pinned name **is routed** on `/mcp` (pinned↔routed) AND its RBAC-registry class **equals** the handler&#39;s declared class (routed↔class). A read-gated handler pinning a WRITE tool&#39;s name → `Write != Read` → test fails. This makes read→write privilege escalation through a gated handler impossible.

**(b) Process-lifetime `Arc` in `ServerState`** (new `mcp_server()` accessor).
- **Why:** #3360 cursor tokens are signed with (and validated against) a **per-instance secret** (`CursorManager::new()` mints a fresh random secret) plus a per-instance live-cursor registry. Constructing `AletheiaMcpServer::new(db)` per request meant a cursor issued on one request could never be resumed on the next (continuation returned `INVALID_ARGUMENT` on both surfaces). Holding one shared instance keeps the secret + registry stable so continuation works. The shared server is anonymous (its built-in tool auth is a no-op); the autumn `Authorized` extractor remains the real access-control gate. **`node_tools` is untouched** (keeps `db_arc()`).
- **Single cursor layer (no double-signing):** the dispatch-routed edge reads use **only** the legacy `CursorManager` inside the shared `Arc`. Lane B&#39;s `security::cursor` module is **scaffold-only** (&#34;do not implement here / No cursor support in PR1&#34;) and has **zero** handler usage — there is no second cursor layer with a different secret. Legacy wins for dispatch-routed reads, by construction.
- **Cap keying is intentionally PROCESS-WIDE:** because there is exactly one shared `CursorManager` for all connections, the per-connection live-cursor cap (default 128) degrades to a single **process-wide** budget keyed by the one in-process registry. This is a **deliberate, documented** choice consistent with the per-process-secret model (the secret is already process-global; the cap registry lives beside it), not an accident. A future per-connection cap would require threading a connection identity into the shared registry.

**(c) Per-surface error-envelope parity — investigated, no fix needed.** The 4 budgetable reads ARE flat-HTTP routes (`GET /edges/{id}`, `GET /nodes/{id}/edges/outgoing`, …) in addition to `/mcp` tools. But the legacy flat-HTTP router (`src/http`) exposes **only** `/status`, `/admin/keys[/revoke]`, `/query` — there is **no** legacy flat `/edges/*` or `/nodes/*` endpoint. So these routes are brand-new MCP projections whose contract (established by PR2) is &#34;return the MCP tool result verbatim with HTTP 200, in-band errors and all&#34;. The flat `AletheiaHttpError` envelope belongs to PR1&#39;s ported legacy routes, not to these tools. The error envelope is therefore the MCP nested `{&#34;error&#34;:{code,message,retriable,details}}` shape on **both** surfaces, so HTTP↔/mcp envelope parity **holds** (identical) — locked by two tests: `get_edge_error_envelope_identical_across_http_and_mcp` (NOT_FOUND) and `too_small_budget_invalid_argument_envelope_across_surfaces` (#3353 INVALID_ARGUMENT).

### Access-class marker ↔ inventory.json (verified by hand; all match)

| Tool | Handler `Authorized` marker | inventory.json `access_class` | Match |
|------|-------------------------------|-------------------------------|-------|
| get_edge | ReadClass | read | ✓ |
| list_edges | ReadClass | read | ✓ |
| count_edges | ReadClass | read | ✓ |
| get_outgoing_edges | ReadClass | read | ✓ |
| get_incoming_edges | ReadClass | read | ✓ |
| create_edge | WriteClass | write | ✓ |
| update_edge | WriteClass | write | ✓ |
| delete_edge | WriteClass | write | ✓ |
| retract_edge | WriteClass | write | ✓ |

### Registry-boundary note
Zero edits under `src/security/**` or `tests/security_*`. B1 already classifies all 9 edge tools, so `mcp_routable_tools_are_all_classified` passes with no registry changes.

### Main-crate widenings
- `src/mcp/server.rs`: `pub fn dispatch_tool_json` (marked `// exposed for autumn-web migration (Issue #3524)`). No other widenings — every edge request type was already public.

### AC evidence — inventory rows → passing parity tests (`crates/aletheia-server/tests/edge_parity.rs`, 24 tests; plus 1 in `tests/server_parity.rs`)

| Inventory tool | Covering test(s) |
|----------------|------------------|
| get_edge | get_edge_byte_parity_and_temporal_block; get_edge_vector_elided_by_default_and_full_with_flag; get_edge_missing_returns_not_found_in_band; get_edge_token_budget_parity; mcp_tools_call_get_edge_matches_http |
| list_edges | list_edges_byte_parity |
| count_edges | count_edges_byte_parity |
| get_outgoing_edges | get_outgoing_edges_byte_parity_and_elision; get_outgoing_edges_include_vectors; get_outgoing_edges_token_budget_shapes_response; get_outgoing_edges_cursor_paging_snapshot_anchored |
| get_incoming_edges | get_incoming_edges_byte_parity |
| create_edge | create_edge_byte_parity_with_legacy_mcp; create_edge_backdated_valid_time_honored; create_edge_anonymous_mode_parity; create_edge_unauthenticated_401; mcp_tools_call_create_edge_matches_http; mcp_write_edge_tool_requires_token |
| update_edge | update_edge_byte_parity_with_legacy_mcp |
| delete_edge | delete_edge_byte_parity |
| retract_edge | retract_edge_idempotent_byte_parity |
| (catalog) | mcp_catalog_advertises_the_nine_edge_tools |
| (security: pinned↔routed↔class) | dispatch_pinned_names_match_routed_class (`tests/server_parity.rs`) |
| (per-surface envelope parity) | get_edge_error_envelope_identical_across_http_and_mcp; too_small_budget_invalid_argument_envelope_across_surfaces |

Verbatim (rebased gate run on head `1a1dd8f`, all 6 gates green):
```
fmt --all -- --check:                                    FMT_CLEAN
clippy -p aletheia-server --all-targets -D warnings:     Finished (clean)
check -p aletheiadb --no-default-features --tests --features http-server:   Finished
cargo test -p aletheia-server:
  edge_parity          test result: ok. 24 passed; 0 failed
  node_writes_parity   test result: ok. 18 passed; 0 failed
  server_parity        test result: ok. 20 passed; 0 failed   (incl. mcp_routable_tools_are_all_classified, dispatch_pinned_names_match_routed_class)
  (+ Lane B security_* suites all green)
parity_http          test result: ok. 33 passed; 0 failed
parity_mcp           test result: ok. 11 passed; 0 failed
clippy -p aletheiadb --features &#34;config-toml,mcp-server,sharding-rpc,simulation&#34; --all-targets -D warnings:   Finished (clean)
```

### Follow-up (report-only; not in this PR)
PR2&#39;s node reads (`get_node`, `list_nodes`, `find_nodes_at_time`) drop #3353 budget and #3360 cursor for the same root cause (typed-method forwarding); recommend a node-lane follow-up applying this same `dispatch_tool_json` + shared-`ServerState` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEwJg2bDPZ7DzcHebqwZVK

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEwJg2bDPZ7DzcHebqwZVK)_

---
**CI note — `codecov/patch` red is a known non-blocking artifact.** The repo's Code Coverage job runs `cargo llvm-cov` scoped to the `aletheiadb` package only (`default-members = ["."]`, no `-p aletheia-server`/`--workspace`), so this crate's tests aren't instrumented and the diff shows `0.00%` patch coverage. The flagged lines (the `dispatch_tool_json` widening) ARE exercised by the `aletheia-server` test suite. `codecov/project` is green (93.52%). A one-line ci.yml coverage-scope fix is tracked separately by CI-infra; this is not a real coverage gap and does not block merge.