### PR TITLE
feat(server): port traversal + temporal MCP tools to autumn-web (PR4, #3524)

### DIFF
--- a/crates/aletheia-server/src/app.rs
+++ b/crates/aletheia-server/src/app.rs
@@ -16,6 +16,7 @@ use crate::http_routes;
 use crate::node_tools;
 use crate::security::{self, SecurityConfig};
 use crate::state::ServerState;
+use crate::traverse_temporal_tools;
 use aletheiadb::AletheiaDB;
 use aletheiadb::auth::{AuthMode, AuthStore};
 use autumn_web::openapi::OpenApiConfig;
@@ -85,6 +86,18 @@ pub fn try_build_server_testapp(
             edge_tools::update_edge,
             edge_tools::delete_edge,
             edge_tools::retract_edge,
+            traverse_temporal_tools::traverse,
+            traverse_temporal_tools::get_node_history,
+            traverse_temporal_tools::get_edge_history,
+            traverse_temporal_tools::get_node_at_time,
+            traverse_temporal_tools::get_edge_at_time,
+            traverse_temporal_tools::list_changes,
+            traverse_temporal_tools::get_node_at_valid_time,
+            traverse_temporal_tools::get_node_at_transaction_time,
+            traverse_temporal_tools::diff_node_versions,
+            traverse_temporal_tools::get_edge_at_valid_time,
+            traverse_temporal_tools::get_edge_at_transaction_time,
+            traverse_temporal_tools::diff_edge_versions,
         ])
         .openapi(OpenApiConfig::new("AletheiaDB", env!("CARGO_PKG_VERSION")))
         .mount_mcp("/mcp");

--- a/crates/aletheia-server/src/edge_tools.rs
+++ b/crates/aletheia-server/src/edge_tools.rs
@@ -81,6 +81,14 @@ use serde_json::{Map, Value};
 /// dispatch-routed too (see [`crate::node_tools`]) and are pinned here in the
 /// same table so the one `dispatch_pinned_names_match_routed_class` conformance
 /// test covers every dispatch-routed read across both clusters.
