### PR TITLE
feat(server): port constraints/lineage/audit-chain tools to autumn-web (#3524 PR7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "subtle",
+ "tempfile",
  "tokio",
  "tower",
  "tower-http",

--- a/crates/aletheia-server/Cargo.toml
+++ b/crates/aletheia-server/Cargo.toml
@@ -53,3 +53,6 @@ zeroize = "1"
 tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "time"] }
 # `tower::ServiceExt::oneshot` drives the legacy 0.4 router in parity tests.
 tower = { version = "0.5", features = ["util"] }
+# Chain-enabled DB fixtures (verify_chain / export_chain_head parity, PR7) need a
+# durable data dir; matches the main crate's tempfile pin.
+tempfile = "3.27"

--- a/crates/aletheia-server/src/app.rs
+++ b/crates/aletheia-server/src/app.rs
@@ -11,6 +11,7 @@
 //! (`routes`/`openapi`/`mount_mcp`/`secure_mcp`/`state_initializer`), so Lane B
 //! can lift this into a `run_server` with minimal change.
 
+use crate::constraints_lineage_audit_tools;
 use crate::edge_tools;
 use crate::http_routes;
 use crate::node_tools;
@@ -108,6 +109,14 @@ pub fn try_build_server_testapp(
             schema_batch_tools::temporal_extent,
             schema_batch_tools::database_stats,
             schema_batch_tools::apply_batch,
+            constraints_lineage_audit_tools::enable_vector_index,
+            constraints_lineage_audit_tools::enable_unique_constraint,
+            constraints_lineage_audit_tools::list_unique_constraints,
+            constraints_lineage_audit_tools::lineage_upstream,
+            constraints_lineage_audit_tools::lineage_downstream,
+            constraints_lineage_audit_tools::audit_export,
+            constraints_lineage_audit_tools::verify_chain,
+            constraints_lineage_audit_tools::export_chain_head,
         ])
         .openapi(OpenApiConfig::new("AletheiaDB", env!("CARGO_PKG_VERSION")))
         .mount_mcp("/mcp");

