### PR TITLE
Add KMS, Vault, and passphrase key providers (#3587)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "aes-gcm",
  "arbitrary",
  "arc-swap",
+ "argon2",
  "arrow",
  "autumn-web 0.4.0",
  "aws-sdk-kms",
@@ -152,6 +153,7 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "parquet",
+ "pbkdf2",
  "proptest",
  "quick_cache",
  "rand 0.8.6",
@@ -163,6 +165,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "sha2 0.10.9",
  "sha2 0.11.0",
  "simsimd",
  "smallvec 1.15.1",
@@ -329,6 +332,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+ "zeroize",
 ]
 
 [[package]]
@@ -1416,6 +1432,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
 dependencies = [
  "no_std_io2",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5767,6 +5792,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5783,6 +5819,16 @@ name = "pastey"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac 0.12.1",
+]
 
 [[package]]
 name = "pdf-extract"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,17 @@ chacha20poly1305 = "0.10"
 hkdf = "0.13"
 sha2 = "0.11"
 zeroize = { version = "1.8", features = ["derive"] }
-aws-sdk-kms = { version = "1.106.0", optional = true }
+aws-sdk-kms = { version = "1.106.0", optional = true, features = ["behavior-version-latest"] }
+
+# Passphrase-wrapped master-key files (Issue #3587). The passphrase module is
+# always compiled with the (non-feature-gated) encryption module, so these KDF
+# crates are non-optional. `argon2` is the memory-hard default; `pbkdf2` is the
+# interoperable fallback. `pbkdf2` 0.12 is built on the digest-0.10 ecosystem,
+# so it is paired with a sha2-0.10 copy aliased as `sha2_pbkdf2` (the primary
+# `sha2` dep is 0.11, a different digest generation).
+argon2 = { version = "0.5", features = ["zeroize"] }
+pbkdf2 = "0.12"
+sha2_pbkdf2 = { package = "sha2", version = "0.10" }
 
 # Constant-time equality for API-key digest comparison (Issue #3350).
 subtle = "2.6"
@@ -350,10 +360,11 @@ mvcc-snapshots-tdd = []
 encryption = ["serde"]
 
 # AWS KMS key provider (optional)
-encryption-aws-kms = ["encryption", "dep:tokio"]
+encryption-aws-kms = ["encryption", "dep:tokio", "aws-sdk-kms", "dep:base64"]
 
-# HashiCorp Vault key provider (optional)
-encryption-vault = ["encryption", "dep:tokio", "dep:reqwest", "dep:native-tls"]
+# HashiCorp Vault key provider (optional). Uses blocking reqwest, so no async
+# runtime bridge (and no `dep:tokio`) is required.
+encryption-vault = ["encryption", "dep:reqwest", "dep:native-tls", "dep:base64"]
 aws-sdk-kms = ["dep:aws-sdk-kms"]
 
 [profile.dev]

