### PR TITLE
Add replace/tombstone (non-PATCH) node &amp; edge write API (#3549)

### DIFF
--- a/src/api/transaction/mod.rs
+++ b/src/api/transaction/mod.rs
@@ -1051,6 +1051,127 @@ pub trait WriteOps: ReadOps {
     fn delete_edge(&mut self, edge_id: EdgeId) -> Result<()> {
         self.delete_edge_with_valid_time(edge_id, None)
     }
+
+    // ===== Replace / tombstone (non-PATCH) writes (Issue #3549) =====
+
+    /// Replace a node's **entire** property map and label (non-PATCH overwrite).
+    ///
+    /// Unlike [`update_node`](Self::update_node) (PATCH: merges the incoming map
+    /// onto the existing one), this performs a full overwrite: the node's
+    /// resulting property map is *exactly* `properties`, and its label becomes
+    /// `label`. Any key present on the prior version but absent from
+    /// `properties` is **removed** from current state — its history is
+    /// preserved and still recallable `AS OF` an earlier bi-temporal coordinate
+    /// (anchor *both* dimensions before the replace). Passing an empty map
+    /// removes all properties while keeping the node in existence.
+    ///
+    /// Node label mutation is only possible through this method;
+    /// [`update_node`](Self::update_node) preserves the label.
+    ///
+    /// This is the most general node-replace method; the other `replace_node*`
+    /// methods delegate to it. The provenance recorded here describes *this*
+    /// version only — it is not inherited from the version being replaced.
+    fn replace_node_with_options(
+        &mut self,
+        node_id: NodeId,
+        label: &str,
+        properties: PropertyMap,
+        options: WriteRequestOptions,
+    ) -> Result<()>;
+
+    /// Replace a node's entire property map and label with an optional backdated
+    /// `valid_from` time. See [`replace_node_with_options`](Self::replace_node_with_options).
+    fn replace_node_with_valid_time(
+        &mut self,
+        node_id: NodeId,
+        label: &str,
+        properties: PropertyMap,
+        valid_from: Option<Timestamp>,
+    ) -> Result<()> {
+        self.replace_node_with_options(
+            node_id,
+            label,
+            properties,
+            WriteRequestOptions {
+                valid_from,
+                provenance: None,
+            },
+        )
+    }
+
+    /// Replace a node's entire property map and label (full overwrite).
+    ///
+    /// Convenience wrapper: `valid_from` defaults to the transaction start time.
+    /// See [`replace_node_with_options`](Self::replace_node_with_options).
+    fn replace_node(
+        &mut self,
+        node_id: NodeId,
+        label: &str,
+        properties: PropertyMap,
+    ) -> Result<()> {
+        self.replace_node_with_valid_time(node_id, label, properties, None)
+    }
+
+    /// Replace an edge's **entire** property map (non-PATCH overwrite).
+    ///
+    /// Overwrites the property map exactly, like
+    /// [`replace_node_with_options`](Self::replace_node_with_options), but the
+    /// edge's `source`, `target`, and edge type (label) are **immutable** and
+    /// preserved from the existing edge (edge-type mutation is out of scope).
+    /// Any key absent from `properties` is removed from current state; history
+    /// is preserved. Passing an empty map removes all properties.
+    ///
+    /// This is the most general edge-replace method; the other `replace_edge*`
+    /// methods delegate to it.
+    fn replace_edge_with_options(
+        &mut self,
+        edge_id: EdgeId,
+        properties: PropertyMap,
+        options: WriteRequestOptions,
+    ) -> Result<()>;
+
+    /// Replace an edge's entire property map with an optional backdated
+    /// `valid_from` time. See [`replace_edge_with_options`](Self::replace_edge_with_options).
+    fn replace_edge_with_valid_time(
+        &mut self,
+        edge_id: EdgeId,
+        properties: PropertyMap,
+        valid_from: Option<Timestamp>,
+    ) -> Result<()> {
+        self.replace_edge_with_options(
+            edge_id,
+            properties,
+            WriteRequestOptions {
+                valid_from,
+                provenance: None,
+            },
+        )
+    }
+
+    /// Replace an edge's entire property map (full overwrite; endpoints/type
+    /// immutable). Convenience wrapper: `valid_from` defaults to the
+    /// transaction start time. See
+    /// [`replace_edge_with_options`](Self::replace_edge_with_options).
+    fn replace_edge(&mut self, edge_id: EdgeId, properties: PropertyMap) -> Result<()> {
+        self.replace_edge_with_valid_time(edge_id, properties, None)
+    }
+
+    /// Remove a single property key from a node (read-modify-replace).
+    ///
+    /// Reads the node's current property map (read-your-own-writes within the
+    /// transaction), drops `key`, and records a full replacement version with
+    /// the reduced map and the node's existing label. Removing a key that is
+    /// **absent** is a no-op that still succeeds and records **no** new version.
+    /// History is preserved: the removed key is still recallable `AS OF` an
+    /// earlier bi-temporal coordinate.
+    fn remove_node_property(&mut self, node_id: NodeId, key: &str) -> Result<()>;
+
+    /// Remove a single property key from an edge (read-modify-replace).
+    ///
+    /// Edge counterpart of [`remove_node_property`](Self::remove_node_property);
+    /// the edge's endpoints and type are preserved. Removing an absent key is a
+    /// no-op success that records no new version.
+    fn remove_edge_property(&mut self, edge_id: EdgeId, key: &str) -> Result<()>;
 }
 
 #[cfg(test)]

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -981,6 +981,90 @@ impl WriteTransaction {
         self.current.get_edge(id)
     }
 
+    /// Shared body for node replace (Issue #3549): buffer a full-overwrite
+    /// `UpdateNode` carrying `label_interned` + the *exact* `properties` map
+    /// (no PATCH merge). Callers pass an already-interned label so
+    /// [`remove_node_property`](WriteOps::remove_node_property) can reuse the
+    /// node's existing label without a (deprecated) interner `resolve`.
+    ///
+    /// Does not record the error metric — the public `WriteOps` entry points
+    /// wrap the call and do so.
+    fn buffer_node_replace(
+        &mut self,
+        node_id: NodeId,
+        label_interned: crate::core::interning::InternedString,
+        properties: PropertyMap,
+        options: WriteRequestOptions,
+    ) -> Result<()> {
+        // Check transaction state
+        if self.state != TxState::Active {
+            return Err(TransactionError::InvalidState {
+                current: format!("{:?}", self.state),
+                expected: "Active".to_string(),
+            }
+            .into());
+        }
+
+        // Verify the node exists (read-your-own-writes, Issue #3417) — a
+        // replace targets an existing entity, never conjures one. Unlike PATCH
+        // `update_node`, the existing map is NOT seeded into the new version:
+        // `properties` becomes the node's map *exactly*, so any prior key it
+        // omits is removed from current state (removal is encoded natively by
+        // the anchor/delta diff and survives WAL replay). The label is
+        // overwritten too.
+        let existing = self.read_own_node(node_id)?;
+        let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
+
+        // A replace may add, change, OR remove vector properties; mark the
+        // buffer so the temporal vector index is notified on commit if either
+        // the old or the new state carries a vector.
+        if !self.buffer.has_vector_operations()
+            && (existing.properties.contains_vector() || properties.contains_vector())
+        {
+            self.buffer.mark_has_vector_operations();
+        }
+
+        // Get timestamp: use provided valid_from or default to transaction start time
+        let timestamp = self.start_timestamp;
+        let valid_from = options.valid_from.unwrap_or(timestamp);
+
+        // Validate valid_from is not too far in future
+        validation::validate_valid_from_future(valid_from)?;
+
+        // Validate valid_from is not before entity creation.
+        let creation_time = {
+            let historical = self.historical.read();
+            historical.node_creation_time(node_id)
+        };
+        if let Some(creation_time) = creation_time {
+            validation::validate_valid_from_not_before_creation(
+                &format!("node:{}", node_id.as_u64()),
+                creation_time,
+                valid_from,
+            )?;
+        }
+
+        // Normalize an all-absent provenance bundle to `None` (Issue #3224).
+        let provenance = options
+            .provenance
+            .filter(|p| !p.is_empty())
+            .map(std::sync::Arc::new);
+
+        // Buffer the FULL overwrite. Reuses the UpdateNode op (no new WAL
+        // variant / format bump, Issue #3549): the exact target map plus a
+        // possibly-new label is the payload.
+        self.buffer.add(super::BufferedWrite::UpdateNode {
+            node_id,
+            version_id,
+            label: label_interned,
+            properties,
+            valid_from,
+            provenance,
+        })?;
+
+        Ok(())
+    }
+
     /// Enumerate edges CREATED earlier in THIS transaction that reference
     /// `node_id` as source or target and are still live in the buffer (Issue
     /// #3416 Pt4).
@@ -1472,6 +1556,162 @@ impl WriteOps for WriteTransaction {
         })();
 
         result.record_error_metric()
