### PR TITLE
fix(mcp/budget): bound priority_properties DoS — O(1) HashSet lookups + configurable length cap

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -463,8 +463,44 @@ HistoricalConfigBuilder::new()
     .reconstruction_cache_size(1000).unwrap()
 ```
 
+## MCP Server Resource Limits
+
+The MCP server (`AletheiaMcpServer`) exposes builder-style knobs that bound
+per-call resource usage, guarding the surface against denial-of-service from
+untrusted callers. All have safe defaults and are optional.
+
+| Knob | Default | Purpose |
+|------|---------|---------|
+| `with_max_batch_operations(n)` | 1000 | Max operations accepted by one `apply_batch` call (Issue #3231). |
+| `with_cursor_config(ttl, max_live_cursors)` | 5 min, 128 | Continuation-cursor TTL and per-connection live-cursor cap (Issue #3360). |
+| `with_max_priority_properties(n)` | 1024 | Max entries in a token-budget `priority_properties` array (Issue #3583). |
+
+### `with_max_priority_properties` (Issue #3583)
+
+The token-budget parameter `priority_properties` (Issue #3353) names the
+property keys a budgeted read protects from elision. It is consulted for every
+property of every returned entity while the response is shaped. Left unbounded,
+a caller could pass an array with hundreds of thousands of entries, turning
+response shaping into multi-second blocking CPU. The per-key lookup is O(1)
+(backed by a `HashSet`), and an array longer than this cap is rejected up front
+with a structured `INVALID_ARGUMENT` error naming the cap and the given length
+(so re-issuing under the cap succeeds), keeping the one-time validation cost
+bounded as well.
+
+```rust
+use std::sync::Arc;
+use aletheiadb::AletheiaDB;
+use aletheiadb::mcp::AletheiaMcpServer;
+
+let db = Arc::new(AletheiaDB::new()?);
+// Tighten the priority_properties cap from the default 1024 to 64.
+let server = AletheiaMcpServer::new(db).with_max_priority_properties(64);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
 ## References
 
 - [WAL Documentation](WAL.md) - Write-ahead log internals
 - [Index Persistence Guide](guides/index-persistence-guide.md) - Index persistence details
 - [Architecture Documentation](ARCHITECTURE.md) - System architecture
+- [MCP Query Tool Guide](guides/mcp-query-tool.md) - Token budgets, cursors, and MCP resource limits

--- a/src/mcp/budget.rs
+++ b/src/mcp/budget.rs
@@ -45,12 +45,29 @@
 //! — their ranked results are never dropped or reordered to meet a budget; only
 //! per-result payloads degrade (Issue #3353 AC7).
 
+use std::collections::HashSet;
+
 use serde_json::{Map, Value, json};
 
 use super::error::{McpError, McpErrorCode};
 
 /// Bytes-per-token divisor. See the module docs for the estimation basis.
 pub(crate) const BYTES_PER_TOKEN: u64 = 4;
+
+/// Default upper bound on the number of entries accepted in a
+/// `priority_properties` array (Issue #3583, surfaced via #3353).
+///
+/// `priority_properties` is matched against every property of every returned
+/// entity at the elide and summarize rungs. Left unbounded, an attacker could
+/// pass a `priority_properties` array with up to hundreds of thousands of
+/// entries (bounded only by the transport body cap), turning response shaping
+/// into multi-second blocking CPU. The scan itself is now an O(1) `HashSet`
+/// lookup, but the array is *still* rejected above this cap so the one-time cost
+/// of building that set (and of validating/allocating the array) stays bounded.
+///
+/// Configurable per server via
+/// [`AletheiaMcpServer::with_max_priority_properties`](crate::mcp::AletheiaMcpServer::with_max_priority_properties).
+pub(crate) const DEFAULT_MAX_PRIORITY_PROPERTIES: usize = 1024;
 
 /// Property values whose pretty-serialized form exceeds this many bytes are
 /// "bulky" and are the first content sacrificed (rung 2). Set above the fixed
