### PR TITLE
feat(clients): TypeScript client SDK (#3369)

### DIFF
--- a/.github/workflows/ts-sdk.yml
+++ b/.github/workflows/ts-sdk.yml
@@ -50,11 +50,14 @@ jobs:
       - name: Typecheck (strict; src + examples)
         run: npm run typecheck
 
-      - name: Test (vitest, record-replay fixtures)
-        run: npm run test
-
+      # Build BEFORE test so test/build.test.ts observes the dist artifacts and
+      # its ESM/CJS smoke `describe` actually runs (it self-skips when dist is
+      # absent). Order: build -> test -> smoke.
       - name: Build (ESM + CJS + d.ts)
         run: npm run build
+
+      - name: Test (vitest, record-replay fixtures)
+        run: npm run test
 
       - name: Entry-point smoke (ESM + CJS import cleanly)
         run: npm run smoke

--- a/.github/workflows/ts-sdk.yml
+++ b/.github/workflows/ts-sdk.yml
@@ -1,0 +1,60 @@
+# TypeScript client SDK checks (Issue #3369).
+#
+# NEW, informational workflow scoped to `clients/typescript/**`. It does NOT
+# modify or gate any existing job; it runs the SDK's own install/lint/typecheck/
+# test/build pipeline on Node LTS. Tests use record-replay fetch fixtures (no
+# live server binary), so no Rust build is required here.
+name: ts-sdk
+
+on:
+  push:
+    paths:
+      - 'clients/typescript/**'
+      - '.github/workflows/ts-sdk.yml'
+  pull_request:
+    paths:
+      - 'clients/typescript/**'
+      - '.github/workflows/ts-sdk.yml'
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: clients/typescript
+
+jobs:
+  build-and-test:
+    name: lint · typecheck · test · build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['18', '20', '22']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: clients/typescript/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint (bans `any` in the public surface)
+        run: npm run lint
+
+      - name: Typecheck (strict; src + examples)
+        run: npm run typecheck
+
+      - name: Test (vitest, record-replay fixtures)
+        run: npm run test
+
+      - name: Build (ESM + CJS + d.ts)
+        run: npm run build
+
+      - name: Entry-point smoke (ESM + CJS import cleanly)
+        run: npm run smoke

--- a/clients/typescript/.gitignore
+++ b/clients/typescript/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+coverage/
+*.tsbuildinfo
+.DS_Store

--- a/clients/typescript/COMPATIBILITY.md
+++ b/clients/typescript/COMPATIBILITY.md
@@ -1,0 +1,40 @@
+# Compatibility & Versioning Policy
+
+`@aletheiadb/client` is a thin, typed wrapper over the AletheiaDB **HTTP API**. This document states which server versions an SDK version supports and how breaking HTTP changes propagate to SDK releases.
+
+## Semantic versioning
+
+The SDK follows [semver](https://semver.org/). Given `MAJOR.MINOR.PATCH`:
+
+- **MAJOR** — a breaking change to the SDK's *public TypeScript surface* (a renamed/removed method, a changed request/response type, a changed error class). Dropping support for a server API version is also MAJOR.
+- **MINOR** — additive, backward-compatible: wrapping a newly-merged endpoint (e.g. graduating a stub to a real call), new optional options, new exported types.
+- **PATCH** — bug fixes and doc changes with no surface change.
+
+## Server ↔ SDK support matrix
+
+The SDK targets the **HTTP surface** described by `tests/parity/inventory.json` and the autumn-server route handlers (`crates/aletheia-server/src/*_tools.rs`). Because the server is pre-1.0 and its HTTP surface is being ported route-by-route, this initial SDK line tracks the surface by capability rather than a frozen server version.
+
+| SDK version | Server HTTP surface | Notes |
+|-------------|---------------------|-------|
+| `0.1.x` | autumn-server node/edge/traverse/temporal + admin/health routes (Issue #3524 PR1–PR4) | 34 merged routes wrapped; vector/hybrid/query/schema/stats/batch/lineage are typed stubs (`NotImplementedError`). |
+
+As the remaining routes merge (vector, hybrid, `query`, schema, stats, batch, lineage), each stub graduates to a real typed call in a **MINOR** release, and this table gains a row naming the server capability/version it requires.
+
+## How breaking HTTP changes propagate
+
+The SDK mirrors the server's wire contract **exactly** (route paths, request/response field names, the `temporal` block, vector-elision descriptors, and the structured error envelope). When the server changes that contract:
+
+1. **Additive server change** (new optional field, new route, new optional param) → **MINOR** SDK release. Existing calls are unaffected; new options/types are added.
+2. **Breaking server change** (renamed/removed field, changed status/enum, changed error `code`) → **MAJOR** SDK release. The SDK pins the old shape until the major bump so an app is never silently mis-typed.
+3. **New structured error `code`** → handled gracefully with **no** release required: an unknown `code` maps to the base `AletheiaError` with `retriable === false` (forward-compatible by design). A dedicated subclass for the new code is added in a **MINOR** release.
+4. **Server gaps found while building the SDK** are filed against the server (per Issue #3369's out-of-scope note), **not** worked around client-side.
+
+## Runtime support
+
+- **Node.js ≥ 18** (global `fetch`). On older Node, inject a `fetch` implementation via `ClientOptions.fetch`.
+- **Standard-`fetch` edge runtimes** (Vercel Edge, Cloudflare Workers, Deno) — the core client has no Node-only dependencies.
+- Both **ESM** (`import`) and **CommonJS** (`require`) entry points are shipped and smoke-tested on every build.
+
+## Deprecation policy
+
+A deprecated method/type is marked with `@deprecated` (surfaced in editors) for at least one MINOR release before removal in the next MAJOR. Stubs that throw `NotImplementedError` are **not** considered deprecations — they are forward-declarations of endpoints that will become live.

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -1,0 +1,174 @@
+# `@aletheiadb/client`
+
+The official **TypeScript SDK** for [AletheiaDB](https://github.com/madmax983/AletheiaDB) — a bi-temporal graph + vector database. Fully typed nodes/edges/properties, ergonomic `asOf()` temporal calls, vector-elision-aware types, and the structured error contract surfaced as a typed error hierarchy with an opt-in retry policy.
+
+- Runs on **Node ≥ 18** and standard-`fetch` edge runtimes (no Node-only deps in the core).
+- **ESM + CJS** dual build with full type declarations.
+- **0 `any`** in the published type surface (lint-enforced).
+
+> **Status:** this is the first cut wrapping the **merged** autumn-server HTTP routes (node/edge/traverse/temporal + admin/health). Vector/hybrid/query/schema/stats/batch/lineage endpoints are typed **stubs** that throw `NotImplementedError` until their REST routes land. See [Coverage](#coverage) and [`COMPATIBILITY.md`](./COMPATIBILITY.md).
+
+## Install
+
+```bash
+npm install @aletheiadb/client
+```
+
+## Quickstart
+
+```ts
+import { AletheiaClient } from '@aletheiadb/client';
+
+const db = new AletheiaClient({
+  baseUrl: 'http://localhost:8080',
+  apiKey: process.env.ALETHEIA_API_KEY, // omit only against an anonymous-mode server
+});
+
+// Health + size
+console.log((await db.status()).status); // "healthy"
+
+// Create nodes and an edge
+const alice = await db.createNode({ label: 'Person', properties: { name: 'Alice' } });
+const bob = await db.createNode({ label: 'Person', properties: { name: 'Bob' } });
+await db.createEdge({ sourceId: alice.id, targetId: bob.id, label: 'KNOWS' });
+
+// Traverse
+const friends = await db.traverse({ startNodeId: alice.id, edgeLabel: 'KNOWS', depth: 2 });
+for (const row of friends.results) console.log(row.node.properties.name);
+```
+
+Time-to-first-query target: **< 5 minutes** from `npm install` given a running server.
+
+## Bi-temporal `asOf` usage
+
+AletheiaDB tracks two independent time dimensions on every fact:
+
+- **valid time** — when the fact was true *in reality* (you control it).
+- **transaction time** — when the fact was *recorded* (system-assigned; read-only).
+
+Every temporal parameter accepts a `Date`, an ISO 8601 string, **or** a number of epoch-**microseconds** — all coerced to the same wire value (millisecond precision for `Date`/string; supply a number for finer resolution).
+
+```ts
+// "Who did Alice know on 2024-01-01?" — a point-in-time traversal.
+const asOf2024 = db.asOf({ validTime: '2024-01-01T00:00:00Z' });
+const knownThen = await asOf2024.traverse({ startNodeId: alice.id, edgeLabel: 'KNOWS' });
+
+// Each dimension is independent — set one, the other, or both:
+db.asOf({ transactionTime: new Date('2024-06-01') });          // tx-time only
+db.asOf({ validTime: 1704067200000000, transactionTime: '…' }); // both
+
+// Back-date a write with valid_time:
+await db.createEdge({
+  sourceId: alice.id, targetId: bob.id, label: 'KNOWS',
+  validTime: new Date('2020-06-01T00:00:00Z'),
+});
+
+// Point-in-time reads:
+await db.getNodeAtTime({ nodeId: alice.id, validTime: '2024-01-01', transactionTime: '2024-06-01' });
+await db.findNodesAtTime({ label: 'Person', propertyKey: 'name', propertyValue: 'Alice', validTime: '2024-01-01' });
+```
+
+## Vector elision (typed)
+
+By default, embedding/vector properties come back as a compact **elided descriptor** rather than the raw float array (Issue #3220). The type is a discriminated union, so you cannot misread a descriptor as data:
+
+```ts
+import { isElidedVector, isFullVector } from '@aletheiadb/client';
+
+const node = await db.getNode(id);                       // elided by default
+const emb = node.properties.embedding;
+if (isElidedVector(emb)) console.log('dim', emb.dim);     // { type:'vector', dim, elided:true }
+
+const full = await db.getNode(id, { includeVectors: true });
+if (isFullVector(full.properties.embedding)) { /* number[] */ }
+```
+
+## Errors and retries
+
+Every error maps to a typed subclass of `AletheiaError`, carrying `code`, `message`, `retriable`, and structured `details` (Issue #3234):
+
+```ts
+import { NotFoundError, PermissionDeniedError, ConflictError, AletheiaError } from '@aletheiadb/client';
+
+try {
+  await db.getNode(999_999);
+} catch (err) {
+  if (err instanceof NotFoundError) { /* ... */ }
+  else if (err instanceof AletheiaError) { console.log(err.code, err.retriable, err.details); }
+}
+```
+
+| Code | Class | Retriable |
+|------|-------|-----------|
+| `NOT_FOUND` | `NotFoundError` | no |
+| `INVALID_ARGUMENT` | `InvalidArgumentError` | no |
+| `CONSTRAINT_VIOLATION` | `ConstraintViolationError` | no |
+| `FAILED_PRECONDITION` | `FailedPreconditionError` | no |
+| `CONFLICT` | `ConflictError` | usually |
+| `UNAVAILABLE` | `UnavailableError` | yes |
+| `INTERNAL` | `InternalError` | no |
+| `UNAUTHENTICATED` | `UnauthenticatedError` | no |
+| `PERMISSION_DENIED` | `PermissionDeniedError` | no |
+| `RESOURCE_EXHAUSTED` | `ResourceExhaustedError` | sometimes |
+
+An **unknown** code degrades to the base `AletheiaError` with `retriable === false`.
+
+The built-in retry policy is **off by default**. When enabled it retries **only** `retriable` errors — never a non-retriable code — with bounded attempts and jittered exponential backoff:
+
+```ts
+const db = new AletheiaClient({
+  baseUrl, apiKey,
+  retry: { enabled: true, maxAttempts: 3, baseDelayMs: 100, maxDelayMs: 2000 },
+});
+```
+
+## Auth & configuration
+
+```ts
+new AletheiaClient({
+  baseUrl: 'http://localhost:8080',
+  apiKey: 'aletheia_sk_…',
+  authScheme: 'bearer',   // default; or 'x-api-key'
+  fetch: customFetch,     // inject a fetch for older Node / tests / polyfills
+  headers: { 'x-tenant': 'acme' },
+});
+```
+
+## Pagination & completeness
+
+Reads that support it accept `limit`/`offset` (#3226), `useCursor`/`cursor` (#3360), and the token budget `maxResponseTokens`/`maxResponseBytes`/`priorityProperties` (#3353). Responses surface `count`, `has_more`, `next_offset`, `truncated`, `sampled`, `cursor`, `snapshot_valid_time`/`snapshot_transaction_time`, and `budget`:
+
+```ts
+const page1 = await db.listNodes({ label: 'Person', useCursor: true });
+if (page1.has_more) {
+  const page2 = await db.listNodes({ cursor: page1.cursor }); // pass cursor alone
+}
+```
+
+## Coverage
+
+**Wrapped (34 merged routes):**
+
+- **Nodes:** `getNode`, `listNodes`, `countNodes`, `createNode`, `updateNode`, `deleteNode`, `deleteNodeCascade`, `retractNode`, `findNodesAtTime`
+- **Edges:** `getEdge`, `listEdges`, `countEdges`, `getOutgoingEdges`, `getIncomingEdges`, `createEdge`, `updateEdge`, `deleteEdge`, `retractEdge`
+- **Traversal / temporal:** `traverse`, `getNodeHistory`, `getEdgeHistory`, `getNodeAtTime`, `getEdgeAtTime`, `getNodeAtValidTime`, `getNodeAtTransactionTime`, `getEdgeAtValidTime`, `getEdgeAtTransactionTime`, `diffNodeVersions`, `diffEdgeVersions`, `listChanges`
+- **Admin / health:** `status`, `createKey`, `listKeys`, `revokeKey`
+
+**Stubbed** (throw `NotImplementedError` — REST routes not merged yet; tracked in the #3369 follow-up, PR5–PR8): `findSimilar`, `hybridQuery`, `query`, `enableVectorIndex`, `listVectorIndexes`, `getSchema`, `databaseStats`, `temporalExtent`, `applyBatch`, `lineageUpstream`, `lineageDownstream`.
+
+## Development
+
+```bash
+npm install
+npm run lint       # eslint (bans `any` in the public surface)
+npm run typecheck  # tsc --noEmit (strict) for src + examples
+npm run test       # vitest (record-replay fetch fixtures)
+npm run build      # tsup -> dist (ESM + CJS + d.ts)
+npm run smoke      # import the built ESM and CJS entry points
+```
+
+The unit tests use **record-replay fetch fixtures** (an injected mock `fetch` returning canned responses shaped to `tests/parity/inventory.json` and the autumn-server `*_tools.rs` handlers), not a live server binary. Integration against a real server binary is a separate CI job wired as the HTTP routes stabilize.
+
+## License
+
+MIT OR Apache-2.0

--- a/clients/typescript/eslint.config.js
+++ b/clients/typescript/eslint.config.js
@@ -1,0 +1,31 @@
+// Flat ESLint config. The load-bearing rule for Issue #3369's success metric is
+// `@typescript-eslint/no-explicit-any: error` — 0 `any` in the public surface.
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    // `scripts/` are plain Node smoke runners (not part of the typed surface).
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**', 'scripts/**'],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      // Success metric: no `any` may appear in the published type surface.
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+      '@typescript-eslint/consistent-type-imports': 'error',
+    },
+  },
+  {
+    // Tests still ban `any`.
+    files: ['test/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+    },
+  },
+);

--- a/clients/typescript/examples/01-connect.ts
+++ b/clients/typescript/examples/01-connect.ts
@@ -1,0 +1,25 @@
+/**
+ * Example 1 — connect and probe.
+ *
+ * Construct a client and hit the health + stats surface. Run against a local
+ * AletheiaDB HTTP server (see the server quickstart to start one).
+ */
+import { AletheiaClient } from '../src/index.js';
+
+async function main(): Promise<void> {
+  const db = new AletheiaClient({
+    baseUrl: process.env['ALETHEIA_URL'] ?? 'http://localhost:8080',
+    apiKey: process.env['ALETHEIA_API_KEY'],
+  });
+
+  const health = await db.status();
+  console.log('server status:', health.status);
+
+  const nodeCount = await db.countNodes();
+  console.log('nodes in graph:', nodeCount.count);
+}
+
+main().catch((err: unknown) => {
+  console.error('connect example failed:', err);
+  process.exitCode = 1;
+});

--- a/clients/typescript/examples/02-crud-valid-time.ts
+++ b/clients/typescript/examples/02-crud-valid-time.ts
@@ -1,0 +1,47 @@
+/**
+ * Example 2 — CRUD with valid time (#3221).
+ *
+ * Create two people, relate them, then back-date when the relationship became
+ * true in the real world. `validTime` accepts a Date, an ISO string, or
+ * epoch-microseconds — all coerced to the same wire value.
+ */
+import { AletheiaClient } from '../src/index.js';
+
+async function main(): Promise<void> {
+  const db = new AletheiaClient({
+    baseUrl: process.env['ALETHEIA_URL'] ?? 'http://localhost:8080',
+    apiKey: process.env['ALETHEIA_API_KEY'],
+  });
+
+  const alice = await db.createNode({
+    label: 'Person',
+    properties: { name: 'Alice' },
+  });
+  const bob = await db.createNode({
+    label: 'Person',
+    properties: { name: 'Bob' },
+  });
+
+  // The friendship became true on 2020-06-01 (a Date), even though we record it now.
+  const edge = await db.createEdge({
+    sourceId: alice.id,
+    targetId: bob.id,
+    label: 'KNOWS',
+    properties: { context: 'university' },
+    validTime: new Date('2020-06-01T00:00:00Z'),
+    provenance: { source: 'address-book-import', confidence: 0.95 },
+  });
+  console.log('edge', edge.id, 'valid_from:', edge.temporal?.valid_from);
+
+  // Update Alice's properties (records a new bi-temporal version).
+  const updated = await db.updateNode({
+    nodeId: alice.id,
+    properties: { name: 'Alice', title: 'Dr' },
+  });
+  console.log('alice is_current:', updated.temporal?.is_current);
+}
+
+main().catch((err: unknown) => {
+  console.error('crud example failed:', err);
+  process.exitCode = 1;
+});

--- a/clients/typescript/examples/03-asof-traverse.ts
+++ b/clients/typescript/examples/03-asof-traverse.ts
@@ -1,0 +1,46 @@
+/**
+ * Example 3 — AS OF traversal (#3225).
+ *
+ * "Who did Alice know on 2024-01-01?" — a bi-temporal, point-in-time traversal.
+ * `asOf` injects `as_of_valid_time` / `as_of_transaction_time`; each dimension
+ * is independent.
+ */
+import { AletheiaClient, isElidedVector } from '../src/index.js';
+
+async function main(): Promise<void> {
+  const db = new AletheiaClient({
+    baseUrl: process.env['ALETHEIA_URL'] ?? 'http://localhost:8080',
+    apiKey: process.env['ALETHEIA_API_KEY'],
+  });
+
+  const [alice] = (await db.findNodesAtTime({
+    label: 'Person',
+    propertyKey: 'name',
+    propertyValue: 'Alice',
+    validTime: '2024-01-01T00:00:00Z',
+  })).nodes;
+
+  if (!alice) {
+    console.log('no Alice as of 2024-01-01');
+    return;
+  }
+
+  const asOf2024 = db.asOf({ validTime: '2024-01-01T00:00:00Z' });
+  const friends = await asOf2024.traverse({
+    startNodeId: alice.id,
+    edgeLabel: 'KNOWS',
+    depth: 2,
+  });
+
+  for (const row of friends.results) {
+    const emb = row.node.properties['embedding'];
+    const note = emb !== undefined && isElidedVector(emb) ? ' (embedding elided)' : '';
+    console.log('knows:', row.node.properties['name'], note);
+  }
+  console.log('total reachable:', friends.count, 'has_more:', friends.has_more);
+}
+
+main().catch((err: unknown) => {
+  console.error('asof traverse example failed:', err);
+  process.exitCode = 1;
+});

--- a/clients/typescript/examples/04-semantic-search-stub.ts
+++ b/clients/typescript/examples/04-semantic-search-stub.ts
@@ -1,0 +1,33 @@
+/**
+ * Example 4 — semantic (vector) search.
+ *
+ * NOTE: `findSimilar` / `hybridQuery` wrap REST routes that are NOT merged
+ * server-side yet, so they currently throw {@link NotImplementedError}. This
+ * example is type-clean under `strict: true` and shows the intended shape;
+ * it will work unchanged once the vector routes land (see COMPATIBILITY.md).
+ * TODO(#3369-followup): wire when the vector/hybrid REST routes land (PR5–PR8).
+ */
+import { AletheiaClient, NotImplementedError } from '../src/index.js';
+
+async function main(): Promise<void> {
+  const db = new AletheiaClient({
+    baseUrl: process.env['ALETHEIA_URL'] ?? 'http://localhost:8080',
+    apiKey: process.env['ALETHEIA_API_KEY'],
+  });
+
+  try {
+    // Intended usage once merged: find nodes similar to a query embedding.
+    await db.findSimilar();
+  } catch (err: unknown) {
+    if (err instanceof NotImplementedError) {
+      console.log('semantic search not yet available over HTTP:', err.message);
+      return;
+    }
+    throw err;
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error('semantic search example failed:', err);
+  process.exitCode = 1;
+});

--- a/clients/typescript/examples/05-cypher-query-stub.ts
+++ b/clients/typescript/examples/05-cypher-query-stub.ts
@@ -1,0 +1,33 @@
+/**
+ * Example 5 — read-only Cypher/AQL query.
+ *
+ * NOTE: `query` wraps the read-only Cypher/AQL REST route, which is NOT merged
+ * server-side yet, so it currently throws {@link NotImplementedError}. This
+ * example is type-clean under `strict: true` and will work unchanged once the
+ * query route lands (see COMPATIBILITY.md).
+ * TODO(#3369-followup): wire when the query REST route lands (PR5–PR8).
+ */
+import { AletheiaClient, NotImplementedError } from '../src/index.js';
+
+async function main(): Promise<void> {
+  const db = new AletheiaClient({
+    baseUrl: process.env['ALETHEIA_URL'] ?? 'http://localhost:8080',
+    apiKey: process.env['ALETHEIA_API_KEY'],
+  });
+
+  try {
+    // Intended usage once merged: a single declarative, read-only statement.
+    await db.query();
+  } catch (err: unknown) {
+    if (err instanceof NotImplementedError) {
+      console.log('Cypher/AQL query not yet available over HTTP:', err.message);
+      return;
+    }
+    throw err;
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error('cypher query example failed:', err);
+  process.exitCode = 1;
+});

--- a/clients/typescript/package-lock.json
+++ b/clients/typescript/package-lock.json
@@ -1,0 +1,3812 @@
+{
+  "name": "@aletheiadb/client",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@aletheiadb/client",
+      "version": "0.1.0",
+      "license": "MIT OR Apache-2.0",
+      "devDependencies": {
+        "@eslint/js": "^9.13.0",
+        "@types/node": "^20.19.43",
+        "eslint": "^9.13.0",
+        "tsup": "^8.3.0",
+        "typescript": "^5.6.0",
+        "typescript-eslint": "^8.11.0",
+        "vitest": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
+      "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/type-utils": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.64.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
+      "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
+      "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.64.0",
+        "@typescript-eslint/types": "^8.64.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
+      "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
+      "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
+      "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
+      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
+      "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.64.0",
+        "@typescript-eslint/tsconfig-utils": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
+      "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
+      "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.64.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsup/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.64.0.tgz",
+      "integrity": "sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.64.0",
+        "@typescript-eslint/parser": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -13,9 +13,14 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@aletheiadb/client",
+  "version": "0.1.0",
+  "description": "Official TypeScript client SDK for AletheiaDB — typed bi-temporal graph + vector queries over the HTTP API.",
+  "license": "MIT OR Apache-2.0",
+  "type": "module",
+  "sideEffects": false,
+  "engines": {
+    "node": ">=18"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "COMPATIBILITY.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.examples.json",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "smoke": "node scripts/smoke.mjs && node scripts/smoke.cjs",
+    "prepublishOnly": "npm run lint && npm run typecheck && npm run test && npm run build"
+  },
+  "keywords": [
+    "aletheiadb",
+    "graph-database",
+    "bi-temporal",
+    "temporal",
+    "vector-search",
+    "llm",
+    "client",
+    "sdk"
+  ],
+  "devDependencies": {
+    "@eslint/js": "^9.13.0",
+    "@types/node": "^20.19.43",
+    "eslint": "^9.13.0",
+    "tsup": "^8.3.0",
+    "typescript": "^5.6.0",
+    "typescript-eslint": "^8.11.0",
+    "vitest": "^2.1.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/madmax983/AletheiaDB.git",
+    "directory": "clients/typescript"
+  }
+}

--- a/clients/typescript/scripts/smoke.cjs
+++ b/clients/typescript/scripts/smoke.cjs
@@ -1,0 +1,15 @@
+// CJS entry-point smoke test: require the built package and assert key exports.
+const { AletheiaClient, NotFoundError, toWireTime } = require('../dist/index.cjs');
+
+if (typeof AletheiaClient !== 'function') {
+  throw new Error('CJS smoke: AletheiaClient is not a constructor');
+}
+if (typeof NotFoundError !== 'function') {
+  throw new Error('CJS smoke: NotFoundError is not exported');
+}
+if (typeof toWireTime !== 'function') {
+  throw new Error('CJS smoke: toWireTime is not exported');
+}
+const db = new AletheiaClient({ baseUrl: 'http://localhost:9999', apiKey: 'k' });
+if (!db) throw new Error('CJS smoke: failed to construct client');
+console.log('CJS smoke OK');

--- a/clients/typescript/scripts/smoke.mjs
+++ b/clients/typescript/scripts/smoke.mjs
@@ -1,0 +1,16 @@
+// ESM entry-point smoke test: import the built package and assert key exports.
+import { AletheiaClient, NotFoundError, toWireTime } from '../dist/index.js';
+
+if (typeof AletheiaClient !== 'function') {
+  throw new Error('ESM smoke: AletheiaClient is not a constructor');
+}
+if (typeof NotFoundError !== 'function') {
+  throw new Error('ESM smoke: NotFoundError is not exported');
+}
+if (typeof toWireTime !== 'function') {
+  throw new Error('ESM smoke: toWireTime is not exported');
+}
+// Exercise a no-network code path.
+const db = new AletheiaClient({ baseUrl: 'http://localhost:9999', apiKey: 'k' });
+if (!db) throw new Error('ESM smoke: failed to construct client');
+console.log('ESM smoke OK');

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -3,8 +3,10 @@
  *
  * Wraps the 34 merged autumn-server REST routes (node/edge/traverse/temporal +
  * admin/health) as typed methods. Endpoints that are not yet merged server-side
- * (vector/hybrid/query/schema/stats/batch/lineage/constraints/audit) are
- * provided as typed stubs that throw {@link NotImplementedError}.
+ * (find_similar, hybrid_query, query, enable_vector_index, list_vector_indexes,
+ * get_schema, database_stats, temporal_extent, apply_batch, lineage_upstream,
+ * lineage_downstream) are provided as typed stubs that throw
+ * {@link NotImplementedError}.
  *
  * @packageDocumentation
  */
@@ -551,7 +553,7 @@ export class AletheiaClient {
   // ───────────────────────────────────────────────────────────────────────────
   // Not-yet-merged endpoints — typed stubs (throw NotImplementedError).
   // TODO(#3369-followup): wire when PR5–PR8 land (vector/hybrid/query/schema/
-  // stats/batch/lineage/constraints/audit REST routes).
+  // stats/batch/lineage REST routes).
   // ───────────────────────────────────────────────────────────────────────────
 
   /** STUB: `find_similar` (vector k-NN). Not merged server-side yet. */
@@ -615,12 +617,12 @@ export class AletheiaClient {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /** Coerce an optional {@link TimeInput} to a wire value, or `undefined`. */
-function optTime(t: TimeInput | undefined): number | undefined {
+function optTime(t: TimeInput | undefined): string | undefined {
   return t === undefined ? undefined : toWireTime(t);
 }
 
 /** Coerce a required {@link TimeInput} to a wire value. */
-function reqTime(t: TimeInput): number {
+function reqTime(t: TimeInput): string {
   return toWireTime(t);
 }
 

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -1,0 +1,677 @@
+/**
+ * The AletheiaDB TypeScript client.
+ *
+ * Wraps the 34 merged autumn-server REST routes (node/edge/traverse/temporal +
+ * admin/health) as typed methods. Endpoints that are not yet merged server-side
+ * (vector/hybrid/query/schema/stats/batch/lineage/constraints/audit) are
+ * provided as typed stubs that throw {@link NotImplementedError}.
+ *
+ * @packageDocumentation
+ */
+
+import { NotImplementedError } from './errors.js';
+import type { ClientOptions, RequestSpec } from './http.js';
+import { Transport, unwrapData } from './http.js';
+import type { TimeInput } from './time.js';
+import { toWireTime } from './time.js';
+import { TemporalView } from './temporal-view.js';
+import type {
+  CountOptions,
+  CountResponse,
+  CreateEdgeRequest,
+  CreateKeyRequest,
+  CreateKeyResponse,
+  CreateNodeRequest,
+  DeleteEdgeRequest,
+  DeleteNodeCascadeRequest,
+  DeleteNodeRequest,
+  DiffEdgeVersionsRequest,
+  DiffNodeVersionsRequest,
+  EdgeAtTransactionTimeRequest,
+  EdgeAtValidTimeRequest,
+  EdgeEntity,
+  EdgeHistoryResponse,
+  EdgeListResponse,
+  FindNodesAtTimeRequest,
+  GetEdgeAtTimeRequest,
+  GetEdgeOptions,
+  GetNodeAtTimeRequest,
+  GetNodeOptions,
+  JsonValue,
+  ListChangesRequest,
+  ListEdgesOptions,
+  ListKeysResponse,
+  ListNodesOptions,
+  AdjacencyOptions,
+  NodeAtTransactionTimeRequest,
+  NodeAtValidTimeRequest,
+  NodeEntity,
+  NodeHistoryOptions,
+  NodeHistoryResponse,
+  NodeListResponse,
+  RetractEdgeRequest,
+  RetractNodeRequest,
+  RevokeKeyRequest,
+  RevokeKeyResponse,
+  StatusResponse,
+  TraverseOptions,
+  TraverseResponse,
+  UpdateEdgeRequest,
+  UpdateNodeRequest,
+  LineageRef,
+  Provenance,
+} from './types.js';
+
+/** Coordinates for {@link AletheiaClient.asOf}. At least one dimension is set. */
+export interface AsOfCoordinates {
+  /** Valid time — when the fact was true in reality (#3225). */
+  validTime?: TimeInput;
+  /** Transaction time — when the fact was recorded (#3225). */
+  transactionTime?: TimeInput;
+}
+
+/** Wire-form provenance (snake_case, unchanged from the server contract). */
+function provenanceToWire(p: Provenance | undefined): Provenance | undefined {
+  return p;
+}
+
+/** Wire-form derivation refs (already snake_case in {@link LineageRef}). */
+function lineageToWire(refs: LineageRef[] | undefined): LineageRef[] | undefined {
+  return refs;
+}
+
+/**
+ * A fully typed client for the AletheiaDB HTTP API.
+ *
+ * @example
+ * ```ts
+ * const db = new AletheiaClient({ baseUrl: 'http://localhost:8080', apiKey: KEY });
+ * const alice = await db.createNode({ label: 'Person', properties: { name: 'Alice' } });
+ * const friends = await db.asOf({ validTime: '2024-01-01T00:00:00Z' })
+ *   .traverse({ startNodeId: alice.id, edgeLabel: 'KNOWS' });
+ * ```
+ */
+export class AletheiaClient {
+  /** @internal The underlying transport. */
+  readonly transport: Transport;
+
+  constructor(options: ClientOptions) {
+    this.transport = new Transport(options);
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Temporal scoping
+  // ───────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Return a temporal view that injects `as_of_valid_time` /
+   * `as_of_transaction_time` into supporting reads (traversal, point-in-time
+   * finds). Each dimension is independent: set one, the other, or both.
+   *
+   * @example
+   * ```ts
+   * // "Who did Alice know on 2024-01-01?"
+   * await db.asOf({ validTime: '2024-01-01' })
+   *   .traverse({ startNodeId: alice.id, edgeLabel: 'KNOWS' });
+   * ```
+   */
+  asOf(coords: AsOfCoordinates): TemporalView {
+    return new TemporalView(this, coords);
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Node reads
+  // ───────────────────────────────────────────────────────────────────────────
+
+  /** `GET /nodes/{id}` — fetch a node by id with bi-temporal bounds. */
+  getNode(id: number, opts: GetNodeOptions = {}): Promise<NodeEntity> {
+    return this.transport.request<NodeEntity>({
+      method: 'GET',
+      path: `/nodes/${id}`,
+      query: {
+        include_vectors: opts.includeVectors,
+        ...budgetQuery(opts),
+      },
+    });
+  }
+
+  /** `GET /nodes` — list nodes with optional label/property filtering + paging. */
+  listNodes(opts: ListNodesOptions = {}): Promise<NodeListResponse> {
+    return this.transport.request<NodeListResponse>({
+      method: 'GET',
+      path: '/nodes',
+      query: {
+        label: opts.label,
+        property_key: opts.propertyKey,
+        property_value: opts.propertyValue,
+        limit: opts.limit,
+        offset: opts.offset,
+        include_vectors: opts.includeVectors,
+        use_cursor: opts.useCursor,
+        cursor: opts.cursor,
+        ...budgetQuery(opts),
+      },
+    });
+  }
+
+  /** `GET /nodes/count` — total node count, or nodes matching a label. */
+  countNodes(opts: CountOptions = {}): Promise<CountResponse> {
+    return this.transport.request<CountResponse>({
+      method: 'GET',
+      path: '/nodes/count',
+      query: { label: opts.label },
+    });
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Node writes
+  // ───────────────────────────────────────────────────────────────────────────
+
+  /** `POST /nodes` — create a node (optional `validTime`, provenance, lineage). */
+  createNode(req: CreateNodeRequest): Promise<NodeEntity> {
+    return this.transport.request<NodeEntity>({
+      method: 'POST',
+      path: '/nodes',
+      body: {
+        label: req.label,
+        properties: req.properties,
+        valid_time: optTime(req.validTime),
+        provenance: provenanceToWire(req.provenance),
+        derived_from: lineageToWire(req.derivedFrom),
+      },
+    });
+  }
+
+  /** `POST /nodes/update` — replace a node's properties, recording a new version. */
+  updateNode(req: UpdateNodeRequest): Promise<NodeEntity> {
+    return this.transport.request<NodeEntity>({
+      method: 'POST',
+      path: '/nodes/update',
+      body: {
+        node_id: req.nodeId,
+        properties: req.properties,
+        valid_time: optTime(req.validTime),
+        provenance: provenanceToWire(req.provenance),
+        derived_from: lineageToWire(req.derivedFrom),
+      },
+    });
+  }
+
+  /** `POST /nodes/delete` — safe-by-default delete; `detach` cascades (#3209). */
+  deleteNode(req: DeleteNodeRequest): Promise<JsonValue> {
+    return this.transport.request<JsonValue>({
+      method: 'POST',
+      path: '/nodes/delete',
+      body: {
+        node_id: req.nodeId,
+        detach: req.detach,
+        valid_time: optTime(req.validTime),
+      },
+    });
+  }
+
+  /** `POST /nodes/delete_cascade` — delete a node and all connected edges atomically. */
+  deleteNodeCascade(req: DeleteNodeCascadeRequest): Promise<JsonValue> {
+    return this.transport.request<JsonValue>({
+      method: 'POST',
+      path: '/nodes/delete_cascade',
+      body: { node_id: req.nodeId },
+    });
+  }
+
+  /** `POST /nodes/retract` — close a node's valid-time interval without deleting history (#3230). */
+  retractNode(req: RetractNodeRequest): Promise<JsonValue> {
+    return this.transport.request<JsonValue>({
+      method: 'POST',
+      path: '/nodes/retract',
+      body: {
+        node_id: req.nodeId,
+        valid_time: optTime(req.validTime),
+        detach: req.detach,
+      },
+    });
+  }
+
+  /** `POST /nodes/find_at_time` — resolve nodes by label/property at a bi-temporal point (#3236). */
+  findNodesAtTime(req: FindNodesAtTimeRequest): Promise<NodeListResponse> {
+    return this.transport.request<NodeListResponse>({
+      method: 'POST',
+      path: '/nodes/find_at_time',
+      body: {
+        label: req.label,
+        property_key: req.propertyKey,
+        property_value: req.propertyValue,
+        valid_time: optTime(req.validTime),
+        transaction_time: optTime(req.transactionTime),
+        limit: req.limit,
+        offset: req.offset,
+        include_vectors: req.includeVectors,
+        use_cursor: req.useCursor,
+        cursor: req.cursor,
+        ...budgetBody(req),
+      },
+    });
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Edge reads
+  // ───────────────────────────────────────────────────────────────────────────
+
+  /** `GET /edges/{id}` — fetch an edge by id with bi-temporal bounds. */
+  getEdge(id: number, opts: GetEdgeOptions = {}): Promise<EdgeEntity> {
+    return this.transport.request<EdgeEntity>({
+      method: 'GET',
+      path: `/edges/${id}`,
+      query: {
+        include_vectors: opts.includeVectors,
+        ...budgetQuery(opts),
+      },
+    });
+  }
+
+  /** `GET /edges` — list edges with optional label filtering + paging. */
+  listEdges(opts: ListEdgesOptions = {}): Promise<EdgeListResponse> {
+    return this.transport.request<EdgeListResponse>({
+      method: 'GET',
+      path: '/edges',
+      query: {
+        label: opts.label,
+        limit: opts.limit,
+        offset: opts.offset,
+        include_vectors: opts.includeVectors,
+        ...budgetQuery(opts),
+      },
+    });
+  }
+
+  /** `GET /edges/count` — total edge count, or edges matching a label. */
+  countEdges(opts: CountOptions = {}): Promise<CountResponse> {
+    return this.transport.request<CountResponse>({
+      method: 'GET',
+      path: '/edges/count',
+      query: { label: opts.label },
+    });
+  }
+
+  /** `GET /nodes/{node_id}/edges/outgoing` — outgoing edges from a node. */
+  getOutgoingEdges(nodeId: number, opts: AdjacencyOptions = {}): Promise<EdgeListResponse> {
+    return this.transport.request<EdgeListResponse>({
+      method: 'GET',
+      path: `/nodes/${nodeId}/edges/outgoing`,
+      query: adjacencyQuery(opts),
+    });
+  }
+
+  /** `GET /nodes/{node_id}/edges/incoming` — incoming edges to a node. */
+  getIncomingEdges(nodeId: number, opts: AdjacencyOptions = {}): Promise<EdgeListResponse> {
+    return this.transport.request<EdgeListResponse>({
+      method: 'GET',
+      path: `/nodes/${nodeId}/edges/incoming`,
+      query: adjacencyQuery(opts),
+    });
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Edge writes
+  // ───────────────────────────────────────────────────────────────────────────
+
+  /** `POST /edges` — create an edge (optional `validTime`, provenance, lineage). */
+  createEdge(req: CreateEdgeRequest): Promise<EdgeEntity> {
+    return this.transport.request<EdgeEntity>({
+      method: 'POST',
+      path: '/edges',
+      body: {
+        source_id: req.sourceId,
+        target_id: req.targetId,
+        label: req.label,
+        properties: req.properties,
+        valid_time: optTime(req.validTime),
+        provenance: provenanceToWire(req.provenance),
+        derived_from: lineageToWire(req.derivedFrom),
+      },
+    });
+  }
+
+  /** `POST /edges/update` — replace an edge's properties, recording a new version. */
+  updateEdge(req: UpdateEdgeRequest): Promise<EdgeEntity> {
+    return this.transport.request<EdgeEntity>({
+      method: 'POST',
+      path: '/edges/update',
+      body: {
+        edge_id: req.edgeId,
+        properties: req.properties,
+        valid_time: optTime(req.validTime),
+        provenance: provenanceToWire(req.provenance),
+        derived_from: lineageToWire(req.derivedFrom),
+      },
+    });
+  }
+
+  /** `POST /edges/delete` — delete an edge (optional `validTime`). */
+  deleteEdge(req: DeleteEdgeRequest): Promise<JsonValue> {
+    return this.transport.request<JsonValue>({
+      method: 'POST',
+      path: '/edges/delete',
+      body: { edge_id: req.edgeId, valid_time: optTime(req.validTime) },
+    });
+  }
+
+  /** `POST /edges/retract` — close an edge's valid-time interval without deleting history (#3230). */
+  retractEdge(req: RetractEdgeRequest): Promise<JsonValue> {
+    return this.transport.request<JsonValue>({
+      method: 'POST',
+      path: '/edges/retract',
+      body: { edge_id: req.edgeId, valid_time: optTime(req.validTime) },
+    });
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Traversal + temporal
+  // ───────────────────────────────────────────────────────────────────────────
+
+  /** `GET /traverse` — multi-hop traversal, optionally as of a bi-temporal point (#3225). */
+  traverse(opts: TraverseOptions = {}): Promise<TraverseResponse> {
+    return this.transport.request<TraverseResponse>({
+      method: 'GET',
+      path: '/traverse',
+      query: {
+        start_node_id: opts.startNodeId,
+        edge_label: opts.edgeLabel,
+        direction: opts.direction,
+        depth: opts.depth,
+        limit: opts.limit,
+        offset: opts.offset,
+        include_vectors: opts.includeVectors,
+        as_of_valid_time: optTime(opts.asOfValidTime),
+        as_of_transaction_time: optTime(opts.asOfTransactionTime),
+        use_cursor: opts.useCursor,
+        cursor: opts.cursor,
+        ...budgetQuery(opts),
+      },
+    });
+  }
+
+  /** `GET /nodes/{id}/history` — full version history of a node, oldest first. */
+  getNodeHistory(id: number, opts: NodeHistoryOptions = {}): Promise<NodeHistoryResponse> {
+    return this.transport.request<NodeHistoryResponse>({
+      method: 'GET',
+      path: `/nodes/${id}/history`,
+      query: { ...budgetQuery(opts) },
+    });
+  }
+
+  /** `GET /edges/{id}/history` — full version history of an edge, oldest first. */
+  getEdgeHistory(id: number): Promise<EdgeHistoryResponse> {
+    return this.transport.request<EdgeHistoryResponse>({
+      method: 'GET',
+      path: `/edges/${id}/history`,
+    });
+  }
+
+  /** `POST /nodes/at_time` — a node's state at `(validTime, transactionTime)`. */
+  getNodeAtTime(req: GetNodeAtTimeRequest): Promise<NodeEntity> {
+    return this.transport.request<NodeEntity>({
+      method: 'POST',
+      path: '/nodes/at_time',
+      body: {
+        node_id: req.nodeId,
+        valid_time: reqTime(req.validTime),
+        transaction_time: optTime(req.transactionTime),
+      },
+    });
+  }
+
+  /** `POST /edges/at_time` — an edge's state at `(validTime, transactionTime)`. */
+  getEdgeAtTime(req: GetEdgeAtTimeRequest): Promise<EdgeEntity> {
+    return this.transport.request<EdgeEntity>({
+      method: 'POST',
+      path: '/edges/at_time',
+      body: {
+        edge_id: req.edgeId,
+        valid_time: reqTime(req.validTime),
+        transaction_time: optTime(req.transactionTime),
+      },
+    });
+  }
+
+  /** `POST /nodes/at_valid_time` — a node's state at a valid time (tx = now). */
+  getNodeAtValidTime(req: NodeAtValidTimeRequest): Promise<NodeEntity> {
+    return this.transport.request<NodeEntity>({
+      method: 'POST',
+      path: '/nodes/at_valid_time',
+      body: { node_id: req.nodeId, valid_time: reqTime(req.validTime) },
+    });
+  }
+
+  /** `POST /nodes/at_transaction_time` — a node's state at a transaction time (valid = now). */
+  getNodeAtTransactionTime(req: NodeAtTransactionTimeRequest): Promise<NodeEntity> {
+    return this.transport.request<NodeEntity>({
+      method: 'POST',
+      path: '/nodes/at_transaction_time',
+      body: { node_id: req.nodeId, transaction_time: reqTime(req.transactionTime) },
+    });
+  }
+
+  /** `POST /edges/at_valid_time` — an edge's state at a valid time (tx = now). */
+  getEdgeAtValidTime(req: EdgeAtValidTimeRequest): Promise<EdgeEntity> {
+    return this.transport.request<EdgeEntity>({
+      method: 'POST',
+      path: '/edges/at_valid_time',
+      body: { edge_id: req.edgeId, valid_time: reqTime(req.validTime) },
+    });
+  }
+
+  /** `POST /edges/at_transaction_time` — an edge's state at a transaction time (valid = now). */
+  getEdgeAtTransactionTime(req: EdgeAtTransactionTimeRequest): Promise<EdgeEntity> {
+    return this.transport.request<EdgeEntity>({
+      method: 'POST',
+      path: '/edges/at_transaction_time',
+      body: { edge_id: req.edgeId, transaction_time: reqTime(req.transactionTime) },
+    });
+  }
+
+  /** `POST /nodes/diff` — property-level diff between two node versions. */
+  diffNodeVersions(req: DiffNodeVersionsRequest): Promise<JsonValue> {
+    return this.transport.request<JsonValue>({
+      method: 'POST',
+      path: '/nodes/diff',
+      body: {
+        node_id: req.nodeId,
+        from_version: req.fromVersion,
+        to_version: req.toVersion,
+      },
+    });
+  }
+
+  /** `POST /edges/diff` — property-level diff between two edge versions. */
+  diffEdgeVersions(req: DiffEdgeVersionsRequest): Promise<JsonValue> {
+    return this.transport.request<JsonValue>({
+      method: 'POST',
+      path: '/edges/diff',
+      body: {
+        edge_id: req.edgeId,
+        from_version: req.fromVersion,
+        to_version: req.toVersion,
+      },
+    });
+  }
+
+  /** `POST /changes` — node/edge versions committed within a transaction-time window. */
+  listChanges(req: ListChangesRequest): Promise<JsonValue> {
+    return this.transport.request<JsonValue>({
+      method: 'POST',
+      path: '/changes',
+      body: {
+        tx_from: reqTime(req.txFrom),
+        tx_to: reqTime(req.txTo),
+        valid_from: optTime(req.validFrom),
+        valid_to: optTime(req.validTo),
+        label: req.label,
+        limit: req.limit,
+        cursor: req.cursor,
+      },
+    });
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Admin + health
+  // ───────────────────────────────────────────────────────────────────────────
+
+  /** `GET /status` — liveness probe. */
+  status(): Promise<StatusResponse> {
+    return this.transport.request<StatusResponse>({ method: 'GET', path: '/status' });
+  }
+
+  /** `POST /admin/keys` — create an API key (admin). Plaintext returned once. */
+  async createKey(req: CreateKeyRequest): Promise<CreateKeyResponse> {
+    const body = await this.transport.request<unknown>({
+      method: 'POST',
+      path: '/admin/keys',
+      body: { name: req.name, role: req.role },
+    });
+    return unwrapData<CreateKeyResponse>(body);
+  }
+
+  /** `GET /admin/keys` — list masked key principals (admin). */
+  async listKeys(): Promise<ListKeysResponse> {
+    const body = await this.transport.request<unknown>({ method: 'GET', path: '/admin/keys' });
+    return unwrapData<ListKeysResponse>(body);
+  }
+
+  /** `POST /admin/keys/revoke` — revoke a key by principal id (admin). */
+  async revokeKey(req: RevokeKeyRequest): Promise<RevokeKeyResponse> {
+    const body = await this.transport.request<unknown>({
+      method: 'POST',
+      path: '/admin/keys/revoke',
+      body: { id: req.id },
+    });
+    return unwrapData<RevokeKeyResponse>(body);
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Not-yet-merged endpoints — typed stubs (throw NotImplementedError).
+  // TODO(#3369-followup): wire when PR5–PR8 land (vector/hybrid/query/schema/
+  // stats/batch/lineage/constraints/audit REST routes).
+  // ───────────────────────────────────────────────────────────────────────────
+
+  /** STUB: `find_similar` (vector k-NN). Not merged server-side yet. */
+  findSimilar(): Promise<never> {
+    return stub('find_similar');
+  }
+
+  /** STUB: `hybrid_query` (graph + vector + temporal). Not merged server-side yet. */
+  hybridQuery(): Promise<never> {
+    return stub('hybrid_query');
+  }
+
+  /** STUB: `query` (read-only Cypher/AQL). Not merged server-side yet. */
+  query(): Promise<never> {
+    return stub('query');
+  }
+
+  /** STUB: `enable_vector_index`. Not merged server-side yet. */
+  enableVectorIndex(): Promise<never> {
+    return stub('enable_vector_index');
+  }
+
+  /** STUB: `list_vector_indexes`. Not merged server-side yet. */
+  listVectorIndexes(): Promise<never> {
+    return stub('list_vector_indexes');
+  }
+
+  /** STUB: `get_schema` (labels/types/property keys with counts). Not merged yet. */
+  getSchema(): Promise<never> {
+    return stub('get_schema');
+  }
+
+  /** STUB: `database_stats` (holistic snapshot). Not merged server-side yet. */
+  databaseStats(): Promise<never> {
+    return stub('database_stats');
+  }
+
+  /** STUB: `temporal_extent` (queryable bi-temporal extent). Not merged yet. */
+  temporalExtent(): Promise<never> {
+    return stub('temporal_extent');
+  }
+
+  /** STUB: `apply_batch` (atomic multi-write batch). Not merged server-side yet. */
+  applyBatch(): Promise<never> {
+    return stub('apply_batch');
+  }
+
+  /** STUB: `lineage_upstream` (derivation closure). Not merged server-side yet. */
+  lineageUpstream(): Promise<never> {
+    return stub('lineage_upstream');
+  }
+
+  /** STUB: `lineage_downstream` (derivation blast radius). Not merged yet. */
+  lineageDownstream(): Promise<never> {
+    return stub('lineage_downstream');
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Coerce an optional {@link TimeInput} to a wire value, or `undefined`. */
+function optTime(t: TimeInput | undefined): number | undefined {
+  return t === undefined ? undefined : toWireTime(t);
+}
+
+/** Coerce a required {@link TimeInput} to a wire value. */
+function reqTime(t: TimeInput): number {
+  return toWireTime(t);
+}
+
+/** Build the #3353 budget query fragment (query-string form). */
+function budgetQuery(opts: {
+  maxResponseTokens?: number;
+  maxResponseBytes?: number;
+  priorityProperties?: string[];
+}): Record<string, string | number | string[] | undefined> {
+  return {
+    max_response_tokens: opts.maxResponseTokens,
+    max_response_bytes: opts.maxResponseBytes,
+    priority_properties: opts.priorityProperties,
+  };
+}
+
+/** Build the #3353 budget body fragment (JSON-body form). */
+function budgetBody(opts: {
+  maxResponseTokens?: number;
+  maxResponseBytes?: number;
+  priorityProperties?: string[];
+}): Record<string, number | string[] | undefined> {
+  return {
+    max_response_tokens: opts.maxResponseTokens,
+    max_response_bytes: opts.maxResponseBytes,
+    priority_properties: opts.priorityProperties,
+  };
+}
+
+/** Build the shared adjacency query (label/flag/#3353 budget/#3360 cursor). */
+function adjacencyQuery(
+  opts: AdjacencyOptions,
+): Record<string, string | number | boolean | string[] | undefined> {
+  return {
+    label: opts.label,
+    include_vectors: opts.includeVectors,
+    limit: opts.limit,
+    use_cursor: opts.useCursor,
+    cursor: opts.cursor,
+    ...budgetQuery(opts),
+  };
+}
+
+/** Throw the standard {@link NotImplementedError} for an un-merged endpoint. */
+function stub(tool: string): Promise<never> {
+  return Promise.reject(
+    new NotImplementedError(
+      `${tool} is not wrapped yet: its REST route is not merged server-side. ` +
+        `Tracking in the #3369 follow-up (PR5–PR8). See COMPATIBILITY.md.`,
+    ),
+  );
+}
+
+export type { RequestSpec };

--- a/clients/typescript/src/errors.ts
+++ b/clients/typescript/src/errors.ts
@@ -1,0 +1,255 @@
+/**
+ * Typed error hierarchy mapping AletheiaDB's structured error contract.
+ *
+ * Two envelope shapes reach this SDK, and both are normalized here:
+ *
+ * 1. **MCP-tool / structured errors (Issue #3234)** — returned in-band with an
+ *    HTTP 200 as `{ error: { code, message, retriable, details? } }`. The node/
+ *    edge/traverse routes forward these verbatim.
+ * 2. **HTTP envelope errors** — real non-2xx responses shaped
+ *    `{ success: false, error, code?, retriable?, details?, trace_id? }` (auth
+ *    401/403 and resource-limit 413/422/429 carry `code`/`retriable`/`details`;
+ *    plain 400/404/500 carry only `{ success, error }`).
+ *
+ * Every error becomes an {@link AletheiaError} subclass keyed off `code`. The
+ * `retriable` flag is preserved exactly and drives the opt-in retry policy;
+ * an unknown code degrades to the base {@link AletheiaError} with
+ * `retriable = false`.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * The stable structured error-code vocabulary. Union of the MCP `code_enum`
+ * and the HTTP `code_vocabulary`. Unknown codes are represented as the literal
+ * string they arrived as; treat any code you don't recognize as non-retriable.
+ */
+export type AletheiaErrorCode =
+  | 'NOT_FOUND'
+  | 'INVALID_ARGUMENT'
+  | 'CONSTRAINT_VIOLATION'
+  | 'FAILED_PRECONDITION'
+  | 'CONFLICT'
+  | 'UNAVAILABLE'
+  | 'INTERNAL'
+  | 'UNAUTHENTICATED'
+  | 'PERMISSION_DENIED'
+  | 'RESOURCE_EXHAUSTED';
+
+/** Structured metadata carried under `error.details`. Shape varies per code. */
+export type ErrorDetails = Record<string, unknown>;
+
+/** The normalized fields every AletheiaDB error exposes. */
+export interface AletheiaErrorInit {
+  code: string;
+  message: string;
+  retriable: boolean;
+  details?: ErrorDetails | undefined;
+  /** HTTP status, when the error originated from a non-2xx response. */
+  httpStatus?: number | undefined;
+  /** Trace id from the HTTP envelope, when observability is enabled server-side. */
+  traceId?: string | undefined;
+}
+
+/**
+ * Base class for every error surfaced by the SDK. Subclasses correspond 1:1 to
+ * a known {@link AletheiaErrorCode}; an unrecognized code lands here directly
+ * with `retriable = false`.
+ */
+export class AletheiaError extends Error {
+  /** The structured error code (may be an unknown string for forward-compat). */
+  readonly code: string;
+  /** Whether the operation is safe to retry. Only ever `true` for transient classes. */
+  readonly retriable: boolean;
+  /** Per-code structured metadata, when present. */
+  readonly details: ErrorDetails | undefined;
+  /** Originating HTTP status, when applicable. */
+  readonly httpStatus: number | undefined;
+  /** Server trace id, when present. */
+  readonly traceId: string | undefined;
+
+  constructor(init: AletheiaErrorInit) {
+    super(init.message);
+    this.name = new.target.name;
+    this.code = init.code;
+    this.retriable = init.retriable;
+    this.details = init.details;
+    this.httpStatus = init.httpStatus;
+    this.traceId = init.traceId;
+    // Restore the prototype chain for extends-Error under downleveled targets.
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/** `NOT_FOUND` — the entity/version does not exist. Non-retriable. */
+export class NotFoundError extends AletheiaError {}
+/** `INVALID_ARGUMENT` — caller-fault input (bad id, unparseable time, …). Non-retriable. */
+export class InvalidArgumentError extends AletheiaError {}
+/** `CONSTRAINT_VIOLATION` — a unique/constraint rule was violated. Non-retriable. */
+export class ConstraintViolationError extends AletheiaError {}
+/** `FAILED_PRECONDITION` — well-formed but the system isn't in the required state. Non-retriable. */
+export class FailedPreconditionError extends AletheiaError {}
+/** `CONFLICT` — a write/serialization conflict. Usually retriable. */
+export class ConflictError extends AletheiaError {}
+/** `UNAVAILABLE` — a transient outage / capacity guard. Retriable. */
+export class UnavailableError extends AletheiaError {}
+/** `INTERNAL` — an unexpected server-side failure. Non-retriable. */
+export class InternalError extends AletheiaError {}
+/** `UNAUTHENTICATED` — missing/invalid/revoked credential (HTTP 401). Non-retriable. */
+export class UnauthenticatedError extends AletheiaError {}
+/** `PERMISSION_DENIED` — authenticated but the role lacks the class (HTTP 403). Non-retriable. */
+export class PermissionDeniedError extends AletheiaError {}
+/** `RESOURCE_EXHAUSTED` — a per-query resource limit (rows/bytes/timeout). Sometimes retriable. */
+export class ResourceExhaustedError extends AletheiaError {}
+
+/** Thrown by SDK methods that wrap endpoints not yet merged server-side. */
+export class NotImplementedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NotImplementedError';
+    Object.setPrototypeOf(this, NotImplementedError.prototype);
+  }
+}
+
+const CODE_TO_CLASS: Record<AletheiaErrorCode, new (init: AletheiaErrorInit) => AletheiaError> = {
+  NOT_FOUND: NotFoundError,
+  INVALID_ARGUMENT: InvalidArgumentError,
+  CONSTRAINT_VIOLATION: ConstraintViolationError,
+  FAILED_PRECONDITION: FailedPreconditionError,
+  CONFLICT: ConflictError,
+  UNAVAILABLE: UnavailableError,
+  INTERNAL: InternalError,
+  UNAUTHENTICATED: UnauthenticatedError,
+  PERMISSION_DENIED: PermissionDeniedError,
+  RESOURCE_EXHAUSTED: ResourceExhaustedError,
+};
+
+/**
+ * Default retriability for a known code, used only when the server envelope
+ * omits `retriable` (the plain HTTP 4xx/5xx shapes do). Mirrors the #3234
+ * contract: only `CONFLICT`, `UNAVAILABLE`, and the timeout flavor of
+ * `RESOURCE_EXHAUSTED` may be transient — and even those default conservatively
+ * to what the server states when it states anything.
+ */
+function defaultRetriable(code: string): boolean {
+  return code === 'CONFLICT' || code === 'UNAVAILABLE';
+}
+
+/**
+ * Construct the correct {@link AletheiaError} subclass from normalized fields.
+ * An unknown `code` yields the base {@link AletheiaError} with `retriable` as
+ * supplied (defaulting to `false`).
+ */
+export function makeError(init: AletheiaErrorInit): AletheiaError {
+  const Ctor = (CODE_TO_CLASS as Record<string, new (init: AletheiaErrorInit) => AletheiaError>)[init.code];
+  if (Ctor) {
+    return new Ctor(init);
+  }
+  // Unknown code -> base class, never retriable (forward-compat rule).
+  return new AletheiaError({ ...init, retriable: false });
+}
+
+/** The MCP-style in-band error object: `{ error: { code, message, retriable, details? } }`. */
+interface McpErrorEnvelope {
+  error: {
+    code: string;
+    message?: string;
+    retriable?: boolean;
+    details?: ErrorDetails;
+  };
+}
+
+/** The HTTP envelope: `{ success: false, error, code?, retriable?, details?, trace_id? }`. */
+interface HttpErrorEnvelope {
+  success: false;
+  error: string;
+  code?: string;
+  retriable?: boolean;
+  details?: ErrorDetails;
+  trace_id?: string;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null;
+}
+
+/**
+ * If `body` is an MCP-style in-band structured error
+ * (`{ error: { code, ... } }`), return its normalized form; else `null`.
+ */
+export function parseMcpError(body: unknown, httpStatus?: number): AletheiaError | null {
+  if (!isObject(body)) return null;
+  const err = body['error'];
+  if (!isObject(err) || typeof err['code'] !== 'string') return null;
+  const envelope = body as unknown as McpErrorEnvelope;
+  const code = envelope.error.code;
+  return makeError({
+    code,
+    message: envelope.error.message ?? code,
+    retriable: envelope.error.retriable ?? defaultRetriable(code),
+    details: envelope.error.details,
+    httpStatus,
+  });
+}
+
+/**
+ * Normalize an HTTP-envelope error (`{ success: false, ... }`) or a bare non-2xx
+ * response into an {@link AletheiaError}. `statusFallbackCode` maps the HTTP
+ * status to a code when the body carries none (401/403 in particular).
+ */
+export function parseHttpError(
+  body: unknown,
+  httpStatus: number,
+  statusFallbackCode: string,
+): AletheiaError {
+  if (isObject(body)) {
+    // Prefer an in-band MCP structured error if present.
+    const mcp = parseMcpError(body, httpStatus);
+    if (mcp) return mcp;
+
+    if (body['success'] === false || typeof body['error'] === 'string' || typeof body['code'] === 'string') {
+      const env = body as unknown as HttpErrorEnvelope;
+      const code = env.code ?? statusFallbackCode;
+      const message = typeof env.error === 'string' ? env.error : `HTTP ${httpStatus}`;
+      return makeError({
+        code,
+        message,
+        retriable: env.retriable ?? defaultRetriable(code),
+        details: env.details,
+        httpStatus,
+        traceId: env.trace_id,
+      });
+    }
+  }
+  // No usable envelope: synthesize from the status.
+  return makeError({
+    code: statusFallbackCode,
+    message: `HTTP ${httpStatus}`,
+    retriable: defaultRetriable(statusFallbackCode),
+    httpStatus,
+  });
+}
+
+/** Map an HTTP status to the fallback structured code used when the body omits one. */
+export function statusToCode(status: number): string {
+  switch (status) {
+    case 400:
+      return 'INVALID_ARGUMENT';
+    case 401:
+      return 'UNAUTHENTICATED';
+    case 403:
+      return 'PERMISSION_DENIED';
+    case 404:
+      return 'NOT_FOUND';
+    case 409:
+      return 'CONFLICT';
+    case 413:
+    case 422:
+    case 429:
+      return 'RESOURCE_EXHAUSTED';
+    case 503:
+      return 'UNAVAILABLE';
+    default:
+      return status >= 500 ? 'INTERNAL' : 'INVALID_ARGUMENT';
+  }
+}

--- a/clients/typescript/src/errors.ts
+++ b/clients/typescript/src/errors.ts
@@ -193,9 +193,20 @@ export function parseMcpError(body: unknown, httpStatus?: number): AletheiaError
 }
 
 /**
- * Normalize an HTTP-envelope error (`{ success: false, ... }`) or a bare non-2xx
- * response into an {@link AletheiaError}. `statusFallbackCode` maps the HTTP
- * status to a code when the body carries none (401/403 in particular).
+ * Default retriability for an HTTP error. Mirrors {@link defaultRetriable} but
+ * additionally treats HTTP 429 (Too Many Requests) as retriable — the server's
+ * plain 429 shape carries no `retriable` flag, yet a backoff-and-retry is the
+ * correct response to rate limiting.
+ */
+function httpRetriableDefault(code: string, httpStatus: number): boolean {
+  return httpStatus === 429 ? true : defaultRetriable(code);
+}
+
+/**
+ * Normalize an HTTP-envelope error (`{ success: false, ... }`), a plain-text
+ * error body, or a bare non-2xx response into an {@link AletheiaError}.
+ * `statusFallbackCode` maps the HTTP status to a code when the body carries
+ * none (401/403 in particular).
  */
 export function parseHttpError(
   body: unknown,
@@ -214,18 +225,22 @@ export function parseHttpError(
       return makeError({
         code,
         message,
-        retriable: env.retriable ?? defaultRetriable(code),
+        retriable: env.retriable ?? httpRetriableDefault(code, httpStatus),
         details: env.details,
         httpStatus,
         traceId: env.trace_id,
       });
     }
   }
+  // A non-empty plain-text body (e.g. a proxy's "502 Bad Gateway" page) becomes
+  // the error message so the caller sees the server's actual payload.
+  const message =
+    typeof body === 'string' && body.length > 0 ? body : `HTTP ${httpStatus}`;
   // No usable envelope: synthesize from the status.
   return makeError({
     code: statusFallbackCode,
-    message: `HTTP ${httpStatus}`,
-    retriable: defaultRetriable(statusFallbackCode),
+    message,
+    retriable: httpRetriableDefault(statusFallbackCode, httpStatus),
     httpStatus,
   });
 }

--- a/clients/typescript/src/http.ts
+++ b/clients/typescript/src/http.ts
@@ -1,0 +1,214 @@
+/**
+ * The fetch-based transport: request building, auth, envelope decoding, and
+ * error normalization. Uses the global `fetch` by default; a custom `fetch`
+ * may be injected (older Node, tests, edge runtimes with a polyfill).
+ *
+ * @packageDocumentation
+ */
+
+import {
+  AletheiaError,
+  parseHttpError,
+  parseMcpError,
+  statusToCode,
+} from './errors.js';
+import type { RetryOptions, ResolvedRetryOptions } from './retry.js';
+import { resolveRetryOptions, withRetry } from './retry.js';
+
+/** The minimal `fetch` signature this SDK depends on. */
+export type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<FetchResponseLike>;
+
+/** The minimal `Response` surface this SDK reads. */
+export interface FetchResponseLike {
+  status: number;
+  ok: boolean;
+  text(): Promise<string>;
+}
+
+/** How the API key is presented to the server. */
+export type AuthScheme = 'bearer' | 'x-api-key';
+
+/** Options for constructing an {@link AletheiaClient}. */
+export interface ClientOptions {
+  /** Base URL of the AletheiaDB HTTP server, e.g. `http://localhost:8080`. */
+  baseUrl: string;
+  /** API key. Omit only against a server running in anonymous mode. */
+  apiKey?: string;
+  /**
+   * How to send the key. `'bearer'` (default) sends
+   * `Authorization: Bearer <key>`; `'x-api-key'` sends the `x-api-key` header.
+   */
+  authScheme?: AuthScheme;
+  /** Inject a custom `fetch`. Defaults to the global `fetch`. */
+  fetch?: FetchLike;
+  /** Extra headers merged into every request. */
+  headers?: Record<string, string>;
+  /** Built-in retry policy. Off by default; honors `retriable` only. */
+  retry?: RetryOptions;
+}
+
+/** An internal request descriptor. */
+export interface RequestSpec {
+  method: 'GET' | 'POST';
+  /** Path beginning with `/`, e.g. `/nodes/1`. */
+  path: string;
+  /** Query parameters; `undefined` values are dropped. */
+  query?: Record<string, string | number | boolean | string[] | undefined>;
+  /** JSON body for POST requests. */
+  body?: unknown;
+}
+
+/**
+ * The HTTP transport. Owns the base URL, auth, fetch, and retry policy, and
+ * exposes a single {@link Transport.request} that returns decoded JSON or
+ * throws a typed {@link AletheiaError}.
+ */
+export class Transport {
+  private readonly baseUrl: string;
+  private readonly apiKey: string | undefined;
+  private readonly authScheme: AuthScheme;
+  private readonly fetchImpl: FetchLike;
+  private readonly baseHeaders: Record<string, string>;
+  private readonly retryCfg: ResolvedRetryOptions;
+
+  constructor(options: ClientOptions) {
+    if (!options.baseUrl) {
+      throw new Error('AletheiaClient: `baseUrl` is required');
+    }
+    this.baseUrl = options.baseUrl.replace(/\/+$/, '');
+    this.apiKey = options.apiKey;
+    this.authScheme = options.authScheme ?? 'bearer';
+    const injected = options.fetch;
+    const globalFetch = (globalThis as { fetch?: FetchLike }).fetch;
+    const chosen = injected ?? globalFetch;
+    if (!chosen) {
+      throw new Error(
+        'AletheiaClient: no global `fetch` available; pass `fetch` in ClientOptions (Node <18 or non-fetch runtime)',
+      );
+    }
+    this.fetchImpl = chosen;
+    this.baseHeaders = { ...(options.headers ?? {}) };
+    this.retryCfg = resolveRetryOptions(options.retry);
+  }
+
+  /** The resolved retry configuration (exposed for a per-call override). */
+  retryConfig(): ResolvedRetryOptions {
+    return this.retryCfg;
+  }
+
+  /** Build the auth headers for a request. */
+  private authHeaders(): Record<string, string> {
+    if (!this.apiKey) return {};
+    if (this.authScheme === 'x-api-key') {
+      return { 'x-api-key': this.apiKey };
+    }
+    return { Authorization: `Bearer ${this.apiKey}` };
+  }
+
+  /** Build a full URL with an encoded query string. */
+  private url(spec: RequestSpec): string {
+    const params: string[] = [];
+    if (spec.query) {
+      for (const [key, value] of Object.entries(spec.query)) {
+        if (value === undefined) continue;
+        if (Array.isArray(value)) {
+          for (const item of value) {
+            params.push(`${encodeURIComponent(key)}=${encodeURIComponent(item)}`);
+          }
+        } else {
+          params.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+        }
+      }
+    }
+    const qs = params.length > 0 ? `?${params.join('&')}` : '';
+    return `${this.baseUrl}${spec.path}${qs}`;
+  }
+
+  /**
+   * Perform a single request (no retry). Decodes the response into JSON and
+   * throws a typed {@link AletheiaError} for any error envelope or non-2xx
+   * status.
+   *
+   * @typeParam T - the expected decoded success shape.
+   */
+  async requestOnce<T>(spec: RequestSpec): Promise<T> {
+    const headers: Record<string, string> = {
+      accept: 'application/json',
+      ...this.baseHeaders,
+      ...this.authHeaders(),
+    };
+    const init: {
+      method?: string;
+      headers?: Record<string, string>;
+      body?: string;
+    } = { method: spec.method, headers };
+    if (spec.body !== undefined) {
+      headers['content-type'] = 'application/json';
+      init.body = JSON.stringify(spec.body);
+    }
+
+    const resp = await this.fetchImpl(this.url(spec), init);
+    const raw = await resp.text();
+    const parsed = raw.length > 0 ? safeJsonParse(raw) : undefined;
+
+    if (!resp.ok) {
+      throw parseHttpError(parsed, resp.status, statusToCode(resp.status));
+    }
+
+    // 2xx: node/edge/traverse routes forward MCP in-band errors with a 200.
+    const inBand = parseMcpError(parsed, resp.status);
+    if (inBand) {
+      throw inBand;
+    }
+    // HTTP admin/status routes wrap success as { success: true, data }.
+    if (isObject(parsed) && parsed['success'] === false) {
+      throw parseHttpError(parsed, resp.status, statusToCode(resp.status));
+    }
+    return parsed as T;
+  }
+
+  /**
+   * Perform a request under the retry policy. With retries disabled (default)
+   * this is a single attempt.
+   *
+   * @typeParam T - the expected decoded success shape.
+   */
+  async request<T>(spec: RequestSpec): Promise<T> {
+    return withRetry(() => this.requestOnce<T>(spec), this.retryCfg);
+  }
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null;
+}
+
+function safeJsonParse(raw: string): unknown {
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    // Non-JSON body (should not happen against the AletheiaDB surface). Surface
+    // it as a plain string so callers still see the payload.
+    return raw;
+  }
+}
+
+/**
+ * Unwrap the HTTP `{ success: true, data }` envelope used by the admin/status
+ * routes. Tool routes return bare entity JSON and bypass this.
+ */
+export function unwrapData<T>(body: unknown): T {
+  if (isObject(body) && 'data' in body) {
+    return body['data'] as T;
+  }
+  return body as T;
+}
+
+export { AletheiaError };

--- a/clients/typescript/src/http.ts
+++ b/clients/typescript/src/http.ts
@@ -8,6 +8,7 @@
 
 import {
   AletheiaError,
+  makeError,
   parseHttpError,
   parseMcpError,
   statusToCode,
@@ -53,6 +54,26 @@ export interface ClientOptions {
   headers?: Record<string, string>;
   /** Built-in retry policy. Off by default; honors `retriable` only. */
   retry?: RetryOptions;
+  /**
+   * A default {@link AbortSignal} applied to every request. Aborting it cancels
+   * the in-flight fetch and, under the retry policy, interrupts any pending
+   * backoff so no further attempts are made.
+   */
+  signal?: AbortSignal;
+  /**
+   * A default per-request timeout in milliseconds. When set, each request
+   * derives an {@link AbortSignal} that fires after `timeoutMs`, combined with
+   * any caller-supplied signal. Omit (or `0`) to disable.
+   */
+  timeoutMs?: number;
+}
+
+/** Per-request overrides for cancellation and timeout. */
+export interface RequestOptions {
+  /** An {@link AbortSignal} for this request; overrides the client-level signal. */
+  signal?: AbortSignal;
+  /** A timeout in milliseconds for this request; overrides the client-level timeout. */
+  timeoutMs?: number;
 }
 
 /** An internal request descriptor. */
@@ -78,6 +99,8 @@ export class Transport {
   private readonly fetchImpl: FetchLike;
   private readonly baseHeaders: Record<string, string>;
   private readonly retryCfg: ResolvedRetryOptions;
+  private readonly defaultSignal: AbortSignal | undefined;
+  private readonly defaultTimeoutMs: number | undefined;
 
   constructor(options: ClientOptions) {
     if (!options.baseUrl) {
@@ -97,6 +120,8 @@ export class Transport {
     this.fetchImpl = chosen;
     this.baseHeaders = { ...(options.headers ?? {}) };
     this.retryCfg = resolveRetryOptions(options.retry);
+    this.defaultSignal = options.signal;
+    this.defaultTimeoutMs = options.timeoutMs;
   }
 
   /** The resolved retry configuration (exposed for a per-call override). */
@@ -135,11 +160,13 @@ export class Transport {
   /**
    * Perform a single request (no retry). Decodes the response into JSON and
    * throws a typed {@link AletheiaError} for any error envelope or non-2xx
-   * status.
+   * status. A rejected fetch (network failure) is surfaced as a retriable
+   * `UNAVAILABLE` {@link AletheiaError}; an aborted/timed-out request propagates
+   * the (non-retriable) abort reason unchanged.
    *
    * @typeParam T - the expected decoded success shape.
    */
-  async requestOnce<T>(spec: RequestSpec): Promise<T> {
+  async requestOnce<T>(spec: RequestSpec, signal?: AbortSignal): Promise<T> {
     const headers: Record<string, string> = {
       accept: 'application/json',
       ...this.baseHeaders,
@@ -149,13 +176,35 @@ export class Transport {
       method?: string;
       headers?: Record<string, string>;
       body?: string;
+      signal?: AbortSignal;
     } = { method: spec.method, headers };
     if (spec.body !== undefined) {
       headers['content-type'] = 'application/json';
       init.body = JSON.stringify(spec.body);
     }
+    if (signal) {
+      // Reject before touching the network if already aborted.
+      if (signal.aborted) throw abortReason(signal);
+      init.signal = signal;
+    }
 
-    const resp = await this.fetchImpl(this.url(spec), init);
+    let resp: FetchResponseLike;
+    try {
+      resp = await this.fetchImpl(this.url(spec), init);
+    } catch (err) {
+      // An abort/timeout is deliberate and non-retriable: propagate it as-is.
+      if (signal?.aborted || isAbortError(err)) {
+        throw err;
+      }
+      // A transient network/DNS/connection failure is retriable under the
+      // opt-in policy.
+      const msg = err instanceof Error ? err.message : String(err);
+      throw makeError({
+        code: 'UNAVAILABLE',
+        message: `Network error: ${msg}`,
+        retriable: true,
+      });
+    }
     const raw = await resp.text();
     const parsed = raw.length > 0 ? safeJsonParse(raw) : undefined;
 
@@ -177,13 +226,92 @@ export class Transport {
 
   /**
    * Perform a request under the retry policy. With retries disabled (default)
-   * this is a single attempt.
+   * this is a single attempt. An effective abort signal is derived from the
+   * per-request options, the client-level default signal, and any timeout;
+   * aborting it cancels the in-flight fetch and interrupts pending backoff.
    *
    * @typeParam T - the expected decoded success shape.
    */
-  async request<T>(spec: RequestSpec): Promise<T> {
-    return withRetry(() => this.requestOnce<T>(spec), this.retryCfg);
+  async request<T>(spec: RequestSpec, options?: RequestOptions): Promise<T> {
+    const caller = options?.signal ?? this.defaultSignal;
+    const timeoutMs = options?.timeoutMs ?? this.defaultTimeoutMs;
+    const handle = makeSignal(caller, timeoutMs);
+    try {
+      return await withRetry(
+        () => this.requestOnce<T>(spec, handle.signal),
+        this.retryCfg,
+        handle.signal,
+      );
+    } finally {
+      handle.cleanup();
+    }
   }
+}
+
+/** The reason to reject with when `signal` is aborted. */
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException('The operation was aborted', 'AbortError');
+}
+
+/** Whether a thrown value is an abort/timeout error (native `AbortError`/`TimeoutError`). */
+function isAbortError(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'name' in err &&
+    ((err as { name: unknown }).name === 'AbortError' ||
+      (err as { name: unknown }).name === 'TimeoutError')
+  );
+}
+
+/** A derived signal plus a cleanup that releases its timers/listeners. */
+interface SignalHandle {
+  signal: AbortSignal | undefined;
+  cleanup: () => void;
+}
+
+/**
+ * Derive an effective {@link AbortSignal} from a caller signal and/or a
+ * timeout, dependency-free (no `AbortSignal.any`, which is not on Node 18).
+ * Returns `{ signal: undefined }` when neither is supplied.
+ */
+function makeSignal(caller: AbortSignal | undefined, timeoutMs: number | undefined): SignalHandle {
+  const hasTimeout = typeof timeoutMs === 'number' && timeoutMs > 0;
+  if (!caller && !hasTimeout) {
+    return { signal: undefined, cleanup: () => {} };
+  }
+
+  const controller = new AbortController();
+  const cleanups: Array<() => void> = [];
+  const abortWith = (reason: unknown): void => {
+    if (!controller.signal.aborted) controller.abort(reason);
+  };
+
+  if (caller) {
+    if (caller.aborted) {
+      abortWith(caller.reason);
+    } else {
+      const onAbort = (): void => abortWith(caller.reason);
+      caller.addEventListener('abort', onAbort, { once: true });
+      cleanups.push(() => caller.removeEventListener('abort', onAbort));
+    }
+  }
+
+  if (hasTimeout && !controller.signal.aborted) {
+    const timer = setTimeout(() => {
+      abortWith(new DOMException(`Request timed out after ${String(timeoutMs)} ms`, 'TimeoutError'));
+    }, timeoutMs);
+    // Don't keep the event loop alive solely for this timer (Node only).
+    (timer as { unref?: () => void }).unref?.();
+    cleanups.push(() => clearTimeout(timer));
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      for (const c of cleanups) c();
+    },
+  };
 }
 
 function isObject(v: unknown): v is Record<string, unknown> {

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -1,0 +1,119 @@
+/**
+ * `@aletheiadb/client` — the official TypeScript SDK for AletheiaDB.
+ *
+ * Typed bi-temporal graph + vector queries over the HTTP API: node/edge CRUD
+ * (with optional `validTime`), traversal (with `asOf` coordinates),
+ * point-in-time reads, structured typed errors, and an opt-in retry policy.
+ *
+ * @example
+ * ```ts
+ * import { AletheiaClient } from '@aletheiadb/client';
+ *
+ * const db = new AletheiaClient({ baseUrl: 'http://localhost:8080', apiKey: KEY });
+ * const alice = await db.createNode({ label: 'Person', properties: { name: 'Alice' } });
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+export { AletheiaClient } from './client.js';
+export type { AsOfCoordinates } from './client.js';
+export { TemporalView } from './temporal-view.js';
+
+export type {
+  ClientOptions,
+  AuthScheme,
+  FetchLike,
+  FetchResponseLike,
+  RequestSpec,
+} from './http.js';
+
+export type { RetryOptions } from './retry.js';
+
+export { toEpochMicros, toWireTime } from './time.js';
+export type { TimeInput } from './time.js';
+
+export {
+  AletheiaError,
+  NotFoundError,
+  InvalidArgumentError,
+  ConstraintViolationError,
+  FailedPreconditionError,
+  ConflictError,
+  UnavailableError,
+  InternalError,
+  UnauthenticatedError,
+  PermissionDeniedError,
+  ResourceExhaustedError,
+  NotImplementedError,
+  makeError,
+} from './errors.js';
+export type { AletheiaErrorCode, AletheiaErrorInit, ErrorDetails } from './errors.js';
+
+export {
+  isElidedVector,
+  isElidedSparseVector,
+  isFullVector,
+} from './types.js';
+
+export type {
+  JsonValue,
+  PropertyValue,
+  PropertyMap,
+  ElidedVector,
+  ElidedSparseVector,
+  VectorProperty,
+  TemporalBounds,
+  Provenance,
+  NodeEntity,
+  EdgeEntity,
+  Completeness,
+  BudgetInfo,
+  NodeListResponse,
+  EdgeListResponse,
+  TraverseResult,
+  TraverseResponse,
+  CountResponse,
+  NodeHistoryResponse,
+  EdgeHistoryResponse,
+  IncludeVectorsOption,
+  BudgetOptions,
+  OffsetPageOptions,
+  CursorOptions,
+  LineageRef,
+  CreateNodeRequest,
+  UpdateNodeRequest,
+  DeleteNodeRequest,
+  DeleteNodeCascadeRequest,
+  RetractNodeRequest,
+  CreateEdgeRequest,
+  UpdateEdgeRequest,
+  DeleteEdgeRequest,
+  RetractEdgeRequest,
+  GetNodeOptions,
+  GetEdgeOptions,
+  ListNodesOptions,
+  ListEdgesOptions,
+  AdjacencyOptions,
+  TraverseOptions,
+  FindNodesAtTimeRequest,
+  GetNodeAtTimeRequest,
+  GetEdgeAtTimeRequest,
+  NodeAtValidTimeRequest,
+  NodeAtTransactionTimeRequest,
+  EdgeAtValidTimeRequest,
+  EdgeAtTransactionTimeRequest,
+  DiffNodeVersionsRequest,
+  DiffEdgeVersionsRequest,
+  ListChangesRequest,
+  NodeHistoryOptions,
+  CountOptions,
+  Role,
+  StatusResponse,
+  CreateKeyRequest,
+  CreateKeyResponse,
+  KeyPrincipal,
+  ListKeysResponse,
+  RevokeKeyRequest,
+  RevokeKeyResponse,
+} from './types.js';

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -22,6 +22,7 @@ export { TemporalView } from './temporal-view.js';
 
 export type {
   ClientOptions,
+  RequestOptions,
   AuthScheme,
   FetchLike,
   FetchResponseLike,

--- a/clients/typescript/src/retry.ts
+++ b/clients/typescript/src/retry.ts
@@ -1,0 +1,108 @@
+/**
+ * Opt-in retry-with-backoff policy.
+ *
+ * Off by default. When enabled it retries **only** errors whose `retriable`
+ * flag is `true` (never a non-retriable code, regardless of class), with a
+ * bounded number of attempts and jittered exponential backoff.
+ *
+ * @packageDocumentation
+ */
+
+import { AletheiaError } from './errors.js';
+
+/** Configuration for the built-in retry policy. */
+export interface RetryOptions {
+  /**
+   * Enable retries. Default `false` — with retries off, a call is attempted
+   * exactly once and any error propagates immediately.
+   */
+  enabled?: boolean;
+  /** Total attempts including the first (so `3` means up to 2 retries). Default `3`. */
+  maxAttempts?: number;
+  /** Base backoff in milliseconds for the first retry. Default `100`. */
+  baseDelayMs?: number;
+  /** Maximum backoff in milliseconds for any single wait. Default `2000`. */
+  maxDelayMs?: number;
+  /**
+   * Jitter fraction in `[0, 1]` applied to each delay. Default `0.5` (each
+   * wait is uniformly sampled between 50% and 100% of the computed backoff).
+   */
+  jitter?: number;
+  /** Injectable sleep, primarily for deterministic tests. Defaults to `setTimeout`. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable RNG in `[0, 1)`, primarily for deterministic tests. Defaults to `Math.random`. */
+  random?: () => number;
+}
+
+/** Fully-resolved retry configuration. */
+export interface ResolvedRetryOptions {
+  enabled: boolean;
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  jitter: number;
+  sleep: (ms: number) => Promise<void>;
+  random: () => number;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/** Merge user-supplied {@link RetryOptions} over the defaults. */
+export function resolveRetryOptions(opts: RetryOptions | undefined): ResolvedRetryOptions {
+  return {
+    enabled: opts?.enabled ?? false,
+    maxAttempts: opts?.maxAttempts ?? 3,
+    baseDelayMs: opts?.baseDelayMs ?? 100,
+    maxDelayMs: opts?.maxDelayMs ?? 2000,
+    jitter: opts?.jitter ?? 0.5,
+    sleep: opts?.sleep ?? defaultSleep,
+    random: opts?.random ?? Math.random,
+  };
+}
+
+/** Whether `err` is a retriable AletheiaDB error. Anything else is never retried. */
+function isRetriable(err: unknown): boolean {
+  return err instanceof AletheiaError && err.retriable === true;
+}
+
+/**
+ * Run `op` under the resolved retry policy. Retries strictly on retriable
+ * {@link AletheiaError}s while attempts remain; a non-retriable error (or a
+ * non-AletheiaDB throwable) propagates on the first occurrence.
+ *
+ * @typeParam T - the operation's resolved value.
+ */
+export async function withRetry<T>(
+  op: () => Promise<T>,
+  cfg: ResolvedRetryOptions,
+): Promise<T> {
+  const attempts = cfg.enabled ? Math.max(1, cfg.maxAttempts) : 1;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await op();
+    } catch (err) {
+      lastError = err;
+      const canRetry = cfg.enabled && attempt < attempts && isRetriable(err);
+      if (!canRetry) {
+        throw err;
+      }
+      await cfg.sleep(computeDelay(attempt, cfg));
+    }
+  }
+  // Unreachable in practice (the loop either returns or throws), but keeps the
+  // type checker satisfied and preserves the last error if it ever is reached.
+  throw lastError;
+}
+
+/** Exponential backoff with jitter for the given 1-based attempt number. */
+function computeDelay(attempt: number, cfg: ResolvedRetryOptions): number {
+  const exp = cfg.baseDelayMs * 2 ** (attempt - 1);
+  const capped = Math.min(exp, cfg.maxDelayMs);
+  const floor = capped * (1 - cfg.jitter);
+  const span = capped - floor;
+  return Math.round(floor + cfg.random() * span);
+}

--- a/clients/typescript/src/retry.ts
+++ b/clients/typescript/src/retry.ts
@@ -71,13 +71,16 @@ function isRetriable(err: unknown): boolean {
 /**
  * Run `op` under the resolved retry policy. Retries strictly on retriable
  * {@link AletheiaError}s while attempts remain; a non-retriable error (or a
- * non-AletheiaDB throwable) propagates on the first occurrence.
+ * non-AletheiaDB throwable) propagates on the first occurrence. If `signal`
+ * aborts during a backoff wait, the wait rejects promptly and no further
+ * attempt is made.
  *
  * @typeParam T - the operation's resolved value.
  */
 export async function withRetry<T>(
   op: () => Promise<T>,
   cfg: ResolvedRetryOptions,
+  signal?: AbortSignal,
 ): Promise<T> {
   const attempts = cfg.enabled ? Math.max(1, cfg.maxAttempts) : 1;
   let lastError: unknown;
@@ -90,12 +93,54 @@ export async function withRetry<T>(
       if (!canRetry) {
         throw err;
       }
-      await cfg.sleep(computeDelay(attempt, cfg));
+      await abortableSleep(cfg.sleep, computeDelay(attempt, cfg), signal);
     }
   }
   // Unreachable in practice (the loop either returns or throws), but keeps the
   // type checker satisfied and preserves the last error if it ever is reached.
   throw lastError;
+}
+
+/** The reason to reject with when `signal` is aborted. */
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException('The operation was aborted', 'AbortError');
+}
+
+/**
+ * Sleep for `ms`, but reject immediately if `signal` aborts first. Without a
+ * signal this is exactly `sleep(ms)`.
+ */
+function abortableSleep(
+  sleep: (ms: number) => Promise<void>,
+  ms: number,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  if (!signal) return sleep(ms);
+  if (signal.aborted) return Promise.reject(abortReason(signal));
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const onAbort = (): void => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener('abort', onAbort);
+      reject(abortReason(signal));
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    sleep(ms).then(
+      () => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener('abort', onAbort);
+        resolve();
+      },
+      (err: unknown) => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener('abort', onAbort);
+        reject(err);
+      },
+    );
+  });
 }
 
 /** Exponential backoff with jitter for the given 1-based attempt number. */

--- a/clients/typescript/src/temporal-view.ts
+++ b/clients/typescript/src/temporal-view.ts
@@ -1,0 +1,66 @@
+/**
+ * A temporal view over an {@link AletheiaClient} that injects bi-temporal
+ * `as_of_*` coordinates into supporting reads (Issue #3225 / #3236).
+ *
+ * Obtained via {@link AletheiaClient.asOf}. Each dimension is independent: a
+ * view scoped with only `validTime` sends only `as_of_valid_time`; only
+ * `transactionTime` sends only `as_of_transaction_time`; both sends both.
+ *
+ * @packageDocumentation
+ */
+
+import type { AletheiaClient, AsOfCoordinates } from './client.js';
+import type {
+  FindNodesAtTimeRequest,
+  NodeListResponse,
+  TraverseOptions,
+  TraverseResponse,
+} from './types.js';
+
+/** A read view pinned to bi-temporal coordinates. */
+export class TemporalView {
+  private readonly client: AletheiaClient;
+  private readonly coords: AsOfCoordinates;
+
+  constructor(client: AletheiaClient, coords: AsOfCoordinates) {
+    this.client = client;
+    this.coords = coords;
+  }
+
+  /** The coordinates this view injects. */
+  coordinates(): AsOfCoordinates {
+    return { ...this.coords };
+  }
+
+  /**
+   * `GET /traverse` scoped to this view's coordinates — injects
+   * `as_of_valid_time` / `as_of_transaction_time` (each independently). Explicit
+   * `asOfValidTime` / `asOfTransactionTime` on `opts` take precedence.
+   */
+  traverse(opts: TraverseOptions): Promise<TraverseResponse> {
+    const merged: TraverseOptions = { ...opts };
+    if (this.coords.validTime !== undefined && merged.asOfValidTime === undefined) {
+      merged.asOfValidTime = this.coords.validTime;
+    }
+    if (this.coords.transactionTime !== undefined && merged.asOfTransactionTime === undefined) {
+      merged.asOfTransactionTime = this.coords.transactionTime;
+    }
+    return this.client.traverse(merged);
+  }
+
+  /**
+   * `POST /nodes/find_at_time` scoped to this view — maps `validTime` /
+   * `transactionTime` from the view onto the request's `validTime` /
+   * `transactionTime` (Issue #3236). Explicit values on `req` take precedence.
+   */
+  findNodesAtTime(req: FindNodesAtTimeRequest): Promise<NodeListResponse> {
+    const merged: FindNodesAtTimeRequest = { ...req };
+    if (this.coords.validTime !== undefined && merged.validTime === undefined) {
+      merged.validTime = this.coords.validTime;
+    }
+    if (this.coords.transactionTime !== undefined && merged.transactionTime === undefined) {
+      merged.transactionTime = this.coords.transactionTime;
+    }
+    return this.client.findNodesAtTime(merged);
+  }
+}

--- a/clients/typescript/src/time.ts
+++ b/clients/typescript/src/time.ts
@@ -1,0 +1,93 @@
+/**
+ * Time coercion for AletheiaDB's bi-temporal API.
+ *
+ * AletheiaDB tracks **two** independent time dimensions on every fact:
+ *
+ * - **valid time** — when the fact was true *in the real world*. You control
+ *   this: back-date an import, or record that something became true in the
+ *   future. Write requests accept an optional `validTime` for exactly this.
+ * - **transaction time** — when the fact was *recorded in the database*. This
+ *   is always system-assigned and can never be set by a caller; it only
+ *   appears on the read side (`as_of_transaction_time`, temporal bounds).
+ *
+ * Every time-typed parameter in this SDK accepts a {@link TimeInput}: a
+ * `Date`, an ISO 8601 / RFC 3339 `string`, or a `number` interpreted as
+ * **microseconds since the Unix epoch**. All three are coerced to a single
+ * canonical wire value — epoch microseconds — so the same instant expressed
+ * three different ways serializes identically.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * A point in time accepted by any temporal parameter of the SDK.
+ *
+ * - `Date` — coerced via {@link Date.getTime} (millisecond precision).
+ * - `string` — parsed as ISO 8601 / RFC 3339 (millisecond precision; any
+ *   sub-millisecond fraction in the string is truncated by the JS parser).
+ * - `number` — taken **as-is** to be microseconds since the Unix epoch. This
+ *   is the only form that can carry microsecond precision.
+ *
+ * @remarks
+ * Precision: `Date` and `string` inputs resolve to millisecond granularity
+ * (the coerced microsecond value is always a multiple of 1000). Supply a
+ * `number` of epoch-microseconds when you need finer resolution.
+ */
+export type TimeInput = Date | string | number;
+
+/** Microseconds per millisecond. */
+const MICROS_PER_MILLI = 1000;
+
+/**
+ * Coerce a {@link TimeInput} to **epoch microseconds** — the canonical wire
+ * value this SDK sends for every temporal parameter.
+ *
+ * @param value - a `Date`, ISO 8601 string, or epoch-microseconds number.
+ * @returns integer microseconds since the Unix epoch.
+ * @throws {RangeError} if a `Date` is invalid, a string cannot be parsed as a
+ *   timestamp, or a number is not finite.
+ *
+ * @example
+ * ```ts
+ * const a = toEpochMicros(new Date('2024-01-15T10:00:00Z'));
+ * const b = toEpochMicros('2024-01-15T10:00:00Z');
+ * const c = toEpochMicros(1705312800000000);
+ * // a === b === c
+ * ```
+ */
+export function toEpochMicros(value: TimeInput): number {
+  if (value instanceof Date) {
+    const ms = value.getTime();
+    if (Number.isNaN(ms)) {
+      throw new RangeError('toEpochMicros: received an invalid Date');
+    }
+    return ms * MICROS_PER_MILLI;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new RangeError('toEpochMicros: numeric time must be a finite number of epoch microseconds');
+    }
+    // A bare number is already epoch microseconds.
+    return Math.trunc(value);
+  }
+  // string: parse as ISO 8601 / RFC 3339.
+  const ms = Date.parse(value);
+  if (Number.isNaN(ms)) {
+    throw new RangeError(`toEpochMicros: could not parse timestamp string '${value}'`);
+  }
+  return ms * MICROS_PER_MILLI;
+}
+
+/**
+ * Coerce a {@link TimeInput} to the value placed on the wire. The AletheiaDB
+ * HTTP surface accepts either an RFC 3339 string or integer epoch microseconds
+ * for every temporal field; this SDK always sends epoch microseconds so that
+ * a `Date`, its ISO string, and its epoch-microsecond number are byte-for-byte
+ * identical requests.
+ *
+ * @param value - the temporal input to serialize.
+ * @returns integer epoch microseconds, ready to embed in a query string or body.
+ */
+export function toWireTime(value: TimeInput): number {
+  return toEpochMicros(value);
+}

--- a/clients/typescript/src/time.ts
+++ b/clients/typescript/src/time.ts
@@ -80,14 +80,17 @@ export function toEpochMicros(value: TimeInput): number {
 
 /**
  * Coerce a {@link TimeInput} to the value placed on the wire. The AletheiaDB
- * HTTP surface accepts either an RFC 3339 string or integer epoch microseconds
- * for every temporal field; this SDK always sends epoch microseconds so that
- * a `Date`, its ISO string, and its epoch-microsecond number are byte-for-byte
- * identical requests.
+ * HTTP surface deserializes every temporal field as a Rust `String` (serde
+ * cannot coerce a JSON number into `String`), so this SDK always sends the
+ * epoch-microseconds value as a **decimal string** — a `Date`, its ISO string,
+ * and its epoch-microsecond number therefore produce byte-for-byte identical
+ * requests. In a query string the value is stringified either way, so the
+ * string form is equally correct there.
  *
  * @param value - the temporal input to serialize.
- * @returns integer epoch microseconds, ready to embed in a query string or body.
+ * @returns epoch microseconds as a decimal string, ready to embed in a query
+ *   string or JSON body.
  */
-export function toWireTime(value: TimeInput): number {
-  return toEpochMicros(value);
+export function toWireTime(value: TimeInput): string {
+  return String(toEpochMicros(value));
 }

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -1,0 +1,524 @@
+/**
+ * Typed request/response models mirroring the AletheiaDB HTTP entity JSON.
+ *
+ * The shapes here track the autumn-server routes (`crates/aletheia-server`) and
+ * the parity inventory (`tests/parity/inventory.json`): the bi-temporal
+ * `temporal` block (#3232), write-time `provenance`, the discriminated
+ * `PropertyValue` union, and vector elision (#3220).
+ *
+ * No `any` appears in this surface — arbitrary JSON is modeled with
+ * {@link JsonValue}, and vectors are a discriminated union of a full
+ * `number[]` array versus an elided descriptor.
+ *
+ * @packageDocumentation
+ */
+
+import type { TimeInput } from './time.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// JSON + property values
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Any JSON value, without ever resorting to `any`. */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/**
+ * The elided descriptor a dense vector property degrades to when
+ * `includeVectors` is not set (Issue #3220). Distinct from `number[]` so a
+ * caller cannot misread a descriptor as data.
+ */
+export interface ElidedVector {
+  type: 'vector';
+  dim: number;
+  elided: true;
+}
+
+/** The elided descriptor for a sparse vector property (Issue #3220). */
+export interface ElidedSparseVector {
+  type: 'sparse_vector';
+  dim: number;
+  nnz: number;
+  elided: true;
+}
+
+/** Either the elided descriptor or the full dense array. */
+export type VectorProperty = number[] | ElidedVector | ElidedSparseVector;
+
+/**
+ * A property value as it appears on the wire. Discriminates a full vector
+ * (`number[]`) from an elided descriptor via {@link isElidedVector} /
+ * {@link isElidedSparseVector}.
+ */
+export type PropertyValue = JsonValue | ElidedVector | ElidedSparseVector;
+
+/** A bag of entity properties keyed by name. */
+export type PropertyMap = Record<string, PropertyValue>;
+
+/** Type guard: `v` is an elided dense-vector descriptor, not a real array. */
+export function isElidedVector(v: PropertyValue): v is ElidedVector {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    !Array.isArray(v) &&
+    (v as { type?: unknown }).type === 'vector' &&
+    (v as { elided?: unknown }).elided === true
+  );
+}
+
+/** Type guard: `v` is an elided sparse-vector descriptor. */
+export function isElidedSparseVector(v: PropertyValue): v is ElidedSparseVector {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    !Array.isArray(v) &&
+    (v as { type?: unknown }).type === 'sparse_vector' &&
+    (v as { elided?: unknown }).elided === true
+  );
+}
+
+/** Type guard: `v` is a full dense vector array (all numbers). */
+export function isFullVector(v: PropertyValue): v is number[] {
+  return Array.isArray(v) && v.every((x) => typeof x === 'number');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Temporal + provenance
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The bi-temporal bounds stamped on every read response (Issue #3232). Lower
+ * bounds are RFC 3339 strings; open upper bounds are explicit `null` (never
+ * omitted). `is_current` is `true` iff the transaction interval is open and now
+ * falls within the valid interval.
+ */
+export interface TemporalBounds {
+  valid_from: string | null;
+  valid_to: string | null;
+  transaction_from: string | null;
+  transaction_to: string | null;
+  is_current: boolean;
+}
+
+/** Write-time provenance bundle recorded against a version (Issue #3224/#3350). */
+export interface Provenance {
+  source?: string;
+  confidence?: number;
+  note?: string;
+  correlation_id?: string;
+  /** Server-stamped principal name when the write was authenticated (#3350). */
+  principal?: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Entities
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A node as returned by the read/write surface. */
+export interface NodeEntity {
+  id: number;
+  label: string;
+  properties: PropertyMap;
+  temporal?: TemporalBounds;
+  provenance?: Provenance;
+  /** The version id of the returned version, when the response carries it. */
+  version_id?: number;
+}
+
+/** An edge as returned by the read/write surface. */
+export interface EdgeEntity {
+  id: number;
+  label: string;
+  source_id: number;
+  target_id: number;
+  properties: PropertyMap;
+  temporal?: TemporalBounds;
+  provenance?: Provenance;
+  version_id?: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Completeness / pagination signals (Issue #3226 / #3360 / #3353)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The per-section token-budget rung applied to a response (Issue #3353). */
+export interface BudgetInfo {
+  [section: string]: unknown;
+}
+
+/**
+ * The completeness/pagination signals a bounded read can carry. All optional —
+ * a given response surfaces only what applies.
+ */
+export interface Completeness {
+  count?: number;
+  has_more?: boolean;
+  next_offset?: number;
+  total_matching?: number;
+  truncated?: boolean;
+  sampled?: boolean;
+  /** Opaque snapshot-anchored cursor token (#3360), present when `use_cursor`. */
+  cursor?: string;
+  /** The snapshot valid time the cursor scan was pinned at (#3360). */
+  snapshot_valid_time?: string;
+  /** The snapshot transaction time the cursor scan was pinned at (#3360). */
+  snapshot_transaction_time?: string;
+  paging?: string;
+  budget?: BudgetInfo;
+}
+
+/** A list-nodes response: the page plus completeness signals. */
+export interface NodeListResponse extends Completeness {
+  nodes: NodeEntity[];
+}
+
+/** A list-edges / adjacency response: the page plus completeness signals. */
+export interface EdgeListResponse extends Completeness {
+  edges: EdgeEntity[];
+}
+
+/** One traversal result row: the reached node plus optional path metadata. */
+export interface TraverseResult {
+  node: NodeEntity;
+  depth?: number;
+  [key: string]: JsonValue | NodeEntity | undefined;
+}
+
+/** A traverse response: the reached rows plus completeness signals. */
+export interface TraverseResponse extends Completeness {
+  results: TraverseResult[];
+}
+
+/** A `{ count, label? }` count response. */
+export interface CountResponse {
+  count: number;
+  label?: string;
+}
+
+/** A node/edge history response: every version oldest-first. */
+export interface NodeHistoryResponse extends Completeness {
+  node_id: number;
+  results?: NodeEntity[];
+  versions?: NodeEntity[];
+}
+
+/** An edge history response: every version oldest-first. */
+export interface EdgeHistoryResponse extends Completeness {
+  edge_id: number;
+  results?: EdgeEntity[];
+  versions?: EdgeEntity[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared request option fragments
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Whether to include full vector arrays instead of the elided descriptor (#3220). */
+export interface IncludeVectorsOption {
+  includeVectors?: boolean;
+}
+
+/** The Issue #3353 token-budget options, accepted by budgetable reads. */
+export interface BudgetOptions {
+  /** Cap the response at roughly this many tokens (estimated `ceil(bytes/4)`). */
+  maxResponseTokens?: number;
+  /** Byte-exact response cap. */
+  maxResponseBytes?: number;
+  /** Property keys to protect first as the response degrades. */
+  priorityProperties?: string[];
+}
+
+/** Offset-based pagination (Issue #3226). */
+export interface OffsetPageOptions {
+  limit?: number;
+  offset?: number;
+}
+
+/** Snapshot-anchored cursor continuation (Issue #3360). */
+export interface CursorOptions {
+  /** Request a cursor on the first page. */
+  useCursor?: boolean;
+  /** Continuation token from a prior page; pass it back alone. */
+  cursor?: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Write request bodies (mirror the MCP request structs)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A version-pinned derivation reference (Issue #3371). */
+export interface LineageRef {
+  entity_kind: 'node' | 'edge';
+  id: number;
+  version: number;
+}
+
+/** Create a node. `validTime` accepts a {@link TimeInput} (#3221). */
+export interface CreateNodeRequest {
+  label: string;
+  properties?: PropertyMap;
+  validTime?: TimeInput;
+  provenance?: Provenance;
+  derivedFrom?: LineageRef[];
+}
+
+/** Update a node's properties (replaces all), recording a new version. */
+export interface UpdateNodeRequest {
+  nodeId: number;
+  properties: PropertyMap;
+  validTime?: TimeInput;
+  provenance?: Provenance;
+  derivedFrom?: LineageRef[];
+}
+
+/** Safe-by-default delete (Issue #3209). `detach` cascades; `validTime` back-dates. */
+export interface DeleteNodeRequest {
+  nodeId: number;
+  detach?: boolean;
+  validTime?: TimeInput;
+}
+
+/** Cascade delete: node + every connected edge, atomically. */
+export interface DeleteNodeCascadeRequest {
+  nodeId: number;
+}
+
+/** Retract a node — close its valid-time interval without deleting history (#3230). */
+export interface RetractNodeRequest {
+  nodeId: number;
+  validTime?: TimeInput;
+  detach?: boolean;
+}
+
+/** Create an edge between two nodes. `validTime` accepts a {@link TimeInput}. */
+export interface CreateEdgeRequest {
+  sourceId: number;
+  targetId: number;
+  label: string;
+  properties?: PropertyMap;
+  validTime?: TimeInput;
+  provenance?: Provenance;
+  derivedFrom?: LineageRef[];
+}
+
+/** Update an edge's properties (replaces all), recording a new version. */
+export interface UpdateEdgeRequest {
+  edgeId: number;
+  properties: PropertyMap;
+  validTime?: TimeInput;
+  provenance?: Provenance;
+  derivedFrom?: LineageRef[];
+}
+
+/** Delete an edge, optionally back-dated (#3221). */
+export interface DeleteEdgeRequest {
+  edgeId: number;
+  validTime?: TimeInput;
+}
+
+/** Retract an edge — close its valid-time interval without deleting history (#3230). */
+export interface RetractEdgeRequest {
+  edgeId: number;
+  validTime?: TimeInput;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Read request options
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Options for {@link AletheiaClient.getNode}. */
+export type GetNodeOptions = IncludeVectorsOption & BudgetOptions;
+
+/** Options for {@link AletheiaClient.getEdge}. */
+export type GetEdgeOptions = IncludeVectorsOption & BudgetOptions;
+
+/** Options for {@link AletheiaClient.listNodes}. */
+export interface ListNodesOptions
+  extends IncludeVectorsOption,
+    BudgetOptions,
+    OffsetPageOptions,
+    CursorOptions {
+  label?: string;
+  propertyKey?: string;
+  propertyValue?: string;
+}
+
+/** Options for {@link AletheiaClient.listEdges}. */
+export interface ListEdgesOptions
+  extends IncludeVectorsOption,
+    BudgetOptions,
+    OffsetPageOptions {
+  label?: string;
+}
+
+/** Options for the adjacency reads (outgoing/incoming edges). */
+export interface AdjacencyOptions
+  extends IncludeVectorsOption,
+    BudgetOptions,
+    CursorOptions {
+  label?: string;
+  limit?: number;
+}
+
+/** Options for a graph traversal (Issue #3225 `as_of_*` handled via {@link TemporalView}). */
+export interface TraverseOptions
+  extends IncludeVectorsOption,
+    BudgetOptions,
+    OffsetPageOptions,
+    CursorOptions {
+  startNodeId?: number;
+  edgeLabel?: string;
+  direction?: 'outgoing' | 'incoming' | 'both';
+  depth?: number;
+  /** Valid-time coordinate (#3225). Prefer {@link AletheiaClient.asOf}. */
+  asOfValidTime?: TimeInput;
+  /** Transaction-time coordinate (#3225). Prefer {@link AletheiaClient.asOf}. */
+  asOfTransactionTime?: TimeInput;
+}
+
+/** Point-in-time node find (Issue #3236). */
+export interface FindNodesAtTimeRequest
+  extends IncludeVectorsOption,
+    BudgetOptions,
+    OffsetPageOptions,
+    CursorOptions {
+  label?: string;
+  propertyKey?: string;
+  propertyValue?: JsonValue;
+  validTime?: TimeInput;
+  transactionTime?: TimeInput;
+}
+
+/** Bi-temporal point-in-time node read (`get_node_at_time`). */
+export interface GetNodeAtTimeRequest {
+  nodeId: number;
+  validTime: TimeInput;
+  transactionTime?: TimeInput;
+}
+
+/** Bi-temporal point-in-time edge read (`get_edge_at_time`). */
+export interface GetEdgeAtTimeRequest {
+  edgeId: number;
+  validTime: TimeInput;
+  transactionTime?: TimeInput;
+}
+
+/** Single-dimension valid-time node read. */
+export interface NodeAtValidTimeRequest {
+  nodeId: number;
+  validTime: TimeInput;
+}
+
+/** Single-dimension transaction-time node read. */
+export interface NodeAtTransactionTimeRequest {
+  nodeId: number;
+  transactionTime: TimeInput;
+}
+
+/** Single-dimension valid-time edge read. */
+export interface EdgeAtValidTimeRequest {
+  edgeId: number;
+  validTime: TimeInput;
+}
+
+/** Single-dimension transaction-time edge read. */
+export interface EdgeAtTransactionTimeRequest {
+  edgeId: number;
+  transactionTime: TimeInput;
+}
+
+/** Property-level diff between two node versions. */
+export interface DiffNodeVersionsRequest {
+  nodeId: number;
+  fromVersion: number;
+  toVersion: number;
+}
+
+/** Property-level diff between two edge versions. */
+export interface DiffEdgeVersionsRequest {
+  edgeId: number;
+  fromVersion: number;
+  toVersion: number;
+}
+
+/** List graph-wide changes in a transaction-time window (`list_changes`). */
+export interface ListChangesRequest {
+  txFrom: TimeInput;
+  txTo: TimeInput;
+  validFrom?: TimeInput;
+  validTo?: TimeInput;
+  label?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+/** History read options: the #3353 token budget on a single-entity history read. */
+export type NodeHistoryOptions = BudgetOptions;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Count options
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Options for {@link AletheiaClient.countNodes} / {@link AletheiaClient.countEdges}. */
+export interface CountOptions {
+  label?: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Admin / health
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The four RBAC roles. */
+export type Role = 'admin' | 'writer' | 'reader' | 'metrics';
+
+/** `GET /status` response. */
+export interface StatusResponse {
+  status: string;
+}
+
+/** `POST /admin/keys` request. */
+export interface CreateKeyRequest {
+  name: string;
+  role: Role;
+}
+
+/** `POST /admin/keys` response — the plaintext key is returned exactly once. */
+export interface CreateKeyResponse {
+  id: string;
+  name: string;
+  role: Role;
+  key_prefix: string;
+  created_at: string;
+  /** Plaintext key material, returned only on creation. */
+  key: string;
+}
+
+/** A masked key principal from `GET /admin/keys` (never full material). */
+export interface KeyPrincipal {
+  id: string;
+  name: string;
+  role: Role;
+  key_prefix: string;
+  created_at: string;
+}
+
+/** `GET /admin/keys` response. */
+export interface ListKeysResponse {
+  keys: KeyPrincipal[];
+}
+
+/** `POST /admin/keys/revoke` request. */
+export interface RevokeKeyRequest {
+  id: string;
+}
+
+/** `POST /admin/keys/revoke` response. */
+export interface RevokeKeyResponse {
+  revoked: boolean;
+  id: string;
+}

--- a/clients/typescript/test/asof.test.ts
+++ b/clients/typescript/test/asof.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { AletheiaClient, toWireTime } from '../src/index.js';
+import { mockFetch } from './fixtures.js';
+
+const traverseBody = { results: [], count: 0, has_more: false };
+
+function traverseClient() {
+  const { fetch, calls } = mockFetch(() => ({ body: traverseBody }));
+  return { db: new AletheiaClient({ baseUrl: 'http://x', apiKey: 'k', fetch }), calls };
+}
+
+describe('asOf temporal ergonomics (#3225)', () => {
+  const vt = '2024-01-01T00:00:00Z';
+  const tt = '2024-06-01T00:00:00Z';
+
+  it('injects BOTH as_of_valid_time and as_of_transaction_time on traverse', async () => {
+    const { db, calls } = traverseClient();
+    await db.asOf({ validTime: vt, transactionTime: tt }).traverse({
+      startNodeId: 1,
+      edgeLabel: 'KNOWS',
+    });
+    const q = calls[0]!.query;
+    expect(q.get('as_of_valid_time')).toBe(String(toWireTime(vt)));
+    expect(q.get('as_of_transaction_time')).toBe(String(toWireTime(tt)));
+    expect(q.get('start_node_id')).toBe('1');
+    expect(q.get('edge_label')).toBe('KNOWS');
+  });
+
+  it('valid-time only: sends as_of_valid_time, omits as_of_transaction_time', async () => {
+    const { db, calls } = traverseClient();
+    await db.asOf({ validTime: vt }).traverse({ startNodeId: 1, edgeLabel: 'KNOWS' });
+    const q = calls[0]!.query;
+    expect(q.get('as_of_valid_time')).toBe(String(toWireTime(vt)));
+    expect(q.has('as_of_transaction_time')).toBe(false);
+  });
+
+  it('transaction-time only: sends as_of_transaction_time, omits as_of_valid_time', async () => {
+    const { db, calls } = traverseClient();
+    await db.asOf({ transactionTime: tt }).traverse({ startNodeId: 1, edgeLabel: 'KNOWS' });
+    const q = calls[0]!.query;
+    expect(q.get('as_of_transaction_time')).toBe(String(toWireTime(tt)));
+    expect(q.has('as_of_valid_time')).toBe(false);
+  });
+
+  it('explicit per-call coordinate wins over the view coordinate', async () => {
+    const { db, calls } = traverseClient();
+    const override = '2020-01-01T00:00:00Z';
+    await db
+      .asOf({ validTime: vt })
+      .traverse({ startNodeId: 1, edgeLabel: 'KNOWS', asOfValidTime: override });
+    expect(calls[0]!.query.get('as_of_valid_time')).toBe(String(toWireTime(override)));
+  });
+
+  it('a plain traverse (no asOf) sends neither coordinate', async () => {
+    const { db, calls } = traverseClient();
+    await db.traverse({ startNodeId: 1, edgeLabel: 'KNOWS' });
+    const q = calls[0]!.query;
+    expect(q.has('as_of_valid_time')).toBe(false);
+    expect(q.has('as_of_transaction_time')).toBe(false);
+  });
+});

--- a/clients/typescript/test/auth.test.ts
+++ b/clients/typescript/test/auth.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AletheiaClient,
+  PermissionDeniedError,
+  UnauthenticatedError,
+  type AletheiaError,
+} from '../src/index.js';
+import { httpError, mockFetch, nodeFixture } from './fixtures.js';
+
+describe('authentication headers + auth errors', () => {
+  it('sends Authorization: Bearer by default', async () => {
+    const { fetch, calls } = mockFetch(() => ({ body: nodeFixture(1, 'Person', {}) }));
+    const db = new AletheiaClient({ baseUrl: 'http://x', apiKey: 'secret-key', fetch });
+    await db.getNode(1);
+    expect(calls[0]!.headers['Authorization']).toBe('Bearer secret-key');
+    expect(calls[0]!.headers['x-api-key']).toBeUndefined();
+  });
+
+  it('sends x-api-key when authScheme is x-api-key', async () => {
+    const { fetch, calls } = mockFetch(() => ({ body: nodeFixture(1, 'Person', {}) }));
+    const db = new AletheiaClient({
+      baseUrl: 'http://x',
+      apiKey: 'secret-key',
+      authScheme: 'x-api-key',
+      fetch,
+    });
+    await db.getNode(1);
+    expect(calls[0]!.headers['x-api-key']).toBe('secret-key');
+    expect(calls[0]!.headers['Authorization']).toBeUndefined();
+  });
+
+  it('maps HTTP 401 to UnauthenticatedError', async () => {
+    const { fetch } = mockFetch(() => httpError(401, 'unauthorized', 'UNAUTHENTICATED', false));
+    const db = new AletheiaClient({ baseUrl: 'http://x', fetch });
+    const err = await db.status().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(UnauthenticatedError);
+    expect((err as AletheiaError).retriable).toBe(false);
+  });
+
+  it('maps HTTP 403 to PermissionDeniedError with details.required_class', async () => {
+    const { fetch } = mockFetch(() =>
+      httpError(403, 'forbidden', 'PERMISSION_DENIED', false, {
+        required_class: 'write',
+        principal_role: 'reader',
+      }),
+    );
+    const db = new AletheiaClient({ baseUrl: 'http://x', apiKey: 'reader-key', fetch });
+    const err = await db.createNode({ label: 'Person' }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(PermissionDeniedError);
+    expect((err as AletheiaError).details).toMatchObject({ required_class: 'write' });
+  });
+
+  it('maps a bare 401 (no envelope body) to UnauthenticatedError via status', async () => {
+    const { fetch } = mockFetch(() => ({ status: 401, raw: '' }));
+    const db = new AletheiaClient({ baseUrl: 'http://x', fetch });
+    await expect(db.status()).rejects.toBeInstanceOf(UnauthenticatedError);
+  });
+});

--- a/clients/typescript/test/build.test.ts
+++ b/clients/typescript/test/build.test.ts
@@ -1,0 +1,30 @@
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const dist = resolve(here, '../dist');
+const esmEntry = resolve(dist, 'index.js');
+const cjsEntry = resolve(dist, 'index.cjs');
+
+const built = existsSync(esmEntry) && existsSync(cjsEntry);
+
+// The build must run before this test observes the dist artifacts. When dist is
+// absent (e.g. `vitest` invoked before `tsup`), the suite is skipped rather than
+// failing; CI runs `build` then `test` so both entry points are exercised.
+describe.skipIf(!built)('dual ESM + CJS build smoke', () => {
+  it('imports the ESM entry cleanly', async () => {
+    const mod = (await import(esmEntry)) as { AletheiaClient?: unknown; NotFoundError?: unknown };
+    expect(typeof mod.AletheiaClient).toBe('function');
+    expect(typeof mod.NotFoundError).toBe('function');
+  });
+
+  it('requires the CJS entry cleanly', () => {
+    const require = createRequire(import.meta.url);
+    const mod = require(cjsEntry) as { AletheiaClient?: unknown; toWireTime?: unknown };
+    expect(typeof mod.AletheiaClient).toBe('function');
+    expect(typeof mod.toWireTime).toBe('function');
+  });
+});

--- a/clients/typescript/test/cursor.test.ts
+++ b/clients/typescript/test/cursor.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { AletheiaClient, type NodeListResponse } from '../src/index.js';
+import { mockFetch, nodeFixture } from './fixtures.js';
+
+describe('cursor continuation (#3360)', () => {
+  it('round-trips: use_cursor:true returns a cursor; continuation passes only cursor', async () => {
+    const page1: NodeListResponse = {
+      nodes: [nodeFixture(1, 'Person', { name: 'A' })] as unknown as NodeListResponse['nodes'],
+      count: 1,
+      has_more: true,
+      cursor: 'CURSOR_TOKEN_1',
+      snapshot_valid_time: '2024-01-01T00:00:00Z',
+      snapshot_transaction_time: '2024-01-01T00:00:00Z',
+      paging: 'cursor',
+    };
+    const page2: NodeListResponse = {
+      nodes: [nodeFixture(2, 'Person', { name: 'B' })] as unknown as NodeListResponse['nodes'],
+      count: 1,
+      has_more: false,
+      snapshot_valid_time: '2024-01-01T00:00:00Z',
+      snapshot_transaction_time: '2024-01-01T00:00:00Z',
+      paging: 'cursor',
+    };
+    const { fetch, calls } = mockFetch((_req, i) => ({ body: i === 0 ? page1 : page2 }));
+    const db = new AletheiaClient({ baseUrl: 'http://x', apiKey: 'k', fetch });
+
+    // First page: request a cursor.
+    const first = await db.listNodes({ label: 'Person', useCursor: true });
+    expect(calls[0]!.query.get('use_cursor')).toBe('true');
+    expect(first.cursor).toBe('CURSOR_TOKEN_1');
+    expect(first.has_more).toBe(true);
+    // Typed snapshot coordinate surfaced.
+    expect(first.snapshot_valid_time).toBe('2024-01-01T00:00:00Z');
+
+    // Continuation: pass ONLY the cursor.
+    const second = await db.listNodes({ cursor: first.cursor });
+    const q = calls[1]!.query;
+    expect(q.get('cursor')).toBe('CURSOR_TOKEN_1');
+    expect(q.has('label')).toBe(false);
+    expect(q.has('use_cursor')).toBe(false);
+    expect(second.has_more).toBe(false);
+  });
+
+  it('cursor round-trips on the adjacency reads too', async () => {
+    const { fetch, calls } = mockFetch((_req, i) => ({
+      body:
+        i === 0
+          ? { edges: [], count: 0, has_more: true, cursor: 'ADJ_1', paging: 'cursor' }
+          : { edges: [], count: 0, has_more: false, paging: 'cursor' },
+    }));
+    const db = new AletheiaClient({ baseUrl: 'http://x', apiKey: 'k', fetch });
+    const first = await db.getOutgoingEdges(5, { useCursor: true });
+    expect(calls[0]!.query.get('use_cursor')).toBe('true');
+    expect(first.cursor).toBe('ADJ_1');
+    await db.getOutgoingEdges(5, { cursor: first.cursor });
+    expect(calls[1]!.query.get('cursor')).toBe('ADJ_1');
+  });
+});

--- a/clients/typescript/test/errors.test.ts
+++ b/clients/typescript/test/errors.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AletheiaClient,
+  AletheiaError,
+  ConflictError,
+  ConstraintViolationError,
+  FailedPreconditionError,
+  InvalidArgumentError,
+  NotFoundError,
+} from '../src/index.js';
+import { mcpError, mockFetch, httpError } from './fixtures.js';
+
+function client(handler: Parameters<typeof mockFetch>[0]) {
+  const { fetch, calls } = mockFetch(handler);
+  return { db: new AletheiaClient({ baseUrl: 'http://x', apiKey: 'k', fetch }), calls };
+}
+
+describe('structured error mapping (#3234)', () => {
+  it('maps NOT_FOUND (in-band, HTTP 200) to NotFoundError, non-retriable', async () => {
+    const { db } = client(() => mcpError('NOT_FOUND', 'no such node', false));
+    await expect(db.getNode(999)).rejects.toBeInstanceOf(NotFoundError);
+    await db.getNode(1).catch((e: unknown) => {
+      expect(e).toBeInstanceOf(NotFoundError);
+      expect((e as AletheiaError).retriable).toBe(false);
+      expect((e as AletheiaError).code).toBe('NOT_FOUND');
+    });
+  });
+
+  it('maps INVALID_ARGUMENT to InvalidArgumentError', async () => {
+    const { db } = client(() => mcpError('INVALID_ARGUMENT', 'bad id', false));
+    await expect(db.getNode(1)).rejects.toBeInstanceOf(InvalidArgumentError);
+  });
+
+  it('maps CONFLICT to ConflictError with retriable true by default', async () => {
+    const { db } = client(() => mcpError('CONFLICT', 'write conflict', true));
+    const err = await db.getNode(1).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ConflictError);
+    expect((err as AletheiaError).retriable).toBe(true);
+  });
+
+  it('carries details for FAILED_PRECONDITION (DETACH refusal #3209)', async () => {
+    const { db } = client(() =>
+      mcpError('FAILED_PRECONDITION', 'has edges', false, { connected_edges: 3 }),
+    );
+    const err = await db.deleteNode({ nodeId: 1 }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(FailedPreconditionError);
+    expect((err as AletheiaError).details).toEqual({ connected_edges: 3 });
+  });
+
+  it('carries details for CONSTRAINT_VIOLATION (unique)', async () => {
+    const { db } = client(() =>
+      mcpError('CONSTRAINT_VIOLATION', 'unique', false, { existing_node_id: 7 }),
+    );
+    const err = await db.createNode({ label: 'Person' }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ConstraintViolationError);
+    expect((err as AletheiaError).details).toEqual({ existing_node_id: 7 });
+  });
+
+  it('maps an unknown code to the base AletheiaError with retriable === false', async () => {
+    const { db } = client(() => mcpError('SOME_FUTURE_CODE', 'weird', true));
+    const err = await db.getNode(1).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(AletheiaError);
+    expect(err).not.toBeInstanceOf(NotFoundError);
+    // Forward-compat rule: unknown codes are never treated as retriable.
+    expect((err as AletheiaError).retriable).toBe(false);
+    expect((err as AletheiaError).code).toBe('SOME_FUTURE_CODE');
+  });
+
+  it('honors an HTTP-envelope error on a non-2xx (RESOURCE_EXHAUSTED 413)', async () => {
+    const { db } = client(() =>
+      httpError(413, 'row cap', 'RESOURCE_EXHAUSTED', false, { dimension: 'result_rows' }),
+    );
+    const err = await db.listNodes().catch((e: unknown) => e);
+    expect((err as AletheiaError).code).toBe('RESOURCE_EXHAUSTED');
+    expect((err as AletheiaError).httpStatus).toBe(413);
+  });
+});

--- a/clients/typescript/test/fixtures.ts
+++ b/clients/typescript/test/fixtures.ts
@@ -1,0 +1,149 @@
+/**
+ * Record-replay fetch fixtures.
+ *
+ * The AletheiaDB server binary is too heavy to build reliably in the SDK CI
+ * sandbox, so these tests inject a mock `fetch` that returns canned responses
+ * whose shapes match `tests/parity/inventory.json` and the autumn-server
+ * `*_tools.rs` handlers. This is the record-replay approach the issue permits
+ * for the unit layer; integration against a live binary is wired separately.
+ */
+
+import type { FetchLike, FetchResponseLike } from '../src/index.js';
+
+/** A request captured by the mock, with its URL, method, headers, and parsed body. */
+export interface RecordedRequest {
+  url: string;
+  path: string;
+  query: URLSearchParams;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+/** A canned response the handler returns for a request. */
+export interface CannedResponse {
+  status?: number;
+  /** JSON body; serialized to the response text. */
+  body: unknown;
+  /** Override the raw text (takes precedence over `body`). */
+  raw?: string;
+}
+
+/** Build a {@link FetchResponseLike} from a status + text. */
+function makeResponse(status: number, text: string): FetchResponseLike {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    text: () => Promise.resolve(text),
+  };
+}
+
+/** A handler maps a recorded request to a canned response. */
+export type MockHandler = (req: RecordedRequest, callIndex: number) => CannedResponse;
+
+/** The mock fetch plus the list of requests it has seen (in order). */
+export interface MockFetch {
+  fetch: FetchLike;
+  calls: RecordedRequest[];
+}
+
+/**
+ * Build a mock `fetch` from a handler. Every call is recorded (with its parsed
+ * URL, query, headers, and JSON body) into `calls`, and the handler's canned
+ * response is replayed.
+ */
+export function mockFetch(handler: MockHandler): MockFetch {
+  const calls: RecordedRequest[] = [];
+  const fetch: FetchLike = (input, init) => {
+    const url = new URL(input);
+    const parsedBody =
+      init?.body !== undefined ? (JSON.parse(init.body) as unknown) : undefined;
+    const recorded: RecordedRequest = {
+      url: input,
+      path: url.pathname,
+      query: url.searchParams,
+      method: init?.method ?? 'GET',
+      headers: init?.headers ?? {},
+      body: parsedBody,
+    };
+    const callIndex = calls.length;
+    calls.push(recorded);
+    const canned = handler(recorded, callIndex);
+    const status = canned.status ?? 200;
+    const text = canned.raw ?? JSON.stringify(canned.body);
+    return Promise.resolve(makeResponse(status, text));
+  };
+  return { fetch, calls };
+}
+
+/** A canned node entity with an open, current temporal block (matches #3232). */
+export function nodeFixture(
+  id: number,
+  label: string,
+  properties: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    id,
+    label,
+    properties,
+    temporal: {
+      valid_from: '2024-01-01T00:00:00Z',
+      valid_to: null,
+      transaction_from: '2024-01-01T00:00:00Z',
+      transaction_to: null,
+      is_current: true,
+    },
+  };
+}
+
+/** A canned edge entity with an open, current temporal block. */
+export function edgeFixture(
+  id: number,
+  label: string,
+  sourceId: number,
+  targetId: number,
+  properties: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    id,
+    label,
+    source_id: sourceId,
+    target_id: targetId,
+    properties,
+    temporal: {
+      valid_from: '2024-01-01T00:00:00Z',
+      valid_to: null,
+      transaction_from: '2024-01-01T00:00:00Z',
+      transaction_to: null,
+      is_current: true,
+    },
+  };
+}
+
+/** The MCP-style in-band structured error envelope (#3234), returned with HTTP 200. */
+export function mcpError(
+  code: string,
+  message: string,
+  retriable: boolean,
+  details?: Record<string, unknown>,
+): CannedResponse {
+  return {
+    status: 200,
+    body: { error: { code, message, retriable, ...(details ? { details } : {}) } },
+  };
+}
+
+/** The HTTP-envelope error shape used by auth/limit variants. */
+export function httpError(
+  status: number,
+  error: string,
+  code?: string,
+  retriable?: boolean,
+  details?: Record<string, unknown>,
+): CannedResponse {
+  const body: Record<string, unknown> = { success: false, error };
+  if (code !== undefined) body['code'] = code;
+  if (retriable !== undefined) body['retriable'] = retriable;
+  if (details !== undefined) body['details'] = details;
+  return { status, body };
+}

--- a/clients/typescript/test/retry.test.ts
+++ b/clients/typescript/test/retry.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { AletheiaClient, ConflictError, NotFoundError } from '../src/index.js';
+import { mcpError, mockFetch, nodeFixture } from './fixtures.js';
+
+const noSleep = () => Promise.resolve();
+const fixedRandom = () => 0.5;
+
+describe('retry-with-backoff policy', () => {
+  it('is OFF by default: a retriable CONFLICT is thrown after ONE attempt', async () => {
+    const { fetch, calls } = mockFetch(() => mcpError('CONFLICT', 'conflict', true));
+    const db = new AletheiaClient({ baseUrl: 'http://x', apiKey: 'k', fetch });
+    await expect(db.getNode(1)).rejects.toBeInstanceOf(ConflictError);
+    expect(calls.length).toBe(1);
+  });
+
+  it('retries a retriable CONFLICT when enabled, then succeeds', async () => {
+    const { fetch, calls } = mockFetch((_req, i) => {
+      if (i < 2) return mcpError('CONFLICT', 'conflict', true);
+      return { body: nodeFixture(1, 'Person', { name: 'Alice' }) };
+    });
+    const db = new AletheiaClient({
+      baseUrl: 'http://x',
+      apiKey: 'k',
+      fetch,
+      retry: { enabled: true, maxAttempts: 3, sleep: noSleep, random: fixedRandom },
+    });
+    const node = await db.getNode(1);
+    expect(node.label).toBe('Person');
+    expect(calls.length).toBe(3);
+  });
+
+  it('NEVER retries a non-retriable NOT_FOUND, even with retries enabled', async () => {
+    const { fetch, calls } = mockFetch(() => mcpError('NOT_FOUND', 'missing', false));
+    const db = new AletheiaClient({
+      baseUrl: 'http://x',
+      apiKey: 'k',
+      fetch,
+      retry: { enabled: true, maxAttempts: 5, sleep: noSleep, random: fixedRandom },
+    });
+    await expect(db.getNode(1)).rejects.toBeInstanceOf(NotFoundError);
+    expect(calls.length).toBe(1);
+  });
+
+  it('gives up after maxAttempts on a persistently retriable error', async () => {
+    const { fetch, calls } = mockFetch(() => mcpError('UNAVAILABLE', 'busy', true));
+    const db = new AletheiaClient({
+      baseUrl: 'http://x',
+      apiKey: 'k',
+      fetch,
+      retry: { enabled: true, maxAttempts: 4, sleep: noSleep, random: fixedRandom },
+    });
+    await expect(db.listNodes()).rejects.toMatchObject({ code: 'UNAVAILABLE' });
+    expect(calls.length).toBe(4);
+  });
+});

--- a/clients/typescript/test/routes.test.ts
+++ b/clients/typescript/test/routes.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest';
+import { AletheiaClient, toWireTime, type RequestSpec } from '../src/index.js';
+import {
+  edgeFixture,
+  mockFetch,
+  nodeFixture,
+  type RecordedRequest,
+} from './fixtures.js';
+
+/** Capture the single request a call makes. */
+async function capture(
+  responseBody: unknown,
+  run: (db: AletheiaClient) => Promise<unknown>,
+): Promise<RecordedRequest> {
+  const { fetch, calls } = mockFetch(() => ({ body: responseBody }));
+  const db = new AletheiaClient({ baseUrl: 'http://x', apiKey: 'k', fetch });
+  await run(db);
+  return calls[0]!;
+}
+
+describe('route + wire param fidelity (mirrors *_tools.rs)', () => {
+  it('createNode -> POST /nodes with label/properties/valid_time/provenance/derived_from', async () => {
+    const req = await capture(nodeFixture(1, 'Person', { name: 'Alice' }), (db) =>
+      db.createNode({
+        label: 'Person',
+        properties: { name: 'Alice' },
+        validTime: '2024-01-15T10:00:00Z',
+        provenance: { source: 'hr', confidence: 0.9 },
+        derivedFrom: [{ entity_kind: 'node', id: 5, version: 2 }],
+      }),
+    );
+    expect(req.method).toBe('POST');
+    expect(req.path).toBe('/nodes');
+    expect(req.body).toMatchObject({
+      label: 'Person',
+      properties: { name: 'Alice' },
+      valid_time: toWireTime('2024-01-15T10:00:00Z'),
+      provenance: { source: 'hr', confidence: 0.9 },
+      derived_from: [{ entity_kind: 'node', id: 5, version: 2 }],
+    });
+  });
+
+  it('updateNode -> POST /nodes/update with node_id', async () => {
+    const req = await capture(nodeFixture(1, 'Person', {}), (db) =>
+      db.updateNode({ nodeId: 1, properties: { name: 'Bob' } }),
+    );
+    expect(req.path).toBe('/nodes/update');
+    expect(req.body).toMatchObject({ node_id: 1, properties: { name: 'Bob' } });
+  });
+
+  it('deleteNode -> POST /nodes/delete with detach', async () => {
+    const req = await capture({ deleted: true }, (db) =>
+      db.deleteNode({ nodeId: 3, detach: true }),
+    );
+    expect(req.path).toBe('/nodes/delete');
+    expect(req.body).toMatchObject({ node_id: 3, detach: true });
+  });
+
+  it('deleteNodeCascade -> POST /nodes/delete_cascade', async () => {
+    const req = await capture({ deleted: true }, (db) => db.deleteNodeCascade({ nodeId: 3 }));
+    expect(req.path).toBe('/nodes/delete_cascade');
+    expect(req.body).toEqual({ node_id: 3 });
+  });
+
+  it('retractNode -> POST /nodes/retract with valid_time + detach', async () => {
+    const req = await capture({ retracted: true }, (db) =>
+      db.retractNode({ nodeId: 3, validTime: '2024-01-15T10:00:00Z', detach: true }),
+    );
+    expect(req.path).toBe('/nodes/retract');
+    expect(req.body).toMatchObject({
+      node_id: 3,
+      valid_time: toWireTime('2024-01-15T10:00:00Z'),
+      detach: true,
+    });
+  });
+
+  it('findNodesAtTime -> POST /nodes/find_at_time with valid_time/transaction_time', async () => {
+    const req = await capture({ nodes: [], count: 0 }, (db) =>
+      db.findNodesAtTime({
+        label: 'Person',
+        propertyKey: 'name',
+        propertyValue: 'Alice',
+        validTime: '2024-01-01',
+        transactionTime: '2024-06-01',
+      }),
+    );
+    expect(req.path).toBe('/nodes/find_at_time');
+    expect(req.body).toMatchObject({
+      label: 'Person',
+      property_key: 'name',
+      property_value: 'Alice',
+      valid_time: toWireTime('2024-01-01'),
+      transaction_time: toWireTime('2024-06-01'),
+    });
+  });
+
+  it('createEdge -> POST /edges with source_id/target_id/label', async () => {
+    const req = await capture(edgeFixture(1, 'KNOWS', 1, 2), (db) =>
+      db.createEdge({ sourceId: 1, targetId: 2, label: 'KNOWS', properties: { since: 2020 } }),
+    );
+    expect(req.path).toBe('/edges');
+    expect(req.body).toMatchObject({
+      source_id: 1,
+      target_id: 2,
+      label: 'KNOWS',
+      properties: { since: 2020 },
+    });
+  });
+
+  it('getOutgoingEdges -> GET /nodes/{id}/edges/outgoing', async () => {
+    const req = await capture({ edges: [], count: 0 }, (db) =>
+      db.getOutgoingEdges(7, { label: 'KNOWS' }),
+    );
+    expect(req.method).toBe('GET');
+    expect(req.path).toBe('/nodes/7/edges/outgoing');
+    expect(req.query.get('label')).toBe('KNOWS');
+  });
+
+  it('getIncomingEdges -> GET /nodes/{id}/edges/incoming', async () => {
+    const req = await capture({ edges: [], count: 0 }, (db) => db.getIncomingEdges(7));
+    expect(req.path).toBe('/nodes/7/edges/incoming');
+  });
+
+  it('getNodeAtTime -> POST /nodes/at_time', async () => {
+    const req = await capture(nodeFixture(1, 'Person', {}), (db) =>
+      db.getNodeAtTime({ nodeId: 1, validTime: '2024-01-01', transactionTime: '2024-06-01' }),
+    );
+    expect(req.path).toBe('/nodes/at_time');
+    expect(req.body).toMatchObject({
+      node_id: 1,
+      valid_time: toWireTime('2024-01-01'),
+      transaction_time: toWireTime('2024-06-01'),
+    });
+  });
+
+  it('getEdgeAtTime -> POST /edges/at_time', async () => {
+    const req = await capture(edgeFixture(1, 'KNOWS', 1, 2), (db) =>
+      db.getEdgeAtTime({ edgeId: 1, validTime: '2024-01-01' }),
+    );
+    expect(req.path).toBe('/edges/at_time');
+    expect(req.body).toMatchObject({ edge_id: 1, valid_time: toWireTime('2024-01-01') });
+  });
+
+  it('diffNodeVersions -> POST /nodes/diff with from_version/to_version', async () => {
+    const req = await capture({ diff: {} }, (db) =>
+      db.diffNodeVersions({ nodeId: 1, fromVersion: 2, toVersion: 5 }),
+    );
+    expect(req.path).toBe('/nodes/diff');
+    expect(req.body).toEqual({ node_id: 1, from_version: 2, to_version: 5 });
+  });
+
+  it('listChanges -> POST /changes with tx_from/tx_to', async () => {
+    const req = await capture({ changes: [] }, (db) =>
+      db.listChanges({ txFrom: '2024-01-01', txTo: '2024-12-31' }),
+    );
+    expect(req.path).toBe('/changes');
+    expect(req.body).toMatchObject({
+      tx_from: toWireTime('2024-01-01'),
+      tx_to: toWireTime('2024-12-31'),
+    });
+  });
+
+  it('getNodeHistory -> GET /nodes/{id}/history', async () => {
+    const req = await capture({ node_id: 1, results: [] }, (db) => db.getNodeHistory(1));
+    expect(req.path).toBe('/nodes/1/history');
+  });
+
+  it('getEdgeHistory -> GET /edges/{id}/history', async () => {
+    const req = await capture({ edge_id: 1, results: [] }, (db) => db.getEdgeHistory(1));
+    expect(req.path).toBe('/edges/1/history');
+  });
+
+  it('countNodes -> GET /nodes/count', async () => {
+    const req = await capture({ count: 42 }, (db) => db.countNodes());
+    expect(req.path).toBe('/nodes/count');
+  });
+
+  it('status -> GET /status', async () => {
+    const req = await capture({ status: 'healthy' }, (db) => db.status());
+    expect(req.path).toBe('/status');
+  });
+
+  it('createKey -> POST /admin/keys and unwraps {success,data}', async () => {
+    const { fetch, calls } = mockFetch(() => ({
+      body: {
+        success: true,
+        data: { id: 'p1', name: 'ci', role: 'writer', key_prefix: 'aletheia_sk_x', created_at: 't', key: 'aletheia_sk_secret' },
+      },
+    }));
+    const db = new AletheiaClient({ baseUrl: 'http://x', apiKey: 'admin', fetch });
+    const created = await db.createKey({ name: 'ci', role: 'writer' });
+    expect(calls[0]!.path).toBe('/admin/keys');
+    expect(created.key).toBe('aletheia_sk_secret');
+    expect(created.role).toBe('writer');
+  });
+
+  it('revokeKey -> POST /admin/keys/revoke and unwraps data', async () => {
+    const { fetch, calls } = mockFetch(() => ({
+      body: { success: true, data: { revoked: true, id: 'p1' } },
+    }));
+    const db = new AletheiaClient({ baseUrl: 'http://x', apiKey: 'admin', fetch });
+    const res = await db.revokeKey({ id: 'p1' });
+    expect(calls[0]!.path).toBe('/admin/keys/revoke');
+    expect(res).toEqual({ revoked: true, id: 'p1' });
+  });
+
+  it('exposes RequestSpec as a public type', () => {
+    const spec: RequestSpec = { method: 'GET', path: '/status' };
+    expect(spec.path).toBe('/status');
+  });
+});

--- a/clients/typescript/test/stubs.test.ts
+++ b/clients/typescript/test/stubs.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { AletheiaClient, NotImplementedError } from '../src/index.js';
+import { mockFetch } from './fixtures.js';
+
+describe('not-yet-merged endpoint stubs', () => {
+  const { fetch } = mockFetch(() => ({ body: {} }));
+  const db = new AletheiaClient({ baseUrl: 'http://x', apiKey: 'k', fetch });
+
+  const stubs: Array<[string, () => Promise<unknown>]> = [
+    ['findSimilar', () => db.findSimilar()],
+    ['hybridQuery', () => db.hybridQuery()],
+    ['query', () => db.query()],
+    ['enableVectorIndex', () => db.enableVectorIndex()],
+    ['listVectorIndexes', () => db.listVectorIndexes()],
+    ['getSchema', () => db.getSchema()],
+    ['databaseStats', () => db.databaseStats()],
+    ['temporalExtent', () => db.temporalExtent()],
+    ['applyBatch', () => db.applyBatch()],
+    ['lineageUpstream', () => db.lineageUpstream()],
+    ['lineageDownstream', () => db.lineageDownstream()],
+  ];
+
+  for (const [name, call] of stubs) {
+    it(`${name} throws NotImplementedError referencing the follow-up`, async () => {
+      const err = await call().catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(NotImplementedError);
+      expect((err as Error).message).toMatch(/not merged server-side/);
+    });
+  }
+});

--- a/clients/typescript/test/time.test.ts
+++ b/clients/typescript/test/time.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { toEpochMicros, toWireTime } from '../src/index.js';
+import { AletheiaClient } from '../src/index.js';
+import { mockFetch, nodeFixture } from './fixtures.js';
+
+describe('time coercion', () => {
+  const instantIso = '2024-01-15T10:00:00.000Z';
+  const instantMs = Date.parse(instantIso);
+  const instantMicros = instantMs * 1000;
+
+  it('coerces Date, ISO string, and epoch-micros to the SAME wire value', () => {
+    const fromDate = toWireTime(new Date(instantIso));
+    const fromString = toWireTime(instantIso);
+    const fromNumber = toWireTime(instantMicros);
+    expect(fromDate).toBe(instantMicros);
+    expect(fromString).toBe(instantMicros);
+    expect(fromNumber).toBe(instantMicros);
+    expect(fromDate).toBe(fromString);
+    expect(fromString).toBe(fromNumber);
+  });
+
+  it('documents millisecond precision for Date/string (multiple of 1000 micros)', () => {
+    expect(toEpochMicros(new Date(instantIso)) % 1000).toBe(0);
+    expect(toEpochMicros(instantIso) % 1000).toBe(0);
+    // A numeric input can carry finer resolution.
+    expect(toEpochMicros(instantMicros + 7)).toBe(instantMicros + 7);
+  });
+
+  it('rejects invalid inputs', () => {
+    expect(() => toEpochMicros(new Date('nope'))).toThrow(RangeError);
+    expect(() => toEpochMicros('not-a-timestamp')).toThrow(RangeError);
+    expect(() => toEpochMicros(Number.POSITIVE_INFINITY)).toThrow(RangeError);
+  });
+
+  it('all three forms produce the same serialized request (create_node valid_time)', async () => {
+    const seen: unknown[] = [];
+    const capture = () => {
+      const { fetch, calls } = mockFetch(() => ({ body: nodeFixture(1, 'Person', {}) }));
+      const db = new AletheiaClient({ baseUrl: 'http://x', apiKey: 'k', fetch });
+      return { db, calls, seen };
+    };
+    for (const t of [new Date(instantIso), instantIso, instantMicros]) {
+      const { db, calls } = capture();
+      await db.createNode({ label: 'Person', properties: {}, validTime: t });
+      seen.push((calls[0]!.body as { valid_time: number }).valid_time);
+    }
+    expect(new Set(seen).size).toBe(1);
+    expect(seen[0]).toBe(instantMicros);
+  });
+});

--- a/clients/typescript/test/time.test.ts
+++ b/clients/typescript/test/time.test.ts
@@ -9,12 +9,16 @@ describe('time coercion', () => {
   const instantMicros = instantMs * 1000;
 
   it('coerces Date, ISO string, and epoch-micros to the SAME wire value', () => {
+    // The wire value is a DECIMAL-MICROSECONDS STRING: the server deserializes
+    // POST-body temporal fields as Rust `String`, so a JSON number would 4xx.
+    const expected = String(instantMicros);
     const fromDate = toWireTime(new Date(instantIso));
     const fromString = toWireTime(instantIso);
     const fromNumber = toWireTime(instantMicros);
-    expect(fromDate).toBe(instantMicros);
-    expect(fromString).toBe(instantMicros);
-    expect(fromNumber).toBe(instantMicros);
+    expect(typeof fromDate).toBe('string');
+    expect(fromDate).toBe(expected);
+    expect(fromString).toBe(expected);
+    expect(fromNumber).toBe(expected);
     expect(fromDate).toBe(fromString);
     expect(fromString).toBe(fromNumber);
   });
@@ -42,9 +46,29 @@ describe('time coercion', () => {
     for (const t of [new Date(instantIso), instantIso, instantMicros]) {
       const { db, calls } = capture();
       await db.createNode({ label: 'Person', properties: {}, validTime: t });
-      seen.push((calls[0]!.body as { valid_time: number }).valid_time);
+      seen.push((calls[0]!.body as { valid_time: string }).valid_time);
     }
     expect(new Set(seen).size).toBe(1);
-    expect(seen[0]).toBe(instantMicros);
+    // Serialized as a decimal-microseconds STRING, not a JSON number.
+    expect(typeof seen[0]).toBe('string');
+    expect(seen[0]).toBe(String(instantMicros));
+  });
+
+  it('serializes POST-body timestamp fields as JSON strings (regression guard #blocker)', async () => {
+    // The server deserializes valid_time/transaction_time as Rust `String`;
+    // a JSON number would fail deserialization with a 4xx. The record-replay
+    // layer parses JSON before we inspect it, so assert on `typeof` here to
+    // pin the wire type and prevent a silent regression to numbers.
+    const { fetch, calls } = mockFetch(() => ({ body: nodeFixture(1, 'Person', {}) }));
+    const db = new AletheiaClient({ baseUrl: 'http://x', apiKey: 'k', fetch });
+
+    await db.createNode({ label: 'Person', properties: {}, validTime: instantMicros });
+    const createBody = calls[0]!.body as { valid_time: unknown };
+    expect(typeof createBody.valid_time).toBe('string');
+
+    await db.getNodeAtTime({ nodeId: 1, validTime: instantIso, transactionTime: instantIso });
+    const atTimeBody = calls[1]!.body as { valid_time: unknown; transaction_time: unknown };
+    expect(typeof atTimeBody.valid_time).toBe('string');
+    expect(typeof atTimeBody.transaction_time).toBe('string');
   });
 });

--- a/clients/typescript/test/transport.test.ts
+++ b/clients/typescript/test/transport.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AletheiaClient,
+  AletheiaError,
+  UnavailableError,
+  type FetchLike,
+  type FetchResponseLike,
+} from '../src/index.js';
+import { mockFetch, nodeFixture } from './fixtures.js';
+
+const noSleep = (): Promise<void> => Promise.resolve();
+const fixedRandom = (): number => 0.5;
+
+/** Build a canned {@link FetchResponseLike} for a status + JSON body. */
+function jsonResponse(status: number, body: unknown): FetchResponseLike {
+  const text = JSON.stringify(body);
+  return { status, ok: status >= 200 && status < 300, text: () => Promise.resolve(text) };
+}
+
+/** A native `AbortError`, matching what `fetch` throws on an aborted signal. */
+function abortError(): Error {
+  const e = new Error('The operation was aborted');
+  e.name = 'AbortError';
+  return e;
+}
+
+describe('network-error retriability (#3369 review: HIGH)', () => {
+  it('retries a rejected fetch (network error) when retry is enabled, then succeeds', async () => {
+    let n = 0;
+    const fetch: FetchLike = () => {
+      n += 1;
+      if (n <= 2) return Promise.reject(new Error('ECONNREFUSED'));
+      return Promise.resolve(jsonResponse(200, nodeFixture(1, 'Person', { name: 'Alice' })));
+    };
+    const db = new AletheiaClient({
+      baseUrl: 'http://x',
+      apiKey: 'k',
+      fetch,
+      retry: { enabled: true, maxAttempts: 3, sleep: noSleep, random: fixedRandom },
+    });
+    const node = await db.getNode(1);
+    expect(node.label).toBe('Person');
+    expect(n).toBe(3);
+  });
+
+  it('throws UNAVAILABLE (retriable) on the first rejected fetch when retry is OFF', async () => {
+    let n = 0;
+    const fetch: FetchLike = () => {
+      n += 1;
+      return Promise.reject(new Error('getaddrinfo ENOTFOUND'));
+    };
+    const db = new AletheiaClient({ baseUrl: 'http://x', apiKey: 'k', fetch });
+    const err = await db.getNode(1).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(UnavailableError);
+    expect((err as AletheiaError).code).toBe('UNAVAILABLE');
+    expect((err as AletheiaError).retriable).toBe(true);
+    expect((err as AletheiaError).message).toContain('Network error');
+    expect(n).toBe(1);
+  });
+});
+
+describe('plain-text error body + 429 retriability (#3369 review: MEDIUM)', () => {
+  it('surfaces a 502 plain-text body as the error message', async () => {
+    const { fetch } = mockFetch(() => ({ status: 502, body: undefined, raw: 'Bad Gateway: upstream timeout' }));
+    const db = new AletheiaClient({ baseUrl: 'http://x', apiKey: 'k', fetch });
+    const err = await db.getNode(1).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(AletheiaError);
+    expect((err as AletheiaError).message).toBe('Bad Gateway: upstream timeout');
+    expect((err as AletheiaError).httpStatus).toBe(502);
+  });
+
+  it('defaults a 429 to retriable (envelope without an explicit flag)', async () => {
+    const { fetch } = mockFetch(() => ({ status: 429, body: { success: false, error: 'slow down' } }));
+    const db = new AletheiaClient({ baseUrl: 'http://x', apiKey: 'k', fetch });
+    const err = await db.listNodes().catch((e: unknown) => e);
+    expect((err as AletheiaError).httpStatus).toBe(429);
+    expect((err as AletheiaError).retriable).toBe(true);
+  });
+
+  it('defaults a bare 429 (no envelope) to retriable', async () => {
+    const { fetch } = mockFetch(() => ({ status: 429, body: undefined, raw: 'Too Many Requests' }));
+    const db = new AletheiaClient({ baseUrl: 'http://x', apiKey: 'k', fetch });
+    const err = await db.getNode(1).catch((e: unknown) => e);
+    expect((err as AletheiaError).message).toBe('Too Many Requests');
+    expect((err as AletheiaError).retriable).toBe(true);
+  });
+});
+
+describe('abort / timeout support (#3369 review: MAJOR)', () => {
+  it('rejects an already-aborted signal before any fetch is issued', async () => {
+    let fetchCalls = 0;
+    const fetch: FetchLike = () => {
+      fetchCalls += 1;
+      return Promise.resolve(jsonResponse(200, nodeFixture(1, 'Person', {})));
+    };
+    const controller = new AbortController();
+    controller.abort();
+    const db = new AletheiaClient({
+      baseUrl: 'http://x',
+      apiKey: 'k',
+      fetch,
+      signal: controller.signal,
+    });
+    await expect(db.getNode(1)).rejects.toBeTruthy();
+    expect(fetchCalls).toBe(0);
+  });
+
+  it('stops retries when the signal aborts during backoff', async () => {
+    let fetchCalls = 0;
+    // Every attempt returns a retriable UNAVAILABLE network error.
+    const fetch: FetchLike = () => {
+      fetchCalls += 1;
+      return Promise.reject(new Error('ECONNRESET'));
+    };
+    const controller = new AbortController();
+    let sleepCalls = 0;
+    // The first backoff wait aborts the request and never resolves; the
+    // abortable sleep must reject on the abort instead of waiting it out.
+    const sleep = (): Promise<void> => {
+      sleepCalls += 1;
+      controller.abort();
+      return new Promise<void>(() => {
+        /* never resolves */
+      });
+    };
+    const db = new AletheiaClient({
+      baseUrl: 'http://x',
+      apiKey: 'k',
+      fetch,
+      signal: controller.signal,
+      retry: { enabled: true, maxAttempts: 5, sleep, random: fixedRandom },
+    });
+    await expect(db.getNode(1)).rejects.toBeTruthy();
+    expect(fetchCalls).toBe(1);
+    expect(sleepCalls).toBe(1);
+  });
+
+  it('times out a hanging request via timeoutMs', async () => {
+    let aborted = false;
+    // A fetch that only settles when its signal aborts (as real fetch does).
+    const fetch: FetchLike = (_input, init) =>
+      new Promise<FetchResponseLike>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          aborted = true;
+          reject(abortError());
+        });
+      });
+    const db = new AletheiaClient({ baseUrl: 'http://x', apiKey: 'k', fetch, timeoutMs: 10 });
+    await expect(db.getNode(1)).rejects.toBeTruthy();
+    expect(aborted).toBe(true);
+  });
+});

--- a/clients/typescript/test/vectors.test.ts
+++ b/clients/typescript/test/vectors.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AletheiaClient,
+  isElidedVector,
+  isFullVector,
+  type PropertyValue,
+} from '../src/index.js';
+import { mockFetch, nodeFixture } from './fixtures.js';
+
+describe('vector elision (#3220)', () => {
+  it('includeVectors:false (default) yields an elided descriptor distinct from number[]', async () => {
+    const { fetch, calls } = mockFetch(() => ({
+      body: nodeFixture(1, 'Document', {
+        title: 'Intro',
+        embedding: { type: 'vector', dim: 8, elided: true },
+      }),
+    }));
+    const db = new AletheiaClient({ baseUrl: 'http://x', apiKey: 'k', fetch });
+    const node = await db.getNode(1);
+
+    // Default request does not ask for full vectors.
+    expect(calls[0]!.query.has('include_vectors')).toBe(false);
+
+    const embedding: PropertyValue = node.properties['embedding']!;
+    expect(isElidedVector(embedding)).toBe(true);
+    expect(isFullVector(embedding)).toBe(false);
+    if (isElidedVector(embedding)) {
+      // Narrowed to the descriptor — typed distinctly from data.
+      expect(embedding.dim).toBe(8);
+      expect(embedding.elided).toBe(true);
+    }
+  });
+
+  it('includeVectors:true sends the flag and returns the full array', async () => {
+    const full = [0, 0.25, 0.5, 0.75];
+    const { fetch, calls } = mockFetch(() => ({
+      body: nodeFixture(1, 'Document', { embedding: full }),
+    }));
+    const db = new AletheiaClient({ baseUrl: 'http://x', apiKey: 'k', fetch });
+    const node = await db.getNode(1, { includeVectors: true });
+
+    expect(calls[0]!.query.get('include_vectors')).toBe('true');
+    const embedding: PropertyValue = node.properties['embedding']!;
+    expect(isFullVector(embedding)).toBe(true);
+    expect(isElidedVector(embedding)).toBe(false);
+    if (isFullVector(embedding)) {
+      expect(embedding).toEqual(full);
+    }
+  });
+});

--- a/clients/typescript/tsconfig.examples.json
+++ b/clients/typescript/tsconfig.examples.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["examples", "src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/clients/typescript/tsconfig.json
+++ b/clients/typescript/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2021", "DOM"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "types": []
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/clients/typescript/tsup.config.ts
+++ b/clients/typescript/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+// Dual ESM + CJS emit with type declarations. Node >=18 / standard-fetch edge
+// runtimes are the target; the core client has no Node-only dependencies.
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  target: 'node18',
+  outExtension({ format }) {
+    return { js: format === 'cjs' ? '.cjs' : '.js' };
+  },
+});

--- a/clients/typescript/vitest.config.ts
+++ b/clients/typescript/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      include: ['src/**/*.ts'],
+    },
+  },
+});


### PR DESCRIPTION
## Before / After (plain language)

**Before:** A TypeScript developer building an LLM app had *nothing* from AletheiaDB — Rust users have the crate, Python users have the PyO3 SDK, but TS devs had to hand-roll untyped `fetch` calls against the HTTP server, with no types, no temporal helpers, and no guidance on bi-temporal semantics.

**After:** `npm install @aletheiadb/client` gives fully typed CRUD, traversal, point-in-time reads, an ergonomic `db.asOf(...)` accessor, vector-elision-aware types, and the structured error contract surfaced as a typed error hierarchy with an opt-in retry policy — on Node ≥ 18 and standard-`fetch` edge runtimes, ESM + CJS, with **0 `any`** in the published types.

> Greenfield: all new code lives under `clients/typescript/`. No `src/**`, `crates/**`, or existing gating workflow was touched. The one new workflow (`.github/workflows/ts-sdk.yml`) is informational and path-scoped to `clients/typescript/**`.

## How (implementation)

Hand-written typed client (not codegen) mirroring the merged autumn-server REST routes exactly (verified against `crates/aletheia-server/src/{node,edge,traverse_temporal}_tools.rs`, `http_routes.rs`, `security/auth.rs`, and `tests/parity/inventory.json`):

- `src/client.ts` — `AletheiaClient` with typed methods for the **34 merged routes**; not-yet-merged endpoints are typed **stubs** throwing `NotImplementedError` (`// TODO(#3369-followup): wire when PR5–PR8 land`).
- `src/types.ts` — request/response models: `temporal` block (#3232), `provenance`, discriminated `PropertyValue` union, and vector elision as `{type:'vector',dim,elided:true} | number[]` with `isElidedVector`/`isFullVector` guards (#3220).
- `src/time.ts` — `TimeInput = Date | string | number(epoch-micros)`, all coerced to one canonical wire value (epoch microseconds), with documented ms-precision behavior.
- `src/temporal-view.ts` — `db.asOf({validTime, transactionTime})` injects `as_of_valid_time`/`as_of_transaction_time` into `traverse`; each dimension independent.
- `src/errors.ts` — `AletheiaError` base + one subclass per #3234 code (and HTTP 401/403 → `UnauthenticatedError`/`PermissionDeniedError`). Unknown code → base `AletheiaError`, `retriable=false`. Maps both the MCP in-band `{error:{...}}` (HTTP 200) and HTTP `{success:false,...}` envelopes.
- `src/retry.ts` — opt-in, off by default; retries **only** `retriable` errors, bounded attempts + jittered exponential backoff, never a non-retriable code.
- `src/http.ts` — fetch transport (global `fetch` by default, injectable), `Authorization: Bearer` default with `x-api-key` option, configurable base URL.

## Acceptance criteria (with evidence)

- [x] **Official npm package covering the stable surface** — `@aletheiadb/client`, semver `0.1.0`. Node/edge CRUD incl. `validTime` (#3221), traversal incl. `as_of` (#3225), point-in-time reads, and pagination/completeness (#3226/#3360/#3353) are wrapped. *Vector/hybrid/query/schema/stats/extent endpoints are not merged server-side yet → typed stubs (see below).* Evidence: `src/client.ts`, `test/routes.test.ts` (20 route-fidelity tests).
- [x] **Fully typed; no `any` in the public surface** — `grep -nE '\bany\b' dist/index.d.ts` returns only prose in docstrings, zero `any` types; `@typescript-eslint/no-explicit-any: error` enforces it. `TimeInput` accepts `Date`/ISO/epoch-micros; vector payloads typed. Evidence: `npm run lint` passes; `npm run typecheck` (strict) passes.
- [x] **Temporal ergonomics** — `db.asOf({validTime, transactionTime})` with TSDoc explaining valid-vs-transaction time. Evidence: `test/asof.test.ts` (both/valid-only/tx-only/override/none).
- [x] **Structured errors → typed hierarchy; retriable drives opt-in retry** — Evidence: `test/errors.test.ts`, `test/retry.test.ts` (off by default; retries CONFLICT when enabled; NEVER retries NOT_FOUND; unknown code → base, `retriable===false`).
- [x] **Node ≥ LTS + fetch edge runtimes; no Node-only core deps; ESM + CJS** — `package.json` `exports` map, `type:module`, dual `tsup` build. Evidence: `npm run build` emits `index.js`+`index.cjs`+`d.ts`; `npm run smoke` imports both cleanly; `test/build.test.ts`.
- [x] **Vector elision represented in types (#3220)** — discriminated union + `includeVectors` request option. Evidence: `test/vectors.test.ts`.
- [x] **Quality gates + strict typecheck-clean examples** — 5 examples (connect, CRUD-with-valid-time, AS OF traverse, semantic-search-stub, cypher-query-stub) compiled under `strict:true` via `tsconfig.examples.json`. New CI workflow runs install/lint/typecheck/test/build/smoke on Node 18/20/22. *Integration against a live server binary is wired as the HTTP routes stabilize — see note below.*
- [x] **Versioning/compat policy documented** — `COMPATIBILITY.md` (server↔SDK matrix, how additive vs breaking HTTP changes propagate, unknown-error-code forward-compat).

## Time coercion (documented precision)

`Date` and ISO strings resolve to **millisecond** granularity (the wire microsecond value is a multiple of 1000); pass a **number of epoch-microseconds** for finer resolution. All three forms for the same instant serialize identically (`test/time.test.ts`).

## Fixtures, not a live server

Per the issue's allowance, the unit suite uses **record-replay fetch fixtures** — an injected mock `fetch` returning canned responses shaped to `tests/parity/inventory.json` and the autumn-server `*_tools.rs` handlers — **not** a live server binary (too heavy to build reliably in the SDK sandbox). Integration against a real binary on SDK releases is a documented follow-up once the HTTP surface stabilizes.

## Stubbed endpoints (not merged server-side yet)

`findSimilar`, `hybridQuery`, `query`, `enableVectorIndex`, `listVectorIndexes`, `getSchema`, `databaseStats`, `temporalExtent`, `applyBatch`, `lineageUpstream`, `lineageDownstream` — each throws `NotImplementedError` referencing the #3369 follow-up (PR5–PR8). No server routes were invented.

## Gate output (all pass, run in `clients/typescript/`)

```
$ npm run lint       # eslint — clean (bans `any` in public surface)
$ npm run typecheck  # tsc --noEmit (strict) src + examples — clean
$ npm run test       # vitest — Test Files 10 passed (10) · Tests 62 passed (62)
$ npm run build      # tsup — ESM dist/index.js 27.13 KB · CJS dist/index.cjs 27.67 KB · DTS dist/index.d.ts 35.69 KB
$ npm run smoke      # ESM smoke OK / CJS smoke OK
```

## AC gaps (with reasons)

- **Live-server integration tests / p99 <1ms overhead / ≥90% endpoint coverage metrics** — not measurable in this sandbox without a built server binary; the unit layer uses record-replay fixtures (issue-sanctioned). The 34 wrapped routes are the currently-merged HTTP surface; the remaining ~11 tools are stubs pending their server routes (out of scope per the issue: "the SDK wraps the existing/in-flight HTTP surface … gaps are filed against the server, not solved client-side").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWBA69EjuRMLcYBavK7SSr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWBA69EjuRMLcYBavK7SSr)_