### PR TITLE
ci: instrument aletheia-server crate in the Code Coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Generate coverage report
-        run: cargo llvm-cov --features "config-toml,mcp-server,sharding-rpc" --lcov --output-path lcov.info
+        run: cargo llvm-cov -p aletheiadb -p aletheia-server --features "config-toml,mcp-server,sharding-rpc" --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
@@ -158,7 +158,7 @@ jobs:
           verbose: true
 
       - name: Check coverage thresholds
-        run: cargo llvm-cov --features "config-toml,mcp-server,sharding-rpc" --fail-under-lines 85 --fail-under-functions 88 --fail-under-regions 88
+        run: cargo llvm-cov -p aletheiadb -p aletheia-server --features "config-toml,mcp-server,sharding-rpc" --fail-under-lines 85 --fail-under-functions 88 --fail-under-regions 88
 
   lint:
     name: Linting


### PR DESCRIPTION
## Before / After
**Before:** Every PR touching the `aletheia-server` crate showed codecov/patch **0%** on its code even when its tests passed — e.g. #3583's coverage artifact, and #3569's widened lines showing 0 hits despite being exercised by the server crate's tests. The `Code Coverage` job ran `cargo llvm-cov` with no package scope, and the root `Cargo.toml` sets `default-members = ["."]`, so llvm-cov only compiled and instrumented the root `aletheiadb` package. `crates/aletheia-server` (≈126 tests across 8 integration files) was never built by the coverage job, so none of its code was measured.

**After:** The coverage job co-selects `-p aletheiadb -p aletheia-server`, so the server crate is compiled and instrumented and its tests count toward coverage — codecov/patch will reflect real hits on server-crate code.

## How
In `.github/workflows/ci.yml` (`Code Coverage` job), both `cargo llvm-cov` invocations (lcov generation and the `--fail-under-*` threshold check) now pass `-p aletheiadb -p aletheia-server`.

The three coverage features (`config-toml`, `mcp-server`, `sharding-rpc`) are defined only on the root `aletheiadb` package; `aletheia-server` defines no features. `cargo llvm-cov -p aletheia-server --features config-toml` alone errors ("does not contain this feature"), so `aletheiadb` is co-selected in the same invocation to satisfy the bare feature names. The intentionally-isolated `aletheia-autumn-spike` crate is deliberately left out (kept off the default CI gates), so `--workspace` was not used.

## Verification
- YAML parses (`python3 yaml.safe_load` → OK).
- Feature/package selection resolves (`cargo tree -p aletheiadb -p aletheia-server --features "config-toml,mcp-server,sharding-rpc"` succeeds; the same selection minus `-p aletheiadb` errors on the features — confirming why both packages are co-selected). A full `cargo llvm-cov` run is exercised by CI itself (cargo-llvm-cov is installed there via `taiki-e/install-action`).

## Note on thresholds
Adding the server crate changes the aggregate line/function/region percentages the `--fail-under-*` gate (85/88/88) checks. The server crate is well-tested, but if the combined number lands below a threshold the coverage job will now surface that as a real gap rather than hiding it. Flagging so the threshold can be revisited against the first measured combined number if needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHypdqT4ML1gmPD9DohhV6)_