+    }
+
+    fn replace_node_with_options(
+        &mut self,
+        node_id: NodeId,
+        label: &str,
+        properties: PropertyMap,
+        options: WriteRequestOptions,
+    ) -> Result<()> {
+        let result = (|| {
+            let label_interned = GLOBAL_INTERNER.intern(label)?;
+            self.buffer_node_replace(node_id, label_interned, properties, options)
+        })();
+
+        result.record_error_metric()
+    }
+
+    fn replace_edge_with_options(
+        &mut self,
+        edge_id: EdgeId,
+        properties: PropertyMap,
+        options: WriteRequestOptions,
+    ) -> Result<()> {
+        let result = (|| {
+            // Check transaction state
+            if self.state != TxState::Active {
+                return Err(TransactionError::InvalidState {
+                    current: format!("{:?}", self.state),
+                    expected: "Active".to_string(),
+                }
+                .into());
+            }
+
+            // Verify the edge exists and capture its immutable endpoints/type
+            // (read-your-own-writes, Issue #3417). Full overwrite of properties
+            // only: source/target/label are preserved from the existing edge.
+            let edge = self.read_own_edge(edge_id)?;
+            let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
+
+            // A replace may add/change/remove vector properties.
+            if !self.buffer.has_vector_operations()
+                && (edge.properties.contains_vector() || properties.contains_vector())
+            {
+                self.buffer.mark_has_vector_operations();
+            }
+
+            // Get timestamp: use provided valid_from or default to transaction start time
+            let timestamp = self.start_timestamp;
+            let valid_from = options.valid_from.unwrap_or(timestamp);
+
+            // Validate valid_from is not too far in future
+            validation::validate_valid_from_future(valid_from)?;
+
+            // Validate valid_from is not before the edge's own creation time
+            let creation_time = {
+                let historical = self.historical.read();
+                historical.edge_creation_time(edge_id)
+            };
+            if let Some(creation_time) = creation_time {
+                validation::validate_valid_from_not_before_creation(
+                    &format!("edge:{}", edge_id.as_u64()),
+                    creation_time,
+                    valid_from,
+                )?;
+            }
+
+            // Normalize an all-absent provenance bundle to `None` (Issue #3224).
+            let provenance = options
+                .provenance
+                .filter(|p| !p.is_empty())
+                .map(std::sync::Arc::new);
+
+            // Buffer the FULL overwrite via the existing UpdateEdge op (no WAL
+            // format change, Issue #3549), preserving endpoints and type.
+            self.buffer.add(super::BufferedWrite::UpdateEdge {
+                edge_id,
+                version_id,
+                source: edge.source,
+                target: edge.target,
+                label: edge.label,
+                properties,
+                valid_from,
+                provenance,
+            })?;
+
+            Ok(())
+        })();
+
+        result.record_error_metric()
+    }
+
+    fn remove_node_property(&mut self, node_id: NodeId, key: &str) -> Result<()> {
+        // Check transaction state up front so an absent-key no-op on an
+        // inactive transaction still reports the state error.
+        if self.state != TxState::Active {
+            return Err(TransactionError::InvalidState {
+                current: format!("{:?}", self.state),
+                expected: "Active".to_string(),
+            }
+            .into())
+            .record_error_metric();
+        }
+
+        // Read-your-own-writes current map.
+        let node = match self.read_own_node(node_id) {
+            Ok(node) => node,
+            Err(e) => return Err(e).record_error_metric(),
+        };
+
+        // Absent key: no-op success, record NO new version (Issue #3549).
+        if !node.properties.contains_key(key) {
+            return Ok(());
+        }
+
+        // Drop the key and replace with the reduced map, preserving the node's
+        // existing (already-interned) label — no interner `resolve` needed.
+        let new_properties = PropertyMapBuilder::from_map(node.properties.clone())
+            .remove(key)
+            .build();
+
+        self.buffer_node_replace(
+            node_id,
+            node.label,
+            new_properties,
+            WriteRequestOptions::default(),
+        )
+        .record_error_metric()
+    }
+
+    fn remove_edge_property(&mut self, edge_id: EdgeId, key: &str) -> Result<()> {
+        if self.state != TxState::Active {
+            return Err(TransactionError::InvalidState {
+                current: format!("{:?}", self.state),
+                expected: "Active".to_string(),
+            }
+            .into())
+            .record_error_metric();
+        }
+
+        let edge = match self.read_own_edge(edge_id) {
+            Ok(edge) => edge,
+            Err(e) => return Err(e).record_error_metric(),
+        };
+
+        // Absent key: no-op success, record NO new version.
+        if !edge.properties.contains_key(key) {
+            return Ok(());
+        }
+
+        let new_properties = PropertyMapBuilder::from_map(edge.properties.clone())
+            .remove(key)
+            .build();
+
+        // `replace_edge_with_options` preserves endpoints/type and records its
+        // own error metric.
+        self.replace_edge_with_options(edge_id, new_properties, WriteRequestOptions::default())
     }
 
     fn delete_node_with_options(

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -1065,6 +1065,82 @@ impl WriteTransaction {
         Ok(())
     }
 
+    /// Shared body for edge replace (Issue #3549): buffer a full-overwrite
+    /// `UpdateEdge` carrying the *exact* `properties` map (no PATCH merge),
+    /// preserving the already-read `edge`'s immutable source/target/type.
+    /// Callers pass an already-read `edge` so
+    /// [`remove_edge_property`](WriteOps::remove_edge_property) need not read it
+    /// a second time (mirrors [`buffer_node_replace`](Self::buffer_node_replace)).
+    ///
+    /// Does not record the error metric — the public `WriteOps` entry points
+    /// wrap the call and do so.
+    fn buffer_edge_replace(
+        &mut self,
+        edge: Edge,
+        properties: PropertyMap,
+        options: WriteRequestOptions,
+    ) -> Result<()> {
+        // Check transaction state
+        if self.state != TxState::Active {
+            return Err(TransactionError::InvalidState {
+                current: format!("{:?}", self.state),
+                expected: "Active".to_string(),
+            }
+            .into());
+        }
+
+        let edge_id = edge.id;
+        let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
+
+        // A replace may add/change/remove vector properties.
+        if !self.buffer.has_vector_operations()
+            && (edge.properties.contains_vector() || properties.contains_vector())
+        {
+            self.buffer.mark_has_vector_operations();
+        }
+
+        // Get timestamp: use provided valid_from or default to transaction start time
+        let timestamp = self.start_timestamp;
+        let valid_from = options.valid_from.unwrap_or(timestamp);
+
+        // Validate valid_from is not too far in future
+        validation::validate_valid_from_future(valid_from)?;
+
+        // Validate valid_from is not before the edge's own creation time
+        let creation_time = {
+            let historical = self.historical.read();
+            historical.edge_creation_time(edge_id)
+        };
+        if let Some(creation_time) = creation_time {
+            validation::validate_valid_from_not_before_creation(
+                &format!("edge:{}", edge_id.as_u64()),
+                creation_time,
+                valid_from,
+            )?;
+        }
+
+        // Normalize an all-absent provenance bundle to `None` (Issue #3224).
+        let provenance = options
+            .provenance
+            .filter(|p| !p.is_empty())
+            .map(std::sync::Arc::new);
+
+        // Buffer the FULL overwrite via the existing UpdateEdge op (no WAL
+        // format change, Issue #3549), preserving endpoints and type.
+        self.buffer.add(super::BufferedWrite::UpdateEdge {
+            edge_id,
+            version_id,
+            source: edge.source,
+            target: edge.target,
+            label: edge.label,
+            properties,
+            valid_from,
+            provenance,
+        })?;
+
+        Ok(())
+    }
+
     /// Enumerate edges CREATED earlier in THIS transaction that reference
     /// `node_id` as source or target and are still live in the buffer (Issue
     /// #3416 Pt4).
@@ -1566,6 +1642,18 @@ impl WriteOps for WriteTransaction {
         options: WriteRequestOptions,
     ) -> Result<()> {
         let result = (|| {
+            // Check transaction state BEFORE interning so a replace on an
+            // inactive tx never interns the label (mirrors
+            // `update_node_with_options`; `buffer_node_replace` re-checks state
+            // for the `remove_node_property` caller).
+            if self.state != TxState::Active {
+                return Err(TransactionError::InvalidState {
+                    current: format!("{:?}", self.state),
+                    expected: "Active".to_string(),
+                }
+                .into());
+            }
+
             let label_interned = GLOBAL_INTERNER.intern(label)?;
             self.buffer_node_replace(node_id, label_interned, properties, options)
         })();
@@ -1593,55 +1681,7 @@ impl WriteOps for WriteTransaction {
             // (read-your-own-writes, Issue #3417). Full overwrite of properties
             // only: source/target/label are preserved from the existing edge.
             let edge = self.read_own_edge(edge_id)?;
-            let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
-
-            // A replace may add/change/remove vector properties.
-            if !self.buffer.has_vector_operations()
-                && (edge.properties.contains_vector() || properties.contains_vector())
-            {
-                self.buffer.mark_has_vector_operations();
-            }
-
-            // Get timestamp: use provided valid_from or default to transaction start time
-            let timestamp = self.start_timestamp;
-            let valid_from = options.valid_from.unwrap_or(timestamp);
-
-            // Validate valid_from is not too far in future
-            validation::validate_valid_from_future(valid_from)?;
-
-            // Validate valid_from is not before the edge's own creation time
-            let creation_time = {
-                let historical = self.historical.read();
-                historical.edge_creation_time(edge_id)
-            };
-            if let Some(creation_time) = creation_time {
-                validation::validate_valid_from_not_before_creation(
-                    &format!("edge:{}", edge_id.as_u64()),
-                    creation_time,
-                    valid_from,
-                )?;
-            }
-
-            // Normalize an all-absent provenance bundle to `None` (Issue #3224).
-            let provenance = options
-                .provenance
-                .filter(|p| !p.is_empty())
-                .map(std::sync::Arc::new);
-
-            // Buffer the FULL overwrite via the existing UpdateEdge op (no WAL
-            // format change, Issue #3549), preserving endpoints and type.
-            self.buffer.add(super::BufferedWrite::UpdateEdge {
-                edge_id,
-                version_id,
-                source: edge.source,
-                target: edge.target,
-                label: edge.label,
-                properties,
-                valid_from,
-                provenance,
-            })?;
-
-            Ok(())
+            self.buffer_edge_replace(edge, properties, options)
         })();
 
         result.record_error_metric()
@@ -1709,9 +1749,11 @@ impl WriteOps for WriteTransaction {
             .remove(key)
             .build();
 
-        // `replace_edge_with_options` preserves endpoints/type and records its
-        // own error metric.
-        self.replace_edge_with_options(edge_id, new_properties, WriteRequestOptions::default())
+        // Reuse the already-read edge (NIT: avoid a second `read_own_edge`).
+        // `buffer_edge_replace` preserves endpoints/type; record the error
+        // metric here since the helper does not.
+        self.buffer_edge_replace(edge, new_properties, WriteRequestOptions::default())
+            .record_error_metric()
     }
 
     fn delete_node_with_options(

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -651,6 +651,113 @@ impl AletheiaDB {
         self.write(|tx| tx.update_edge_with_options(edge_id, properties, options))
     }
 
+    // ===== Replace / tombstone (non-PATCH) writes (Issue #3549) =====
+
+    /// Replace a node's entire property map AND label (full overwrite, non-PATCH).
+    ///
+    /// Unlike [`update_node`](Self::update_node) (PATCH-merge), the node's
+    /// resulting map is *exactly* `properties`: any prior key it omits is
+    /// removed from current state (history preserved), and the label is
+    /// overwritten. See
+    /// [`WriteOps::replace_node_with_options`](crate::api::transaction::WriteOps::replace_node_with_options).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn replace_node(
+        &self,
+        node_id: NodeId,
+        label: &str,
+        properties: PropertyMap,
+    ) -> Result<()> {
+        self.write(|tx| tx.replace_node(node_id, label, properties))
+    }
+
+    /// Replace a node's entire map and label with an optional backdated valid time.
+    ///
+    /// See [`replace_node`](Self::replace_node).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn replace_node_with_valid_time(
+        &self,
+        node_id: NodeId,
+        label: &str,
+        properties: PropertyMap,
+        valid_from: Option<Timestamp>,
+    ) -> Result<()> {
+        self.write(|tx| tx.replace_node_with_valid_time(node_id, label, properties, valid_from))
+    }
+
+    /// Replace a node's entire map and label with an optional
+    /// [`WriteRequestOptions`](crate::api::transaction::WriteRequestOptions)
+    /// bundle (backdated `valid_from` and/or write-time provenance).
+    ///
+    /// See [`replace_node`](Self::replace_node).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn replace_node_with_options(
+        &self,
+        node_id: NodeId,
+        label: &str,
+        properties: PropertyMap,
+        options: crate::api::transaction::WriteRequestOptions,
+    ) -> Result<()> {
+        self.write(|tx| tx.replace_node_with_options(node_id, label, properties, options))
+    }
+
+    /// Replace an edge's entire property map (full overwrite, non-PATCH).
+    ///
+    /// The edge's source, target, and type are immutable and preserved; any
+    /// prior property key omitted from `properties` is removed from current
+    /// state (history preserved). See
+    /// [`WriteOps::replace_edge_with_options`](crate::api::transaction::WriteOps::replace_edge_with_options).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn replace_edge(&self, edge_id: EdgeId, properties: PropertyMap) -> Result<()> {
+        self.write(|tx| tx.replace_edge(edge_id, properties))
+    }
+
+    /// Replace an edge's entire map with an optional backdated valid time.
+    ///
+    /// See [`replace_edge`](Self::replace_edge).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn replace_edge_with_valid_time(
+        &self,
+        edge_id: EdgeId,
+        properties: PropertyMap,
+        valid_from: Option<Timestamp>,
+    ) -> Result<()> {
+        self.write(|tx| tx.replace_edge_with_valid_time(edge_id, properties, valid_from))
+    }
+
+    /// Replace an edge's entire map with an optional
+    /// [`WriteRequestOptions`](crate::api::transaction::WriteRequestOptions) bundle.
+    ///
+    /// See [`replace_edge`](Self::replace_edge).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn replace_edge_with_options(
+        &self,
+        edge_id: EdgeId,
+        properties: PropertyMap,
+        options: crate::api::transaction::WriteRequestOptions,
+    ) -> Result<()> {
+        self.write(|tx| tx.replace_edge_with_options(edge_id, properties, options))
+    }
+
+    /// Remove a single property key from a node (read-modify-replace).
+    ///
+    /// Removing an absent key is a no-op success that records no new version.
+    /// See
+    /// [`WriteOps::remove_node_property`](crate::api::transaction::WriteOps::remove_node_property).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn remove_node_property(&self, node_id: NodeId, key: &str) -> Result<()> {
+        self.write(|tx| tx.remove_node_property(node_id, key))
+    }
+
+    /// Remove a single property key from an edge (read-modify-replace).
+    ///
+    /// Removing an absent key is a no-op success that records no new version.
+    /// See
+    /// [`WriteOps::remove_edge_property`](crate::api::transaction::WriteOps::remove_edge_property).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn remove_edge_property(&self, edge_id: EdgeId, key: &str) -> Result<()> {
+        self.write(|tx| tx.remove_edge_property(edge_id, key))
+    }
+
     /// Get the provenance bundle attached to a node's *current* version, if any.
     ///
     /// Returns `Ok(None)` (not an error) if the node has no provenance --