+///
+/// The two dispatch-routed **traversal/temporal** reads (`traverse`,
+/// `get_node_history`) are pinned here too (see
+/// [`crate::traverse_temporal_tools`]): both are budgetable (#3353) so they
+/// forward raw arguments through `dispatch_tool_json`, `traverse` additionally
+/// cursorable (#3360). The other ten tools in that cluster are not budgetable /
+/// cursorable and forward through typed methods, so they are not dispatch-routed
+/// and do not appear here.
 pub const DISPATCH_ROUTED_READ_TOOLS: &[(&str, AccessClass)] = &[
     ("get_edge", AccessClass::Read),
     ("list_edges", AccessClass::Read),
@@ -89,6 +97,8 @@ pub const DISPATCH_ROUTED_READ_TOOLS: &[(&str, AccessClass)] = &[
     ("get_node", AccessClass::Read),
     ("list_nodes", AccessClass::Read),
     ("find_nodes_at_time", AccessClass::Read),
+    ("traverse", AccessClass::Read),
+    ("get_node_history", AccessClass::Read),
 ];
 
 /// Parse an MCP tool method's JSON string result into a [`Value`] for the HTTP

--- a/crates/aletheia-server/src/lib.rs
+++ b/crates/aletheia-server/src/lib.rs
@@ -33,6 +33,7 @@ pub mod http_routes;
 pub mod node_tools;
 pub mod security;
 pub mod state;
+pub mod traverse_temporal_tools;
 
 pub use app::{
     build_server_client, build_server_client_with_config, build_server_testapp,

--- a/crates/aletheia-server/src/traverse_temporal_tools.rs
+++ b/crates/aletheia-server/src/traverse_temporal_tools.rs
@@ -1,0 +1,539 @@
+//! Traversal + temporal tools: the multi-hop `traverse` and the eleven
+//! time-travel reads `get_node_history` / `get_edge_history` / `get_node_at_time`
+//! / `get_edge_at_time` / `list_changes` / `get_node_at_valid_time` /
+//! `get_node_at_transaction_time` / `diff_node_versions` /
+//! `get_edge_at_valid_time` / `get_edge_at_transaction_time` /
+//! `diff_edge_versions` (Issue #3524, PR4).
+//!
+//! Each is a single `#[get(...)]`/`#[post(...)]` + `#[api_doc(description=...,
+//! mcp)]` handler, so one definition surfaces on **HTTP**, **MCP-over-HTTP**
+//! (`/mcp`), and **OpenAPI** at once. The response body is produced by the
+//! *exact* main-crate MCP surface, so it is byte-identical to the legacy MCP
+//! surface (bare entity JSON + the `temporal` block #3232, #3220 vector elision
+//! on the traversal read path, and #3225 point-in-time traversal semantics) —
+//! asserted in the parity suite against the shared
+//! [`AletheiaMcpServer`](aletheiadb::mcp::AletheiaMcpServer) over the same
+//! `Arc<AletheiaDB>`.
+//!
+//! # Forwarding: dispatch-routed vs. typed methods vs. local-body dispatch
+//!
+//! The **single source of truth** for which reads honor the Issue #3353 token
+//! budget is `aletheiadb::mcp`'s `BUDGETABLE_READ_TOOLS`, and for the Issue
+//! #3360 cursor the `inject_cursor_schema_params` set. Verified against source,
+//! of this cluster's twelve tools **only `traverse` and `get_node_history` are
+//! budgetable**, and **only `traverse` is cursorable**. That split drives three
+//! forwarding shapes:
+//!
+//! 1. **`traverse`** — budgetable + cursorable + potentially ms-scale. Forwards
+//!    the raw JSON arguments through
+//!    [`AletheiaMcpServer::dispatch_tool_json`](aletheiadb::mcp::AletheiaMcpServer::dispatch_tool_json)
+//!    (so the #3353 budget and #3360 cursor pipelines, read off the raw
+//!    arguments in `dispatch_tool`, apply) via the process-lifetime shared
+//!    [`ServerState::mcp_server`](crate::state::ServerState::mcp_server) (so the
+//!    cursor signing secret + live-cursor registry persist across the
+//!    continuation requests). It runs under the **exact** B4 resource-limits
+//!    wiring `list_nodes` uses — a bounded in-flight admission guard released by
+//!    RAII on any exit, a per-query wall-clock [`run_with_timeout`], and a
+//!    serialized-byte cap ([`check_byte_cap_of`]) — because a deep traversal is
+//!    the one potentially-slow read in this cluster (mirroring the legacy HTTP
+//!    `/query` execution model). `traverse` is registered in
+//!    [`crate::edge_tools::DISPATCH_ROUTED_READ_TOOLS`] with the hardcoded literal
+//!    `"traverse"`.
+//! 2. **`get_node_history`** — budgetable (but NOT cursorable). Forwards raw
+//!    arguments through `dispatch_tool_json` (budget only) so the #3353 budget
+//!    applies. History reconstruction is fast, so it runs **inline** (no
+//!    in-flight guard / timeout). Registered in `DISPATCH_ROUTED_READ_TOOLS` with
+//!    the hardcoded literal `"get_node_history"`.
+//! 3. **The other ten** — NOT budgetable, NOT cursorable. They forward through a
+//!    **typed** path, inline (like the edge writes / `count_nodes`):
+//!    - the four that have a public typed per-tool method
+//!      (`get_node_at_time`, `get_edge_at_time`, `list_changes`,
+//!      `get_edge_history`) take that method's re-exported request struct as the
+//!      `Json<T>` body (or a `Path` id) and call
+//!      `AletheiaMcpServer::get_node_at_time(req)` etc. directly — zero
+//!      reserialization, using only already-public symbols;
+//!    - the six that have **no** public typed method
+//!      (`get_node_at_valid_time`, `get_node_at_transaction_time`,
+//!      `diff_node_versions`, `get_edge_at_valid_time`,
+//!      `get_edge_at_transaction_time`, `diff_edge_versions`) take a **local**
+//!      typed body struct (mirroring the main-crate request shape, one-to-one, so
+//!      `/openapi.json` gets a named per-operation component — never a generic
+//!      `Value`) and forward through `dispatch_tool_json` with a hardcoded literal
+//!      tool name. `dispatch_tool_json` is the *only* public entry for these six
+//!      (their `handle_*` methods are private) and, being non-budgetable /
+//!      non-cursorable, it reproduces a hypothetical typed method's output
+//!      byte-for-byte (same `handle_*`). This keeps the migration free of any
+//!      main-crate change for these six.
+//!
+//! All twelve are classified [`ReadClass`]; the marker rides in each handler's
+//! `Authorized<C>` signature (the one place the class is declared), which autumn
+//! replays for `/mcp tools/call`. The two dispatch-routed budgetable reads are
+//! pinned with **hardcoded literal** tool names and registered in
+//! `DISPATCH_ROUTED_READ_TOOLS` so the shared
+//! `dispatch_pinned_names_match_routed_class` conformance test proves a
+//! read-gated handler can never pin a write tool's name.
+//!
+//! The MCP tool result carries in-band errors (e.g. a missing node →
+//! `{"error":{"code":"NOT_FOUND",...}}`); we return that JSON verbatim with a
+//! 200, matching the MCP method's `String` return exactly.
+
+use crate::edge_tools::{insert_budget, insert_opt};
+use crate::security::resource_limits::{check_byte_cap_of, run_with_timeout};
+use crate::security::{Authorized, ReadClass, ServerSecurityState};
+use crate::state::ServerState;
+use aletheiadb::http::AletheiaHttpError;
+use aletheiadb::mcp::{
+    GetEdgeAtTimeRequest, GetEdgeHistoryRequest, GetNodeAtTimeRequest, ListChangesRequest,
+};
+use autumn_web::prelude::{Json, Path, Query, get, post};
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+/// Parse an MCP tool method's JSON string result into a [`Value`] for the HTTP
+/// response. A non-JSON result (should not happen) degrades to a JSON string.
+fn tool_json(s: String) -> Json<Value> {
+    Json(serde_json::from_str::<Value>(&s).unwrap_or(Value::String(s)))
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// traverse — [`ReadClass`], budgetable (#3353) + cursorable (#3360) + the one
+// potentially-slow read in this cluster. Forwards raw arguments through
+// `dispatch_tool_json` (so budget + cursor apply) under the exact B4
+// resource-limits wiring `list_nodes` uses.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Query options for [`traverse`] — every field optional so a #3360
+/// cursor-continuation request (`?cursor=…`, with no `start_node_id` /
+/// `edge_label`) still deserializes; requiredness of `start_node_id` /
+/// `edge_label` on a fresh call stays a runtime concern the dispatch layer
+/// enforces with a structured `INVALID_ARGUMENT`. Carries the traversal params
+/// plus the #3353 token budget and the #3360 cursor parameters.
+#[derive(Debug, Default, Deserialize)]
+pub struct TraverseQuery {
+    /// Starting node id for the traversal (logically required; enforced at
+    /// dispatch, and superseded by the token on a cursor continuation).
+    pub start_node_id: Option<u64>,
+    /// Edge label to follow (logically required; enforced at dispatch).
+    pub edge_label: Option<String>,
+    /// Traversal direction: `outgoing` (default), `incoming`, or `both`.
+    pub direction: Option<String>,
+    /// Maximum traversal depth (default 1).
+    pub depth: Option<usize>,
+    /// Maximum number of results to return.
+    pub limit: Option<usize>,
+    /// Number of results to skip (offset pagination, #3226).
+    pub offset: Option<usize>,
+    /// Return full vector/embedding arrays instead of the elided descriptor.
+    pub include_vectors: Option<bool>,
+    /// #3225: valid time (ISO 8601 / RFC 3339 or microseconds since epoch) —
+    /// switches to a bi-temporal, point-in-time traversal.
+    pub as_of_valid_time: Option<String>,
+    /// #3225: transaction time (ISO 8601 / RFC 3339 or microseconds since epoch).
+    pub as_of_transaction_time: Option<String>,
+    /// #3353: cap the response at roughly this many tokens (utf8_bytes / 4).
+    pub max_response_tokens: Option<u64>,
+    /// #3353: byte-exact response cap.
+    pub max_response_bytes: Option<u64>,
+    /// #3353: property keys to protect first as the response degrades.
+    pub priority_properties: Option<Vec<String>>,
+    /// #3360: request a snapshot-anchored cursor on the first page.
+    pub use_cursor: Option<bool>,
+    /// #3360: opaque continuation token from a prior page (passed back alone).
+    pub cursor: Option<String>,
+}
+
+/// `traverse` — multi-hop graph traversal from a start node following edges of a
+/// label, with optional #3225 bi-temporal `as_of_*` coordinates. [`ReadClass`];
+/// vectors elided by default (#3220); budgetable (#3353) and cursorable (#3360).
+/// HTTP + MCP tool.
+///
+/// Forwards raw arguments through `dispatch_tool_json` (so the #3353 budget and
+/// #3360 cursor pipelines apply) under the B4 resource-limits wiring — a bounded
+/// in-flight admission guard (503 at capacity, released by RAII on any exit), a
+/// per-query wall-clock timeout (429 on deadline), and a serialized-byte cap
+/// (413) — identical to `list_nodes`, because a deep traversal is the one
+/// potentially-slow read here (mirroring the legacy `/query` execution model).
+#[get("/traverse")]
+#[api_doc(
+    description = "Traverse the graph from a start node following edges of a label, optionally as of a bi-temporal point",
+    mcp
+)]
+pub async fn traverse(
+    _auth: Authorized<ReadClass>,
+    security: ServerSecurityState,
+    state: ServerState,
+    Query(opts): Query<TraverseQuery>,
+) -> Result<Json<Value>, AletheiaHttpError> {
+    // B4 resource-limits wiring (#3542 / #3550), identical to `list_nodes`: a
+    // bounded in-flight admission guard (503 UNAVAILABLE at capacity, released by
+    // RAII on any exit), a per-query wall-clock timeout (429 on deadline), and a
+    // serialized-byte cap on the exact wire response (413). Generous defaults
+    // make this a no-op on the parity path.
+    let limits = security.limits();
+    let _guard = security.in_flight().try_acquire()?;
+
+    // Route through the shared server's `dispatch_tool_json` so the #3353 token
+    // budget and #3360 cursor paging (read off the raw arguments) apply — the
+    // typed `traverse` method bypasses that pipeline. The cursor secret lives on
+    // the process-lifetime shared server, so continuations resume correctly.
+    let server = state.mcp_server();
+    let mut args = Map::new();
+    insert_opt(
+        &mut args,
+        "start_node_id",
+        opts.start_node_id.map(Value::from),
+    );
+    insert_opt(&mut args, "edge_label", opts.edge_label.map(Value::from));
+    insert_opt(&mut args, "direction", opts.direction.map(Value::from));
+    insert_opt(&mut args, "depth", opts.depth.map(Value::from));
+    insert_opt(&mut args, "limit", opts.limit.map(Value::from));
+    insert_opt(&mut args, "offset", opts.offset.map(Value::from));
+    insert_opt(
+        &mut args,
+        "include_vectors",
+        opts.include_vectors.map(Value::from),
+    );
+    insert_opt(
+        &mut args,
+        "as_of_valid_time",
+        opts.as_of_valid_time.map(Value::from),
+    );
+    insert_opt(
+        &mut args,
+        "as_of_transaction_time",
+        opts.as_of_transaction_time.map(Value::from),
+    );
+    insert_budget(
+        &mut args,
+        opts.max_response_tokens,
+        opts.max_response_bytes,
+        opts.priority_properties,
+    );
+    insert_opt(&mut args, "use_cursor", opts.use_cursor.map(Value::from));
+    insert_opt(&mut args, "cursor", opts.cursor.map(Value::from));
+    let args = Value::Object(args);
+
+    let out = run_with_timeout(limits.timeout, false, async move {
+        server.dispatch_tool_json("traverse", args)
+    })
+    .await?;
+
+    let value = serde_json::from_str::<Value>(&out).unwrap_or(Value::String(out));
+    // Cap against the exact serialized response bytes (undercount-proof).
+    check_byte_cap_of(&value, limits.max_response_bytes)?;
+    Ok(Json(value))
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// get_node_history — [`ReadClass`], budgetable (#3353) but NOT cursorable.
+// Forwards raw arguments through `dispatch_tool_json` (budget only). Inline
+// (history reconstruction is fast).
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Query options for [`get_node_history`] / (shape-shared) the #3353 token
+/// budget on a single-entity history read.
+#[derive(Debug, Default, Deserialize)]
+pub struct HistoryBudgetQuery {
+    /// #3353: cap the response at roughly this many tokens (utf8_bytes / 4).
+    pub max_response_tokens: Option<u64>,
+    /// #3353: byte-exact response cap.
+    pub max_response_bytes: Option<u64>,
+    /// #3353: property keys to protect first as the response degrades.
+    pub priority_properties: Option<Vec<String>>,
+}
+
+/// `get_node_history` — the complete version history of a node, oldest first.
+/// [`ReadClass`]; budgetable (#3353), not cursorable. Forwards raw arguments
+/// through `dispatch_tool_json` so the token budget applies. HTTP + MCP tool.
+#[get("/nodes/{id}/history")]
+#[api_doc(
+    description = "Get the complete version history of a node, oldest first, with per-version provenance",
+    mcp
+)]
+pub async fn get_node_history(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Path(id): Path<u64>,
+    Query(opts): Query<HistoryBudgetQuery>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    let mut args = Map::new();
+    args.insert("node_id".to_string(), Value::from(id));
+    insert_budget(
+        &mut args,
+        opts.max_response_tokens,
+        opts.max_response_bytes,
+        opts.priority_properties,
+    );
+    tool_json(server.dispatch_tool_json("get_node_history", Value::Object(args)))
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Typed-method reads (NOT budgetable, NOT cursorable): forward through the exact
+// public typed per-tool method, inline, like the edge writes / count_nodes.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// `get_node_at_time` — time-travel a node to a bi-temporal `(valid_time,
+/// transaction_time)` point (#3232 temporal block). [`ReadClass`]. HTTP + MCP.
+#[post("/nodes/at_time")]
+#[api_doc(
+    description = "Get a node's state at a specific valid time and transaction time (bi-temporal point-in-time read)",
+    mcp
+)]
+pub async fn get_node_at_time(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Json(req): Json<GetNodeAtTimeRequest>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    tool_json(server.get_node_at_time(req))
+}
+
+/// `get_edge_at_time` — time-travel an edge to a bi-temporal `(valid_time,
+/// transaction_time)` point (#3232 temporal block). [`ReadClass`]. HTTP + MCP.
+#[post("/edges/at_time")]
+#[api_doc(
+    description = "Get an edge's state at a specific valid time and transaction time (bi-temporal point-in-time read)",
+    mcp
+)]
+pub async fn get_edge_at_time(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Json(req): Json<GetEdgeAtTimeRequest>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    tool_json(server.get_edge_at_time(req))
+}
+
+/// `list_changes` — the nodes and edges whose versions were committed in a
+/// transaction-time window `[tx_from, tx_to)`, with optional valid-time / label
+/// filtering and stable cursor pagination. [`ReadClass`]. HTTP + MCP.
+#[post("/changes")]
+#[api_doc(
+    description = "List nodes and edges whose versions were committed within a transaction-time window",
+    mcp
+)]
+pub async fn list_changes(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Json(req): Json<ListChangesRequest>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    tool_json(server.list_changes(req))
+}
+
+/// `get_edge_history` — the complete version history of an edge, oldest first.
+/// [`ReadClass`]; NOT budgetable (so it forwards through the typed method, not
+/// `dispatch_tool_json`). HTTP + MCP tool.
+#[get("/edges/{id}/history")]
+#[api_doc(
+    description = "Get the complete version history of an edge, oldest first, with per-version provenance",
+    mcp
+)]
+pub async fn get_edge_history(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Path(id): Path<u64>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    tool_json(server.get_edge_history(GetEdgeHistoryRequest { edge_id: id }))
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Local-body dispatch reads (NOT budgetable, NOT cursorable, NO public typed
+// method): a local typed body (mirroring the main-crate request shape one-to-one
+// so /openapi.json gets a named per-operation component) forwarded through
+// `dispatch_tool_json` with a hardcoded literal tool name — the only public
+// entry for these six. Byte-identical to a hypothetical typed method (same
+// `handle_*`), so no main-crate change is required.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Request body for [`get_node_at_valid_time`] — mirrors the main-crate
+/// `GetNodeAtValidTimeRequest`.
+#[derive(Debug, Deserialize)]
+pub struct NodeAtValidTimeBody {
+    /// The unique identifier of the node.
+    pub node_id: u64,
+    /// Valid time (ISO 8601 / RFC 3339): when the fact was true in reality.
+    pub valid_time: String,
+}
+
+/// `get_node_at_valid_time` — a node's state at a specific valid time
+/// (independent-dimension query, transaction time = now). [`ReadClass`]. HTTP +
+/// MCP tool.
+#[post("/nodes/at_valid_time")]
+#[api_doc(
+    description = "Get a node's state at a specific valid time (independent-dimension query)",
+    mcp
+)]
+pub async fn get_node_at_valid_time(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Json(req): Json<NodeAtValidTimeBody>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    let mut args = Map::new();
+    args.insert("node_id".to_string(), Value::from(req.node_id));
+    args.insert("valid_time".to_string(), Value::from(req.valid_time));
+    tool_json(server.dispatch_tool_json("get_node_at_valid_time", Value::Object(args)))
+}
+
+/// Request body for [`get_node_at_transaction_time`] — mirrors the main-crate
+/// `GetNodeAtTransactionTimeRequest`.
+#[derive(Debug, Deserialize)]
+pub struct NodeAtTransactionTimeBody {
+    /// The unique identifier of the node.
+    pub node_id: u64,
+    /// Transaction time (ISO 8601 / RFC 3339): when the fact was recorded.
+    pub transaction_time: String,
+}
+
+/// `get_node_at_transaction_time` — a node's state at a specific transaction
+/// time (independent-dimension query, valid time = now). [`ReadClass`]. HTTP +
+/// MCP tool.
+#[post("/nodes/at_transaction_time")]
+#[api_doc(
+    description = "Get a node's state at a specific transaction time (independent-dimension query)",
+    mcp
+)]
+pub async fn get_node_at_transaction_time(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Json(req): Json<NodeAtTransactionTimeBody>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    let mut args = Map::new();
+    args.insert("node_id".to_string(), Value::from(req.node_id));
+    args.insert(
+        "transaction_time".to_string(),
+        Value::from(req.transaction_time),
+    );
+    tool_json(server.dispatch_tool_json("get_node_at_transaction_time", Value::Object(args)))
+}
+
+/// Request body for [`diff_node_versions`] — mirrors the main-crate
+/// `DiffNodeVersionsRequest`.
+#[derive(Debug, Deserialize)]
+pub struct DiffNodeVersionsBody {
+    /// The unique identifier of the node.
+    pub node_id: u64,
+    /// The id of the older version (from).
+    pub from_version: u64,
+    /// The id of the newer version (to).
+    pub to_version: u64,
+}
+
+/// `diff_node_versions` — the property-level difference between two versions of
+/// a node. [`ReadClass`]. HTTP + MCP tool.
+#[post("/nodes/diff")]
+#[api_doc(
+    description = "Compute the property-level difference between two versions of a node",
+    mcp
+)]
+pub async fn diff_node_versions(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Json(req): Json<DiffNodeVersionsBody>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    let mut args = Map::new();
+    args.insert("node_id".to_string(), Value::from(req.node_id));
+    args.insert("from_version".to_string(), Value::from(req.from_version));
+    args.insert("to_version".to_string(), Value::from(req.to_version));
+    tool_json(server.dispatch_tool_json("diff_node_versions", Value::Object(args)))
+}
+
+/// Request body for [`get_edge_at_valid_time`] — mirrors the main-crate
+/// `GetEdgeAtValidTimeRequest`.
+#[derive(Debug, Deserialize)]
+pub struct EdgeAtValidTimeBody {
+    /// The unique identifier of the edge.
+    pub edge_id: u64,
+    /// Valid time (ISO 8601 / RFC 3339): when the fact was true in reality.
+    pub valid_time: String,
+}
+
+/// `get_edge_at_valid_time` — an edge's state at a specific valid time
+/// (independent-dimension query, transaction time = now). [`ReadClass`]. HTTP +
+/// MCP tool.
+#[post("/edges/at_valid_time")]
+#[api_doc(
+    description = "Get an edge's state at a specific valid time (independent-dimension query)",
+    mcp
+)]
+pub async fn get_edge_at_valid_time(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Json(req): Json<EdgeAtValidTimeBody>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    let mut args = Map::new();
+    args.insert("edge_id".to_string(), Value::from(req.edge_id));
+    args.insert("valid_time".to_string(), Value::from(req.valid_time));
+    tool_json(server.dispatch_tool_json("get_edge_at_valid_time", Value::Object(args)))
+}
+
+/// Request body for [`get_edge_at_transaction_time`] — mirrors the main-crate
+/// `GetEdgeAtTransactionTimeRequest`.
+#[derive(Debug, Deserialize)]
+pub struct EdgeAtTransactionTimeBody {
+    /// The unique identifier of the edge.
+    pub edge_id: u64,
+    /// Transaction time (ISO 8601 / RFC 3339): when the fact was recorded.
+    pub transaction_time: String,
+}
+
+/// `get_edge_at_transaction_time` — an edge's state at a specific transaction
+/// time (independent-dimension query, valid time = now). [`ReadClass`]. HTTP +
+/// MCP tool.
+#[post("/edges/at_transaction_time")]
+#[api_doc(
+    description = "Get an edge's state at a specific transaction time (independent-dimension query)",
+    mcp
+)]
+pub async fn get_edge_at_transaction_time(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Json(req): Json<EdgeAtTransactionTimeBody>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    let mut args = Map::new();
+    args.insert("edge_id".to_string(), Value::from(req.edge_id));
+    args.insert(
+        "transaction_time".to_string(),
+        Value::from(req.transaction_time),
+    );
+    tool_json(server.dispatch_tool_json("get_edge_at_transaction_time", Value::Object(args)))
+}
+
+/// Request body for [`diff_edge_versions`] — mirrors the main-crate
+/// `DiffEdgeVersionsRequest`.
+#[derive(Debug, Deserialize)]
+pub struct DiffEdgeVersionsBody {
+    /// The unique identifier of the edge.
+    pub edge_id: u64,
+    /// The id of the older version (from).
+    pub from_version: u64,
+    /// The id of the newer version (to).
+    pub to_version: u64,
+}
+
+/// `diff_edge_versions` — the property-level difference between two versions of
+/// an edge. [`ReadClass`]. HTTP + MCP tool.
+#[post("/edges/diff")]
+#[api_doc(
+    description = "Compute the property-level difference between two versions of an edge",
+    mcp
+)]
+pub async fn diff_edge_versions(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Json(req): Json<DiffEdgeVersionsBody>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    let mut args = Map::new();
+    args.insert("edge_id".to_string(), Value::from(req.edge_id));
+    args.insert("from_version".to_string(), Value::from(req.from_version));
+    args.insert("to_version".to_string(), Value::from(req.to_version));
+    tool_json(server.dispatch_tool_json("diff_edge_versions", Value::Object(args)))
+}

