### PR TITLE
feat(server): port find_similar/hybrid_query/query/list_vector_indexes to autumn-web (#3524 PR5)

### DIFF
--- a/crates/aletheia-server/src/app.rs
+++ b/crates/aletheia-server/src/app.rs
@@ -17,6 +17,7 @@ use crate::node_tools;
 use crate::security::{self, SecurityConfig};
 use crate::state::ServerState;
 use crate::traverse_temporal_tools;
+use crate::vector_query_tools;
 use aletheiadb::AletheiaDB;
 use aletheiadb::auth::{AuthMode, AuthStore};
 use autumn_web::openapi::OpenApiConfig;
@@ -98,6 +99,10 @@ pub fn try_build_server_testapp(
             traverse_temporal_tools::get_edge_at_valid_time,
             traverse_temporal_tools::get_edge_at_transaction_time,
             traverse_temporal_tools::diff_edge_versions,
+            vector_query_tools::find_similar,
+            vector_query_tools::hybrid_query,
+            vector_query_tools::query,
+            vector_query_tools::list_vector_indexes,
         ])
         .openapi(OpenApiConfig::new("AletheiaDB", env!("CARGO_PKG_VERSION")))
         .mount_mcp("/mcp");

--- a/crates/aletheia-server/src/edge_tools.rs
+++ b/crates/aletheia-server/src/edge_tools.rs
@@ -89,6 +89,14 @@ use serde_json::{Map, Value};
 /// cursorable (#3360). The other ten tools in that cluster are not budgetable /
 /// cursorable and forward through typed methods, so they are not dispatch-routed
 /// and do not appear here.
