### PR TITLE
Provenance projection: review fixes (follow-up to #3354b / #3600)

### DIFF
--- a/src/cypher/converter.rs
+++ b/src/cypher/converter.rs
@@ -33,7 +33,7 @@
 //! # }
 //! ```
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 
 use super::ast::*;
@@ -474,9 +474,13 @@ impl CypherConverter {
                 }
 
                 // Provenance accessor projection (Issue #3354) runs LAST so it
-                // never perturbs ordering/pagination. Only on the non-aggregate
-                // path: aggregation produces its own computed columns.
-                if !aggregated && let Some(op) = self.build_provenance_projection(&return_clause)? {
+                // never perturbs ordering/pagination. `build_provenance_projection`
+                // is always consulted (even when aggregated) so an accessor mixed
+                // with aggregation is REJECTED rather than silently dropped; a
+                // normal aggregate query with no accessor still yields `None`.
+                if let Some(op) =
+                    self.build_provenance_projection(&return_clause, &pattern, aggregated)?
+                {
                     ops.push(op);
                 }
 
@@ -1687,12 +1691,31 @@ impl CypherConverter {
     /// argument is a structured error (never silently dropped), reusing the same
     /// [`as_provenance_accessor`](Self::as_provenance_accessor) recognition the
     /// `WHERE` half uses.
+    ///
+    /// v1 supports only the clean single-entity forms
+    /// (`RETURN <entity>, <accessor(s)>` and `RETURN <accessor(s)>` over the
+    /// single bound node). Building general property-projection-into-columns is
+    /// out of scope, so an accessor mixed with a property projection
+    /// (`RETURN n.name, source(n)`), an aggregate
+    /// (`RETURN n.dept, count(*), source(n)`), or a variable other than the
+    /// single bound entity (`RETURN a, source(b)`) is **rejected** with a
+    /// structured [`CypherError::UnsupportedFeature`] rather than silently
+    /// dropping a column or resolving the wrong entity. (Edge/traversal-variable
+    /// accessors never reach this path: a multi-variable MATCH routes to the
+    /// multi-pattern evaluator, so provenance projection is node-entity-scoped in
+    /// v1.)
     fn build_provenance_projection(
         &self,
         return_clause: &CypherReturn,
+        patterns: &[CypherPattern],
+        aggregated: bool,
     ) -> Result<Option<QueryOp>, CypherError> {
         let mut items = Vec::new();
         let mut entity_binding: Option<String> = None;
+        // Distinct entity variables referenced across the bare entity and every
+        // accessor argument; the supported form references exactly one.
+        let mut referenced_vars: BTreeSet<String> = BTreeSet::new();
+        let mut has_property_projection = false;
         for item in &return_clause.items {
             let (expr, alias) = match item {
                 CypherReturnItem::Expression { expr, alias } => (expr, alias.clone()),
@@ -1702,6 +1725,7 @@ impl CypherConverter {
                     if entity_binding.is_none() {
                         entity_binding = Some(name.clone());
                     }
+                    referenced_vars.insert(name.clone());
                     continue;
                 }
                 CypherReturnItem::Star => continue,
@@ -1712,6 +1736,12 @@ impl CypherConverter {
                     if entity_binding.is_none() {
                         entity_binding = Some(name.clone());
                     }
+                    referenced_vars.insert(name.clone());
+                }
+                // A property projection (`n.name`) alongside an accessor is the
+                // unsupported mix (rejected below once an accessor is present).
+                CypherExpr::Property { .. } => {
+                    has_property_projection = true;
                 }
                 CypherExpr::FunctionCall { args, .. } => {
                     if let Some(field) = self.as_provenance_accessor(expr)? {
@@ -1721,6 +1751,7 @@ impl CypherConverter {
                             [CypherExpr::Variable(v)] => v.clone(),
                             _ => String::new(),
                         };
+                        referenced_vars.insert(var.clone());
                         let output_name =
                             alias.unwrap_or_else(|| format!("{}({})", field.accessor_name(), var));
                         items.push(ProvenanceProjectionItem { output_name, field });
@@ -1730,13 +1761,64 @@ impl CypherConverter {
             }
         }
         if items.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(QueryOp::ProjectProvenance(ProvenanceProjection {
-                entity_binding,
-                items,
-            })))
+            return Ok(None);
         }
+
+        // An accessor is projected: enforce the v1 single-entity contract.
+        if aggregated {
+            return Err(CypherError::UnsupportedFeature(
+                "combining a provenance accessor with an aggregate in RETURN is not supported \
+                 (v1); an aggregating RETURN produces its own computed columns"
+                    .to_string(),
+            ));
+        }
+        if has_property_projection {
+            return Err(CypherError::UnsupportedFeature(
+                "combining a property projection with a provenance accessor in RETURN is not \
+                 supported (v1); return the entity itself (RETURN n, source(n)) or the accessors \
+                 alone (RETURN source(n))"
+                    .to_string(),
+            ));
+        }
+        // The supported form binds exactly one entity: a single MATCH node with a
+        // variable. Every referenced variable (bare entity + accessor args) must
+        // be that node. This rejects the multi-variable mismatch
+        // (`RETURN a, source(b)`, including an accessor over an unbound variable),
+        // which the single-entity positional pipeline would otherwise resolve
+        // against the wrong (or a nonexistent) entity.
+        let sole_entity = Self::sole_pattern_node_var(patterns);
+        let matches_sole = match &sole_entity {
+            Some(v) => referenced_vars.len() == 1 && referenced_vars.contains(v),
+            None => false,
+        };
+        if !matches_sole {
+            return Err(CypherError::UnsupportedFeature(
+                "provenance projection in RETURN is supported only for a single bound entity \
+                 whose accessor variable matches the returned node (RETURN n, source(n)); \
+                 projecting an accessor over a different variable or a multi-entity match is not \
+                 supported (v1)"
+                    .to_string(),
+            ));
+        }
+
+        Ok(Some(QueryOp::ProjectProvenance(ProvenanceProjection {
+            entity_binding,
+            items,
+        })))
+    }
+
+    /// The variable of the single bound node when the MATCH is exactly one
+    /// pattern consisting of one node element with a variable and no
+    /// relationships; `None` otherwise. This is the one entity the single-entity
+    /// positional pipeline can correctly attribute a provenance accessor to.
+    fn sole_pattern_node_var(patterns: &[CypherPattern]) -> Option<String> {
+        let [pattern] = patterns else {
+            return None;
+        };
+        let [CypherPatternElement::Node(node)] = pattern.elements.as_slice() else {
+            return None;
+        };
+        node.variable.clone()
     }
 
     // =======================================================================

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -167,7 +167,7 @@
 //! - **Avoid large IN lists**: Large `IN [...]` clauses are converted to sequential
 //!   value checks; consider using joins for very large lists
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
 use crate::core::NodeId;
@@ -617,7 +617,7 @@ impl AstConverter {
         //    projected provenance columns (and preserves a bare entity via the
         //    bindings channel) as the final 1:1 step.
         if let Some(ref return_clause) = ast.return_clause
-            && let Some(op) = self.build_provenance_projection(return_clause)?
+            && let Some(op) = self.build_provenance_projection(return_clause, &ast.source)?
         {
             ops.push(op);
         }
@@ -635,9 +635,26 @@ impl AstConverter {
     /// provenance-named accessor with a malformed argument is a structured error
     /// (never silently dropped), mirroring the `WHERE`-clause accessor
     /// recognition.
-    fn build_provenance_projection(&self, return_clause: &ReturnClause) -> Result<Option<QueryOp>> {
+    ///
+    /// v1 supports only the clean single-entity forms
+    /// (`RETURN <entity>, <accessor(s)>` and `RETURN <accessor(s)>` over a single
+    /// bound node). Building general property-projection-into-columns is out of
+    /// scope, so a `RETURN` that mixes an accessor with a property projection
+    /// (`RETURN n.name, source(n)`), or references a variable other than the
+    /// single bound MATCH entity (`RETURN a, source(b)`, or an accessor over an
+    /// edge/traversal variable), is **rejected** with a structured error rather
+    /// than silently dropping the property or resolving the wrong entity.
+    fn build_provenance_projection(
+        &self,
+        return_clause: &ReturnClause,
+        source: &SourceClause,
+    ) -> Result<Option<QueryOp>> {
         let mut items = Vec::new();
         let mut entity_binding: Option<String> = None;
+        // Distinct entity variables referenced across the bare entity and every
+        // accessor argument; the supported form references exactly one.
+        let mut referenced_vars: BTreeSet<String> = BTreeSet::new();
+        let mut has_property_projection = false;
         for item in &return_clause.items {
             match &item.expression {
                 // A bare variable returned alongside the accessors is preserved
@@ -646,6 +663,13 @@ impl AstConverter {
                     if entity_binding.is_none() {
                         entity_binding = Some(name.clone());
                     }
+                    referenced_vars.insert(name.clone());
+                }
+                // A property projection (`n.name`) alongside an accessor is the
+                // unsupported mix (rejected below once we know an accessor is
+                // present).
+                Expression::Property(_) => {
+                    has_property_projection = true;
                 }
                 Expression::FunctionCall { name, args } => {
                     if let Some(field) = provenance_field_name(name) {
@@ -661,6 +685,7 @@ impl AstConverter {
                                 }));
                             }
                         };
+                        referenced_vars.insert(var.clone());
                         let output_name = item
                             .alias
                             .clone()
@@ -672,13 +697,62 @@ impl AstConverter {
             }
         }
         if items.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(QueryOp::ProjectProvenance(ProvenanceProjection {
-                entity_binding,
-                items,
-            })))
+            return Ok(None);
         }
+
+        // An accessor is projected: enforce the v1 single-entity contract.
+        if has_property_projection {
+            return Err(Error::Query(QueryError::SyntaxError {
+                message: "combining a property projection with a provenance accessor in RETURN \
+                          is not supported (v1); return the entity itself \
+                          (RETURN n, source(n)) or the accessors alone (RETURN source(n))"
+                    .to_string(),
+            }));
+        }
+        // The supported form binds exactly one entity: a single MATCH node with a
+        // variable. Every referenced variable (bare entity + accessor args) must
+        // be that node. This rejects the multi-variable mismatch
+        // (`RETURN a, source(b)`) and edge/traversal-variable accessors, which the
+        // single-entity positional pipeline would otherwise resolve against the
+        // wrong (or a nonexistent) entity.
+        let sole_entity = Self::sole_match_node_var(source);
+        let matches_sole = match &sole_entity {
+            Some(v) => referenced_vars.len() == 1 && referenced_vars.contains(v),
+            None => false,
+        };
+        if !matches_sole {
+            return Err(Error::Query(QueryError::SyntaxError {
+                message: "provenance projection in RETURN is supported only for a single bound \
+                          entity whose accessor variable matches the returned node \
+                          (RETURN n, source(n)); projecting an accessor over a different \
+                          variable, an edge/traversal variable, or a multi-entity match is not \
+                          supported (v1)"
+                    .to_string(),
+            }));
+        }
+
+        Ok(Some(QueryOp::ProjectProvenance(ProvenanceProjection {
+            entity_binding,
+            items,
+        })))
+    }
+
+    /// The variable of the single bound node when `source` is a `MATCH` of
+    /// exactly one node pattern with a variable and no relationships; `None`
+    /// otherwise (a traversal, multiple patterns, an unnamed node, or a
+    /// vector/similarity source). This is the one entity the single-entity
+    /// positional pipeline can correctly attribute a provenance accessor to.
+    fn sole_match_node_var(source: &SourceClause) -> Option<String> {
+        let SourceClause::Match(patterns) = source else {
+            return None;
+        };
+        let [pattern] = patterns.as_slice() else {
+            return None;
+        };
+        let [PatternElement::Node(node)] = pattern.elements.as_slice() else {
+            return None;
+        };
+        node.variable.clone()
     }
 
     fn convert_where_clause(
@@ -1327,13 +1401,12 @@ impl AstConverter {
                 Expression::FunctionCall { name, args }
                     if provenance_field_name(name).is_some() =>
                 {
-                    // `provenance_field_name` just matched, so this is safe; the
-                    // arm guard guarantees `Some`.
-                    let field = provenance_field_name(name).ok_or_else(|| {
-                        Error::Query(QueryError::SyntaxError {
+                    // The arm guard guarantees `Some`; bind it once.
+                    let Some(field) = provenance_field_name(name) else {
+                        return Err(Error::Query(QueryError::SyntaxError {
                             message: "unrecognized provenance accessor in ORDER BY".to_string(),
-                        })
-                    })?;
+                        }));
+                    };
                     match args.as_slice() {
                         [Expression::Identifier(_)] => SortKey::Provenance(field),
                         _ => {

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -3212,6 +3212,19 @@ fn provenance_field_value(prov: Option<&Provenance>, field: ProvenanceField) -> 
     }
 }
 
+/// Provenance field value as an `Option`, collapsing [`PropertyValue::Null`]
+/// (absent bundle or missing field) to `None` so a sort treats it as a null
+/// (Issue #3354). Used by the decorate-sort-undecorate provenance ordering path.
+fn provenance_field_value_opt(
+    prov: Option<&Provenance>,
+    field: ProvenanceField,
+) -> Option<PropertyValue> {
+    match provenance_field_value(prov, field) {
+        PropertyValue::Null => None,
+        v => Some(v),
+    }
+}
+
 /// Look up a value for ordering by column/property name: first a node property
 /// (entity rows), then a computed aggregate column (`row.columns`) so ORDER BY
 /// can sort grouped/aggregate rows by a group key or aggregate alias.
@@ -3286,8 +3299,43 @@ impl SortIterator {
         while let Some(row) = input.next() {
             rows.push(row?);
         }
-        rows.sort_by(|a, b| self.cmp_rows(a, b));
-        self.output = rows.into_iter();
+
+        // Decorate-sort-undecorate for provenance sort keys (Issue #3354): a
+        // `SortKey::Provenance` resolution is a historical read under the shared
+        // `historical` lock. Resolving it inside the comparator would cost
+        // O(n log n) locked lookups; instead resolve each row's provenance
+        // bundle EXACTLY ONCE (n lookups, a single lock span), sort against the
+        // precomputed bundles, then strip. This mirrors the WHERE path's
+        // per-row memoization. Null placement and stable ordering are identical
+        // to the on-the-fly path. When no provenance key is present (the common
+        // case) the ordinary comparator runs and historical is never touched.
+        if self
+            .keys
+            .iter()
+            .any(|(k, _)| matches!(k, SortKey::Provenance(_)))
+        {
+            let mut decorated: Vec<(Option<Provenance>, QueryRow)> = rows
+                .into_iter()
+                .map(|row| {
+                    let prov = self
+                        .historical
+                        .as_ref()
+                        .and_then(|h| resolve_entity_provenance(&row.entity, h));
+                    (prov, row)
+                })
+                .collect();
+            decorated.sort_by(|(a_prov, a), (b_prov, b)| {
+                self.cmp_decorated(a_prov.as_ref(), a, b_prov.as_ref(), b)
+            });
+            self.output = decorated
+                .into_iter()
+                .map(|(_, row)| row)
+                .collect::<Vec<_>>()
+                .into_iter();
+        } else {
+            rows.sort_by(|a, b| self.cmp_rows(a, b));
+            self.output = rows.into_iter();
+        }
         Ok(())
     }
 
@@ -3295,6 +3343,35 @@ impl SortIterator {
         use std::cmp::Ordering;
         for (key, descending) in &self.keys {
             let ord = self.cmp_by_key(a, b, key, *descending);
+            if ord != Ordering::Equal {
+                return ord;
+            }
+        }
+        Ordering::Equal
+    }
+
+    /// Compare two rows whose provenance bundles have already been resolved once
+    /// (decorate-sort-undecorate, Issue #3354). A `SortKey::Provenance` key reads
+    /// the precomputed bundle instead of re-resolving; every other key falls
+    /// through to [`cmp_by_key`](Self::cmp_by_key). Ordering (including
+    /// openCypher null placement) is identical to the on-the-fly comparator.
+    fn cmp_decorated(
+        &self,
+        a_prov: Option<&Provenance>,
+        a: &QueryRow,
+        b_prov: Option<&Provenance>,
+        b: &QueryRow,
+    ) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        for (key, descending) in &self.keys {
+            let ord = match key {
+                SortKey::Provenance(field) => {
+                    let av = provenance_field_value_opt(a_prov, *field);
+                    let bv = provenance_field_value_opt(b_prov, *field);
+                    Self::cmp_optional(av.as_ref(), bv.as_ref(), *descending)
+                }
+                other => self.cmp_by_key(a, b, other, *descending),
+            };
             if ord != Ordering::Equal {
                 return ord;
             }
@@ -3347,17 +3424,16 @@ impl SortIterator {
             SortKey::Property(prop) => {
                 Self::cmp_optional(row_value(a, prop), row_value(b, prop), descending)
             }
-            // Resolve each row entity's provenance value on the fly (Issue
-            // #3354). Matches the WHERE-clause resolution: an unattributed row
-            // (or a bundle missing the field) sorts as null.
+            // Fallback on-the-fly resolution (Issue #3354). The hot path routes
+            // provenance keys through `cmp_decorated` (resolve once per row), so
+            // this arm is only a defensive fallback; it matches the WHERE-clause
+            // resolution: an unattributed row (or a bundle missing the field)
+            // sorts as null.
             SortKey::Provenance(field) => {
                 let resolve = |row: &QueryRow| -> Option<PropertyValue> {
                     let historical = self.historical.as_ref()?;
                     let prov = resolve_entity_provenance(&row.entity, historical);
-                    match provenance_field_value(prov.as_ref(), *field) {
-                        PropertyValue::Null => None,
-                        v => Some(v),
-                    }
+                    provenance_field_value_opt(prov.as_ref(), *field)
                 };
                 Self::cmp_optional(resolve(a).as_ref(), resolve(b).as_ref(), descending)
             }
@@ -3420,10 +3496,11 @@ impl ProvenanceProjectIterator {
         }
     }
 
-    /// Build the projected columns for one row's entity.
-    fn project_row(&self, row: &QueryRow) -> QueryRow {
+    /// Build the projected columns for one row's entity, consuming the input
+    /// row (it is 1:1 replaced by the projected row).
+    fn project_row(&self, row: QueryRow) -> QueryRow {
         let prov = resolve_entity_provenance(&row.entity, &self.historical);
-        let columns: Vec<(String, PropertyValue)> = self
+        let projected: Vec<(String, PropertyValue)> = self
             .projection
             .items
             .iter()
@@ -3444,10 +3521,17 @@ impl ProvenanceProjectIterator {
             .as_ref()
             .map(|var| vec![(var.clone(), row.entity.clone())]);
 
+        // Defense-in-depth (Issue #3354 findings #5/#7): MERGE onto any
+        // pre-existing columns rather than overwriting them. No upstream op
+        // currently populates `columns` before this iterator, but merging keeps
+        // the projection strictly additive if one ever does.
+        let mut columns = row.columns.unwrap_or_default();
+        columns.extend(projected);
+
         QueryRow {
             entity: EntityResult::Null,
             score: row.score,
-            path: row.path.clone(),
+            path: row.path,
             timestamp: row.timestamp,
             columns: Some(columns),
             bindings,
@@ -3458,7 +3542,7 @@ impl ProvenanceProjectIterator {
 impl ResultIterator for ProvenanceProjectIterator {
     fn next(&mut self) -> Option<Result<QueryRow>> {
         match self.input.next()? {
-            Ok(row) => Some(Ok(self.project_row(&row))),
+            Ok(row) => Some(Ok(self.project_row(row))),
             Err(e) => Some(Err(e)),
         }
     }

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -534,6 +534,7 @@ impl QueryPlanner {
             QueryOp::Aggregate { .. } => "Aggregate",
             QueryOp::Distinct => "Distinct",
             QueryOp::Project(_) => "Project",
+            QueryOp::ProjectProvenance(_) => "ProjectProvenance",
             QueryOp::Sort { .. } => "Sort",
             QueryOp::RankBySimilarity { .. } => "RankBySimilarity",
             QueryOp::GetEdges { .. } => "GetEdges",

--- a/tests/aql_provenance_projection.rs
+++ b/tests/aql_provenance_projection.rs
@@ -219,17 +219,164 @@ fn order_by_confidence_not_in_return_sorts_and_hides_column() {
 }
 
 #[test]
+fn reason_projects_real_string_value() {
+    let db = make_db();
+    // alice's reason is a real string ("verified") -- assert the projected value,
+    // not just the Null case.
+    let rows = rows(&db, "MATCH (n:Person) RETURN n, reason(n)");
+    let alice = rows
+        .iter()
+        .find(|r| row_name(r).as_deref() == Some("String(\"alice\")"))
+        .expect("alice row");
+    assert_eq!(
+        col(alice, "reason(n)"),
+        Some(&PropertyValue::String("verified".into()))
+    );
+}
+
+#[test]
 fn source_only_projection_without_entity_is_columns_row() {
     let db = make_db();
     // No bare entity returned -> a pure columns row (like aggregation output).
     let rows = rows(&db, "MATCH (n:Person) RETURN source(n)");
     assert_eq!(rows.len(), 4);
+    // Every row is a pure columns row: no bindings, entity is Null (matching this
+    // test's name -- a columns-only shape).
+    for r in &rows {
+        assert!(r.bindings.is_none(), "columns-only row carries no bindings");
+        assert!(
+            matches!(r.entity, EntityResult::Null),
+            "columns-only row has a Null entity"
+        );
+    }
     let sources: Vec<PropertyValue> = rows
         .iter()
         .filter_map(|r| col(r, "source(n)").cloned())
         .collect();
     assert!(sources.contains(&PropertyValue::String("hr-system".into())));
     assert!(sources.contains(&PropertyValue::Null)); // dave
+}
+
+#[test]
+fn where_provenance_filter_composes_with_projection() {
+    let db = make_db();
+    // WHERE narrows to the two hr-system rows (alice, carol); the projected
+    // confidence column must still be correct on the surviving rows.
+    let rows = rows(
+        &db,
+        "MATCH (n:Person) WHERE source(n) = 'hr-system' RETURN n, confidence(n)",
+    );
+    let mut names: Vec<String> = rows.iter().filter_map(row_name).collect();
+    names.sort();
+    assert_eq!(
+        names,
+        vec![
+            "String(\"alice\")".to_string(),
+            "String(\"carol\")".to_string()
+        ],
+        "filter narrows to the two hr-system rows"
+    );
+    let alice = rows
+        .iter()
+        .find(|r| row_name(r).as_deref() == Some("String(\"alice\")"))
+        .expect("alice row");
+    match col(alice, "confidence(n)") {
+        Some(PropertyValue::Float(f)) => assert!((f - 0.95).abs() < 1e-9, "got {f}"),
+        other => panic!("expected 0.95, got {other:?}"),
+    }
+}
+
+#[test]
+fn order_by_confidence_desc_with_skip_limit_pages_projected_rows() {
+    // ProjectProvenance runs LAST (after Sort/Skip/Limit), so it is strictly 1:1
+    // over the paged rows. Full DESC order is [dave(null), alice 0.95, carol 0.80,
+    // bob 0.60]; SKIP 1 LIMIT 2 keeps exactly [alice, carol], each carrying its
+    // own projected confidence column.
+    let db = make_db();
+    let rows = rows(
+        &db,
+        "MATCH (n:Person) RETURN n, confidence(n) ORDER BY confidence(n) DESC SKIP 1 LIMIT 2",
+    );
+    let order: Vec<String> = rows.iter().filter_map(row_name).collect();
+    assert_eq!(
+        order,
+        vec![
+            "String(\"alice\")".to_string(),
+            "String(\"carol\")".to_string()
+        ],
+        "SKIP 1 LIMIT 2 over the DESC ordering keeps alice then carol"
+    );
+    // Each surviving row carries the correct projected confidence.
+    match col(&rows[0], "confidence(n)") {
+        Some(PropertyValue::Float(f)) => assert!((f - 0.95).abs() < 1e-9, "alice got {f}"),
+        other => panic!("expected alice 0.95, got {other:?}"),
+    }
+    match col(&rows[1], "confidence(n)") {
+        Some(PropertyValue::Float(f)) => assert!((f - 0.80).abs() < 1e-9, "carol got {f}"),
+        other => panic!("expected carol 0.80, got {other:?}"),
+    }
+}
+
+#[test]
+fn order_by_source_string_places_two_nulls_last() {
+    // Two unattributed nodes exercise the (None, None) comparison arm and the
+    // String ORDER BY path with openCypher null placement (nulls last for ASC).
+    let db = AletheiaDB::new().expect("db");
+    create_person(&db, "alice", Some(prov(Some("hr-system"), None, None)));
+    create_person(&db, "bob", Some(prov(Some("crm-sync"), None, None)));
+    create_person(&db, "dave", None); // unattributed
+    create_person(&db, "erin", None); // second unattributed -> two nulls
+    let rows = rows(&db, "MATCH (n:Person) RETURN n ORDER BY source(n)");
+    let order: Vec<String> = rows.iter().filter_map(row_name).collect();
+    // ASC on the string source: crm-sync (bob) < hr-system (alice), then the two
+    // nulls last, stable in insertion order (dave before erin).
+    assert_eq!(
+        order,
+        vec![
+            "String(\"bob\")",
+            "String(\"alice\")",
+            "String(\"dave\")",
+            "String(\"erin\")",
+        ]
+    );
+}
+
+#[test]
+fn rejects_property_and_accessor_mix() {
+    // (a) A property projection mixed with an accessor is a structured error, not
+    // a silently-dropped property.
+    let db = make_db();
+    assert!(
+        db.execute_aql("MATCH (n:Person) RETURN n.name, source(n)")
+            .is_err(),
+        "property + accessor mix must be rejected"
+    );
+}
+
+#[test]
+fn rejects_multi_variable_accessor_mismatch() {
+    // (c) The accessor names a variable other than the single bound entity: must
+    // be rejected rather than resolving the wrong (or a nonexistent) entity.
+    let db = make_db();
+    assert!(
+        db.execute_aql("MATCH (n:Person) RETURN n, source(m)")
+            .is_err(),
+        "accessor over a non-bound variable must be rejected"
+    );
+}
+
+#[test]
+fn rejects_edge_variable_accessor() {
+    // MUST-FIX 3: edge-entity provenance projection is not supported in v1 (the
+    // AQL positional pipeline never binds an edge as the row entity). An accessor
+    // over an edge/traversal variable must REJECT with a structured error rather
+    // than silently resolving the traversal-terminal node's provenance.
+    let db = make_db();
+    assert!(
+        db.execute_aql("MATCH (a:Person)-[r:KNOWS]->(b:Person) RETURN r, source(r)")
+            .is_err(),
+        "edge-variable accessor must be rejected (node-entity-scoped in v1)"
+    );
 }
 
 #[test]

--- a/tests/cypher_provenance_projection.rs
+++ b/tests/cypher_provenance_projection.rs
@@ -189,6 +189,15 @@ fn source_only_projection_without_entity_is_columns_row() {
     let db = make_db();
     let rows = rows(&db, "MATCH (n:Person) RETURN source(n)");
     assert_eq!(rows.len(), 4);
+    // Every row is a pure columns row: no bindings, entity is Null (matching this
+    // test's name).
+    for r in &rows {
+        assert!(r.bindings.is_none(), "columns-only row carries no bindings");
+        assert!(
+            matches!(r.entity, EntityResult::Null),
+            "columns-only row has a Null entity"
+        );
+    }
     let sources: Vec<PropertyValue> = rows
         .iter()
         .filter_map(|r| col(r, "source(n)").cloned())
@@ -312,6 +321,155 @@ fn distinct_projection_unaffected() {
     assert_eq!(rows.len(), 4, "four distinct people");
 }
 
+#[test]
+fn reason_projects_real_string_value() {
+    let db = make_db();
+    let rows = rows(&db, "MATCH (n:Person) RETURN n, reason(n)");
+    let alice = rows
+        .iter()
+        .find(|r| row_name(r).as_deref() == Some("String(\"alice\")"))
+        .expect("alice row");
+    assert_eq!(
+        col(alice, "reason(n)"),
+        Some(&PropertyValue::String("verified".into()))
+    );
+}
+
+#[test]
+fn where_provenance_filter_composes_with_projection() {
+    let db = make_db();
+    let rows = rows(
+        &db,
+        "MATCH (n:Person) WHERE source(n) = 'hr-system' RETURN n, confidence(n)",
+    );
+    let mut names: Vec<String> = rows.iter().filter_map(row_name).collect();
+    names.sort();
+    assert_eq!(
+        names,
+        vec![
+            "String(\"alice\")".to_string(),
+            "String(\"carol\")".to_string()
+        ],
+        "filter narrows to the two hr-system rows"
+    );
+    let alice = rows
+        .iter()
+        .find(|r| row_name(r).as_deref() == Some("String(\"alice\")"))
+        .expect("alice row");
+    match col(alice, "confidence(n)") {
+        Some(PropertyValue::Float(f)) => assert!((f - 0.95).abs() < 1e-9, "got {f}"),
+        other => panic!("expected 0.95, got {other:?}"),
+    }
+}
+
+#[test]
+fn order_by_confidence_desc_with_skip_limit_pages_projected_rows() {
+    // ProjectProvenance runs LAST (after Sort/Skip/Limit), strictly 1:1 over the
+    // paged rows. DESC order [dave(null), alice, carol, bob]; SKIP 1 LIMIT 2 keeps
+    // [alice, carol], each carrying its own projected confidence column.
+    let db = make_db();
+    let rows = rows(
+        &db,
+        "MATCH (n:Person) RETURN n, confidence(n) ORDER BY confidence(n) DESC SKIP 1 LIMIT 2",
+    );
+    let order: Vec<String> = rows.iter().filter_map(row_name).collect();
+    assert_eq!(
+        order,
+        vec![
+            "String(\"alice\")".to_string(),
+            "String(\"carol\")".to_string()
+        ],
+        "SKIP 1 LIMIT 2 over the DESC ordering keeps alice then carol"
+    );
+    match col(&rows[0], "confidence(n)") {
+        Some(PropertyValue::Float(f)) => assert!((f - 0.95).abs() < 1e-9, "alice got {f}"),
+        other => panic!("expected alice 0.95, got {other:?}"),
+    }
+    match col(&rows[1], "confidence(n)") {
+        Some(PropertyValue::Float(f)) => assert!((f - 0.80).abs() < 1e-9, "carol got {f}"),
+        other => panic!("expected carol 0.80, got {other:?}"),
+    }
+}
+
+#[test]
+fn order_by_source_string_places_two_nulls_last() {
+    // Two unattributed nodes exercise the (None, None) comparison arm and the
+    // String ORDER BY path with openCypher null placement (nulls last for ASC).
+    let db = AletheiaDB::new().expect("db");
+    create_person(&db, "alice", Some(prov(Some("hr-system"), None, None)));
+    create_person(&db, "bob", Some(prov(Some("crm-sync"), None, None)));
+    create_person(&db, "dave", None);
+    create_person(&db, "erin", None);
+    let rows = rows(&db, "MATCH (n:Person) RETURN n ORDER BY source(n)");
+    let order: Vec<String> = rows.iter().filter_map(row_name).collect();
+    assert_eq!(
+        order,
+        vec![
+            "String(\"bob\")",
+            "String(\"alice\")",
+            "String(\"dave\")",
+            "String(\"erin\")",
+        ]
+    );
+}
+
+#[test]
+fn rejects_property_and_accessor_mix() {
+    // (a) property projection + accessor -> structured error, never a silently
+    // dropped property.
+    let db = make_db();
+    let msg = err_msg(&db, "MATCH (n:Person) RETURN n.name, source(n)");
+    assert!(!msg.is_empty(), "expected a structured error message");
+}
+
+#[test]
+fn rejects_aggregate_and_accessor_mix() {
+    // (b) aggregate + accessor -> structured error, never a silently omitted
+    // accessor column.
+    let db = make_db();
+    assert!(
+        db.execute_cypher("MATCH (n:Person) RETURN n.dept, count(*), source(n)")
+            .is_err(),
+        "aggregate + accessor mix must be rejected"
+    );
+}
+
+#[test]
+fn rejects_multi_variable_accessor_mismatch() {
+    // (c) accessor names a variable other than the single bound entity.
+    let db = make_db();
+    assert!(
+        db.execute_cypher("MATCH (n:Person) RETURN n, source(m)")
+            .is_err(),
+        "accessor over a non-bound variable must be rejected"
+    );
+}
+
+#[test]
+fn rejects_edge_variable_accessor() {
+    // MUST-FIX 3: an edge/traversal-variable accessor routes to the multi-pattern
+    // evaluator (edge provenance projection is node-entity-scoped in v1) and must
+    // REJECT with a structured error, never silently resolve the wrong entity. An
+    // actual edge is present so the evaluator reaches (and rejects) the scalar
+    // accessor rather than short-circuiting on an empty match.
+    let db = AletheiaDB::new().expect("db");
+    let a = create_person(&db, "alice", Some(prov(Some("hr-system"), Some(0.9), None)));
+    let b = create_person(&db, "bob", Some(prov(Some("crm-sync"), Some(0.5), None)));
+    db.create_edge_with_options(
+        a,
+        b,
+        "KNOWS",
+        PropertyMapBuilder::new().build(),
+        WriteRequestOptions::new().with_provenance(prov(Some("edge-src"), Some(0.7), None)),
+    )
+    .expect("create edge");
+    assert!(
+        db.execute_cypher("MATCH (a:Person)-[r:KNOWS]->(b:Person) RETURN r, source(r)")
+            .is_err(),
+        "edge-variable accessor must be rejected (node-entity-scoped in v1)"
+    );
+}
+
 /// Cross-surface parity: for the same fixture and equivalent queries, AQL and
 /// Cypher must project the same provenance columns (criterion 3).
 #[test]
@@ -348,6 +506,15 @@ fn cypher_aql_parity_over_projection_queries() {
             .iter()
             .map(|r| format!("{:?}", col(r, colname)))
             .collect();
+        // Non-vacuity guard: the source case must carry a known real value so an
+        // all-None collapse (which would make the parity compare trivially pass)
+        // fails loudly.
+        if colname == "source(n)" {
+            assert!(
+                via_cypher.iter().any(|v| v.contains("hr-system")),
+                "expected a real 'hr-system' source among the projected values, got {via_cypher:?}"
+            );
+        }
         via_cypher.sort();
         via_aql.sort();
         assert_eq!(via_cypher, via_aql, "parity mismatch for {cypher}");


### PR DESCRIPTION
## Summary

Follow-up to **#3354b** — the provenance-projection PR **#3600 has merged into trunk**. Three adversarial reviewers found real issues in that code; this PR fixes them on top of merged trunk. The diff vs `trunk` is **only** the review fixes (no re-introduction of the feature) — 6 files, +593/−39.

## Before / After (the fixes)

| Area | Before (merged #3600) | After (this PR) |
|---|---|---|
| `RETURN n.name, source(n)` (property + accessor) | `n.name` **silently dropped** — entity nulled, caller gets only the source column | **structured error** — the unsupported mix is rejected, never a silent partial result |
| `RETURN n.dept, count(*), source(n)` (aggregate + accessor, Cypher) | accessor **silently omitted** | **structured error** |
| `RETURN a, source(b)` / edge-var `RETURN r, source(r)` (variable mismatch) | resolved the row's **primary** entity, not `b`/`r` → **silent wrong provenance** | **structured error** (variable must match the single bound node) |
| `ORDER BY confidence(n)` cost | provenance resolved **inside** the comparator → ~O(n·log n) historical lookups under the `historical` lock | **decorate-sort-undecorate**: each row's bundle resolved **once** (O(n), single lock span); null placement + stable order unchanged |
| `ProvenanceProjectIterator` columns | overwrote any pre-existing `row.columns` | **merges** onto pre-existing columns (defense-in-depth) |

This preserves AletheiaDB's "never a silent wrong result" ethos (mirroring the MCP safe-by-default contract): general property-projection-into-columns is out of scope for v1, so the unsupported mixes are **rejected with a structured error** rather than silently mis-answered — exactly like the existing `RETURN n, count(*)` `UnsupportedFeature` rejection.

## How

- **Converters** (`src/query/converter.rs`, `src/cypher/converter.rs`): `build_provenance_projection` now takes the MATCH source/pattern (and, for Cypher, the `aggregated` flag). When any provenance accessor is projected it enforces the v1 contract — rejecting a property projection alongside the accessor, an aggregate alongside it (Cypher), and any referenced variable other than the single bound MATCH node (via new `sole_match_node_var` / `sole_pattern_node_var` helpers). The Cypher call site is consulted even when aggregated so an aggregate+accessor mix is rejected rather than skipped. Malformed-accessor errors from the WHERE half are preserved.
- **Executor** (`src/query/executor/iterators.rs`):
  - `SortIterator::drain` decorates each row with its provenance bundle resolved **once**, sorts against the decoration (`cmp_decorated`), then strips — one lock span, n lookups. The on-the-fly `SortKey::Provenance` arm remains as a defensive fallback. New `provenance_field_value_opt` helper shared by both paths.
  - `ProvenanceProjectIterator::project_row` consumes the row by value and **merges** projected columns onto any pre-existing `row.columns`.
- **Planner** (`src/query/planner/mod.rs`): explicit `QueryOp::ProjectProvenance` arm in `missing_source_error` for label parity.
- AQL `ORDER BY` binds `provenance_field_name` once (nit).

## v1 limitations / supported forms

**Supported (unchanged, still pass):**
- `RETURN <entity>, <accessor(s)…>` — bare entity + one or more accessors, `AS` aliases allowed
- `RETURN <accessor(s)…>` — accessors only (pure columns row)
- `ORDER BY <accessor>` (whether or not the accessor is also in `RETURN`)
- over a **single bound node** whose variable matches the accessor's variable

**Explicitly rejected with a structured error (no silent wrong/partial result):**
- **property + accessor** (`RETURN n.name, source(n)`) — AQL `SyntaxError`, Cypher `UnsupportedFeature`
- **aggregate + accessor** (`RETURN n.dept, count(*), source(n)`) — structured error (Cypher; not expressible in AQL, which has no aggregation)
- **multi-variable mismatch** (`RETURN a, source(b)`, accessor over an unbound variable) — structured error
- **edge-entity accessor** (`RETURN r, source(r)`) — provenance projection is **node-entity-scoped in v1**. Empirically, an edge never becomes the single-entity row's primary entity: AQL's positional pipeline yields the traversal-terminal node, and Cypher routes any relationship-variable reference to the multi-pattern evaluator (out of scope). Both surfaces therefore **reject** the edge accessor with a structured error rather than mis-resolving. Edge-entity projection lands with edge-returning query support.

## AC-evidence (new tests)

`tests/aql_provenance_projection.rs` (18) and `tests/cypher_provenance_projection.rs` (20) — all green.

| Concern | New test(s) — both surfaces unless noted |
|---|---|
| Reject property + accessor | `rejects_property_and_accessor_mix` |
| Reject aggregate + accessor | `rejects_aggregate_and_accessor_mix` (Cypher) |
| Reject multi-variable mismatch | `rejects_multi_variable_accessor_mismatch` |
| Reject edge-variable accessor | `rejects_edge_variable_accessor` |
| LIMIT/SKIP 1:1 after ProjectProvenance | `order_by_confidence_desc_with_skip_limit_pages_projected_rows` (asserts exact surviving rows + each projected column value) |
| `reason(x)` real string value | `reason_projects_real_string_value` |
| (None,None) sort + String `ORDER BY source(n)` null placement | `order_by_source_string_places_two_nulls_last` (two unattributed nodes) |
| WHERE + projection composition | `where_provenance_filter_composes_with_projection` |
| Columns-only row shape | `source_only_projection_without_entity_is_columns_row` (asserts `bindings.is_none()` + Null entity) |
| Parity non-vacuity guard | `cypher_aql_parity_over_projection_queries` (asserts a real `hr-system` value present) |

## Gates

`cargo fmt --all --check`, `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings`, and `cargo clippy --all-targets --all-features -- -D warnings` all clean on this branch. `cargo test` (isolated target, `CARGO_PROFILE_TEST_DEBUG=0`): the 38 projection tests pass; the lib suite is green except one **pre-existing** environmental flake (`cypher::tests::multi_pattern::test_multi_pattern_binding_cap_enforced` — a non-monotonic-wallclock `InvalidTimeRange` during `AletheiaDB::with_unified_config`, reproduced identically on clean trunk **without** these changes; unrelated to provenance projection).

No `src/mcp/**` changes — MCP already renders both the bindings+columns and columns-only row shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BhzWPXAxWQ8mhivodKYos

---
_Generated by [Claude Code](https://claude.ai/code/session_014BhzWPXAxWQ8mhivodKYos)_