--- a/tests/recovery.rs
+++ b/tests/recovery.rs
@@ -114,3 +114,6 @@ mod property_based_tests;
 
 #[path = "recovery/tombstone_version_id_tests.rs"]
 mod tombstone_version_id_tests;
+
+#[path = "recovery/replace_tombstone_recovery.rs"]
+mod replace_tombstone_recovery;

--- a/tests/recovery/replace_tombstone_recovery.rs
+++ b/tests/recovery/replace_tombstone_recovery.rs
@@ -3,9 +3,19 @@
 //! A replace that REMOVES keys is buffered as an `UpdateNode`/`UpdateEdge` WAL
 //! op carrying the *exact* target property map (no PATCH merge). This proves the
 //! removal survives pure WAL replay: a durable database records create+replace,
-//! is dropped WITHOUT persisting indexes (forcing WAL-only recovery), then
-//! reopened — the reconstructed map must be the reduced one, and a relabel must
-//! recover the new label.
+//! is dropped, its **index snapshot + manifest are deleted**, then reopened —
+//! forcing recovery to replay the FULL WAL from `LSN::initial()` and decode the
+//! replace's `UpdateNode`/`UpdateEdge` entries (rather than being satisfied by
+//! an index snapshot written at a later LSN by the background persistence worker
+//! on shutdown). The reconstructed map must be the reduced one, and a relabel
+//! must recover the new label.
+//!
+//! Deleting the `indexes/` directory is load-bearing: `AletheiaDB::open()`
+//! enables index persistence whose background worker does an unconditional
+//! `persist_all_indexes` on drop, writing a manifest at an LSN AFTER the
+//! replace ops; without removing it, replay would start at that manifest LSN
+//! and skip the replace's WAL entries, so the assertions would be satisfied by
+//! the snapshot, not by WAL decode.
 //!
 //! Mirrors the harness in `tests/wal_string_labels_recovery.rs`.
 
@@ -66,11 +76,20 @@ fn replace_removed_keys_survive_wal_replay() {
         )
         .expect("replace edge");
 
-        // Deliberately NO persist_indexes(): recovery must come from WAL alone.
+        // Deliberately NO explicit persist_indexes(). The background worker
+        // still persists on drop, so we delete the snapshot below to force
+        // WAL-only replay.
         drop(db);
     }
 
-    // Reopen — forces WAL replay (no index snapshot exists).
+    // Delete the index snapshot + manifest that the background persistence
+    // worker wrote on shutdown at an LSN AFTER the replace ops. Without this,
+    // reopen would load the snapshot and replay the WAL only from the manifest
+    // LSN, SKIPPING the replace's WAL entries — the assertions below would then
+    // pass via the snapshot, not via genuine WAL decode of UpdateNode/UpdateEdge.
+    std::fs::remove_dir_all(data_dir.join("indexes")).ok();
+
+    // Reopen — forces a full WAL replay from LSN::initial() (no index snapshot).
     let db = AletheiaDB::open(&data_dir).expect("reopen durable db");
 
     let node = db