--- a/crates/aletheia-server/src/constraints_lineage_audit_tools.rs
+++ b/crates/aletheia-server/src/constraints_lineage_audit_tools.rs
@@ -1,0 +1,346 @@
+//! Constraints / index-admin + lineage + audit-chain tools: the write
+//! index/constraint admin `enable_vector_index` / `enable_unique_constraint`,
+//! the read `list_unique_constraints`, the derivation-lineage queries
+//! `lineage_upstream` / `lineage_downstream`, and the provenance-hash-chain
+//! tools `audit_export` / `verify_chain` / `export_chain_head` (Issue #3524,
+//! PR7 — the FINAL tool slice, completing all 46 MCP tools on the autumn
+//! surface).
+//!
+//! Each is a single `#[get(...)]`/`#[post(...)]` + `#[api_doc(description=...,
+//! mcp)]` handler, so one definition surfaces on **HTTP**, **MCP-over-HTTP**
+//! (`/mcp`), and **OpenAPI** at once. The response body is produced by the
+//! *exact* main-crate MCP surface, so it is byte-identical to the legacy MCP
+//! surface — asserted in the parity suite against the shared
+//! [`AletheiaMcpServer`](aletheiadb::mcp::AletheiaMcpServer) over the same
+//! `Arc<AletheiaDB>`.
+//!
+//! # Forwarding: all eight are typed / inline (no budget, no cursor, no guard)
+//!
+//! The **single source of truth** for which reads honor the Issue #3353 token
+//! budget is `aletheiadb::mcp`'s `BUDGETABLE_READ_TOOLS`, and for the Issue
+//! #3360 cursor the `inject_cursor_schema_params` set. Verified against source,
+//! **none of these eight is budgetable and none is cursorable**. So — unlike the
+//! read-heavy PR5/PR6 clusters — there is **no** dispatch-routed slow read here:
+//! no `DISPATCH_ROUTED_READ_TOOLS` addition, no in-flight admission guard, no
+//! wall-clock timeout, no byte cap. Every handler forwards **inline**, in one of
+//! two shapes that mirror the proven PR3–PR6 patterns exactly:
+//!
+//! 1. **Five tools with a public typed per-tool method** — `enable_vector_index`
+//!    / `enable_unique_constraint` (writes) and `list_unique_constraints` /
+//!    `lineage_upstream` / `lineage_downstream` (reads) — forward through that
+//!    method's re-exported request struct
+//!    (`AletheiaMcpServer::enable_vector_index(req)` etc.), inline (like the edge
+//!    writes / `count_nodes` / `list_vector_indexes`) — zero reserialization,
+//!    reusing only already-public symbols. `lineage_upstream` / `_downstream`
+//!    forward the whole [`LineageQueryRequest`] verbatim, so the entire #3371
+//!    contract — version-pinned root ref, the #3226 `has_more`/`next_offset`
+//!    pagination, per-entry `depth` + `FactStatus`, the `as_of_transaction_time`
+//!    scoping, and the #3234 structured error codes (`NOT_FOUND` for a dangling
+//!    ref, `INVALID_ARGUMENT` for a bad entity kind / self-cycle,
+//!    `FAILED_PRECONDITION` for an already-recorded write) — is preserved with
+//!    **zero** reimplementation.
+//! 2. **Three tools with NO public typed method** — the provenance-hash-chain
+//!    tools `audit_export` / `verify_chain` / `export_chain_head` (their
+//!    `handle_*` methods are private and their request types are not
+//!    re-exported). Each takes a **local** typed body struct (mirroring the
+//!    main-crate request shape one-to-one so `/openapi.json` gets a named
+//!    per-operation component — never a generic `Value`, the #3589 lesson) and
+//!    forwards through
+//!    [`AletheiaMcpServer::dispatch_tool_json`](aletheiadb::mcp::AletheiaMcpServer::dispatch_tool_json)
+//!    with a **hardcoded literal** tool name — the only public entry for these
+//!    three. Being non-budgetable / non-cursorable, `dispatch_tool_json`
+//!    reproduces a hypothetical typed method's output byte-for-byte (same
+//!    `handle_*`), so the full #3351 contract — signed offline-verifiable audit
+//!    artifact + redaction, the full / entity-scoped / anchor-extension verify
+//!    modes, the exported chain head, and the "chain not enabled" →
+//!    `FAILED_PRECONDITION` — is preserved with no main-crate change. Because
+//!    each pins its **own** tool name (a read handler pinning `"verify_chain"`
+//!    routes to `verify_chain`), there is structurally no cross-tool escalation,
+//!    so they are intentionally NOT registered in
+//!    [`crate::edge_tools::DISPATCH_ROUTED_READ_TOOLS`] (that table binds the
+//!    budgetable/cursorable slow reads whose pinned name could otherwise differ
+//!    from the route).
+//!
+//! The two writes are classified [`WriteClass`] and the six reads [`ReadClass`]
+//! — each verified BY HAND against `tests/parity/inventory.json`'s
+//! `access_class` (`enable_vector_index`=write, `enable_unique_constraint`=write,
+//! `list_unique_constraints`=read, `lineage_upstream`=read,
+//! `lineage_downstream`=read, `audit_export`=read, `verify_chain`=read,
+//! `export_chain_head`=read). The marker rides in each handler's `Authorized<C>`
+//! signature (the one place the class is declared), which autumn replays for
+//! `/mcp tools/call`. The write handlers (and the POST-body reads) take their
+//! arguments as a JSON **body** (autumn maps `Json<T>` to the reserved `body`
+//! MCP argument key), so the `tools/call` `arguments` wrap the request under
+//! `"body"`.
+//!
+//! The MCP tool result carries in-band errors (e.g. a dangling lineage ref →
+//! `{"error":{"code":"NOT_FOUND",...}}`, a disabled chain →
+//! `{"error":{"code":"FAILED_PRECONDITION",...}}`); we return that JSON verbatim
+//! with a 200, matching the MCP method's `String` return exactly.
+
+use crate::security::{Authorized, ReadClass, WriteClass};
+use crate::state::ServerState;
+use aletheiadb::mcp::{
+    EnableUniqueConstraintRequest, EnableVectorIndexRequest, LineageQueryRequest,
+    ListUniqueConstraintsRequest,
+};
+use autumn_web::prelude::{Json, get, post};
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+/// Parse an MCP tool method's JSON string result into a [`Value`] for the HTTP
+/// response. A non-JSON result (should not happen) degrades to a JSON string.
+fn tool_json(s: String) -> Json<Value> {
+    Json(serde_json::from_str::<Value>(&s).unwrap_or(Value::String(s)))
+}
+
+/// Fold a present optional value into the raw MCP arguments object under `key`.
+fn insert_opt(args: &mut Map<String, Value>, key: &str, val: Option<Value>) {
+    if let Some(v) = val {
+        args.insert(key.to_string(), v);
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// enable_vector_index — [`WriteClass`], NOT budgetable, NOT cursorable. Typed
+// forwarding to the legacy `enable_vector_index` method, inline.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// `enable_vector_index` — enable HNSW vector indexing on a node property so
+/// `find_similar` / `hybrid_query` can k-NN-search its embeddings. [`WriteClass`].
+/// HTTP + MCP tool. Forwards the whole [`EnableVectorIndexRequest`] to the exact
+/// legacy `AletheiaMcpServer::enable_vector_index` typed method and returns its
+/// `String` verbatim (`{success, property_name, dimensions, distance_metric}`
+/// on success; a structured error otherwise).
+#[post("/vector/indexes")]
+#[api_doc(
+    description = "Enable HNSW vector indexing on a node property for k-NN similarity search",
+    mcp
+)]
+pub async fn enable_vector_index(
+    _auth: Authorized<WriteClass>,
+    state: ServerState,
+    Json(req): Json<EnableVectorIndexRequest>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    tool_json(server.enable_vector_index(req))
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// enable_unique_constraint — [`WriteClass`], NOT budgetable, NOT cursorable.
+// Typed forwarding to the legacy `enable_unique_constraint` method, inline.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// `enable_unique_constraint` — enforce that a `property` is unique within a node
+/// `label` (e.g. `Person.email`). [`WriteClass`]. HTTP + MCP tool. Forwards the
+/// whole [`EnableUniqueConstraintRequest`] to the exact legacy
+/// `AletheiaMcpServer::enable_unique_constraint` typed method and returns its
+/// `String` verbatim (`{success, label, property}` on success; a structured
+/// error otherwise).
+#[post("/constraints/unique")]
+#[api_doc(
+    description = "Enable a uniqueness constraint on a node label + property pair",
+    mcp
+)]
+pub async fn enable_unique_constraint(
+    _auth: Authorized<WriteClass>,
+    state: ServerState,
+    Json(req): Json<EnableUniqueConstraintRequest>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    tool_json(server.enable_unique_constraint(req))
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// list_unique_constraints — [`ReadClass`], NOT budgetable, NOT cursorable, no
+// arguments. Typed forwarding to the legacy method, inline (like
+// list_vector_indexes / count_nodes).
+// ════════════════════════════════════════════════════════════════════════════
+
+/// `list_unique_constraints` — list all active uniqueness constraints as
+/// `{label, property}` pairs. [`ReadClass`]; not budgetable, not cursorable,
+/// takes no arguments. HTTP + MCP tool. Forwards through the typed
+/// `AletheiaMcpServer::list_unique_constraints` method inline.
+#[get("/constraints/unique")]
+#[api_doc(
+    description = "List all active uniqueness constraints (label + property pairs)",
+    mcp
+)]
+pub async fn list_unique_constraints(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    tool_json(server.list_unique_constraints(ListUniqueConstraintsRequest {}))
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// lineage_upstream / lineage_downstream — [`ReadClass`], NOT budgetable, NOT
+// cursorable. Typed forwarding to the legacy methods, inline. The whole
+// LineageQueryRequest is forwarded verbatim, so the #3371 contract (version-
+// pinned root, #3226 has_more/next_offset, per-entry depth + FactStatus,
+// as_of_transaction_time scoping) and the #3234 error codes are preserved.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// `lineage_upstream` — the transitive **evidence chain**: what a fact was
+/// derived from (Issue #3371). [`ReadClass`]. HTTP + MCP tool. Forwards the whole
+/// [`LineageQueryRequest`] to the exact legacy `AletheiaMcpServer::lineage_upstream`
+/// typed method, so the version-pinned root ref, the #3226 `has_more` /
+/// `next_offset` pagination, each entry's `depth` + `FactStatus`, the
+/// `as_of_transaction_time` scoping, and the #3234 structured error codes
+/// (`NOT_FOUND` for a dangling ref, `INVALID_ARGUMENT` for a bad entity kind) are
+/// preserved byte-for-byte.
+#[post("/lineage/upstream")]
+#[api_doc(
+    description = "Query the upstream derivation lineage of a fact: what it was derived from (evidence chain)",
+    mcp
+)]
+pub async fn lineage_upstream(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Json(req): Json<LineageQueryRequest>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    tool_json(server.lineage_upstream(req))
+}
+
+/// `lineage_downstream` — the transitive **blast radius**: what has been derived
+/// from a fact (Issue #3371), the report a caller consults before retracting it.
+/// [`ReadClass`]. HTTP + MCP tool. Forwards the whole [`LineageQueryRequest`] to
+/// the exact legacy `AletheiaMcpServer::lineage_downstream` typed method (same
+/// contract preservation as [`lineage_upstream`]).
+#[post("/lineage/downstream")]
+#[api_doc(
+    description = "Query the downstream derivation lineage of a fact: what has been derived from it (blast radius)",
+    mcp
+)]
+pub async fn lineage_downstream(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Json(req): Json<LineageQueryRequest>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    tool_json(server.lineage_downstream(req))
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Local-body dispatch reads (NOT budgetable, NOT cursorable, NO public typed
+// method): the provenance-hash-chain tools (Issue #3351). A local typed body
+// (mirroring the main-crate request shape one-to-one so /openapi.json gets a
+// named per-operation component) forwarded through `dispatch_tool_json` with a
+// hardcoded literal tool name — the only public entry for these three.
+// Byte-identical to a hypothetical typed method (same `handle_*`), so no
+// main-crate change is required. Each pins its OWN tool name (no cross-tool
+// escalation), so none is registered in DISPATCH_ROUTED_READ_TOOLS.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Request body for [`audit_export`] — mirrors the main-crate
+/// `AuditExportRequest`. `entity_type` + `entity_id` are required; `database_id`
+/// and `redact_keys` are optional (omitted → the main-crate `#[serde(default)]`
+/// applies, i.e. the default database id and no redaction).
+#[derive(Debug, Deserialize)]
+pub struct AuditExportBody {
+    /// Entity kind to export: `node` or `edge`.
+    pub entity_type: String,
+    /// The unique identifier of the node or edge to export.
+    pub entity_id: u64,
+    /// Optional database identity recorded in the artifact metadata.
+    pub database_id: Option<String>,
+    /// Optional list of property keys to redact at export; their values are
+    /// omitted but the redaction is recorded and remains verifiable.
+    pub redact_keys: Option<Vec<String>>,
+}
+
+/// `audit_export` — produce a signed, offline-verifiable evidence artifact of an
+/// entity's complete bi-temporal history (Issue #3351/#3358). [`ReadClass`]. HTTP
+/// + MCP tool.
+///
+/// Forwards through `dispatch_tool_json("audit_export", ...)` (the only public
+/// entry — its `handle_audit_export` is private), so the full contract is
+/// preserved: the Ed25519 signing key is operator-provided out of band via
+/// `ALETHEIADB_AUDIT_SIGNING_KEY` (a missing key is a structured
+/// `FAILED_PRECONDITION`, never a silent unsigned export), the secret never
+/// leaves the process (only the public key travels in the artifact), and
+/// `redact_keys` omit their values while keeping the redaction verifiable.
+#[post("/audit/export")]
+#[api_doc(
+    description = "Produce a signed, offline-verifiable audit artifact of an entity's complete bi-temporal history",
+    mcp
+)]
+pub async fn audit_export(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Json(req): Json<AuditExportBody>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    let mut args = Map::new();
+    args.insert("entity_type".to_string(), Value::from(req.entity_type));
+    args.insert("entity_id".to_string(), Value::from(req.entity_id));
+    insert_opt(&mut args, "database_id", req.database_id.map(Value::from));
+    insert_opt(&mut args, "redact_keys", req.redact_keys.map(Value::from));
+    tool_json(server.dispatch_tool_json("audit_export", Value::Object(args)))
+}
+
+/// Request body for [`verify_chain`] — mirrors the main-crate
+/// `VerifyChainRequest`. Every field is optional: an empty body verifies the
+/// **full** chain; `entity_kind` + `id` scope to one entity; `against` verifies
+/// the current chain append-only-extends a previously exported head.
+#[derive(Debug, Default, Deserialize)]
+pub struct VerifyChainBody {
+    /// For an entity-scoped verify, the entity kind: `node` or `edge` (requires
+    /// `id`). Omit for a full-chain verify.
+    pub entity_kind: Option<String>,
+    /// For an entity-scoped verify, the entity id (requires `entity_kind`).
+    pub id: Option<u64>,
+    /// A previously-exported chain head (as returned by `export_chain_head`) to
+    /// verify the current chain append-only-extends, detecting rollback
+    /// (truncation) and fork (divergence).
+    pub against: Option<Value>,
+}
+
+/// `verify_chain` — verify the tamper-evident provenance hash chain: full,
+/// entity-scoped, or against an exported anchor (Issue #3351). [`ReadClass`].
+/// HTTP + MCP tool.
+///
+/// Forwards through `dispatch_tool_json("verify_chain", ...)` (the only public
+/// entry), so the full contract is preserved: the anchor > entity-scoped > full
+/// precedence, the `{scope, passed, head_seq, head_digest, earliest_broken_seq,
+/// reason, transactions_checked}` result shape, the `INVALID_ARGUMENT` on a bad
+/// entity kind / malformed anchor, and — when the chain is not enabled for this
+/// data dir — the structured `FAILED_PRECONDITION` (never a silent empty pass).
+#[post("/chain/verify")]
+#[api_doc(
+    description = "Verify the tamper-evident provenance hash chain (full, entity-scoped, or against an exported anchor)",
+    mcp
+)]
+pub async fn verify_chain(
+    _auth: Authorized<ReadClass>,
+    state: ServerState,
+    Json(req): Json<VerifyChainBody>,
+) -> Json<Value> {
+    let server = state.mcp_server();
+    let mut args = Map::new();
+    insert_opt(&mut args, "entity_kind", req.entity_kind.map(Value::from));
+    insert_opt(&mut args, "id", req.id.map(Value::from));
+    insert_opt(&mut args, "against", req.against);
+    tool_json(server.dispatch_tool_json("verify_chain", Value::Object(args)))
+}
+
+/// `export_chain_head` — export the current provenance-chain head as an external
+/// anchor for offline storage and later fork/rollback detection via
+/// `verify_chain`'s `against` argument (Issue #3351). [`ReadClass`]; takes no
+/// arguments. HTTP + MCP tool.
+///
+/// Forwards through `dispatch_tool_json("export_chain_head", ...)` (the only
+/// public entry), so the exported head payload is returned verbatim and — when
+/// the chain is not enabled for this data dir — a structured
+/// `FAILED_PRECONDITION` (never a fabricated head).
+#[get("/chain/head")]
+#[api_doc(
+    description = "Export the current provenance-chain head as an external anchor for offline fork/rollback detection",
+    mcp
+)]
+pub async fn export_chain_head(_auth: Authorized<ReadClass>, state: ServerState) -> Json<Value> {
+    let server = state.mcp_server();
+    tool_json(server.dispatch_tool_json("export_chain_head", Value::Object(Map::new())))
+}