@@ -109,7 +126,18 @@ impl Rung {
 /// `max_response_tokens`) is simply ignored — consistent with the surface's
 /// unknown-field tolerance — so the request is served in full rather than
 /// silently budgeted under a key the caller did not intend.
-pub(crate) fn parse_budget(args: &Value) -> Result<Option<BudgetRequest>, McpError> {
+///
+/// `max_priority_properties` bounds the length of the `priority_properties`
+/// array (defense-in-depth against the Issue #3583 DoS): an array longer than
+/// the cap is rejected with a structured `INVALID_ARGUMENT` error naming both
+/// the cap and the given length, so re-issuing under the cap succeeds. The cap
+/// is configurable per server via
+/// [`AletheiaMcpServer::with_max_priority_properties`](crate::mcp::AletheiaMcpServer::with_max_priority_properties)
+/// (default [`DEFAULT_MAX_PRIORITY_PROPERTIES`]).
+pub(crate) fn parse_budget(
+    args: &Value,
+    max_priority_properties: usize,
+) -> Result<Option<BudgetRequest>, McpError> {
     let obj = match args.as_object() {
         Some(o) => o,
         None => return Ok(None),
@@ -125,6 +153,23 @@ pub(crate) fn parse_budget(args: &Value) -> Result<Option<BudgetRequest>, McpErr
     let priority_properties = match obj.get("priority_properties") {
         None | Some(Value::Null) => Vec::new(),
         Some(Value::Array(items)) => {
+            // Defense-in-depth (Issue #3583): reject an over-long array up front,
+            // before allocating/validating each element, so an oversized array
+            // cannot turn response shaping into unbounded work.
+            if items.len() > max_priority_properties {
+                return Err(McpError::new(
+                    McpErrorCode::InvalidArgument,
+                    format!(
+                        "priority_properties may contain at most {max_priority_properties} \
+                         entries, but {} were given",
+                        items.len()
+                    ),
+                )
+                .details(json!({
+                    "max_priority_properties": max_priority_properties,
+                    "given": items.len(),
+                })));
+            }
             let mut out = Vec::with_capacity(items.len());
             for item in items {
                 match item.as_str() {
@@ -342,11 +387,20 @@ fn build_candidate(
     cap: u64,
 ) -> Value {
     let ctx = derive_ctx(&value, tool);
+    // Build the protected-key lookup once per candidate (Issue #3583): the elide
+    // and summarize rungs consult it per-property-per-entity, so an O(1)
+    // `HashSet` lookup replaces the previous O(len(priority_properties)) linear
+    // scan and keeps shaping cost independent of the array length.
+    let priority: HashSet<&str> = budget
+        .priority_properties
+        .iter()
+        .map(String::as_str)
+        .collect();
     let mut sections: Vec<Value> = Vec::new();
     match rung {
         Rung::Full => {}
         Rung::ElideProperties => {
-            let n = elide_bulky_properties(&mut value, &budget.priority_properties, &ctx);
+            let n = elide_bulky_properties(&mut value, &priority, &ctx);
             if n > 0 {
                 sections.push(json!({
                     "section": "properties",
@@ -356,7 +410,7 @@ fn build_candidate(
             }
         }
         Rung::Summaries => {
-            let n = summarize_entities(&mut value, &budget.priority_properties, &ctx);
+            let n = summarize_entities(&mut value, &priority, &ctx);
             if n > 0 {
                 sections.push(json!({
                     "section": "properties",
@@ -366,7 +420,7 @@ fn build_candidate(
         }
         Rung::CountsAndHandles => {
             // First reduce every entity to its summary, then truncate arrays.
-            summarize_entities(&mut value, &budget.priority_properties, &ctx);
+            summarize_entities(&mut value, &priority, &ctx);
             let mut sections_so_far = vec![json!({
                 "section": "properties",
                 "rung": "entity_summaries",
@@ -499,7 +553,7 @@ fn entity_fetch_handle(map: &Map<String, Value>, ctx: &ShapeCtx) -> Value {
 /// number of values elided. A value is elided only when its `{elided,...}`
 /// descriptor serializes *smaller* than the value it replaces, so this rung can
 /// never enlarge the response (Issue #3353 F3).
-fn elide_bulky_properties(value: &mut Value, priority: &[String], ctx: &ShapeCtx) -> usize {
+fn elide_bulky_properties(value: &mut Value, priority: &HashSet<&str>, ctx: &ShapeCtx) -> usize {
     let mut count = 0;
     match value {
         Value::Object(map) => {
@@ -507,7 +561,7 @@ fn elide_bulky_properties(value: &mut Value, priority: &[String], ctx: &ShapeCtx
                 let handle = entity_fetch_handle(map, ctx);
                 if let Some(Value::Object(props)) = map.get_mut("properties") {
                     for (key, val) in props.iter_mut() {
-                        if priority.iter().any(|p| p == key) {
+                        if priority.contains(key.as_str()) {
                             continue;
                         }
                         if already_elided(val) {
@@ -553,7 +607,7 @@ fn elide_bulky_properties(value: &mut Value, priority: &[String], ctx: &ShapeCtx
 
 /// Rung 3: reduce each entity's `properties` to protected keys only. Returns the
 /// number of entities summarized (i.e. that dropped at least one property).
-fn summarize_entities(value: &mut Value, priority: &[String], ctx: &ShapeCtx) -> usize {
+fn summarize_entities(value: &mut Value, priority: &HashSet<&str>, ctx: &ShapeCtx) -> usize {
     let mut count = 0;
     match value {
         Value::Object(map) => {
@@ -563,7 +617,7 @@ fn summarize_entities(value: &mut Value, priority: &[String], ctx: &ShapeCtx) ->
                     let original_len = props.len();
                     let mut kept = Map::new();
                     for (key, val) in props.iter() {
-                        if priority.iter().any(|p| p == key) {
+                        if priority.contains(key.as_str()) {
                             kept.insert(key.clone(), val.clone());
                         }
                     }
@@ -1074,5 +1128,133 @@ mod unit_tests {
         assert!(out.len() <= 90, "byte cap holds: {} bytes", out.len());
         // Valid UTF-8 by construction (String), and re-checkable:
         assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+    }
+
+    // ---- Issue #3583: priority_properties DoS bound ------------------------
+
+    /// The protected-key `HashSet` lookup path protects *exactly* the same keys
+    /// as the previous linear scan: a representative node with a mix of
+    /// protected and unprotected bulky properties keeps the protected ones in
+    /// full and elides the unprotected ones. Behavior-preserving evidence for
+    /// the O(1) rewrite.
+    #[test]
+    fn priority_hashset_protects_same_keys_as_linear_scan() {
+        let node = json!({
+            "id": 1,
+            "label": "Doc",
+            "properties": {
+                "bio": "x".repeat(4000),      // protected → survives
+                "notes": "y".repeat(4000),    // unprotected → elided
+                "summary": "z".repeat(4000),  // protected → survives
+                "extra": "w".repeat(4000),    // unprotected → elided
+            }
+        });
+        let budget = budget_req(100_000, &["bio", "summary"]);
+        let args = json!({});
+        let elided = build_candidate(
+            node,
+            Rung::ElideProperties,
+            &budget,
+            "get_node",
+            &args,
+            100_000,
+        );
+        let props = &elided["properties"];
+        // Protected keys retain their full value.
+        assert_eq!(props["bio"].as_str().map(str::len), Some(4000));
+        assert_eq!(props["summary"].as_str().map(str::len), Some(4000));
+        // Unprotected bulky keys are elided descriptors, not the raw string.
+        assert_eq!(props["notes"]["elided"], json!(true));
+        assert_eq!(props["extra"]["elided"], json!(true));
+    }
+
+    /// The summarize rung keeps exactly the protected keys via the `HashSet`
+    /// path (plus the disclosure marker), dropping everything else — matching
+    /// the pre-rewrite linear-scan semantics.
+    #[test]
+    fn priority_hashset_summarize_keeps_only_protected() {
+        let node = json!({
+            "id": 7,
+            "label": "Doc",
+            "properties": {
+                "bio": "x".repeat(4000),
+                "notes": "y".repeat(4000),
+                "keepme": "k".repeat(10),
+            }
+        });
+        let budget = budget_req(500, &["keepme"]);
+        let args = json!({});
+        let shaped = build_candidate(node, Rung::Summaries, &budget, "get_node", &args, 500);
+        let props = shaped["properties"].as_object().expect("properties object");
+        assert!(props.contains_key("keepme"), "protected key survives");
+        assert!(!props.contains_key("bio"), "unprotected key dropped");
+        assert!(!props.contains_key("notes"), "unprotected key dropped");
+        assert!(
+            props.contains_key("_budget_omitted"),
+            "summary discloses the omission"
+        );
+    }
+
+    /// A `priority_properties` array at or below the cap parses successfully.
+    #[test]
+    fn parse_budget_accepts_priority_at_cap() {
+        let items: Vec<Value> = (0..DEFAULT_MAX_PRIORITY_PROPERTIES)
+            .map(|i| json!(format!("p{i}")))
+            .collect();
+        let args = json!({
+            "max_response_tokens": 1000,
+            "priority_properties": items,
+        });
+        let parsed = parse_budget(&args, DEFAULT_MAX_PRIORITY_PROPERTIES)
+            .expect("at-cap array is accepted")
+            .expect("budget present");
+        assert_eq!(
+            parsed.priority_properties.len(),
+            DEFAULT_MAX_PRIORITY_PROPERTIES
+        );
+    }
+
+    /// A `priority_properties` array over the cap is rejected with a structured
+    /// `INVALID_ARGUMENT` error naming the cap and the given length, before any
+    /// shaping work — the #3583 defense-in-depth bound.
+    #[test]
+    fn parse_budget_rejects_priority_over_cap() {
+        let cap = 8usize;
+        let items: Vec<Value> = (0..cap + 1).map(|i| json!(format!("p{i}"))).collect();
+        let given = items.len();
+        let args = json!({
+            "max_response_tokens": 1000,
+            "priority_properties": items,
+        });
+        let err = parse_budget(&args, cap).expect_err("over-cap array must be rejected");
+        assert_eq!(err.code(), McpErrorCode::InvalidArgument);
+        assert!(!err.is_retriable(), "caller-fault error is non-retriable");
+        let json = err.to_json();
+        assert_eq!(json["details"]["max_priority_properties"], json!(cap));
+        assert_eq!(json["details"]["given"], json!(given));
+        // The message names both the cap and the given length.
+        assert!(err.message().contains(&cap.to_string()));
+        assert!(err.message().contains(&given.to_string()));
+        // Self-consistent: re-issuing under the cap succeeds.
+        let ok_items: Vec<Value> = (0..cap).map(|i| json!(format!("p{i}"))).collect();
+        let ok_args = json!({
+            "max_response_tokens": 1000,
+            "priority_properties": ok_items,
+        });
+        assert!(
+            parse_budget(&ok_args, cap).is_ok(),
+            "re-issuing under the cap must succeed"
+        );
+    }
+
+    /// The cap is inert when `priority_properties` is absent or empty (the
+    /// common case): behavior is completely unchanged.
+    #[test]
+    fn parse_budget_cap_inert_without_priority() {
+        let args = json!({ "max_response_tokens": 1000 });
+        let parsed = parse_budget(&args, 1)
+            .expect("no priority array")
+            .expect("budget present");
+        assert!(parsed.priority_properties.is_empty());
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -380,7 +380,7 @@ impl AletheiaMcpServer {
     /// shaping runs, keeping response-shaping cost bounded regardless of caller
     /// input. The per-key lookup itself is O(1); this cap additionally bounds the
     /// one-time cost of validating the array and building the lookup set.
-    #[must_use]
+    #[must_use = "with_max_priority_properties returns a new server; discarding it drops the configured limit"]
     pub fn with_max_priority_properties(mut self, max_priority_properties: usize) -> Self {
         self.max_priority_properties = max_priority_properties;
         self

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -223,6 +223,10 @@ pub struct AletheiaMcpServer {
     db: Arc<AletheiaDB>,
     /// Maximum operations accepted by one `apply_batch` call (Issue #3231).
     pub(crate) max_batch_operations: usize,
+    /// Maximum number of entries accepted in a `priority_properties` budget
+    /// array (Issue #3583). Bounds the one-time cost of building the protected-
+    /// key set; an over-cap array is rejected with `INVALID_ARGUMENT`.
+    pub(crate) max_priority_properties: usize,
     auth: SessionAuth,
     /// Snapshot-anchored keyset continuation cursors (Issue #3360). Shared
     /// (one manager == one MCP connection) so its live-cursor cap is a
@@ -309,6 +313,7 @@ impl AletheiaMcpServer {
         Self {
             db,
             max_batch_operations: DEFAULT_MAX_BATCH_OPERATIONS,
+            max_priority_properties: budget::DEFAULT_MAX_PRIORITY_PROPERTIES,
             auth: SessionAuth::Anonymous,
             cursors: Arc::new(CursorManager::new()),
             query_limits: Arc::new(QueryLimitsConfig::default()),
@@ -364,6 +369,23 @@ impl AletheiaMcpServer {
         self
     }
 
+    /// Override the maximum number of entries accepted in a `priority_properties`
+    /// token-budget array (default: 1024, Issue #3583).
+    ///
+    /// `priority_properties` (Issue #3353) names the property keys a budgeted
+    /// read protects from elision. It is consulted for every property of every
+    /// returned entity, so an unbounded array is a denial-of-service vector:
+    /// this cap rejects an over-long array up front with a structured
+    /// `INVALID_ARGUMENT` error (naming the cap and the given length) before any
+    /// shaping runs, keeping response-shaping cost bounded regardless of caller
+    /// input. The per-key lookup itself is O(1); this cap additionally bounds the
+    /// one-time cost of validating the array and building the lookup set.
+    #[must_use]
+    pub fn with_max_priority_properties(mut self, max_priority_properties: usize) -> Self {
+        self.max_priority_properties = max_priority_properties;
+        self
+    }
+
     /// Create an MCP server with authentication and role-based
     /// authorization (Issue #3350, Phase 2).
     ///
@@ -398,6 +420,7 @@ impl AletheiaMcpServer {
         Self {
             db,
             max_batch_operations: DEFAULT_MAX_BATCH_OPERATIONS,
+            max_priority_properties: budget::DEFAULT_MAX_PRIORITY_PROPERTIES,
             auth: SessionAuth::from(auth),
             cursors: Arc::new(CursorManager::new()),
             query_limits: Arc::new(QueryLimitsConfig::default()),
@@ -6264,7 +6287,7 @@ impl AletheiaMcpServer {
         // budget with a disclosed truncation contract. Omitting the budget
         // parameters leaves behavior completely unchanged.
         if is_budgetable_read_tool(name) {
-            match budget::parse_budget(&args) {
+            match budget::parse_budget(&args, self.max_priority_properties) {
                 Ok(Some(budget_req)) => {
                     // Retain the original arguments so the rung-4 truncation
                     // handle can emit a concrete offset-based resume call

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -14172,6 +14172,77 @@ mod budget_tests {
         assert_eq!(value["error"]["code"], json!("INVALID_ARGUMENT"));
     }
 
+    // ---- Issue #3583: priority_properties DoS bound (e2e) ------------------
+
+    /// An over-cap `priority_properties` array is rejected at the MCP surface
+    /// with a structured `INVALID_ARGUMENT` error — bounded, not a hang — and
+    /// the error names the configured cap.
+    #[test]
+    fn issue3583_over_cap_priority_properties_rejected() {
+        let cap = 16usize;
+        let server = create_test_server().with_max_priority_properties(cap);
+        let id = seed_big_node(&server, "Person", "Alice");
+        let over: Vec<String> = (0..cap + 1).map(|i| format!("p{i}")).collect();
+        let (value, is_error) = dispatch_json(
+            &server,
+            "get_node",
+            json!({
+                "node_id": id,
+                "max_response_tokens": 1000,
+                "priority_properties": over,
+            }),
+        );
+        assert!(is_error, "over-cap array must be rejected: {value}");
+        assert_eq!(value["error"]["code"], json!("INVALID_ARGUMENT"));
+        assert_eq!(value["error"]["retriable"], json!(false));
+        assert_eq!(
+            value["error"]["details"]["max_priority_properties"],
+            json!(cap)
+        );
+        assert_eq!(value["error"]["details"]["given"], json!(cap + 1));
+    }
+
+    /// A large-but-valid `priority_properties` array completes successfully in
+    /// bounded time — the O(1) lookup path is not a hang — and the protected key
+    /// (`bio`) survives in full. (Forced-degradation protection semantics are
+    /// covered exhaustively by the `budget::unit_tests` HashSet tests; here the
+    /// budget is generous so the large echoed array does not itself dominate the
+    /// minimal-viable size, keeping the assertion robust.)
+    #[test]
+    fn issue3583_large_valid_priority_properties_completes() {
+        let cap = 512usize;
+        let server = create_test_server().with_max_priority_properties(cap);
+        let id = seed_big_node(&server, "Person", "Alice");
+        // A large (at-cap) array including the real protected key "bio".
+        let mut priority: Vec<String> = (0..cap - 1).map(|i| format!("p{i}")).collect();
+        priority.push("bio".to_string());
+        let byte_budget = 200_000u64;
+        let (shaped, is_error) = dispatch_json(
+            &server,
+            "get_node",
+            json!({
+                "node_id": id,
+                "max_response_bytes": byte_budget,
+                "priority_properties": priority,
+            }),
+        );
+        assert!(!is_error, "at-cap valid array must complete: {shaped}");
+        // The response is bounded by the stated budget and the budget block is
+        // present (shaping ran end-to-end without hanging).
+        let serialized = serde_json::to_string_pretty(&shaped).unwrap();
+        assert!(
+            serialized.len() as u64 <= byte_budget,
+            "response stays within the byte budget: {} bytes",
+            serialized.len()
+        );
+        assert!(shaped.get("budget").is_some(), "budget block attached");
+        assert_eq!(
+            shaped["properties"]["bio"].as_str().map(|s| s.len()),
+            Some(4000),
+            "protected key survives via the HashSet lookup path"
+        );
+    }
+
     // ---- AC7: ranked tools never drop/reorder results ----------------------
 
     #[test]


### PR DESCRIPTION
## Summary

Security-hardening follow-up: bounds a superlinear DoS in the #3353
token-budget response-shaping pipeline caused by the `priority_properties`
parameter.

## Before / After (plain language)

**Before:** `priority_properties` (a `Vec<String>` budget parameter) was matched
against every returned property of every returned entity via a **linear scan**
(`priority.iter().any(|p| p == key)`) at both the elide and summarize rungs.
Response shaping rebuilds the whole response tree ~13× per request, so total
work was roughly `O(builds · N · K · P)` where `P = len(priority_properties)`
(unbounded — up to hundreds of thousands of entries within the transport body
cap) and `N · K` is entities × properties (`N` up to the tool `limit`, e.g.
10,000, independent of body size). A large `priority_properties` array on a
budgeted read could therefore burn **multiple seconds of blocking CPU** per
request. There was also no length cap at parse time (legacy stdio has no body
cap at all).

**After:** the per-key check is an **O(1) `HashSet` lookup**, so shaping cost is
independent of the array length; results are **byte-identical** to before (the
same keys are protected). A **configurable length cap** (default **1024**)
additionally rejects an over-long `priority_properties` array up front with a
structured `INVALID_ARGUMENT` error, keeping even the one-time
validation/allocation cost bounded. Work is now bounded and results are
unchanged.

## How

- **`src/mcp/budget.rs:510` / `:566`** — build a `HashSet<&str>` from
  `priority_properties` once per candidate and replace the two
  `priority.iter().any(|p| p == key)` linear scans with O(1) `set.contains(key)`.
  `elide_bulky_properties` / `summarize_entities` now take `&HashSet<&str>`.
  Behavior-preserving: an empty priority list yields an empty set, protecting
  the same (zero) keys as before.
- **`parse_budget`** — reject `priority_properties` longer than the cap **before
  allocating/validating elements**, with a #3234-style structured
  `INVALID_ARGUMENT` error whose message names the cap and the given length and
  whose `details` carries `{max_priority_properties, given}` (self-consistent —
  re-issuing under the cap succeeds).
- **Config knob** — `AletheiaMcpServer::with_max_priority_properties(n)` (new
  `max_priority_properties` field, default
  `budget::DEFAULT_MAX_PRIORITY_PROPERTIES = 1024`), threaded into
  `parse_budget`. Documented in `docs/CONFIGURATION.md` under a new **MCP Server
  Resource Limits** section alongside the existing `with_max_batch_operations` /
  `with_cursor_config` knobs.

## Tests (strict TDD)

- **Behavior-preserving:** existing budget/shape_response tests pass unchanged;
  added `priority_hashset_protects_same_keys_as_linear_scan` and
  `priority_hashset_summarize_keeps_only_protected` asserting the HashSet path
  protects exactly the same keys.
- **Cap rejection:** `parse_budget_rejects_priority_over_cap` (structured error,
  cap + length echoed, non-retriable, self-consistent),
  `parse_budget_accepts_priority_at_cap`, `parse_budget_cap_inert_without_priority`.
- **e2e (through `dispatch_tool`/`shape_response`):**
  `issue3583_over_cap_priority_properties_rejected` (structured error, not a
  hang) and `issue3583_large_valid_priority_properties_completes` (large valid
  array completes bounded, protected key survives).

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --features mcp-server --lib` — 4480 passed, 0 failed (all budget
  tests green). The full integration-test-binary build (`--test` targets like
  `durability_modes`, unrelated to this change) hit a sandbox disk limit; those
  binaries do not touch budget code and are left to CI.

## Refs

Surfaced via #3583 (DoS-MEDIUM); hardens the #3353 token-budget pipeline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9nP1hfyQTVovFgM48MfME)_