--- a/tests/recovery/replace_tombstone_recovery.rs
+++ b/tests/recovery/replace_tombstone_recovery.rs
@@ -1,0 +1,113 @@
+//! Issue #3549 — crash + WAL-replay round-trip for the replace/tombstone API.
+//!
+//! A replace that REMOVES keys is buffered as an `UpdateNode`/`UpdateEdge` WAL
+//! op carrying the *exact* target property map (no PATCH merge). This proves the
+//! removal survives pure WAL replay: a durable database records create+replace,
+//! is dropped WITHOUT persisting indexes (forcing WAL-only recovery), then
+//! reopened — the reconstructed map must be the reduced one, and a relabel must
+//! recover the new label.
+//!
+//! Mirrors the harness in `tests/wal_string_labels_recovery.rs`.
+
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+
+fn props3(name: &str, age: i64, city: &str) -> aletheiadb::core::PropertyMap {
+    PropertyMapBuilder::new()
+        .insert("name", name)
+        .insert("age", age)
+        .insert("city", city)
+        .build()
+}
+
+#[test]
+fn replace_removed_keys_survive_wal_replay() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let data_dir = tempdir.path().join("db");
+
+    let node_id: u64;
+    let edge_id: u64;
+
+    {
+        let db = AletheiaDB::open(&data_dir).expect("open durable db");
+
+        let a = db
+            .create_node("Person", props3("Alice", 30, "London"))
+            .expect("create node");
+        let b = db
+            .create_node("Person", props3("Bob", 40, "Paris"))
+            .expect("create node b");
+        node_id = a.as_u64();
+
+        let e = db
+            .create_edge(
+                a,
+                b,
+                "KNOWS",
+                PropertyMapBuilder::new()
+                    .insert("since", 2020i64)
+                    .insert("weight", 7i64)
+                    .build(),
+            )
+            .expect("create edge");
+        edge_id = e.as_u64();
+
+        // Replace node: drop age & city AND relabel Person -> Employee.
+        db.replace_node(
+            a,
+            "Employee",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .expect("replace node");
+
+        // Replace edge: keep only {since}, drop weight (endpoints/type immutable).
+        db.replace_edge(
+            e,
+            PropertyMapBuilder::new().insert("since", 2024i64).build(),
+        )
+        .expect("replace edge");
+
+        // Deliberately NO persist_indexes(): recovery must come from WAL alone.
+        drop(db);
+    }
+
+    // Reopen — forces WAL replay (no index snapshot exists).
+    let db = AletheiaDB::open(&data_dir).expect("reopen durable db");
+
+    let node = db
+        .get_node(aletheiadb::core::NodeId::new(node_id).expect("nid"))
+        .expect("get node after replay");
+    assert!(node.get_property("name").is_some(), "name recovered");
+    assert!(
+        node.get_property("age").is_none(),
+        "age must stay REMOVED across WAL replay, got {:?}",
+        node.get_property("age")
+    );
+    assert!(
+        node.get_property("city").is_none(),
+        "city must stay REMOVED across WAL replay"
+    );
+
+    // Relabel recovered: label index reflects Employee, not Person.
+    let employees = db.get_nodes_by_label("Employee");
+    assert_eq!(employees.len(), 1, "one Employee after replay");
+    assert_eq!(employees[0].id.as_u64(), node_id);
+    assert!(
+        db.get_nodes_by_label("Person")
+            .iter()
+            .all(|n| n.id.as_u64() != node_id),
+        "relabeled node must not appear under old Person label"
+    );
+
+    let edge = db
+        .get_edge(aletheiadb::core::EdgeId::new(edge_id).expect("eid"))
+        .expect("get edge after replay");
+    assert_eq!(
+        edge.get_property("since").and_then(|v| v.as_int()),
+        Some(2024),
+        "edge since overwritten value recovered"
+    );
+    assert!(
+        edge.get_property("weight").is_none(),
+        "edge weight must stay REMOVED across WAL replay"
+    );
+}

--- a/tests/replace_tombstone.rs
+++ b/tests/replace_tombstone.rs
@@ -9,10 +9,11 @@
 //!
 //! These are end-to-end API tests against the public `AletheiaDB` surface.
 
-use aletheiadb::api::transaction::WriteOps;
+use aletheiadb::api::transaction::{ReadOps, WriteOps};
 use aletheiadb::core::GLOBAL_INTERNER;
 use aletheiadb::core::hlc::HybridTimestamp;
 use aletheiadb::core::temporal::time;
+use aletheiadb::core::{EdgeId, NodeId};
 use aletheiadb::{AletheiaDB, PropertyMapBuilder};
 
 fn node_label(n: &aletheiadb::core::graph::Node) -> Option<String> {
@@ -130,6 +131,17 @@ fn replace_removal_survives_delta_reconstruction() {
         "the replace must be stored as a delta to exercise delta removal, delta_count={}",
         stats.node_delta_count
     );
+
+    // Clear the property reconstruction cache FIRST. `HistoricalStorage`
+    // populates `node_property_cache` with the fully-materialized map for every
+    // version at write time, so a cached `get_node_at_version` would return
+    // that map WITHOUT ever running `reconstruct_node_properties_iterative` /
+    // `PropertyDelta::apply`'s removed-set subtraction — a broken delta
+    // encoding would still pass. Clearing forces genuine reconstruction from
+    // the anchor+delta chain.
+    db.__test_historical_storage()
+        .read()
+        .__test_clear_property_cache();
 
     // Reconstruct v2 THROUGH the delta chain (anchor v1 + delta v2).
     let v2 = db.get_node_at_version(id, 2).expect("version 2");
@@ -430,6 +442,17 @@ fn replace_honors_valid_time_and_provenance() {
         "at/after replace_valid the replacement map (no age) is valid"
     );
 
+    // Half-open interval [valid_from, valid_to) boundary exactness: AT EXACTLY
+    // replace_valid the NEW replacement map holds (the interval start is
+    // inclusive), so age is already gone at the boundary itself.
+    let at_boundary = db
+        .get_node_at_time(id, replace_valid, time::now())
+        .expect("as-of exactly replace_valid");
+    assert!(
+        at_boundary.get_property("age").is_none(),
+        "at EXACTLY replace_valid the replacement map (no age) holds — half-open interval start is inclusive"
+    );
+
     // Before replace_valid the OLD map (with age) is valid — anchor BOTH
     // dimensions before the replace commit.
     let mid = HybridTimestamp::new(time::now().wallclock() - 5_400_000_000, 0).expect("ts"); // 1.5h ago
@@ -556,3 +579,540 @@ fn replace_removes_vector_property_updates_index() {
         "untouched decoy remains indexed"
     );
 }