+///
+/// The three dispatch-routed **vector/hybrid/query** reads (`find_similar`,
+/// `hybrid_query`, `query`) are pinned here too (see
+/// [`crate::vector_query_tools`]): all three are budgetable (#3353) so they
+/// forward raw arguments through `dispatch_tool_json` under the slow-read guard;
+/// none is cursorable. The fourth tool in that cluster, `list_vector_indexes`,
+/// is not budgetable / cursorable and forwards through a typed method, so it is
+/// not dispatch-routed and does not appear here.
 pub const DISPATCH_ROUTED_READ_TOOLS: &[(&str, AccessClass)] = &[
     ("get_edge", AccessClass::Read),
     ("list_edges", AccessClass::Read),
@@ -99,6 +107,9 @@ pub const DISPATCH_ROUTED_READ_TOOLS: &[(&str, AccessClass)] = &[
     ("find_nodes_at_time", AccessClass::Read),
     ("traverse", AccessClass::Read),
     ("get_node_history", AccessClass::Read),
+    ("find_similar", AccessClass::Read),
+    ("hybrid_query", AccessClass::Read),
+    ("query", AccessClass::Read),
 ];
 
 /// Parse an MCP tool method's JSON string result into a [`Value`] for the HTTP

--- a/crates/aletheia-server/src/lib.rs
+++ b/crates/aletheia-server/src/lib.rs
@@ -34,6 +34,7 @@ pub mod node_tools;
 pub mod security;
 pub mod state;
 pub mod traverse_temporal_tools;
+pub mod vector_query_tools;
 
 pub use app::{
     build_server_client, build_server_client_with_config, build_server_testapp,

--- a/crates/aletheia-server/src/vector_query_tools.rs
+++ b/crates/aletheia-server/src/vector_query_tools.rs
@@ -1,0 +1,420 @@
+//! Vector + hybrid + declarative-query tools: `find_similar`,
+//! `list_vector_indexes`, `hybrid_query`, and `query` (Issue #3524, PR5).
+//!
+//! Each is a single `#[get(...)]`/`#[post(...)]` + `#[api_doc(description=...,
+//! mcp)]` handler, so one definition surfaces on **HTTP**, **MCP-over-HTTP**
+//! (`/mcp`), and **OpenAPI** at once. The response body is produced by the
+//! *exact* main-crate MCP surface, so it is byte-identical to the legacy MCP
+//! surface (bare tool-result JSON, #3220 vector elision on `find_similar` /
+//! `hybrid_query`, the #3353 token budget on the three budgetable reads, and the
+//! `query` tool's full structured-error contract — `{error:{kind,message,
+//! clause?,language}}` with the uniform #3234 `code`/`retriable` carried
+//! additively, read-only enforcement, `language_unavailable` when the `cypher`
+//! feature is not compiled, and the #3360 cursor → `unsupported_construct`
+//! rejection) — asserted in the parity suite against the shared
+//! [`AletheiaMcpServer`](aletheiadb::mcp::AletheiaMcpServer) over the same
+//! `Arc<AletheiaDB>`.
+//!
+//! # Forwarding: dispatch-routed slow reads vs. a typed inline read
+//!
+//! The **single source of truth** for which reads honor the Issue #3353 token
+//! budget is `aletheiadb::mcp`'s `BUDGETABLE_READ_TOOLS`, and for the Issue
+//! #3360 cursor the `inject_cursor_schema_params` set. Verified against source,
+//! of this cluster's four tools **`find_similar`, `hybrid_query`, and `query`
+//! are budgetable** and **none of the four is cursorable**. That split drives
+//! two forwarding shapes:
+//!
+//! 1. **`find_similar` / `hybrid_query` / `query`** — budgetable (#3353) +
+//!    potentially slow (k-NN search / hybrid graph+vector+temporal / declarative
+//!    query execution). Each forwards the raw JSON arguments through
+//!    [`AletheiaMcpServer::dispatch_tool_json`](aletheiadb::mcp::AletheiaMcpServer::dispatch_tool_json)
+//!    (so the #3353 budget pipeline, read off the raw arguments in
+//!    `dispatch_tool`, applies) via the process-lifetime shared
+//!    [`ServerState::mcp_server`](crate::state::ServerState::mcp_server). Each
+//!    runs under the **exact** B4 resource-limits wiring `traverse` / `list_nodes`
+//!    use — a bounded in-flight admission guard released by RAII on any exit, a
+//!    per-query wall-clock [`run_with_timeout`], and a serialized-byte cap
+//!    ([`check_byte_cap_of`]) — because all three are potentially-slow reads
+//!    (mirroring the legacy HTTP `/query` execution model). Each is registered in
+//!    [`crate::edge_tools::DISPATCH_ROUTED_READ_TOOLS`] with its hardcoded literal
+//!    tool name so the shared `dispatch_pinned_names_match_routed_class`
+//!    conformance test proves a read-gated handler can never pin a write tool's
+//!    name. `query`'s structured-error contract, read-only enforcement,
+//!    `language_unavailable`, and cursor → `unsupported_construct` behavior are
+//!    **all** produced by dispatch — the handler reimplements none of it; it
+//!    forwards the raw arguments (including `use_cursor` / `cursor`, so the
+//!    dispatch layer can reject them) and returns the result verbatim.
+//! 2. **`list_vector_indexes`** — NOT budgetable, NOT cursorable, no arguments.
+//!    Forwards through the **typed** per-tool method
+//!    (`AletheiaMcpServer::list_vector_indexes`), inline (like `count_nodes` /
+//!    the edge writes) — zero reserialization, reusing only already-public
+//!    symbols.
+//!
+//! All four are classified [`ReadClass`]; the marker rides in each handler's
+//! `Authorized<C>` signature (the one place the class is declared), which autumn
+//! replays for `/mcp tools/call`.
+//!
+//! The three slow reads take a **typed all-optional** request body
+//! (`#[derive(Default, Deserialize)]`, every field `Option<_>`) so that (a)
+//! `/openapi.json` gets a named, per-operation request schema instead of the
+//! shared generic `Value` a raw `Json<Value>` body would emit (the #3589
+//! lesson), and (b) requiredness (e.g. `query`'s `query` string,
+//! `find_similar`'s `property_name` / `embedding`) stays a **runtime** concern
+//! the dispatch layer enforces with a structured `INVALID_ARGUMENT`. The handler
+//! rebuilds the raw MCP arguments object from the `Some` fields and forwards it,
+//! so a no-budget call is byte-identical to the legacy tool. Embedding inputs
+//! (`find_similar.embedding`, `hybrid_query.query_embedding`) and `query.params`
+//! (numeric arrays treated as embeddings) round-trip through the rebuilt args
+//! map unchanged.
+//!
+//! The MCP tool result carries in-band errors (e.g. a missing property index →
+//! `{"error":{"code":...}}`); we return that JSON verbatim with a 200, matching
+//! the MCP method's `String` return exactly.
+
+use crate::edge_tools::{insert_budget, insert_opt};
+use crate::security::resource_limits::{check_byte_cap_of, run_with_timeout};
+use crate::security::{Authorized, ReadClass, ServerSecurityState};
+use crate::state::ServerState;
+use aletheiadb::http::AletheiaHttpError;
+use aletheiadb::mcp::ListVectorIndexesRequest;
+use autumn_web::prelude::{Json, get, post};
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+/// Parse an MCP tool method's JSON string result into a [`Value`] for the HTTP
+/// response. A non-JSON result (should not happen) degrades to a JSON string.
+fn tool_json(s: String) -> Json<Value> {
+    Json(serde_json::from_str::<Value>(&s).unwrap_or(Value::String(s)))
+}
+
+/// Run a dispatch-routed slow read under the B4 resource-limits wiring (identical
+/// to `traverse` / `list_nodes`): a bounded in-flight admission guard (503
+/// UNAVAILABLE at capacity, released by RAII on any exit), a per-query wall-clock
+/// timeout (429 on deadline), and a serialized-byte cap on the exact wire
+/// response (413). Generous defaults make this a no-op on the parity path.
+///
+/// Forwards the rebuilt raw `args` through the shared server's
+/// `dispatch_tool_json` (so the #3353 token budget, read off the raw arguments,
+/// applies) with the hardcoded literal `tool` name.
+async fn dispatch_slow_read(
+    security: &ServerSecurityState,
+    state: &ServerState,
+    tool: &'static str,
+    args: Value,
+) -> Result<Json<Value>, AletheiaHttpError> {
+    let limits = security.limits();
+    let _guard = security.in_flight().try_acquire()?;
+
+    let server = state.mcp_server();
+    let out = run_with_timeout(limits.timeout, false, async move {
+        server.dispatch_tool_json(tool, args)
+    })
+    .await?;
+
+    let value = serde_json::from_str::<Value>(&out).unwrap_or(Value::String(out));
+    // Cap against the exact serialized response bytes (undercount-proof).
+    check_byte_cap_of(&value, limits.max_response_bytes)?;
+    Ok(Json(value))
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// find_similar — [`ReadClass`], budgetable (#3353), NOT cursorable, potentially
+// slow (k-NN). Forwards raw arguments through `dispatch_tool_json` (budget
+// applies) under the B4 resource-limits wiring. #3220 vector elision applies to
+// the response; the budget never drops/reorders ranked results (dispatch handles
+// that — the handler does not post-process).
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Request body for [`find_similar`] — an **all-optional** mirror of the legacy
+/// `FindSimilarRequest` plus the #3353 token budget. `property_name` and
+/// `embedding` are logically required for a fresh query, but requiredness stays a
+/// **runtime** concern (`dispatch_tool` returns a structured `INVALID_ARGUMENT`
+/// when they are missing); keeping every field optional restores a named,
+/// per-operation `/openapi.json` request schema (vs. a generic `Value`).
+#[derive(Debug, Default, Deserialize)]
+pub struct FindSimilarBody {
+    /// The property name that contains the vector embedding (logically required;
+    /// enforced at dispatch).
+    pub property_name: Option<String>,
+    /// The query embedding vector (logically required; enforced at dispatch).
+    pub embedding: Option<Vec<f32>>,
+    /// Number of similar results to return (default 10).
+    pub k: Option<usize>,
+    /// Number of results to skip (offset pagination, #3226).
+    pub offset: Option<usize>,
+    /// Return full vector/embedding arrays instead of the elided descriptor
+    /// (#3220). Never affects the similarity `score`.
+    pub include_vectors: Option<bool>,
+    /// #3353: cap the response at roughly this many tokens (utf8_bytes / 4).
+    pub max_response_tokens: Option<u64>,
+    /// #3353: byte-exact response cap.
+    pub max_response_bytes: Option<u64>,
+    /// #3353: property keys to protect first as the response degrades.
+    pub priority_properties: Option<Vec<String>>,
+}
+
+/// `find_similar` — k-nearest-neighbor search for nodes whose `property_name`
+/// embedding is closest to a query `embedding`. [`ReadClass`]; vectors elided by
+/// default (#3220); budgetable (#3353), not cursorable. HTTP + MCP tool.
+///
+/// Forwards raw arguments through `dispatch_tool_json` (so the #3353 budget
+/// applies) under the B4 resource-limits wiring (in-flight guard, wall-clock
+/// timeout, byte cap), because k-NN is a potentially-slow read. The budget never
+/// drops or reorders ranked results (only per-result payloads degrade) — the
+/// handler forwards raw and does not post-process.
+#[post("/find_similar")]
+#[api_doc(
+    description = "Find the k nodes whose embedding property is most similar to a query embedding vector",
+    mcp
+)]
+pub async fn find_similar(
+    _auth: Authorized<ReadClass>,
+    security: ServerSecurityState,
+    state: ServerState,
+    Json(opts): Json<FindSimilarBody>,
+) -> Result<Json<Value>, AletheiaHttpError> {
+    let mut args = Map::new();
+    insert_opt(
+        &mut args,
+        "property_name",
+        opts.property_name.map(Value::from),
+    );
+    insert_opt(&mut args, "embedding", opts.embedding.map(Value::from));
+    insert_opt(&mut args, "k", opts.k.map(Value::from));
+    insert_opt(&mut args, "offset", opts.offset.map(Value::from));
+    insert_opt(
+        &mut args,
+        "include_vectors",
+        opts.include_vectors.map(Value::from),
+    );
+    insert_budget(
+        &mut args,
+        opts.max_response_tokens,
+        opts.max_response_bytes,
+        opts.priority_properties,
+    );
+    dispatch_slow_read(&security, &state, "find_similar", Value::Object(args)).await
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// hybrid_query — [`ReadClass`], budgetable (#3353), NOT cursorable, slow
+// (graph + vector + temporal). Same wiring as find_similar.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Request body for [`hybrid_query`] — an **all-optional** mirror of the legacy
+/// `HybridQueryRequest` plus the #3353 token budget. Every field is already
+/// `Option<_>` in the legacy request; the body restores a named,
+/// per-operation `/openapi.json` schema.
+#[derive(Debug, Default, Deserialize)]
+pub struct HybridQueryBody {
+    /// Starting node id (optional, for graph-first queries).
+    pub start_node_id: Option<u64>,
+    /// Edge label for traversal (optional).
+    pub traverse_edge: Option<String>,
+    /// Traversal depth (optional, default 1).
+    pub traverse_depth: Option<usize>,
+    /// Property name for vector similarity (optional).
+    pub vector_property: Option<String>,
+    /// Query embedding for vector similarity (optional).
+    pub query_embedding: Option<Vec<f32>>,
+    /// Number of similar results for vector search (optional).
+    pub top_k: Option<usize>,
+    /// Valid time for temporal filtering (optional, ISO 8601).
+    pub valid_time: Option<String>,
+    /// Transaction time for temporal filtering (optional, ISO 8601).
+    pub transaction_time: Option<String>,
+    /// Filter by node label (optional).
+    pub filter_label: Option<String>,
+    /// Maximum number of results (optional, default 100).
+    pub limit: Option<usize>,
+    /// Return full vector/embedding arrays instead of the elided descriptor
+    /// (#3220). Never affects the `similarity_score`.
+    pub include_vectors: Option<bool>,
+    /// #3353: cap the response at roughly this many tokens (utf8_bytes / 4).
+    pub max_response_tokens: Option<u64>,
+    /// #3353: byte-exact response cap.
+    pub max_response_bytes: Option<u64>,
+    /// #3353: property keys to protect first as the response degrades.
+    pub priority_properties: Option<Vec<String>>,
+}
+
+/// `hybrid_query` — combined graph traversal + vector similarity + temporal
+/// filtering in one query. [`ReadClass`]; vectors elided by default (#3220);
+/// budgetable (#3353), not cursorable. HTTP + MCP tool.
+///
+/// Same wiring as [`find_similar`]: forwards raw arguments through
+/// `dispatch_tool_json` (budget applies) under the B4 resource-limits guard. The
+/// budget never drops or reorders ranked results (only per-result payloads
+/// degrade).
+#[post("/hybrid_query")]
+#[api_doc(
+    description = "Combined graph traversal, vector similarity, and temporal filtering in a single query",
+    mcp
+)]
+pub async fn hybrid_query(
+    _auth: Authorized<ReadClass>,
+    security: ServerSecurityState,
+    state: ServerState,
+    Json(opts): Json<HybridQueryBody>,
+) -> Result<Json<Value>, AletheiaHttpError> {
+    let mut args = Map::new();
+    insert_opt(
+        &mut args,
+        "start_node_id",
+        opts.start_node_id.map(Value::from),
+    );
+    insert_opt(
+        &mut args,
+        "traverse_edge",
+        opts.traverse_edge.map(Value::from),
+    );
+    insert_opt(
+        &mut args,
+        "traverse_depth",
+        opts.traverse_depth.map(Value::from),
+    );
+    insert_opt(
+        &mut args,
+        "vector_property",
+        opts.vector_property.map(Value::from),
+    );
+    insert_opt(
+        &mut args,
+        "query_embedding",
+        opts.query_embedding.map(Value::from),
+    );
+    insert_opt(&mut args, "top_k", opts.top_k.map(Value::from));
+    insert_opt(&mut args, "valid_time", opts.valid_time.map(Value::from));
+    insert_opt(
+        &mut args,
+        "transaction_time",
+        opts.transaction_time.map(Value::from),
+    );
+    insert_opt(
+        &mut args,
+        "filter_label",
+        opts.filter_label.map(Value::from),
+    );
+    insert_opt(&mut args, "limit", opts.limit.map(Value::from));
+    insert_opt(
+        &mut args,
+        "include_vectors",
+        opts.include_vectors.map(Value::from),
+    );
+    insert_budget(
+        &mut args,
+        opts.max_response_tokens,
+        opts.max_response_bytes,
+        opts.priority_properties,
+    );
+    dispatch_slow_read(&security, &state, "hybrid_query", Value::Object(args)).await
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// query — [`ReadClass`], budgetable (#3353), NOT cursorable, slow (declarative
+// query execution). Same wiring. The full structured-error contract, read-only
+// enforcement, `language_unavailable`, and cursor → `unsupported_construct` are
+// ALL produced by dispatch — the handler reimplements none of it, forwarding raw
+// arguments (including `use_cursor` / `cursor`, so dispatch can reject them) and
+// returning the result verbatim.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Request body for [`query`] — an **all-optional** mirror of the legacy
+/// `QueryRequest` plus the #3353 token budget and the #3360 cursor parameters
+/// (carried only so the dispatch layer can reject them with a structured
+/// `unsupported_construct`; the `query` tool is not cursorable in v1). `language`
+/// and `query` are logically required, but requiredness stays a **runtime**
+/// concern the dispatch layer enforces; keeping every field optional restores a
+/// named, per-operation `/openapi.json` schema.
+///
+/// `params` (Cypher `$param` bindings; numeric arrays are treated as embeddings)
+/// and `limits` (the #3368 per-call resource-limit override) round-trip through
+/// the rebuilt args map unchanged. `limits` is passed through as a raw [`Value`]
+/// so the handler needs no dependency on the internal override type.
+#[derive(Debug, Default, Deserialize)]
+pub struct QueryBody {
+    /// Query language: "cypher" or "aql" (logically required; enforced at
+    /// dispatch).
+    pub language: Option<String>,
+    /// The read-only query string to execute (logically required; enforced at
+    /// dispatch).
+    pub query: Option<String>,
+    /// Optional `$param` bindings (Cypher only). Numeric arrays are treated as
+    /// embeddings.
+    pub params: Option<Map<String, Value>>,
+    /// Maximum number of rows to return (default 100, capped at 10000).
+    pub limit: Option<usize>,
+    /// Optional per-call resource-limit override (#3368): `{timeout_ms,
+    /// max_result_rows, max_response_bytes}`. Passed through verbatim.
+    pub limits: Option<Value>,
+    /// #3353: cap the response at roughly this many tokens (utf8_bytes / 4).
+    pub max_response_tokens: Option<u64>,
+    /// #3353: byte-exact response cap.
+    pub max_response_bytes: Option<u64>,
+    /// #3353: property keys to protect first as the response degrades.
+    pub priority_properties: Option<Vec<String>>,
+    /// #3360: not supported by the `query` tool in v1 — forwarded so the dispatch
+    /// layer returns a structured `unsupported_construct` (no silent fallback).
+    pub use_cursor: Option<bool>,
+    /// #3360: not supported by the `query` tool in v1 (see `use_cursor`).
+    pub cursor: Option<String>,
+}
+
+/// `query` — execute a single read-only declarative statement (Cypher or AQL)
+/// and return structured rows + column metadata, or the query tool's structured
+/// error payload. [`ReadClass`]; budgetable (#3353), not cursorable. HTTP + MCP.
+///
+/// Forwards raw arguments through `dispatch_tool_json` (budget applies) under the
+/// B4 resource-limits wiring, because query execution is potentially slow. The
+/// tool's full contract — mutating-clause rejection (`read_only_violation`),
+/// `language_unavailable` when `cypher` is not compiled, cursor →
+/// `unsupported_construct`, and the structured `{error:{kind,message,clause?,
+/// language}}` payload with the additive #3234 `code`/`retriable` — is produced
+/// entirely by dispatch and returned verbatim.
+#[post("/query")]
+#[api_doc(
+    description = "Execute a single read-only Cypher or AQL statement, returning structured rows and columns",
+    mcp
+)]
+pub async fn query(
+    _auth: Authorized<ReadClass>,
+    security: ServerSecurityState,
+    state: ServerState,
+    Json(opts): Json<QueryBody>,
+) -> Result<Json<Value>, AletheiaHttpError> {
+    let mut args = Map::new();
+    insert_opt(&mut args, "language", opts.language.map(Value::from));
+    insert_opt(&mut args, "query", opts.query.map(Value::from));
+    insert_opt(&mut args, "params", opts.params.map(Value::Object));
+    insert_opt(&mut args, "limit", opts.limit.map(Value::from));
+    insert_opt(&mut args, "limits", opts.limits);
+    insert_budget(
+        &mut args,
+        opts.max_response_tokens,
+        opts.max_response_bytes,
+        opts.priority_properties,
+    );
+    insert_opt(&mut args, "use_cursor", opts.use_cursor.map(Value::from));
+    insert_opt(&mut args, "cursor", opts.cursor.map(Value::from));
+    dispatch_slow_read(&security, &state, "query", Value::Object(args)).await
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// list_vector_indexes — [`ReadClass`], NOT budgetable, NOT cursorable, no
+// arguments. Forwards through the typed per-tool method, inline (like
+// count_nodes).
+// ════════════════════════════════════════════════════════════════════════════
+
+/// `list_vector_indexes` — list all active vector indexes and their
+/// configuration (property, dimensions, distance metric). [`ReadClass`]; not
+/// budgetable, not cursorable, takes no arguments. HTTP + MCP tool. Forwards
+/// through the typed `AletheiaMcpServer::list_vector_indexes` method inline.
+#[get("/vector/indexes")]
+#[api_doc(
+    description = "List all active vector indexes and their configuration (property, dimensions, metric)",
+    mcp
+)]
+pub async fn list_vector_indexes(_auth: Authorized<ReadClass>, state: ServerState) -> Json<Value> {
+    let server = state.mcp_server();
+    tool_json(server.list_vector_indexes(ListVectorIndexesRequest {}))
+}