--- a/crates/aletheia-server/src/edge_tools.rs
+++ b/crates/aletheia-server/src/edge_tools.rs
@@ -113,6 +113,51 @@ pub const DISPATCH_ROUTED_READ_TOOLS: &[(&str, AccessClass)] = &[
     ("get_schema", AccessClass::Read),
 ];
 
+/// The **superset** of *every* handler that forwards a hardcoded literal tool
+/// name through [`AletheiaMcpServer::dispatch_tool_json`](aletheiadb::mcp::AletheiaMcpServer::dispatch_tool_json)
+/// — the single source of truth for the pinned-name ↔ routed-name ↔
+/// registry-class conformance across **all** dispatch-routed call sites, not
+/// just the budgetable ones.
+///
+/// It is [`DISPATCH_ROUTED_READ_TOOLS`] (the budgetable/cursorable slow reads)
+/// **plus** the three provenance-hash-chain tools (`audit_export`,
+/// `verify_chain`, `export_chain_head`, Issue #3524 PR7) which also pin a literal
+/// name in `dispatch_tool_json` but are **not** budgetable/cursorable (so they
+/// stay out of `DISPATCH_ROUTED_READ_TOOLS`, whose semantic remains "budgetable
+/// reads"). The three chain handlers pin their **own** tool name (a
+/// `Authorized<ReadClass>` handler routing to the `audit_export` read tool), so
+/// there is structurally no cross-tool escalation — but pinning them here brings
+/// them under the same `dispatch_pinned_names_match_routed_class` conformance
+/// guard the budgetable reads have, closing the coverage gap for every
+/// `dispatch_tool_json` call site.
+///
+/// `dispatch_pinned_names_match_routed_class` (in `tests/server_parity.rs`)
+/// iterates this superset and additionally asserts
+/// `DISPATCH_ROUTED_READ_TOOLS ⊆ ALL_DISPATCH_ROUTED`, so the two tables can
+/// never drift. `pub` for the integration test, exactly like
+/// `DISPATCH_ROUTED_READ_TOOLS`.
+pub const ALL_DISPATCH_ROUTED: &[(&str, AccessClass)] = &[
+    ("get_edge", AccessClass::Read),
+    ("list_edges", AccessClass::Read),
+    ("get_outgoing_edges", AccessClass::Read),
+    ("get_incoming_edges", AccessClass::Read),
+    ("get_node", AccessClass::Read),
+    ("list_nodes", AccessClass::Read),
+    ("find_nodes_at_time", AccessClass::Read),
+    ("traverse", AccessClass::Read),
+    ("get_node_history", AccessClass::Read),
+    ("find_similar", AccessClass::Read),
+    ("hybrid_query", AccessClass::Read),
+    ("query", AccessClass::Read),
+    ("get_schema", AccessClass::Read),
+    // Issue #3524 PR7 — dispatch_tool_json call sites that are NOT budgetable
+    // (so absent from DISPATCH_ROUTED_READ_TOOLS). Literals match the pinned
+    // names in `constraints_lineage_audit_tools.rs` char-for-char.
+    ("audit_export", AccessClass::Read),
+    ("verify_chain", AccessClass::Read),
+    ("export_chain_head", AccessClass::Read),
+];
+
 /// Parse an MCP tool method's JSON string result into a [`Value`] for the HTTP
 /// response. A non-JSON result (should not happen) degrades to a JSON string.
 fn tool_json(s: String) -> Json<Value> {

--- a/crates/aletheia-server/src/lib.rs
+++ b/crates/aletheia-server/src/lib.rs
@@ -28,6 +28,7 @@
 #![warn(missing_docs)]
 
 pub mod app;
+pub mod constraints_lineage_audit_tools;
 pub mod edge_tools;
 pub mod http_routes;
 pub mod node_tools;

--- a/crates/aletheia-server/tests/constraints_lineage_audit_parity.rs
+++ b/crates/aletheia-server/tests/constraints_lineage_audit_parity.rs
@@ -700,13 +700,19 @@ async fn all_eight_tools_routable_on_mcp_with_correct_class() {
 
 // ════════════════════════════════════════════════════════════════════════════
 // Conformance: none of the eight is budgetable/cursorable, so none is registered
-// in the shared DISPATCH_ROUTED_READ_TOOLS pinned-name table (the three
-// audit-chain tools use dispatch_tool_json but pin their OWN name — no
-// cross-tool escalation, so they are intentionally not pinned).
+// in the shared DISPATCH_ROUTED_READ_TOOLS (budgetable-reads) pinned-name table.
+// The three audit-chain tools DO forward through dispatch_tool_json (pinning
+// their OWN name — no cross-tool escalation), so they appear in the
+// ALL_DISPATCH_ROUTED superset (Issue #3524 PR7) that the shared
+// `dispatch_pinned_names_match_routed_class` conformance test now iterates; the
+// five typed-method tools are in NEITHER table.
 // ════════════════════════════════════════════════════════════════════════════
 
 #[tokio::test]
-async fn none_of_the_eight_is_dispatch_routed() {
+async fn dispatch_routed_split_is_exactly_the_three_chain_tools() {
+    use aletheia_server::edge_tools::ALL_DISPATCH_ROUTED;
+
+    // None of the eight is budgetable/cursorable → none in DISPATCH_ROUTED_READ_TOOLS.
     for name in [
         "enable_vector_index",
         "enable_unique_constraint",
@@ -719,7 +725,33 @@ async fn none_of_the_eight_is_dispatch_routed() {
     ] {
         assert!(
             !DISPATCH_ROUTED_READ_TOOLS.iter().any(|(n, _)| *n == name),
-            "{name} is non-budgetable/non-cursorable and must NOT be dispatch-routed"
+            "{name} is non-budgetable/non-cursorable and must NOT be in DISPATCH_ROUTED_READ_TOOLS"
+        );
+    }
+
+    // The three chain tools DO use dispatch_tool_json → they must be in the
+    // ALL_DISPATCH_ROUTED superset (Read class), covered by the conformance test.
+    for name in ["audit_export", "verify_chain", "export_chain_head"] {
+        assert!(
+            ALL_DISPATCH_ROUTED
+                .iter()
+                .any(|(n, c)| *n == name && *c == AccessClass::Read),
+            "{name} forwards via dispatch_tool_json and must be pinned in ALL_DISPATCH_ROUTED (Read)"
+        );
+    }
+
+    // The five typed-method tools forward via a public method (not
+    // dispatch_tool_json), so they are in NEITHER table.
+    for name in [
+        "enable_vector_index",
+        "enable_unique_constraint",
+        "list_unique_constraints",
+        "lineage_upstream",
+        "lineage_downstream",
+    ] {
+        assert!(
+            !ALL_DISPATCH_ROUTED.iter().any(|(n, _)| *n == name),
+            "{name} forwards via a typed method and must NOT be in ALL_DISPATCH_ROUTED"
         );
     }
 }

--- a/crates/aletheia-server/tests/constraints_lineage_audit_parity.rs
+++ b/crates/aletheia-server/tests/constraints_lineage_audit_parity.rs
@@ -1,0 +1,769 @@
+//! Parity + behavior tests for the CONSTRAINTS / INDEX-ADMIN + LINEAGE +
+//! AUDIT-CHAIN cluster (Issue #3524, PR7 — the FINAL tool slice, completing all
+//! 46 MCP tools on the autumn surface): `enable_vector_index`,
+//! `enable_unique_constraint`, `list_unique_constraints`, `lineage_upstream`,
+//! `lineage_downstream`, `audit_export`, `verify_chain`, `export_chain_head`.
+//!
+//! Each test drives the new crate's autumn [`TestClient`] and asserts the
+//! response equals the **legacy MCP surface** — byte-for-byte where the payload
+//! is deterministic (`trace_id` + wall-clock-volatile bi-temporal timestamps
+//! normalized), and via an offline-verify roundtrip for the one signed
+//! (non-deterministic) payload, `audit_export`. Reads compare over the same
+//! `Arc<AletheiaDB>` (no mutation); the writes (`enable_*`) compare over an
+//! identically-seeded twin DB.
+//!
+//! Access-class cross-check (verified BY HAND against
+//! `tests/parity/inventory.json`): `enable_vector_index`=**write**,
+//! `enable_unique_constraint`=**write**, `list_unique_constraints`=read,
+//! `lineage_upstream`=read, `lineage_downstream`=read, `audit_export`=read,
+//! `verify_chain`=read, `export_chain_head`=read. Every handler's `Authorized<C>`
+//! marker equals its inventory `access_class`; `write_auth_gating_*` proves the
+//! two writes reject a reader token.
+//!
+//! #3220 (vector elision) / #3232 (temporal block) are N/A for this cluster: no
+//! tool here returns an entity-property read payload (lineage entries carry only
+//! version-pinned refs + depth + status; the chain tools return digests /
+//! signed artifacts; `enable_*` return `{success,...}`), so there is no vector
+//! or temporal block to assert.
+
+use std::sync::Mutex;
+use std::sync::{Arc, OnceLock};
+
+use aletheia_server::build_server_client;
+use aletheia_server::edge_tools::DISPATCH_ROUTED_READ_TOOLS;
+use aletheia_server::security::rbac;
+use aletheiadb::audit::{AuditSigningKey, verify_json_bytes};
+use aletheiadb::auth::{AccessClass, AuthMode, AuthStore, Role};
+use aletheiadb::config::{AletheiaDBConfig, WalConfigBuilder};
+use aletheiadb::core::NodeId;
+use aletheiadb::mcp::AletheiaMcpServer;
+use aletheiadb::provenance_chain::{ChainConfig, ChainFsyncMode};
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+use autumn_web::test::TestClient;
+use serde_json::{Value, json};
+
+const ADMIN_TOKEN: &str = "admin-token-abcdefghijklmnop";
+const READER_TOKEN: &str = "reader-token-abcdefghijklmnop";
+
+/// A 32-byte Ed25519 seed for the audit-export signing-key env var.
+const AUDIT_SEED: [u8; 32] = [23u8; 32];
+
+/// Serializes the two tests that mutate the process-global
+/// `ALETHEIADB_AUDIT_SIGNING_KEY` env var (this crate has no `serial_test`
+/// dev-dep; a static mutex is sufficient because cargo runs each integration
+/// test file as its own binary, so the only in-process racers are here).
+fn audit_env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn make_store() -> Arc<AuthStore> {
+    let store = Arc::new(AuthStore::new());
+    store
+        .insert_bootstrap_key("admin", Role::Admin, ADMIN_TOKEN)
+        .expect("insert admin key");
+    store
+        .insert_bootstrap_key("reader", Role::Reader, READER_TOKEN)
+        .expect("insert reader key");
+    store
+}
+
+fn mcp_server(db: &Arc<AletheiaDB>) -> AletheiaMcpServer {
+    AletheiaMcpServer::new(db.clone())
+}
+
+fn fresh_db() -> Arc<AletheiaDB> {
+    Arc::new(AletheiaDB::new().expect("create db"))
+}
+
+/// A durable, chain-enabled database rooted at a tempdir. Returns the guard so
+/// the data dir outlives the DB.
+fn chain_enabled_db() -> (tempfile::TempDir, Arc<AletheiaDB>) {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let config = AletheiaDBConfig::builder()
+        .wal(
+            WalConfigBuilder::new()
+                .wal_dir(dir.path().join("wal"))
+                .build(),
+        )
+        .chain(ChainConfig {
+            enabled: true,
+            fsync: ChainFsyncMode::Batched,
+            dir: None,
+        })
+        .build();
+    let db = AletheiaDB::with_unified_config(config).expect("chain-enabled db");
+    (dir, Arc::new(db))
+}
+
+/// Recursively drop the per-request `trace_id` and wall-clock-volatile
+/// bi-temporal timestamps so an autumn response and a legacy reference compare.
+fn normalize(v: Value) -> Value {
+    match v {
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .filter(|(k, _)| {
+                    !matches!(
+                        k.as_str(),
+                        "trace_id"
+                            | "valid_from"
+                            | "valid_to"
+                            | "transaction_from"
+                            | "transaction_to"
+                            | "transaction_time"
+                    )
+                })
+                .map(|(k, val)| (k, normalize(val)))
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(items.into_iter().map(normalize).collect()),
+        other => other,
+    }
+}
+
+async fn get(client: &TestClient, uri: &str, bearer: Option<&str>) -> (u16, Value) {
+    let mut req = client.get(uri);
+    if let Some(token) = bearer {
+        req = req.header("authorization", &format!("Bearer {token}"));
+    }
+    let resp = req.send().await;
+    let status = resp.status.as_u16();
+    let body: Value = serde_json::from_str(&resp.text()).expect("new body is JSON");
+    (status, body)
+}
+
+async fn post(client: &TestClient, uri: &str, body: &Value, bearer: Option<&str>) -> (u16, Value) {
+    let mut req = client.post(uri);
+    if let Some(token) = bearer {
+        req = req.header("authorization", &format!("Bearer {token}"));
+    }
+    let resp = req.json(body).send().await;
+    let status = resp.status.as_u16();
+    let body: Value = serde_json::from_str(&resp.text()).expect("new body is JSON");
+    (status, body)
+}
+
+/// The current version id of a node (for building version-pinned lineage refs).
+fn node_ver(db: &Arc<AletheiaDB>, id: u64) -> u64 {
+    db.node_lineage_ref(NodeId::new(id).expect("valid node id"))
+        .expect("node has a current version")
+        .version
+        .as_u64()
+}
+
+/// Seed a lineage subgraph on `db` via the legacy MCP create_node path: two
+/// source docs A and B, and a summary C derived from both. Returns
+/// `(a_id, a_ver, b_id, b_ver, c_id, c_ver)`.
+fn seed_lineage(
+    server: &AletheiaMcpServer,
+    db: &Arc<AletheiaDB>,
+) -> (u64, u64, u64, u64, u64, u64) {
+    let a: Value = serde_json::from_str(&server.dispatch_tool_json(
+        "create_node",
+        json!({"label": "Doc", "properties": {"t": "A"}}),
+    ))
+    .expect("create A");
+    let a_id = a["id"].as_u64().expect("a id");
+    let a_ver = node_ver(db, a_id);
+
+    let b: Value = serde_json::from_str(&server.dispatch_tool_json(
+        "create_node",
+        json!({"label": "Doc", "properties": {"t": "B"}}),
+    ))
+    .expect("create B");
+    let b_id = b["id"].as_u64().expect("b id");
+    let b_ver = node_ver(db, b_id);
+
+    let c: Value = serde_json::from_str(&server.dispatch_tool_json(
+        "create_node",
+        json!({
+            "label": "Summary",
+            "properties": {"t": "A+B"},
+            "derived_from": [
+                {"entity_kind": "node", "id": a_id, "version": a_ver},
+                {"entity_kind": "node", "id": b_id, "version": b_ver},
+            ],
+        }),
+    ))
+    .expect("create C");
+    let c_id = c["id"].as_u64().expect("c id");
+    let c_ver = node_ver(db, c_id);
+
+    (a_id, a_ver, b_id, b_ver, c_id, c_ver)
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// list_unique_constraints + lineage_upstream/downstream: byte-parity vs the
+// legacy MCP surface over the SAME DB (reads — no mutation), in both auth modes.
+// ════════════════════════════════════════════════════════════════════════════
+
+async fn assert_reads_parity(mode: AuthMode, token: Option<&'static str>) {
+    let db = fresh_db();
+    let server = mcp_server(&db);
+    // Seed a constraint + a lineage subgraph.
+    db.unique_constraint("Person", "email")
+        .enable()
+        .expect("enable constraint");
+    let (a_id, a_ver, _b_id, _b_ver, c_id, c_ver) = seed_lineage(&server, &db);
+
+    let client = build_server_client(db.clone(), make_store(), mode);
+
+    // 1. list_unique_constraints (GET) — typed-method reference.
+    let (s, autumn) = get(&client, "/constraints/unique", token).await;
+    assert_eq!(s, 200, "list_unique_constraints: {autumn}");
+    let legacy: Value =
+        serde_json::from_str(&server.dispatch_tool_json("list_unique_constraints", json!({})))
+            .expect("legacy list_unique_constraints json");
+    assert_eq!(
+        normalize(autumn.clone()),
+        normalize(legacy),
+        "list_unique_constraints parity"
+    );
+    assert_eq!(autumn["count"], json!(1), "one constraint: {autumn}");
+
+    // 2. lineage_upstream (POST) of the summary C — both docs at depth 1.
+    let up_req = json!({"entity_kind": "node", "id": c_id, "version": c_ver});
+    let (s, autumn) = post(&client, "/lineage/upstream", &up_req, token).await;
+    assert_eq!(s, 200, "lineage_upstream: {autumn}");
+    let legacy: Value =
+        serde_json::from_str(&server.dispatch_tool_json("lineage_upstream", up_req.clone()))
+            .expect("legacy lineage_upstream json");
+    assert_eq!(
+        normalize(autumn.clone()),
+        normalize(legacy),
+        "lineage_upstream parity"
+    );
+    assert_eq!(autumn["direction"], "upstream");
+    assert_eq!(autumn["count"].as_u64(), Some(2), "two upstream: {autumn}");
+    assert_eq!(autumn["has_more"], json!(false));
+
+    // 3. lineage_downstream (POST) of doc A — reaches the summary C.
+    let down_req = json!({"entity_kind": "node", "id": a_id, "version": a_ver});
+    let (s, autumn) = post(&client, "/lineage/downstream", &down_req, token).await;
+    assert_eq!(s, 200, "lineage_downstream: {autumn}");
+    let legacy: Value =
+        serde_json::from_str(&server.dispatch_tool_json("lineage_downstream", down_req.clone()))
+            .expect("legacy lineage_downstream json");
+    assert_eq!(
+        normalize(autumn.clone()),
+        normalize(legacy),
+        "lineage_downstream parity"
+    );
+    assert_eq!(autumn["direction"], "downstream");
+    assert_eq!(autumn["entries"][0]["id"].as_u64(), Some(c_id));
+}
+
+#[tokio::test]
+async fn reads_byte_parity_required_mode() {
+    assert_reads_parity(AuthMode::Required, Some(READER_TOKEN)).await;
+}
+
+#[tokio::test]
+async fn reads_byte_parity_anonymous_mode() {
+    assert_reads_parity(AuthMode::Anonymous, None).await;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// lineage: #3226 pagination (has_more / next_offset) + #3234 error kind.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn lineage_upstream_pagination_has_more_and_next_offset() {
+    let db = fresh_db();
+    let server = mcp_server(&db);
+    let (a_id, a_ver, b_id, b_ver, c_id, c_ver) = seed_lineage(&server, &db);
+    let _ = (a_id, a_ver, b_id, b_ver);
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    // C has two upstream parents; limit=1 → one entry, has_more=true, next_offset=1.
+    let req = json!({"entity_kind": "node", "id": c_id, "version": c_ver, "limit": 1});
+    let (s, autumn) = post(&client, "/lineage/upstream", &req, Some(READER_TOKEN)).await;
+    assert_eq!(s, 200, "paged upstream: {autumn}");
+    let legacy: Value =
+        serde_json::from_str(&server.dispatch_tool_json("lineage_upstream", req.clone()))
+            .expect("legacy paged json");
+    assert_eq!(
+        normalize(autumn.clone()),
+        normalize(legacy),
+        "lineage pagination parity"
+    );
+    assert_eq!(autumn["count"].as_u64(), Some(1), "one per page: {autumn}");
+    assert_eq!(autumn["has_more"], json!(true), "more pages: {autumn}");
+    assert_eq!(
+        autumn["next_offset"].as_u64(),
+        Some(1),
+        "next_offset advances: {autumn}"
+    );
+}
+
+#[tokio::test]
+async fn lineage_upstream_bad_entity_kind_is_invalid_argument() {
+    let db = fresh_db();
+    let client = build_server_client(db, make_store(), AuthMode::Required);
+
+    // A structurally-invalid root ref (bad entity kind) is the #3234
+    // INVALID_ARGUMENT the query tool preserves. (The write-path dangling-ref
+    // NOT_FOUND lives on create_node/create_edge's `derived_from`, PR2/PR3.)
+    let req = json!({"entity_kind": "widget", "id": 1, "version": 1});
+    let (s, autumn) = post(&client, "/lineage/upstream", &req, Some(READER_TOKEN)).await;
+    assert_eq!(s, 200, "in-band error still 200: {autumn}");
+    assert_eq!(
+        autumn["error"]["code"], "INVALID_ARGUMENT",
+        "bad entity kind → INVALID_ARGUMENT: {autumn}"
+    );
+    assert_eq!(autumn["error"]["retriable"], json!(false));
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// enable_vector_index / enable_unique_constraint: WriteClass twin-DB parity +
+// idempotency + write-auth gating (a reader token is denied).
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn enable_vector_index_twin_db_parity_and_idempotent() {
+    let a = fresh_db();
+    let b = fresh_db();
+    let client = build_server_client(a.clone(), make_store(), AuthMode::Required);
+
+    let req = json!({"property_name": "embedding", "dimensions": 4, "distance_metric": "cosine"});
+    let (s, autumn) = post(&client, "/vector/indexes", &req, Some(ADMIN_TOKEN)).await;
+    assert_eq!(s, 200, "enable_vector_index: {autumn}");
+    let legacy: Value = serde_json::from_str(
+        &mcp_server(&b).dispatch_tool_json("enable_vector_index", req.clone()),
+    )
+    .expect("legacy json");
+    assert_eq!(
+        normalize(autumn.clone()),
+        normalize(legacy),
+        "enable_vector_index parity"
+    );
+    assert_eq!(autumn["success"], json!(true), "enabled: {autumn}");
+    assert_eq!(autumn["property_name"], "embedding");
+
+    // Re-enable: same index, byte-parity against the twin re-enabling too.
+    let (s, autumn2) = post(&client, "/vector/indexes", &req, Some(ADMIN_TOKEN)).await;
+    assert_eq!(s, 200, "re-enable: {autumn2}");
+    let legacy2: Value = serde_json::from_str(
+        &mcp_server(&b).dispatch_tool_json("enable_vector_index", req.clone()),
+    )
+    .expect("legacy re-enable json");
+    assert_eq!(
+        normalize(autumn2),
+        normalize(legacy2),
+        "enable_vector_index idempotency parity"
+    );
+}
+
+#[tokio::test]
+async fn enable_unique_constraint_twin_db_parity_and_idempotent() {
+    let a = fresh_db();
+    let b = fresh_db();
+    let client = build_server_client(a.clone(), make_store(), AuthMode::Required);
+
+    let req = json!({"label": "Person", "property": "email"});
+    let (s, autumn) = post(&client, "/constraints/unique", &req, Some(ADMIN_TOKEN)).await;
+    assert_eq!(s, 200, "enable_unique_constraint: {autumn}");
+    let legacy: Value = serde_json::from_str(
+        &mcp_server(&b).dispatch_tool_json("enable_unique_constraint", req.clone()),
+    )
+    .expect("legacy json");
+    assert_eq!(
+        normalize(autumn.clone()),
+        normalize(legacy),
+        "enable_unique_constraint parity"
+    );
+    assert_eq!(autumn["success"], json!(true), "enabled: {autumn}");
+    assert_eq!(autumn["label"], "Person");
+    assert_eq!(autumn["property"], "email");
+
+    // The constraint is now visible via list_unique_constraints on db `a`.
+    let (s, list) = get(&client, "/constraints/unique", Some(READER_TOKEN)).await;
+    assert_eq!(s, 200, "list after enable: {list}");
+    assert_eq!(list["count"], json!(1), "constraint listed: {list}");
+
+    // Idempotent re-enable parity.
+    let (s, autumn2) = post(&client, "/constraints/unique", &req, Some(ADMIN_TOKEN)).await;
+    assert_eq!(s, 200, "re-enable: {autumn2}");
+    let legacy2: Value = serde_json::from_str(
+        &mcp_server(&b).dispatch_tool_json("enable_unique_constraint", req.clone()),
+    )
+    .expect("legacy re-enable json");
+    assert_eq!(
+        normalize(autumn2),
+        normalize(legacy2),
+        "enable_unique_constraint idempotency parity"
+    );
+}
+
+#[tokio::test]
+async fn write_auth_gating_reader_denied_on_enables() {
+    // The two enable_* tools are WriteClass: a reader token (grants only Read)
+    // must be denied (403 PERMISSION_DENIED) — proving the handler class is
+    // Write, not Read.
+    let db = fresh_db();
+    let client = build_server_client(db, make_store(), AuthMode::Required);
+
+    let (s, body) = post(
+        &client,
+        "/vector/indexes",
+        &json!({"property_name": "embedding", "dimensions": 4}),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(s, 403, "reader denied enable_vector_index: {body}");
+    assert_eq!(body["code"], "PERMISSION_DENIED", "denial code: {body}");
+
+    let (s, body) = post(
+        &client,
+        "/constraints/unique",
+        &json!({"label": "Person", "property": "email"}),
+        Some(READER_TOKEN),
+    )
+    .await;
+    assert_eq!(s, 403, "reader denied enable_unique_constraint: {body}");
+    assert_eq!(body["code"], "PERMISSION_DENIED", "denial code: {body}");
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// verify_chain / export_chain_head: provenance-hash-chain parity over a
+// chain-enabled DB (same DB — reads), plus the disabled-chain FAILED_PRECONDITION.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn verify_and_export_chain_parity_on_enabled_chain() {
+    let (_guard, db) = chain_enabled_db();
+    let server = mcp_server(&db);
+    // Seal real transactions so the chain has content.
+    for _ in 0..5 {
+        db.create_node("Person", PropertyMapBuilder::new().build())
+            .expect("seed node");
+    }
+    let client = build_server_client(db.clone(), make_store(), AuthMode::Required);
+
+    // export_chain_head (GET) — deterministic head digest on the same DB.
+    let (s, head) = get(&client, "/chain/head", Some(READER_TOKEN)).await;
+    assert_eq!(s, 200, "export_chain_head: {head}");
+    let legacy_head: Value =
+        serde_json::from_str(&server.dispatch_tool_json("export_chain_head", json!({})))
+            .expect("legacy head json");
+    assert_eq!(
+        normalize(head.clone()),
+        normalize(legacy_head),
+        "export_chain_head parity"
+    );
+    assert!(head["digest"].as_str().is_some(), "head has digest: {head}");
+
+    // verify_chain (POST, full) — passes, deterministic result on the same DB.
+    let (s, full) = post(&client, "/chain/verify", &json!({}), Some(READER_TOKEN)).await;
+    assert_eq!(s, 200, "verify_chain full: {full}");
+    let legacy_full: Value =
+        serde_json::from_str(&server.dispatch_tool_json("verify_chain", json!({})))
+            .expect("legacy full json");
+    assert_eq!(
+        normalize(full.clone()),
+        normalize(legacy_full),
+        "verify_chain full parity"
+    );
+    assert_eq!(full["passed"], json!(true), "full verify passes: {full}");
+    assert_eq!(full["scope"], "full");
+
+    // verify_chain against the exported head — anchor-extension mode passes.
+    let against = json!({ "against": head.clone() });
+    let (s, anchor) = post(&client, "/chain/verify", &against, Some(READER_TOKEN)).await;
+    assert_eq!(s, 200, "verify_chain anchor: {anchor}");
+    let legacy_anchor: Value =
+        serde_json::from_str(&server.dispatch_tool_json("verify_chain", against.clone()))
+            .expect("legacy anchor json");
+    assert_eq!(
+        normalize(anchor.clone()),
+        normalize(legacy_anchor),
+        "verify_chain anchor parity"
+    );
+    assert_eq!(anchor["scope"], "anchor", "anchor scope: {anchor}");
+    assert_eq!(anchor["passed"], json!(true));
+}
+
+#[tokio::test]
+async fn verify_and_export_chain_disabled_is_failed_precondition() {
+    // The default (non-chain) DB → both tools return a structured
+    // FAILED_PRECONDITION (never a silent pass / fabricated head).
+    let db = fresh_db();
+    let client = build_server_client(db, make_store(), AuthMode::Required);
+
+    let (s, v) = post(&client, "/chain/verify", &json!({}), Some(READER_TOKEN)).await;
+    assert_eq!(s, 200, "verify (disabled) in-band error 200: {v}");
+    assert_eq!(
+        v["error"]["code"], "FAILED_PRECONDITION",
+        "verify disabled: {v}"
+    );
+    assert_eq!(v["error"]["retriable"], json!(false));
+
+    let (s, e) = get(&client, "/chain/head", Some(READER_TOKEN)).await;
+    assert_eq!(s, 200, "export (disabled) in-band error 200: {e}");
+    assert_eq!(
+        e["error"]["code"], "FAILED_PRECONDITION",
+        "export disabled: {e}"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// audit_export: signed-artifact roundtrip (offline-verify) + the missing-key
+// FAILED_PRECONDITION. The signed payload embeds volatile export timestamps, so
+// a byte compare is not meaningful; instead we verify the artifact offline
+// against the operator public key exactly as the legacy tool guarantees.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+// The env-var serialization lock intentionally spans the request `.await`: the
+// process-global `ALETHEIADB_AUDIT_SIGNING_KEY` must stay set for the duration of
+// the audit_export call. `#[tokio::test]` is a current-thread runtime, so the
+// std `MutexGuard` never crosses threads.
+#[allow(clippy::await_holding_lock)]
+async fn audit_export_roundtrip_signs_and_redacts() {
+    let _lock = audit_env_lock().lock().expect("audit env lock");
+    // SAFETY: env mutation serialized via `audit_env_lock` within this binary;
+    // restored below.
+    let seed_hex: String = AUDIT_SEED.iter().map(|b| format!("{b:02x}")).collect();
+    unsafe {
+        std::env::set_var("ALETHEIADB_AUDIT_SIGNING_KEY", &seed_hex);
+    }
+
+    let db = fresh_db();
+    let alice = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .insert("ssn", "secret")
+                .build(),
+        )
+        .expect("create alice");
+    let client = build_server_client(db, make_store(), AuthMode::Required);
+
+    let req = json!({
+        "entity_type": "node",
+        "entity_id": alice.as_u64(),
+        "database_id": "prod-db",
+        "redact_keys": ["ssn"],
+    });
+    let (s, resp) = post(&client, "/audit/export", &req, Some(READER_TOKEN)).await;
+    assert_eq!(s, 200, "audit_export: {resp}");
+    assert_eq!(
+        resp["version_count"].as_u64(),
+        Some(1),
+        "one version: {resp}"
+    );
+
+    let expected_pub = AuditSigningKey::from_seed_bytes(AUDIT_SEED).public_key();
+    assert_eq!(
+        resp["public_key"].as_str(),
+        Some(expected_pub.to_hex().as_str()),
+        "public key travels in the response: {resp}"
+    );
+
+    // The artifact verifies offline against the operator's public key, and the
+    // redacted value never leaked into it.
+    let artifact_bytes = serde_json::to_vec(&resp["artifact"]).expect("artifact bytes");
+    let report = verify_json_bytes(&artifact_bytes, Some(&expected_pub))
+        .expect("autumn-produced artifact must verify offline");
+    assert!(report.passed, "offline verification passes");
+    assert!(
+        report.redacted_keys.iter().any(|k| k == "ssn"),
+        "ssn redacted"
+    );
+    assert!(
+        !String::from_utf8(artifact_bytes)
+            .expect("utf8")
+            .contains("secret"),
+        "redacted value must not leak"
+    );
+
+    unsafe {
+        std::env::remove_var("ALETHEIADB_AUDIT_SIGNING_KEY");
+    }
+}
+
+#[tokio::test]
+// See `audit_export_roundtrip_signs_and_redacts`: the env-var lock spans the
+// request `.await` by design (current-thread runtime).
+#[allow(clippy::await_holding_lock)]
+async fn audit_export_without_signing_key_is_failed_precondition() {
+    let _lock = audit_env_lock().lock().expect("audit env lock");
+    // SAFETY: env mutation serialized via `audit_env_lock`.
+    unsafe {
+        std::env::remove_var("ALETHEIADB_AUDIT_SIGNING_KEY");
+    }
+
+    let db = fresh_db();
+    let alice = db
+        .create_node("Person", PropertyMapBuilder::new().insert("n", "a").build())
+        .expect("create alice");
+    let client = build_server_client(db, make_store(), AuthMode::Required);
+
+    let req = json!({"entity_type": "node", "entity_id": alice.as_u64()});
+    let (s, resp) = post(&client, "/audit/export", &req, Some(READER_TOKEN)).await;
+    assert_eq!(s, 200, "in-band error 200: {resp}");
+    assert_eq!(
+        resp["error"]["code"], "FAILED_PRECONDITION",
+        "missing signing key → FAILED_PRECONDITION: {resp}"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Auth: keyless required-mode calls are 401 for all eight tools.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn all_eight_tools_require_credential_in_required_mode() {
+    let db = fresh_db();
+    let client = build_server_client(db, make_store(), AuthMode::Required);
+
+    // GET reads.
+    for uri in ["/constraints/unique", "/chain/head"] {
+        let resp = client.get(uri).send().await;
+        assert_eq!(resp.status.as_u16(), 401, "{uri} unauth");
+        assert_eq!(resp.header("www-authenticate"), Some("Bearer"));
+    }
+    // POST tools (writes + reads).
+    let posts: &[(&str, Value)] = &[
+        (
+            "/vector/indexes",
+            json!({"property_name": "e", "dimensions": 4}),
+        ),
+        (
+            "/constraints/unique",
+            json!({"label": "Person", "property": "email"}),
+        ),
+        (
+            "/lineage/upstream",
+            json!({"entity_kind": "node", "id": 1, "version": 1}),
+        ),
+        (
+            "/lineage/downstream",
+            json!({"entity_kind": "node", "id": 1, "version": 1}),
+        ),
+        (
+            "/audit/export",
+            json!({"entity_type": "node", "entity_id": 1}),
+        ),
+        ("/chain/verify", json!({})),
+    ];
+    for (uri, body) in posts {
+        let resp = client.post(uri).json(body).send().await;
+        assert_eq!(resp.status.as_u16(), 401, "{uri} unauth");
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Routing: all eight tools are routed on /mcp with their inventory access_class.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn all_eight_tools_routable_on_mcp_with_correct_class() {
+    let db = fresh_db();
+    let client = build_server_client(db, make_store(), AuthMode::Required);
+
+    let rpc = json!({ "jsonrpc": "2.0", "id": 1, "method": "tools/list" });
+    let resp = client
+        .post("/mcp")
+        .header("authorization", &format!("Bearer {ADMIN_TOKEN}"))
+        .json(&rpc)
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200);
+    let body: Value = serde_json::from_str(&resp.text()).expect("json");
+    let tools = body["result"]["tools"].as_array().expect("tools array");
+
+    // Every one of the eight is advertised, and its RBAC class matches inventory.
+    let expected: &[(&str, AccessClass)] = &[
+        ("enable_vector_index", AccessClass::Write),
+        ("enable_unique_constraint", AccessClass::Write),
+        ("list_unique_constraints", AccessClass::Read),
+        ("lineage_upstream", AccessClass::Read),
+        ("lineage_downstream", AccessClass::Read),
+        ("audit_export", AccessClass::Read),
+        ("verify_chain", AccessClass::Read),
+        ("export_chain_head", AccessClass::Read),
+    ];
+    for (name, class) in expected {
+        assert!(
+            tools.iter().any(|t| t["name"] == json!(name)),
+            "/mcp must advertise {name}: {body}"
+        );
+        assert_eq!(
+            rbac::tool_access_class(name),
+            Some(*class),
+            "{name} RBAC class must equal inventory access_class {class:?}"
+        );
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Conformance: none of the eight is budgetable/cursorable, so none is registered
+// in the shared DISPATCH_ROUTED_READ_TOOLS pinned-name table (the three
+// audit-chain tools use dispatch_tool_json but pin their OWN name — no
+// cross-tool escalation, so they are intentionally not pinned).
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn none_of_the_eight_is_dispatch_routed() {
+    for name in [
+        "enable_vector_index",
+        "enable_unique_constraint",
+        "list_unique_constraints",
+        "lineage_upstream",
+        "lineage_downstream",
+        "audit_export",
+        "verify_chain",
+        "export_chain_head",
+    ] {
+        assert!(
+            !DISPATCH_ROUTED_READ_TOOLS.iter().any(|(n, _)| *n == name),
+            "{name} is non-budgetable/non-cursorable and must NOT be dispatch-routed"
+        );
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// OpenAPI fidelity: the POST-body tools expose a named per-operation request
+// schema (never the shared generic `Value` a `Json<Value>` body emits, the #3589
+// lesson); the two GET reads are documented.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn openapi_documents_the_eight_tools_with_named_bodies() {
+    let db = fresh_db();
+    let client = build_server_client(db, make_store(), AuthMode::Required);
+    let resp = client.get("/openapi.json").send().await;
+    assert_eq!(resp.status.as_u16(), 200);
+    let spec: Value = serde_json::from_str(&resp.text()).expect("openapi json");
+
+    // POST bodies ref a typed per-operation schema, never the generic Value.
+    for path in [
+        "/vector/indexes",
+        "/constraints/unique",
+        "/lineage/upstream",
+        "/lineage/downstream",
+        "/audit/export",
+        "/chain/verify",
+    ] {
+        let schema =
+            &spec["paths"][path]["post"]["requestBody"]["content"]["application/json"]["schema"];
+        let sref = schema["$ref"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{path} requestBody must be a $ref: {schema}"));
+        assert_ne!(
+            sref, "#/components/schemas/Value",
+            "{path} must not degrade to the shared generic Value component"
+        );
+    }
+
+    // The two GET reads are documented.
+    for path in ["/constraints/unique", "/chain/head"] {
+        assert!(
+            !spec["paths"][path]["get"].is_null(),
+            "GET {path} documented: {}",
+            spec["paths"]
+        );
+    }
+}

--- a/crates/aletheia-server/tests/server_parity.rs
+++ b/crates/aletheia-server/tests/server_parity.rs
@@ -563,7 +563,7 @@ async fn mcp_routable_tools_are_all_classified() {
 /// drift to a non-Read (e.g. write) pinned name fails here.
 #[tokio::test]
 async fn dispatch_pinned_names_match_routed_class() {
-    use aletheia_server::edge_tools::DISPATCH_ROUTED_READ_TOOLS;
+    use aletheia_server::edge_tools::{ALL_DISPATCH_ROUTED, DISPATCH_ROUTED_READ_TOOLS};
     use std::collections::BTreeSet;
 
     let (db, store, _) = fixture();
@@ -586,11 +586,15 @@ async fn dispatch_pinned_names_match_routed_class() {
         .map(|t| t["name"].as_str().expect("tool name").to_string())
         .collect();
 
+    // Iterate the SUPERSET `ALL_DISPATCH_ROUTED` so EVERY dispatch_tool_json call
+    // site is covered — the budgetable/cursorable slow reads AND the three
+    // non-budgetable provenance-hash-chain tools (`audit_export`, `verify_chain`,
+    // `export_chain_head`, Issue #3524 PR7) that also pin a literal name.
     assert!(
-        !DISPATCH_ROUTED_READ_TOOLS.is_empty(),
+        !ALL_DISPATCH_ROUTED.is_empty(),
         "the pinned-name table must not be empty"
     );
-    for (pinned, class) in DISPATCH_ROUTED_READ_TOOLS {
+    for (pinned, class) in ALL_DISPATCH_ROUTED {
         // (1) pinned ↔ routed: the literal a handler forwards must be a real,
         // routed tool name (never a typo or an off-surface name).
         assert!(
@@ -605,6 +609,17 @@ async fn dispatch_pinned_names_match_routed_class() {
             Some(*class),
             "pinned dispatch name {pinned:?} registry class must equal the handler's \
              Authorized<C> class ({class:?}) — a read handler pinning a write name is escalation"
+        );
+    }
+
+    // Subset invariant: every budgetable-routed entry must appear in the superset,
+    // so `DISPATCH_ROUTED_READ_TOOLS` and `ALL_DISPATCH_ROUTED` can never drift
+    // (a budgetable read added to one but not the other would fail here).
+    for entry in DISPATCH_ROUTED_READ_TOOLS {
+        assert!(
+            ALL_DISPATCH_ROUTED.contains(entry),
+            "DISPATCH_ROUTED_READ_TOOLS entry {entry:?} is missing from the \
+             ALL_DISPATCH_ROUTED superset — the two tables have drifted"
         );
     }
 }


### PR DESCRIPTION
## Autumn-web migration PR7 (FINAL slice): CONSTRAINTS / INDEX-ADMIN + LINEAGE + AUDIT-CHAIN (Issue #3524)

Ports the last 8 MCP tools to the `aletheia-server` autumn-web crate, so each is surfaced on **HTTP**, **MCP-over-HTTP** (`/mcp`), and **OpenAPI** from one handler definition. **This completes all 46 MCP tools on the autumn surface.**

The 8: `enable_vector_index`, `enable_unique_constraint`, `list_unique_constraints`, `lineage_upstream`, `lineage_downstream`, `audit_export`, `verify_chain`, `export_chain_head`.

### Before / After

- **Before:** these 8 tools existed only on the legacy `AletheiaMcpServer` MCP surface (`src/mcp/server.rs`); no HTTP route, no OpenAPI operation, no autumn `/mcp` advertisement.
- **After:** each has an `#[api_doc(mcp)]` handler in `crates/aletheia-server/src/constraints_lineage_audit_tools.rs`, registered in `app.rs`, byte-identical to the legacy MCP surface (proven in the new parity suite), with a named per-operation OpenAPI request schema.

### Execution model — all 8 are typed / inline (no budget, no cursor, no guard)

Verified against source: **none** of the 8 is in `BUDGETABLE_READ_TOOLS` (`src/mcp/server.rs`) and **none** is in the cursorable set (`make_cursor_input_schema` call sites). So there is no dispatch-routed slow read here — **no `DISPATCH_ROUTED_READ_TOOLS` addition, no in-flight guard, no timeout, no byte cap**. Two forwarding shapes, both mirroring PR3–PR6:

1. **5 tools with a public typed method** (`enable_vector_index`, `enable_unique_constraint`, `list_unique_constraints`, `lineage_upstream`, `lineage_downstream`) forward the re-exported request struct to `AletheiaMcpServer::<method>(req)` inline — zero reserialization, already-public symbols only. Lineage forwards `LineageQueryRequest` verbatim, preserving the #3226 `has_more`/`next_offset` pagination, version-pinned refs, per-entry `FactStatus`, `as_of_transaction_time` scoping, and the #3234 error codes.
2. **3 provenance-hash-chain tools with NO public typed method** (`audit_export`, `verify_chain`, `export_chain_head`) take a **local** typed body (named OpenAPI component, the #3589 lesson) and forward raw args through the already-public `AletheiaMcpServer::dispatch_tool_json` with a hardcoded literal tool name — the only public entry (their `handle_*` are private). Being non-budgetable/non-cursorable, dispatch reproduces a hypothetical typed method byte-for-byte, so **no main-crate change** is required. Each pins its **own** tool name (no cross-tool escalation), so none is registered in `DISPATCH_ROUTED_READ_TOOLS`.

### 8-tool marker ↔ inventory access_class table (verified BY HAND)

| Tool | inventory `access_class` | handler `Authorized<C>` marker |
|------|--------------------------|--------------------------------|
| `enable_vector_index` | `write` | `WriteClass` |
| `enable_unique_constraint` | `write` | `WriteClass` |
| `list_unique_constraints` | `read` | `ReadClass` |
| `lineage_upstream` | `read` | `ReadClass` |
| `lineage_downstream` | `read` | `ReadClass` |
| `audit_export` | `read` | `ReadClass` |
| `verify_chain` | `read` | `ReadClass` |
| `export_chain_head` | `read` | `ReadClass` |

Cross-checked against `tests/parity/inventory.json` and `src/mcp/auth.rs::TOOL_ACCESS_CLASSES`. `all_eight_tools_routable_on_mcp_with_correct_class` asserts each is routed on `/mcp` with the RBAC-registry class equal to its inventory class; `write_auth_gating_reader_denied_on_enables` proves the two writes reject a reader token (403 `PERMISSION_DENIED`).

### Main-crate widenings

**None.** Zero source changes to the `aletheiadb` crate. The three tools lacking a public typed method forward through the already-public `dispatch_tool_json` instead (the task-preferred alternative to widening). Only server-crate files + its `Cargo.toml` (add `tempfile` dev-dep for the chain-enabled fixtures) + the resulting `Cargo.lock` change.

### Registry-boundary note

No `src/security/**` or `tests/security_*.rs` edits. `DISPATCH_ROUTED_READ_TOOLS` is left **unchanged** (its semantic stays "budgetable reads"; none of the 8 is budgetable). RBAC classification of all 8 already lives in the inventory-anchored registry (Lane B).

### Security conformance: `ALL_DISPATCH_ROUTED` closes every `dispatch_tool_json` call site

A follow-up commit adds `ALL_DISPATCH_ROUTED` (in `edge_tools.rs`), the **superset** of every handler that pins a hardcoded literal tool name in `dispatch_tool_json`: the existing `DISPATCH_ROUTED_READ_TOOLS` (budgetable/cursorable slow reads) **plus** the three provenance-hash-chain tools (`audit_export`, `verify_chain`, `export_chain_head`) which forward via `dispatch_tool_json` but are **not** budgetable/cursorable (they stay out of `DISPATCH_ROUTED_READ_TOOLS`). The shared `dispatch_pinned_names_match_routed_class` conformance test now iterates `ALL_DISPATCH_ROUTED` — asserting, for **every** dispatch call site, that the pinned name is routable on `/mcp` **and** `rbac::tool_access_class(name)` equals the handler's `Authorized<C>` class — and additionally asserts `DISPATCH_ROUTED_READ_TOOLS ⊆ ALL_DISPATCH_ROUTED` so the two tables can never drift. This closes the pinned-name coverage gap for the three chain tools' dispatch sites (each pins its **own** Read-class name — no cross-tool escalation — now under the same guard as the budgetable reads). Verified verbatim:

```
test dispatch_pinned_names_match_routed_class ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 19 filtered out
test dispatch_routed_split_is_exactly_the_three_chain_tools ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 14 filtered out
```

### Codecov

The `aletheia-server` crate is instrumented; the new module + test file are covered by `constraints_lineage_audit_parity.rs` (15 tests).

### AC-evidence: inventory rows → passing parity tests

| Tool (inventory row) | Covering test(s) |
|----------------------|------------------|
| `enable_vector_index` (write) | `enable_vector_index_twin_db_parity_and_idempotent`, `write_auth_gating_reader_denied_on_enables` |
| `enable_unique_constraint` (write) | `enable_unique_constraint_twin_db_parity_and_idempotent`, `write_auth_gating_reader_denied_on_enables` |
| `list_unique_constraints` (read) | `reads_byte_parity_required_mode`, `reads_byte_parity_anonymous_mode` |
| `lineage_upstream` (read) | `reads_byte_parity_{required,anonymous}_mode`, `lineage_upstream_pagination_has_more_and_next_offset`, `lineage_upstream_bad_entity_kind_is_invalid_argument` |
| `lineage_downstream` (read) | `reads_byte_parity_{required,anonymous}_mode` |
| `audit_export` (read) | `audit_export_roundtrip_signs_and_redacts`, `audit_export_without_signing_key_is_failed_precondition` |
| `verify_chain` (read) | `verify_and_export_chain_parity_on_enabled_chain`, `verify_and_export_chain_disabled_is_failed_precondition` |
| `export_chain_head` (read) | `verify_and_export_chain_parity_on_enabled_chain`, `verify_and_export_chain_disabled_is_failed_precondition` |

Plus cross-cutting: `all_eight_tools_require_credential_in_required_mode`, `all_eight_tools_routable_on_mcp_with_correct_class`, `dispatch_routed_split_is_exactly_the_three_chain_tools`, `openapi_documents_the_eight_tools_with_named_bodies`.

`#3220` (vector elision) / `#3232` (temporal block) are **N/A** for this cluster — no tool returns an entity-property read payload.

```
running 15 tests
test all_eight_tools_require_credential_in_required_mode ... ok
test all_eight_tools_routable_on_mcp_with_correct_class ... ok
test enable_vector_index_twin_db_parity_and_idempotent ... ok
test lineage_upstream_bad_entity_kind_is_invalid_argument ... ok
test audit_export_roundtrip_signs_and_redacts ... ok
test dispatch_routed_split_is_exactly_the_three_chain_tools ... ok
test openapi_documents_the_eight_tools_with_named_bodies ... ok
test audit_export_without_signing_key_is_failed_precondition ... ok
test lineage_upstream_pagination_has_more_and_next_offset ... ok
test enable_unique_constraint_twin_db_parity_and_idempotent ... ok
test verify_and_export_chain_disabled_is_failed_precondition ... ok
test reads_byte_parity_anonymous_mode ... ok
test write_auth_gating_reader_denied_on_enables ... ok
test reads_byte_parity_required_mode ... ok
test verify_and_export_chain_parity_on_enabled_chain ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

### Gates (all 6 green, isolated `CARGO_TARGET_DIR`)

- `cargo clippy -p aletheia-server --all-targets -- -D warnings` ✅
- `cargo test -p aletheia-server` ✅ (incl. updated `dispatch_pinned_names_match_routed_class`)
- `cargo fmt --all -- --check` ✅
- `cargo check -p aletheiadb --no-default-features --tests --features http-server` ✅
- `cargo test --features http-server,mcp-server --test parity_http --test parity_mcp` ✅ (parity_http + parity_mcp: 11 passed, incl. `tool_inventory_golden_is_stable`)
- `cargo clippy -p aletheiadb --features "config-toml,mcp-server,sharding-rpc,simulation" --all-targets -- -D warnings` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEwJg2bDPZ7DzcHebqwZVK