+
+// -------------------------------------------------------------------------
+// MAJOR 3 — a removed key cannot resurface when a fresh anchor is rebuilt.
+// -------------------------------------------------------------------------
+
+/// After a key is removed, applying enough further updates to force a fresh
+/// ANCHOR (default `anchor_interval` = 10) to be materialized from a delta
+/// chain that includes the removal must NOT resurrect the removed key: a
+/// version reconstructed from/through the rebuilt anchor still lacks it.
+#[test]
+fn removal_survives_anchor_rebuild() {
+    let db = AletheiaDB::new().expect("db");
+
+    // v1 anchor: {a, b, c}
+    let id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("a", 1i64)
+                .insert("b", 2i64)
+                .insert("c", 3i64)
+                .build(),
+        )
+        .expect("create");
+
+    // v2 delta: drop b -> {a, c}
+    db.remove_node_property(id, "b").expect("remove b");
+
+    // Apply 10 more PATCH updates (v3..v12), none re-adding b, to force a fresh
+    // ANCHOR to be MATERIALIZED past the removal (v11 becomes the 2nd anchor).
+    for i in 0..10i64 {
+        db.update_node_with_valid_time(
+            id,
+            PropertyMapBuilder::new().insert("a", 10 + i).build(),
+            None,
+        )
+        .expect("update");
+    }
+
+    // Confirm a second anchor was actually built past the removal.
+    let stats = db.historical_stats().expect("stats");
+    assert!(
+        stats.node_anchor_count >= 2,
+        "expected a rebuilt anchor past the removal, anchor_count={}",
+        stats.node_anchor_count
+    );
+
+    // Defeat the write-time property cache so reconstruction genuinely runs
+    // the anchor+delta chain (see `replace_removal_survives_delta_reconstruction`).
+    db.__test_historical_storage()
+        .read()
+        .__test_clear_property_cache();
+
+    // Reconstruct the LATEST version (from the rebuilt anchor) — b must be gone.
+    let latest = db.get_node_history(id).expect("hist").version_count() as u64;
+    let node = db
+        .get_node_at_version(id, latest)
+        .expect("reconstruct latest version");
+    assert!(
+        node.get_property("b").is_none(),
+        "removed key 'b' must not resurface when a new anchor is materialized"
+    );
+    assert!(node.get_property("a").is_some(), "a still present");
+    assert_eq!(
+        node.get_property("c").and_then(|v| v.as_int()),
+        Some(3),
+        "untouched c still present after anchor rebuild"
+    );
+}
+
+// -------------------------------------------------------------------------
+// MAJOR 4 — error paths return Err (never panic) on missing / deleted ids.
+// -------------------------------------------------------------------------
+
+/// `replace_node` errors (not panics) on a never-created id and on a
+/// previously-deleted id.
+#[test]
+fn replace_node_errors_on_missing_and_deleted() {
+    let db = AletheiaDB::new().expect("db");
+
+    // (a) never existed
+    let missing = NodeId::new(999_999).expect("nid");
+    let err = db
+        .replace_node(missing, "Person", PropertyMapBuilder::new().build())
+        .expect_err("replace on nonexistent node must error");
+    assert!(
+        format!("{err:?}").contains("NodeNotFound"),
+        "expected NodeNotFound, got {err:?}"
+    );
+
+    // (b) created then deleted
+    let id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .expect("create");
+    db.delete_node_with_valid_time(id, None).expect("delete");
+    let err = db
+        .replace_node(id, "Person", PropertyMapBuilder::new().build())
+        .expect_err("replace on deleted node must error");
+    assert!(
+        format!("{err:?}").contains("NodeNotFound"),
+        "expected NodeNotFound on deleted node, got {err:?}"
+    );
+}
+
+/// `replace_edge` errors on a never-created id and on a previously-deleted id.
+#[test]
+fn replace_edge_errors_on_missing_and_deleted() {
+    let db = AletheiaDB::new().expect("db");
+
+    let missing = EdgeId::new(999_999).expect("eid");
+    let err = db
+        .replace_edge(missing, PropertyMapBuilder::new().build())
+        .expect_err("replace on nonexistent edge must error");
+    assert!(
+        format!("{err:?}").contains("EdgeNotFound"),
+        "expected EdgeNotFound, got {err:?}"
+    );
+
+    let a = db
+        .create_node("N", PropertyMapBuilder::new().build())
+        .expect("a");
+    let b = db
+        .create_node("N", PropertyMapBuilder::new().build())
+        .expect("b");
+    let e = db
+        .create_edge(
+            a,
+            b,
+            "R",
+            PropertyMapBuilder::new().insert("x", 1i64).build(),
+        )
+        .expect("edge");
+    db.delete_edge_with_valid_time(e, None)
+        .expect("delete edge");
+    let err = db
+        .replace_edge(e, PropertyMapBuilder::new().build())
+        .expect_err("replace on deleted edge must error");
+    assert!(
+        format!("{err:?}").contains("EdgeNotFound"),
+        "expected EdgeNotFound on deleted edge, got {err:?}"
+    );
+}
+
+/// `remove_node_property` errors on a never-created id and on a deleted id.
+#[test]
+fn remove_node_property_errors_on_missing_and_deleted() {
+    let db = AletheiaDB::new().expect("db");
+
+    let missing = NodeId::new(999_999).expect("nid");
+    let err = db
+        .remove_node_property(missing, "age")
+        .expect_err("remove on nonexistent node must error");
+    assert!(
+        format!("{err:?}").contains("NodeNotFound"),
+        "expected NodeNotFound, got {err:?}"
+    );
+
+    let id = db
+        .create_node("Person", props3("Alice", 30, "London"))
+        .expect("create");
+    db.delete_node_with_valid_time(id, None).expect("delete");
+    let err = db
+        .remove_node_property(id, "age")
+        .expect_err("remove on deleted node must error");
+    assert!(
+        format!("{err:?}").contains("NodeNotFound"),
+        "expected NodeNotFound on deleted node, got {err:?}"
+    );
+}
+
+/// `remove_edge_property` errors on a never-created id and on a deleted id.
+#[test]
+fn remove_edge_property_errors_on_missing_and_deleted() {
+    let db = AletheiaDB::new().expect("db");
+
+    let missing = EdgeId::new(999_999).expect("eid");
+    let err = db
+        .remove_edge_property(missing, "x")
+        .expect_err("remove on nonexistent edge must error");
+    assert!(
+        format!("{err:?}").contains("EdgeNotFound"),
+        "expected EdgeNotFound, got {err:?}"
+    );
+
+    let a = db
+        .create_node("N", PropertyMapBuilder::new().build())
+        .expect("a");
+    let b = db
+        .create_node("N", PropertyMapBuilder::new().build())
+        .expect("b");
+    let e = db
+        .create_edge(
+            a,
+            b,
+            "R",
+            PropertyMapBuilder::new().insert("x", 1i64).build(),
+        )
+        .expect("edge");
+    db.delete_edge_with_valid_time(e, None)
+        .expect("delete edge");
+    let err = db
+        .remove_edge_property(e, "x")
+        .expect_err("remove on deleted edge must error");
+    assert!(
+        format!("{err:?}").contains("EdgeNotFound"),
+        "expected EdgeNotFound on deleted edge, got {err:?}"
+    );
+}
+
+// -------------------------------------------------------------------------
+// MINOR — same-transaction read-your-own-writes (buffer-aware, Issue #3417).
+// -------------------------------------------------------------------------
+
+/// Inside ONE transaction: create a node then replace it before commit. The
+/// replace must see the buffered (still-uncommitted) create, not 404 against
+/// committed storage.
+#[test]
+fn same_tx_create_then_replace_node_ryow() {
+    let db = AletheiaDB::new().expect("db");
+    let mut tx = db.write_transaction().expect("tx");
+
+    let id = tx
+        .create_node("Person", props3("Alice", 30, "London"))
+        .expect("buffered create");
+
+    // Replace the still-uncommitted node (full overwrite: only {name}).
+    tx.replace_node(
+        id,
+        "Employee",
+        PropertyMapBuilder::new().insert("name", "Alice").build(),
+    )
+    .expect("replace must see the buffered create");
+
+    // Read-your-own-writes reflects the replacement immediately.
+    let buffered = tx.get_node(id).expect("read own");
+    assert!(buffered.get_property("age").is_none(), "age gone in buffer");
+    assert_eq!(node_label(&buffered).as_deref(), Some("Employee"));
+
+    tx.commit().expect("commit");
+
+    let node = db.get_node(id).expect("get after commit");
+    assert!(node.get_property("name").is_some());
+    assert!(node.get_property("age").is_none(), "age removed by replace");
+    assert!(node.get_property("city").is_none());
+    assert_eq!(node_label(&node).as_deref(), Some("Employee"));
+}
+
+/// Inside ONE transaction: create a node then `remove_node_property` on it
+/// before commit — the remove must see the buffered create.
+#[test]
+fn same_tx_create_then_remove_property_node_ryow() {
+    let db = AletheiaDB::new().expect("db");
+    let mut tx = db.write_transaction().expect("tx");
+
+    let id = tx
+        .create_node("Person", props3("Alice", 30, "London"))
+        .expect("buffered create");
+
+    tx.remove_node_property(id, "age")
+        .expect("remove must see the buffered create");
+
+    let buffered = tx.get_node(id).expect("read own");
+    assert!(
+        buffered.get_property("age").is_none(),
+        "age removed in buffer"
+    );
+    assert!(buffered.get_property("name").is_some());
+
+    tx.commit().expect("commit");
+
+    let node = db.get_node(id).expect("get after commit");
+    assert!(node.get_property("age").is_none());
+    assert!(node.get_property("name").is_some());
+    assert!(node.get_property("city").is_some());
+}
+
+/// Inside ONE transaction: create an edge then replace / remove-property on it
+/// before commit — both must see the buffered create.
+#[test]
+fn same_tx_create_then_replace_edge_ryow() {
+    let db = AletheiaDB::new().expect("db");
+    let mut tx = db.write_transaction().expect("tx");
+
+    let a = tx
+        .create_node("N", PropertyMapBuilder::new().build())
+        .expect("a");
+    let b = tx
+        .create_node("N", PropertyMapBuilder::new().build())
+        .expect("b");
+    let e = tx
+        .create_edge(
+            a,
+            b,
+            "R",
+            PropertyMapBuilder::new()
+                .insert("x", 1i64)
+                .insert("y", 2i64)
+                .build(),
+        )
+        .expect("buffered edge");
+
+    // Replace the still-uncommitted edge (keep only {x: 9}).
+    tx.replace_edge(e, PropertyMapBuilder::new().insert("x", 9i64).build())
+        .expect("replace must see the buffered edge");
+
+    let buffered = tx.get_edge(e).expect("read own edge");
+    assert_eq!(buffered.get_property("x").and_then(|v| v.as_int()), Some(9));
+    assert!(buffered.get_property("y").is_none(), "y gone in buffer");
+    assert_eq!(buffered.source, a, "endpoints preserved through buffer");
+    assert_eq!(buffered.target, b);
+
+    // remove_edge_property on the same buffered edge.
+    tx.remove_edge_property(e, "x")
+        .expect("remove must see the buffered edge");
+
+    tx.commit().expect("commit");
+
+    let edge = db.get_edge(e).expect("get after commit");
+    assert!(edge.get_property("x").is_none(), "x removed");
+    assert!(edge.get_property("y").is_none(), "y removed");
+    assert_eq!(edge.source, a);
+    assert_eq!(edge.target, b);
+}
+
+// -------------------------------------------------------------------------
+// MINOR — replace on a node with connected edges leaves the edges intact.
+// -------------------------------------------------------------------------
+
+/// Replacing (and relabeling) a node with connected edges leaves the edge, its
+/// endpoints, and its type unchanged, and the node stays traversable.
+#[test]
+fn replace_node_with_connected_edges_keeps_edges() {
+    let db = AletheiaDB::new().expect("db");
+    let a = db
+        .create_node("Person", PropertyMapBuilder::new().insert("n", "A").build())
+        .expect("a");
+    let b = db
+        .create_node("Person", PropertyMapBuilder::new().insert("n", "B").build())
+        .expect("b");
+    let e = db
+        .create_edge(
+            a,
+            b,
+            "KNOWS",
+            PropertyMapBuilder::new().insert("since", 2020i64).build(),
+        )
+        .expect("edge");
+
+    // Replace A, including a relabel to Employee.
+    db.replace_node(
+        a,
+        "Employee",
+        PropertyMapBuilder::new().insert("n", "A2").build(),
+    )
+    .expect("replace a");
+
+    // The edge is unchanged: endpoints and type intact.
+    let edge = db.get_edge(e).expect("get edge");
+    assert_eq!(edge.source, a, "edge source unchanged");
+    assert_eq!(edge.target, b, "edge target unchanged");
+    assert_eq!(
+        edge_label(&edge).as_deref(),
+        Some("KNOWS"),
+        "type unchanged"
+    );
+    assert_eq!(
+        edge.get_property("since").and_then(|v| v.as_int()),
+        Some(2020),
+        "edge properties unchanged"
+    );
+
+    // A -> B still traversable.
+    let outs = db.get_outgoing_edges(a);
+    assert!(outs.contains(&e), "A->B edge still present after replace");
+
+    // Endpoints intact; A relabeled, B untouched.
+    let na = db.get_node(a).expect("a");
+    assert_eq!(node_label(&na).as_deref(), Some("Employee"));
+    let nb = db.get_node(b).expect("b");
+    assert_eq!(node_label(&nb).as_deref(), Some("Person"));
+}
+
+// -------------------------------------------------------------------------
+// MINOR — self-loop edge (source == target) replace / remove.
+// -------------------------------------------------------------------------
+
+/// `replace_edge` and `remove_edge_property` behave correctly on a self-loop
+/// edge (source == target).
+#[test]
+fn replace_and_remove_on_self_loop_edge() {
+    let db = AletheiaDB::new().expect("db");
+    let a = db
+        .create_node("N", PropertyMapBuilder::new().build())
+        .expect("a");
+    let e = db
+        .create_edge(
+            a,
+            a,
+            "SELF",
+            PropertyMapBuilder::new()
+                .insert("x", 1i64)
+                .insert("y", 2i64)
+                .build(),
+        )
+        .expect("self-loop edge");
+
+    // Replace: keep only {x: 9}; y must vanish, endpoints stay (a, a).
+    db.replace_edge(e, PropertyMapBuilder::new().insert("x", 9i64).build())
+        .expect("replace self-loop");
+    let edge = db.get_edge(e).expect("get");
+    assert_eq!(edge.source, a, "self-loop source stays");
+    assert_eq!(edge.target, a, "self-loop target stays");
+    assert_eq!(edge.get_property("x").and_then(|v| v.as_int()), Some(9));
+    assert!(edge.get_property("y").is_none(), "y removed on self-loop");
+
+    // remove_edge_property on the self-loop.
+    db.remove_edge_property(e, "x").expect("remove x");
+    let edge = db.get_edge(e).expect("get2");
+    assert!(edge.get_property("x").is_none(), "x removed on self-loop");
+    assert_eq!(edge.source, a);
+    assert_eq!(edge.target, a);
+}
+
+// -------------------------------------------------------------------------
+// MINOR — remove a present key twice: first records a version, second no-ops.
+// -------------------------------------------------------------------------
+
+/// Removing a present key records exactly one new version; removing it a second
+/// time (now absent) is a no-op that records no further version.
+#[test]
+fn remove_present_property_twice_second_is_noop() {
+    let db = AletheiaDB::new().expect("db");
+    let id = db
+        .create_node("Person", props3("Alice", 30, "London"))
+        .expect("create");
+
+    let v0 = db.get_node_history(id).expect("hist").version_count();
+
+    // First removal of a PRESENT key records +1 version.
+    db.remove_node_property(id, "age").expect("remove age #1");
+    let v1 = db.get_node_history(id).expect("hist").version_count();
+    assert_eq!(
+        v1,
+        v0 + 1,
+        "first removal of present key records one version"
+    );
+
+    // Second removal of the now-ABSENT key is a no-op: no new version.
+    db.remove_node_property(id, "age")
+        .expect("remove age #2 noop");
+    let v2 = db.get_node_history(id).expect("hist").version_count();
+    assert_eq!(v2, v1, "second (absent) removal records no new version");
+
+    let node = db.get_node(id).expect("get");
+    assert!(node.get_property("age").is_none(), "age stays removed");
+    assert!(node.get_property("name").is_some());
+}
+
+// -------------------------------------------------------------------------
+// MINOR — removal delta survives index-persistence save + reload
+// (complements the WAL-replay recovery test).
+// -------------------------------------------------------------------------
+
+/// A delta-encoded key removal reconstructs correctly after an
+/// index-persistence save + reopen (the persisted temporal index restores the
+/// anchor+delta chain).
+#[test]
+fn removal_delta_survives_index_persistence_reload() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let data_dir = tempdir.path().join("db");
+
+    let node_id: u64;
+    {
+        let db = AletheiaDB::open(&data_dir).expect("open durable db");
+        let id = db
+            .create_node("Person", props3("Alice", 30, "London"))
+            .expect("create"); // v1 anchor
+        node_id = id.as_u64();
+
+        db.replace_node(
+            id,
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .expect("replace"); // v2 delta (removes age, city)
+
+        // Explicitly persist the indexes (including the temporal chain).
+        db.persist_indexes().expect("persist indexes");
+        drop(db);
+    }
+
+    // Reopen — loads the persisted indexes (current + historical chain).
+    let db = AletheiaDB::open(&data_dir).expect("reopen durable db");
+    let id = NodeId::new(node_id).expect("nid");
+
+    // Current state carries the reduced map.
+    let node = db.get_node(id).expect("get after reload");
+    assert!(
+        node.get_property("age").is_none(),
+        "age must stay removed after index-persistence reload"
+    );
+    assert!(node.get_property("name").is_some(), "name retained");
+
+    // The delta-encoded v2 reconstructs through the restored chain. Clear the
+    // property cache first so reconstruction genuinely runs.
+    db.__test_historical_storage()
+        .read()
+        .__test_clear_property_cache();
+    let v2 = db
+        .get_node_at_version(id, 2)
+        .expect("reconstruct v2 after reload");
+    assert!(
+        v2.get_property("age").is_none(),
+        "delta removal must reconstruct (age absent) after reload"
+    );
+    assert!(
+        v2.get_property("city").is_none(),
+        "delta removal must reconstruct (city absent) after reload"
+    );
+    assert!(v2.get_property("name").is_some(), "name retained in v2");
+}
+
+// NOTE (temporal vector index removal — deliberately NOT tested here):
+// replacing away a vector property does NOT de-index the *temporal* vector
+// index. The temporal-index write path (`CurrentStorage::update_node_direct`
+// -> `try_index_temporal_vector`, src/storage/current/mod.rs) only ADDS
+// vectors present in the new property map; it never calls
+// `try_remove_temporal_vector` when a property is dropped (only
+// `delete_node_direct` removes). This add-only behavior is shared with PATCH
+// `update_node` and predates Issue #3549 — the replace path correctly buffers
+// an `UpdateNode` carrying the reduced map (the CURRENT vector index DOES
+// de-index it, see `replace_removes_vector_property_updates_index`). Asserting
+// temporal de-indexing would test behavior that does not exist; wiring a
+// removal into the temporal update path is a separate follow-up.