--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -475,8 +475,35 @@ fn keys_generate(args: &[String]) -> Result<(), String> {
     // silently clobbered (closes the check-then-write TOCTOU). The key file is
     // created with mode 0600 *before* any key bytes are written on Unix, so it
     // is never world-readable at any instant.
-    let result = aletheiadb::encryption::cli::generate_key_with_overwrite(path, force)
-        .map_err(|e| format!("failed to generate key: {e}"))?;
+    //
+    // With `--passphrase` (Issue #3587) the MEK is wrapped under a passphrase
+    // read from the ALETHEIADB_KEY_PASSPHRASE environment variable. The
+    // passphrase is NEVER taken from argv (it would leak via the process table),
+    // NEVER echoed, and NEVER printed; a missing/empty variable fails closed.
+    let result = if args.iter().any(|a| a == "--passphrase") {
+        let passphrase = std::env::var("ALETHEIADB_KEY_PASSPHRASE").map_err(|_| {
+            "the --passphrase flag requires the ALETHEIADB_KEY_PASSPHRASE environment variable to be set"
+                .to_string()
+        })?;
+        if passphrase.is_empty() {
+            return Err(
+                "ALETHEIADB_KEY_PASSPHRASE must not be empty when --passphrase is used".to_string(),
+            );
+        }
+        let result = aletheiadb::encryption::cli::generate_passphrase_key_with_overwrite(
+            path,
+            &passphrase,
+            force,
+        )
+        .map_err(|e| format!("failed to generate passphrase key: {e}"));
+        // Drop the passphrase from this frame promptly; the generator already
+        // consumed it into a zeroizing buffer for the KDF.
+        drop(passphrase);
+        result?
+    } else {
+        aletheiadb::encryption::cli::generate_key_with_overwrite(path, force)
+            .map_err(|e| format!("failed to generate key: {e}"))?
+    };
 
     // Defense-in-depth: re-assert owner-only permissions. `generate_key_with_overwrite`
     // already creates the file 0600 at creation time on Unix, so this is a

--- a/src/db/rotation.rs
+++ b/src/db/rotation.rs
@@ -62,7 +62,6 @@ use crate::encryption::cipher::Cipher;
 use crate::encryption::config::{EncryptionConfig, KeyProviderConfig};
 use crate::encryption::factory::create_cipher;
 use crate::encryption::key_derivation::KeyDerivation;
-use crate::encryption::key_provider::{EnvKeyProvider, FileKeyProvider, KeyProvider};
 use crate::storage::index_persistence::common::ENC_INDEX_KEY_VERSION_V1;
 use crate::storage::index_persistence::{
     IndexKeyRotation, IndexPersistenceManager, RotationError, RotationStatus,
@@ -117,11 +116,14 @@ fn rotation_failure_category(e: &Error) -> &'static str {
 }
 
 /// Source an MEK from a key-provider config (no key material is logged).
+///
+/// Delegates to the central [`KeyProviderConfig::build_provider`] dispatch
+/// (Issue #3587) so every provider backend — file, env, passphrase, KMS, Vault
+/// — is constructed in exactly one place.
 fn load_mek(cfg: &KeyProviderConfig) -> std::result::Result<Zeroizing<[u8; 32]>, RotationError> {
-    let provider: Box<dyn KeyProvider> = match cfg {
-        KeyProviderConfig::File { path } => Box::new(FileKeyProvider::new(path)),
-        KeyProviderConfig::Env { variable } => Box::new(EnvKeyProvider::new(variable)),
-    };
+    let provider = cfg
+        .build_provider()
+        .map_err(|e| RotationError::KeyProvider(e.to_string()))?;
     provider
         .get_mek()
         .map_err(|e| RotationError::KeyProvider(e.to_string()))
@@ -486,9 +488,26 @@ fn write_rotation_state(
     new_source: &KeyProviderConfig,
     direction: RotationDirection,
 ) -> Result<()> {
+    // Only file/env sources carry a single, non-secret identifying reference the
+    // breadcrumb can persist and reconstruct on crash-resume. Rotating TO a
+    // passphrase/KMS/Vault source is a documented follow-up (Issue #3587): those
+    // carry secrets (passphrase/token env) or multi-field config that the simple
+    // line breadcrumb cannot round-trip, so refuse fail-closed rather than write
+    // a breadcrumb that would not resume. Note that index-key rotation already
+    // refuses whenever any non-index encrypted layer is present, so the current
+    // MEK source is unaffected — this bounds only the NEW source.
     let (kind, value) = match new_source {
         KeyProviderConfig::File { path } => ("file", path.to_string_lossy().into_owned()),
         KeyProviderConfig::Env { variable } => ("env", variable.clone()),
+        KeyProviderConfig::PassphraseFile { .. }
+        | KeyProviderConfig::Kms { .. }
+        | KeyProviderConfig::Vault { .. } => {
+            let (provider_type, _) = new_source.describe();
+            return Err(StorageError::PersistenceError(format!(
+                "index key rotation to a {provider_type} key source is not yet supported"
+            ))
+            .into());
+        }
     };
     let body = format!(
         "version=1\ndirection={}\nnew_version={new_version}\nnew_source_kind={kind}\nnew_source_value={value}\n",

--- a/src/encryption/cli.rs
+++ b/src/encryption/cli.rs
@@ -9,9 +9,10 @@
 use std::path::Path;
 
 use crate::encryption::KeyProviderError;
-use crate::encryption::config::{EncryptionConfig, KeyProviderConfig};
+use crate::encryption::config::EncryptionConfig;
 use crate::encryption::factory::Algorithm;
 use crate::encryption::key_provider::{FileKeyProvider, KeyProvider};
+use crate::encryption::passphrase::generate_passphrase_key_file;
 
 /// Result of a key generation operation.
 #[derive(Debug)]
@@ -79,6 +80,38 @@ pub fn generate_key_with_overwrite(
     })
 }
 
+/// Generate a new passphrase-wrapped master key file (Issue #3587).
+///
+/// Generates a random 256-bit MEK, wraps it under `passphrase` using the default
+/// Argon2id KDF, and writes a self-describing `AEKF` key file at `output_path`.
+/// When `overwrite` is `false` an existing file is never clobbered (`O_EXCL`);
+/// on Unix the file is created `0600` before any bytes are written.
+///
+/// # Security
+///
+/// The passphrase is consumed only to derive the wrapping key and is **never**
+/// written to disk, logged, or placed in the returned result or any error. The
+/// generated plaintext MEK is dropped (zeroized) before this function returns —
+/// only the wrapped file persists.
+///
+/// # Errors
+///
+/// Returns [`KeyProviderError`] if key derivation, encryption, or file writing
+/// fails, or (when `overwrite` is `false`) if a file already exists.
+pub fn generate_passphrase_key_with_overwrite(
+    output_path: &Path,
+    passphrase: &str,
+    overwrite: bool,
+) -> Result<KeyGenResult, KeyProviderError> {
+    // The returned MEK is dropped (zeroized) here; only the wrapped file remains.
+    let _mek = generate_passphrase_key_file(output_path, passphrase, overwrite)?;
+    Ok(KeyGenResult {
+        path: output_path.display().to_string(),
+        algorithm: "AES-256-GCM / ChaCha20-Poly1305 (passphrase-wrapped, Argon2id)".into(),
+        key_length: 32,
+    })
+}
+
 /// Information about the current encryption configuration.
 #[derive(Debug)]
 pub struct EncryptionStatus {
@@ -127,10 +160,7 @@ pub fn get_encryption_status(config: &EncryptionConfig) -> EncryptionStatus {
         Algorithm::Auto => "Auto (AES-256-GCM if AES-NI, else ChaCha20-Poly1305)",
     };
 
-    let (provider_type, provider_detail) = match &config.key_provider {
-        KeyProviderConfig::File { path } => ("file", path.display().to_string()),
-        KeyProviderConfig::Env { variable } => ("env", variable.clone()),
-    };
+    let (provider_type, provider_detail) = config.key_provider.describe();
 
     EncryptionStatus {
         enabled: true,
@@ -222,6 +252,7 @@ pub fn format_encryption_status(status: &EncryptionStatus) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::encryption::config::KeyProviderConfig;
     use std::path::PathBuf;
 
     #[test]

--- a/src/encryption/config.rs
+++ b/src/encryption/config.rs
@@ -7,7 +7,10 @@
 use std::path::PathBuf;
 
 use crate::encryption::audit::AuditLevel;
+use crate::encryption::error::KeyProviderError;
 use crate::encryption::factory::Algorithm;
+use crate::encryption::key_provider::{EnvKeyProvider, FileKeyProvider, KeyProvider};
+use crate::encryption::passphrase::PassphraseFileKeyProvider;
 
 /// Where audit log lines are written.
 ///
@@ -94,6 +97,208 @@ pub enum KeyProviderConfig {
         /// Name of the environment variable.
         variable: String,
     },
+    /// Load the MEK from a passphrase-wrapped key file (Issue #3587).
+    ///
+    /// The passphrase itself is **never** stored in config; it is read at
+    /// startup from the environment variable named by `passphrase_env`.
+    PassphraseFile {
+        /// Path to the passphrase-wrapped key file (`AEKF` format).
+        path: PathBuf,
+        /// Name of the environment variable holding the passphrase.
+        passphrase_env: String,
+    },
+    /// Decrypt the MEK from an AWS KMS-wrapped data key (Issue #3587).
+    ///
+    /// Requires the `encryption-aws-kms` feature; otherwise
+    /// [`build_provider`](KeyProviderConfig::build_provider) returns
+    /// [`KeyProviderError::Unavailable`].
+    Kms {
+        /// KMS key id or ARN used to decrypt the data key.
+        key_id: String,
+        /// Base64-encoded KMS-encrypted data-key ciphertext blob (wrapped MEK).
+        encrypted_data_key: String,
+        /// AWS region (defaults to `us-east-1` / `AWS_REGION` if unset).
+        #[cfg_attr(feature = "serde", serde(default))]
+        region: Option<String>,
+        /// Optional custom endpoint URL (e.g. LocalStack or a VPC endpoint).
+        #[cfg_attr(feature = "serde", serde(default))]
+        endpoint_url: Option<String>,
+    },
+    /// Read the MEK from a HashiCorp Vault KV v2 secret (Issue #3587).
+    ///
+    /// The Vault token is **never** stored in config; it is read at startup
+    /// from the environment variable named by `token_env`. Requires the
+    /// `encryption-vault` feature; otherwise
+    /// [`build_provider`](KeyProviderConfig::build_provider) returns
+    /// [`KeyProviderError::Unavailable`].
+    Vault {
+        /// Base address, e.g. `https://vault.example.com:8200`.
+        address: String,
+        /// Name of the environment variable holding the Vault token.
+        token_env: String,
+        /// KV v2 mount point (default `secret`).
+        #[cfg_attr(feature = "serde", serde(default = "default_vault_mount"))]
+        mount: String,
+        /// Secret path under the mount.
+        path: String,
+        /// Field within the secret data holding the key (default `key`).
+        #[cfg_attr(feature = "serde", serde(default = "default_vault_key_field"))]
+        key_field: String,
+        /// Optional Vault namespace (Enterprise).
+        #[cfg_attr(feature = "serde", serde(default))]
+        namespace: Option<String>,
+        /// Optional path to a PEM CA certificate for TLS verification.
+        #[cfg_attr(feature = "serde", serde(default))]
+        ca_cert: Option<PathBuf>,
+    },
+}
+
+/// Serde default for [`KeyProviderConfig::Vault::mount`].
+#[cfg(feature = "serde")]
+fn default_vault_mount() -> String {
+    "secret".to_string()
+}
+
+/// Serde default for [`KeyProviderConfig::Vault::key_field`].
+#[cfg(feature = "serde")]
+fn default_vault_key_field() -> String {
+    "key".to_string()
+}
+
+impl KeyProviderConfig {
+    /// Construct the concrete [`KeyProvider`] backend for this configuration.
+    ///
+    /// Central dispatch used by the encryption manager and key-rotation engine
+    /// so provider construction lives in exactly one place. Feature-gated
+    /// backends (`Kms`, `Vault`) return [`KeyProviderError::Unavailable`] with a
+    /// key-safe message when their feature is not compiled in — never a panic.
+    ///
+    /// # Security
+    ///
+    /// Secret material (passphrase, Vault token) is read from the environment at
+    /// call time and moved directly into the provider; it is never stored in the
+    /// config, logged, or placed in an error message. A missing secret env var
+    /// yields [`KeyProviderError::Unavailable`] naming only the variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KeyProviderError`] if a required secret environment variable is
+    /// absent, a feature-gated backend is not compiled in, or the backend fails
+    /// to construct (e.g. an invalid KMS ciphertext blob).
+    pub fn build_provider(&self) -> Result<Box<dyn KeyProvider>, KeyProviderError> {
+        match self {
+            KeyProviderConfig::File { path } => Ok(Box::new(FileKeyProvider::new(path))),
+            KeyProviderConfig::Env { variable } => Ok(Box::new(EnvKeyProvider::new(variable))),
+            KeyProviderConfig::PassphraseFile {
+                path,
+                passphrase_env,
+            } => {
+                let passphrase = std::env::var(passphrase_env).map_err(|_| {
+                    // Name only the variable — never the passphrase value.
+                    KeyProviderError::Unavailable(format!(
+                        "passphrase environment variable {passphrase_env} is not set"
+                    ))
+                })?;
+                Ok(Box::new(PassphraseFileKeyProvider::new(path, passphrase)))
+            }
+            KeyProviderConfig::Kms {
+                key_id,
+                encrypted_data_key,
+                region,
+                endpoint_url,
+            } => {
+                #[cfg(feature = "encryption-aws-kms")]
+                {
+                    let cfg = crate::encryption::kms_provider::KmsConfig {
+                        key_id: key_id.clone(),
+                        encrypted_data_key: encrypted_data_key.clone(),
+                        region: region.clone(),
+                        endpoint_url: endpoint_url.clone(),
+                    };
+                    Ok(Box::new(
+                        crate::encryption::kms_provider::KmsKeyProvider::new(&cfg)?,
+                    ))
+                }
+                #[cfg(not(feature = "encryption-aws-kms"))]
+                {
+                    // Silence unused-binding warnings without touching secrets.
+                    let _ = (key_id, encrypted_data_key, region, endpoint_url);
+                    Err(KeyProviderError::Unavailable(
+                        "KMS key provider is not compiled in (enable the encryption-aws-kms feature)"
+                            .to_string(),
+                    ))
+                }
+            }
+            KeyProviderConfig::Vault {
+                address,
+                token_env,
+                mount,
+                path,
+                key_field,
+                namespace,
+                ca_cert,
+            } => {
+                #[cfg(feature = "encryption-vault")]
+                {
+                    let token = std::env::var(token_env).map_err(|_| {
+                        // Name only the variable — never the token value.
+                        KeyProviderError::Unavailable(format!(
+                            "Vault token environment variable {token_env} is not set"
+                        ))
+                    })?;
+                    let cfg = crate::encryption::vault_provider::VaultConfig {
+                        address: address.clone(),
+                        token,
+                        mount: mount.clone(),
+                        path: path.clone(),
+                        key_field: key_field.clone(),
+                        namespace: namespace.clone(),
+                        ca_cert: ca_cert.clone(),
+                    };
+                    Ok(Box::new(
+                        crate::encryption::vault_provider::VaultKeyProvider::new(&cfg)?,
+                    ))
+                }
+                #[cfg(not(feature = "encryption-vault"))]
+                {
+                    let _ = (
+                        address, token_env, mount, path, key_field, namespace, ca_cert,
+                    );
+                    Err(KeyProviderError::Unavailable(
+                        "Vault key provider is not compiled in (enable the encryption-vault feature)"
+                            .to_string(),
+                    ))
+                }
+            }
+        }
+    }
+
+    /// A non-secret `(type, detail)` status pair describing this provider, for
+    /// diagnostics and the `encryption status` CLI command.
+    ///
+    /// # Security
+    ///
+    /// The returned detail is deliberately non-secret: a file path, an env var
+    /// *name*, a KMS key id, or a Vault address — **never** a passphrase, token,
+    /// or key material.
+    #[must_use]
+    pub fn describe(&self) -> (&'static str, String) {
+        match self {
+            KeyProviderConfig::File { path } => ("file", path.display().to_string()),
+            KeyProviderConfig::Env { variable } => ("env", variable.clone()),
+            KeyProviderConfig::PassphraseFile {
+                path,
+                passphrase_env,
+            } => (
+                "passphrase",
+                format!("{} (passphrase from ${passphrase_env})", path.display()),
+            ),
+            KeyProviderConfig::Kms { key_id, .. } => ("kms", key_id.clone()),
+            KeyProviderConfig::Vault { address, path, .. } => {
+                ("vault", format!("{address} ({path})"))
+            }
+        }
+    }
 }
 
 impl Default for KeyProviderConfig {

--- a/src/encryption/key_provider.rs
+++ b/src/encryption/key_provider.rs
@@ -19,6 +19,18 @@ pub trait KeyProvider: Send + Sync {
     /// Retrieve the 32-byte master encryption key.
     fn get_mek(&self) -> Result<Zeroizing<[u8; 32]>, KeyProviderError>;
 
+    /// Retrieve a specific key version (Issue #3587).
+    ///
+    /// The default implementation is for single-version providers (file, env,
+    /// passphrase): they hold exactly one key, so any requested version resolves
+    /// to that sole key via [`get_mek`](Self::get_mek). Multi-version backends
+    /// (e.g. KMS/Vault envelope models) override this to reject unknown versions
+    /// with [`KeyProviderError::KeyNotFound`] rather than silently returning the
+    /// current key. It never panics.
+    fn get_key_version(&self, _version: u32) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+        self.get_mek()
+    }
+
     /// Human-readable provider name for logging/diagnostics.
     fn provider_name(&self) -> &str;
 
@@ -444,5 +456,37 @@ mod tests {
 
         let env_provider = EnvKeyProvider::new("MY_KEY");
         assert_eq!(env_provider.provider_name(), "env");
+    }
+
+    #[test]
+    fn file_provider_get_key_version_returns_sole_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("versioned.hex");
+
+        let (hex_str, expected) = hex_key_string();
+        std::fs::write(&path, &hex_str).unwrap();
+
+        let provider = FileKeyProvider::new(&path);
+        // A single-version provider resolves ANY requested version to its sole key.
+        let v = provider.get_key_version(42).unwrap();
+        assert_eq!(v.as_ref(), expected.as_ref());
+        assert_eq!(
+            provider.get_key_version(0).unwrap().as_ref(),
+            expected.as_ref()
+        );
+    }
+
+    #[test]
+    fn env_provider_get_key_version_returns_sole_key() {
+        let var = unique_env_var("VERSIONED");
+        let (hex_str, expected) = hex_key_string();
+        // SAFETY: test-only, unique var names prevent races
+        unsafe { std::env::set_var(&var, &hex_str) };
+
+        let provider = EnvKeyProvider::new(&var);
+        let v = provider.get_key_version(7).unwrap();
+        assert_eq!(v.as_ref(), expected.as_ref());
+
+        unsafe { std::env::remove_var(&var) };
     }
 }

--- a/src/encryption/kms_provider.rs
+++ b/src/encryption/kms_provider.rs
@@ -1,0 +1,377 @@
+//! AWS KMS key provider (Issue #3587), gated behind `encryption-aws-kms`.
+//!
+//! # Envelope model
+//!
+//! The Master Encryption Key (MEK) is never stored in plaintext. Instead the
+//! configuration carries:
+//! - a KMS key id / ARN, and
+//! - a **base64-encoded KMS-encrypted data-key ciphertext blob** (the wrapped
+//!   MEK).
+//!
+//! At startup [`get_mek`](KmsKeyProvider::get_mek) calls KMS `Decrypt` on the
+//! blob and returns the recovered 32-byte plaintext as a
+//! [`Zeroizing<[u8; 32]>`]. Nothing sensitive is logged or exposed via `Debug`.
+//!
+//! # Async bridge
+//!
+//! `aws-sdk-kms` is async but the [`KeyProvider`] trait is synchronous, so this
+//! provider owns an internal current-thread Tokio runtime and blocks on the
+//! `Decrypt` future. If a call happens to occur *inside* an ambient Tokio
+//! runtime (which would make a nested `block_on` panic), the future is run on a
+//! dedicated OS thread instead, detected via
+//! [`Handle::try_current`](tokio::runtime::Handle::try_current).
+//!
+//! # Credentials
+//!
+//! Credentials are read from the standard `AWS_ACCESS_KEY_ID` /
+//! `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` environment variables. A full
+//! default credential provider chain (instance metadata, SSO, config files) via
+//! `aws-config` is a deliberate follow-up; the envelope-decrypt flow is
+//! identical either way.
+
+use std::fmt;
+
+use aws_sdk_kms::Client;
+use aws_sdk_kms::config::{BehaviorVersion, Credentials, Region};
+use aws_sdk_kms::error::{ProvideErrorMetadata, SdkError};
+use aws_sdk_kms::operation::decrypt::DecryptError;
+use aws_sdk_kms::primitives::Blob;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use tokio::runtime::{Handle, Runtime};
+use zeroize::Zeroizing;
+
+use crate::encryption::KeyProviderError;
+use crate::encryption::key_provider::KeyProvider;
+
+/// The single logical key version this envelope model exposes.
+const CURRENT_VERSION: u32 = 1;
+
+/// Configuration for the AWS KMS key provider.
+#[derive(Clone)]
+pub struct KmsConfig {
+    /// KMS key id or ARN used to decrypt the data key.
+    pub key_id: String,
+    /// Base64-encoded KMS-encrypted data-key ciphertext blob (the wrapped MEK).
+    pub encrypted_data_key: String,
+    /// AWS region (defaults to `us-east-1` if unset).
+    pub region: Option<String>,
+    /// Optional custom endpoint URL (e.g. LocalStack or a VPC endpoint).
+    pub endpoint_url: Option<String>,
+}
+
+impl fmt::Debug for KmsConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Redact the wrapped-key blob; key_id/region/endpoint are not secret but
+        // the ciphertext blob is treated as sensitive material.
+        f.debug_struct("KmsConfig")
+            .field("key_id", &self.key_id)
+            .field("encrypted_data_key", &"<redacted>")
+            .field("region", &self.region)
+            .field("endpoint_url", &self.endpoint_url)
+            .finish()
+    }
+}
+
+/// Decrypts a KMS-wrapped data key into the MEK on demand.
+pub struct KmsKeyProvider {
+    client: Client,
+    key_id: String,
+    /// Raw (base64-decoded) ciphertext blob.
+    blob: Vec<u8>,
+    runtime: Runtime,
+}
+
+impl fmt::Debug for KmsKeyProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // NEVER expose the wrapped-key blob.
+        f.debug_struct("KmsKeyProvider")
+            .field("key_id", &self.key_id)
+            .field("blob", &"<redacted>")
+            .finish()
+    }
+}
+
+impl KmsKeyProvider {
+    /// Build a KMS key provider from config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KeyProviderError::InvalidKeyFormat`] if the ciphertext blob is
+    /// not valid base64, or [`KeyProviderError::Unavailable`] if the internal
+    /// runtime cannot be constructed.
+    pub fn new(config: &KmsConfig) -> Result<Self, KeyProviderError> {
+        let blob = BASE64
+            .decode(config.encrypted_data_key.as_bytes())
+            .map_err(|_| {
+                KeyProviderError::InvalidKeyFormat(
+                    "encrypted_data_key is not valid base64".to_string(),
+                )
+            })?;
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| {
+                KeyProviderError::Unavailable(format!("failed to build KMS runtime: {e}"))
+            })?;
+
+        // Credentials from the standard AWS_* environment variables. Missing
+        // credentials simply yield an auth failure at Decrypt time (typed
+        // AccessDenied), never a panic.
+        let access = std::env::var("AWS_ACCESS_KEY_ID").unwrap_or_default();
+        let secret = std::env::var("AWS_SECRET_ACCESS_KEY").unwrap_or_default();
+        let session = std::env::var("AWS_SESSION_TOKEN").ok();
+        let creds = Credentials::new(access, secret, session, None, "aletheia-env");
+
+        let region = config
+            .region
+            .clone()
+            .or_else(|| std::env::var("AWS_REGION").ok())
+            .unwrap_or_else(|| "us-east-1".to_string());
+
+        let mut builder = aws_sdk_kms::config::Builder::default()
+            .behavior_version(BehaviorVersion::latest())
+            .region(Region::new(region))
+            .credentials_provider(creds)
+            // Fail fast rather than retrying against an unreachable endpoint.
+            .retry_config(aws_sdk_kms::config::retry::RetryConfig::disabled())
+            .timeout_config(
+                aws_sdk_kms::config::timeout::TimeoutConfig::builder()
+                    .operation_timeout(std::time::Duration::from_secs(10))
+                    .operation_attempt_timeout(std::time::Duration::from_secs(5))
+                    .build(),
+            );
+        if let Some(ep) = &config.endpoint_url {
+            builder = builder.endpoint_url(ep.clone());
+        }
+        let client = Client::from_conf(builder.build());
+
+        Ok(Self {
+            client,
+            key_id: config.key_id.clone(),
+            blob,
+            runtime,
+        })
+    }
+
+    /// Run the (owned, `'static`) decrypt future to completion, bridging the
+    /// async client into the synchronous trait without panicking inside an
+    /// ambient runtime.
+    fn block_on_decrypt(&self) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+        let fut = decrypt(self.client.clone(), self.key_id.clone(), self.blob.clone());
+
+        if Handle::try_current().is_ok() {
+            // We are inside another Tokio runtime; a nested block_on would
+            // panic. Run on a dedicated OS thread with our runtime's handle.
+            let handle = self.runtime.handle().clone();
+            let jh = std::thread::spawn(move || handle.block_on(fut));
+            jh.join().unwrap_or_else(|_| {
+                Err(KeyProviderError::Unavailable(
+                    "KMS decrypt worker thread panicked".to_string(),
+                ))
+            })
+        } else {
+            self.runtime.block_on(fut)
+        }
+    }
+}
+
+/// The owned, `'static` decrypt future body.
+async fn decrypt(
+    client: Client,
+    key_id: String,
+    blob: Vec<u8>,
+) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+    let out = client
+        .decrypt()
+        .key_id(key_id)
+        .ciphertext_blob(Blob::new(blob))
+        .send()
+        .await
+        .map_err(map_decrypt_err)?;
+
+    let plaintext = out.plaintext().ok_or_else(|| {
+        KeyProviderError::InvalidKeyFormat("KMS returned no plaintext".to_string())
+    })?;
+    plaintext_to_key(plaintext.as_ref())
+}
+
+/// Convert a decrypted plaintext byte slice into a 32-byte MEK.
+fn plaintext_to_key(bytes: &[u8]) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+    if bytes.len() != 32 {
+        return Err(KeyProviderError::InvalidKeyFormat(format!(
+            "KMS plaintext data key is {} bytes, expected 32",
+            bytes.len()
+        )));
+    }
+    let mut key = Zeroizing::new([0u8; 32]);
+    key.copy_from_slice(bytes);
+    Ok(key)
+}
+
+/// Map a KMS `Decrypt` SDK error into a typed [`KeyProviderError`] without
+/// leaking any request/response body.
+fn map_decrypt_err<R>(e: SdkError<DecryptError, R>) -> KeyProviderError {
+    match &e {
+        SdkError::TimeoutError(_) => {
+            KeyProviderError::Unavailable("KMS request timed out".to_string())
+        }
+        SdkError::DispatchFailure(_) => {
+            KeyProviderError::Unavailable("KMS transport/dispatch failure".to_string())
+        }
+        SdkError::ResponseError(_) => {
+            KeyProviderError::Unavailable("KMS returned an unparseable response".to_string())
+        }
+        SdkError::ServiceError(se) => {
+            let code = se.err().code().unwrap_or("Unknown");
+            if code.contains("AccessDenied")
+                || code.contains("NotAuthorized")
+                || code.contains("Unauthorized")
+                || code.contains("Disabled")
+                || code.contains("InvalidState")
+            {
+                KeyProviderError::AccessDenied(format!("KMS denied decrypt ({code})"))
+            } else if code.contains("Throttling")
+                || code.contains("Internal")
+                || code.contains("Unavailable")
+                || code.contains("DependencyTimeout")
+            {
+                KeyProviderError::Unavailable(format!("KMS transient error ({code})"))
+            } else {
+                KeyProviderError::Provider(Box::new(std::io::Error::other(format!(
+                    "KMS decrypt error ({code})"
+                ))))
+            }
+        }
+        _ => KeyProviderError::Provider(Box::new(std::io::Error::other(
+            "KMS decrypt failed".to_string(),
+        ))),
+    }
+}
+
+impl KeyProvider for KmsKeyProvider {
+    fn get_mek(&self) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+        self.block_on_decrypt()
+    }
+
+    fn get_key_version(&self, version: u32) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+        // The envelope model wraps a single data key. Only the current version
+        // is retrievable; any other version is a typed KeyNotFound (never a
+        // panic). Native KMS key-rotation history is a follow-up.
+        if version == CURRENT_VERSION || version == 0 {
+            self.get_mek()
+        } else {
+            Err(KeyProviderError::KeyNotFound)
+        }
+    }
+
+    fn provider_name(&self) -> &str {
+        "kms"
+    }
+
+    fn health_check(&self) -> Result<(), KeyProviderError> {
+        self.get_mek().map(|_| ())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> KmsConfig {
+        KmsConfig {
+            key_id: "alias/test".to_string(),
+            // base64 of arbitrary bytes -- decodes fine; decrypt would need a
+            // live KMS, which these tests deliberately avoid.
+            encrypted_data_key: BASE64.encode(b"wrapped-data-key-ciphertext"),
+            region: Some("us-east-1".to_string()),
+            endpoint_url: None,
+        }
+    }
+
+    #[test]
+    fn plaintext_to_key_accepts_32_bytes() {
+        let bytes = [7u8; 32];
+        let key = plaintext_to_key(&bytes).unwrap();
+        assert_eq!(key.as_ref(), &bytes);
+    }
+
+    #[test]
+    fn plaintext_to_key_rejects_non_32() {
+        for len in [0usize, 16, 31, 33, 64] {
+            let bytes = vec![0u8; len];
+            let err = plaintext_to_key(&bytes).unwrap_err();
+            assert!(
+                matches!(err, KeyProviderError::InvalidKeyFormat(_)),
+                "len {len} should be InvalidKeyFormat, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn new_rejects_invalid_base64_blob() {
+        let cfg = KmsConfig {
+            encrypted_data_key: "not!valid!base64!!!".to_string(),
+            ..test_config()
+        };
+        let err = KmsKeyProvider::new(&cfg).unwrap_err();
+        assert!(
+            matches!(err, KeyProviderError::InvalidKeyFormat(_)),
+            "expected InvalidKeyFormat, got: {err}"
+        );
+    }
+
+    #[test]
+    fn new_succeeds_with_valid_config() {
+        let provider = KmsKeyProvider::new(&test_config()).unwrap();
+        assert_eq!(provider.provider_name(), "kms");
+    }
+
+    #[test]
+    fn unreachable_endpoint_returns_typed_error_not_panic() {
+        // Point at a closed local port so the request fails fast with a
+        // transport error. This exercises the async bridge + error mapping
+        // without a live KMS (see the KMS coverage-boundary note in the PR).
+        let cfg = KmsConfig {
+            endpoint_url: Some("http://127.0.0.1:1".to_string()),
+            ..test_config()
+        };
+        let provider = KmsKeyProvider::new(&cfg).unwrap();
+        let err = provider.get_mek().unwrap_err();
+        // Transport failure or a denied/typed error -- crucially, NOT a panic
+        // and NOT a hang.
+        assert!(
+            matches!(
+                err,
+                KeyProviderError::Unavailable(_)
+                    | KeyProviderError::AccessDenied(_)
+                    | KeyProviderError::Provider(_)
+            ),
+            "expected a typed transport/denied error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn get_key_version_unknown_is_key_not_found() {
+        let provider = KmsKeyProvider::new(&test_config()).unwrap();
+        let err = provider.get_key_version(999).unwrap_err();
+        assert!(
+            matches!(err, KeyProviderError::KeyNotFound),
+            "unknown version must be KeyNotFound, got: {err}"
+        );
+    }
+
+    #[test]
+    fn debug_does_not_leak_blob() {
+        let provider = KmsKeyProvider::new(&test_config()).unwrap();
+        let dbg = format!("{provider:?}");
+        assert!(dbg.contains("redacted"));
+        assert!(!dbg.contains("wrapped-data-key"));
+
+        let cfg_dbg = format!("{:?}", test_config());
+        assert!(cfg_dbg.contains("redacted"));
+        // The base64 blob string must not appear.
+        assert!(!cfg_dbg.contains(&BASE64.encode(b"wrapped-data-key-ciphertext")));
+    }
+}

--- a/src/encryption/manager.rs
+++ b/src/encryption/manager.rs
@@ -8,13 +8,13 @@ use std::sync::Arc;
 
 use crate::encryption::audit::{AuditEvent, EncryptionAuditLogger};
 use crate::encryption::cipher::Cipher;
-use crate::encryption::config::{EncryptionConfig, KeyProviderConfig};
+use crate::encryption::config::EncryptionConfig;
 use crate::encryption::error::KeyProviderError;
 use crate::encryption::factory::create_cipher;
 use crate::encryption::key_derivation::{
     CHECKPOINT_DEK_CONTEXT, COLD_DEK_CONTEXT, INDEX_DEK_CONTEXT, KeyDerivation, WAL_DEK_CONTEXT,
 };
-use crate::encryption::key_provider::{EnvKeyProvider, FileKeyProvider, KeyProvider};
+use crate::encryption::key_provider::KeyProvider;
 
 /// The key version tracked by the manager for the currently-loaded MEK.
 ///
@@ -107,10 +107,20 @@ impl EncryptionManager {
         config: &EncryptionConfig,
         audit: EncryptionAuditLogger,
     ) -> Result<Self, KeyProviderError> {
-        // 1. Create the key provider.
-        let provider: Box<dyn KeyProvider> = match &config.key_provider {
-            KeyProviderConfig::File { path } => Box::new(FileKeyProvider::new(path)),
-            KeyProviderConfig::Env { variable } => Box::new(EnvKeyProvider::new(variable)),
+        // 1. Create the key provider via central dispatch (Issue #3587). A
+        //    provider that fails to construct (e.g. a missing passphrase/token
+        //    env var, or a feature-gated backend not compiled in) is audited
+        //    with a key-safe category before returning.
+        let provider: Box<dyn KeyProvider> = match config.key_provider.build_provider() {
+            Ok(p) => p,
+            Err(e) => {
+                let (kind, _) = config.key_provider.describe();
+                audit.log(&AuditEvent::KeyAccessDenied {
+                    provider: kind.to_string(),
+                    error: error_category(&e).to_string(),
+                });
+                return Err(e);
+            }
         };
 
         let name = provider.provider_name().to_string();

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -21,8 +21,13 @@ pub mod error;
 pub mod factory;
 pub mod key_derivation;
 pub mod key_provider;
+#[cfg(feature = "encryption-aws-kms")]
+pub mod kms_provider;
 pub mod manager;
+pub mod passphrase;
 pub mod rotation;
+#[cfg(feature = "encryption-vault")]
+pub mod vault_provider;
 pub mod wal_encryption;
 
 pub use audit::{AuditEvent, AuditLevel, EncryptionAuditLogger};
@@ -31,7 +36,8 @@ pub use cipher::{
 };
 pub use cli::{
     EncryptionStatus, KeyGenResult, format_encryption_status, generate_key,
-    generate_key_with_overwrite, get_encryption_status, validate_key_file,
+    generate_key_with_overwrite, generate_passphrase_key_with_overwrite, get_encryption_status,
+    validate_key_file,
 };
 pub use config::{AuditConfig, AuditDestination, EncryptionConfig, KeyProviderConfig};
 pub use error::{EncryptionError, KeyDerivationError, KeyProviderError};
@@ -40,6 +46,14 @@ pub use key_derivation::{
     CHECKPOINT_DEK_CONTEXT, COLD_DEK_CONTEXT, INDEX_DEK_CONTEXT, KeyDerivation, WAL_DEK_CONTEXT,
 };
 pub use key_provider::{EnvKeyProvider, FileKeyProvider, KeyFormat, KeyProvider};
+#[cfg(feature = "encryption-aws-kms")]
+pub use kms_provider::{KmsConfig, KmsKeyProvider};
 pub use manager::EncryptionManager;
+pub use passphrase::{
+    PassphraseFileKeyProvider, PassphraseKdf, generate_passphrase_key_file,
+    generate_passphrase_key_file_with_kdf,
+};
 pub use rotation::{KeyRotationManager, KeyVersion, RotationState};
+#[cfg(feature = "encryption-vault")]
+pub use vault_provider::{VaultConfig, VaultKeyProvider};
 pub use wal_encryption::{decrypt_wal_payload, encrypt_wal_payload};

--- a/src/encryption/passphrase.rs
+++ b/src/encryption/passphrase.rs
@@ -1,0 +1,565 @@
+//! Passphrase-wrapped master-key files (Issue #3587).
+//!
+//! A passphrase key file stores the 32-byte Master Encryption Key (MEK)
+//! **wrapped** (AES-256-GCM encrypted) under a key derived from a
+//! human-supplied passphrase via a memory-/CPU-hard KDF. The passphrase itself
+//! is never written to disk; only a salt, KDF parameters, and the AEAD-sealed
+//! MEK are persisted. This lets an operator carry a single secret in their head
+//! (or a secrets manager) instead of a raw 256-bit key file.
+//!
+//! # File format (self-describing binary)
+//!
+//! ```text
+//! offset  size  field
+//! 0       4     magic         = b"AEKF"
+//! 4       1     format_version = 1
+//! 5       1     kdf_id         (1 = Argon2id, 2 = PBKDF2-HMAC-SHA256)
+//! 6       16    kdf_params     (fixed 16 bytes, interpreted per kdf_id)
+//! 22      16    salt
+//! 38      12    aes-gcm nonce
+//! 50      32    ciphertext     (AES-256-GCM sealed MEK)
+//! 82      16    aes-gcm tag
+//! total   98 bytes
+//! ```
+//!
+//! `kdf_params` layout:
+//! - Argon2id: `m_cost: u32 | t_cost: u32 | p_cost: u32 | reserved: u32` (BE)
+//! - PBKDF2:   `iterations: u32 | reserved [12 bytes]` (BE)
+//!
+//! # Security
+//!
+//! - The passphrase lives only in a [`Zeroizing`] buffer and is never logged,
+//!   returned in an error string, or exposed via `Debug`.
+//! - The recovered MEK is a [`Zeroizing<[u8; 32]>`], erased on drop.
+//! - A wrong passphrase derives the wrong wrapping key, so the AES-GCM tag check
+//!   fails and [`get_mek`](PassphraseFileKeyProvider::get_mek) returns
+//!   [`KeyProviderError::AccessDenied`] -- it never panics.
+//! - On Unix the generated file is created `0600` before any bytes are written.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use aes_gcm::aead::Aead;
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce as AesNonce};
+use rand::RngCore;
+use zeroize::Zeroizing;
+
+use crate::encryption::KeyProviderError;
+use crate::encryption::key_provider::KeyProvider;
+
+/// Magic bytes identifying a passphrase-wrapped key file.
+const MAGIC: &[u8; 4] = b"AEKF";
+/// Current on-disk format version.
+const FORMAT_VERSION: u8 = 1;
+/// KDF identifier: Argon2id.
+const KDF_ARGON2ID: u8 = 1;
+/// KDF identifier: PBKDF2-HMAC-SHA256.
+const KDF_PBKDF2: u8 = 2;
+
+const KDF_PARAMS_LEN: usize = 16;
+const SALT_LEN: usize = 16;
+const NONCE_LEN: usize = 12;
+const CT_LEN: usize = 32;
+const TAG_LEN: usize = 16;
+
+const OFF_MAGIC: usize = 0;
+const OFF_FORMAT: usize = 4;
+const OFF_KDF_ID: usize = 5;
+const OFF_KDF_PARAMS: usize = 6;
+const OFF_SALT: usize = OFF_KDF_PARAMS + KDF_PARAMS_LEN; // 22
+const OFF_NONCE: usize = OFF_SALT + SALT_LEN; // 38
+const OFF_CT: usize = OFF_NONCE + NONCE_LEN; // 50
+const OFF_TAG: usize = OFF_CT + CT_LEN; // 82
+const FILE_LEN: usize = OFF_TAG + TAG_LEN; // 98
+
+/// Key-derivation function used to derive the wrapping key from a passphrase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PassphraseKdf {
+    /// Argon2id (memory-hard, preferred).
+    Argon2id {
+        /// Memory cost in KiB.
+        m_cost: u32,
+        /// Iteration (time) cost.
+        t_cost: u32,
+        /// Degree of parallelism.
+        p_cost: u32,
+    },
+    /// PBKDF2-HMAC-SHA256 (widely interoperable fallback).
+    Pbkdf2 {
+        /// Iteration count.
+        iterations: u32,
+    },
+}
+
+impl PassphraseKdf {
+    /// Secure defaults for interactive use (OWASP-aligned).
+    #[must_use]
+    pub fn argon2id_default() -> Self {
+        // 19 MiB, 2 passes, 1 lane.
+        Self::Argon2id {
+            m_cost: 19 * 1024,
+            t_cost: 2,
+            p_cost: 1,
+        }
+    }
+
+    /// Secure default for the PBKDF2 fallback.
+    #[must_use]
+    pub fn pbkdf2_default() -> Self {
+        Self::Pbkdf2 {
+            iterations: 600_000,
+        }
+    }
+
+    fn kdf_id(self) -> u8 {
+        match self {
+            Self::Argon2id { .. } => KDF_ARGON2ID,
+            Self::Pbkdf2 { .. } => KDF_PBKDF2,
+        }
+    }
+
+    fn encode_params(self) -> [u8; KDF_PARAMS_LEN] {
+        let mut out = [0u8; KDF_PARAMS_LEN];
+        match self {
+            Self::Argon2id {
+                m_cost,
+                t_cost,
+                p_cost,
+            } => {
+                out[0..4].copy_from_slice(&m_cost.to_be_bytes());
+                out[4..8].copy_from_slice(&t_cost.to_be_bytes());
+                out[8..12].copy_from_slice(&p_cost.to_be_bytes());
+            }
+            Self::Pbkdf2 { iterations } => {
+                out[0..4].copy_from_slice(&iterations.to_be_bytes());
+            }
+        }
+        out
+    }
+
+    fn decode(kdf_id: u8, params: &[u8; KDF_PARAMS_LEN]) -> Result<Self, KeyProviderError> {
+        let u32_at = |i: usize| {
+            let mut b = [0u8; 4];
+            b.copy_from_slice(&params[i..i + 4]);
+            u32::from_be_bytes(b)
+        };
+        match kdf_id {
+            KDF_ARGON2ID => Ok(Self::Argon2id {
+                m_cost: u32_at(0),
+                t_cost: u32_at(4),
+                p_cost: u32_at(8),
+            }),
+            KDF_PBKDF2 => Ok(Self::Pbkdf2 {
+                iterations: u32_at(0),
+            }),
+            other => Err(KeyProviderError::InvalidKeyFormat(format!(
+                "unknown KDF id {other}"
+            ))),
+        }
+    }
+
+    /// Derive a 32-byte wrapping key from the passphrase and salt.
+    fn derive(
+        self,
+        passphrase: &[u8],
+        salt: &[u8],
+    ) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+        let mut key = Zeroizing::new([0u8; 32]);
+        match self {
+            Self::Argon2id {
+                m_cost,
+                t_cost,
+                p_cost,
+            } => {
+                use argon2::{Algorithm, Argon2, Params, Version};
+                let params = Params::new(m_cost, t_cost, p_cost, Some(32)).map_err(|e| {
+                    KeyProviderError::InvalidKeyFormat(format!("invalid Argon2 params: {e}"))
+                })?;
+                let argon = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+                argon
+                    .hash_password_into(passphrase, salt, key.as_mut())
+                    .map_err(|e| {
+                        // The error carries only parameter/length context, never
+                        // the passphrase bytes.
+                        KeyProviderError::Provider(Box::new(std::io::Error::other(format!(
+                            "Argon2 derivation failed: {e}"
+                        ))))
+                    })?;
+            }
+            Self::Pbkdf2 { iterations } => {
+                // pbkdf2 0.12 is built on the digest 0.10 ecosystem; pair it with
+                // the sha2 0.10 copy aliased as `sha2_pbkdf2`.
+                pbkdf2::pbkdf2_hmac::<sha2_pbkdf2::Sha256>(
+                    passphrase,
+                    salt,
+                    iterations,
+                    key.as_mut(),
+                );
+            }
+        }
+        Ok(key)
+    }
+}
+
+/// Reads the MEK from a passphrase-wrapped key file.
+///
+/// The passphrase is supplied at construction and held only in a zeroizing
+/// buffer. `Debug` deliberately omits it.
+pub struct PassphraseFileKeyProvider {
+    path: PathBuf,
+    passphrase: Zeroizing<String>,
+}
+
+impl fmt::Debug for PassphraseFileKeyProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // NEVER expose the passphrase.
+        f.debug_struct("PassphraseFileKeyProvider")
+            .field("path", &self.path)
+            .field("passphrase", &"<redacted>")
+            .finish()
+    }
+}
+
+impl PassphraseFileKeyProvider {
+    /// Create a provider that unwraps the MEK at `path` using `passphrase`.
+    pub fn new(path: impl Into<PathBuf>, passphrase: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            passphrase: Zeroizing::new(passphrase.into()),
+        }
+    }
+
+    fn unwrap_key(&self, raw: &[u8]) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+        if raw.len() != FILE_LEN {
+            return Err(KeyProviderError::InvalidKeyFormat(format!(
+                "expected {FILE_LEN}-byte passphrase key file, got {}",
+                raw.len()
+            )));
+        }
+        if &raw[OFF_MAGIC..OFF_MAGIC + 4] != MAGIC {
+            return Err(KeyProviderError::InvalidKeyFormat(
+                "bad magic (not a passphrase key file)".to_string(),
+            ));
+        }
+        let format_version = raw[OFF_FORMAT];
+        if format_version != FORMAT_VERSION {
+            return Err(KeyProviderError::InvalidKeyFormat(format!(
+                "unsupported format version {format_version}"
+            )));
+        }
+        let kdf_id = raw[OFF_KDF_ID];
+        let mut params = [0u8; KDF_PARAMS_LEN];
+        params.copy_from_slice(&raw[OFF_KDF_PARAMS..OFF_SALT]);
+        let kdf = PassphraseKdf::decode(kdf_id, &params)?;
+
+        let salt = &raw[OFF_SALT..OFF_NONCE];
+        let nonce = &raw[OFF_NONCE..OFF_CT];
+        // ciphertext || tag is what aes-gcm's `decrypt` expects.
+        let sealed = &raw[OFF_CT..FILE_LEN];
+
+        let wrapping = kdf.derive(self.passphrase.as_bytes(), salt)?;
+        let cipher = Aes256Gcm::new_from_slice(wrapping.as_ref()).map_err(|_| {
+            KeyProviderError::InvalidKeyFormat("invalid wrapping key length".to_string())
+        })?;
+        let plaintext = cipher
+            .decrypt(AesNonce::from_slice(nonce), sealed)
+            .map_err(|_| {
+                // A GCM tag mismatch is the expected outcome of a wrong
+                // passphrase or tampered file. Return AccessDenied WITHOUT any
+                // key/passphrase material.
+                KeyProviderError::AccessDenied(
+                    "passphrase key unwrap failed (wrong passphrase or corrupt file)".to_string(),
+                )
+            })?;
+        if plaintext.len() != 32 {
+            return Err(KeyProviderError::InvalidKeyFormat(format!(
+                "unwrapped key is {} bytes, expected 32",
+                plaintext.len()
+            )));
+        }
+        let mut key = Zeroizing::new([0u8; 32]);
+        key.copy_from_slice(&plaintext);
+        Ok(key)
+    }
+}
+
+impl KeyProvider for PassphraseFileKeyProvider {
+    fn get_mek(&self) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+        let raw = std::fs::read(&self.path).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                KeyProviderError::KeyNotFound
+            } else {
+                KeyProviderError::Io(e)
+            }
+        })?;
+        self.unwrap_key(&raw)
+    }
+
+    fn provider_name(&self) -> &str {
+        "passphrase"
+    }
+
+    fn health_check(&self) -> Result<(), KeyProviderError> {
+        self.get_mek().map(|_| ())
+    }
+}
+
+/// Generate a new random MEK, wrap it under `passphrase`, and write a
+/// passphrase key file at `path` using the default Argon2id KDF.
+///
+/// Returns the generated (plaintext) MEK so a caller can immediately use it.
+///
+/// # Security
+///
+/// On Unix the file is created `0600` before any bytes are written. When
+/// `overwrite` is `false` an existing file is never clobbered (`O_EXCL`).
+///
+/// # Errors
+///
+/// Returns [`KeyProviderError`] if key derivation, encryption, or file writing
+/// fails, or (when `overwrite` is `false`) if a file already exists.
+pub fn generate_passphrase_key_file(
+    path: &Path,
+    passphrase: &str,
+    overwrite: bool,
+) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+    generate_passphrase_key_file_with_kdf(
+        path,
+        passphrase,
+        overwrite,
+        PassphraseKdf::argon2id_default(),
+    )
+}
+
+/// Like [`generate_passphrase_key_file`] but with an explicit KDF choice.
+///
+/// Primarily used to select PBKDF2 or fast test parameters.
+///
+/// # Errors
+///
+/// See [`generate_passphrase_key_file`].
+pub fn generate_passphrase_key_file_with_kdf(
+    path: &Path,
+    passphrase: &str,
+    overwrite: bool,
+    kdf: PassphraseKdf,
+) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+    use std::io::Write;
+
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    // Generate MEK, salt, and nonce.
+    let mut mek = Zeroizing::new([0u8; 32]);
+    rand::thread_rng().fill_bytes(mek.as_mut());
+    let mut salt = [0u8; SALT_LEN];
+    rand::thread_rng().fill_bytes(&mut salt);
+    let mut nonce = [0u8; NONCE_LEN];
+    rand::thread_rng().fill_bytes(&mut nonce);
+
+    // Derive wrapping key and seal the MEK.
+    let wrapping = kdf.derive(passphrase.as_bytes(), &salt)?;
+    let cipher = Aes256Gcm::new_from_slice(wrapping.as_ref()).map_err(|_| {
+        KeyProviderError::InvalidKeyFormat("invalid wrapping key length".to_string())
+    })?;
+    let sealed = cipher
+        .encrypt(AesNonce::from_slice(&nonce), &mek[..])
+        .map_err(|e| {
+            KeyProviderError::Provider(Box::new(std::io::Error::other(format!(
+                "key wrap failed: {e}"
+            ))))
+        })?;
+    // sealed = ciphertext(32) || tag(16)
+    if sealed.len() != CT_LEN + TAG_LEN {
+        return Err(KeyProviderError::InvalidKeyFormat(format!(
+            "unexpected sealed length {}",
+            sealed.len()
+        )));
+    }
+
+    // Assemble the file buffer.
+    let mut buf = Zeroizing::new(Vec::with_capacity(FILE_LEN));
+    buf.extend_from_slice(MAGIC);
+    buf.push(FORMAT_VERSION);
+    buf.push(kdf.kdf_id());
+    buf.extend_from_slice(&kdf.encode_params());
+    buf.extend_from_slice(&salt);
+    buf.extend_from_slice(&nonce);
+    buf.extend_from_slice(&sealed);
+    debug_assert_eq!(buf.len(), FILE_LEN);
+
+    // Create the file 0600 at creation time; O_EXCL unless overwriting.
+    if overwrite {
+        match std::fs::remove_file(path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let mut f = opts.open(path)?;
+    f.write_all(&buf)?;
+    f.flush()?;
+
+    Ok(mek)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fast_argon() -> PassphraseKdf {
+        // Tiny cost so tests are fast; still exercises the Argon2id code path.
+        PassphraseKdf::Argon2id {
+            m_cost: 8,
+            t_cost: 1,
+            p_cost: 1,
+        }
+    }
+
+    fn fast_pbkdf2() -> PassphraseKdf {
+        PassphraseKdf::Pbkdf2 { iterations: 1000 }
+    }
+
+    #[test]
+    fn round_trip_argon2id() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("argon.aekf");
+
+        let generated = generate_passphrase_key_file_with_kdf(
+            &path,
+            "correct horse battery",
+            true,
+            fast_argon(),
+        )
+        .unwrap();
+
+        let provider = PassphraseFileKeyProvider::new(&path, "correct horse battery");
+        let loaded = provider.get_mek().unwrap();
+        assert_eq!(generated.as_ref(), loaded.as_ref());
+        assert!(provider.health_check().is_ok());
+        assert_eq!(provider.provider_name(), "passphrase");
+    }
+
+    #[test]
+    fn round_trip_pbkdf2() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pbkdf2.aekf");
+
+        let generated =
+            generate_passphrase_key_file_with_kdf(&path, "hunter2-is-bad", true, fast_pbkdf2())
+                .unwrap();
+
+        let provider = PassphraseFileKeyProvider::new(&path, "hunter2-is-bad");
+        let loaded = provider.get_mek().unwrap();
+        assert_eq!(generated.as_ref(), loaded.as_ref());
+    }
+
+    #[test]
+    fn wrong_passphrase_is_access_denied_not_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wrong.aekf");
+        generate_passphrase_key_file_with_kdf(&path, "the-right-one", true, fast_argon()).unwrap();
+
+        let provider = PassphraseFileKeyProvider::new(&path, "the-WRONG-one");
+        let err = provider.get_mek().unwrap_err();
+        assert!(
+            matches!(err, KeyProviderError::AccessDenied(_)),
+            "expected AccessDenied, got: {err}"
+        );
+        // The error text must not leak the passphrase.
+        let text = err.to_string();
+        assert!(!text.contains("the-WRONG-one"));
+        assert!(!text.contains("the-right-one"));
+    }
+
+    #[test]
+    fn truncated_file_is_invalid_format() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("trunc.aekf");
+        std::fs::write(&path, b"AEKF short").unwrap();
+
+        let provider = PassphraseFileKeyProvider::new(&path, "whatever");
+        let err = provider.get_mek().unwrap_err();
+        assert!(
+            matches!(err, KeyProviderError::InvalidKeyFormat(_)),
+            "expected InvalidKeyFormat, got: {err}"
+        );
+    }
+
+    #[test]
+    fn garbage_full_length_file_is_invalid_or_denied() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("garbage.aekf");
+        // Right length, wrong magic.
+        std::fs::write(&path, vec![0xABu8; FILE_LEN]).unwrap();
+
+        let provider = PassphraseFileKeyProvider::new(&path, "whatever");
+        let err = provider.get_mek().unwrap_err();
+        assert!(
+            matches!(err, KeyProviderError::InvalidKeyFormat(_)),
+            "expected InvalidKeyFormat for bad magic, got: {err}"
+        );
+    }
+
+    #[test]
+    fn missing_file_is_key_not_found() {
+        let provider = PassphraseFileKeyProvider::new("/nonexistent/pp.aekf", "x");
+        let err = provider.get_mek().unwrap_err();
+        assert!(matches!(err, KeyProviderError::KeyNotFound), "got: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn generated_file_is_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("perm.aekf");
+        generate_passphrase_key_file_with_kdf(&path, "pw", true, fast_argon()).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "got {mode:o}");
+    }
+
+    #[test]
+    fn no_overwrite_refuses_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("exists.aekf");
+        std::fs::write(&path, b"pre-existing").unwrap();
+        let err =
+            generate_passphrase_key_file_with_kdf(&path, "pw", false, fast_argon()).unwrap_err();
+        assert!(matches!(err, KeyProviderError::Io(_)), "got: {err}");
+        assert_eq!(std::fs::read(&path).unwrap(), b"pre-existing");
+    }
+
+    #[test]
+    fn debug_does_not_leak_passphrase() {
+        let provider = PassphraseFileKeyProvider::new("/tmp/k.aekf", "super-secret-phrase");
+        let dbg = format!("{provider:?}");
+        assert!(
+            !dbg.contains("super-secret-phrase"),
+            "debug leaked passphrase: {dbg}"
+        );
+        assert!(dbg.contains("redacted"));
+    }
+
+    #[test]
+    fn get_key_version_returns_sole_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("v.aekf");
+        let generated =
+            generate_passphrase_key_file_with_kdf(&path, "pw", true, fast_argon()).unwrap();
+        let provider = PassphraseFileKeyProvider::new(&path, "pw");
+        // Single-version provider: any version -> the sole key.
+        let v = provider.get_key_version(99).unwrap();
+        assert_eq!(v.as_ref(), generated.as_ref());
+    }
+}

