### PR TITLE
hardening: post-merge review fixes for KeyProviders (Refs #3587)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,7 @@ dependencies = [
  "arrow",
  "autumn-web 0.4.0",
  "aws-sdk-kms",
+ "aws-smithy-mocks",
  "axum",
  "base64 0.22.1",
  "bitcode",
@@ -544,6 +545,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1020,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -1085,28 +1096,34 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-protocol-test",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
+ "bytes",
  "h2 0.3.27",
  "h2 0.4.13",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
+ "http-body 1.0.1",
  "hyper 0.14.32",
  "hyper 1.9.0",
  "hyper-rustls 0.24.2",
  "hyper-rustls 0.27.9",
  "hyper-util",
+ "indexmap",
  "pin-project-lite",
  "rustls 0.21.12",
  "rustls 0.23.39",
  "rustls-native-certs",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower",
@@ -1123,12 +1140,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-mocks"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0922f8ee1ce1f90f0baf9c9036f566161547a7ab9f09571d61d56455ba35598"
+dependencies = [
+ "aws-smithy-http-client",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.0",
+]
+
+[[package]]
 name = "aws-smithy-observability"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
 dependencies = [
  "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-protocol-test"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f76511a0e223ce78deb6a78b8afebda99cb737cfbc8a58d96dcb190f012dd40a"
+dependencies = [
+ "assert-json-diff",
+ "aws-smithy-runtime-api",
+ "base64-simd",
+ "cbor-diag",
+ "ciborium",
+ "http 0.2.12",
+ "pretty_assertions",
+ "regex-lite",
+ "roxmltree",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1164,13 +1212,14 @@ dependencies = [
  "pin-utils",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+checksum = "22ed1ebe6e0a95ea84570225f5a8208dec4b8f77e61a9b0d6f51773fcb4612f0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -1186,9 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api-macros"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1197,9 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.7"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1513,6 +1562,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "built"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1715,6 +1773,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
  "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbor-diag"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc245b6ecd09b23901a4fbad1ad975701fd5061ceaef6afa93a2d70605a64429"
+dependencies = [
+ "bs58",
+ "chrono",
+ "data-encoding",
+ "half",
+ "nom 7.1.3",
+ "num-bigint 0.4.6",
+ "num-rational 0.4.2",
+ "num-traits",
+ "separator",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -2644,6 +2721,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -6149,6 +6232,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7031,6 +7124,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7371,6 +7473,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "separator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
+
+[[package]]
 name = "seq-macro"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7423,6 +7531,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -9542,6 +9651,12 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,12 @@ hkdf = "0.13"
 sha2 = "0.11"
 zeroize = { version = "1.8", features = ["derive"] }
 aws-sdk-kms = { version = "1.106.0", optional = true, features = ["behavior-version-latest"] }
+# Mocked AWS transport for the KMS provider's Decrypt success-path test
+# (Issue #3587 review). Enabled ONLY by the `encryption-aws-kms` feature and
+# referenced solely from `#[cfg(test)]` code, so it never touches a normal build
+# without KMS. aws-sdk-kms already pulls the smithy runtime transitively; this
+# adds the purpose-built mock client on top.
+aws-smithy-mocks = { version = "0.3.0", optional = true }
 
 # Passphrase-wrapped master-key files (Issue #3587). The passphrase module is
 # always compiled with the (non-feature-gated) encryption module, so these KDF
@@ -360,11 +366,24 @@ mvcc-snapshots-tdd = []
 encryption = ["serde"]
 
 # AWS KMS key provider (optional)
-encryption-aws-kms = ["encryption", "dep:tokio", "aws-sdk-kms", "dep:base64"]
+# `aws-sdk-kms/test-util` supplies the `with_test_defaults_v2` config hook the
+# `mock_client!` macro needs for the #3587 Decrypt success-path test; it is only
+# pulled in when this feature is enabled and is referenced solely from
+# `#[cfg(test)]` code.
+encryption-aws-kms = [
+    "encryption",
+    "dep:tokio",
+    "aws-sdk-kms",
+    "aws-sdk-kms/test-util",
+    "dep:base64",
+    "dep:aws-smithy-mocks",
+]
 
 # HashiCorp Vault key provider (optional). Uses blocking reqwest, so no async
-# runtime bridge (and no `dep:tokio`) is required.
-encryption-vault = ["encryption", "dep:reqwest", "dep:native-tls", "dep:base64"]
+# runtime bridge (and no `dep:tokio`) is required. The vault path is TLS-backend
+# agnostic — reqwest's `rustls-tls` plus `reqwest::Certificate::from_pem` — so no
+# `native-tls`/OpenSSL dependency is pulled in.
+encryption-vault = ["encryption", "dep:reqwest", "dep:base64"]
 aws-sdk-kms = ["dep:aws-sdk-kms"]
 
 [profile.dev]

--- a/docs/ENCRYPTION.md
+++ b/docs/ENCRYPTION.md
@@ -155,6 +155,86 @@ export ALETHEIADB_MEK="a1b2c3d4e5f6...64 hex chars..."
 This is useful for container deployments where secrets are injected as environment
 variables (Kubernetes Secrets, Docker secrets, AWS ECS task definitions).
 
+### Passphrase-Wrapped Key File Provider (Issue #3587)
+
+Reads the MEK from a **passphrase-wrapped key file** (`AEKF` format). The 32-byte
+MEK is stored AES-256-GCM-sealed under a wrapping key derived from a
+human-supplied passphrase via a memory-hard KDF (Argon2id by default; PBKDF2
+fallback). Only a salt, the KDF parameters, and the sealed MEK are persisted —
+**the passphrase is never written to disk**. The seal binds the file header
+(magic/version/KDF id/params/salt/nonce) as AEAD associated data, and KDF cost
+params read from the file are clamped to sane ceilings, so a tampered or crafted
+header fails closed rather than deriving a wrong key or attempting a huge
+allocation.
+
+The passphrase is supplied at startup from the environment variable named by
+`passphrase_env` — **never** on the command line (which would leak via the
+process table).
+
+```toml
+[encryption.key_provider]
+type = "passphrase_file"
+path = "/etc/aletheiadb/master.aekf"
+passphrase_env = "ALETHEIADB_KEY_PASSPHRASE"
+```
+
+Generate a passphrase-wrapped key file via the CLI (the passphrase is read from
+`ALETHEIADB_KEY_PASSPHRASE`, never argv, never echoed, never printed):
+
+```bash
+export ALETHEIADB_KEY_PASSPHRASE="correct horse battery staple"
+aletheia keys generate --passphrase --key-file /etc/aletheiadb/master.aekf
+```
+
+A missing or empty `ALETHEIADB_KEY_PASSPHRASE` fails closed. The passphrase is
+held only in a zeroizing buffer for the duration of key derivation.
+
+### AWS KMS Provider (`encryption-aws-kms` feature)
+
+Decrypts the MEK from a **KMS-wrapped data key** (envelope encryption). The
+config carries a KMS key id/ARN and a base64-encoded KMS-encrypted data-key
+ciphertext blob; at startup the provider calls KMS `Decrypt` to recover the
+32-byte MEK. The plaintext MEK is never stored on disk, logged, or exposed via
+`Debug` (the wrapped blob is redacted).
+
+```toml
+[encryption.key_provider]
+type = "kms"
+key_id = "arn:aws:kms:us-east-1:123456789012:key/abcd-…"
+encrypted_data_key = "<base64 KMS ciphertext blob>"
+region = "us-east-1"          # optional; defaults to $AWS_REGION or us-east-1
+# endpoint_url = "http://localhost:4566"  # optional (LocalStack / VPC endpoint)
+```
+
+Credentials come from the standard `AWS_ACCESS_KEY_ID` /
+`AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` environment variables. Requires
+building with `--features encryption-aws-kms`; without it the provider returns a
+typed `Unavailable` error (never a panic).
+
+### HashiCorp Vault Provider (`encryption-vault` feature)
+
+Reads the MEK from a Vault **KV v2** secret over HTTPS. The Vault token is
+supplied at startup from the environment variable named by `token_env` (never
+stored in config, never logged). The key material may be stored as 64 hex
+characters or base64 of 32 bytes. Construct/call this provider from a
+**synchronous** context (it uses `reqwest::blocking`).
+
+```toml
+[encryption.key_provider]
+type = "vault"
+address = "https://vault.example.com:8200"
+token_env = "VAULT_TOKEN"
+mount = "secret"              # optional; KV v2 mount (default "secret")
+path = "aletheiadb/mek"
+key_field = "key"             # optional; field within the secret (default "key")
+# namespace = "team-a"        # optional (Vault Enterprise)
+# ca_cert = "/etc/ssl/vault-ca.pem"  # optional PEM CA for TLS verification
+```
+
+Requires building with `--features encryption-vault`; without it the provider
+returns a typed `Unavailable` error. The Vault path is TLS-backend agnostic
+(reqwest `rustls-tls` + `reqwest::Certificate::from_pem`).
+
 ### Generating Keys
 
 Generate a new random 256-bit key file:
@@ -347,6 +427,18 @@ rotation.complete_rotation()?;
 
 **Note:** Background re-encryption of existing data written with the old key is
 planned for a future phase. Currently, rotation applies only to new writes.
+
+**Rotating _to_ passphrase/KMS/Vault sources is not yet supported (fail-closed).**
+Index-key rotation (`rotate_index_keys`) refuses — on the target source's variant
+alone, before any key-source/network call — to rotate _to_ a `passphrase_file`,
+`kms`, or `vault` key source, returning a typed "not yet supported" error. The
+durable rotation breadcrumb records only a single non-secret reference (a file
+path or env-var name) so an interrupted rotation can resume; passphrase/KMS/Vault
+sources carry secrets (passphrase/token env vars) or multi-field config the
+line-based breadcrumb cannot round-trip. This refusal is checked statically, so
+rotating _to_ an unreachable KMS/Vault endpoint surfaces the clean refusal rather
+than a transport error. Full-MEK rotation across every layer (which would also
+re-key the WAL/checkpoint/cold files) is the tracked follow-up.
 
 ## Audit Logging
 

--- a/docs/adr/0028-encryption-at-rest.md
+++ b/docs/adr/0028-encryption-at-rest.md
@@ -405,6 +405,23 @@ pub struct TlsConfig {
 - **KV v2**: Static secrets storage
 - **Transit**: Encryption-as-a-service (envelope encryption)
 
+> **Implementation status (Issue #3587).** The shipped `KeyProviderConfig` enum
+> now provides the `File`, `Env`, `PassphraseFile`, `Kms`, and `Vault` variants,
+> constructed through a single `KeyProviderConfig::build_provider` dispatch. The
+> implemented `KeyProvider` trait is **synchronous** (unlike the `async fn new`
+> sketched above): the KMS provider bridges the async `aws-sdk-kms` client with
+> an internal runtime, and the Vault provider uses `reqwest::blocking` (call it
+> from a synchronous context). `PassphraseFile` wraps the MEK in a self-describing
+> `AEKF` file (Argon2id/PBKDF2 KDF, AES-256-GCM seal binding the header as AAD,
+> KDF params clamped against a hostile file). `Kms` and `Vault` are gated behind
+> the `encryption-aws-kms` / `encryption-vault` features (a typed `Unavailable`
+> error when absent). Passphrase/token secrets are read from named environment
+> variables into zeroizing buffers, never stored in config, logged, or exposed
+> via `Debug` (the KMS wrapped-key blob and Vault token are redacted).
+> Index-key rotation _to_ a passphrase/KMS/Vault source is refused fail-closed
+> (the durable resume breadcrumb cannot round-trip their secret/multi-field
+> config); GCP Cloud KMS and Azure Key Vault below remain future work.
+
 #### 5. GCP Cloud KMS Provider
 
 ```rust

--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -497,10 +497,14 @@ fn keys_generate(args: &[String]) -> Result<(), String> {
     // passphrase is NEVER taken from argv (it would leak via the process table),
     // NEVER echoed, and NEVER printed; a missing/empty variable fails closed.
     let result = if args.iter().any(|a| a == "--passphrase") {
-        let passphrase = std::env::var("ALETHEIADB_KEY_PASSPHRASE").map_err(|_| {
-            "the --passphrase flag requires the ALETHEIADB_KEY_PASSPHRASE environment variable to be set"
-                .to_string()
-        })?;
+        // Land the secret in a zeroizing buffer immediately so it is wiped on
+        // drop rather than lingering in a plain `String`.
+        let passphrase = zeroize::Zeroizing::new(
+            std::env::var("ALETHEIADB_KEY_PASSPHRASE").map_err(|_| {
+                "the --passphrase flag requires the ALETHEIADB_KEY_PASSPHRASE environment variable to be set"
+                    .to_string()
+            })?,
+        );
         if passphrase.is_empty() {
             return Err(
                 "ALETHEIADB_KEY_PASSPHRASE must not be empty when --passphrase is used".to_string(),
@@ -508,12 +512,11 @@ fn keys_generate(args: &[String]) -> Result<(), String> {
         }
         let result = aletheiadb::encryption::cli::generate_passphrase_key_with_overwrite(
             path,
-            &passphrase,
+            passphrase.as_str(),
             force,
         )
         .map_err(|e| format!("failed to generate passphrase key: {e}"));
-        // Drop the passphrase from this frame promptly; the generator already
-        // consumed it into a zeroizing buffer for the KDF.
+        // Drop the passphrase from this frame promptly; it is zeroized on drop.
         drop(passphrase);
         result?
     } else {

--- a/src/db/rotation.rs
+++ b/src/db/rotation.rs
@@ -129,6 +129,30 @@ fn load_mek(cfg: &KeyProviderConfig) -> std::result::Result<Zeroizing<[u8; 32]>,
         .map_err(|e| RotationError::KeyProvider(e.to_string()))
 }
 
+/// Statically refuse rotating TO a key source the durable breadcrumb cannot
+/// round-trip (passphrase/KMS/Vault), on the *variant alone* — BEFORE any
+/// `load_mek`/network call (Issue #3587).
+///
+/// Without this, rotating to an unreachable KMS/Vault endpoint would surface a
+/// network/transport error from `load_mek` instead of the clean "not yet
+/// supported" refusal. `write_rotation_state` performs the same check as
+/// defense-in-depth; this one fails fast and offline. Fail-closed: only
+/// file/env sources proceed.
+fn refuse_unsupported_new_source(new_source: &KeyProviderConfig) -> Result<()> {
+    match new_source {
+        KeyProviderConfig::File { .. } | KeyProviderConfig::Env { .. } => Ok(()),
+        KeyProviderConfig::PassphraseFile { .. }
+        | KeyProviderConfig::Kms { .. }
+        | KeyProviderConfig::Vault { .. } => {
+            let (provider_type, _) = new_source.describe();
+            Err(StorageError::PersistenceError(format!(
+                "index key rotation to a {provider_type} key source is not yet supported"
+            ))
+            .into())
+        }
+    }
+}
+
 /// Derive the index DEK for a MEK using the shared HKDF context.
 fn derive_index_dek(
     mek: Zeroizing<[u8; 32]>,
@@ -401,6 +425,11 @@ impl AletheiaDB {
         new_key_source: &KeyProviderConfig,
         started: Instant,
     ) -> Result<RotationReport> {
+        // Refuse an unsupported NEW source on its variant alone, BEFORE any
+        // load_mek / network call — rotating to an unreachable KMS/Vault must
+        // surface the clean refusal, not a transport error (Issue #3587).
+        refuse_unsupported_new_source(new_key_source)?;
+
         // Shared, mutable keyring handle (mutations are observed by the manager).
         let keyring = manager
             .keyring()
@@ -1013,6 +1042,54 @@ mod tests {
         assert!(
             report.is_none(),
             "resume with no breadcrumb must report nothing pending (Ok(None)), got {report:?}"
+        );
+    }
+
+    #[test]
+    fn rotate_to_remote_source_refuses_without_reaching_endpoint() {
+        // Rotating TO a KMS/Vault/passphrase source must return the clean
+        // "not yet supported" refusal on the variant alone — BEFORE any network
+        // call — so an unreachable endpoint never turns the refusal into a
+        // transport error (Issue #3587). Index-only DB so we reach run_rotation.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let old_key = root.join("old.key");
+        crate::encryption::FileKeyProvider::generate_key_file(&old_key).unwrap();
+
+        let db = build_db_index_only(root, &old_key);
+        seed(&db);
+
+        // Vault pointed at an unreachable address: must NOT be dialed.
+        let err = db
+            .rotate_index_keys(KeyProviderConfig::Vault {
+                address: "https://127.0.0.1:1".to_string(),
+                token_env: "NOPE_TOKEN".to_string(),
+                mount: "secret".to_string(),
+                path: "app/mek".to_string(),
+                key_field: "key".to_string(),
+                namespace: None,
+                ca_cert: None,
+            })
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("not yet supported") && err.to_string().contains("vault"),
+            "expected clean vault refusal, got: {err}"
+        );
+        // And no breadcrumb was written by the refused rotation.
+        assert!(!root.join("data").join("rotation.state").exists());
+
+        // KMS is refused the same way (no endpoint contacted).
+        let err = db
+            .rotate_index_keys(KeyProviderConfig::Kms {
+                key_id: "alias/prod".to_string(),
+                encrypted_data_key: "AAAA".to_string(),
+                region: None,
+                endpoint_url: Some("http://127.0.0.1:1".to_string()),
+            })
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("not yet supported") && err.to_string().contains("kms"),
+            "expected clean kms refusal, got: {err}"
         );
     }
 

--- a/src/encryption/config.rs
+++ b/src/encryption/config.rs
@@ -4,7 +4,10 @@
 //! top-level [`AletheiaDBConfig`](crate::config::AletheiaDBConfig) so that all
 //! persistence settings are in one place.
 
+use std::fmt;
 use std::path::PathBuf;
+
+use zeroize::Zeroizing;
 
 use crate::encryption::audit::AuditLevel;
 use crate::encryption::error::KeyProviderError;
@@ -77,7 +80,12 @@ impl Default for AuditConfig {
 /// Key provider backend configuration.
 ///
 /// Determines where the Master Encryption Key (MEK) is sourced from at startup.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// `Debug` is implemented manually (never derived) so the KMS
+/// `encrypted_data_key` wrapped-key blob is redacted, mirroring
+/// [`KmsConfig`](crate::encryption::kms_provider::KmsConfig)'s redacting `Debug`.
+/// Non-secret fields (paths, env-var names, key ids, addresses) remain visible.
+#[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(tag = "type", rename_all = "snake_case"))]
 /// Configuration options for the Master Encryption Key (MEK) provider.
@@ -153,6 +161,58 @@ pub enum KeyProviderConfig {
     },
 }
 
+impl fmt::Debug for KeyProviderConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // The KMS `encrypted_data_key` is a wrapped-key ciphertext blob and is
+        // treated as sensitive material — NEVER print it. Every other field
+        // (paths, env-var NAMES, key ids, addresses, mounts) is non-secret.
+        match self {
+            KeyProviderConfig::File { path } => f.debug_struct("File").field("path", path).finish(),
+            KeyProviderConfig::Env { variable } => {
+                f.debug_struct("Env").field("variable", variable).finish()
+            }
+            KeyProviderConfig::PassphraseFile {
+                path,
+                passphrase_env,
+            } => f
+                .debug_struct("PassphraseFile")
+                .field("path", path)
+                .field("passphrase_env", passphrase_env)
+                .finish(),
+            KeyProviderConfig::Kms {
+                key_id,
+                encrypted_data_key: _,
+                region,
+                endpoint_url,
+            } => f
+                .debug_struct("Kms")
+                .field("key_id", key_id)
+                .field("encrypted_data_key", &"<redacted>")
+                .field("region", region)
+                .field("endpoint_url", endpoint_url)
+                .finish(),
+            KeyProviderConfig::Vault {
+                address,
+                token_env,
+                mount,
+                path,
+                key_field,
+                namespace,
+                ca_cert,
+            } => f
+                .debug_struct("Vault")
+                .field("address", address)
+                .field("token_env", token_env)
+                .field("mount", mount)
+                .field("path", path)
+                .field("key_field", key_field)
+                .field("namespace", namespace)
+                .field("ca_cert", ca_cert)
+                .finish(),
+        }
+    }
+}
+
 /// Serde default for [`KeyProviderConfig::Vault::mount`].
 #[cfg(feature = "serde")]
 fn default_vault_mount() -> String {
@@ -193,13 +253,18 @@ impl KeyProviderConfig {
                 path,
                 passphrase_env,
             } => {
-                let passphrase = std::env::var(passphrase_env).map_err(|_| {
+                // Land the secret in a zeroizing buffer immediately so it is
+                // wiped on drop rather than lingering in a plain `String`.
+                let passphrase = Zeroizing::new(std::env::var(passphrase_env).map_err(|_| {
                     // Name only the variable — never the passphrase value.
                     KeyProviderError::Unavailable(format!(
                         "passphrase environment variable {passphrase_env} is not set"
                     ))
-                })?;
-                Ok(Box::new(PassphraseFileKeyProvider::new(path, passphrase)))
+                })?);
+                Ok(Box::new(PassphraseFileKeyProvider::new(
+                    path,
+                    passphrase.as_str(),
+                )))
             }
             KeyProviderConfig::Kms {
                 key_id,
@@ -240,15 +305,18 @@ impl KeyProviderConfig {
             } => {
                 #[cfg(feature = "encryption-vault")]
                 {
-                    let token = std::env::var(token_env).map_err(|_| {
+                    // Land the bearer token in a zeroizing buffer immediately so
+                    // it is wiped on drop rather than lingering in a plain
+                    // `String`.
+                    let token = Zeroizing::new(std::env::var(token_env).map_err(|_| {
                         // Name only the variable — never the token value.
                         KeyProviderError::Unavailable(format!(
                             "Vault token environment variable {token_env} is not set"
                         ))
-                    })?;
+                    })?);
                     let cfg = crate::encryption::vault_provider::VaultConfig {
                         address: address.clone(),
-                        token,
+                        token: token.as_str().to_owned(),
                         mount: mount.clone(),
                         path: path.clone(),
                         key_field: key_field.clone(),
@@ -469,6 +537,44 @@ retention_days = 90
                 .level,
             AuditLevel::None
         );
+    }
+
+    #[test]
+    fn key_provider_config_debug_does_not_leak_blob() {
+        // The KMS wrapped-key ciphertext blob must never appear in Debug output,
+        // for the enum itself or the enclosing EncryptionConfig.
+        let blob = "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVowMTIzNDU2Nzg5"; // arbitrary base64
+        let cfg = KeyProviderConfig::Kms {
+            key_id: "alias/prod".to_string(),
+            encrypted_data_key: blob.to_string(),
+            region: Some("us-east-1".to_string()),
+            endpoint_url: None,
+        };
+
+        let dbg = format!("{cfg:?}");
+        assert!(
+            !dbg.contains(blob),
+            "KeyProviderConfig Debug leaked the wrapped-key blob: {dbg}"
+        );
+        assert!(dbg.contains("redacted"), "expected redaction marker: {dbg}");
+        // Non-secret fields stay visible for diagnostics.
+        assert!(dbg.contains("alias/prod"));
+        assert!(dbg.contains("us-east-1"));
+
+        // The blob must also not leak through the enclosing EncryptionConfig's
+        // (derived) Debug, which delegates to the manual impl above.
+        let enclosing = EncryptionConfig {
+            enabled: true,
+            algorithm: Algorithm::default(),
+            key_provider: cfg,
+            audit: AuditConfig::default(),
+        };
+        let enc_dbg = format!("{enclosing:?}");
+        assert!(
+            !enc_dbg.contains(blob),
+            "EncryptionConfig Debug leaked the wrapped-key blob: {enc_dbg}"
+        );
+        assert!(enc_dbg.contains("redacted"));
     }
 
     #[cfg(feature = "config-toml")]

--- a/src/encryption/key_provider.rs
+++ b/src/encryption/key_provider.rs
@@ -11,6 +11,13 @@ use zeroize::Zeroizing;
 
 use crate::encryption::KeyProviderError;
 
+/// The single logical key version a single-version provider exposes.
+///
+/// File/env/passphrase providers hold exactly one key; it answers to this
+/// version (and the sentinel `0`). Multi-version backends (KMS/Vault envelope
+/// models) use the same value for their current generation.
+pub const CURRENT_KEY_VERSION: u32 = 1;
+
 /// Sources the Master Encryption Key (MEK) for the database.
 ///
 /// Implementations must be `Send + Sync` to allow concurrent access from
@@ -22,13 +29,18 @@ pub trait KeyProvider: Send + Sync {
     /// Retrieve a specific key version (Issue #3587).
     ///
     /// The default implementation is for single-version providers (file, env,
-    /// passphrase): they hold exactly one key, so any requested version resolves
-    /// to that sole key via [`get_mek`](Self::get_mek). Multi-version backends
-    /// (e.g. KMS/Vault envelope models) override this to reject unknown versions
-    /// with [`KeyProviderError::KeyNotFound`] rather than silently returning the
-    /// current key. It never panics.
-    fn get_key_version(&self, _version: u32) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
-        self.get_mek()
+    /// passphrase): they hold exactly one key, so the **current** version
+    /// ([`CURRENT_KEY_VERSION`]) and the sentinel `0` resolve to that sole key
+    /// via [`get_mek`](Self::get_mek); any **other** version is rejected with
+    /// [`KeyProviderError::KeyNotFound`]. This mirrors the KMS/Vault envelope
+    /// backends' contract (unknown version → `KeyNotFound`) instead of silently
+    /// returning the current key for an arbitrary version. It never panics.
+    fn get_key_version(&self, version: u32) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+        if version == 0 || version == CURRENT_KEY_VERSION {
+            self.get_mek()
+        } else {
+            Err(KeyProviderError::KeyNotFound)
+        }
     }
 
     /// Human-readable provider name for logging/diagnostics.
@@ -467,13 +479,20 @@ mod tests {
         std::fs::write(&path, &hex_str).unwrap();
 
         let provider = FileKeyProvider::new(&path);
-        // A single-version provider resolves ANY requested version to its sole key.
-        let v = provider.get_key_version(42).unwrap();
-        assert_eq!(v.as_ref(), expected.as_ref());
+        // A single-version provider resolves the current version (1) and the
+        // sentinel 0 to its sole key; any other version is KeyNotFound.
+        assert_eq!(
+            provider.get_key_version(1).unwrap().as_ref(),
+            expected.as_ref()
+        );
         assert_eq!(
             provider.get_key_version(0).unwrap().as_ref(),
             expected.as_ref()
         );
+        assert!(matches!(
+            provider.get_key_version(42).unwrap_err(),
+            KeyProviderError::KeyNotFound
+        ));
     }
 
     #[test]
@@ -484,8 +503,20 @@ mod tests {
         unsafe { std::env::set_var(&var, &hex_str) };
 
         let provider = EnvKeyProvider::new(&var);
-        let v = provider.get_key_version(7).unwrap();
-        assert_eq!(v.as_ref(), expected.as_ref());
+        // Current version (1) and the sentinel 0 resolve to the sole key; any
+        // other version is KeyNotFound.
+        assert_eq!(
+            provider.get_key_version(1).unwrap().as_ref(),
+            expected.as_ref()
+        );
+        assert_eq!(
+            provider.get_key_version(0).unwrap().as_ref(),
+            expected.as_ref()
+        );
+        assert!(matches!(
+            provider.get_key_version(7).unwrap_err(),
+            KeyProviderError::KeyNotFound
+        ));
 
         unsafe { std::env::remove_var(&var) };
     }

--- a/src/encryption/kms_provider.rs
+++ b/src/encryption/kms_provider.rs
@@ -155,6 +155,24 @@ impl KmsKeyProvider {
         })
     }
 
+    /// Test-only constructor injecting an already-built KMS `Client` (e.g. one
+    /// backed by a mocked transport) plus the raw ciphertext blob, bypassing the
+    /// real AWS credential/endpoint config. Not part of the public API; lets the
+    /// Decrypt success path be exercised without a live KMS.
+    #[cfg(test)]
+    fn with_client_for_test(client: Client, blob: Vec<u8>) -> Self {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        Self {
+            client,
+            key_id: "alias/test".to_string(),
+            blob,
+            runtime,
+        }
+    }
+
     /// Run the (owned, `'static`) decrypt future to completion, bridging the
     /// async client into the synchronous trait without panicking inside an
     /// ambient runtime.
@@ -359,6 +377,49 @@ mod tests {
         assert!(
             matches!(err, KeyProviderError::KeyNotFound),
             "unknown version must be KeyNotFound, got: {err}"
+        );
+    }
+
+    #[test]
+    fn mocked_decrypt_returns_exact_plaintext() {
+        // Replay a canned KMS Decrypt success whose plaintext is a fixed, known
+        // 32 bytes and assert get_mek() returns exactly those bytes — the
+        // success path the unreachable-endpoint test cannot cover.
+        use aws_sdk_kms::operation::decrypt::DecryptOutput;
+        use aws_smithy_mocks::{mock, mock_client};
+
+        let expected = [0x5Au8; 32];
+        let rule = mock!(aws_sdk_kms::Client::decrypt).then_output(move || {
+            DecryptOutput::builder()
+                .plaintext(Blob::new(expected.to_vec()))
+                .build()
+        });
+        let client = mock_client!(aws_sdk_kms, &[&rule]);
+
+        let provider = KmsKeyProvider::with_client_for_test(client, b"wrapped-blob".to_vec());
+        let mek = provider.get_mek().expect("mocked decrypt should succeed");
+        assert_eq!(mek.as_ref(), &expected);
+    }
+
+    #[test]
+    fn mocked_decrypt_non_32_byte_plaintext_is_invalid_format() {
+        // A mocked Decrypt returning a non-32-byte plaintext must map to a typed
+        // InvalidKeyFormat, never a panic.
+        use aws_sdk_kms::operation::decrypt::DecryptOutput;
+        use aws_smithy_mocks::{mock, mock_client};
+
+        let rule = mock!(aws_sdk_kms::Client::decrypt).then_output(|| {
+            DecryptOutput::builder()
+                .plaintext(Blob::new(vec![1u8; 16]))
+                .build()
+        });
+        let client = mock_client!(aws_sdk_kms, &[&rule]);
+
+        let provider = KmsKeyProvider::with_client_for_test(client, b"wrapped-blob".to_vec());
+        let err = provider.get_mek().unwrap_err();
+        assert!(
+            matches!(err, KeyProviderError::InvalidKeyFormat(_)),
+            "non-32-byte plaintext must be InvalidKeyFormat, got: {err}"
         );
     }
 

--- a/src/encryption/passphrase.rs
+++ b/src/encryption/passphrase.rs
@@ -39,7 +39,7 @@
 use std::fmt;
 use std::path::{Path, PathBuf};
 
-use aes_gcm::aead::Aead;
+use aes_gcm::aead::{Aead, Payload};
 use aes_gcm::{Aes256Gcm, KeyInit, Nonce as AesNonce};
 use rand::RngCore;
 use zeroize::Zeroizing;
@@ -71,6 +71,21 @@ const OFF_NONCE: usize = OFF_SALT + SALT_LEN; // 38
 const OFF_CT: usize = OFF_NONCE + NONCE_LEN; // 50
 const OFF_TAG: usize = OFF_CT + CT_LEN; // 82
 const FILE_LEN: usize = OFF_TAG + TAG_LEN; // 98
+
+// Sane ceilings on KDF cost parameters read from an *untrusted* key file. A
+// crafted AEKF header could otherwise carry, e.g., `m_cost ≈ u32::MAX` and
+// trigger a multi-terabyte allocation the instant the file is opened. Params
+// beyond these bounds are rejected with `InvalidKeyFormat` BEFORE any Argon2
+// allocation is attempted. The ceilings are far above any legitimate config
+// (the Argon2id default is 19 MiB / 2 passes / 1 lane).
+/// Max Argon2 memory cost accepted from a key file: 2 GiB (in KiB).
+const MAX_ARGON2_M_COST_KIB: u32 = 2 * 1024 * 1024;
+/// Max Argon2 time cost (passes) accepted from a key file.
+const MAX_ARGON2_T_COST: u32 = 4096;
+/// Max Argon2 parallelism (lanes) accepted from a key file.
+const MAX_ARGON2_P_COST: u32 = 256;
+/// Max PBKDF2 iteration count accepted from a key file (~67M, bounds CPU DoS).
+const MAX_PBKDF2_ITERATIONS: u32 = 1 << 26;
 
 /// Key-derivation function used to derive the wrapping key from a passphrase.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -172,6 +187,18 @@ impl PassphraseKdf {
                 p_cost,
             } => {
                 use argon2::{Algorithm, Argon2, Params, Version};
+                // Reject absurd cost params from an untrusted key file BEFORE
+                // constructing `Params` (which would let a huge `m_cost` reach
+                // the allocator). Fail-closed with a typed error, never OOM.
+                if m_cost > MAX_ARGON2_M_COST_KIB
+                    || t_cost > MAX_ARGON2_T_COST
+                    || p_cost > MAX_ARGON2_P_COST
+                {
+                    return Err(KeyProviderError::InvalidKeyFormat(format!(
+                        "Argon2 KDF parameters exceed safe limits \
+                         (m_cost={m_cost} KiB, t_cost={t_cost}, p_cost={p_cost})"
+                    )));
+                }
                 let params = Params::new(m_cost, t_cost, p_cost, Some(32)).map_err(|e| {
                     KeyProviderError::InvalidKeyFormat(format!("invalid Argon2 params: {e}"))
                 })?;
@@ -187,6 +214,12 @@ impl PassphraseKdf {
                     })?;
             }
             Self::Pbkdf2 { iterations } => {
+                // Bound the iteration count from an untrusted file to cap CPU DoS.
+                if iterations > MAX_PBKDF2_ITERATIONS {
+                    return Err(KeyProviderError::InvalidKeyFormat(format!(
+                        "PBKDF2 iteration count {iterations} exceeds safe limit"
+                    )));
+                }
                 // pbkdf2 0.12 is built on the digest 0.10 ecosystem; pair it with
                 // the sha2 0.10 copy aliased as `sha2_pbkdf2`.
                 pbkdf2::pbkdf2_hmac::<sha2_pbkdf2::Sha256>(
@@ -256,17 +289,26 @@ impl PassphraseFileKeyProvider {
         let nonce = &raw[OFF_NONCE..OFF_CT];
         // ciphertext || tag is what aes-gcm's `decrypt` expects.
         let sealed = &raw[OFF_CT..FILE_LEN];
+        // The entire pre-ciphertext prefix (magic, version, kdf_id, kdf params,
+        // salt, nonce) is bound as AEAD associated data so tampering with any
+        // header byte — including the otherwise-unauthenticated reserved KDF
+        // param bytes — fails the authenticated decrypt rather than silently
+        // deriving/using a key.
+        let aad = &raw[OFF_MAGIC..OFF_CT];
 
         let wrapping = kdf.derive(self.passphrase.as_bytes(), salt)?;
         let cipher = Aes256Gcm::new_from_slice(wrapping.as_ref()).map_err(|_| {
             KeyProviderError::InvalidKeyFormat("invalid wrapping key length".to_string())
         })?;
-        let plaintext = cipher
-            .decrypt(AesNonce::from_slice(nonce), sealed)
+        // Bind the plaintext MEK in a zeroizing buffer so it is wiped on drop
+        // even before it is copied into the fixed-size array below.
+        let plaintext: Zeroizing<Vec<u8>> = cipher
+            .decrypt(AesNonce::from_slice(nonce), Payload { msg: sealed, aad })
+            .map(Zeroizing::new)
             .map_err(|_| {
                 // A GCM tag mismatch is the expected outcome of a wrong
-                // passphrase or tampered file. Return AccessDenied WITHOUT any
-                // key/passphrase material.
+                // passphrase or a tampered file/header. Return AccessDenied
+                // WITHOUT any key/passphrase material.
                 KeyProviderError::AccessDenied(
                     "passphrase key unwrap failed (wrong passphrase or corrupt file)".to_string(),
                 )
@@ -360,13 +402,32 @@ pub fn generate_passphrase_key_file_with_kdf(
     let mut nonce = [0u8; NONCE_LEN];
     rand::thread_rng().fill_bytes(&mut nonce);
 
-    // Derive wrapping key and seal the MEK.
+    // Build the header (everything before the ciphertext: magic, version,
+    // kdf_id, kdf params, salt, nonce) FIRST so it can be bound as AEAD
+    // associated data on the seal — authenticating the whole header, including
+    // the reserved KDF param bytes, against tampering.
+    let mut header = Vec::with_capacity(OFF_CT);
+    header.extend_from_slice(MAGIC);
+    header.push(FORMAT_VERSION);
+    header.push(kdf.kdf_id());
+    header.extend_from_slice(&kdf.encode_params());
+    header.extend_from_slice(&salt);
+    header.extend_from_slice(&nonce);
+    debug_assert_eq!(header.len(), OFF_CT);
+
+    // Derive wrapping key and seal the MEK, binding the header as AAD.
     let wrapping = kdf.derive(passphrase.as_bytes(), &salt)?;
     let cipher = Aes256Gcm::new_from_slice(wrapping.as_ref()).map_err(|_| {
         KeyProviderError::InvalidKeyFormat("invalid wrapping key length".to_string())
     })?;
     let sealed = cipher
-        .encrypt(AesNonce::from_slice(&nonce), &mek[..])
+        .encrypt(
+            AesNonce::from_slice(&nonce),
+            Payload {
+                msg: &mek[..],
+                aad: &header,
+            },
+        )
         .map_err(|e| {
             KeyProviderError::Provider(Box::new(std::io::Error::other(format!(
                 "key wrap failed: {e}"
@@ -380,14 +441,9 @@ pub fn generate_passphrase_key_file_with_kdf(
         )));
     }
 
-    // Assemble the file buffer.
+    // Assemble the file buffer: header || ciphertext || tag.
     let mut buf = Zeroizing::new(Vec::with_capacity(FILE_LEN));
-    buf.extend_from_slice(MAGIC);
-    buf.push(FORMAT_VERSION);
-    buf.push(kdf.kdf_id());
-    buf.extend_from_slice(&kdf.encode_params());
-    buf.extend_from_slice(&salt);
-    buf.extend_from_slice(&nonce);
+    buf.extend_from_slice(&header);
     buf.extend_from_slice(&sealed);
     debug_assert_eq!(buf.len(), FILE_LEN);
 
@@ -558,8 +614,70 @@ mod tests {
         let generated =
             generate_passphrase_key_file_with_kdf(&path, "pw", true, fast_argon()).unwrap();
         let provider = PassphraseFileKeyProvider::new(&path, "pw");
-        // Single-version provider: any version -> the sole key.
-        let v = provider.get_key_version(99).unwrap();
-        assert_eq!(v.as_ref(), generated.as_ref());
+        // Single-version provider: the current version (1) and the sentinel 0
+        // resolve to the sole key; any other version is a typed KeyNotFound.
+        assert_eq!(
+            provider.get_key_version(0).unwrap().as_ref(),
+            generated.as_ref()
+        );
+        assert_eq!(
+            provider.get_key_version(1).unwrap().as_ref(),
+            generated.as_ref()
+        );
+        assert!(matches!(
+            provider.get_key_version(99).unwrap_err(),
+            KeyProviderError::KeyNotFound
+        ));
+    }
+
+    #[test]
+    fn flipping_header_byte_fails_authenticated_decrypt() {
+        // The seal binds the whole header as AAD, so tampering with an
+        // otherwise-unauthenticated header byte fails the authenticated decrypt
+        // (AccessDenied) instead of silently succeeding. A *reserved* KDF param
+        // byte is chosen deliberately: it neither changes the derived key nor is
+        // read by `decode`, so before AAD binding this flip would decrypt fine.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("aad.aekf");
+        generate_passphrase_key_file_with_kdf(&path, "pw", true, fast_argon()).unwrap();
+
+        let mut raw = std::fs::read(&path).unwrap();
+        // Argon2id kdf_params layout: m_cost|t_cost|p_cost|reserved (each u32 BE).
+        // The reserved word starts 12 bytes into kdf_params.
+        let reserved_off = OFF_KDF_PARAMS + 12;
+        raw[reserved_off] ^= 0xFF;
+        std::fs::write(&path, &raw).unwrap();
+
+        let provider = PassphraseFileKeyProvider::new(&path, "pw");
+        let err = provider.get_mek().unwrap_err();
+        assert!(
+            matches!(
+                err,
+                KeyProviderError::AccessDenied(_) | KeyProviderError::InvalidKeyFormat(_)
+            ),
+            "tampered header must fail authenticated decrypt, got: {err}"
+        );
+    }
+
+    #[test]
+    fn absurd_m_cost_header_is_rejected_without_oom() {
+        // A crafted AEKF whose Argon2 m_cost is ~u32::MAX must be rejected with a
+        // typed InvalidKeyFormat BEFORE any Argon2 allocation is attempted — no
+        // OOM. The clamp in `derive` fires ahead of the AEAD decrypt.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("absurd.aekf");
+        generate_passphrase_key_file_with_kdf(&path, "pw", true, fast_argon()).unwrap();
+
+        let mut raw = std::fs::read(&path).unwrap();
+        // Overwrite the m_cost word (first 4 bytes of kdf_params) with u32::MAX.
+        raw[OFF_KDF_PARAMS..OFF_KDF_PARAMS + 4].copy_from_slice(&u32::MAX.to_be_bytes());
+        std::fs::write(&path, &raw).unwrap();
+
+        let provider = PassphraseFileKeyProvider::new(&path, "pw");
+        let err = provider.get_mek().unwrap_err();
+        assert!(
+            matches!(err, KeyProviderError::InvalidKeyFormat(_)),
+            "absurd m_cost must be rejected as InvalidKeyFormat, got: {err}"
+        );
     }
 }

--- a/src/encryption/vault_provider.rs
+++ b/src/encryption/vault_provider.rs
@@ -98,6 +98,14 @@ impl VaultConfig {
 }
 
 /// Reads the MEK from a Vault KV v2 secret over HTTPS/HTTP.
+///
+/// # Runtime context
+///
+/// This provider uses `reqwest::blocking` internally, so it must be
+/// **constructed and called from a synchronous context** (not from within a
+/// running Tokio runtime, which would panic on the nested blocking call).
+/// Unlike the KMS provider it has no ambient-runtime bridge; sourcing the MEK at
+/// synchronous database startup is the intended path.
 pub struct VaultKeyProvider {
     client: reqwest::blocking::Client,
     address: String,
@@ -229,9 +237,10 @@ impl VaultKeyProvider {
 fn decode_key_material(value: &str) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
     let trimmed = value.trim();
 
-    // Hex first (64 chars).
+    // Hex first (64 chars). Hold the decoded key material in a zeroizing buffer
+    // so it is wiped on drop even before it is copied into the fixed array.
     if trimmed.len() == 64
-        && let Some(decoded) = crate::core::hex::decode(trimmed)
+        && let Some(decoded) = crate::core::hex::decode(trimmed).map(Zeroizing::new)
         && decoded.len() == 32
     {
         let mut key = Zeroizing::new([0u8; 32]);
@@ -240,7 +249,7 @@ fn decode_key_material(value: &str) -> Result<Zeroizing<[u8; 32]>, KeyProviderEr
     }
 
     // Base64 of exactly 32 bytes.
-    if let Ok(decoded) = BASE64.decode(trimmed.as_bytes())
+    if let Ok(decoded) = BASE64.decode(trimmed.as_bytes()).map(Zeroizing::new)
         && decoded.len() == 32
     {
         let mut key = Zeroizing::new([0u8; 32]);


### PR DESCRIPTION
Refs #3587, follow-up to merged #3599 (this hardening delta was never part of #3599 — it is a new, standalone change layered on the merged base). Does **not** close any issue.

## Before / After (what changes for a reader)

- **Before:** `Debug`-printing an `EncryptionConfig` / `KeyProviderConfig` printed the KMS `encrypted_data_key` (the base64 wrapped-key blob) in the clear. **After:** that blob is rendered `"<redacted>"` — non-secret fields (paths, env-var *names*, key ids, addresses) stay visible.
- **Before:** a tampered/crafted passphrase key-file header could be silently accepted, and a hostile `m_cost` could trigger a huge allocation on open. **After:** the whole AEKF header is bound as AEAD associated data (tampering fails authenticated decrypt) and KDF cost params are clamped before any allocation.
- **Before:** intermediate plaintext master-key / passphrase / token buffers lingered un-wiped in plain `Vec`/`String`. **After:** each is held in a `Zeroizing` buffer and erased on drop.
- **Before:** rotating the index key *to* an (unreachable) KMS/Vault source surfaced a confusing network/transport error. **After:** it returns a clean "not yet supported" refusal decided on the config variant alone, before any network call.
- **Before:** single-version providers (file/env/passphrase) returned their sole key for *any* requested version number. **After:** they answer version `0`/current and return `KeyNotFound` otherwise — consistent with KMS/Vault.
- **Before:** the KMS Decrypt success path had no test (only an unreachable-endpoint typed-error test). **After:** a mocked-transport test asserts exact 32-byte recovery.

## How

Purely additive hardening layered on the merged #3587 base: a manual redacting `Debug` for `KeyProviderConfig`; AES-256-GCM `Payload{msg, aad}` on both seal and open of the AEKF file with the header as AAD; KDF-param ceilings enforced in `PassphraseKdf::derive`; `Zeroizing` wrappers at every intermediate secret; a static `refuse_unsupported_new_source` precheck as the first statement of `run_rotation`; a consistent default `get_key_version` contract; and a `#[cfg(test)]`-only KMS client injector wired to `aws-smithy-mocks` (KMS-feature-gated) so a canned Decrypt 200 can be replayed. Docs updated. No public API shape changed (only the documented `get_key_version` contract tweak).

## Findings (each with its test as evidence)

- **A [SECURITY MED] — KMS wrapped-key blob no longer leaks via `Debug`.** Manual `impl Debug for KeyProviderConfig` redacting `encrypted_data_key`. Test: `encryption::config::tests::key_provider_config_debug_does_not_leak_blob` (also asserts the enclosing `EncryptionConfig` Debug).
- **B [SECURITY LOW] — zeroize intermediate secret buffers.** Decrypted MEK bound as `Zeroizing<Vec<u8>>` (`passphrase::unwrap_key`); Vault hex/base64 material zeroized (`vault_provider::decode_key_material`); passphrase/token env reads wrapped in `Zeroizing<String>` (`config::build_provider`, `src/bin/aletheia.rs`). Covered by existing round-trip/recovery tests (`round_trip_argon2id`, `get_mek_recovers_hex_key`, `get_mek_recovers_base64_key`).
- **C [CRYPTO] — bind the AEKF header as AEAD AAD.** Header bound on both seal + open. Test: `encryption::passphrase::tests::flipping_header_byte_fails_authenticated_decrypt` (flips a reserved KDF-param byte — one that does not affect key derivation or decode — so it genuinely proves AAD, not a wrong-key artifact). Existing `wrong_passphrase_is_access_denied_not_panic` / `truncated_file_is_invalid_format` still green.
- **D [CRYPTO] — clamp untrusted KDF params.** Argon2 `m_cost`/`t_cost`/`p_cost` (and PBKDF2 iterations) rejected above sane ceilings before `Params::new`. Test: `encryption::passphrase::tests::absurd_m_cost_header_is_rejected_without_oom` (u32::MAX m_cost → `InvalidKeyFormat`, no OOM).
- **E [FEATURES] — drop vestigial `native-tls` from `encryption-vault`.** The vault path is TLS-backend-agnostic (reqwest `rustls-tls` + `reqwest::Certificate::from_pem`). Verified by the standalone `cargo check --no-default-features --tests --features encryption-vault` (green).
- **F [FEATURES / coverage] — KMS Decrypt success test via mocked transport.** Added `aws-smithy-mocks` (optional, enabled only by `encryption-aws-kms`, `#[cfg(test)]`-only) plus a test-only `KmsKeyProvider::with_client_for_test` injector — no public API change. Tests: `encryption::kms_provider::tests::mocked_decrypt_returns_exact_plaintext` and `mocked_decrypt_non_32_byte_plaintext_is_invalid_format`.
- **G [FEATURES] — rotation refusal ordering.** `refuse_unsupported_new_source` runs before any `load_mek`/network call. Test: `db::rotation::tests::rotate_to_remote_source_refuses_without_reaching_endpoint` (Vault/KMS at an unreachable endpoint → clean refusal, no breadcrumb).
- **H [CRYPTO] — align `get_key_version` contract.** Default impl returns the sole key for version `0`/`CURRENT_KEY_VERSION`, else `KeyNotFound`. Tests: `file_provider_get_key_version_returns_sole_key`, `env_provider_get_key_version_returns_sole_key`, `passphrase::tests::get_key_version_returns_sole_key`.
- **I [DOCS] — encryption docs updated.** `docs/ENCRYPTION.md` gains PassphraseFile/KMS/Vault provider sections, the `keys generate --passphrase` flow (passphrase via `ALETHEIADB_KEY_PASSPHRASE`, never argv), and the fail-closed rotation-refusal note; `docs/adr/0028-encryption-at-rest.md` gets an implementation-status callout.

## Notes

- **argon2 and pbkdf2 KDF crates are unconditionally compiled with the (non-feature-gated) encryption module — a conscious choice so passphrase key files work in any build; gating them behind a feature is a possible follow-up.**
- **Deferred (documented, not addressed here):** KMS concurrent `get_mek` under an ambient runtime; base64 unpadded interop for Vault key material. The Vault provider carries a "construct/call from a synchronous context" doc note.
- **Pre-existing, non-blocking:** `cargo clippy --all-targets --all-features -- -D warnings` reports `result_large_err` in `src/mcp/server.rs` (MCP lane — not this diff, byte-identical on trunk, and **not** a CI gate; CI's clippy gate is `--features "config-toml,mcp-server,sharding-rpc,simulation"`, which passes here).

## Gates (all green on this branch, rebased on current trunk)

- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` — clean (the CI clippy gate)
- `cargo test --features encryption-vault -- encryption` — 129 passed
- `cargo test --features encryption-aws-kms -- encryption` — 129 passed (incl. both KMS mock tests)
- `cargo test -- encryption` — 120 passed
- `cargo test --lib -- db::rotation::tests` — 18 passed (both the merged `resume_pending_index_rotation_is_none_when_no_breadcrumb` and the new `rotate_to_remote_source_refuses_without_reaching_endpoint`)
- `cargo check --no-default-features --tests --features {encryption,encryption-vault,encryption-aws-kms}` — all exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfZqK5Hqerd1DoKmxzamd5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfZqK5Hqerd1DoKmxzamd5)_