--- a/crates/aletheia-server/tests/vector_query_parity.rs
+++ b/crates/aletheia-server/tests/vector_query_parity.rs
@@ -1,0 +1,603 @@
+//! Parity + behavior tests for the VECTOR + HYBRID + QUERY cluster (Issue #3524,
+//! PR5): `find_similar`, `list_vector_indexes`, `hybrid_query`, and `query`.
+//!
+//! Each test drives the new crate's autumn [`TestClient`] and asserts the
+//! response equals the **legacy MCP surface** over the same `Arc<AletheiaDB>` —
+//! byte-for-byte (parsed-JSON equality, `trace_id` + wall-clock-volatile
+//! bi-temporal timestamps normalized) — in both anonymous and required auth
+//! modes. The legacy reference is `dispatch_tool_json` for the three
+//! dispatch-routed budgetable reads (`find_similar`, `hybrid_query`, `query`) and
+//! the typed `list_vector_indexes` method. Plus: #3220 vector elision on
+//! `find_similar` / `hybrid_query`, #3353 budget shaping (results never
+//! dropped/reordered — only per-result payloads degrade), the `query` tool's
+//! structured-error-kind preservation (`parse_error`, `read_only_violation`,
+//! cursor → `unsupported_construct`, and `language_unavailable` — the `cypher`
+//! feature is NOT compiled into this crate, so `language:"cypher"` is
+//! unavailable), and the shared `DISPATCH_ROUTED_READ_TOOLS` pin.
+
+use std::sync::Arc;
+
+use aletheia_server::build_server_client;
+use aletheiadb::auth::{AccessClass, AuthMode, AuthStore, Role};
+use aletheiadb::mcp::{AletheiaMcpServer, EnableVectorIndexRequest, ListVectorIndexesRequest};
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+use autumn_web::test::TestClient;
+use serde_json::{Value, json};
+
+const ADMIN_TOKEN: &str = "admin-token-abcdefghijklmnop";
+const READER_TOKEN: &str = "reader-token-abcdefghijklmnop";
+
+/// A long note so a single ranked result comfortably exceeds a modest byte
+/// budget, forcing the #3353 ladder to shape it down without dropping results.
+const LONG_NOTE: &str = "a deliberately long note property, repeated so the full \
+     serialized response comfortably exceeds a moderate byte budget and the #3353 \
+     ladder must shape it down: lorem ipsum dolor sit amet consectetur adipiscing \
+     elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua ut enim \
+     ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex";
+
+struct Fixture {
+    db: Arc<AletheiaDB>,
+    store: Arc<AuthStore>,
+    alice: u64,
+}
+
+fn make_store() -> Arc<AuthStore> {
+    let store = Arc::new(AuthStore::new());
+    store
+        .insert_bootstrap_key("admin", Role::Admin, ADMIN_TOKEN)
+        .expect("insert admin key");
+    store
+        .insert_bootstrap_key("reader", Role::Reader, READER_TOKEN)
+        .expect("insert reader key");
+    store
+}
+
+fn mcp_server(db: &Arc<AletheiaDB>) -> AletheiaMcpServer {
+    AletheiaMcpServer::new(db.clone())
+}
+
+/// A shared DB with a `cosine` vector index on `embedding` (dim 4) and a small
+/// graph: Alice --KNOWS--> {Bob, Carol, Dave}, each Document/Person bearing a
+/// distinct embedding + a bulky `note` so ranked responses are budgetable.
+fn fixture() -> Fixture {
+    let db = Arc::new(AletheiaDB::new().expect("create db"));
+    // Enable the vector index up front (writer/admin op done directly on the db,
+    // bypassing the autumn gate — this is fixture setup, not the surface under
+    // test).
+    let setup = mcp_server(&db);
+    let enabled = setup.enable_vector_index(EnableVectorIndexRequest {
+        property_name: "embedding".to_string(),
+        dimensions: 4,
+        distance_metric: Some("cosine".to_string()),
+    });
+    assert!(
+        serde_json::from_str::<Value>(&enabled).expect("json")["success"] == json!(true),
+        "vector index must enable: {enabled}"
+    );
+
+    // A bulky note so a full ranked/query response comfortably exceeds a cap set
+    // above the #3353 minimal-rung "min viable" budget (which strips property
+    // values, so it does NOT grow with note size).
+    let bulky = LONG_NOTE.repeat(8);
+    let alice = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .insert("note", bulky.as_str())
+                .insert_vector("embedding", &[0.10_f32, 0.20, 0.30, 0.40])
+                .build(),
+        )
+        .expect("create alice")
+        .as_u64();
+
+    let mut idx = 1.0_f32;
+    for name in ["Bob", "Carol", "Dave"] {
+        let target = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("name", name)
+                    .insert("note", bulky.as_str())
+                    .insert_vector(
+                        "embedding",
+                        &[0.10 * idx, 0.20 * idx, 0.30 * idx, 0.40 * idx],
+                    )
+                    .build(),
+            )
+            .expect("create target");
+        db.create_edge(
+            aletheiadb::core::NodeId::new(alice).unwrap(),
+            target,
+            "KNOWS",
+            PropertyMapBuilder::new().insert("since", 2020_i64).build(),
+        )
+        .expect("create edge");
+        idx += 1.0;
+    }
+
+    Fixture {
+        db,
+        store: make_store(),
+        alice,
+    }
+}
+
+/// Recursively drop the per-request `trace_id` and the wall-clock-volatile
+/// bi-temporal timestamps so an autumn response and a legacy reference compare.
+fn normalize(v: Value) -> Value {
+    match v {
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .filter(|(k, _)| {
+                    !matches!(
+                        k.as_str(),
+                        "trace_id"
+                            | "valid_from"
+                            | "valid_to"
+                            | "transaction_from"
+                            | "transaction_to"
+                            | "transaction_time"
+                            | "timestamp"
+                            | "snapshot_valid_time"
+                            | "snapshot_transaction_time"
+                            | "cursor"
+                            | "cursor_ttl_seconds"
+                    )
+                })
+                .map(|(k, val)| (k, normalize(val)))
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(items.into_iter().map(normalize).collect()),
+        other => other,
+    }
+}
+
+fn len_of(v: &Value) -> usize {
+    serde_json::to_string(v).expect("serialize").len()
+}
+
+async fn get(client: &TestClient, uri: &str, bearer: Option<&str>) -> (u16, Value) {
+    let mut req = client.get(uri);
+    if let Some(token) = bearer {
+        req = req.header("authorization", &format!("Bearer {token}"));
+    }
+    let resp = req.send().await;
+    let status = resp.status.as_u16();
+    let body: Value = serde_json::from_str(&resp.text()).expect("new body is JSON");
+    (status, body)
+}
+
+async fn post(client: &TestClient, uri: &str, body: &Value, bearer: Option<&str>) -> (u16, Value) {
+    let mut req = client.post(uri);
+    if let Some(token) = bearer {
+        req = req.header("authorization", &format!("Bearer {token}"));
+    }
+    let resp = req.json(body).send().await;
+    let status = resp.status.as_u16();
+    let body: Value = serde_json::from_str(&resp.text()).expect("new body is JSON");
+    (status, body)
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Byte-parity for all four tools vs the legacy MCP surface, in both auth modes.
+// ════════════════════════════════════════════════════════════════════════════
+
+async fn assert_all_four_parity(mode: AuthMode, token: Option<&'static str>) {
+    let fx = fixture();
+    let client = build_server_client(fx.db.clone(), fx.store.clone(), mode);
+    let server = mcp_server(&fx.db);
+
+    // 1. find_similar (POST) — dispatch reference. `FindSimilarRequest` is
+    //    `#[non_exhaustive]` (cannot be built out-of-crate), so the legacy
+    //    reference is the equivalent public `dispatch_tool_json` path — exactly
+    //    what the autumn handler forwards to.
+    let fs_args = json!({
+        "property_name": "embedding",
+        "embedding": [0.10, 0.20, 0.30, 0.40],
+        "k": 3
+    });
+    let (s, autumn) = post(&client, "/find_similar", &fs_args, token).await;
+    assert_eq!(s, 200, "find_similar: {autumn}");
+    let legacy: Value =
+        serde_json::from_str(&server.dispatch_tool_json("find_similar", fs_args.clone()))
+            .expect("legacy find_similar json");
+    assert_eq!(normalize(autumn), normalize(legacy), "find_similar parity");
+
+    // 2. hybrid_query (POST) — dispatch reference.
+    let hq_args = json!({
+        "start_node_id": fx.alice,
+        "traverse_edge": "KNOWS",
+        "traverse_depth": 1,
+        "vector_property": "embedding",
+        "query_embedding": [0.10, 0.20, 0.30, 0.40],
+        "top_k": 3
+    });
+    let (s, autumn) = post(&client, "/hybrid_query", &hq_args, token).await;
+    assert_eq!(s, 200, "hybrid_query: {autumn}");
+    let legacy: Value =
+        serde_json::from_str(&server.dispatch_tool_json("hybrid_query", hq_args.clone()))
+            .expect("legacy hybrid_query json");
+    assert_eq!(normalize(autumn), normalize(legacy), "hybrid_query parity");
+
+    // 3. query (POST, AQL — always available) — dispatch reference.
+    let q_args = json!({ "language": "aql", "query": "MATCH (n:Person) RETURN n" });
+    let (s, autumn) = post(&client, "/query", &q_args, token).await;
+    assert_eq!(s, 200, "query: {autumn}");
+    let legacy: Value = serde_json::from_str(&server.dispatch_tool_json("query", q_args.clone()))
+        .expect("legacy query json");
+    assert_eq!(normalize(autumn), normalize(legacy), "query parity");
+
+    // 4. list_vector_indexes (GET) — typed method reference.
+    let (s, autumn) = get(&client, "/vector/indexes", token).await;
+    assert_eq!(s, 200, "list_vector_indexes: {autumn}");
+    let legacy: Value =
+        serde_json::from_str(&server.list_vector_indexes(ListVectorIndexesRequest {}))
+            .expect("legacy list_vector_indexes json");
+    assert_eq!(
+        normalize(autumn),
+        normalize(legacy),
+        "list_vector_indexes parity"
+    );
+}
+
+#[tokio::test]
+async fn all_four_byte_parity_required_mode() {
+    assert_all_four_parity(AuthMode::Required, Some(READER_TOKEN)).await;
+}
+
+#[tokio::test]
+async fn all_four_byte_parity_anonymous_mode() {
+    assert_all_four_parity(AuthMode::Anonymous, None).await;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// #3220 vector elision on find_similar / hybrid_query, plus include_vectors.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn find_similar_elides_vectors_by_default_and_preserves_score() {
+    let fx = fixture();
+    let client = build_server_client(fx.db.clone(), fx.store.clone(), AuthMode::Required);
+
+    let args = json!({
+        "property_name": "embedding",
+        "embedding": [0.10, 0.20, 0.30, 0.40],
+        "k": 3
+    });
+    let (status, body) = post(&client, "/find_similar", &args, Some(READER_TOKEN)).await;
+    assert_eq!(status, 200, "find_similar: {body}");
+    let results = body["results"].as_array().expect("results array");
+    assert!(!results.is_empty(), "expected ranked results: {body}");
+    let first = &results[0];
+    // The similarity score is always returned in full (never elided).
+    assert!(
+        first["score"].is_number(),
+        "score returned in full: {first}"
+    );
+    // #3220: the embedding is elided by default on the vector read path.
+    assert_eq!(
+        first["node"]["properties"]["embedding"]["elided"], true,
+        "embedding elided by default: {first}"
+    );
+
+    // include_vectors=true returns the raw array.
+    let mut raw_args = args.clone();
+    raw_args["include_vectors"] = json!(true);
+    let (_s, raw) = post(&client, "/find_similar", &raw_args, Some(READER_TOKEN)).await;
+    assert!(
+        raw["results"][0]["node"]["properties"]["embedding"].is_array(),
+        "include_vectors=true returns the raw array: {raw}"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// #3353 token budget: find_similar / hybrid_query / query are budgetable. The
+// budget shapes the response and matches the legacy dispatch; find_similar /
+// hybrid_query NEVER drop or reorder ranked results (only per-result payloads
+// degrade).
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn find_similar_budget_shapes_without_dropping_results_and_matches_legacy() {
+    let fx = fixture();
+    let client = build_server_client(fx.db.clone(), fx.store.clone(), AuthMode::Required);
+    let server = mcp_server(&fx.db);
+
+    let base = json!({
+        "property_name": "embedding",
+        "embedding": [0.10, 0.20, 0.30, 0.40],
+        "k": 4
+    });
+
+    // Full (no budget): no `budget` block, exceeds the cap.
+    let (status, full) = post(&client, "/find_similar", &base, Some(READER_TOKEN)).await;
+    assert_eq!(status, 200);
+    assert!(full.get("budget").is_none(), "no budget block: {full}");
+    let full_count = full["results"].as_array().expect("results").len();
+    assert!(full_count >= 3, "need several ranked results: {full}");
+    // Capture the full ranked order for the drop/reorder check.
+    let full_ids: Vec<u64> = full["results"]
+        .as_array()
+        .expect("results")
+        .iter()
+        .map(|r| r["node"]["id"].as_u64().expect("node id"))
+        .collect();
+    // Above the #3353 min-viable budget (~3116B for these results) yet below the
+    // bulky full response, so the ladder shapes (not rejects) the response.
+    let cap: u64 = 5000;
+    assert!(
+        len_of(&full) as u64 > cap,
+        "full response should exceed the cap: {}",
+        len_of(&full)
+    );
+
+    // Legacy dispatch is the reference; its emitted string is the exact bytes the
+    // #3353 contract bounds.
+    let mut budget_args = base.clone();
+    budget_args["max_response_bytes"] = json!(cap);
+    let legacy_text = server.dispatch_tool_json("find_similar", budget_args.clone());
+    assert!(
+        legacy_text.len() as u64 <= cap,
+        "emitted string must fit the byte budget: {} > {cap}",
+        legacy_text.len()
+    );
+    let legacy: Value = serde_json::from_str(&legacy_text).expect("legacy json");
+    assert!(legacy["budget"].is_object(), "budget block: {legacy}");
+
+    // Autumn with the same budget: shaped, matches legacy, results not dropped
+    // or reordered (only per-result payloads degrade).
+    let (status, budgeted) = post(&client, "/find_similar", &budget_args, Some(READER_TOKEN)).await;
+    assert_eq!(status, 200);
+    assert!(budgeted["budget"].is_object(), "shaped: {budgeted}");
+    assert!(
+        len_of(&budgeted) < len_of(&full),
+        "shaped response smaller: {} !< {}",
+        len_of(&budgeted),
+        len_of(&full)
+    );
+    let budgeted_ids: Vec<u64> = budgeted["results"]
+        .as_array()
+        .expect("results")
+        .iter()
+        .map(|r| r["node"]["id"].as_u64().expect("node id"))
+        .collect();
+    assert_eq!(
+        budgeted_ids, full_ids,
+        "ranked results must NOT be dropped or reordered by the budget: {budgeted}"
+    );
+    assert_eq!(
+        normalize(budgeted),
+        normalize(legacy),
+        "budgeted autumn find_similar must equal the legacy dispatch"
+    );
+}
+
+#[tokio::test]
+async fn query_budget_shapes_response_and_matches_legacy() {
+    let fx = fixture();
+    let client = build_server_client(fx.db.clone(), fx.store.clone(), AuthMode::Required);
+    let server = mcp_server(&fx.db);
+
+    let base = json!({ "language": "aql", "query": "MATCH (n:Person) RETURN n" });
+    let (status, full) = post(&client, "/query", &base, Some(READER_TOKEN)).await;
+    assert_eq!(status, 200, "query: {full}");
+    assert!(full.get("budget").is_none(), "no budget block: {full}");
+    // Above the #3353 min-viable budget (~1508B) yet below the bulky full
+    // response, so the ladder shapes (not rejects) the response.
+    let cap: u64 = 3000;
+    assert!(
+        len_of(&full) as u64 > cap,
+        "full response should exceed the cap: {}",
+        len_of(&full)
+    );
+
+    let mut budget_args = base.clone();
+    budget_args["max_response_bytes"] = json!(cap);
+    let legacy_text = server.dispatch_tool_json("query", budget_args.clone());
+    assert!(
+        legacy_text.len() as u64 <= cap,
+        "emitted string must fit the byte budget: {} > {cap}",
+        legacy_text.len()
+    );
+    let legacy: Value = serde_json::from_str(&legacy_text).expect("legacy json");
+    assert!(legacy["budget"].is_object(), "budget block: {legacy}");
+
+    let (status, budgeted) = post(&client, "/query", &budget_args, Some(READER_TOKEN)).await;
+    assert_eq!(status, 200);
+    assert!(budgeted["budget"].is_object(), "shaped: {budgeted}");
+    assert!(
+        len_of(&budgeted) < len_of(&full),
+        "shaped response smaller: {} !< {}",
+        len_of(&budgeted),
+        len_of(&full)
+    );
+    assert_eq!(
+        normalize(budgeted),
+        normalize(legacy),
+        "budgeted autumn query must equal the legacy dispatch"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// `query` structured-error-kind preservation. All error semantics are produced
+// by dispatch and returned verbatim; each kind must match the legacy dispatch.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Assert the autumn `/query` response equals the legacy dispatch for `args` and
+/// carries the expected structured error `kind`.
+async fn assert_query_error_kind(
+    client: &TestClient,
+    server: &AletheiaMcpServer,
+    args: Value,
+    kind: &str,
+) {
+    let (status, autumn) = post(client, "/query", &args, Some(READER_TOKEN)).await;
+    assert_eq!(
+        status, 200,
+        "query error returns 200 with in-band error: {autumn}"
+    );
+    let legacy: Value = serde_json::from_str(&server.dispatch_tool_json("query", args.clone()))
+        .expect("legacy query error json");
+    assert_eq!(
+        normalize(autumn.clone()),
+        normalize(legacy),
+        "query error parity for kind {kind}: {args}"
+    );
+    assert_eq!(
+        autumn["error"]["kind"],
+        json!(kind),
+        "expected error kind {kind}: {autumn}"
+    );
+}
+
+#[tokio::test]
+async fn query_read_only_violation_kind_preserved() {
+    let fx = fixture();
+    let client = build_server_client(fx.db.clone(), fx.store.clone(), AuthMode::Required);
+    let server = mcp_server(&fx.db);
+    // A mutating clause is rejected BEFORE execution.
+    assert_query_error_kind(
+        &client,
+        &server,
+        json!({ "language": "aql", "query": "CREATE (n:Person {name: 'Mallory'}) RETURN n" }),
+        "read_only_violation",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn query_parse_error_kind_preserved() {
+    let fx = fixture();
+    let client = build_server_client(fx.db.clone(), fx.store.clone(), AuthMode::Required);
+    let server = mcp_server(&fx.db);
+    // Syntactically invalid AQL (passes the read-only guard, fails to parse).
+    assert_query_error_kind(
+        &client,
+        &server,
+        json!({ "language": "aql", "query": "MATCH (n:Person RETURN n !!!" }),
+        "parse_error",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn query_cursor_request_is_unsupported_construct() {
+    let fx = fixture();
+    let client = build_server_client(fx.db.clone(), fx.store.clone(), AuthMode::Required);
+    let server = mcp_server(&fx.db);
+    // Cursor paging is not supported for the `query` tool in v1 — no silent
+    // fallback; a structured `unsupported_construct` is returned.
+    assert_query_error_kind(
+        &client,
+        &server,
+        json!({ "language": "aql", "query": "MATCH (n:Person) RETURN n", "use_cursor": true }),
+        "unsupported_construct",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn query_cypher_language_unavailable_when_feature_off() {
+    // The `cypher` feature is NOT compiled into the aletheia-server crate (its
+    // `aletheiadb` dep enables only `http-server` + `mcp-server` + defaults), so
+    // `language:"cypher"` returns `language_unavailable`. Both the autumn handler
+    // and the legacy reference run in this same compiled crate, so parity holds.
+    let fx = fixture();
+    let client = build_server_client(fx.db.clone(), fx.store.clone(), AuthMode::Required);
+    let server = mcp_server(&fx.db);
+    assert_query_error_kind(
+        &client,
+        &server,
+        json!({ "language": "cypher", "query": "MATCH (n:Person) RETURN n" }),
+        "language_unavailable",
+    )
+    .await;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Auth: the four tools are ReadClass — a keyless required-mode call is 401.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn vector_query_tools_require_credential_in_required_mode() {
+    let fx = fixture();
+    let client = build_server_client(fx.db, fx.store, AuthMode::Required);
+
+    // GET list_vector_indexes.
+    let resp = client.get("/vector/indexes").send().await;
+    assert_eq!(resp.status.as_u16(), 401, "list_vector_indexes unauth");
+    assert_eq!(resp.header("www-authenticate"), Some("Bearer"));
+
+    // POST find_similar / hybrid_query / query.
+    for uri in ["/find_similar", "/hybrid_query", "/query"] {
+        let resp = client.post(uri).json(&json!({})).send().await;
+        assert_eq!(resp.status.as_u16(), 401, "{uri} unauth");
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Conformance: the three dispatch-routed budgetable reads are pinned in the
+// shared DISPATCH_ROUTED_READ_TOOLS table with Read class (extends the coverage
+// the `dispatch_pinned_names_match_routed_class` test in server_parity.rs
+// asserts). `list_vector_indexes` (typed, non-budgetable) is intentionally NOT
+// pinned.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn dispatch_routed_table_includes_vector_query_reads() {
+    use aletheia_server::edge_tools::DISPATCH_ROUTED_READ_TOOLS;
+    for name in ["find_similar", "hybrid_query", "query"] {
+        let entry = DISPATCH_ROUTED_READ_TOOLS
+            .iter()
+            .find(|(n, _)| *n == name)
+            .unwrap_or_else(|| panic!("{name} must be pinned in DISPATCH_ROUTED_READ_TOOLS"));
+        assert_eq!(entry.1, AccessClass::Read, "{name} pinned as Read");
+    }
+    assert!(
+        !DISPATCH_ROUTED_READ_TOOLS
+            .iter()
+            .any(|(n, _)| *n == "list_vector_indexes"),
+        "list_vector_indexes is typed/non-budgetable and must NOT be dispatch-routed"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// OpenAPI schema fidelity: the three POST reads must expose a named,
+// per-operation request schema in /openapi.json — never the generic `Value`.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn openapi_post_reads_have_typed_request_schemas() {
+    let fx = fixture();
+    let client = build_server_client(fx.db, fx.store, AuthMode::Required);
+    let resp = client.get("/openapi.json").send().await;
+    assert_eq!(resp.status.as_u16(), 200);
+    let spec: Value = serde_json::from_str(&resp.text()).expect("openapi json");
+
+    for (path, expected_suffix) in [
+        ("/find_similar", "/FindSimilarBody"),
+        ("/hybrid_query", "/HybridQueryBody"),
+        ("/query", "/QueryBody"),
+    ] {
+        let schema =
+            &spec["paths"][path]["post"]["requestBody"]["content"]["application/json"]["schema"];
+        let sref = schema["$ref"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{path} requestBody schema must be a $ref: {schema}"));
+        assert!(
+            sref.ends_with(expected_suffix),
+            "{path} request body must ref a typed per-operation schema, got {sref}"
+        );
+        assert_ne!(
+            sref, "#/components/schemas/Value",
+            "{path} must not degrade to the shared generic Value component"
+        );
+    }
+    // GET list_vector_indexes is documented.
+    assert!(
+        !spec["paths"]["/vector/indexes"]["get"].is_null(),
+        "GET /vector/indexes documented: {}",
+        spec["paths"]
+    );
+}


### PR DESCRIPTION
## Summary

PR5 of the Issue #3524 autumn-web migration: the **VECTOR + HYBRID + QUERY** MCP tool cluster (`find_similar`, `list_vector_indexes`, `hybrid_query`, `query`) ported to the `aletheia-server` crate. Each is a single `#[get]`/`#[post]` + `#[api_doc(mcp)]` handler surfacing on **HTTP**, **MCP-over-HTTP** (`/mcp`), and **OpenAPI** at once, producing responses byte-identical to the legacy MCP surface. Mirrors the proven PR2/PR3/PR4 + node-reads-retrofit patterns exactly. **No main-crate changes.**

Merge-base: `b833ad6` (= `origin/trunk` tip, contains PR4 — `traverse_temporal_tools.rs` present, `DISPATCH_ROUTED_READ_TOOLS` includes `traverse` + `get_node_history`).

## Before / After

| | Before (PR4 tip) | After (this PR) |
|---|---|---|
| `find_similar` | not on autumn surface | `POST /find_similar`, HTTP+MCP+OpenAPI, dispatch-routed + slow-read guard |
| `hybrid_query` | not on autumn surface | `POST /hybrid_query`, HTTP+MCP+OpenAPI, dispatch-routed + slow-read guard |
| `query` | not on autumn surface | `POST /query`, HTTP+MCP+OpenAPI, dispatch-routed + slow-read guard |
| `list_vector_indexes` | not on autumn surface | `GET /vector/indexes`, HTTP+MCP+OpenAPI, typed inline |
| `DISPATCH_ROUTED_READ_TOOLS` | 9 entries | 12 (adds `find_similar`, `hybrid_query`, `query`) |

## Verified classification (`BUDGETABLE_READ_TOOLS`, `src/mcp/server.rs:6437`)

`find_similar`, `hybrid_query`, `query` are in `BUDGETABLE_READ_TOOLS`; `list_vector_indexes` is **not**. The cursorable set (`inject_cursor_schema_params`, `src/mcp/server.rs:6491`) is exactly `list_nodes, find_nodes_at_time, get_outgoing_edges, get_incoming_edges, traverse` — **none** of the four PR5 tools is cursorable. Classification in the task brief confirmed correct against source.

## Execution / budget matrix

| Tool | Class | Budgetable (#3353) | Cursorable (#3360) | Forwarding | Guard? |
|---|---|---|---|---|---|
| `find_similar` | Read | yes | no | `dispatch_tool_json("find_similar", …)` | in-flight guard + `run_with_timeout` + byte cap |
| `hybrid_query` | Read | yes | no | `dispatch_tool_json("hybrid_query", …)` | in-flight guard + `run_with_timeout` + byte cap |
| `query` | Read | yes | no | `dispatch_tool_json("query", …)` | in-flight guard + `run_with_timeout` + byte cap |
| `list_vector_indexes` | Read | no | no | typed `AletheiaMcpServer::list_vector_indexes` | inline (none) |

`query`'s full structured-error contract (`{error:{kind,message,clause?,language}}`; kinds `read_only_violation`/`parse_error`/`unsupported_construct`/`language_unavailable`/…), read-only enforcement, and cursor → `unsupported_construct` are **produced entirely by dispatch** and returned verbatim — the handler reimplements none of it (it forwards raw args including `use_cursor`/`cursor` so dispatch can reject them).

## Marker ↔ inventory cross-check (Lane B B4)

All four handler `Authorized<C>` markers == inventory `access_class`:

| Tool | Handler marker | Inventory `access_class` | Match |
|---|---|---|---|
| `find_similar` | `Authorized<ReadClass>` | `read` | ✅ |
| `hybrid_query` | `Authorized<ReadClass>` | `read` | ✅ |
| `query` | `Authorized<ReadClass>` | `read` | ✅ |
| `list_vector_indexes` | `Authorized<ReadClass>` | `read` | ✅ |

## Feature set used for `query`

The `cypher` feature is **NOT** compiled into `aletheia-server` (its `aletheiadb` dep enables `http-server` + `mcp-server` + crate defaults `config-toml`/`audit-export`/`simsimd`; `cypher` is not a default and is not added). So `language:"cypher"` returns `language_unavailable` — matched by the parity test, and consistent with the `cargo test --features http-server,mcp-server --test parity_mcp` gate (cypher off there too). AQL is always available; parity holds because both the autumn handler and the legacy `dispatch_tool_json` reference run in the same compiled crate.

## Main-crate widenings

**None.** `dispatch_tool_json` (the raw-args entry these three reads forward through) and all four request types (`FindSimilarRequest`, `HybridQueryRequest`, `QueryRequest`, `ListVectorIndexesRequest`) were already public from prior PRs. Diff is confined to `crates/aletheia-server/`.

## Registry-boundary note

Touched **no** `src/security/**` and no `tests/security_*.rs`. Lane B1 classifies all four in the RBAC registry; Lane A only extended `crate::edge_tools::DISPATCH_ROUTED_READ_TOOLS` for the three dispatch-routed budgetable reads (`list_vector_indexes` is typed/non-budgetable and intentionally NOT pinned).

## Codecov / patch coverage

Non-blocking — coverage delta advisory only.

## AC evidence — inventory rows → passing parity tests

| Inventory row (`read`) | Pinned by (new) | Result |
|---|---|---|
| `find_similar` | `all_four_byte_parity_{required,anonymous}_mode`, `find_similar_elides_vectors_by_default_and_preserves_score`, `find_similar_budget_shapes_without_dropping_results_and_matches_legacy` | pass |
| `hybrid_query` | `all_four_byte_parity_{required,anonymous}_mode` | pass |
| `query` | `all_four_byte_parity_*`, `query_budget_shapes_response_and_matches_legacy`, `query_{read_only_violation,parse_error}_kind_preserved`, `query_cursor_request_is_unsupported_construct`, `query_cypher_language_unavailable_when_feature_off` | pass |
| `list_vector_indexes` | `all_four_byte_parity_*`, `dispatch_routed_table_includes_vector_query_reads` (negative) | pass |

Plus `openapi_post_reads_have_typed_request_schemas`, `vector_query_tools_require_credential_in_required_mode`, and the extended `server_parity::dispatch_pinned_names_match_routed_class` (now covers the 3 new pins).

```
tests/vector_query_parity.rs ... test result: ok. 12 passed; 0 failed; 0 ignored
```

## Gates (isolated CARGO_TARGET_DIR)

```
cargo clippy -p aletheia-server --all-targets -- -D warnings         Finished (0 warnings)
cargo test  -p aletheia-server                                       all binaries ok:
  edge_parity 24 · node_reads_budget_cursor 10 · node_writes_parity 18
  security_acceptance 26 · security_cursor 11 · security_mcp_gate 10
  security_rate_limit 9 · security_rbac 15 · security_resource_limits 17
  server_parity 20 · traverse_temporal_parity 10 · vector_query_parity 12
cargo fmt --all -- --check                                           clean
cargo check -p aletheiadb --no-default-features --tests --features http-server   Finished (exit 0)
cargo test --features http-server,mcp-server --test parity_http --test parity_mcp
  parity_http 33 passed · parity_mcp 11 passed
cargo clippy -p aletheiadb --features "config-toml,mcp-server,sharding-rpc,simulation" --all-targets -- -D warnings   Finished (0 warnings)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEwJg2bDPZ7DzcHebqwZVK

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEwJg2bDPZ7DzcHebqwZVK)_