--- a/tests/replace_tombstone.rs
+++ b/tests/replace_tombstone.rs
@@ -1,0 +1,558 @@
+//! Issue #3549 — replace / tombstone (non-PATCH) node & edge write API.
+//!
+//! `update_node`/`update_edge` are PATCH-merge: keys absent from the incoming
+//! map are preserved. The replace API is a full overwrite — the resulting
+//! property map is *exactly* the supplied map (any prior key not present is
+//! removed from current state, while history is preserved), and for nodes the
+//! label is overwritten too. `remove_node_property`/`remove_edge_property` are
+//! read-modify-replace conveniences that drop a single key.
+//!
+//! These are end-to-end API tests against the public `AletheiaDB` surface.
+
+use aletheiadb::api::transaction::WriteOps;
+use aletheiadb::core::GLOBAL_INTERNER;
+use aletheiadb::core::hlc::HybridTimestamp;
+use aletheiadb::core::temporal::time;
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+
+fn node_label(n: &aletheiadb::core::graph::Node) -> Option<String> {
+    GLOBAL_INTERNER.resolve_with(n.label, |s| s.to_string())
+}
+
+fn edge_label(e: &aletheiadb::core::graph::Edge) -> Option<String> {
+    GLOBAL_INTERNER.resolve_with(e.label, |s| s.to_string())
+}
+
+fn props3(name: &str, age: i64, city: &str) -> aletheiadb::core::PropertyMap {
+    PropertyMapBuilder::new()
+        .insert("name", name)
+        .insert("age", age)
+        .insert("city", city)
+        .build()
+}
+
+/// Case 1: replace overwrites the whole map — a key present before but absent
+/// from the replacement is gone from current state.
+#[test]
+fn replace_node_removes_absent_key_current_state() {
+    let db = AletheiaDB::new().expect("db");
+    let id = db
+        .create_node("Person", props3("Alice", 30, "London"))
+        .expect("create");
+
+    // Replace with only {name} — age and city must disappear.
+    db.replace_node(
+        id,
+        "Person",
+        PropertyMapBuilder::new().insert("name", "Alice").build(),
+    )
+    .expect("replace");
+
+    let node = db.get_node(id).expect("get");
+    assert!(node.get_property("name").is_some(), "name kept");
+    assert!(
+        node.get_property("age").is_none(),
+        "age removed by replace, got {:?}",
+        node.get_property("age")
+    );
+    assert!(
+        node.get_property("city").is_none(),
+        "city removed by replace"
+    );
+}
+
+/// Case 2: history is preserved — anchoring BOTH bi-temporal dimensions before
+/// the replace still shows the removed keys.
+#[test]
+fn replace_node_preserves_history_as_of_earlier() {
+    let db = AletheiaDB::new().expect("db");
+
+    // Backdate the create so valid-time anchoring is unambiguous.
+    let create_valid =
+        HybridTimestamp::new(time::now().wallclock() - 3_600_000_000, 0).expect("ts");
+    let id = db
+        .create_node_with_valid_time("Person", props3("Alice", 30, "London"), Some(create_valid))
+        .expect("create");
+
+    // Capture a transaction-time coordinate strictly between the create commit
+    // and the replace commit.
+    let tx_before_replace = time::now();
+
+    db.replace_node(
+        id,
+        "Person",
+        PropertyMapBuilder::new().insert("name", "Alice").build(),
+    )
+    .expect("replace");
+
+    // Anchor BOTH dimensions before the replace: the old version is recalled
+    // with all its keys.
+    let old = db
+        .get_node_at_time(id, create_valid, tx_before_replace)
+        .expect("as-of read");
+    assert_eq!(
+        old.get_property("age").and_then(|v| v.as_int()),
+        Some(30),
+        "age recalled as-of earlier"
+    );
+    assert!(
+        old.get_property("city").is_some(),
+        "city recalled as-of earlier"
+    );
+
+    // Current state still lacks them.
+    let now = db.get_node(id).expect("get");
+    assert!(now.get_property("age").is_none(), "age gone now");
+}
+
+/// Case 4 (critical risk): a replace-with-key-removed stored as a **Delta**
+/// (2nd version, well under the default anchor interval of 10) must reconstruct
+/// to a map WITHOUT the removed key when replayed through the anchor+delta
+/// chain (`get_node_at_version` reconstructs from historical, not current).
+#[test]
+fn replace_removal_survives_delta_reconstruction() {
+    let db = AletheiaDB::new().expect("db");
+    let id = db
+        .create_node("Person", props3("Alice", 30, "London"))
+        .expect("create"); // v1 = anchor
+
+    db.replace_node(
+        id,
+        "Person",
+        PropertyMapBuilder::new().insert("name", "Alice").build(),
+    )
+    .expect("replace"); // v2 = delta (removes age, city)
+
+    // Prove the version really was stored as a delta (not an anchor snapshot).
+    let stats = db.historical_stats().expect("stats");
+    assert!(
+        stats.node_delta_count >= 1,
+        "the replace must be stored as a delta to exercise delta removal, delta_count={}",
+        stats.node_delta_count
+    );
+
+    // Reconstruct v2 THROUGH the delta chain (anchor v1 + delta v2).
+    let v2 = db.get_node_at_version(id, 2).expect("version 2");
+    assert!(
+        v2.get_property("age").is_none(),
+        "delta must encode key REMOVAL: age still present after reconstruction"
+    );
+    assert!(
+        v2.get_property("city").is_none(),
+        "delta must encode key REMOVAL: city still present after reconstruction"
+    );
+    assert!(v2.get_property("name").is_some(), "name retained");
+}
+
+/// Case 5: node replace can mutate the label; the old label survives as-of
+/// earlier and current-state label indexing is consistent.
+#[test]
+fn replace_node_mutates_label() {
+    let db = AletheiaDB::new().expect("db");
+
+    let create_valid =
+        HybridTimestamp::new(time::now().wallclock() - 3_600_000_000, 0).expect("ts");
+    let id = db
+        .create_node_with_valid_time(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+            Some(create_valid),
+        )
+        .expect("create");
+    let tx_before = time::now();
+
+    // Replace with a NEW label.
+    db.replace_node(
+        id,
+        "Employee",
+        PropertyMapBuilder::new().insert("name", "Alice").build(),
+    )
+    .expect("replace");
+
+    // Current-state label index reflects the new label.
+    let employees = db.get_nodes_by_label("Employee");
+    assert_eq!(employees.len(), 1, "one Employee now");
+    assert_eq!(employees[0].id, id);
+    assert!(
+        db.get_nodes_by_label("Person").is_empty(),
+        "no Person in current state after relabel"
+    );
+
+    let node = db.get_node(id).expect("get");
+    assert_eq!(
+        node_label(&node).as_deref(),
+        Some("Employee"),
+        "current label"
+    );
+
+    // Old label survives as-of earlier (both dimensions anchored).
+    let old = db
+        .get_node_at_time(id, create_valid, tx_before)
+        .expect("as-of");
+    assert_eq!(
+        node_label(&old).as_deref(),
+        Some("Person"),
+        "old label recalled as-of earlier"
+    );
+}
+
+/// Case 6: edge replace overwrites properties only; source, target, and edge
+/// type remain immutable.
+#[test]
+fn replace_edge_properties_only_endpoints_immutable() {
+    let db = AletheiaDB::new().expect("db");
+    let alice = db
+        .create_node("Person", PropertyMapBuilder::new().insert("n", "A").build())
+        .expect("a");
+    let bob = db
+        .create_node("Person", PropertyMapBuilder::new().insert("n", "B").build())
+        .expect("b");
+    let e = db
+        .create_edge(
+            alice,
+            bob,
+            "KNOWS",
+            PropertyMapBuilder::new()
+                .insert("since", 2020i64)
+                .insert("weight", 5i64)
+                .build(),
+        )
+        .expect("edge");
+
+    // Replace with only {since: 2024}. weight must vanish; endpoints/type stay.
+    db.replace_edge(
+        e,
+        PropertyMapBuilder::new().insert("since", 2024i64).build(),
+    )
+    .expect("replace edge");
+
+    let edge = db.get_edge(e).expect("get edge");
+    assert_eq!(edge.source, alice, "source immutable");
+    assert_eq!(edge.target, bob, "target immutable");
+    assert_eq!(
+        edge_label(&edge).as_deref(),
+        Some("KNOWS"),
+        "type immutable"
+    );
+    assert_eq!(
+        edge.get_property("since").and_then(|v| v.as_int()),
+        Some(2024),
+        "since overwritten"
+    );
+    assert!(
+        edge.get_property("weight").is_none(),
+        "weight removed by replace"
+    );
+}
+
+/// Case 7: removing an absent key is a no-op success that records NO new
+/// version.
+#[test]
+fn remove_absent_property_is_noop_success() {
+    let db = AletheiaDB::new().expect("db");
+    let id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .expect("create");
+
+    let versions_before = db.get_node_history(id).expect("hist").version_count();
+
+    // "age" is not present — must succeed and record no version.
+    db.remove_node_property(id, "age").expect("noop remove");
+
+    let versions_after = db.get_node_history(id).expect("hist").version_count();
+    assert_eq!(
+        versions_before, versions_after,
+        "no-op remove must not record a new version"
+    );
+
+    // The node is untouched.
+    let node = db.get_node(id).expect("get");
+    assert!(node.get_property("name").is_some());
+}
+
+/// Case 7b: removing a present key drops it and records a version.
+#[test]
+fn remove_present_property_drops_key() {
+    let db = AletheiaDB::new().expect("db");
+    let id = db
+        .create_node("Person", props3("Alice", 30, "London"))
+        .expect("create");
+
+    let before = db.get_node_history(id).expect("hist").version_count();
+    db.remove_node_property(id, "age").expect("remove age");
+    let after = db.get_node_history(id).expect("hist").version_count();
+    assert_eq!(after, before + 1, "removal records exactly one new version");
+
+    let node = db.get_node(id).expect("get");
+    assert!(node.get_property("age").is_none(), "age dropped");
+    assert!(node.get_property("name").is_some(), "name kept");
+    assert!(
+        node.get_property("city").is_some(),
+        "city kept (single-key remove)"
+    );
+}
+
+/// Case 7c: `remove_edge_property` mirror.
+#[test]
+fn remove_edge_property_drops_key() {
+    let db = AletheiaDB::new().expect("db");
+    let a = db
+        .create_node("N", PropertyMapBuilder::new().build())
+        .expect("a");
+    let b = db
+        .create_node("N", PropertyMapBuilder::new().build())
+        .expect("b");
+    let e = db
+        .create_edge(
+            a,
+            b,
+            "R",
+            PropertyMapBuilder::new()
+                .insert("x", 1i64)
+                .insert("y", 2i64)
+                .build(),
+        )
+        .expect("edge");
+
+    db.remove_edge_property(e, "y").expect("remove y");
+    let edge = db.get_edge(e).expect("get");
+    assert_eq!(edge.get_property("x").and_then(|v| v.as_int()), Some(1));
+    assert!(edge.get_property("y").is_none(), "y removed");
+
+    // Absent-key no-op.
+    let before = db.get_edge_history(e).expect("hist").version_count();
+    db.remove_edge_property(e, "zzz").expect("noop");
+    let after = db.get_edge_history(e).expect("hist").version_count();
+    assert_eq!(before, after, "no-op edge remove records nothing");
+}
+
+/// Case 8: replace with an empty map removes ALL properties; the node still
+/// exists.
+#[test]
+fn replace_node_empty_map_removes_all_props_but_keeps_node() {
+    let db = AletheiaDB::new().expect("db");
+    let id = db
+        .create_node("Person", props3("Alice", 30, "London"))
+        .expect("create");
+
+    db.replace_node(id, "Person", PropertyMapBuilder::new().build())
+        .expect("replace empty");
+
+    let node = db.get_node(id).expect("node still exists");
+    assert_eq!(node.id, id);
+    assert!(node.get_property("name").is_none(), "name removed");
+    assert!(node.get_property("age").is_none(), "age removed");
+    assert!(node.get_property("city").is_none(), "city removed");
+}
+
+/// Case 9 (regression): PATCH `update_node`/`update_edge` semantics are
+/// UNCHANGED — keys not in the incoming map are preserved.
+#[test]
+fn update_still_patches_not_replaces() {
+    let db = AletheiaDB::new().expect("db");
+    let id = db
+        .create_node("Person", props3("Alice", 30, "London"))
+        .expect("create");
+
+    // PATCH: only age changes; name & city preserved.
+    db.update_node_with_valid_time(
+        id,
+        PropertyMapBuilder::new().insert("age", 31i64).build(),
+        None,
+    )
+    .expect("update");
+
+    let node = db.get_node(id).expect("get");
+    assert_eq!(node.get_property("age").and_then(|v| v.as_int()), Some(31));
+    assert!(node.get_property("name").is_some(), "PATCH preserves name");
+    assert!(node.get_property("city").is_some(), "PATCH preserves city");
+}
+
+/// Case 12: valid_time + provenance options are honored on replace, at parity
+/// with update.
+#[test]
+fn replace_honors_valid_time_and_provenance() {
+    use aletheiadb::Provenance;
+    use aletheiadb::api::transaction::WriteRequestOptions;
+
+    let db = AletheiaDB::new().expect("db");
+
+    let create_valid =
+        HybridTimestamp::new(time::now().wallclock() - 7_200_000_000, 0).expect("ts");
+    let id = db
+        .create_node_with_valid_time("Person", props3("Alice", 30, "London"), Some(create_valid))
+        .expect("create");
+
+    // A transaction-time coordinate strictly between the create commit and the
+    // replace commit — needed to recall the pre-replace valid history (both
+    // bi-temporal dimensions must be anchored before the superseding write).
+    let tx_before_replace = time::now();
+
+    // Replace effective from 1 hour ago (after creation) with provenance.
+    let replace_valid =
+        HybridTimestamp::new(time::now().wallclock() - 3_600_000_000, 0).expect("ts");
+    let prov = Provenance::builder()
+        .source("hr-system")
+        .confidence(0.9)
+        .build()
+        .expect("prov");
+
+    db.replace_node_with_options(
+        id,
+        "Person",
+        PropertyMapBuilder::new().insert("name", "Alice").build(),
+        WriteRequestOptions::new()
+            .with_valid_from(replace_valid)
+            .with_provenance(prov),
+    )
+    .expect("replace with options");
+
+    // Provenance recorded on the current (replacement) version.
+    let got = db.get_node_provenance(id).expect("prov read");
+    assert_eq!(
+        got.and_then(|p| p.source().map(|s| s.to_string())),
+        Some("hr-system".to_string()),
+        "provenance stamped on replace version"
+    );
+
+    // valid_from honored on the NEW version: at (valid = 30 min ago, tx = now)
+    // — after replace_valid (1h ago) — only {name} remains (age gone).
+    let after_replace =
+        HybridTimestamp::new(time::now().wallclock() - 1_800_000_000, 0).expect("ts");
+    let new_ver = db
+        .get_node_at_time(id, after_replace, time::now())
+        .expect("as-of after replace_valid");
+    assert!(
+        new_ver.get_property("age").is_none(),
+        "at/after replace_valid the replacement map (no age) is valid"
+    );
+
+    // Before replace_valid the OLD map (with age) is valid — anchor BOTH
+    // dimensions before the replace commit.
+    let mid = HybridTimestamp::new(time::now().wallclock() - 5_400_000_000, 0).expect("ts"); // 1.5h ago
+    let old = db
+        .get_node_at_time(id, mid, tx_before_replace)
+        .expect("as-of mid");
+    assert_eq!(
+        old.get_property("age").and_then(|v| v.as_int()),
+        Some(30),
+        "before replace_valid the old map (with age) is valid"
+    );
+}
+
+/// Case 10: concurrent replace of the same node — snapshot isolation
+/// first-committer-wins still fires (`SerializationFailure`).
+#[test]
+fn concurrent_replace_first_committer_wins() {
+    let db = AletheiaDB::new().expect("db");
+    let id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("age", 30i64).build(),
+        )
+        .expect("create");
+
+    // Two transactions both snapshot the committed base version.
+    let mut tx1 = db.write_transaction().expect("tx1");
+    tx1.replace_node(
+        id,
+        "Person",
+        PropertyMapBuilder::new().insert("age", 31i64).build(),
+    )
+    .expect("tx1 replace");
+
+    let mut tx2 = db.write_transaction().expect("tx2");
+    tx2.replace_node(
+        id,
+        "Person",
+        PropertyMapBuilder::new().insert("age", 32i64).build(),
+    )
+    .expect("tx2 replace");
+
+    // tx2 commits first — wins.
+    tx2.commit().expect("tx2 commit wins");
+
+    // tx1 must abort with SerializationFailure (write-write conflict).
+    let err = tx1.commit().expect_err("tx1 must conflict");
+    assert!(
+        format!("{err:?}").contains("SerializationFailure"),
+        "expected SerializationFailure, got: {err:?}"
+    );
+
+    // First committer's value stands.
+    let node = db.get_node(id).expect("get");
+    assert_eq!(node.get_property("age").and_then(|v| v.as_int()), Some(32));
+}
+
+/// Case 11: replacing away a vector/embedding property updates the vector index
+/// so the node is no longer returned by similarity search on that property
+/// (while an untouched node remains indexed).
+#[test]
+fn replace_removes_vector_property_updates_index() {
+    use aletheiadb::db::SimilarityQuery;
+    use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
+
+    let db = AletheiaDB::new().expect("db");
+    db.vector_index("embedding")
+        .hnsw(HnswConfig::new(3, DistanceMetric::Cosine))
+        .enable()
+        .expect("enable vector index");
+
+    let target = db
+        .create_node(
+            "Doc",
+            PropertyMapBuilder::new()
+                .insert("name", "target")
+                .insert_vector("embedding", &[1.0f32, 0.0, 0.0])
+                .build(),
+        )
+        .expect("create target");
+    let decoy = db
+        .create_node(
+            "Doc",
+            PropertyMapBuilder::new()
+                .insert("name", "decoy")
+                .insert_vector("embedding", &[0.9f32, 0.1, 0.0])
+                .build(),
+        )
+        .expect("create decoy");
+
+    // Before removal: searching [1,0,0] finds the target.
+    let before = db
+        .similarity_search(SimilarityQuery::from_embedding(vec![1.0f32, 0.0, 0.0]).k(10))
+        .expect("search before");
+    assert!(
+        before.iter().any(|(nid, _)| *nid == target),
+        "target indexed before replace"
+    );
+
+    // Replace away the embedding (keep only name).
+    db.replace_node(
+        target,
+        "Doc",
+        PropertyMapBuilder::new().insert("name", "target").build(),
+    )
+    .expect("replace removes vector");
+
+    let node = db.get_node(target).expect("get");
+    assert!(
+        node.get_property("embedding").is_none(),
+        "embedding removed from current state"
+    );
+
+    // After removal: target is gone from the index; decoy still present.
+    let after = db
+        .similarity_search(SimilarityQuery::from_embedding(vec![1.0f32, 0.0, 0.0]).k(10))
+        .expect("search after");
+    assert!(
+        !after.iter().any(|(nid, _)| *nid == target),
+        "target must be removed from the vector index after replace, got {after:?}"
+    );
+    assert!(
+        after.iter().any(|(nid, _)| *nid == decoy),
+        "untouched decoy remains indexed"
+    );
+}