--- a/src/encryption/vault_provider.rs
+++ b/src/encryption/vault_provider.rs
@@ -1,0 +1,448 @@
+//! HashiCorp Vault key provider (Issue #3587), gated behind `encryption-vault`.
+//!
+//! Reads the Master Encryption Key (MEK) from a Vault **KV v2** secret. Because
+//! the [`KeyProvider`] trait is synchronous, this provider uses
+//! `reqwest::blocking` -- no async runtime bridge is required.
+//!
+//! # Model
+//!
+//! `get_mek()` issues `GET {address}/v1/{mount}/data/{path}` with an
+//! `X-Vault-Token` header, parses the JSON body, and reads
+//! `data.data.<key_field>`. The value may be either 64 hex characters or a
+//! base64-encoded 32-byte key.
+//!
+//! # Security
+//!
+//! The Vault token is a bearer secret: it is held in a zeroizing wrapper, is
+//! redacted by `Debug`, and is **never** placed in any error `Display`/`Debug`
+//! output.
+
+use std::fmt;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use zeroize::Zeroizing;
+
+use crate::encryption::KeyProviderError;
+use crate::encryption::key_provider::KeyProvider;
+
+/// Default KV mount point.
+pub const DEFAULT_MOUNT: &str = "secret";
+/// Default field within the secret holding the key material.
+pub const DEFAULT_KEY_FIELD: &str = "key";
+/// The single logical key version this provider exposes.
+const CURRENT_VERSION: u32 = 1;
+
+/// A Vault bearer token that never appears in logs or `Debug` output.
+struct SecretToken(Zeroizing<String>);
+
+impl fmt::Debug for SecretToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<redacted>")
+    }
+}
+
+/// Configuration for the Vault key provider.
+#[derive(Clone)]
+pub struct VaultConfig {
+    /// Base address, e.g. `https://vault.example.com:8200`.
+    pub address: String,
+    /// Vault token (bearer credential).
+    pub token: String,
+    /// KV v2 mount point (default `secret`).
+    pub mount: String,
+    /// Secret path under the mount.
+    pub path: String,
+    /// Field within the secret data holding the key (default `key`).
+    pub key_field: String,
+    /// Optional Vault namespace (Enterprise).
+    pub namespace: Option<String>,
+    /// Optional path to a PEM CA certificate for TLS verification.
+    pub ca_cert: Option<PathBuf>,
+}
+
+impl fmt::Debug for VaultConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Redact the token; everything else is non-secret configuration.
+        f.debug_struct("VaultConfig")
+            .field("address", &self.address)
+            .field("token", &"<redacted>")
+            .field("mount", &self.mount)
+            .field("path", &self.path)
+            .field("key_field", &self.key_field)
+            .field("namespace", &self.namespace)
+            .field("ca_cert", &self.ca_cert)
+            .finish()
+    }
+}
+
+impl VaultConfig {
+    /// Create a config with default mount/key_field and no namespace/CA.
+    pub fn new(
+        address: impl Into<String>,
+        token: impl Into<String>,
+        path: impl Into<String>,
+    ) -> Self {
+        Self {
+            address: address.into(),
+            token: token.into(),
+            mount: DEFAULT_MOUNT.to_string(),
+            path: path.into(),
+            key_field: DEFAULT_KEY_FIELD.to_string(),
+            namespace: None,
+            ca_cert: None,
+        }
+    }
+}
+
+/// Reads the MEK from a Vault KV v2 secret over HTTPS/HTTP.
+pub struct VaultKeyProvider {
+    client: reqwest::blocking::Client,
+    address: String,
+    token: SecretToken,
+    mount: String,
+    path: String,
+    key_field: String,
+    namespace: Option<String>,
+}
+
+impl fmt::Debug for VaultKeyProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // NEVER expose the token.
+        f.debug_struct("VaultKeyProvider")
+            .field("address", &self.address)
+            .field("token", &"<redacted>")
+            .field("mount", &self.mount)
+            .field("path", &self.path)
+            .field("key_field", &self.key_field)
+            .field("namespace", &self.namespace)
+            .finish()
+    }
+}
+
+impl VaultKeyProvider {
+    /// Build a Vault key provider from config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KeyProviderError::Unavailable`] if the HTTP client (including
+    /// optional custom CA loading) cannot be constructed.
+    pub fn new(config: &VaultConfig) -> Result<Self, KeyProviderError> {
+        let mut builder = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .connect_timeout(Duration::from_secs(5));
+
+        if let Some(ca_path) = &config.ca_cert {
+            let pem = std::fs::read(ca_path).map_err(|e| {
+                KeyProviderError::Unavailable(format!("failed to read Vault CA cert: {e}"))
+            })?;
+            let cert = reqwest::Certificate::from_pem(&pem).map_err(|e| {
+                KeyProviderError::Unavailable(format!("invalid Vault CA cert: {e}"))
+            })?;
+            builder = builder.add_root_certificate(cert);
+        }
+
+        let client = builder.build().map_err(|e| {
+            KeyProviderError::Unavailable(format!("failed to build Vault HTTP client: {e}"))
+        })?;
+
+        let mount = if config.mount.is_empty() {
+            DEFAULT_MOUNT.to_string()
+        } else {
+            config.mount.clone()
+        };
+        let key_field = if config.key_field.is_empty() {
+            DEFAULT_KEY_FIELD.to_string()
+        } else {
+            config.key_field.clone()
+        };
+
+        Ok(Self {
+            client,
+            address: config.address.trim_end_matches('/').to_string(),
+            token: SecretToken(Zeroizing::new(config.token.clone())),
+            mount,
+            path: config.path.clone(),
+            key_field,
+            namespace: config.namespace.clone(),
+        })
+    }
+
+    fn secret_url(&self) -> String {
+        format!("{}/v1/{}/data/{}", self.address, self.mount, self.path)
+    }
+
+    fn fetch(&self) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+        let mut req = self
+            .client
+            .get(self.secret_url())
+            .header("X-Vault-Token", self.token.0.as_str());
+        if let Some(ns) = &self.namespace {
+            req = req.header("X-Vault-Namespace", ns);
+        }
+
+        let resp = req.send().map_err(|e| {
+            // Transport-level failure (connection refused, TLS, timeout). The
+            // reqwest error may embed the URL but never the token header.
+            if e.is_timeout() {
+                KeyProviderError::Unavailable("Vault request timed out".to_string())
+            } else {
+                KeyProviderError::Unavailable("Vault transport failure".to_string())
+            }
+        })?;
+
+        let status = resp.status();
+        if status == reqwest::StatusCode::FORBIDDEN {
+            return Err(KeyProviderError::AccessDenied(
+                "Vault denied access (403)".to_string(),
+            ));
+        }
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(KeyProviderError::KeyNotFound);
+        }
+        if !status.is_success() {
+            return Err(KeyProviderError::Unavailable(format!(
+                "Vault returned HTTP {}",
+                status.as_u16()
+            )));
+        }
+
+        let body: serde_json::Value = resp.json().map_err(|_| {
+            KeyProviderError::InvalidKeyFormat("Vault response was not valid JSON".to_string())
+        })?;
+
+        // KV v2 shape: { "data": { "data": { "<key_field>": "..." } } }
+        let value = body
+            .get("data")
+            .and_then(|d| d.get("data"))
+            .and_then(|d| d.get(&self.key_field))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| KeyProviderError::KeyNotFound)?;
+
+        decode_key_material(value)
+    }
+}
+
+/// Decode a Vault-stored key value: 64 hex chars, or base64 of 32 bytes.
+fn decode_key_material(value: &str) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+    let trimmed = value.trim();
+
+    // Hex first (64 chars).
+    if trimmed.len() == 64
+        && let Some(decoded) = crate::core::hex::decode(trimmed)
+        && decoded.len() == 32
+    {
+        let mut key = Zeroizing::new([0u8; 32]);
+        key.copy_from_slice(&decoded);
+        return Ok(key);
+    }
+
+    // Base64 of exactly 32 bytes.
+    if let Ok(decoded) = BASE64.decode(trimmed.as_bytes())
+        && decoded.len() == 32
+    {
+        let mut key = Zeroizing::new([0u8; 32]);
+        key.copy_from_slice(&decoded);
+        return Ok(key);
+    }
+
+    Err(KeyProviderError::InvalidKeyFormat(
+        "Vault key field is neither 64 hex chars nor base64 of 32 bytes".to_string(),
+    ))
+}
+
+impl KeyProvider for VaultKeyProvider {
+    fn get_mek(&self) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+        self.fetch()
+    }
+
+    fn get_key_version(&self, version: u32) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+        // v1 reads the current secret version only; explicit KV-v2 version
+        // selection is a follow-up. Unknown versions are a typed KeyNotFound.
+        if version == CURRENT_VERSION || version == 0 {
+            self.get_mek()
+        } else {
+            Err(KeyProviderError::KeyNotFound)
+        }
+    }
+
+    fn provider_name(&self) -> &str {
+        "vault"
+    }
+
+    fn health_check(&self) -> Result<(), KeyProviderError> {
+        self.get_mek().map(|_| ())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    const TEST_TOKEN: &str = "s.SUPERSECRETVAULTTOKEN123";
+
+    static PORT_HINT: AtomicU64 = AtomicU64::new(0);
+
+    /// Spawn a one-shot HTTP server that returns `response` (raw HTTP/1.1) for a
+    /// single request, then closes. Returns the bound `127.0.0.1:PORT` address.
+    fn spawn_once(response: &'static str) -> String {
+        let _ = PORT_HINT.fetch_add(1, Ordering::Relaxed);
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 2048];
+                let _ = stream.read(&mut buf);
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.flush();
+            }
+        });
+        format!("http://127.0.0.1:{}", addr.port())
+    }
+
+    fn hex_body(hex: &str) -> String {
+        let json = format!("{{\"data\":{{\"data\":{{\"key\":\"{hex}\"}},\"metadata\":{{}}}}}}");
+        format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            json.len(),
+            json
+        )
+    }
+
+    #[test]
+    fn get_mek_recovers_hex_key() {
+        // 64 hex chars = 32 bytes of 0xAB.
+        let hex = "ab".repeat(32);
+        let response: &'static str = Box::leak(hex_body(&hex).into_boxed_str());
+        let addr = spawn_once(response);
+
+        let cfg = VaultConfig::new(addr, TEST_TOKEN, "myapp/mek");
+        let provider = VaultKeyProvider::new(&cfg).unwrap();
+        let mek = provider.get_mek().unwrap();
+        assert_eq!(mek.as_ref(), &[0xABu8; 32]);
+        assert_eq!(provider.provider_name(), "vault");
+    }
+
+    #[test]
+    fn get_mek_recovers_base64_key() {
+        let raw = [0x11u8; 32];
+        let b64 = BASE64.encode(raw);
+        let json = format!("{{\"data\":{{\"data\":{{\"key\":\"{b64}\"}}}}}}");
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            json.len(),
+            json
+        );
+        let response: &'static str = Box::leak(response.into_boxed_str());
+        let addr = spawn_once(response);
+
+        let cfg = VaultConfig::new(addr, TEST_TOKEN, "myapp/mek");
+        let provider = VaultKeyProvider::new(&cfg).unwrap();
+        let mek = provider.get_mek().unwrap();
+        assert_eq!(mek.as_ref(), &raw);
+    }
+
+    #[test]
+    fn forbidden_is_access_denied() {
+        let response = "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+        let addr = spawn_once(response);
+        let cfg = VaultConfig::new(addr, TEST_TOKEN, "myapp/mek");
+        let provider = VaultKeyProvider::new(&cfg).unwrap();
+        let err = provider.get_mek().unwrap_err();
+        assert!(
+            matches!(err, KeyProviderError::AccessDenied(_)),
+            "expected AccessDenied, got: {err}"
+        );
+        // Token must not leak in the error.
+        assert!(!err.to_string().contains(TEST_TOKEN));
+    }
+
+    #[test]
+    fn missing_field_is_typed_error() {
+        let json = "{\"data\":{\"data\":{\"other\":\"value\"}}}";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            json.len(),
+            json
+        );
+        let response: &'static str = Box::leak(response.into_boxed_str());
+        let addr = spawn_once(response);
+        let cfg = VaultConfig::new(addr, TEST_TOKEN, "myapp/mek");
+        let provider = VaultKeyProvider::new(&cfg).unwrap();
+        let err = provider.get_mek().unwrap_err();
+        assert!(
+            matches!(err, KeyProviderError::KeyNotFound),
+            "expected KeyNotFound for missing field, got: {err}"
+        );
+    }
+
+    #[test]
+    fn connection_refused_is_unavailable() {
+        // Nothing listening on this port -> connection refused, fast.
+        let cfg = VaultConfig::new("http://127.0.0.1:1", TEST_TOKEN, "myapp/mek");
+        let provider = VaultKeyProvider::new(&cfg).unwrap();
+        let err = provider.get_mek().unwrap_err();
+        assert!(
+            matches!(err, KeyProviderError::Unavailable(_)),
+            "expected Unavailable, got: {err}"
+        );
+        assert!(!err.to_string().contains(TEST_TOKEN));
+    }
+
+    #[test]
+    fn not_found_status_is_key_not_found() {
+        let response = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+        let addr = spawn_once(response);
+        let cfg = VaultConfig::new(addr, TEST_TOKEN, "myapp/mek");
+        let provider = VaultKeyProvider::new(&cfg).unwrap();
+        let err = provider.get_mek().unwrap_err();
+        assert!(matches!(err, KeyProviderError::KeyNotFound), "got: {err}");
+    }
+
+    #[test]
+    fn debug_does_not_leak_token() {
+        let cfg = VaultConfig::new("https://vault.example.com", TEST_TOKEN, "myapp/mek");
+        let provider = VaultKeyProvider::new(&cfg).unwrap();
+        let dbg = format!("{provider:?}");
+        assert!(
+            !dbg.contains(TEST_TOKEN),
+            "provider Debug leaked token: {dbg}"
+        );
+        assert!(dbg.contains("redacted"));
+
+        let cfg_dbg = format!("{cfg:?}");
+        assert!(
+            !cfg_dbg.contains(TEST_TOKEN),
+            "config Debug leaked token: {cfg_dbg}"
+        );
+        assert!(cfg_dbg.contains("redacted"));
+    }
+
+    #[test]
+    fn get_key_version_unknown_is_key_not_found() {
+        let cfg = VaultConfig::new("http://127.0.0.1:1", TEST_TOKEN, "myapp/mek");
+        let provider = VaultKeyProvider::new(&cfg).unwrap();
+        let err = provider.get_key_version(7).unwrap_err();
+        assert!(matches!(err, KeyProviderError::KeyNotFound), "got: {err}");
+    }
+
+    #[test]
+    fn decode_key_material_variants() {
+        // hex
+        let hex = "cd".repeat(32);
+        assert_eq!(decode_key_material(&hex).unwrap().as_ref(), &[0xCDu8; 32]);
+        // base64
+        let b64 = BASE64.encode([0x22u8; 32]);
+        assert_eq!(decode_key_material(&b64).unwrap().as_ref(), &[0x22u8; 32]);
+        // garbage
+        assert!(matches!(
+            decode_key_material("nope").unwrap_err(),
+            KeyProviderError::InvalidKeyFormat(_)
+        ));
+    }
+}


