### PR TITLE
feat(autumn-server): route node reads through budget/cursor dispatch (#3524 follow-up)

### DIFF
--- a/crates/aletheia-server/src/edge_tools.rs
+++ b/crates/aletheia-server/src/edge_tools.rs
@@ -76,11 +76,19 @@ use serde_json::{Map, Value};
 /// `pub` (not `pub(crate)`) because the conformance test is an integration test
 /// — an external crate — exactly like the already-`pub`
 /// `security::rbac::MCP_TOOL_CLASSES` it cross-checks against.
+///
+/// The three **node** reads (`get_node`, `list_nodes`, `find_nodes_at_time`) are
+/// dispatch-routed too (see [`crate::node_tools`]) and are pinned here in the
+/// same table so the one `dispatch_pinned_names_match_routed_class` conformance
+/// test covers every dispatch-routed read across both clusters.
 pub const DISPATCH_ROUTED_READ_TOOLS: &[(&str, AccessClass)] = &[
     ("get_edge", AccessClass::Read),
     ("list_edges", AccessClass::Read),
     ("get_outgoing_edges", AccessClass::Read),
     ("get_incoming_edges", AccessClass::Read),
+    ("get_node", AccessClass::Read),
+    ("list_nodes", AccessClass::Read),
+    ("find_nodes_at_time", AccessClass::Read),
 ];
 
 /// Parse an MCP tool method's JSON string result into a [`Value`] for the HTTP
@@ -90,7 +98,7 @@ fn tool_json(s: String) -> Json<Value> {
 }
 
 /// Fold a present optional value into the raw MCP arguments object under `key`.
-fn insert_opt(args: &mut Map<String, Value>, key: &str, val: Option<Value>) {
+pub(crate) fn insert_opt(args: &mut Map<String, Value>, key: &str, val: Option<Value>) {
     if let Some(v) = val {
         args.insert(key.to_string(), v);
     }
@@ -103,7 +111,7 @@ fn insert_opt(args: &mut Map<String, Value>, key: &str, val: Option<Value>) {
 /// `AletheiaMcpServer::dispatch_tool`), so budgetable edge read handlers forward
 /// them via `AletheiaMcpServer::dispatch_tool_json` rather than the typed
 /// per-tool methods (which would silently drop them).
-fn insert_budget(
+pub(crate) fn insert_budget(
     args: &mut Map<String, Value>,
     max_response_tokens: Option<u64>,
     max_response_bytes: Option<u64>,

--- a/crates/aletheia-server/src/node_tools.rs
+++ b/crates/aletheia-server/src/node_tools.rs
@@ -6,19 +6,52 @@
 //! Each is a single `#[get(...)]`/`#[post(...)]` + `#[api_doc(description=...,
 //! mcp)]` handler, so one definition surfaces on **HTTP**, **MCP-over-HTTP**
 //! (`/mcp`), and **OpenAPI** at once. The response body is produced by the
-//! *exact* main-crate MCP typed method
-//! ([`AletheiaMcpServer::get_node`]/`create_node`/`update_node`/…), so it is
-//! byte-identical to the legacy MCP surface (bare entity JSON + the `temporal`
-//! block #3232, #3220 vector elision, the #3209 DETACH refuse/detach contract on
-//! `delete_node`, the #3230 retraction contract, #3221 `valid_time`, and #3236
-//! point-in-time reconstruction) — asserted in the parity suite against a fresh
+//! *exact* main-crate MCP surface, so it is byte-identical to the legacy MCP
+//! surface (bare entity JSON + the `temporal` block #3232, #3220 vector elision,
+//! the #3209 DETACH refuse/detach contract on `delete_node`, the #3230
+//! retraction contract, #3221 `valid_time`, and #3236 point-in-time
+//! reconstruction) — asserted in the parity suite against a fresh
 //! [`AletheiaMcpServer`] over the same `Arc<AletheiaDB>`.
 //!
-//! These reuse **already-public** symbols
-//! (`aletheiadb::mcp::{AletheiaMcpServer, GetNodeRequest, ListNodesRequest,
-//! CountNodesRequest, CreateNodeRequest, UpdateNodeRequest, DeleteNodeRequest,
-//! DeleteNodeCascadeRequest, RetractNodeRequest, FindNodesAtTimeRequest}`), so no
-//! main-crate visibility widening is required.
+//! # Forwarding: typed methods vs. raw-argument dispatch
+//!
+//! The **writes** (`create_node`/`update_node`/`delete_node`/
+//! `delete_node_cascade`/`retract_node`) and `count_nodes` forward through the
+//! main crate's typed per-tool methods (`AletheiaMcpServer::create_node`, …).
+//! The three **budgetable reads** (`get_node`, `list_nodes`,
+//! `find_nodes_at_time`) instead forward the raw JSON arguments through
+//! `AletheiaMcpServer::dispatch_tool_json`, because the Issue #3353 token budget
+//! (`max_response_tokens`/`max_response_bytes`/`priority_properties`, all three)
+//! and the Issue #3360 cursor paging (`use_cursor`/`cursor`, `list_nodes` /
+//! `find_nodes_at_time` only — `get_node` is a single-entity read and is not
+//! cursorable) are read off the raw arguments and applied in `dispatch_tool` —
+//! the typed per-tool methods bypass that pipeline and their request structs do
+//! not carry those params, so typed forwarding would silently drop them (the gap
+//! this retrofit closes). With neither budget nor cursor present,
+//! `dispatch_tool_json` reproduces the typed method's output byte-for-byte (same
+//! `handle_*`; the shared server is anonymous, so its built-in tool
+//! authorization is a no-op — the autumn `Authorized<C>` extractor is the real
+//! gate). Cursor tokens are validated against a per-instance secret, so these
+//! handlers use the process-lifetime shared
+//! [`ServerState::mcp_server`](crate::state::ServerState::mcp_server) rather than
+//! constructing a server per request. `find_nodes_at_time` takes its arguments as
+//! a raw JSON **body** ([`Json<Value>`]) rather than a typed request so a #3360
+//! cursor-continuation POST (`{"cursor": "…"}`, with no `label`/`valid_time`)
+//! deserializes — those fields are required on the typed request but absent on a
+//! continuation.
+//!
+//! The three dispatch-routed reads are pinned with **hardcoded literal** tool
+//! names (`"get_node"`/`"list_nodes"`/`"find_nodes_at_time"`, never
+//! request-derived) and registered in
+//! [`crate::edge_tools::DISPATCH_ROUTED_READ_TOOLS`] so the shared
+//! `dispatch_pinned_names_match_routed_class` conformance test proves a
+//! read-gated handler can never pin a write tool's name.
+//!
+//! The writes and `count_nodes` reuse **already-public** symbols
+//! (`aletheiadb::mcp::{AletheiaMcpServer, CountNodesRequest, CreateNodeRequest,
+//! UpdateNodeRequest, DeleteNodeRequest, DeleteNodeCascadeRequest,
+//! RetractNodeRequest}`); `dispatch_tool_json` (the reads' entry) is the
+//! main-crate widening PR3 already landed. No further widening is required.
 //!
 //! The MCP tool result carries in-band errors (e.g. a missing node →
 //! `{"error":{"code":"NOT_FOUND",...}}`); we return that JSON verbatim with a
@@ -32,18 +65,18 @@
 //! (autumn maps `Json<T>` to the reserved `body` MCP argument key), so the
 //! `tools/call` `arguments` wrap the request under `"body"`.
 
+use crate::edge_tools::{insert_budget, insert_opt};
 use crate::security::resource_limits::{check_byte_cap_of, run_with_timeout};
 use crate::security::{Authorized, ReadClass, ServerSecurityState, WriteClass};
 use crate::state::ServerState;
 use aletheiadb::http::AletheiaHttpError;
 use aletheiadb::mcp::{
     AletheiaMcpServer, CountNodesRequest, CreateNodeRequest, DeleteNodeCascadeRequest,
-    DeleteNodeRequest, FindNodesAtTimeRequest, GetNodeRequest, ListNodesRequest,
-    RetractNodeRequest, UpdateNodeRequest,
+    DeleteNodeRequest, RetractNodeRequest, UpdateNodeRequest,
 };
 use autumn_web::prelude::{Json, Path, Query, get, post};
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 /// Parse an MCP tool method's JSON string result into a [`Value`] for the HTTP
 /// response. A non-JSON result (should not happen) degrades to a JSON string.
@@ -51,14 +84,24 @@ fn tool_json(s: String) -> Json<Value> {
     Json(serde_json::from_str::<Value>(&s).unwrap_or(Value::String(s)))
 }
 
-/// Query options for [`get_node`].
+/// Query options for [`get_node`] — the entity flag plus the #3353 token-budget
+/// parameters. `get_node` is a single-entity read: budgetable (#3353) but not
+/// cursorable (#3360).
 #[derive(Debug, Default, Deserialize)]
 pub struct GetNodeQuery {
     /// Return full vector/embedding arrays instead of the elided descriptor.
     pub include_vectors: Option<bool>,
+    /// #3353: cap the response at roughly this many tokens (utf8_bytes / 4).
+    pub max_response_tokens: Option<u64>,
+    /// #3353: byte-exact response cap.
+    pub max_response_bytes: Option<u64>,
+    /// #3353: property keys to protect first as the response degrades.
+    pub priority_properties: Option<Vec<String>>,
 }
 
 /// `get_node` — fetch a node by id, with bi-temporal bounds. HTTP + MCP tool.
+/// Budgetable (#3353); forwards raw arguments through `dispatch_tool_json` so the
+/// token budget applies (the typed method bypasses that pipeline).
 #[get("/nodes/{id}")]
 #[api_doc(
     description = "Fetch a node by id, returning its properties and bi-temporal bounds",
@@ -70,15 +113,26 @@ pub async fn get_node(
     Path(id): Path<u64>,
     Query(opts): Query<GetNodeQuery>,
 ) -> Json<Value> {
-    let server = AletheiaMcpServer::new(state.db_arc());
-    let out = server.get_node(GetNodeRequest {
-        node_id: id,
-        include_vectors: opts.include_vectors,
-    });
-    tool_json(out)
+    let server = state.mcp_server();
+    let mut args = Map::new();
+    args.insert("node_id".to_string(), Value::from(id));
+    insert_opt(
+        &mut args,
+        "include_vectors",
+        opts.include_vectors.map(Value::from),
+    );
+    insert_budget(
+        &mut args,
+        opts.max_response_tokens,
+        opts.max_response_bytes,
+        opts.priority_properties,
+    );
+    tool_json(server.dispatch_tool_json("get_node", Value::Object(args)))
 }
 
-/// Query options for [`list_nodes`].
+/// Query options for [`list_nodes`] — label/property/paging plus the #3353 token
+/// budget and the #3360 cursor parameters. `list_nodes` is budgetable **and**
+/// cursorable.
 #[derive(Debug, Default, Deserialize)]
 pub struct ListNodesQuery {
     /// Filter by node label.
@@ -93,10 +147,22 @@ pub struct ListNodesQuery {
     pub offset: Option<usize>,
     /// Return full vector/embedding arrays instead of the elided descriptor.
     pub include_vectors: Option<bool>,
+    /// #3353: cap the response at roughly this many tokens (utf8_bytes / 4).
+    pub max_response_tokens: Option<u64>,
+    /// #3353: byte-exact response cap.
+    pub max_response_bytes: Option<u64>,
+    /// #3353: property keys to protect first as the response degrades.
+    pub priority_properties: Option<Vec<String>>,
+    /// #3360: request a snapshot-anchored cursor on the first page.
+    pub use_cursor: Option<bool>,
+    /// #3360: opaque continuation token from a prior page (passed back alone).
+    pub cursor: Option<String>,
 }
 
 /// `list_nodes` — list nodes with optional label/property filtering + paging.
-/// HTTP + MCP tool.
+/// HTTP + MCP tool. Budgetable (#3353) and cursorable (#3360): forwards raw
+/// arguments through `dispatch_tool_json` so both pipelines apply (the typed
+/// method bypasses them).
 #[get("/nodes")]
 #[api_doc(
     description = "List nodes with optional label/property filtering and pagination",
@@ -118,17 +184,44 @@ pub async fn list_nodes(
     let limits = security.limits();
     let _guard = security.in_flight().try_acquire()?;
 
-    let db = state.db_arc();
-    let request = ListNodesRequest {
-        label: opts.label,
-        property_key: opts.property_key,
-        property_value: opts.property_value.map(Value::String),
-        limit: opts.limit,
-        offset: opts.offset,
-        include_vectors: opts.include_vectors,
-    };
+    // Route through the shared server's `dispatch_tool_json` so the #3353 token
+    // budget and #3360 cursor paging (read off the raw arguments) apply — the
+    // typed `list_nodes` method bypasses that pipeline. The cursor secret lives
+    // on the process-lifetime shared server, so continuations resume correctly.
+    let server = state.mcp_server();
+    let mut args = Map::new();
+    insert_opt(&mut args, "label", opts.label.map(Value::from));
+    insert_opt(
+        &mut args,
+        "property_key",
+        opts.property_key.map(Value::from),
+    );
+    // property_value arrives as a string on the HTTP query surface (matching the
+    // prior typed forwarding, which wrapped it in `Value::String`).
+    insert_opt(
+        &mut args,
+        "property_value",
+        opts.property_value.map(Value::from),
+    );
+    insert_opt(&mut args, "limit", opts.limit.map(Value::from));
+    insert_opt(&mut args, "offset", opts.offset.map(Value::from));
+    insert_opt(
+        &mut args,
+        "include_vectors",
+        opts.include_vectors.map(Value::from),
+    );
+    insert_budget(
+        &mut args,
+        opts.max_response_tokens,
+        opts.max_response_bytes,
+        opts.priority_properties,
+    );
+    insert_opt(&mut args, "use_cursor", opts.use_cursor.map(Value::from));
+    insert_opt(&mut args, "cursor", opts.cursor.map(Value::from));
+    let args = Value::Object(args);
+
     let out = run_with_timeout(limits.timeout, false, async move {
-        AletheiaMcpServer::new(db).list_nodes(request)
+        server.dispatch_tool_json("list_nodes", args)
     })
     .await?;
 
@@ -163,14 +256,15 @@ pub async fn count_nodes(
 
 // ════════════════════════════════════════════════════════════════════════════
 // Node-write cluster (Issue #3524, PR2): create / update / delete /
-// delete_cascade / retract — all [`WriteClass`], plus the [`ReadClass`]
-// point-in-time finder `find_nodes_at_time`.
+// delete_cascade / retract — all [`WriteClass`].
 //
 // Each handler forwards its request body to the exact legacy MCP typed method
 // and returns that method's `String` verbatim, so every contract those methods
 // implement — #3221 `valid_time`, #3209 DETACH refuse/detach, #3230 retraction
-// idempotency, #3232 temporal block, #3220 vector elision, #3236 point-in-time
-// reconstruction — is preserved byte-for-byte with **zero** reserialization.
+// idempotency, #3232 temporal block, #3220 vector elision — is preserved
+// byte-for-byte with **zero** reserialization. The [`ReadClass`] point-in-time
+// finder `find_nodes_at_time` follows the reads (below), routing through
+// `dispatch_tool_json` so the #3353 budget and #3360 cursor pipelines apply.
 // ════════════════════════════════════════════════════════════════════════════
 
 /// `create_node` — create a node with properties and optional bi-temporal
@@ -260,7 +354,17 @@ pub async fn retract_node(
 /// `find_nodes_at_time` — resolve nodes by label (+ optional exact property
 /// match) as they existed at a bi-temporal point (#3236), reconstructing each
 /// node's state at `(valid_time, transaction_time)`. Read-only ([`ReadClass`]);
-/// vectors elided by default (#3220). HTTP + MCP tool.
+/// vectors elided by default (#3220). Budgetable (#3353) and cursorable (#3360).
+/// HTTP + MCP tool.
+///
+/// The request rides as a raw JSON **body** ([`Value`]) forwarded verbatim
+/// through `dispatch_tool_json`, so (a) the #3353 budget
+/// (`max_response_tokens`/`max_response_bytes`/`priority_properties`) and #3360
+/// cursor (`use_cursor`/`cursor`) params flow through, and (b) a cursor
+/// continuation (`{"cursor": "…"}`, which omits the otherwise-required `label` /
+/// `valid_time`) deserializes — a typed request would reject it. With no
+/// budget/cursor present the body is exactly a `FindNodesAtTimeRequest`, so the
+/// result is byte-identical to the typed method.
 #[post("/nodes/find_at_time")]
 #[api_doc(
     description = "Find nodes by label/property as of a bi-temporal point, reconstructed at that time",
@@ -269,8 +373,8 @@ pub async fn retract_node(
 pub async fn find_nodes_at_time(
     _auth: Authorized<ReadClass>,
     state: ServerState,
-    Json(req): Json<FindNodesAtTimeRequest>,
+    Json(args): Json<Value>,
 ) -> Json<Value> {
-    let server = AletheiaMcpServer::new(state.db_arc());
-    tool_json(server.find_nodes_at_time(req))
+    let server = state.mcp_server();
+    tool_json(server.dispatch_tool_json("find_nodes_at_time", args))
 }

--- a/crates/aletheia-server/src/node_tools.rs
+++ b/crates/aletheia-server/src/node_tools.rs
@@ -34,11 +34,13 @@
 //! gate). Cursor tokens are validated against a per-instance secret, so these
 //! handlers use the process-lifetime shared
 //! [`ServerState::mcp_server`](crate::state::ServerState::mcp_server) rather than
-//! constructing a server per request. `find_nodes_at_time` takes its arguments as
-//! a raw JSON **body** ([`Json<Value>`]) rather than a typed request so a #3360
-//! cursor-continuation POST (`{"cursor": "…"}`, with no `label`/`valid_time`)
-//! deserializes — those fields are required on the typed request but absent on a
-//! continuation.
+//! constructing a server per request. `find_nodes_at_time` takes an
+//! **all-optional** typed body ([`FindNodesAtTimeQuery`]) — every field
+//! `Option<_>` — so a #3360 cursor-continuation POST (`{"cursor": "…"}`, with no
+//! `label`/`valid_time`) still deserializes (those two are logically required but
+//! their requiredness stays a runtime concern the dispatch layer enforces),
+//! while `/openapi.json` still gets a named, per-operation request schema instead
+//! of the shared generic `Value` component a raw `Json<Value>` body would emit.
 //!
 //! The three dispatch-routed reads are pinned with **hardcoded literal** tool
 //! names (`"get_node"`/`"list_nodes"`/`"find_nodes_at_time"`, never
@@ -351,20 +353,73 @@ pub async fn retract_node(
     tool_json(server.retract_node(req))
 }
 
+/// Request body for [`find_nodes_at_time`] — an **all-optional** mirror of the
+/// legacy `FindNodesAtTimeRequest` plus the #3353 token budget and the #3360
+/// cursor parameters.
+///
+/// Every field is `Option<_>` on purpose. `label` and `valid_time` are logically
+/// required for a fresh query, but requiredness stays a **runtime** concern:
+/// `dispatch_tool` already returns a structured `INVALID_ARGUMENT` when they are
+/// missing. Keeping them optional here is what lets a #3360 cursor-continuation
+/// body (`{"cursor": "…"}`, which omits `label` / `valid_time`) still
+/// deserialize. The handler rebuilds the raw MCP arguments object from the
+/// `Some` fields and forwards it through `dispatch_tool_json`, so budget/cursor
+/// still apply and a no-budget/no-cursor call is byte-identical to before.
+///
+/// This typed body (vs. a bare `Json<Value>`) is what restores a named,
+/// per-operation request schema in `/openapi.json` — mirroring the typed sibling
+/// handlers (`Json<CreateNodeRequest>` etc.) — instead of the shared, generic
+/// `Value` component the raw body produced.
+#[derive(Debug, Default, Deserialize)]
+pub struct FindNodesAtTimeQuery {
+    /// The node label to match (logically required; enforced at dispatch).
+    pub label: Option<String>,
+    /// Filter by property key (with `property_value`).
+    pub property_key: Option<String>,
+    /// Filter by exact property value (with `property_key`).
+    pub property_value: Option<Value>,
+    /// Valid time (logically required; enforced at dispatch): ISO 8601 / RFC 3339
+    /// or microseconds since epoch.
+    pub valid_time: Option<String>,
+    /// Transaction time (defaults to now when omitted).
+    pub transaction_time: Option<String>,
+    /// Maximum number of nodes to return.
+    pub limit: Option<usize>,
+    /// Number of matching nodes to skip.
+    pub offset: Option<usize>,
+    /// Return full vector/embedding arrays instead of the elided descriptor.
+    pub include_vectors: Option<bool>,
+    /// #3353: cap the response at roughly this many tokens (utf8_bytes / 4).
+    pub max_response_tokens: Option<u64>,
+    /// #3353: byte-exact response cap.
+    pub max_response_bytes: Option<u64>,
+    /// #3353: property keys to protect first as the response degrades.
+    pub priority_properties: Option<Vec<String>>,
+    /// #3360: request a snapshot-anchored cursor on the first page.
+    pub use_cursor: Option<bool>,
+    /// #3360: opaque continuation token from a prior page (passed back alone).
+    pub cursor: Option<String>,
+}
+
 /// `find_nodes_at_time` — resolve nodes by label (+ optional exact property
 /// match) as they existed at a bi-temporal point (#3236), reconstructing each
 /// node's state at `(valid_time, transaction_time)`. Read-only ([`ReadClass`]);
 /// vectors elided by default (#3220). Budgetable (#3353) and cursorable (#3360).
 /// HTTP + MCP tool.
 ///
-/// The request rides as a raw JSON **body** ([`Value`]) forwarded verbatim
-/// through `dispatch_tool_json`, so (a) the #3353 budget
+/// Takes the typed all-optional [`FindNodesAtTimeQuery`] body and rebuilds the
+/// raw MCP arguments (only the `Some` fields) before forwarding through
+/// `dispatch_tool_json`, so (a) the #3353 budget
 /// (`max_response_tokens`/`max_response_bytes`/`priority_properties`) and #3360
 /// cursor (`use_cursor`/`cursor`) params flow through, and (b) a cursor
 /// continuation (`{"cursor": "…"}`, which omits the otherwise-required `label` /
-/// `valid_time`) deserializes — a typed request would reject it. With no
-/// budget/cursor present the body is exactly a `FindNodesAtTimeRequest`, so the
-/// result is byte-identical to the typed method.
+/// `valid_time`) deserializes — required-ness stays a runtime concern the
+/// dispatch layer enforces with a structured `INVALID_ARGUMENT`. With no
+/// budget/cursor present the rebuilt args equal a `FindNodesAtTimeRequest`, so
+/// the result is byte-identical to the legacy method. A non-object body is not
+/// representable through the typed extractor; were one to reach dispatch it would
+/// degrade to the same structured `INVALID_ARGUMENT` as the legacy `Value::Null`
+/// contract (no guard needed).
 #[post("/nodes/find_at_time")]
 #[api_doc(
     description = "Find nodes by label/property as of a bi-temporal point, reconstructed at that time",
@@ -373,8 +428,38 @@ pub async fn retract_node(
 pub async fn find_nodes_at_time(
     _auth: Authorized<ReadClass>,
     state: ServerState,
-    Json(args): Json<Value>,
+    Json(opts): Json<FindNodesAtTimeQuery>,
 ) -> Json<Value> {
     let server = state.mcp_server();
-    tool_json(server.dispatch_tool_json("find_nodes_at_time", args))
+    let mut args = Map::new();
+    insert_opt(&mut args, "label", opts.label.map(Value::from));
+    insert_opt(
+        &mut args,
+        "property_key",
+        opts.property_key.map(Value::from),
+    );
+    // property_value is already a JSON value (string/number/bool/null).
+    insert_opt(&mut args, "property_value", opts.property_value);
+    insert_opt(&mut args, "valid_time", opts.valid_time.map(Value::from));
+    insert_opt(
+        &mut args,
+        "transaction_time",
+        opts.transaction_time.map(Value::from),
+    );
+    insert_opt(&mut args, "limit", opts.limit.map(Value::from));
+    insert_opt(&mut args, "offset", opts.offset.map(Value::from));
+    insert_opt(
+        &mut args,
+        "include_vectors",
+        opts.include_vectors.map(Value::from),
+    );
+    insert_budget(
+        &mut args,
+        opts.max_response_tokens,
+        opts.max_response_bytes,
+        opts.priority_properties,
+    );
+    insert_opt(&mut args, "use_cursor", opts.use_cursor.map(Value::from));
+    insert_opt(&mut args, "cursor", opts.cursor.map(Value::from));
+    tool_json(server.dispatch_tool_json("find_nodes_at_time", Value::Object(args)))
 }

--- a/crates/aletheia-server/tests/node_reads_budget_cursor.rs
+++ b/crates/aletheia-server/tests/node_reads_budget_cursor.rs
@@ -1,0 +1,612 @@
+//! Budget-shaping + cursor-paging conformance for the three dispatch-routed node
+//! reads (`get_node`, `list_nodes`, `find_nodes_at_time`) — the NODE-READS
+//! BUDGET/CURSOR RETROFIT (Issue #3524 follow-up).
+//!
+//! PR2 forwarded these three reads through the main crate's **typed** per-tool
+//! methods (`AletheiaMcpServer::get_node`/`list_nodes`/`find_nodes_at_time`),
+//! which bypass `dispatch_tool` — so the Issue #3353 token budget
+//! (`max_response_tokens`/`max_response_bytes`/`priority_properties`) and the
+//! Issue #3360 cursor paging (`use_cursor`/`cursor`) were **silently dropped**.
+//! The retrofit routes them through `AletheiaMcpServer::dispatch_tool_json` with
+//! a hardcoded literal tool name via the process-lifetime shared
+//! `ServerState::mcp_server()` (so the cursor secret persists across requests),
+//! exactly like the four budgetable edge reads (`tests/edge_parity.rs`).
+//!
+//! Each test drives the autumn [`TestClient`] and asserts the response equals
+//! the **legacy dispatch** (`AletheiaMcpServer::dispatch_tool_json`) byte-for-byte
+//! for the same budget, that omitting the budget/cursor reproduces the full
+//! output, and — the **parity blind spot** these tests close — that a small
+//! budget actually SHAPES the node-read response (a `budget` block appears and
+//! the response shrinks) rather than being ignored as the typed forwarding did.
+
+use std::sync::Arc;
+
+use aletheia_server::build_server_client;
+use aletheiadb::AletheiaDB;
+use aletheiadb::PropertyMapBuilder;
+use aletheiadb::auth::{AuthMode, AuthStore, Role};
+use aletheiadb::core::NodeId;
+use aletheiadb::mcp::AletheiaMcpServer;
+use autumn_web::test::TestClient;
+use serde_json::{Value, json};
+
+const READER_TOKEN: &str = "reader-token-abcdefghijklmnop";
+const EMBEDDING: &[f32] = &[0.10, 0.20, 0.30, 0.40];
+
+/// A long property value so a single node / a small fan-out comfortably exceeds
+/// a modest byte budget, forcing the #3353 ladder to shape the response down.
+const LONG_NOTE: &str = "a deliberately long note property, repeated so the full \
+     serialized response comfortably exceeds a moderate byte budget and the #3353 \
+     ladder must shape it down: lorem ipsum dolor sit amet consectetur adipiscing \
+     elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua ut enim \
+     ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex";
+
+fn make_store() -> Arc<AuthStore> {
+    let store = Arc::new(AuthStore::new());
+    store
+        .insert_bootstrap_key("reader", Role::Reader, READER_TOKEN)
+        .expect("insert reader key");
+    store
+}
+
+fn fresh_db() -> Arc<AletheiaDB> {
+    Arc::new(AletheiaDB::new().expect("create db"))
+}
+
+fn mcp_server(db: &Arc<AletheiaDB>) -> AletheiaMcpServer {
+    AletheiaMcpServer::new(db.clone())
+}
+
+/// Recursively drop the per-request `trace_id`, the wall-clock-volatile
+/// bi-temporal timestamps, and the `find_nodes_at_time`-echoed
+/// `transaction_time` so an autumn response and a legacy dispatch are comparable.
+fn normalize(v: Value) -> Value {
+    match v {
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .filter(|(k, _)| {
+                    !matches!(
+                        k.as_str(),
+                        "trace_id"
+                            | "valid_from"
+                            | "valid_to"
+                            | "transaction_from"
+                            | "transaction_to"
+                            | "transaction_time"
+                            | "snapshot_valid_time"
+                            | "snapshot_transaction_time"
+                            | "cursor"
+                            | "cursor_ttl_seconds"
+                    )
+                })
+                .map(|(k, val)| (k, normalize(val)))
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(items.into_iter().map(normalize).collect()),
+        other => other,
+    }
+}
+
+async fn get(client: &TestClient, uri: &str, bearer: Option<&str>) -> (u16, Value) {
+    let mut req = client.get(uri);
+    if let Some(token) = bearer {
+        req = req.header("authorization", &format!("Bearer {token}"));
+    }
+    let resp = req.send().await;
+    let status = resp.status.as_u16();
+    let body: Value = serde_json::from_str(&resp.text()).expect("new body is JSON");
+    (status, body)
+}
+
+async fn post(client: &TestClient, uri: &str, body: &Value, bearer: Option<&str>) -> (u16, Value) {
+    let mut req = client.post(uri);
+    if let Some(token) = bearer {
+        req = req.header("authorization", &format!("Bearer {token}"));
+    }
+    let resp = req.json(body).send().await;
+    let status = resp.status.as_u16();
+    let body: Value = serde_json::from_str(&resp.text()).expect("new body is JSON");
+    (status, body)
+}
+
+/// Seed `count` `Person{idx, note:<long>}` nodes, returning their ids (ascending,
+/// deterministic on a fresh db). The long `note` makes the full response bulky.
+fn seed_people(db: &Arc<AletheiaDB>, count: usize) -> Vec<NodeId> {
+    let mut ids = Vec::new();
+    for i in 0..count {
+        let id = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("idx", i as i64)
+                    .insert("note", LONG_NOTE)
+                    .build(),
+            )
+            .expect("seed person");
+        ids.push(id);
+    }
+    ids
+}
+
+fn len_of(v: &Value) -> usize {
+    serde_json::to_string(v).expect("serialize").len()
+}
+
+/// Seed a single `Person` whose full read comfortably exceeds the #3353
+/// single-entity minimal-rung floor (~852 bytes), so a budget above that floor
+/// but below the full size forces the ladder to shape (elide the bulky note).
+fn seed_bulky_person(db: &Arc<AletheiaDB>) -> NodeId {
+    let big_note = LONG_NOTE.repeat(6); // ~2.4 KiB, well above the floor
+    db.create_node(
+        "Person",
+        PropertyMapBuilder::new()
+            .insert("name", "Alice")
+            .insert("note", big_note.as_str())
+            .insert_vector("embedding", EMBEDDING)
+            .build(),
+    )
+    .expect("seed bulky person")
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// #3353 token budget on the three node reads. The budget rides the RAW arguments
+// and is applied in `AletheiaMcpServer::dispatch_tool` (the typed per-tool
+// methods bypass it), so the handlers forward through `dispatch_tool_json`. The
+// tests use that same public entry as the legacy reference.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn list_nodes_token_budget_shapes_response_and_matches_legacy() {
+    let db = fresh_db();
+    seed_people(&db, 6);
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    // `list_nodes` enumerates only under a `label` filter (an unlabeled list is a
+    // stub `count:0` message), so the whole budget path is exercised with
+    // `label=Person`. Full (no budget): larger than the cap, no `budget` block.
+    let (status, full) = get(&client, "/nodes?label=Person", Some(READER_TOKEN)).await;
+    assert_eq!(status, 200);
+    assert!(full.get("budget").is_none(), "no budget block: {full}");
+    assert_eq!(full["count"], 6);
+    let cap: u64 = 2000;
+    assert!(
+        len_of(&full) as u64 > cap,
+        "full response should exceed the cap: {}",
+        len_of(&full)
+    );
+
+    // Legacy dispatch is the reference; its emitted string is the exact bytes the
+    // #3353 contract bounds.
+    let budget_args = json!({ "label": "Person", "max_response_bytes": cap });
+    let legacy_text = mcp_server(&db).dispatch_tool_json("list_nodes", budget_args);
+    assert!(
+        legacy_text.len() as u64 <= cap,
+        "emitted string must fit the byte budget: {} > {cap}",
+        legacy_text.len()
+    );
+    let legacy: Value = serde_json::from_str(&legacy_text).expect("legacy json");
+    assert!(
+        legacy["budget"].is_object(),
+        "budget block discloses the applied rung: {legacy}"
+    );
+
+    // Autumn surface with the same budget must match the legacy dispatch.
+    let (status, budgeted) = get(
+        &client,
+        &format!("/nodes?label=Person&max_response_bytes={cap}"),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert!(budgeted["budget"].is_object(), "shaped: {budgeted}");
+    assert_eq!(
+        normalize(budgeted),
+        normalize(legacy),
+        "budgeted autumn list_nodes must equal the legacy dispatch for the same budget"
+    );
+}
+
+#[tokio::test]
+async fn get_node_token_budget_parity() {
+    // The single-entity budgetable read forwards the budget: a byte budget above
+    // the minimal-rung floor but below the full size yields the same shaped
+    // result as the legacy dispatch.
+    let db = fresh_db();
+    let id = seed_bulky_person(&db);
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    let cap: u64 = 2000;
+    let (status, budgeted) = get(
+        &client,
+        &format!("/nodes/{}?max_response_bytes={cap}", id.as_u64()),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert!(budgeted["budget"].is_object(), "shaped: {budgeted}");
+
+    let legacy_text = mcp_server(&db).dispatch_tool_json(
+        "get_node",
+        json!({ "node_id": id.as_u64(), "max_response_bytes": cap }),
+    );
+    assert!(
+        legacy_text.len() as u64 <= cap,
+        "emitted string must fit the byte budget: {} > {cap}",
+        legacy_text.len()
+    );
+    let legacy: Value = serde_json::from_str(&legacy_text).expect("legacy json");
+    assert_eq!(
+        normalize(budgeted),
+        normalize(legacy),
+        "get_node budgeted autumn response must equal the legacy dispatch"
+    );
+}
+
+#[tokio::test]
+async fn find_nodes_at_time_token_budget_shapes_response_and_matches_legacy() {
+    let db = fresh_db();
+    seed_people(&db, 6);
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    let vt = "2999-01-01T00:00:00Z"; // after creation → resolves all seeded nodes
+    let base = json!({ "label": "Person", "valid_time": vt });
+
+    // Full (no budget): no `budget` block, exceeds the cap.
+    let (status, full) = post(&client, "/nodes/find_at_time", &base, Some(READER_TOKEN)).await;
+    assert_eq!(status, 200);
+    assert!(full.get("budget").is_none(), "no budget block: {full}");
+    assert_eq!(full["count"], 6);
+    let cap: u64 = 2000;
+    assert!(
+        len_of(&full) as u64 > cap,
+        "full response should exceed the cap: {}",
+        len_of(&full)
+    );
+
+    let legacy_text = mcp_server(&db).dispatch_tool_json(
+        "find_nodes_at_time",
+        json!({ "label": "Person", "valid_time": vt, "max_response_bytes": cap }),
+    );
+    assert!(
+        legacy_text.len() as u64 <= cap,
+        "emitted string must fit the byte budget: {} > {cap}",
+        legacy_text.len()
+    );
+    let legacy: Value = serde_json::from_str(&legacy_text).expect("legacy json");
+    assert!(legacy["budget"].is_object(), "budget block: {legacy}");
+
+    let mut budgeted_req = base.clone();
+    budgeted_req["max_response_bytes"] = json!(cap);
+    let (status, budgeted) = post(
+        &client,
+        "/nodes/find_at_time",
+        &budgeted_req,
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert!(budgeted["budget"].is_object(), "shaped: {budgeted}");
+    assert_eq!(
+        normalize(budgeted),
+        normalize(legacy),
+        "budgeted autumn find_nodes_at_time must equal the legacy dispatch"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// PARITY BLIND SPOT: the node reads must HONOR a budget, not merely default.
+//
+// The original gap was invisible to a pure default-output parity test: typed
+// forwarding produced byte-identical DEFAULT output, so parity passed while the
+// budget was silently dropped. These tests assert the *shaped* behavior — a
+// `budget` block appears AND the response shrinks under a small budget — which is
+// exactly what typed forwarding could NOT do and what would have caught the gap.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn list_nodes_budget_is_honored_not_silently_dropped() {
+    let db = fresh_db();
+    seed_people(&db, 6);
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    let (_s, full) = get(&client, "/nodes?label=Person", Some(READER_TOKEN)).await;
+    let (_s, budgeted) = get(
+        &client,
+        "/nodes?label=Person&max_response_bytes=2000",
+        Some(READER_TOKEN),
+    )
+    .await;
+
+    // Pre-retrofit (typed forwarding) these two would be byte-identical with no
+    // `budget` block — the silent-drop bug. Post-retrofit the budgeted response
+    // is shaped: it carries a `budget` block and is strictly smaller.
+    assert!(
+        full.get("budget").is_none(),
+        "unbudgeted response must not be shaped: {full}"
+    );
+    assert!(
+        budgeted["budget"].is_object(),
+        "budget MUST be honored (shaped), not dropped: {budgeted}"
+    );
+    assert!(
+        len_of(&budgeted) < len_of(&full),
+        "shaped response must be smaller than the full one: {} !< {}",
+        len_of(&budgeted),
+        len_of(&full)
+    );
+    assert!(
+        len_of(&budgeted) <= 2000,
+        "shaped response must fit the byte budget: {}",
+        len_of(&budgeted)
+    );
+}
+
+#[tokio::test]
+async fn find_nodes_at_time_budget_is_honored_not_silently_dropped() {
+    let db = fresh_db();
+    seed_people(&db, 6);
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    let vt = "2999-01-01T00:00:00Z";
+    let (_s, full) = post(
+        &client,
+        "/nodes/find_at_time",
+        &json!({ "label": "Person", "valid_time": vt }),
+        Some(READER_TOKEN),
+    )
+    .await;
+    let (_s, budgeted) = post(
+        &client,
+        "/nodes/find_at_time",
+        &json!({ "label": "Person", "valid_time": vt, "max_response_bytes": 2000 }),
+        Some(READER_TOKEN),
+    )
+    .await;
+
+    assert!(
+        full.get("budget").is_none(),
+        "unbudgeted not shaped: {full}"
+    );
+    assert!(
+        budgeted["budget"].is_object(),
+        "budget MUST be honored, not dropped: {budgeted}"
+    );
+    assert!(
+        len_of(&budgeted) < len_of(&full),
+        "shaped response must be smaller: {} !< {}",
+        len_of(&budgeted),
+        len_of(&full)
+    );
+}
+
+#[tokio::test]
+async fn get_node_budget_is_honored_not_silently_dropped() {
+    let db = fresh_db();
+    let id = seed_bulky_person(&db);
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    let (_s, full) = get(
+        &client,
+        &format!("/nodes/{}", id.as_u64()),
+        Some(READER_TOKEN),
+    )
+    .await;
+    let (_s, budgeted) = get(
+        &client,
+        &format!("/nodes/{}?max_response_bytes=2000", id.as_u64()),
+        Some(READER_TOKEN),
+    )
+    .await;
+
+    assert!(
+        full.get("budget").is_none(),
+        "unbudgeted not shaped: {full}"
+    );
+    assert!(
+        budgeted["budget"].is_object(),
+        "budget MUST be honored on the single-entity read, not dropped: {budgeted}"
+    );
+    assert!(
+        len_of(&budgeted) < len_of(&full),
+        "shaped single-entity response must be smaller: {} !< {}",
+        len_of(&budgeted),
+        len_of(&full)
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// #3360 cursor paging on `list_nodes` and `find_nodes_at_time`. `use_cursor:true`
+// opens a snapshot-anchored scan returning an opaque cursor + first page; passing
+// the cursor back (alone) continues it, duplicate-free and gap-free, until the
+// union equals the full result. The cursor secret lives on the process-lifetime
+// shared server in `ServerState`, so a token issued on one request resumes on
+// the next — the scan is driven autumn-only (a separate `AletheiaMcpServer`
+// instance signs with a different secret and could not decode the token).
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn list_nodes_cursor_paging_snapshot_anchored() {
+    let db = fresh_db();
+    let ids = seed_people(&db, 3);
+    let expected: std::collections::BTreeSet<u64> = ids.iter().map(|n| n.as_u64()).collect();
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    // First page: cursor paging requires `label` (an enumerable candidate set);
+    // per-page size of 1 forces continuation.
+    let (status, page1) = get(
+        &client,
+        "/nodes?label=Person&use_cursor=true&limit=1",
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert_eq!(
+        page1["paging"], "cursor",
+        "cursor paging disclosed: {page1}"
+    );
+    assert!(
+        page1["snapshot_valid_time"].is_string(),
+        "snapshot disclosed: {page1}"
+    );
+    assert!(
+        page1["cursor"].as_str().is_some(),
+        "first page returns a continuation token: {page1}"
+    );
+
+    let mut seen: Vec<u64> = Vec::new();
+    let mut page = page1.clone();
+    let mut prev_snapshot = page1["snapshot_valid_time"].clone();
+    let mut guard = 0;
+    loop {
+        for n in page["nodes"].as_array().expect("nodes array") {
+            seen.push(n["id"].as_u64().expect("node id"));
+        }
+        let Some(token) = page["cursor"].as_str() else {
+            break;
+        };
+        // Continuation: the token carries all discriminating state; it is passed
+        // back alone. The base64url no-pad token is URL-safe.
+        let token = token.to_string();
+        let (status, next) = get(
+            &client,
+            &format!("/nodes?cursor={token}"),
+            Some(READER_TOKEN),
+        )
+        .await;
+        assert_eq!(status, 200, "continuation page: {next}");
+        assert_eq!(
+            next["snapshot_valid_time"], prev_snapshot,
+            "continuation stays on the pinned snapshot: {next}"
+        );
+        prev_snapshot = next["snapshot_valid_time"].clone();
+        page = next;
+        guard += 1;
+        assert!(guard < 10, "cursor scan did not terminate");
+    }
+
+    let seen_set: std::collections::BTreeSet<u64> = seen.iter().copied().collect();
+    assert_eq!(seen.len(), seen_set.len(), "no duplicates across pages");
+    assert_eq!(
+        seen_set, expected,
+        "union of pages equals the full node set"
+    );
+}
+
+#[tokio::test]
+async fn find_nodes_at_time_cursor_paging_snapshot_anchored() {
+    let db = fresh_db();
+    let ids = seed_people(&db, 3);
+    let expected: std::collections::BTreeSet<u64> = ids.iter().map(|n| n.as_u64()).collect();
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    let vt = "2999-01-01T00:00:00Z";
+    let (status, page1) = post(
+        &client,
+        "/nodes/find_at_time",
+        &json!({ "label": "Person", "valid_time": vt, "use_cursor": true, "limit": 1 }),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert_eq!(
+        page1["paging"], "cursor",
+        "cursor paging disclosed: {page1}"
+    );
+    assert!(
+        page1["cursor"].as_str().is_some(),
+        "first page returns a continuation token: {page1}"
+    );
+
+    let mut seen: Vec<u64> = Vec::new();
+    let mut page = page1.clone();
+    let mut prev_snapshot = page1["snapshot_valid_time"].clone();
+    let mut guard = 0;
+    loop {
+        for n in page["nodes"].as_array().expect("nodes array") {
+            seen.push(n["id"].as_u64().expect("node id"));
+        }
+        let Some(token) = page["cursor"].as_str() else {
+            break;
+        };
+        // #3360: the continuation body carries ONLY the cursor (no label /
+        // valid_time) — which is exactly why the handler forwards a raw JSON body
+        // rather than a typed request (those fields are otherwise required).
+        let (status, next) = post(
+            &client,
+            "/nodes/find_at_time",
+            &json!({ "cursor": token }),
+            Some(READER_TOKEN),
+        )
+        .await;
+        assert_eq!(status, 200, "continuation page: {next}");
+        assert_eq!(
+            next["snapshot_valid_time"], prev_snapshot,
+            "continuation stays on the pinned snapshot: {next}"
+        );
+        prev_snapshot = next["snapshot_valid_time"].clone();
+        page = next;
+        guard += 1;
+        assert!(guard < 10, "cursor scan did not terminate");
+    }
+
+    let seen_set: std::collections::BTreeSet<u64> = seen.iter().copied().collect();
+    assert_eq!(seen.len(), seen_set.len(), "no duplicates across pages");
+    assert_eq!(
+        seen_set, expected,
+        "union of pages equals the full node set"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Default (no budget/cursor) parity: the retrofit must not change today's output.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn node_reads_default_output_unchanged() {
+    let db = fresh_db();
+    seed_people(&db, 2);
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    // get_node
+    let (_s, get_body) = get(&client, "/nodes/1", Some(READER_TOKEN)).await;
+    let legacy_get: Value = serde_json::from_str(
+        &mcp_server(&db).dispatch_tool_json("get_node", json!({ "node_id": 1 })),
+    )
+    .expect("legacy get_node json");
+    assert_eq!(
+        normalize(get_body),
+        normalize(legacy_get),
+        "default get_node output must be unchanged"
+    );
+
+    // list_nodes
+    let (_s, list_body) = get(&client, "/nodes", Some(READER_TOKEN)).await;
+    let legacy_list: Value =
+        serde_json::from_str(&mcp_server(&db).dispatch_tool_json("list_nodes", json!({})))
+            .expect("legacy list_nodes json");
+    assert_eq!(
+        normalize(list_body),
+        normalize(legacy_list),
+        "default list_nodes output must be unchanged"
+    );
+
+    // find_nodes_at_time
+    let vt = "2999-01-01T00:00:00Z";
+    let (_s, find_body) = post(
+        &client,
+        "/nodes/find_at_time",
+        &json!({ "label": "Person", "valid_time": vt }),
+        Some(READER_TOKEN),
+    )
+    .await;
+    let legacy_find: Value = serde_json::from_str(&mcp_server(&db).dispatch_tool_json(
+        "find_nodes_at_time",
+        json!({ "label": "Person", "valid_time": vt }),
+    ))
+    .expect("legacy find json");
+    assert_eq!(
+        normalize(find_body),
+        normalize(legacy_find),
+        "default find_nodes_at_time output must be unchanged"
+    );
+}

--- a/crates/aletheia-server/tests/node_reads_budget_cursor.rs
+++ b/crates/aletheia-server/tests/node_reads_budget_cursor.rs
@@ -610,3 +610,61 @@ async fn node_reads_default_output_unchanged() {
         "default find_nodes_at_time output must be unchanged"
     );
 }
+
+// ════════════════════════════════════════════════════════════════════════════
+// OpenAPI schema fidelity (Gemini review follow-up): the `find_nodes_at_time`
+// POST body must expose a named, per-operation request schema in /openapi.json —
+// mirroring the typed sibling write handlers — instead of the shared generic
+// `Value` component a raw `Json<Value>` body produced.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn openapi_find_nodes_at_time_has_typed_request_schema() {
+    let db = fresh_db();
+    let client = build_server_client(db, make_store(), AuthMode::Required);
+    let resp = client.get("/openapi.json").send().await;
+    assert_eq!(resp.status.as_u16(), 200);
+    let spec: Value = serde_json::from_str(&resp.text()).expect("openapi json");
+
+    // find_nodes_at_time (POST /nodes/find_at_time): the request body schema is a
+    // named, per-operation component ref — NOT the shared, generic `Value`
+    // component the old `Json<Value>` body emitted.
+    let find_schema = &spec["paths"]["/nodes/find_at_time"]["post"]["requestBody"]["content"]["application/json"]
+        ["schema"];
+    let find_ref = find_schema["$ref"].as_str().unwrap_or_else(|| {
+        panic!(
+            "find_at_time requestBody schema must be a $ref: {}",
+            spec["paths"]["/nodes/find_at_time"]
+        )
+    });
+    assert!(
+        find_ref.ends_with("/FindNodesAtTimeQuery"),
+        "find_at_time request body must ref a typed per-operation schema, got {find_ref}"
+    );
+    assert_ne!(
+        find_ref, "#/components/schemas/Value",
+        "must not degrade to the shared generic Value component"
+    );
+
+    // The referenced component exists as a typed object.
+    let comp = &spec["components"]["schemas"]["FindNodesAtTimeQuery"];
+    assert_eq!(
+        comp["type"], "object",
+        "FindNodesAtTimeQuery must be a typed object component: {comp}"
+    );
+
+    // Mirror a typed sibling: create_node (POST /nodes) refs its own named
+    // component the same way — so find_at_time is no longer uniquely untyped.
+    let sibling_ref = spec["paths"]["/nodes"]["post"]["requestBody"]["content"]["application/json"]
+        ["schema"]["$ref"]
+        .as_str()
+        .expect("create_node requestBody must be a $ref (typed sibling)");
+    assert!(
+        sibling_ref.starts_with("#/components/schemas/"),
+        "typed sibling uses a named component ref: {sibling_ref}"
+    );
+    assert!(
+        !sibling_ref.ends_with("/Value"),
+        "typed sibling is not the generic Value component: {sibling_ref}"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to PR3 (Issue #3524). Closes a real gap in the merged node read handlers.

### Before / After

**Before:** `get_node`, `list_nodes`, and `find_nodes_at_time` in `crates/aletheia-server/src/node_tools.rs` forwarded through the **typed** `AletheiaMcpServer` per-tool methods (`server.get_node(req)`, …). Those typed methods call `handle_*` directly and **bypass** `AletheiaMcpServer::dispatch_tool`, where the cross-cutting read features live. Their request structs do not carry the budget/cursor params, so the **#3353 token budget** (`max_response_tokens` / `max_response_bytes` / `priority_properties`) and the **#3360 cursor paging** (`use_cursor` / `cursor`) were **silently dropped** — a caller could pass a budget and get the full, unshaped response back.

**After:** the three node reads route the **raw JSON arguments** through the shared `ServerState::mcp_server()` Arc's `dispatch_tool_json("<pinned>", args)` — exactly the pattern PR3 established for the four budgetable edge reads. Both pipelines now apply, and the reads honor a budget / open a cursor instead of ignoring them.

- `get_node` — carries the #3353 budget params (single-entity read, **not** cursorable).
- `list_nodes` — carries #3353 budget **and** #3360 cursor; keeps its B4 resource-limits wiring (in-flight guard / timeout / byte cap).
- `find_nodes_at_time` — carries #3353 budget **and** #3360 cursor. Takes an **all-optional typed body** (`Json<FindNodesAtTimeQuery>`) so a cursor-continuation POST (`{"cursor": "…"}`, which omits the otherwise-required `label` / `valid_time`) still deserializes, while `/openapi.json` keeps a named, per-operation request schema (see the review-follow-up section below).
- `count_nodes` and the write cluster are unchanged (neither budgetable nor cursorable → typed forwarding retained).

Default (no budget/cursor) output stays **byte-identical** to today — asserted by `node_reads_default_output_unchanged`.

### Why (root cause)

The typed per-tool methods (`AletheiaMcpServer::{get_node,list_nodes,find_nodes_at_time}`) invoke `handle_*` directly. Budget shaping and cursor paging are applied in `dispatch_tool` off the **raw arguments**, invisible to the typed request structs. Routing through `dispatch_tool_json` (the entry PR3 added) is the fix. The shared, process-lifetime `mcp_server()` Arc is required so the cursor signing secret and live-cursor registry persist across requests.

**Main-crate widenings: none** (`dispatch_tool_json` already on trunk from PR3, marker `// exposed for autumn-web migration (Issue #3524)`).

### Merge-base

Verified PR3 present on the base: `crates/aletheia-server/src/edge_tools.rs` exists and `src/mcp/server.rs` has `pub fn dispatch_tool_json` (line 655) with the `autumn-web migration (Issue #3524)` marker (line 654).

## Marker ↔ inventory

`tests/parity/inventory.json` classifies all three node reads `access_class: read`; each handler's `Authorized<C>` marker is `ReadClass`, and each is pinned in `DISPATCH_ROUTED_READ_TOOLS` with `AccessClass::Read`.

| Tool | inventory `access_class` | handler marker | pinned class | budgetable | cursorable |
|------|--------------------------|----------------|--------------|------------|------------|
| `get_node` | read | `Authorized<ReadClass>` | `Read` | yes | no |
| `list_nodes` | read | `Authorized<ReadClass>` | `Read` | yes | yes |
| `find_nodes_at_time` | read | `Authorized<ReadClass>` | `Read` | yes | yes |

## Pinned call sites (never request-derived)

- `node_tools::get_node` → `dispatch_tool_json("get_node", …)`
- `node_tools::list_nodes` → `dispatch_tool_json("list_nodes", …)`
- `node_tools::find_nodes_at_time` → `dispatch_tool_json("find_nodes_at_time", …)`

## Tests / AC evidence

New file `crates/aletheia-server/tests/node_reads_budget_cursor.rs`, plus the extended conformance table.

| AC | Test | Evidence |
|----|------|----------|
| Budget shapes + matches legacy dispatch byte-for-byte | `list_nodes_token_budget_shapes_response_and_matches_legacy`, `get_node_token_budget_parity`, `find_nodes_at_time_token_budget_shapes_response_and_matches_legacy` | ok |
| **Blind spot**: reads HONOR a budget (shaped + smaller), not dropped — would have caught the original gap | `list_nodes_budget_is_honored_not_silently_dropped`, `find_nodes_at_time_budget_is_honored_not_silently_dropped`, `get_node_budget_is_honored_not_silently_dropped` | ok |
| Cursor: opaque token + snapshot-anchored, duplicate-free continuation | `list_nodes_cursor_paging_snapshot_anchored`, `find_nodes_at_time_cursor_paging_snapshot_anchored` | ok |
| Omitting budget/cursor reproduces full output (parity) | `node_reads_default_output_unchanged` | ok |
| OpenAPI: `find_nodes_at_time` request body is a typed per-operation schema (not generic `Value`) | `openapi_find_nodes_at_time_has_typed_request_schema` | ok |
| Conformance table now covers the 3 node reads | `server_parity::dispatch_pinned_names_match_routed_class` | ok |

```
running 10 tests
test get_node_budget_is_honored_not_silently_dropped ... ok
test get_node_token_budget_parity ... ok
test find_nodes_at_time_cursor_paging_snapshot_anchored ... ok
test find_nodes_at_time_token_budget_shapes_response_and_matches_legacy ... ok
test find_nodes_at_time_budget_is_honored_not_silently_dropped ... ok
test list_nodes_cursor_paging_snapshot_anchored ... ok
test list_nodes_budget_is_honored_not_silently_dropped ... ok
test node_reads_default_output_unchanged ... ok
test openapi_find_nodes_at_time_has_typed_request_schema ... ok
test list_nodes_token_budget_shapes_response_and_matches_legacy ... ok
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.22s
```

```
test dispatch_pinned_names_match_routed_class ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 19 filtered out
```

## Review follow-up (Gemini) — commit `2db0a88`

The reviewer flagged that `find_nodes_at_time`'s original `Json<Value>` body (a) could hit non-object payloads and (b) degrades the OpenAPI schema.

- **(a) assessed as already-graceful — no guard added.** `dispatch_tool_json` handles a non-object body gracefully: `as_object() → None` / `serde_json::from_value → Err` yield a structured `INVALID_ARGUMENT`, matching the legacy `Value::Null` contract. No validation guard is warranted.
- **(b) real — fixed.** `Json<Value>` made this route's `/openapi.json` request-body `$ref` the shared, generic `Value` component — uniquely untyped among the node reads. Restored OpenAPI typed-schema fidelity with the same typed-struct pattern already used for `list_nodes`: a new **all-optional** `FindNodesAtTimeQuery` (mirroring the legacy `FindNodesAtTimeRequest` plus the #3353 budget trio and #3360 `use_cursor`/`cursor`). The handler rebuilds the raw args from the `Some` fields (`insert_opt`/`insert_budget`) and dispatches as before. `label`/`valid_time` stay `Option` (requiredness remains a runtime concern the dispatch layer enforces), so a cursor-only continuation body still deserializes. Behavior is byte-identical for a full query and a cursor-only continuation; new `openapi_find_nodes_at_time_has_typed_request_schema` asserts the request body now `$ref`s the named `FindNodesAtTimeQuery` object component, mirroring a typed sibling (`create_node` → `CreateNodeRequest`).

All 6 gates re-run green after this commit.

## Gates (isolated `CARGO_TARGET_DIR`)

All green:

- `cargo clippy -p aletheia-server --all-targets -- -D warnings` → Finished (clean)
- `cargo test -p aletheia-server` → all suites pass (0 failed)
- `cargo fmt --all -- --check` → clean
- `cargo check -p aletheiadb --no-default-features --tests --features http-server` → Finished
- `cargo test --features http-server,mcp-server --test parity_http --test parity_mcp` → 33 + 11 passed, 0 failed
- `cargo clippy -p aletheiadb --features "config-toml,mcp-server,sharding-rpc,simulation" --all-targets -- -D warnings` → Finished (clean)

## Coverage note

The codecov/patch check is non-blocking here: the coverage job does not instrument the new `aletheia-server` crate (the `ci.yml` scope fix is tracked by CI-infra). New tests are exercised by the standard `cargo test -p aletheia-server` gate above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEwJg2bDPZ7DzcHebqwZVK

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEwJg2bDPZ7DzcHebqwZVK)_