### PR TITLE
ci: pin nightly toolchain to nightly-2026-07-12 to dodge rustc ICE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,13 @@ jobs:
     # redden the required stable cells: the matrix runs fail-fast: false so a
     # broken cell cannot cancel its siblings, and nightly cells are
     # continue-on-error so their failures stay visible without failing the run.
-    continue-on-error: ${{ matrix.rust == 'nightly' }}
+    continue-on-error: ${{ startsWith(matrix.rust, 'nightly') }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: [stable, nightly]
+        # nightly pinned to a known-good date: nightly-2026-07-13+ ICEs on a standard #[test] (rustc_test_entrypoint_marker) — upstream https://github.com/rust-lang/rust/issues/100263 . Bump/remove once the ICE is fixed upstream.
+        rust: [stable, nightly-2026-07-12]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Before

The nightly "Test Suite" matrix cells fail on **every PR** with a rustc ICE:

```
thread 'rustc' panicked at compiler/rustc_ast/src/attr/mod.rs:307:
"attribute is missing tokens"
```

Even though those cells are advisory (`continue-on-error`), the red X produces
recurring triage cost / red-noise on every run.

## After

The nightly matrix cell now uses **`nightly-2026-07-12`** — the last nightly
that compiles the repo clean — so the cell is green again while staying
**advisory** (`continue-on-error` still applies to it).

## How

- Matrix axis `rust: [stable, nightly]` → `[stable, nightly-2026-07-12]`.
- `continue-on-error: ${{ matrix.rust == 'nightly' }}` →
  `${{ startsWith(matrix.rust, 'nightly') }}` so the **dated** channel still
  counts as advisory (a literal `== 'nightly'` would have turned the pinned
  cell into a *required, gating* cell — the opposite of what we want).
- A YAML comment above the matrix `rust:` line documents the pin and links the
  upstream ICE.

This is a **workflow-only** change — no Rust code touched. Only the Test Suite
matrix and its nightly condition are modified; the Mutants check and all other
jobs are untouched.

```diff
-    continue-on-error: ${{ matrix.rust == 'nightly' }}
+    continue-on-error: ${{ startsWith(matrix.rust, 'nightly') }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: [stable, nightly]
+        # nightly pinned to a known-good date: nightly-2026-07-13+ ICEs on a standard #[test] (rustc_test_entrypoint_marker) — upstream https://github.com/rust-lang/rust/issues/100263 . Bump/remove once the ICE is fixed upstream.
+        rust: [stable, nightly-2026-07-12]
```

## Root cause

A pure **upstream rustc regression** between nightly-2026-07-11 (clean) and
nightly-2026-07-13 (`daf2e5e18`, ICE). The panic is in the libtest
`#[test]` → `rustc_test_entrypoint_marker` attribute expansion, matching the
long-open upstream issue https://github.com/rust-lang/rust/issues/100263 .

Our code is **not** at fault: a standard `#[test]` (e.g. `src/db/config.rs:955`)
triggers it, and both **stable 1.94.1** and **nightly-2026-07-12**
(`be8e82435`, built 2026-07-11) compile the repo clean.

## Follow-up

Bump or remove the pin once the upstream ICE is fixed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzQHD6Dis2jSyrVKsFT622)_