### PR TITLE
Provenance accessors in RETURN / ORDER BY projection (#3354)

### DIFF
--- a/src/cypher/converter.rs
+++ b/src/cypher/converter.rs
@@ -47,8 +47,8 @@ use crate::query::converter::{
 };
 use crate::query::ir::{
     AggregateArg, AggregateFunc, AggregateGroupKey, AggregateSpec, Predicate, PredicateValue,
-    ProvenanceCmp, ProvenanceField, ProvenanceOperand, ProvenancePredicate, QueryOp,
-    ScoreComparison, ScoreThreshold, SortKey, TraversalDepth,
+    ProvenanceCmp, ProvenanceField, ProvenanceOperand, ProvenancePredicate, ProvenanceProjection,
+    ProvenanceProjectionItem, QueryOp, ScoreComparison, ScoreThreshold, SortKey, TraversalDepth,
 };
 use crate::query::plan::{QueryHints, TemporalContext};
 
@@ -425,7 +425,9 @@ impl CypherConverter {
                 //    yields (computed column rows), so RETURN DISTINCT and the
                 //    ORDER BY / vector-rank projection are only applied on the
                 //    non-aggregate path.
-                if let Some(aggregate_op) = self.build_aggregate(&return_clause)? {
+                let aggregate_op = self.build_aggregate(&return_clause)?;
+                let aggregated = aggregate_op.is_some();
+                if let Some(aggregate_op) = aggregate_op {
                     ops.push(aggregate_op);
                     // ORDER BY over aggregate output: sort by the output column
                     // name / aggregate alias (RETURN DISTINCT is subsumed by
@@ -469,6 +471,13 @@ impl CypherConverter {
                     // If we already emitted a RankBySimilarity (which includes top_k),
                     // still emit the Limit for the general pipeline.
                     ops.push(QueryOp::Limit(limit));
+                }
+
+                // Provenance accessor projection (Issue #3354) runs LAST so it
+                // never perturbs ordering/pagination. Only on the non-aggregate
+                // path: aggregation produces its own computed columns.
+                if !aggregated && let Some(op) = self.build_provenance_projection(&return_clause)? {
+                    ops.push(op);
                 }
 
                 Ok(Query {
@@ -1651,11 +1660,17 @@ impl CypherConverter {
     /// # Errors
     ///
     /// Returns [`CypherError::UnsupportedFeature`] if the expression is not a
-    /// property access or variable reference.
+    /// property access, variable reference, or provenance accessor.
     fn convert_order_item_to_sort_key(
         &self,
         item: &CypherOrderItem,
     ) -> Result<SortKey, CypherError> {
+        // ORDER BY a provenance accessor (Issue #3354): resolved per row from
+        // the row entity's write-time provenance. `as_provenance_accessor`
+        // returns `Err` for a malformed accessor argument (never silent).
+        if let Some(field) = self.as_provenance_accessor(&item.expr)? {
+            return Ok(SortKey::Provenance(field));
+        }
         match &item.expr {
             CypherExpr::Property { property, .. } => Ok(SortKey::Property(property.clone())),
             CypherExpr::Variable(name) => Ok(SortKey::Property(name.clone())),
@@ -1663,6 +1678,64 @@ impl CypherConverter {
                 "unsupported expression in ORDER BY clause: {:?}",
                 item.expr
             ))),
+        }
+    }
+
+    /// Detect provenance accessors in a `RETURN` clause and build a
+    /// [`QueryOp::ProjectProvenance`] op (Issue #3354), or `None` when the
+    /// clause projects none. A provenance-named accessor with a malformed
+    /// argument is a structured error (never silently dropped), reusing the same
+    /// [`as_provenance_accessor`](Self::as_provenance_accessor) recognition the
+    /// `WHERE` half uses.
+    fn build_provenance_projection(
+        &self,
+        return_clause: &CypherReturn,
+    ) -> Result<Option<QueryOp>, CypherError> {
+        let mut items = Vec::new();
+        let mut entity_binding: Option<String> = None;
+        for item in &return_clause.items {
+            let (expr, alias) = match item {
+                CypherReturnItem::Expression { expr, alias } => (expr, alias.clone()),
+                // A bare `RETURN n` variable item -- preserve it as the entity
+                // binding so it stays observable alongside projected columns.
+                CypherReturnItem::Variable(name) => {
+                    if entity_binding.is_none() {
+                        entity_binding = Some(name.clone());
+                    }
+                    continue;
+                }
+                CypherReturnItem::Star => continue,
+            };
+            match expr {
+                // The parser emits a bare variable as an `Expression` item.
+                CypherExpr::Variable(name) => {
+                    if entity_binding.is_none() {
+                        entity_binding = Some(name.clone());
+                    }
+                }
+                CypherExpr::FunctionCall { args, .. } => {
+                    if let Some(field) = self.as_provenance_accessor(expr)? {
+                        // `as_provenance_accessor` guarantees exactly one bound
+                        // variable argument.
+                        let var = match args.as_slice() {
+                            [CypherExpr::Variable(v)] => v.clone(),
+                            _ => String::new(),
+                        };
+                        let output_name =
+                            alias.unwrap_or_else(|| format!("{}({})", field.accessor_name(), var));
+                        items.push(ProvenanceProjectionItem { output_name, field });
+                    }
+                }
+                _ => {}
+            }
+        }
+        if items.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(QueryOp::ProjectProvenance(ProvenanceProjection {
+                entity_binding,
+                items,
+            })))
         }
     }
 

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -183,7 +183,8 @@ use super::ast::{
 use super::builder::Query;
 use super::ir::{
     Predicate, PredicateValue, ProvenanceCmp, ProvenanceField, ProvenanceOperand,
-    ProvenancePredicate, QueryOp, SortKey, TraversalDepth,
+    ProvenancePredicate, ProvenanceProjection, ProvenanceProjectionItem, QueryOp, SortKey,
+    TraversalDepth,
 };
 use super::plan::{QueryHints, TemporalContext};
 
@@ -611,11 +612,73 @@ impl AstConverter {
         // 7. Convert SKIP and LIMIT
         self.convert_pagination(ast.skip, ast.limit, &mut ops);
 
+        // 8. Provenance accessor projection (Issue #3354). Emitted LAST so it
+        //    never perturbs entity-based ordering or pagination; it attaches the
+        //    projected provenance columns (and preserves a bare entity via the
+        //    bindings channel) as the final 1:1 step.
+        if let Some(ref return_clause) = ast.return_clause
+            && let Some(op) = self.build_provenance_projection(return_clause)?
+        {
+            ops.push(op);
+        }
+
         Ok(Query {
             ops,
             temporal_context,
             hints,
         })
+    }
+
+    /// Detect provenance accessors (`source(x)`/`confidence(x)`/`reason(x)`) in
+    /// a `RETURN` clause and build a [`QueryOp::ProjectProvenance`] op
+    /// (Issue #3354), or `None` when the clause projects none. A
+    /// provenance-named accessor with a malformed argument is a structured error
+    /// (never silently dropped), mirroring the `WHERE`-clause accessor
+    /// recognition.
+    fn build_provenance_projection(&self, return_clause: &ReturnClause) -> Result<Option<QueryOp>> {
+        let mut items = Vec::new();
+        let mut entity_binding: Option<String> = None;
+        for item in &return_clause.items {
+            match &item.expression {
+                // A bare variable returned alongside the accessors is preserved
+                // through the bindings channel so it stays observable.
+                Expression::Identifier(name) => {
+                    if entity_binding.is_none() {
+                        entity_binding = Some(name.clone());
+                    }
+                }
+                Expression::FunctionCall { name, args } => {
+                    if let Some(field) = provenance_field_name(name) {
+                        let var = match args.as_slice() {
+                            [Expression::Identifier(v)] => v.clone(),
+                            _ => {
+                                return Err(Error::Query(QueryError::SyntaxError {
+                                    message: format!(
+                                        "{}(x) provenance accessor requires exactly one bound \
+                                         variable argument",
+                                        field.accessor_name()
+                                    ),
+                                }));
+                            }
+                        };
+                        let output_name = item
+                            .alias
+                            .clone()
+                            .unwrap_or_else(|| format!("{}({})", field.accessor_name(), var));
+                        items.push(ProvenanceProjectionItem { output_name, field });
+                    }
+                }
+                _ => {}
+            }
+        }
+        if items.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(QueryOp::ProjectProvenance(ProvenanceProjection {
+                entity_binding,
+                items,
+            })))
+        }
     }
 
     fn convert_where_clause(
@@ -1257,6 +1320,31 @@ impl AstConverter {
                         "score" => SortKey::Score,
                         "timestamp" => SortKey::Timestamp,
                         _ => SortKey::Property(name.clone()),
+                    }
+                }
+                // ORDER BY a provenance accessor (Issue #3354): the value is
+                // resolved per row from the row entity's write-time provenance.
+                Expression::FunctionCall { name, args }
+                    if provenance_field_name(name).is_some() =>
+                {
+                    // `provenance_field_name` just matched, so this is safe; the
+                    // arm guard guarantees `Some`.
+                    let field = provenance_field_name(name).ok_or_else(|| {
+                        Error::Query(QueryError::SyntaxError {
+                            message: "unrecognized provenance accessor in ORDER BY".to_string(),
+                        })
+                    })?;
+                    match args.as_slice() {
+                        [Expression::Identifier(_)] => SortKey::Provenance(field),
+                        _ => {
+                            return Err(Error::Query(QueryError::SyntaxError {
+                                message: format!(
+                                    "{}(x) provenance accessor requires exactly one bound \
+                                     variable argument",
+                                    field.accessor_name()
+                                ),
+                            }));
+                        }
                     }
                 }
                 _ => {

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -20,7 +20,8 @@ use crate::core::vector::DistanceMetric as VectorMetric;
 use crate::core::{NodeId, Timestamp};
 use crate::query::ir::{
     AggregateArg, AggregateFunc, AggregateGroupKey, AggregateSpec, Direction, Predicate,
-    PredicateValue, ProvenancePredicate, ScoreThreshold, SortKey,
+    PredicateValue, ProvenanceField, ProvenancePredicate, ProvenanceProjection, ScoreThreshold,
+    SortKey,
 };
 use crate::storage::current::CurrentStorage;
 use crate::storage::historical::HistoricalStorage;
@@ -3165,6 +3166,52 @@ impl ResultIterator for DistinctIterator {
     }
 }
 
+/// Resolve the write-time provenance bundle recorded on the version a row's
+/// entity represents (node or edge), at the query's bi-temporal coordinate
+/// (Issue #3354).
+///
+/// The entity's `current_version` already reflects an `AS OF` reconstruction
+/// (mirroring [`FilterIterator::resolve_node_provenance`]), so provenance is
+/// read as recorded at that coordinate. Returns `None` for an unattributed
+/// version, a non-entity row, or a lookup error.
+fn resolve_entity_provenance(
+    entity: &EntityResult,
+    historical: &Arc<RwLock<HistoricalStorage>>,
+) -> Option<Provenance> {
+    match entity {
+        EntityResult::Node(n) => historical
+            .read()
+            .get_node_version_provenance(n.current_version)
+            .ok()
+            .flatten(),
+        EntityResult::Edge(e) => historical
+            .read()
+            .get_edge_version_provenance(e.current_version)
+            .ok()
+            .flatten(),
+        _ => None,
+    }
+}
+
+/// Map a provenance field to its projected [`PropertyValue`] (Issue #3354).
+///
+/// An absent bundle, or a bundle missing the requested field, projects
+/// [`PropertyValue::Null`] -- distinguishing "no value" from any real value,
+/// exactly as the `WHERE` accessor semantics treat a missing field.
+fn provenance_field_value(prov: Option<&Provenance>, field: ProvenanceField) -> PropertyValue {
+    match field {
+        ProvenanceField::Source => prov
+            .and_then(Provenance::source)
+            .map_or(PropertyValue::Null, |s| PropertyValue::String(s.into())),
+        ProvenanceField::Confidence => prov
+            .and_then(Provenance::confidence)
+            .map_or(PropertyValue::Null, PropertyValue::Float),
+        ProvenanceField::Reason => prov
+            .and_then(Provenance::note)
+            .map_or(PropertyValue::Null, |s| PropertyValue::String(s.into())),
+    }
+}
+
 /// Look up a value for ordering by column/property name: first a node property
 /// (entity rows), then a computed aggregate column (`row.columns`) so ORDER BY
 /// can sort grouped/aggregate rows by a group key or aggregate alias.
@@ -3190,16 +3237,43 @@ pub struct SortIterator {
     keys: Vec<(SortKey, bool)>,
     output: std::vec::IntoIter<QueryRow>,
     drained: bool,
+    /// Historical storage, needed only to resolve a [`SortKey::Provenance`] key
+    /// (Issue #3354) from each row entity's write-time provenance. `None` when
+    /// no provenance sort key is present (the common case), so an ordinary
+    /// property/score sort never touches historical storage.
+    historical: Option<Arc<RwLock<HistoricalStorage>>>,
 }
 
 impl SortIterator {
     /// Create a new ORDER BY iterator sorting by `keys` (first = primary).
+    ///
+    /// Carries no historical handle, so a [`SortKey::Provenance`] key would
+    /// resolve to null for every row. Use [`with_historical`](Self::with_historical)
+    /// when an `ORDER BY` may reference a provenance accessor.
     pub fn new(input: Box<dyn ResultIterator>, keys: Vec<(SortKey, bool)>) -> Self {
         SortIterator {
             input: Some(input),
             keys,
             output: Vec::new().into_iter(),
             drained: false,
+            historical: None,
+        }
+    }
+
+    /// Create a sort iterator with access to historical storage so a
+    /// [`SortKey::Provenance`] key (Issue #3354) resolves each row entity's
+    /// write-time provenance at the version the row represents.
+    pub fn with_historical(
+        input: Box<dyn ResultIterator>,
+        keys: Vec<(SortKey, bool)>,
+        historical: Arc<RwLock<HistoricalStorage>>,
+    ) -> Self {
+        SortIterator {
+            input: Some(input),
+            keys,
+            output: Vec::new().into_iter(),
+            drained: false,
+            historical: Some(historical),
         }
     }
 
@@ -3220,7 +3294,7 @@ impl SortIterator {
     fn cmp_rows(&self, a: &QueryRow, b: &QueryRow) -> std::cmp::Ordering {
         use std::cmp::Ordering;
         for (key, descending) in &self.keys {
-            let ord = Self::cmp_by_key(a, b, key, *descending);
+            let ord = self.cmp_by_key(a, b, key, *descending);
             if ord != Ordering::Equal {
                 return ord;
             }
@@ -3228,9 +3302,41 @@ impl SortIterator {
         Ordering::Equal
     }
 
+    /// Compare two nullable values with openCypher null placement (nulls last
+    /// for ASC, first for DESC), applying `descending` to present-present pairs.
+    fn cmp_optional(
+        x: Option<&PropertyValue>,
+        y: Option<&PropertyValue>,
+        descending: bool,
+    ) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        match (x, y) {
+            (Some(x), Some(y)) => {
+                let ord = compare_property(x, y);
+                if descending { ord.reverse() } else { ord }
+            }
+            (Some(_), None) => {
+                if descending {
+                    Ordering::Greater
+                } else {
+                    Ordering::Less
+                }
+            }
+            (None, Some(_)) => {
+                if descending {
+                    Ordering::Less
+                } else {
+                    Ordering::Greater
+                }
+            }
+            (None, None) => Ordering::Equal,
+        }
+    }
+
     /// Compare two rows by a single key, applying openCypher null placement
     /// (nulls last for ASC, first for DESC).
     fn cmp_by_key(
+        &self,
         a: &QueryRow,
         b: &QueryRow,
         key: &SortKey,
@@ -3238,28 +3344,23 @@ impl SortIterator {
     ) -> std::cmp::Ordering {
         use std::cmp::Ordering;
         match key {
-            SortKey::Property(prop) => match (row_value(a, prop), row_value(b, prop)) {
-                (Some(x), Some(y)) => {
-                    let ord = compare_property(x, y);
-                    if descending { ord.reverse() } else { ord }
-                }
-                // openCypher: nulls last for ASC, first for DESC.
-                (Some(_), None) => {
-                    if descending {
-                        Ordering::Greater
-                    } else {
-                        Ordering::Less
+            SortKey::Property(prop) => {
+                Self::cmp_optional(row_value(a, prop), row_value(b, prop), descending)
+            }
+            // Resolve each row entity's provenance value on the fly (Issue
+            // #3354). Matches the WHERE-clause resolution: an unattributed row
+            // (or a bundle missing the field) sorts as null.
+            SortKey::Provenance(field) => {
+                let resolve = |row: &QueryRow| -> Option<PropertyValue> {
+                    let historical = self.historical.as_ref()?;
+                    let prov = resolve_entity_provenance(&row.entity, historical);
+                    match provenance_field_value(prov.as_ref(), *field) {
+                        PropertyValue::Null => None,
+                        v => Some(v),
                     }
-                }
-                (None, Some(_)) => {
-                    if descending {
-                        Ordering::Less
-                    } else {
-                        Ordering::Greater
-                    }
-                }
-                (None, None) => Ordering::Equal,
-            },
+                };
+                Self::cmp_optional(resolve(a).as_ref(), resolve(b).as_ref(), descending)
+            }
             SortKey::Score => {
                 let ord = a.score.partial_cmp(&b.score).unwrap_or(Ordering::Equal);
                 if descending { ord.reverse() } else { ord }
@@ -3283,6 +3384,87 @@ impl ResultIterator for SortIterator {
             }
         }
         self.output.next().map(Ok)
+    }
+}
+
+/// Provenance-projection iterator (Issue #3354): for each input row, resolves
+/// the row entity's write-time provenance and attaches one output column per
+/// projected accessor (`RETURN source(n)`, `RETURN n, confidence(n) AS conf`).
+///
+/// When the projection names a bare entity variable (`entity_binding`), the row
+/// is emitted through the **bindings + columns** shape so the entity stays
+/// observable alongside the projected columns (mirroring the multi-variable /
+/// aggregation row shape, and keeping the entity from being dropped by a
+/// columns-only consumer); otherwise a pure columns row is produced. The score,
+/// path, and timestamp of the input row are preserved.
+///
+/// Runs last in the pipeline (after Sort/Skip/Limit), so it is 1:1 and never
+/// perturbs ordering or pagination.
+pub struct ProvenanceProjectIterator {
+    input: Box<dyn ResultIterator>,
+    projection: ProvenanceProjection,
+    historical: Arc<RwLock<HistoricalStorage>>,
+}
+
+impl ProvenanceProjectIterator {
+    /// Create a provenance-projection iterator resolving against `historical`.
+    pub fn new(
+        input: Box<dyn ResultIterator>,
+        projection: ProvenanceProjection,
+        historical: Arc<RwLock<HistoricalStorage>>,
+    ) -> Self {
+        ProvenanceProjectIterator {
+            input,
+            projection,
+            historical,
+        }
+    }
+
+    /// Build the projected columns for one row's entity.
+    fn project_row(&self, row: &QueryRow) -> QueryRow {
+        let prov = resolve_entity_provenance(&row.entity, &self.historical);
+        let columns: Vec<(String, PropertyValue)> = self
+            .projection
+            .items
+            .iter()
+            .map(|item| {
+                (
+                    item.output_name.clone(),
+                    provenance_field_value(prov.as_ref(), item.field),
+                )
+            })
+            .collect();
+
+        // Preserve any bare entity via the bindings channel so it survives
+        // columns-only consumers (e.g. the MCP serializer); otherwise emit a
+        // pure columns row like aggregation output.
+        let bindings = self
+            .projection
+            .entity_binding
+            .as_ref()
+            .map(|var| vec![(var.clone(), row.entity.clone())]);
+
+        QueryRow {
+            entity: EntityResult::Null,
+            score: row.score,
+            path: row.path.clone(),
+            timestamp: row.timestamp,
+            columns: Some(columns),
+            bindings,
+        }
+    }
+}
+
+impl ResultIterator for ProvenanceProjectIterator {
+    fn next(&mut self) -> Option<Result<QueryRow>> {
+        match self.input.next()? {
+            Ok(row) => Some(Ok(self.project_row(&row))),
+            Err(e) => Some(Err(e)),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.input.size_hint()
     }
 }
 

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -522,7 +522,23 @@ impl QueryExecutor {
 
             PhysicalOp::Sort { input, keys } => {
                 let input_iter = self.build_op(input, profile, child_depth)?;
-                Box::new(iterators::SortIterator::new(input_iter, keys.clone()))
+                // Pass historical storage so a `SortKey::Provenance` key
+                // (Issue #3354) can resolve each row entity's write-time
+                // provenance; property/score sorts never touch it.
+                Box::new(iterators::SortIterator::with_historical(
+                    input_iter,
+                    keys.clone(),
+                    Arc::clone(&self.historical),
+                ))
+            }
+
+            PhysicalOp::ProjectProvenance { input, projection } => {
+                let input_iter = self.build_op(input, profile, child_depth)?;
+                Box::new(iterators::ProvenanceProjectIterator::new(
+                    input_iter,
+                    projection.clone(),
+                    Arc::clone(&self.historical),
+                ))
             }
 
             PhysicalOp::Count { input } => {

--- a/src/query/ir.rs
+++ b/src/query/ir.rs
@@ -212,6 +212,45 @@ pub enum QueryOp {
 
     /// Project specific properties
     Project(Vec<String>),
+
+    /// Project one or more provenance accessors (`RETURN source(x)`,
+    /// `RETURN n, confidence(n) AS conf`, Issue #3354) as output columns.
+    ///
+    /// This op runs **last** in the pipeline (after any Sort/Skip/Limit) so it
+    /// never interferes with entity-based ordering or pagination. For each input
+    /// row it resolves the row entity's write-time provenance (at the query's
+    /// bi-temporal coordinate, exactly as the `WHERE` provenance leaves do) and
+    /// attaches one column per projection. When the `RETURN` also names a bare
+    /// entity variable, the row is emitted through the bindings+columns shape so
+    /// the entity survives alongside the projected columns (mirroring the
+    /// multi-variable / aggregation row shape); otherwise a pure columns row is
+    /// produced.
+    ProjectProvenance(ProvenanceProjection),
+}
+
+/// A single provenance accessor projected as an output column
+/// (`source(x) AS alias`, Issue #3354).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProvenanceProjectionItem {
+    /// The output column name (the alias if one was given, else the accessor
+    /// rendered as `"<accessor>(<var>)"`).
+    pub output_name: String,
+    /// Which provenance field to resolve.
+    pub field: ProvenanceField,
+}
+
+/// The plan for [`QueryOp::ProjectProvenance`]: the bare-entity binding to
+/// preserve (if any) plus the ordered provenance columns to project
+/// (Issue #3354).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProvenanceProjection {
+    /// The variable name of a bare entity also returned (`RETURN n, source(n)`),
+    /// preserved via the bindings channel so it stays observable. `None` when
+    /// only accessors are projected (`RETURN source(n)`), yielding a pure
+    /// columns row.
+    pub entity_binding: Option<String>,
+    /// The provenance columns to project, in `RETURN` order.
+    pub items: Vec<ProvenanceProjectionItem>,
 }
 
 /// A comparison operator for a [`ScoreThreshold`].
@@ -421,6 +460,14 @@ pub enum SortKey {
     Score,
     /// Sort by timestamp (for temporal queries)
     Timestamp,
+    /// Sort by a provenance accessor (`ORDER BY source(x)`/`confidence(x)`/
+    /// `reason(x)`, Issue #3354). The value is resolved per row from the write-
+    /// time provenance recorded on the version the row represents (the historical
+    /// version at the query's bi-temporal coordinate for an `AS OF` query),
+    /// exactly as the `WHERE`-clause provenance leaves resolve it. An
+    /// unattributed row (or a bundle missing the field) sorts as a null value,
+    /// following the same openCypher null placement as any other key.
+    Provenance(ProvenanceField),
 }
 
 /// Property predicates for filtering nodes and edges.

--- a/src/query/plan.rs
+++ b/src/query/plan.rs
@@ -242,6 +242,10 @@ pub enum UnaryOp {
     /// Project specific properties
     Project(Vec<String>),
 
+    /// Project provenance accessors as output columns (Issue #3354). Mirrors
+    /// [`super::ir::QueryOp::ProjectProvenance`].
+    ProjectProvenance(super::ir::ProvenanceProjection),
+
     /// Limit number of results
     Limit(usize),
 

--- a/src/query/planner/cost.rs
+++ b/src/query/planner/cost.rs
@@ -465,6 +465,7 @@ impl CostModel {
             }
 
             PhysicalOp::Project { input, .. }
+            | PhysicalOp::ProjectProvenance { input, .. }
             | PhysicalOp::Distinct { input }
             | PhysicalOp::Count { input }
             | PhysicalOp::Aggregate { input, .. }
@@ -543,7 +544,9 @@ impl CostModel {
             PhysicalOp::Limit { count, input, .. } => {
                 (*count).min(self.estimate_cardinality(input, stats))
             }
-            PhysicalOp::Sort { input, .. } | PhysicalOp::Project { input, .. } => {
+            PhysicalOp::Sort { input, .. }
+            | PhysicalOp::Project { input, .. }
+            | PhysicalOp::ProjectProvenance { input, .. } => {
                 self.estimate_cardinality(input, stats)
             }
             PhysicalOp::Distinct { input } => {

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -489,6 +489,11 @@ impl QueryPlanner {
 
             QueryOp::Project(props) => Ok(LogicalOp::unary(UnaryOp::Project(props.clone()), input)),
 
+            QueryOp::ProjectProvenance(projection) => Ok(LogicalOp::unary(
+                UnaryOp::ProjectProvenance(projection.clone()),
+                input,
+            )),
+
             QueryOp::Sort { key, descending } => Ok(LogicalOp::unary(
                 UnaryOp::Sort {
                     key: key.clone(),
@@ -940,6 +945,11 @@ impl QueryPlanner {
             UnaryOp::Project(props) => Ok(PhysicalOp::Project {
                 input: Box::new(input),
                 properties: props.clone(),
+            }),
+
+            UnaryOp::ProjectProvenance(projection) => Ok(PhysicalOp::ProjectProvenance {
+                input: Box::new(input),
+                projection: projection.clone(),
             }),
 
             UnaryOp::Distinct => Ok(PhysicalOp::Distinct {

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -356,6 +356,7 @@ impl PhysicalPlan {
             | PhysicalOp::Sort { input, .. }
             | PhysicalOp::Limit { input, .. }
             | PhysicalOp::Project { input, .. }
+            | PhysicalOp::ProjectProvenance { input, .. }
             | PhysicalOp::Distinct { input, .. }
             | PhysicalOp::Count { input, .. }
             | PhysicalOp::Aggregate { input, .. }
@@ -676,6 +677,17 @@ pub enum PhysicalOp {
         properties: Vec<String>,
     },
 
+    /// Project provenance accessors as output columns (Issue #3354). The
+    /// executor resolves each row entity's write-time provenance (via the
+    /// historical store handle the executor injects) and attaches one column per
+    /// projection, preserving a bare entity via the bindings channel when named.
+    ProjectProvenance {
+        /// Input operator
+        input: Box<PhysicalOp>,
+        /// The provenance projection plan.
+        projection: crate::query::ir::ProvenanceProjection,
+    },
+
     /// Distinct/deduplicate
     Distinct {
         /// Input operator
@@ -789,6 +801,7 @@ impl PhysicalOp {
             PhysicalOp::Sort { .. } => "Sort",
             PhysicalOp::Limit { .. } => "Limit",
             PhysicalOp::Project { .. } => "Project",
+            PhysicalOp::ProjectProvenance { .. } => "ProjectProvenance",
             PhysicalOp::Distinct { .. } => "Distinct",
             PhysicalOp::Count { .. } => "Count",
             PhysicalOp::Aggregate { .. } => "Aggregate",
@@ -840,6 +853,7 @@ impl PhysicalOp {
             | PhysicalOp::Sort { input, .. }
             | PhysicalOp::Limit { input, .. }
             | PhysicalOp::Project { input, .. }
+            | PhysicalOp::ProjectProvenance { input, .. }
             | PhysicalOp::Distinct { input, .. }
             | PhysicalOp::Count { input, .. }
             | PhysicalOp::Aggregate { input, .. }
@@ -1048,6 +1062,7 @@ impl PhysicalOp {
             | PhysicalOp::Sort { input, .. }
             | PhysicalOp::Limit { input, .. }
             | PhysicalOp::Project { input, .. }
+            | PhysicalOp::ProjectProvenance { input, .. }
             | PhysicalOp::Distinct { input, .. }
             | PhysicalOp::Count { input, .. }
             | PhysicalOp::Aggregate { input, .. }

--- a/tests/aql_provenance_projection.rs
+++ b/tests/aql_provenance_projection.rs
@@ -1,0 +1,349 @@
+//! Integration tests for AQL provenance accessors in `RETURN` / `ORDER BY`
+//! projection (Issue #3354, projection half).
+//!
+//! The WHERE-filtering half (Issue #3354a) shipped previously
+//! (`tests/aql_provenance_where.rs`). This suite covers the complementary
+//! ability to *project* a provenance accessor (`source(n)` / `confidence(n)` /
+//! `reason(n)`) as an output column and to `ORDER BY` one, end-to-end through
+//! `execute_aql`.
+//!
+//! To keep the returned entity observable alongside the projected columns, a
+//! projection that also returns a bare entity emits the row through the
+//! bindings+columns shape (mirroring #549 multi-var / #558 aggregation), so the
+//! entity survives and the columns carry the provenance values.
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::PropertyMapBuilder;
+use aletheiadb::api::transaction::WriteRequestOptions;
+use aletheiadb::core::NodeId;
+use aletheiadb::core::property::PropertyValue;
+use aletheiadb::core::provenance::Provenance;
+use aletheiadb::query::executor::{EntityResult, QueryRow};
+
+fn prov(source: Option<&str>, confidence: Option<f64>, reason: Option<&str>) -> Provenance {
+    let mut b = Provenance::builder();
+    if let Some(s) = source {
+        b = b.source(s);
+    }
+    if let Some(c) = confidence {
+        b = b.confidence(c);
+    }
+    if let Some(r) = reason {
+        b = b.note(r);
+    }
+    b.build().expect("valid provenance")
+}
+
+fn create_person(db: &AletheiaDB, name: &str, provenance: Option<Provenance>) -> NodeId {
+    let props = PropertyMapBuilder::new().insert("name", name).build();
+    let mut opts = WriteRequestOptions::new();
+    if let Some(p) = provenance {
+        opts = opts.with_provenance(p);
+    }
+    db.create_node_with_options("Person", props, opts)
+        .expect("create person")
+}
+
+fn make_db() -> AletheiaDB {
+    let db = AletheiaDB::new().expect("db");
+    create_person(
+        &db,
+        "alice",
+        Some(prov(Some("hr-system"), Some(0.95), Some("verified"))),
+    );
+    create_person(
+        &db,
+        "bob",
+        Some(prov(Some("crm-sync"), Some(0.60), Some("imported"))),
+    );
+    create_person(
+        &db,
+        "carol",
+        Some(prov(Some("hr-system"), Some(0.80), None)),
+    );
+    create_person(&db, "dave", None); // unattributed
+    db
+}
+
+/// Collect all rows of an AQL query.
+fn rows(db: &AletheiaDB, aql: &str) -> Vec<QueryRow> {
+    db.execute_aql(aql)
+        .expect("query executes")
+        .collect_all()
+        .expect("collect rows")
+}
+
+/// The `name` property of whatever entity a row carries (from `entity` or the
+/// first node binding), or `None`.
+fn row_name(row: &QueryRow) -> Option<String> {
+    let node = match &row.entity {
+        EntityResult::Node(n) => Some(n),
+        _ => row.bindings.as_ref().and_then(|b| {
+            b.iter().find_map(|(_, e)| match e {
+                EntityResult::Node(n) => Some(n),
+                _ => None,
+            })
+        }),
+    }?;
+    node.get_property("name").map(|v| format!("{v:?}"))
+}
+
+/// Look up a projected column value by name in a row.
+fn col<'a>(row: &'a QueryRow, name: &str) -> Option<&'a PropertyValue> {
+    row.columns
+        .as_ref()
+        .and_then(|cols| cols.iter().find(|(k, _)| k == name).map(|(_, v)| v))
+}
+
+#[test]
+fn return_entity_and_source_projects_column_and_keeps_entity() {
+    let db = make_db();
+    let rows = rows(&db, "MATCH (n:Person) RETURN n, source(n)");
+    assert_eq!(rows.len(), 4, "one row per person");
+    // Every row must still expose its entity (via bindings) AND the projected
+    // source column.
+    let alice = rows
+        .iter()
+        .find(|r| row_name(r).as_deref() == Some("String(\"alice\")"))
+        .expect("alice row present with observable entity");
+    assert_eq!(
+        col(alice, "source(n)"),
+        Some(&PropertyValue::String("hr-system".into()))
+    );
+    // Bob's source differs.
+    let bob = rows
+        .iter()
+        .find(|r| row_name(r).as_deref() == Some("String(\"bob\")"))
+        .expect("bob row");
+    assert_eq!(
+        col(bob, "source(n)"),
+        Some(&PropertyValue::String("crm-sync".into()))
+    );
+}
+
+#[test]
+fn source_alias_is_column_name() {
+    let db = make_db();
+    let rows = rows(&db, "MATCH (n:Person) RETURN source(n) AS src");
+    let alice = rows
+        .iter()
+        .find(|r| col(r, "src") == Some(&PropertyValue::String("hr-system".into())));
+    assert!(alice.is_some(), "aliased column `src` carries the source");
+}
+
+#[test]
+fn confidence_projects_numeric_value() {
+    let db = make_db();
+    let rows = rows(&db, "MATCH (n:Person) RETURN n, confidence(n)");
+    let alice = rows
+        .iter()
+        .find(|r| row_name(r).as_deref() == Some("String(\"alice\")"))
+        .expect("alice row");
+    match col(alice, "confidence(n)") {
+        Some(PropertyValue::Float(f)) => assert!((f - 0.95).abs() < 1e-9, "got {f}"),
+        other => panic!("expected numeric Float confidence, got {other:?}"),
+    }
+}
+
+#[test]
+fn unattributed_projects_null() {
+    let db = make_db();
+    let rows = rows(&db, "MATCH (n:Person) RETURN n, source(n), confidence(n)");
+    let dave = rows
+        .iter()
+        .find(|r| row_name(r).as_deref() == Some("String(\"dave\")"))
+        .expect("dave row present");
+    assert_eq!(col(dave, "source(n)"), Some(&PropertyValue::Null));
+    assert_eq!(col(dave, "confidence(n)"), Some(&PropertyValue::Null));
+}
+
+#[test]
+fn missing_field_of_partial_bundle_projects_null() {
+    let db = make_db();
+    // carol has a bundle but no reason -> reason projects Null (distinct from
+    // dave, who has no bundle at all).
+    let rows = rows(&db, "MATCH (n:Person) RETURN n, reason(n)");
+    let carol = rows
+        .iter()
+        .find(|r| row_name(r).as_deref() == Some("String(\"carol\")"))
+        .expect("carol row");
+    assert_eq!(col(carol, "reason(n)"), Some(&PropertyValue::Null));
+}
+
+#[test]
+fn order_by_confidence_desc_sorts_by_projected_provenance() {
+    let db = make_db();
+    let rows = rows(
+        &db,
+        "MATCH (n:Person) RETURN n, confidence(n) ORDER BY confidence(n) DESC",
+    );
+    let order: Vec<String> = rows.iter().filter_map(row_name).collect();
+    // alice 0.95, carol 0.80, bob 0.60, then dave (null) last for DESC? Null
+    // placement: nulls first for DESC. So dave (null) leads, then desc values.
+    assert_eq!(
+        order,
+        vec![
+            "String(\"dave\")",
+            "String(\"alice\")",
+            "String(\"carol\")",
+            "String(\"bob\")",
+        ],
+        "DESC: nulls first (openCypher), then descending confidence"
+    );
+}
+
+#[test]
+fn order_by_confidence_not_in_return_sorts_and_hides_column() {
+    let db = make_db();
+    // confidence(n) drives the ordering but is NOT a RETURN item -> it must not
+    // appear as an output column.
+    let rows = rows(&db, "MATCH (n:Person) RETURN n ORDER BY confidence(n)");
+    let order: Vec<String> = rows.iter().filter_map(row_name).collect();
+    // ASC: ascending values then nulls last. bob 0.60, carol 0.80, alice 0.95, dave null.
+    assert_eq!(
+        order,
+        vec![
+            "String(\"bob\")",
+            "String(\"carol\")",
+            "String(\"alice\")",
+            "String(\"dave\")",
+        ]
+    );
+    // No provenance column leaked into output.
+    for r in &rows {
+        assert!(
+            col(r, "confidence(n)").is_none(),
+            "ORDER BY-only accessor must not surface as a column"
+        );
+    }
+}
+
+#[test]
+fn source_only_projection_without_entity_is_columns_row() {
+    let db = make_db();
+    // No bare entity returned -> a pure columns row (like aggregation output).
+    let rows = rows(&db, "MATCH (n:Person) RETURN source(n)");
+    assert_eq!(rows.len(), 4);
+    let sources: Vec<PropertyValue> = rows
+        .iter()
+        .filter_map(|r| col(r, "source(n)").cloned())
+        .collect();
+    assert!(sources.contains(&PropertyValue::String("hr-system".into())));
+    assert!(sources.contains(&PropertyValue::Null)); // dave
+}
+
+#[test]
+fn as_of_projects_provenance_at_that_coordinate() {
+    // The projected provenance reflects the version visible at the query's
+    // bi-temporal coordinate, not the latest version. Recalling the superseded
+    // v1 (confidence 0.50) requires anchoring BOTH dimensions before the update:
+    // v1's valid interval is [t1, t2) and its transaction interval closed at the
+    // update, so `(valid in [t1,t2), tx < update)` selects it, while
+    // `(valid >= t2, tx = now)` selects the current v2 (0.95).
+    use aletheiadb::core::temporal::Timestamp;
+    use std::thread::sleep;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    // Wallclock microseconds since the Unix epoch -- the same scale the database
+    // assigns transaction timestamps on.
+    let now_micros = || -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_micros() as i64
+    };
+
+    let db = AletheiaDB::new().expect("db");
+    let t1: i64 = 1_000_000_000_000;
+    let t2: i64 = 2_000_000_000_000;
+    let t3: i64 = 3_000_000_000_000;
+    let t_mid: i64 = 1_500_000_000_000; // strictly inside [t1, t2) -> selects v1
+
+    let props = PropertyMapBuilder::new().insert("name", "alice").build();
+    let node_id = db
+        .create_node_with_options(
+            "Person",
+            props,
+            WriteRequestOptions::new()
+                .with_valid_from(Timestamp::from(t1))
+                .with_provenance(prov(Some("hr-system"), Some(0.50), None)),
+        )
+        .expect("create v1");
+
+    // Capture a transaction-time coordinate strictly between the create and the
+    // update (small sleeps guarantee microsecond separation on the shared clock).
+    sleep(Duration::from_millis(20));
+    let tx_between: i64 = now_micros();
+    sleep(Duration::from_millis(20));
+
+    let props2 = PropertyMapBuilder::new().insert("name", "alice").build();
+    db.update_node_with_options(
+        node_id,
+        props2,
+        WriteRequestOptions::new()
+            .with_valid_from(Timestamp::from(t2))
+            .with_provenance(prov(Some("hr-system"), Some(0.95), None)),
+    )
+    .expect("update v2");
+
+    // Before the update (valid in [t1,t2), tx before the update): confidence was
+    // 0.50. AQL `AS OF <valid>, <tx>` anchors both dimensions.
+    let before = rows(
+        &db,
+        &format!("AS OF {t_mid}, {tx_between} MATCH (n:Person) RETURN n, confidence(n)"),
+    );
+    let v = before
+        .iter()
+        .find_map(|r| col(r, "confidence(n)").cloned())
+        .expect("a confidence column at the pre-update coordinate");
+    match v {
+        PropertyValue::Float(f) => {
+            assert!((f - 0.50).abs() < 1e-9, "pre-update expected 0.50, got {f}")
+        }
+        other => panic!("expected Float, got {other:?}"),
+    }
+
+    // Current coordinate (valid >= t2, tx = now): confidence is 0.95.
+    let after = rows(
+        &db,
+        &format!("AS OF {t3} MATCH (n:Person) RETURN n, confidence(n)"),
+    );
+    let v = after
+        .iter()
+        .find_map(|r| col(r, "confidence(n)").cloned())
+        .expect("a confidence column at the current coordinate");
+    match v {
+        PropertyValue::Float(f) => {
+            assert!((f - 0.95).abs() < 1e-9, "current expected 0.95, got {f}")
+        }
+        other => panic!("expected Float, got {other:?}"),
+    }
+}
+
+#[test]
+fn invalid_accessor_argument_is_error_not_silent() {
+    let db = make_db();
+    // A provenance-named accessor with a malformed argument must be a structured
+    // error, never a silently dropped projection.
+    for q in [
+        "MATCH (n:Person) RETURN source(n.foo)",
+        "MATCH (n:Person) RETURN confidence(n, m)",
+        "MATCH (n:Person) RETURN source()",
+    ] {
+        assert!(db.execute_aql(q).is_err(), "expected error for: {q}");
+    }
+}
+
+#[test]
+fn plain_return_entity_unaffected() {
+    // Regression: a RETURN with no provenance accessor is byte-identical to
+    // before (plain entity rows, no columns/bindings).
+    let db = make_db();
+    let rows = rows(&db, "MATCH (n:Person) RETURN n");
+    assert_eq!(rows.len(), 4);
+    for r in &rows {
+        assert!(matches!(r.entity, EntityResult::Node(_)));
+        assert!(r.columns.is_none());
+        assert!(r.bindings.is_none());
+    }
+}

--- a/tests/cypher_provenance_projection.rs
+++ b/tests/cypher_provenance_projection.rs
@@ -1,0 +1,355 @@
+//! Integration tests for Cypher provenance accessors in `RETURN` / `ORDER BY`
+//! projection (Issue #3354, projection half). Mirrors the AQL suite
+//! (`tests/aql_provenance_projection.rs`) for the Cypher surface, and adds a
+//! cross-surface parity gate.
+
+#![cfg(feature = "cypher")]
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::PropertyMapBuilder;
+use aletheiadb::api::transaction::WriteRequestOptions;
+use aletheiadb::core::NodeId;
+use aletheiadb::core::property::PropertyValue;
+use aletheiadb::core::provenance::Provenance;
+use aletheiadb::query::executor::{EntityResult, QueryRow};
+
+fn prov(source: Option<&str>, confidence: Option<f64>, reason: Option<&str>) -> Provenance {
+    let mut b = Provenance::builder();
+    if let Some(s) = source {
+        b = b.source(s);
+    }
+    if let Some(c) = confidence {
+        b = b.confidence(c);
+    }
+    if let Some(r) = reason {
+        b = b.note(r);
+    }
+    b.build().expect("valid provenance")
+}
+
+fn create_person(db: &AletheiaDB, name: &str, provenance: Option<Provenance>) -> NodeId {
+    let props = PropertyMapBuilder::new().insert("name", name).build();
+    let mut opts = WriteRequestOptions::new();
+    if let Some(p) = provenance {
+        opts = opts.with_provenance(p);
+    }
+    db.create_node_with_options("Person", props, opts)
+        .expect("create person")
+}
+
+fn make_db() -> AletheiaDB {
+    let db = AletheiaDB::new().expect("db");
+    create_person(
+        &db,
+        "alice",
+        Some(prov(Some("hr-system"), Some(0.95), Some("verified"))),
+    );
+    create_person(
+        &db,
+        "bob",
+        Some(prov(Some("crm-sync"), Some(0.60), Some("imported"))),
+    );
+    create_person(
+        &db,
+        "carol",
+        Some(prov(Some("hr-system"), Some(0.80), None)),
+    );
+    create_person(&db, "dave", None); // unattributed
+    db
+}
+
+fn rows(db: &AletheiaDB, cypher: &str) -> Vec<QueryRow> {
+    db.execute_cypher(cypher)
+        .expect("query executes")
+        .collect_all()
+        .expect("collect rows")
+}
+
+fn err_msg(db: &AletheiaDB, cypher: &str) -> String {
+    match db.execute_cypher(cypher) {
+        Ok(_) => panic!("expected error for query: {cypher}"),
+        Err(e) => e.to_string(),
+    }
+}
+
+fn row_name(row: &QueryRow) -> Option<String> {
+    let node = match &row.entity {
+        EntityResult::Node(n) => Some(n),
+        _ => row.bindings.as_ref().and_then(|b| {
+            b.iter().find_map(|(_, e)| match e {
+                EntityResult::Node(n) => Some(n),
+                _ => None,
+            })
+        }),
+    }?;
+    node.get_property("name").map(|v| format!("{v:?}"))
+}
+
+fn col<'a>(row: &'a QueryRow, name: &str) -> Option<&'a PropertyValue> {
+    row.columns
+        .as_ref()
+        .and_then(|cols| cols.iter().find(|(k, _)| k == name).map(|(_, v)| v))
+}
+
+#[test]
+fn return_entity_and_source_projects_column_and_keeps_entity() {
+    let db = make_db();
+    let rows = rows(&db, "MATCH (n:Person) RETURN n, source(n)");
+    assert_eq!(rows.len(), 4);
+    let alice = rows
+        .iter()
+        .find(|r| row_name(r).as_deref() == Some("String(\"alice\")"))
+        .expect("alice row present with observable entity");
+    assert_eq!(
+        col(alice, "source(n)"),
+        Some(&PropertyValue::String("hr-system".into()))
+    );
+}
+
+#[test]
+fn source_alias_is_column_name() {
+    let db = make_db();
+    let rows = rows(&db, "MATCH (n:Person) RETURN source(n) AS src");
+    let alice = rows
+        .iter()
+        .find(|r| col(r, "src") == Some(&PropertyValue::String("hr-system".into())));
+    assert!(alice.is_some(), "aliased column `src` carries the source");
+}
+
+#[test]
+fn confidence_projects_numeric_value() {
+    let db = make_db();
+    let rows = rows(&db, "MATCH (n:Person) RETURN n, confidence(n)");
+    let alice = rows
+        .iter()
+        .find(|r| row_name(r).as_deref() == Some("String(\"alice\")"))
+        .expect("alice row");
+    match col(alice, "confidence(n)") {
+        Some(PropertyValue::Float(f)) => assert!((f - 0.95).abs() < 1e-9, "got {f}"),
+        other => panic!("expected numeric Float confidence, got {other:?}"),
+    }
+}
+
+#[test]
+fn unattributed_projects_null() {
+    let db = make_db();
+    let rows = rows(&db, "MATCH (n:Person) RETURN n, source(n), confidence(n)");
+    let dave = rows
+        .iter()
+        .find(|r| row_name(r).as_deref() == Some("String(\"dave\")"))
+        .expect("dave row present");
+    assert_eq!(col(dave, "source(n)"), Some(&PropertyValue::Null));
+    assert_eq!(col(dave, "confidence(n)"), Some(&PropertyValue::Null));
+}
+
+#[test]
+fn order_by_confidence_desc_sorts_by_projected_provenance() {
+    let db = make_db();
+    let rows = rows(
+        &db,
+        "MATCH (n:Person) RETURN n, confidence(n) ORDER BY confidence(n) DESC",
+    );
+    let order: Vec<String> = rows.iter().filter_map(row_name).collect();
+    assert_eq!(
+        order,
+        vec![
+            "String(\"dave\")",
+            "String(\"alice\")",
+            "String(\"carol\")",
+            "String(\"bob\")",
+        ],
+        "DESC: nulls first (openCypher), then descending confidence"
+    );
+}
+
+#[test]
+fn order_by_confidence_not_in_return_sorts_and_hides_column() {
+    let db = make_db();
+    let rows = rows(&db, "MATCH (n:Person) RETURN n ORDER BY confidence(n)");
+    let order: Vec<String> = rows.iter().filter_map(row_name).collect();
+    assert_eq!(
+        order,
+        vec![
+            "String(\"bob\")",
+            "String(\"carol\")",
+            "String(\"alice\")",
+            "String(\"dave\")",
+        ]
+    );
+    for r in &rows {
+        assert!(
+            col(r, "confidence(n)").is_none(),
+            "ORDER BY-only accessor must not surface as a column"
+        );
+    }
+}
+
+#[test]
+fn source_only_projection_without_entity_is_columns_row() {
+    let db = make_db();
+    let rows = rows(&db, "MATCH (n:Person) RETURN source(n)");
+    assert_eq!(rows.len(), 4);
+    let sources: Vec<PropertyValue> = rows
+        .iter()
+        .filter_map(|r| col(r, "source(n)").cloned())
+        .collect();
+    assert!(sources.contains(&PropertyValue::String("hr-system".into())));
+    assert!(sources.contains(&PropertyValue::Null));
+}
+
+#[test]
+fn as_of_projects_provenance_at_that_coordinate() {
+    // Recalling the superseded v1 requires anchoring BOTH dimensions before the
+    // update (see the AQL suite for the bitemporal rationale).
+    use aletheiadb::core::temporal::Timestamp;
+    use std::thread::sleep;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    let now_micros = || -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_micros() as i64
+    };
+
+    let db = AletheiaDB::new().expect("db");
+    let t1: i64 = 1_000_000_000_000;
+    let t2: i64 = 2_000_000_000_000;
+    let t3: i64 = 3_000_000_000_000;
+    let t_mid: i64 = 1_500_000_000_000; // strictly inside [t1, t2) -> selects v1
+
+    let props = PropertyMapBuilder::new().insert("name", "alice").build();
+    let node_id = db
+        .create_node_with_options(
+            "Person",
+            props,
+            WriteRequestOptions::new()
+                .with_valid_from(Timestamp::from(t1))
+                .with_provenance(prov(Some("hr-system"), Some(0.50), None)),
+        )
+        .expect("create v1");
+
+    sleep(Duration::from_millis(20));
+    let tx_between: i64 = now_micros();
+    sleep(Duration::from_millis(20));
+
+    let props2 = PropertyMapBuilder::new().insert("name", "alice").build();
+    db.update_node_with_options(
+        node_id,
+        props2,
+        WriteRequestOptions::new()
+            .with_valid_from(Timestamp::from(t2))
+            .with_provenance(prov(Some("hr-system"), Some(0.95), None)),
+    )
+    .expect("update v2");
+
+    let before = rows(
+        &db,
+        &format!(
+            "MATCH (n:Person) AS OF VALID_TIME '{t_mid}' AS OF SYSTEM_TIME '{tx_between}' \
+             RETURN n, confidence(n)"
+        ),
+    );
+    let v = before
+        .iter()
+        .find_map(|r| col(r, "confidence(n)").cloned())
+        .expect("a confidence column at the pre-update coordinate");
+    match v {
+        PropertyValue::Float(f) => {
+            assert!((f - 0.50).abs() < 1e-9, "pre-update expected 0.50, got {f}")
+        }
+        other => panic!("expected Float, got {other:?}"),
+    }
+
+    let after = rows(
+        &db,
+        &format!("MATCH (n:Person) AS OF VALID_TIME '{t3}' RETURN n, confidence(n)"),
+    );
+    let v = after
+        .iter()
+        .find_map(|r| col(r, "confidence(n)").cloned())
+        .expect("a confidence column at the current coordinate");
+    match v {
+        PropertyValue::Float(f) => {
+            assert!((f - 0.95).abs() < 1e-9, "current expected 0.95, got {f}")
+        }
+        other => panic!("expected Float, got {other:?}"),
+    }
+}
+
+#[test]
+fn invalid_accessor_argument_is_error_not_silent() {
+    let db = make_db();
+    for q in [
+        "MATCH (n:Person) RETURN source(n.foo)",
+        "MATCH (n:Person) RETURN confidence(n, m)",
+    ] {
+        assert!(db.execute_cypher(q).is_err(), "expected error for: {q}");
+    }
+    // A structured error, not a silent empty result.
+    let msg = err_msg(&db, "MATCH (n:Person) RETURN source(n.foo)");
+    assert!(!msg.is_empty());
+}
+
+#[test]
+fn plain_return_entity_unaffected() {
+    let db = make_db();
+    let rows = rows(&db, "MATCH (n:Person) RETURN n");
+    assert_eq!(rows.len(), 4);
+    for r in &rows {
+        assert!(matches!(r.entity, EntityResult::Node(_)));
+        assert!(r.columns.is_none());
+        assert!(r.bindings.is_none());
+    }
+}
+
+#[test]
+fn distinct_projection_unaffected() {
+    // Regression: RETURN DISTINCT still dedupes by entity id; projection rides
+    // on top without changing that.
+    let db = make_db();
+    let rows = rows(&db, "MATCH (n:Person) RETURN DISTINCT n, source(n)");
+    assert_eq!(rows.len(), 4, "four distinct people");
+}
+
+/// Cross-surface parity: for the same fixture and equivalent queries, AQL and
+/// Cypher must project the same provenance columns (criterion 3).
+#[test]
+fn cypher_aql_parity_over_projection_queries() {
+    let db = make_db();
+    // (cypher, aql, column name)
+    let cases = [
+        (
+            "MATCH (n:Person) RETURN source(n)",
+            "MATCH (n:Person) RETURN source(n)",
+            "source(n)",
+        ),
+        (
+            "MATCH (n:Person) RETURN confidence(n)",
+            "MATCH (n:Person) RETURN confidence(n)",
+            "confidence(n)",
+        ),
+        (
+            "MATCH (n:Person) RETURN reason(n)",
+            "MATCH (n:Person) RETURN reason(n)",
+            "reason(n)",
+        ),
+    ];
+    for (cypher, aql, colname) in cases {
+        let mut via_cypher: Vec<String> = rows(&db, cypher)
+            .iter()
+            .map(|r| format!("{:?}", col(r, colname)))
+            .collect();
+        let mut via_aql: Vec<String> = db
+            .execute_aql(aql)
+            .expect("aql executes")
+            .collect_all()
+            .expect("collect")
+            .iter()
+            .map(|r| format!("{:?}", col(r, colname)))
+            .collect();
+        via_cypher.sort();
+        via_aql.sort();
+        assert_eq!(via_cypher, via_aql, "parity mismatch for {cypher}");
+    }
+}


### PR DESCRIPTION
## Summary

Implements the remaining half of #3354: **projecting provenance accessors** in `RETURN` and using them as `ORDER BY` keys, for both AQL and Cypher. The WHERE-filtering half (#3354a) already shipped; this is the complementary read/projection surface.

## Before / After

For a query author:

| | Before | After |
|---|---|---|
| `RETURN m, source(r)` / `RETURN n, source(n)` | the accessor was **silently dropped** (AQL `convert_return` `_ => {}` arm) — you got the entity but no source | entity **and** a `source(n)` column, both observable |
| `RETURN source(n) AS src` | dropped | a `src` column carrying the source string |
| `RETURN n, confidence(n)` | dropped | a numeric `confidence(n)` column (`Float`, not a string) |
| `ORDER BY confidence(n)` | **errored** (`ORDER BY expression must be a property access or identifier` / Cypher `unsupported expression in ORDER BY`) | sorts rows by the per-row provenance value |

An unattributed version (or a bundle missing the field) projects `PropertyValue::Null` — distinguishing "no value" from any real value, exactly as the WHERE accessor semantics treat a missing field.

## How

- **IR** (`src/query/ir.rs`): new `QueryOp::ProjectProvenance(ProvenanceProjection)` — an optional bare-entity binding plus the ordered `(output_name, ProvenanceField)` columns — and a new `SortKey::Provenance(ProvenanceField)` variant.
- **Planner** (`plan.rs`, `planner/mod.rs`, `planner/physical.rs`, `planner/cost.rs`): lower the op through `UnaryOp::ProjectProvenance` → `PhysicalOp::ProjectProvenance`; the executor injects the historical-storage handle.
- **Executor** (`executor/iterators.rs`, `executor/mod.rs`):
  - `ProvenanceProjectIterator` resolves each row entity's write-time provenance (at the query's bi-temporal coordinate, via the entity's `current_version` — the same resolution the WHERE `FilterIterator` uses) and attaches one column per accessor. When the `RETURN` also names a bare entity, the row is emitted through the **bindings + columns** row shape so the entity stays observable alongside the columns (mirroring #549 multi-var / #558 aggregation).
  - `SortIterator` gained a historical handle and resolves `SortKey::Provenance` on the fly, so an `ORDER BY` accessor **not** present in `RETURN` sorts correctly and never leaks a hidden column (openCypher null placement preserved).
  - The projection op is emitted **last** (after Sort/Skip/Limit), so it is strictly 1:1 and never perturbs ordering or pagination.
- **Converters** (`query/converter.rs`, `cypher/converter.rs`): recognize provenance accessors in `RETURN` (emit `ProjectProvenance`) and `ORDER BY` (map to `SortKey::Provenance`), reusing the shared `provenance_field_name` / `as_provenance_accessor` recognition from the WHERE half. A provenance-named accessor with a malformed argument (`source(n.foo)`, `confidence(n, m)`, `source()`) is a **structured error**, never a silent drop.

## No `src/mcp/**` changes

MCP observability is preserved by construction: the projected entity rides the **bindings + columns** shape, which the MCP serializer's merge branch renders correctly, so the entity is not dropped by the columns-only branch. No MCP edits were needed or made.

## Acceptance-criteria evidence (#3354)

Criteria 1, 3 (WHERE portion), 5, and 6 shipped in the WHERE half (#3354a). This PR covers the projection criteria:

| Criterion | Evidence (test names, both `aql_` and `cypher_provenance_projection.rs` unless noted) |
|---|---|
| **#2 — accessor in RETURN and ORDER BY** | `return_entity_and_source_projects_column_and_keeps_entity`, `source_alias_is_column_name`, `confidence_projects_numeric_value`, `source_only_projection_without_entity_is_columns_row`, `order_by_confidence_desc_sorts_by_projected_provenance`, `order_by_confidence_not_in_return_sorts_and_hides_column` |
| **#4 — unattributed / missing field projects as null** | `unattributed_projects_null`; AQL `missing_field_of_partial_bundle_projects_null` |
| #3 (cross-surface parity, reinforced) | `cypher_aql_parity_over_projection_queries` |
| Point-in-time resolution | `as_of_projects_provenance_at_that_coordinate` (recalls a superseded version by anchoring both bi-temporal dimensions) |
| Regression | `plain_return_entity_unaffected`, `distinct_projection_unaffected` (Cypher), `invalid_accessor_argument_is_error_not_silent` |

## Tests

`tests/aql_provenance_projection.rs` (11) and `tests/cypher_provenance_projection.rs` (12) — all green. Full `cargo test --features cypher`: 6140 passed, 125 ignored, only the two known uid-0-sandbox havoc tests failing (`test_flush_deadlock_on_io_error`, `test_metadata_corruption_on_error` — both assert a filesystem write *fails*, which it doesn't under root; unrelated to this change). `cargo fmt --all`, `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings`, and `cargo clippy --all-targets --all-features -- -D warnings` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BhzWPXAxWQ8mhivodKYos

---
_Generated by [Claude Code](https://claude.ai/code/session_014BhzWPXAxWQ8mhivodKYos)_