### PR DESCRIPTION
## Summary

Adds a **full-overwrite (non-PATCH)** counterpart to `update_node`/`update_edge`, plus single-key removal conveniences. Closes the gap in #3549 where you could only *merge* properties and could never change a node's label.

### Before
- `update_node(id, {age: 31})` is PATCH-merge: `name`/`city` are preserved. There is **no way** to remove a property, and **no way** to change a node's label.

### After
- `replace_node(id, "Employee", {name: "Alice"})` overwrites the map **exactly** (`age`/`city` are gone from current state) **and** sets a new label.
- `replace_edge(id, {since: 2024})` overwrites edge properties only — `source`/`target`/edge-type stay immutable.
- `remove_node_property(id, "age")` / `remove_edge_property(id, "y")` drop one key (read-modify-replace). Removing an **absent** key is a no-op success that records **no** new version.
- The existing PATCH `update_*` methods are **unchanged** (back-compat).

History is fully preserved: a removed key or an old label is still recallable `AS OF` an earlier bi-temporal coordinate (anchor **both** dimensions before the replace).

## How

- New methods on the `WriteOps` trait (`replace_node*`, `replace_edge*`, `remove_*_property`), implemented on `WriteTransaction`, with `AletheiaDB` convenience wrappers in `src/db/ops.rs`. Options parity (`valid_time` + `provenance`) matches the update path exactly.
- **No WAL format change.** Replace reuses the existing `UpdateNode`/`UpdateEdge` WAL op: it buffers that op carrying the *exact* target property map (skipping the PATCH `from_map(existing)` seed) plus a possibly-new node label.
- Key removal is encoded **natively** by the anchor/delta diff (`PropertyDelta::removed`) and reconstructs correctly through the delta chain — so **no anchor forcing was needed** and removals survive pure WAL replay. This was proven empirically before trusting the approach (see the delta-path and recovery tests).
- A small private `buffer_node_replace` helper is shared by `replace_node_with_options` (interns the new label) and `remove_node_property` (reuses the node's existing interned label, avoiding a deprecated interner `resolve`).

## Tests

`tests/replace_tombstone.rs` (13 end-to-end API cases):
- current-state key removal; as-of-earlier history preservation
- **delta-path removal proof** (asserts the version is stored as a Delta via `historical_stats().node_delta_count`, then reconstructs through the anchor+delta chain and asserts the key is gone)
- node label mutation (new label AS-OF-now, old label AS-OF-earlier, label index consistent)
- edge properties-only overwrite with immutable endpoints/type
- empty-map replace (all props gone, entity persists)
- absent-key `remove_*` no-op records no version; present-key removal records exactly one
- PATCH `update_*` regression (still merges)
- concurrent replace → SI first-committer-wins (`SerializationFailure`)
- vector-property removal via replace updates the HNSW index
- `valid_time` + `provenance` honored on replace

`tests/recovery/replace_tombstone_recovery.rs`: crash + **WAL-only replay** round-trip (drop without persisting indexes, reopen) — node relabel + key removal and edge key removal all survive replay.

### Gates
- `cargo fmt --all` clean
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test` (full suite, `--no-fail-fast`): all pass except the two pre-existing uid-0 sandbox tests (`test_flush_deadlock_on_io_error`, `test_metadata_corruption_on_error`) that force I/O errors via read-only directories — root bypasses those permissions; both are in the WAL flush path and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZPgMzUSorQdkaW8pM1wXo

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZPgMzUSorQdkaW8pM1wXo)_