### PR DESCRIPTION
## Before

Encryption-at-rest could source its Master Encryption Key (MEK) from only two places: a key **file** on disk or an **environment variable**. There was no way to keep the MEK in a managed secrets backend (AWS KMS, HashiCorp Vault) or to protect an on-disk key with a human passphrase, and the `KeyProvider` trait had no concept of a key *version*.

## After

Three new MEK sources, plus a versioned-key trait method, all constructed through one central dispatch:

- **Passphrase-wrapped key files** (always compiled): the MEK is AES-256-GCM–sealed under a key derived from a passphrase via Argon2id (default) or PBKDF2. A self-describing `AEKF` file stores only the salt, KDF params, and sealed key — never the passphrase. Wrong passphrase → `AccessDenied` (never a panic).
- **AWS KMS** (`encryption-aws-kms`): envelope model — the config carries a KMS key id and a base64 KMS-wrapped data key; the provider calls KMS `Decrypt` to recover the 32-byte MEK.
- **HashiCorp Vault** (`encryption-vault`): reads the MEK from a KV v2 secret over blocking `reqwest` (hex or base64 material).
- **`KeyProvider::get_key_version(version)`**: single-version providers (file/env/passphrase) resolve any version to their sole key; KMS/Vault reject unknown versions with a typed `KeyNotFound`.
- **CLI**: `aletheia keys generate --passphrase` wraps the MEK under `ALETHEIADB_KEY_PASSPHRASE` (never taken from argv, never echoed).

