### PR TITLE
⚡ Bolt: Remove unnecessary Vec allocation in apply_changes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**[Optimize apply_changes allocation]
+**Learning:** Found unnecessary `.collect::<Vec<_>>().into_iter()` when replaying tombstone versions during `apply_changes`. The iterator maps `VersionId` to `u64`, which doesn't need to be collected into an intermediate vector before iterating. The parameter `tombstone_ids` in `apply_single_write` can be generalized to take `&mut impl Iterator<Item = u64>` instead of `&mut std::vec::IntoIter<u64>`.
+**Action:** Remove unnecessary `.collect::<Vec<_>>().into_iter()` and update function signatures to take a generic mutable iterator.

--- a/src/api/transaction/write/apply.rs
+++ b/src/api/transaction/write/apply.rs
@@ -426,7 +426,7 @@ pub(crate) fn apply_single_write(
     write: &crate::api::transaction::BufferedWrite,
     commit_timestamp: Timestamp,
     historical: &mut HistoricalStorage,
-    tombstone_ids: &mut std::vec::IntoIter<u64>,
+    tombstone_ids: &mut impl Iterator<Item = u64>,
     num_deletes: usize,
 ) -> Result<()> {
     match write {
@@ -673,11 +673,7 @@ pub(crate) fn apply_changes<'a>(
     // so the identical ids are recorded in the WAL and applied here. We simply
     // replay them in the same buffer order they were generated and logged.
     let num_deletes = closing_version_ids.len();
-    let mut tombstone_ids = closing_version_ids
-        .iter()
-        .map(|v| v.as_u64())
-        .collect::<Vec<u64>>()
-        .into_iter();
+    let mut tombstone_ids = closing_version_ids.iter().map(|v| v.as_u64());
 
     for write in tx.buffer.operations() {
         apply_single_write(


### PR DESCRIPTION
💡 What: Changed `apply_single_write` to accept a generic `impl Iterator` and removed `.collect::<Vec<u64>>().into_iter()` from `apply_changes`.
🎯 Why: Creating an intermediate `Vec<u64>` causes unnecessary heap allocations during transaction commit.
📊 Impact: Removes one O(N) heap allocation per write transaction commit where N is the number of tombstoned records.
🔬 Measurement: Verify with `cargo bench` or by observing reduced allocator pressure during high-throughput ingest.

---
*PR created automatically by Jules for task [8914026825548349330](https://jules.google.com/task/8914026825548349330) started by @madmax983*