--- a/crates/aletheia-server/tests/traverse_temporal_parity.rs
+++ b/crates/aletheia-server/tests/traverse_temporal_parity.rs
@@ -1,0 +1,810 @@
+//! Parity + behavior tests for the TRAVERSAL + TEMPORAL cluster (Issue #3524,
+//! PR4): `traverse`, `get_node_history`, `get_edge_history`, `get_node_at_time`,
+//! `get_edge_at_time`, `list_changes`, `get_node_at_valid_time`,
+//! `get_node_at_transaction_time`, `diff_node_versions`,
+//! `get_edge_at_valid_time`, `get_edge_at_transaction_time`,
+//! `diff_edge_versions`.
+//!
+//! Each test drives the new crate's autumn [`TestClient`] and asserts the
+//! response equals the **legacy MCP surface** over the same `Arc<AletheiaDB>` —
+//! byte-for-byte (parsed-JSON equality, `trace_id` + wall-clock-volatile
+//! bi-temporal timestamps normalized) — in both anonymous and required auth
+//! modes. The legacy reference is the typed per-tool method where one exists
+//! (`traverse`/`get_node_history`/`get_edge_history`/`get_node_at_time`/
+//! `get_edge_at_time`/`list_changes`) and `dispatch_tool_json` for the six tools
+//! that have no public typed method. Plus: `traverse` behavior-pinned assertions
+//! (#3225), #3353 budget shaping for the two budgetable reads (`traverse`,
+//! `get_node_history`), #3360 snapshot-anchored cursor paging for `traverse`,
+//! #3232 temporal block presence, and #3220 vector elision on the traversal
+//! path.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use aletheia_server::build_server_client;
+use aletheiadb::auth::{AccessClass, AuthMode, AuthStore, Role};
+use aletheiadb::mcp::{
+    AletheiaMcpServer, GetEdgeAtTimeRequest, GetEdgeHistoryRequest, GetNodeAtTimeRequest,
+    GetNodeHistoryRequest, ListChangesRequest, UpdateEdgeRequest, UpdateNodeRequest,
+};
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+use autumn_web::test::TestClient;
+use serde_json::{Value, json};
+
+const ADMIN_TOKEN: &str = "admin-token-abcdefghijklmnop";
+const READER_TOKEN: &str = "reader-token-abcdefghijklmnop";
+const EMBEDDING: &[f32] = &[0.10, 0.20, 0.30, 0.40];
+
+/// A long note so a single traversal result / a single node history comfortably
+/// exceeds a modest byte budget, forcing the #3353 ladder to shape it down.
+const LONG_NOTE: &str = "a deliberately long note property, repeated so the full \
+     serialized response comfortably exceeds a moderate byte budget and the #3353 \
+     ladder must shape it down: lorem ipsum dolor sit amet consectetur adipiscing \
+     elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua ut enim \
+     ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex";
+
+/// A far-future valid time that resolves every committed fact.
+const FUTURE_VT: &str = "2999-01-01T00:00:00Z";
+
+struct Fixture {
+    db: Arc<AletheiaDB>,
+    store: Arc<AuthStore>,
+    alice: u64,
+    bob: u64,
+    edge: u64,
+}
+
+fn make_store() -> Arc<AuthStore> {
+    let store = Arc::new(AuthStore::new());
+    store
+        .insert_bootstrap_key("admin", Role::Admin, ADMIN_TOKEN)
+        .expect("insert admin key");
+    store
+        .insert_bootstrap_key("reader", Role::Reader, READER_TOKEN)
+        .expect("insert reader key");
+    store
+}
+
+fn mcp_server(db: &Arc<AletheiaDB>) -> AletheiaMcpServer {
+    AletheiaMcpServer::new(db.clone())
+}
+
+/// A shared DB with Alice --KNOWS--> Bob (both bearing an embedding), each entity
+/// carrying two versions so history / diff / at-time reads have real depth.
+fn fixture() -> Fixture {
+    let db = Arc::new(AletheiaDB::new().expect("create db"));
+    let alice = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .insert("age", 30_i64)
+                .insert("note", LONG_NOTE)
+                .insert_vector("embedding", EMBEDDING)
+                .build(),
+        )
+        .expect("create alice")
+        .as_u64();
+    let bob = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Bob")
+                .insert("age", 25_i64)
+                .insert("note", LONG_NOTE)
+                .insert_vector("embedding", EMBEDDING)
+                .build(),
+        )
+        .expect("create bob")
+        .as_u64();
+    let edge = db
+        .create_edge(
+            aletheiadb::core::NodeId::new(alice).unwrap(),
+            aletheiadb::core::NodeId::new(bob).unwrap(),
+            "KNOWS",
+            PropertyMapBuilder::new().insert("since", 2020_i64).build(),
+        )
+        .expect("create edge")
+        .as_u64();
+
+    // Second version of each entity so history/diff have two versions.
+    let server = mcp_server(&db);
+    let _ = server.update_node(UpdateNodeRequest {
+        node_id: alice,
+        properties: [
+            ("name".to_string(), json!("Alice")),
+            ("age".to_string(), json!(31)),
+            ("note".to_string(), json!(LONG_NOTE)),
+        ]
+        .into_iter()
+        .collect(),
+        valid_time: None,
+        provenance: None,
+        derived_from: None,
+    });
+    let _ = server.update_edge(UpdateEdgeRequest {
+        edge_id: edge,
+        properties: [("since".to_string(), json!(2021))].into_iter().collect(),
+        valid_time: None,
+        provenance: None,
+        derived_from: None,
+    });
+
+    Fixture {
+        db,
+        store: make_store(),
+        alice,
+        bob,
+        edge,
+    }
+}
+
+/// Recursively drop the per-request `trace_id`, the wall-clock-volatile
+/// bi-temporal timestamps, and the echoed volatile `transaction_time` so an
+/// autumn response and a legacy reference are comparable.
+fn normalize(v: Value) -> Value {
+    match v {
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .filter(|(k, _)| {
+                    !matches!(
+                        k.as_str(),
+                        "trace_id"
+                            | "valid_from"
+                            | "valid_to"
+                            | "transaction_from"
+                            | "transaction_to"
+                            | "transaction_time"
+                            | "snapshot_valid_time"
+                            | "snapshot_transaction_time"
+                            | "cursor"
+                            | "cursor_ttl_seconds"
+                    )
+                })
+                .map(|(k, val)| (k, normalize(val)))
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(items.into_iter().map(normalize).collect()),
+        other => other,
+    }
+}
+
+fn len_of(v: &Value) -> usize {
+    serde_json::to_string(v).expect("serialize").len()
+}
+
+async fn get(client: &TestClient, uri: &str, bearer: Option<&str>) -> (u16, Value) {
+    let mut req = client.get(uri);
+    if let Some(token) = bearer {
+        req = req.header("authorization", &format!("Bearer {token}"));
+    }
+    let resp = req.send().await;
+    let status = resp.status.as_u16();
+    let body: Value = serde_json::from_str(&resp.text()).expect("new body is JSON");
+    (status, body)
+}
+
+async fn post(client: &TestClient, uri: &str, body: &Value, bearer: Option<&str>) -> (u16, Value) {
+    let mut req = client.post(uri);
+    if let Some(token) = bearer {
+        req = req.header("authorization", &format!("Bearer {token}"));
+    }
+    let resp = req.json(body).send().await;
+    let status = resp.status.as_u16();
+    let body: Value = serde_json::from_str(&resp.text()).expect("new body is JSON");
+    (status, body)
+}
+
+/// Fetch the two oldest `version_id`s of a node from its history (autumn).
+async fn node_versions(client: &TestClient, id: u64, bearer: Option<&str>) -> (u64, u64) {
+    let (status, body) = get(client, &format!("/nodes/{id}/history"), bearer).await;
+    assert_eq!(status, 200, "history: {body}");
+    let versions = body["versions"].as_array().expect("versions array");
+    assert!(versions.len() >= 2, "need two versions: {body}");
+    (
+        versions[0]["version_id"].as_u64().expect("v0 id"),
+        versions[1]["version_id"].as_u64().expect("v1 id"),
+    )
+}
+
+/// Fetch the two oldest `version_id`s of an edge from its history (autumn).
+async fn edge_versions(client: &TestClient, id: u64, bearer: Option<&str>) -> (u64, u64) {
+    let (status, body) = get(client, &format!("/edges/{id}/history"), bearer).await;
+    assert_eq!(status, 200, "history: {body}");
+    let versions = body["versions"].as_array().expect("versions array");
+    assert!(versions.len() >= 2, "need two versions: {body}");
+    (
+        versions[0]["version_id"].as_u64().expect("v0 id"),
+        versions[1]["version_id"].as_u64().expect("v1 id"),
+    )
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Byte-parity for all twelve tools vs the legacy MCP surface, in both auth modes.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Drive every one of the twelve tools through the autumn surface and assert the
+/// response equals the legacy MCP reference. `mode`/`token` parameterize the
+/// auth mode so the same coverage runs anonymous and required.
+async fn assert_all_twelve_parity(mode: AuthMode, token: Option<&'static str>) {
+    let fx = fixture();
+    let client = build_server_client(fx.db.clone(), fx.store.clone(), mode);
+    let server = mcp_server(&fx.db);
+    let (nv0, nv1) = node_versions(&client, fx.alice, token).await;
+    let (ev0, ev1) = edge_versions(&client, fx.edge, token).await;
+
+    // 1. traverse (GET) — legacy typed method.
+    let (s, autumn) = get(
+        &client,
+        &format!("/traverse?start_node_id={}&edge_label=KNOWS", fx.alice),
+        token,
+    )
+    .await;
+    assert_eq!(s, 200, "traverse: {autumn}");
+    // `TraverseRequest` is `#[non_exhaustive]` (cannot be built out-of-crate), so
+    // the legacy reference is the equivalent public `dispatch_tool_json` path —
+    // which is exactly what the autumn handler forwards to.
+    let legacy: Value = serde_json::from_str(&server.dispatch_tool_json(
+        "traverse",
+        json!({ "start_node_id": fx.alice, "edge_label": "KNOWS" }),
+    ))
+    .expect("legacy traverse json");
+    assert_eq!(normalize(autumn), normalize(legacy), "traverse parity");
+
+    // 2. get_node_history (GET) — legacy typed method.
+    let (_s, autumn) = get(&client, &format!("/nodes/{}/history", fx.alice), token).await;
+    let legacy: Value =
+        serde_json::from_str(&server.get_node_history(GetNodeHistoryRequest { node_id: fx.alice }))
+            .expect("legacy node history json");
+    assert_eq!(
+        normalize(autumn),
+        normalize(legacy),
+        "get_node_history parity"
+    );
+
+    // 3. get_edge_history (GET) — legacy typed method.
+    let (_s, autumn) = get(&client, &format!("/edges/{}/history", fx.edge), token).await;
+    let legacy: Value =
+        serde_json::from_str(&server.get_edge_history(GetEdgeHistoryRequest { edge_id: fx.edge }))
+            .expect("legacy edge history json");
+    assert_eq!(
+        normalize(autumn),
+        normalize(legacy),
+        "get_edge_history parity"
+    );
+
+    // 4. get_node_at_time (POST) — legacy typed method.
+    let (_s, autumn) = post(
+        &client,
+        "/nodes/at_time",
+        &json!({ "node_id": fx.alice, "valid_time": FUTURE_VT }),
+        token,
+    )
+    .await;
+    let legacy: Value = serde_json::from_str(&server.get_node_at_time(GetNodeAtTimeRequest {
+        node_id: fx.alice,
+        valid_time: FUTURE_VT.to_string(),
+        transaction_time: None,
+    }))
+    .expect("legacy node at_time json");
+    assert_eq!(
+        normalize(autumn),
+        normalize(legacy),
+        "get_node_at_time parity"
+    );
+
+    // 5. get_edge_at_time (POST) — legacy typed method.
+    let (_s, autumn) = post(
+        &client,
+        "/edges/at_time",
+        &json!({ "edge_id": fx.edge, "valid_time": FUTURE_VT }),
+        token,
+    )
+    .await;
+    let legacy: Value = serde_json::from_str(&server.get_edge_at_time(GetEdgeAtTimeRequest {
+        edge_id: fx.edge,
+        valid_time: FUTURE_VT.to_string(),
+        transaction_time: None,
+    }))
+    .expect("legacy edge at_time json");
+    assert_eq!(
+        normalize(autumn),
+        normalize(legacy),
+        "get_edge_at_time parity"
+    );
+
+    // 6. list_changes (POST) — legacy typed method.
+    let changes_body = json!({
+        "tx_from": "1970-01-01T00:00:00Z",
+        "tx_to": FUTURE_VT,
+    });
+    let (_s, autumn) = post(&client, "/changes", &changes_body, token).await;
+    let legacy: Value = serde_json::from_str(&server.list_changes(ListChangesRequest {
+        tx_from: "1970-01-01T00:00:00Z".to_string(),
+        tx_to: FUTURE_VT.to_string(),
+        valid_from: None,
+        valid_to: None,
+        label: None,
+        limit: None,
+        cursor: None,
+    }))
+    .expect("legacy list_changes json");
+    assert_eq!(normalize(autumn), normalize(legacy), "list_changes parity");
+
+    // 7. get_node_at_valid_time (POST) — dispatch reference (no typed method).
+    let body = json!({ "node_id": fx.alice, "valid_time": FUTURE_VT });
+    let (_s, autumn) = post(&client, "/nodes/at_valid_time", &body, token).await;
+    let legacy: Value =
+        serde_json::from_str(&server.dispatch_tool_json("get_node_at_valid_time", body.clone()))
+            .expect("legacy node at_valid_time json");
+    assert_eq!(
+        normalize(autumn),
+        normalize(legacy),
+        "get_node_at_valid_time parity"
+    );
+
+    // 8. get_node_at_transaction_time (POST) — dispatch reference.
+    let body = json!({ "node_id": fx.alice, "transaction_time": FUTURE_VT });
+    let (_s, autumn) = post(&client, "/nodes/at_transaction_time", &body, token).await;
+    let legacy: Value = serde_json::from_str(
+        &server.dispatch_tool_json("get_node_at_transaction_time", body.clone()),
+    )
+    .expect("legacy node at_transaction_time json");
+    assert_eq!(
+        normalize(autumn),
+        normalize(legacy),
+        "get_node_at_transaction_time parity"
+    );
+
+    // 9. diff_node_versions (POST) — dispatch reference.
+    let body = json!({ "node_id": fx.alice, "from_version": nv0, "to_version": nv1 });
+    let (_s, autumn) = post(&client, "/nodes/diff", &body, token).await;
+    let legacy: Value =
+        serde_json::from_str(&server.dispatch_tool_json("diff_node_versions", body.clone()))
+            .expect("legacy diff_node json");
+    assert_eq!(
+        normalize(autumn),
+        normalize(legacy),
+        "diff_node_versions parity"
+    );
+
+    // 10. get_edge_at_valid_time (POST) — dispatch reference.
+    let body = json!({ "edge_id": fx.edge, "valid_time": FUTURE_VT });
+    let (_s, autumn) = post(&client, "/edges/at_valid_time", &body, token).await;
+    let legacy: Value =
+        serde_json::from_str(&server.dispatch_tool_json("get_edge_at_valid_time", body.clone()))
+            .expect("legacy edge at_valid_time json");
+    assert_eq!(
+        normalize(autumn),
+        normalize(legacy),
+        "get_edge_at_valid_time parity"
+    );
+
+    // 11. get_edge_at_transaction_time (POST) — dispatch reference.
+    let body = json!({ "edge_id": fx.edge, "transaction_time": FUTURE_VT });
+    let (_s, autumn) = post(&client, "/edges/at_transaction_time", &body, token).await;
+    let legacy: Value = serde_json::from_str(
+        &server.dispatch_tool_json("get_edge_at_transaction_time", body.clone()),
+    )
+    .expect("legacy edge at_transaction_time json");
+    assert_eq!(
+        normalize(autumn),
+        normalize(legacy),
+        "get_edge_at_transaction_time parity"
+    );
+
+    // 12. diff_edge_versions (POST) — dispatch reference.
+    let body = json!({ "edge_id": fx.edge, "from_version": ev0, "to_version": ev1 });
+    let (_s, autumn) = post(&client, "/edges/diff", &body, token).await;
+    let legacy: Value =
+        serde_json::from_str(&server.dispatch_tool_json("diff_edge_versions", body.clone()))
+            .expect("legacy diff_edge json");
+    assert_eq!(
+        normalize(autumn),
+        normalize(legacy),
+        "diff_edge_versions parity"
+    );
+}
+
+#[tokio::test]
+async fn all_twelve_byte_parity_required_mode() {
+    assert_all_twelve_parity(AuthMode::Required, Some(READER_TOKEN)).await;
+}
+
+#[tokio::test]
+async fn all_twelve_byte_parity_anonymous_mode() {
+    assert_all_twelve_parity(AuthMode::Anonymous, None).await;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// traverse behavior-pinned assertions (#3225, #3232, #3220).
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn traverse_behavior_pinned() {
+    let fx = fixture();
+    let client = build_server_client(fx.db.clone(), fx.store.clone(), AuthMode::Required);
+
+    let (status, body) = get(
+        &client,
+        &format!("/traverse?start_node_id={}&edge_label=KNOWS", fx.alice),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200, "traverse: {body}");
+
+    let results = body["results"].as_array().expect("results array");
+    // Alice --KNOWS--> Bob at depth 1: exactly Bob.
+    let reached: BTreeSet<u64> = results
+        .iter()
+        .map(|r| r["node"]["id"].as_u64().expect("node id"))
+        .collect();
+    assert_eq!(reached, BTreeSet::from([fx.bob]), "traverse reaches Bob");
+    assert_eq!(body["count"], 1);
+
+    let bob = &results[0]["node"];
+    // #3232: each traversal node carries the temporal block.
+    assert!(
+        bob["temporal"].is_object(),
+        "traversal node has temporal block: {bob}"
+    );
+    // #3220: the embedding is elided by default on the traversal read path.
+    assert_eq!(
+        bob["properties"]["embedding"]["elided"], true,
+        "embedding elided by default: {bob}"
+    );
+
+    // include_vectors=true returns the raw array.
+    let (_s, raw) = get(
+        &client,
+        &format!(
+            "/traverse?start_node_id={}&edge_label=KNOWS&include_vectors=true",
+            fx.alice
+        ),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert!(
+        raw["results"][0]["node"]["properties"]["embedding"].is_array(),
+        "include_vectors=true returns the raw array: {raw}"
+    );
+}
+
+#[tokio::test]
+async fn traverse_unauthenticated_401() {
+    let fx = fixture();
+    let client = build_server_client(fx.db, fx.store, AuthMode::Required);
+    let resp = client
+        .get(&format!(
+            "/traverse?start_node_id={}&edge_label=KNOWS",
+            fx.alice
+        ))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 401);
+    assert_eq!(resp.header("www-authenticate"), Some("Bearer"));
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// #3353 token budget on the two budgetable reads (traverse, get_node_history).
+// The budget rides the RAW arguments and is applied in `dispatch_tool`; the
+// handlers forward through `dispatch_tool_json`, so the same public entry is the
+// legacy reference.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn traverse_token_budget_shapes_response_and_matches_legacy() {
+    // Alice --KNOWS--> three targets, each with a bulky note, so the full
+    // traversal comfortably exceeds a modest byte budget and the #3353 ladder
+    // must shape it down.
+    let db = Arc::new(AletheiaDB::new().expect("create db"));
+    let big_note = LONG_NOTE.repeat(3);
+    let alice = db
+        .create_node("Person", PropertyMapBuilder::new().insert("n", "A").build())
+        .expect("alice")
+        .as_u64();
+    for name in ["Bob", "Carol", "Dave"] {
+        let t = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("n", name)
+                    .insert("note", big_note.as_str())
+                    .build(),
+            )
+            .expect("target");
+        db.create_edge(
+            aletheiadb::core::NodeId::new(alice).unwrap(),
+            t,
+            "KNOWS",
+            PropertyMapBuilder::new().build(),
+        )
+        .expect("edge");
+    }
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+    let server = mcp_server(&db);
+
+    // Full (no budget): no `budget` block, exceeds the cap.
+    let base = format!("/traverse?start_node_id={alice}&edge_label=KNOWS");
+    let (status, full) = get(&client, &base, Some(READER_TOKEN)).await;
+    assert_eq!(status, 200);
+    assert!(full.get("budget").is_none(), "no budget block: {full}");
+    let cap: u64 = 2000;
+    assert!(
+        len_of(&full) as u64 > cap,
+        "full response should exceed the cap: {}",
+        len_of(&full)
+    );
+
+    // Legacy dispatch is the reference; its emitted string is the exact bytes the
+    // #3353 contract bounds.
+    let legacy_text = server.dispatch_tool_json(
+        "traverse",
+        json!({ "start_node_id": alice, "edge_label": "KNOWS", "max_response_bytes": cap }),
+    );
+    assert!(
+        legacy_text.len() as u64 <= cap,
+        "emitted string must fit the byte budget: {} > {cap}",
+        legacy_text.len()
+    );
+    let legacy: Value = serde_json::from_str(&legacy_text).expect("legacy json");
+    assert!(
+        legacy["budget"].is_object(),
+        "budget block discloses the applied rung: {legacy}"
+    );
+
+    // Autumn with the same budget must match the legacy dispatch AND be shaped.
+    let (status, budgeted) = get(
+        &client,
+        &format!("{base}&max_response_bytes={cap}"),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert!(budgeted["budget"].is_object(), "shaped: {budgeted}");
+    assert!(
+        len_of(&budgeted) < len_of(&full),
+        "shaped response must be smaller than full: {} !< {}",
+        len_of(&budgeted),
+        len_of(&full)
+    );
+    assert_eq!(
+        normalize(budgeted),
+        normalize(legacy),
+        "budgeted autumn traverse must equal the legacy dispatch for the same budget"
+    );
+}
+
+#[tokio::test]
+async fn get_node_history_token_budget_shapes_response_and_matches_legacy() {
+    let fx = fixture();
+    let client = build_server_client(fx.db.clone(), fx.store.clone(), AuthMode::Required);
+    let server = mcp_server(&fx.db);
+
+    let base = format!("/nodes/{}/history", fx.alice);
+    let (status, full) = get(&client, &base, Some(READER_TOKEN)).await;
+    assert_eq!(status, 200);
+    assert!(full.get("budget").is_none(), "no budget block: {full}");
+    let cap: u64 = 900;
+    assert!(
+        len_of(&full) as u64 > cap,
+        "full response should exceed the cap: {}",
+        len_of(&full)
+    );
+
+    let legacy_text = server.dispatch_tool_json(
+        "get_node_history",
+        json!({ "node_id": fx.alice, "max_response_bytes": cap }),
+    );
+    assert!(
+        legacy_text.len() as u64 <= cap,
+        "emitted string must fit the byte budget: {} > {cap}",
+        legacy_text.len()
+    );
+    let legacy: Value = serde_json::from_str(&legacy_text).expect("legacy json");
+    assert!(legacy["budget"].is_object(), "budget block: {legacy}");
+
+    let (status, budgeted) = get(
+        &client,
+        &format!("{base}?max_response_bytes={cap}"),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert!(
+        budgeted["budget"].is_object(),
+        "budget MUST be honored (shaped), not dropped: {budgeted}"
+    );
+    assert!(
+        len_of(&budgeted) < len_of(&full),
+        "shaped response must be smaller: {} !< {}",
+        len_of(&budgeted),
+        len_of(&full)
+    );
+    assert_eq!(
+        normalize(budgeted),
+        normalize(legacy),
+        "budgeted autumn get_node_history must equal the legacy dispatch"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// #3360 snapshot-anchored cursor paging on traverse. `use_cursor:true` opens a
+// snapshot-anchored scan returning an opaque cursor + first page; passing the
+// cursor back (alone) continues it, duplicate-free and gap-free, until the union
+// equals the full result. The cursor secret lives on the process-lifetime shared
+// server in `ServerState`, so a token issued on one request resumes on the next.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn traverse_cursor_paging_snapshot_anchored() {
+    // A star: Alice --KNOWS--> {Bob, Carol, Dave}. Per-page size of 1 forces
+    // continuation across three snapshot-anchored pages.
+    let db = Arc::new(AletheiaDB::new().expect("create db"));
+    let alice = db
+        .create_node("Person", PropertyMapBuilder::new().insert("n", "A").build())
+        .expect("alice")
+        .as_u64();
+    let mut expected: BTreeSet<u64> = BTreeSet::new();
+    for name in ["Bob", "Carol", "Dave"] {
+        let t = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("n", name).build(),
+            )
+            .expect("target");
+        db.create_edge(
+            aletheiadb::core::NodeId::new(alice).unwrap(),
+            t,
+            "KNOWS",
+            PropertyMapBuilder::new().build(),
+        )
+        .expect("edge");
+        expected.insert(t.as_u64());
+    }
+    let client = build_server_client(db, make_store(), AuthMode::Required);
+
+    let (status, page1) = get(
+        &client,
+        &format!("/traverse?start_node_id={alice}&edge_label=KNOWS&use_cursor=true&limit=1"),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(status, 200, "page1: {page1}");
+    assert_eq!(
+        page1["paging"], "cursor",
+        "cursor paging disclosed: {page1}"
+    );
+    assert!(
+        page1["snapshot_valid_time"].is_string(),
+        "snapshot disclosed: {page1}"
+    );
+    assert!(
+        page1["cursor"].as_str().is_some(),
+        "first page returns a continuation token: {page1}"
+    );
+
+    let mut seen: Vec<u64> = Vec::new();
+    let mut page = page1.clone();
+    let mut prev_snapshot = page1["snapshot_valid_time"].clone();
+    let mut guard = 0;
+    loop {
+        for r in page["results"].as_array().expect("results array") {
+            seen.push(r["node"]["id"].as_u64().expect("node id"));
+        }
+        let Some(token) = page["cursor"].as_str() else {
+            break;
+        };
+        // Continuation: the token carries all discriminating state; passed alone.
+        let token = token.to_string();
+        let (status, next) = get(
+            &client,
+            &format!("/traverse?cursor={token}"),
+            Some(READER_TOKEN),
+        )
+        .await;
+        assert_eq!(status, 200, "continuation page: {next}");
+        assert_eq!(
+            next["snapshot_valid_time"], prev_snapshot,
+            "continuation stays on the pinned snapshot: {next}"
+        );
+        prev_snapshot = next["snapshot_valid_time"].clone();
+        page = next;
+        guard += 1;
+        assert!(guard < 10, "cursor scan did not terminate");
+    }
+
+    let seen_set: BTreeSet<u64> = seen.iter().copied().collect();
+    assert_eq!(seen.len(), seen_set.len(), "no duplicates across pages");
+    assert_eq!(
+        seen_set, expected,
+        "union of pages equals the full target set"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// #3232 temporal block presence on the point-in-time single-entity reads.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn temporal_block_present_on_point_in_time_reads() {
+    let fx = fixture();
+    let client = build_server_client(fx.db.clone(), fx.store.clone(), AuthMode::Required);
+
+    // get_node_at_time returns the node under a `node` key with a temporal block.
+    let (_s, node_at) = post(
+        &client,
+        "/nodes/at_time",
+        &json!({ "node_id": fx.alice, "valid_time": FUTURE_VT }),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert!(
+        node_at["node"]["temporal"].is_object(),
+        "get_node_at_time carries a temporal block: {node_at}"
+    );
+
+    let (_s, edge_at) = post(
+        &client,
+        "/edges/at_time",
+        &json!({ "edge_id": fx.edge, "valid_time": FUTURE_VT }),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert!(
+        edge_at["edge"]["temporal"].is_object(),
+        "get_edge_at_time carries a temporal block: {edge_at}"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Conformance: the two dispatch-routed budgetable reads are pinned in the shared
+// DISPATCH_ROUTED_READ_TOOLS table with Read class (extends the coverage the
+// `dispatch_pinned_names_match_routed_class` test in server_parity.rs asserts).
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn dispatch_routed_table_includes_traverse_and_get_node_history() {
+    use aletheia_server::edge_tools::DISPATCH_ROUTED_READ_TOOLS;
+    for name in ["traverse", "get_node_history"] {
+        let entry = DISPATCH_ROUTED_READ_TOOLS
+            .iter()
+            .find(|(n, _)| *n == name)
+            .unwrap_or_else(|| panic!("{name} must be pinned in DISPATCH_ROUTED_READ_TOOLS"));
+        assert_eq!(entry.1, AccessClass::Read, "{name} pinned as Read");
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// OpenAPI schema fidelity: a local-body dispatch tool must expose a named,
+// per-operation request schema in /openapi.json — never the generic `Value`.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn openapi_diff_node_versions_has_typed_request_schema() {
+    let fx = fixture();
+    let client = build_server_client(fx.db, fx.store, AuthMode::Required);
+    let resp = client.get("/openapi.json").send().await;
+    assert_eq!(resp.status.as_u16(), 200);
+    let spec: Value = serde_json::from_str(&resp.text()).expect("openapi json");
+
+    let schema = &spec["paths"]["/nodes/diff"]["post"]["requestBody"]["content"]["application/json"]
+        ["schema"];
+    let sref = schema["$ref"].as_str().unwrap_or_else(|| {
+        panic!(
+            "/nodes/diff requestBody schema must be a $ref: {}",
+            spec["paths"]["/nodes/diff"]
+        )
+    });
+    assert!(
+        sref.ends_with("/DiffNodeVersionsBody"),
+        "diff request body must ref a typed per-operation schema, got {sref}"
+    );
+    assert_ne!(
+        sref, "#/components/schemas/Value",
+        "must not degrade to the shared generic Value component"
+    );
+    // traverse (GET) documents its start_node_id query parameter.
+    let op = &spec["paths"]["/traverse"]["get"];
+    assert!(!op.is_null(), "GET /traverse documented: {}", spec["paths"]);
+}


### PR DESCRIPTION
## PR4 — TRAVERSAL + TEMPORAL cluster (Issue #3524, autumn-web migration, Lane A)

Ports the 12-tool traversal + temporal cluster onto the `aletheia-server` autumn-web surface, projecting each tool to **HTTP**, **MCP-over-HTTP** (`/mcp`), and **OpenAPI** from a single handler definition — byte-identical to the legacy MCP surface. Mirrors the proven PR2/PR3/retrofit patterns.

### Before / After
- **Before:** these 12 tools existed only on the legacy `src/mcp` surface; the autumn-web crate covered only the node + edge clusters.
- **After:** all 12 are handlers in the new `traverse_temporal_tools.rs`, wired into `app.rs` routes, surfaced on HTTP + `/mcp` + `/openapi.json`, and pinned by a new parity suite against the legacy MCP surface over the same `Arc<AletheiaDB>`.

### Marker ↔ inventory cross-check (by hand)
Every handler's `Authorized<C>` marker equals the tool's `access_class` in `tests/parity/inventory.json` (all `read`); all 12 are already classified `AccessClass::Read` in `security::rbac::MCP_TOOL_CLASSES` (Lane B / B1), so **no registry edit** was needed.

| # | tool | handler marker | inventory access_class | match |
|---|------|----------------|------------------------|-------|
| 1 | `traverse` | `ReadClass` | read | ✅ |
| 2 | `get_node_history` | `ReadClass` | read | ✅ |
| 3 | `get_edge_history` | `ReadClass` | read | ✅ |
| 4 | `get_node_at_time` | `ReadClass` | read | ✅ |
| 5 | `get_edge_at_time` | `ReadClass` | read | ✅ |
| 6 | `list_changes` | `ReadClass` | read | ✅ |
| 7 | `get_node_at_valid_time` | `ReadClass` | read | ✅ |
| 8 | `get_node_at_transaction_time` | `ReadClass` | read | ✅ |
| 9 | `diff_node_versions` | `ReadClass` | read | ✅ |
| 10 | `get_edge_at_valid_time` | `ReadClass` | read | ✅ |
| 11 | `get_edge_at_transaction_time` | `ReadClass` | read | ✅ |
| 12 | `diff_edge_versions` | `ReadClass` | read | ✅ |

### Per-tool execution / budget / cursor matrix
Classification verified against source: `aletheiadb::mcp::BUDGETABLE_READ_TOOLS` (budgetable) and `inject_cursor_schema_params`'s five-tool set (cursorable). Of this cluster, **only `traverse` and `get_node_history` are budgetable**, and **only `traverse` is cursorable**.

| tool | HTTP route | verb | forwarding | budgetable | cursorable | execution |
|------|-----------|------|-----------|:---------:|:---------:|-----------|
| `traverse` | `/traverse` | GET | `dispatch_tool_json` | ✅ | ✅ | in-flight guard + `run_with_timeout` + byte cap (list_nodes wiring) |
| `get_node_history` | `/nodes/{id}/history` | GET | `dispatch_tool_json` | ✅ | ❌ | inline |
| `get_edge_history` | `/edges/{id}/history` | GET | typed method | ❌ | ❌ | inline |
| `get_node_at_time` | `/nodes/at_time` | POST | typed method | ❌ | ❌ | inline |
| `get_edge_at_time` | `/edges/at_time` | POST | typed method | ❌ | ❌ | inline |
| `list_changes` | `/changes` | POST | typed method | ❌ | ❌ | inline |
| `get_node_at_valid_time` | `/nodes/at_valid_time` | POST | `dispatch_tool_json` (local body) | ❌ | ❌ | inline |
| `get_node_at_transaction_time` | `/nodes/at_transaction_time` | POST | `dispatch_tool_json` (local body) | ❌ | ❌ | inline |
| `diff_node_versions` | `/nodes/diff` | POST | `dispatch_tool_json` (local body) | ❌ | ❌ | inline |
| `get_edge_at_valid_time` | `/edges/at_valid_time` | POST | `dispatch_tool_json` (local body) | ❌ | ❌ | inline |
| `get_edge_at_transaction_time` | `/edges/at_transaction_time` | POST | `dispatch_tool_json` (local body) | ❌ | ❌ | inline |
| `diff_edge_versions` | `/edges/diff` | POST | `dispatch_tool_json` (local body) | ❌ | ❌ | inline |

**Forwarding rationale.** `traverse` and `get_node_history` route raw arguments through `dispatch_tool_json` so the #3353 budget (and #3360 cursor, `traverse` only) pipelines apply — the typed methods bypass them. The four non-budgetable tools with a public typed per-tool method call it directly with the re-exported request struct (zero reserialization, already-public symbols). The six with **no** public typed method take a **local** typed body (named per-operation OpenAPI component, never `Json<Value>`) forwarded through `dispatch_tool_json` — the only public entry (their `handle_*` are private) and, being non-budgetable/non-cursorable, byte-identical to a hypothetical typed method (same `handle_*`). This keeps the port **free of any main-crate change**.

**`traverse` slow-read wiring.** `traverse` runs under the exact B4 resource-limits composition `list_nodes` already uses: the bounded in-flight admission guard (`security.in_flight().try_acquire()`, RAII-released on any exit), the per-query wall-clock `run_with_timeout`, and the serialized-byte cap `check_byte_cap_of`. Terminology note: the named template (`list_nodes`) wraps the **synchronous** `dispatch_tool_json` call in `run_with_timeout`, not `tokio::task::spawn_blocking`; this handler mirrors that demonstrated pattern exactly rather than introducing an undemonstrated `spawn_blocking ∘ dispatch` composition.

### Main-crate widenings
**None.** No file under `src/` was touched (`git status` confirms only the five `crates/aletheia-server/` files changed). `dispatch_tool_json` and every request struct used were already public (widened in earlier PRs).

### Registry boundary
No file under `src/security/**` or `tests/security_*.rs` was modified. Only the Lane-A `edge_tools::DISPATCH_ROUTED_READ_TOOLS` table was extended (with `traverse` + `get_node_history`), so the RBAC conformance tests (`mcp_routable_tools_are_all_classified`, `registry_matches_inventory_exactly`, `dispatch_pinned_names_match_routed_class`) pass unchanged.

### Coverage note
The codecov/patch check is **non-blocking** here: the coverage job does not instrument the new `aletheia-server` crate (a CI-infra fix is tracked separately). Behavior is fully pinned by the parity suite below.

### AC evidence — inventory rows → passing parity tests

| inventory tool | covering test(s) (`traverse_temporal_parity.rs`, all pass) |
|----------------|-------------------------------------------------------------|
| `traverse` | `all_twelve_byte_parity_{required,anonymous}_mode`, `traverse_behavior_pinned`, `traverse_token_budget_shapes_response_and_matches_legacy`, `traverse_cursor_paging_snapshot_anchored`, `traverse_unauthenticated_401` |
| `get_node_history` | `all_twelve_byte_parity_*`, `get_node_history_token_budget_shapes_response_and_matches_legacy` |
| `get_edge_history` | `all_twelve_byte_parity_*` |
| `get_node_at_time` | `all_twelve_byte_parity_*`, `temporal_block_present_on_point_in_time_reads` |
| `get_edge_at_time` | `all_twelve_byte_parity_*`, `temporal_block_present_on_point_in_time_reads` |
| `list_changes` | `all_twelve_byte_parity_*` |
| `get_node_at_valid_time` | `all_twelve_byte_parity_*` |
| `get_node_at_transaction_time` | `all_twelve_byte_parity_*` |
| `diff_node_versions` | `all_twelve_byte_parity_*`, `openapi_diff_node_versions_has_typed_request_schema` |
| `get_edge_at_valid_time` | `all_twelve_byte_parity_*` |
| `get_edge_at_transaction_time` | `all_twelve_byte_parity_*` |
| `diff_edge_versions` | `all_twelve_byte_parity_*` |

Plus `dispatch_routed_table_includes_traverse_and_get_node_history` and the shared `dispatch_pinned_names_match_routed_class` (server_parity.rs) now covering the two new dispatch-routed reads.

```
# cargo test -p aletheia-server (verbatim, isolated CARGO_TARGET_DIR)
     Running tests/traverse_temporal_parity.rs
running 10 tests
test dispatch_routed_table_includes_traverse_and_get_node_history ... ok
test get_node_history_token_budget_shapes_response_and_matches_legacy ... ok
test all_twelve_byte_parity_required_mode ... ok
test all_twelve_byte_parity_anonymous_mode ... ok
test temporal_block_present_on_point_in_time_reads ... ok
test traverse_behavior_pinned ... ok
test traverse_token_budget_shapes_response_and_matches_legacy ... ok
test traverse_cursor_paging_snapshot_anchored ... ok
test traverse_unauthenticated_401 ... ok
test openapi_diff_node_versions_has_typed_request_schema ... ok
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

# server_parity.rs: 20 passed  (incl. dispatch_pinned_names_match_routed_class,
#   mcp_routable_tools_are_all_classified)
# security_rbac.rs: 15 passed  (incl. registry_matches_inventory_exactly)
# edge_parity 24 / node_reads_budget_cursor 10 / node_writes_parity 18 /
#   security_* all pass (1 ignored: uid-0 havoc)
```

Gates (isolated `CARGO_TARGET_DIR`), all green:
- `cargo clippy -p aletheia-server --all-targets -- -D warnings` ✅
- `cargo test -p aletheia-server` ✅
- `cargo fmt --all -- --check` ✅
- `cargo check -p aletheiadb --no-default-features --tests --features http-server` ✅
- `cargo test --features http-server,mcp-server --test parity_http --test parity_mcp` ✅ (33 + 11)
- `cargo clippy -p aletheiadb --features "config-toml,mcp-server,sharding-rpc,simulation" --all-targets -- -D warnings` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEwJg2bDPZ7DzcHebqwZVK

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEwJg2bDPZ7DzcHebqwZVK)_