## How

`KeyProviderConfig` gains `PassphraseFile` / `Kms` / `Vault` variants. Two methods centralize the wiring: `build_provider()` constructs the concrete backend (reading passphrase/token secrets from the environment at call time, returning `Unavailable` when a feature-gated backend isn't compiled in) and `describe()` returns a non-secret `(type, detail)` status pair. The encryption **manager**, the CLI **status** command, and the index-key **rotation** engine (`src/db/rotation.rs`) all dispatch through these instead of hand-matching `File`/`Env`. Rotation *to* a passphrase/KMS/Vault source is refused fail-closed (the crash-resume breadcrumb can't round-trip those secrets yet — a documented follow-up).

New crates: `argon2` + `pbkdf2` (+ a `sha2` 0.10 alias for pbkdf2's digest generation), non-optional since the passphrase module compiles with the always-present encryption module. `encryption-aws-kms` now pulls `aws-sdk-kms` (behavior-version-latest) + `base64`; `encryption-vault` pulls blocking `reqwest` + `native-tls` + `base64`.

**Security invariants:** all key/token/passphrase material lives in `Zeroizing`, is redacted by `Debug`, and never appears in logs, spans, error strings, or unencrypted on disk. No `.unwrap()`/`.expect()` on any network or crypto path. The AEIX-header plaintext-bypass guard test still passes.

## Acceptance criteria (#3587)

| AC | Evidence |
|----|----------|
| Passphrase-wrapped key provider | `PassphraseFileKeyProvider` (`src/encryption/passphrase.rs`); `round_trip_argon2id`, `round_trip_pbkdf2`, `wrong_passphrase_is_access_denied_not_panic`, `generated_file_is_0600` pass |
| AWS KMS key provider | `KmsKeyProvider` (`src/encryption/kms_provider.rs`); `new_succeeds_with_valid_config`, `unreachable_endpoint_returns_typed_error_not_panic`, `plaintext_to_key_*` pass under `encryption-aws-kms` |
| HashiCorp Vault key provider | `VaultKeyProvider` (`src/encryption/vault_provider.rs`); `get_mek_recovers_hex_key`, `get_mek_recovers_base64_key`, `forbidden_is_access_denied`, `not_found_status_is_key_not_found` pass under `encryption-vault` |
| Versioned key retrieval | `KeyProvider::get_key_version` default + KMS/Vault overrides; `*_get_key_version_returns_sole_key`, `get_key_version_unknown_is_key_not_found` pass |
| Central config dispatch | `KeyProviderConfig::build_provider` / `describe`; manager + CLI + rotation route through them |
| CLI passphrase generation | `aletheia keys generate --passphrase` via `generate_passphrase_key_with_overwrite` |
| No secret leakage | `debug_does_not_leak_passphrase`, `debug_does_not_leak_token`, `debug_does_not_leak_blob` pass; all material in `Zeroizing` |
| Feature isolation | all 18 `check-features` standalone checks compile (incl. `encryption`, `encryption-vault`, `encryption-aws-kms`) |

### Gates
- `cargo fmt --all` — clean
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — green except one pre-existing uid-0 sandbox artifact (`havoc_flush_deadlock::test_flush_deadlock_on_io_error`, which asserts an I/O error that root bypasses; unrelated to this change)
- `cargo test --features encryption-vault` / `--features encryption-aws-kms` — encryption suites green
- `check-features` equivalent — all 18 configs exit 0

### Coverage boundary
KMS decrypt is exercised only against an unreachable endpoint (typed-error / no-panic / no-hang path) — there is no mocked KMS `Decrypt` success in-tree, so the live envelope-decrypt round trip is not asserted. Durable rotation to remote (KMS/Vault/passphrase) key sources is refused fail-closed and left as a follow-up.

Refs #3587

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfZqK5Hqerd1DoKmxzamd5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfZqK5Hqerd1DoKmxzamd5)_