### PR TITLE
fix(mcp): silence pre-existing result_large_err on the all-features clippy gate

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1277,6 +1277,11 @@ impl AletheiaMcpServer {
     ///
     /// Collapses the otherwise-duplicated "if present, parse, else None" handling for the
     /// changefeed's optional time bounds.
+    // clippy::result_large_err: the Err is rmcp's `CallToolResult` (~176B), the
+    // MCP error-response type carried across the whole tool surface; boxing it
+    // would ripple through the entire MCP `Result` API and every `?` call site.
+    // Cold error path. Allowed pending a deliberate Box refactor.
+    #[allow(clippy::result_large_err)]
     fn parse_opt_timestamp(
         &self,
         label: &str,
@@ -1301,6 +1306,9 @@ impl AletheiaMcpServer {
     /// (transaction_time defaults to now), matching the Rust API's
     /// `get_node_at_valid_time`/`get_node_at_transaction_time` convenience
     /// methods, which default the unspecified dimension the same way.
+    // clippy::result_large_err: Err is rmcp's `CallToolResult` (~176B); see
+    // `parse_opt_timestamp` — boxing would cascade through the MCP `Result` API.
+    #[allow(clippy::result_large_err)]
     fn resolve_bitemporal_as_of(
         &self,
         as_of_valid_time: &Option<String>,
@@ -1335,6 +1343,9 @@ impl AletheiaMcpServer {
     /// deliberately has no `principal` field, so callers cannot forge it.
     /// Anonymous-mode sessions (and the embedded `new()` constructor)
     /// record no principal -- the field is absent, not an empty string.
+    // clippy::result_large_err: Err is rmcp's `CallToolResult` (~176B); see
+    // `parse_opt_timestamp` — boxing would cascade through the MCP `Result` API.
+    #[allow(clippy::result_large_err)]
     pub(crate) fn parse_opt_provenance(
         &self,
         value: Option<crate::mcp::tools::ProvenanceRequest>,
@@ -1391,6 +1402,9 @@ impl AletheiaMcpServer {
     /// Invalid values fail closed with a structured `INVALID_ARGUMENT` whose
     /// `details.field` names the offending parameter (AC5) — never a silent
     /// empty result.
+    // clippy::result_large_err: Err is rmcp's `CallToolResult` (~176B); see
+    // `parse_opt_timestamp` — boxing would cascade through the MCP `Result` API.
+    #[allow(clippy::result_large_err)]
     pub(crate) fn parse_provenance_filter(
         &self,
         args: &serde_json::Value,
@@ -1491,6 +1505,9 @@ impl AletheiaMcpServer {
     /// version actually *exists* is checked by the write path
     /// (`validate_sources`) so a dangling reference becomes a `NOT_FOUND`
     /// rather than an `INVALID_ARGUMENT`.
+    // clippy::result_large_err: Err is rmcp's `CallToolResult` (~176B); see
+    // `parse_opt_timestamp` — boxing would cascade through the MCP `Result` API.
+    #[allow(clippy::result_large_err)]
     fn parse_lineage_ref(
         &self,
         req: &crate::mcp::tools::LineageRefRequest,
@@ -1516,6 +1533,10 @@ impl AletheiaMcpServer {
     /// Parse the optional `derived_from` list on a write request into core
     /// [`LineageRef`](crate::core::lineage::LineageRef)s (Issue #3371). `None`
     /// or an empty list yields an empty vec (no lineage recorded).
+    // clippy::result_large_err: Err is rmcp's `CallToolResult` (~176B); see
+    // `parse_opt_timestamp` — boxing would cascade through the MCP `Result` API.
+    // Also covers the inner `map(|r| self.parse_lineage_ref(r))` closure.
+    #[allow(clippy::result_large_err)]
     fn parse_derived_from(
         &self,
         value: &Option<Vec<crate::mcp::tools::LineageRefRequest>>,
@@ -1894,6 +1915,9 @@ impl AletheiaMcpServer {
     /// applying the same optional exact-property filter `list_nodes` /
     /// `find_nodes_at_time` support. Returns a structured error result on a
     /// bad property value.
+    // clippy::result_large_err: Err is rmcp's `CallToolResult` (~176B); see
+    // `parse_opt_timestamp` — boxing would cascade through the MCP `Result` API.
+    #[allow(clippy::result_large_err)]
     fn fetch_node_candidates(
         &self,
         label: &str,


### PR DESCRIPTION
## What

Silence a **pre-existing** `clippy::result_large_err` that fails the
`cargo clippy --all-targets --all-features -- -D warnings` gate mandated by
`CLAUDE.md` and run locally by every lane. Targeted `#[allow]` + justification
on the seven offending internal helpers in `src/mcp/server.rs`. **Zero
behavior change** — no error semantics, messages, or public signatures touched
(24 insertions, all comments/attributes).

## The lint (verbatim, from `--all-features`)

```
error: the `Err`-variant returned from this function is very large
    --> src/mcp/server.rs:1284:10
     |
1284 |     ) -> std::result::Result<Option<Timestamp>, CallToolResult> {
     |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `Err`-variant is at least 176 bytes
     |
     = help: try reducing the size of `rmcp::model::CallToolResult`, for example by boxing large elements or replacing it with `Box<rmcp::model::CallToolResult>`
     = note: `-D clippy::result-large-err` implied by `-D warnings`
```

Same lint fires on **8 items** (7 functions + 1 closure) — all internal
helpers returning `Result<T, CallToolResult>`:

| Line | Item |
|------|------|
| 1284 | `parse_opt_timestamp` |
| 1308 | `resolve_bitemporal_as_of` |
| 1341 | `parse_opt_provenance` |
| 1397 | `parse_provenance_filter` |
| 1497 | `parse_lineage_ref` |
| 1522 | `parse_derived_from` |
| 1525 | closure inside `parse_derived_from` (`map(|r| self.parse_lineage_ref(r))`) |
| 1903 | `fetch_node_candidates` |

The `Err` type is `rmcp::model::CallToolResult` (≥176 bytes) — the MCP
error-response type. These helpers are the small subset of the MCP surface
where `CallToolResult` is the **Err** variant (the actual tool handlers return
`Result<CallToolResult, McpError>`, where it is the Ok variant and never trips
the lint).

## Why this is pre-existing (not introduced here)

Byte-identical on `origin/trunk`; commit `d0cad33` explicitly documents it as
_"Pre-existing, non-blocking: `cargo clippy --all-targets --all-features -- -D
warnings` reports `result_large_err` in `src/mcp/server.rs` (MCP lane — not
this diff, byte-identical on trunk, and not a CI gate)."_ This PR is the
dedicated follow-up that clears it.

## Why the fix is zero-behavior (Option A: targeted allow + justification)

`CallToolResult` is an external **rmcp public-API type** used pervasively as
the MCP `Result` error across the whole tool surface. Boxing it would ripple
through the entire MCP `Result` API and every `?` call site — the large-
blast-radius path the task warns against. Instead, a targeted
`#[allow(clippy::result_large_err)]` with a justification comment sits on each
of the seven offending helpers (the allow on `parse_derived_from` also covers
its inner closure). No `#[allow]` at crate scope; nothing else is suppressed.

## Why CI is unaffected

CI's gating clippy profile is `--features
"config-toml,mcp-server,sharding-rpc,simulation"` (not `--all-features`) and
does not exercise the path that trips the lint, so CI has been and stays
green. This PR unblocks every lane's **local** `--all-features` clippy gate
while leaving CI's gating profile behavior unchanged.

## Before / after (`cargo clippy -p aletheiadb --all-targets --all-features -- -D warnings`)

**Before:**
```
error: could not compile `aletheiadb` (lib) due to 8 previous errors
```
(exit 101; 9 `result_large_err` mentions)

**After:**
```
    Checking aletheiadb v0.3.0 (...)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7m 36s
```
(exit 0; 0 `result_large_err` mentions)

## Gates (each in an isolated `CARGO_TARGET_DIR`)

- `cargo clippy -p aletheiadb --all-targets --all-features -- -D warnings` — **clean (exit 0)** ✅ (the point of this PR)
- `cargo clippy -p aletheiadb --features "config-toml,mcp-server,sharding-rpc,simulation" --all-targets -- -D warnings` — clean (CI profile unaffected) ✅
- `cargo fmt --all -- --check` — clean ✅
- `cargo check -p aletheiadb --no-default-features --tests --features http-server` — exit 0 ✅
- `cargo test --features http-server,mcp-server --test parity_http --test parity_mcp` — **33 + 11 passed** (proves zero behavior change) ✅
- `cargo clippy -p aletheia-server --all-targets -- -D warnings` — clean ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEwJg2bDPZ7DzcHebqwZVK)_