### PR TITLE
feat(query): execute SQL EdgeScan and assert ORDER BY sorted output (#311)

### DIFF
--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -5156,6 +5156,40 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_edge_scan_iterator_skips_edge_deleted_after_snapshot() {
+        // Exercises the `EdgeNotFound => continue` skip arm: the id snapshot is
+        // taken at construction, then one edge is deleted from storage before
+        // the scan is drained. The deleted id must be skipped (no panic, no
+        // error) and only the surviving edges yielded.
+        let current = edge_scan_fixture(); // 3 edges
+        let all_ids = current.get_all_edge_ids();
+        assert_eq!(all_ids.len(), 3, "fixture must start with 3 edges");
+
+        // Construct the iterator first so it snapshots all 3 ids...
+        let iter = EdgeScanIterator::new(None, Arc::clone(&current));
+        // ...then delete one edge out from under the snapshot.
+        current
+            .delete_edge(all_ids[0])
+            .expect("delete_edge should succeed");
+
+        let edges = drain(iter);
+        assert_eq!(
+            edges.len(),
+            2,
+            "the edge deleted after the snapshot must be skipped, leaving 2"
+        );
+    }
+
+    #[test]
+    fn test_edge_scan_iterator_size_hint_reports_edge_count() {
+        // A full (unfiltered) scan's size_hint upper bound equals the number of
+        // snapshotted edge ids.
+        let current = edge_scan_fixture(); // 3 edges
+        let iter = EdgeScanIterator::new(None, current);
+        assert_eq!(iter.size_hint(), (0, Some(3)));
+    }
+
     // ==================== VectorResultIterator Tests ====================
 
     #[test]

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -17,7 +17,7 @@ use crate::core::interning::GLOBAL_INTERNER;
 use crate::core::property::PropertyValue;
 use crate::core::provenance::Provenance;
 use crate::core::vector::DistanceMetric as VectorMetric;
-use crate::core::{NodeId, Timestamp};
+use crate::core::{EdgeId, NodeId, Timestamp};
 use crate::query::ir::{
     AggregateArg, AggregateFunc, AggregateGroupKey, AggregateSpec, Direction, Predicate,
     PredicateValue, ProvenanceField, ProvenancePredicate, ProvenanceProjection, ScoreThreshold,
@@ -585,6 +585,129 @@ impl ResultIterator for NodeScanIterator {
             // Paged: the remaining live count is not cheaply known here.
             ScanMode::Paged { .. } => (0, None),
         }
+    }
+}
+
+/// Edge-type filter state for an [`EdgeScanIterator`], resolved once at
+/// construction.
+///
+/// Mirrors [`ScanFilter`] for the node scan: a requested edge type is resolved
+/// to its interned id up front so each candidate edge is accepted/rejected by a
+/// cheap `InternedString` comparison rather than a string compare.
+enum EdgeScanFilter {
+    /// No edge-type filter: every existing edge is yielded.
+    All,
+    /// Yield only edges whose interned label equals this id.
+    Type(crate::core::interning::InternedString),
+    /// An edge type was requested but has never been interned, so no edge can
+    /// match. The scan yields nothing (as opposed to [`EdgeScanFilter::All`]).
+    None,
+}
+
+/// Sequential edge scan iterator, optionally applying an edge-type filter.
+///
+/// This is the edge counterpart to [`NodeScanIterator`] and backs the SQL
+/// `SELECT * FROM edges` path (`PhysicalOp::EdgeScan`). Edges have no id
+/// high-water mark analogous to [`CurrentStorage::get_max_node_id`], so the
+/// dense `[0, max_id)` sweep the node scan uses does not apply. Instead the
+/// iterator snapshots the live edge id set once at construction
+/// (via [`CurrentStorage::get_all_edge_ids`] -- an id-only snapshot, which does
+/// not clone the edges) and then materializes each [`Edge`] lazily with
+/// [`CurrentStorage::get_edge`] as `next()` is pulled. Only 8-byte ids are held
+/// resident; edge payloads are never all materialized at once.
+///
+/// # Filtering
+///
+/// An edge type is resolved to its interned id once. A requested-but-never-
+/// interned type short-circuits to an empty scan (mirroring the node scan's
+/// unknown-label semantics: unknown type yields nothing, **not** an unfiltered
+/// scan). SQL always emits `edge_type: None` (a bare `FROM edges`), so the
+/// `Type` path is exercised at the iterator/IR level; a `WHERE` predicate over
+/// edge properties is applied by the `FilterIterator` layered above this scan.
+///
+/// # Concurrency
+///
+/// No storage lock is held across a `next()` yield: the id snapshot is taken
+/// once, and each per-edge `get_edge` acquires and releases its shard lock
+/// internally. An edge deleted after the snapshot but before its `get_edge`
+/// surfaces as `EdgeNotFound` and is skipped (relaxed, non-isolated snapshot
+/// semantics, exactly like the node scan tolerating deleted ids).
+pub struct EdgeScanIterator {
+    filter: EdgeScanFilter,
+    edge_ids: std::vec::IntoIter<EdgeId>,
+    current: Arc<CurrentStorage>,
+}
+
+impl EdgeScanIterator {
+    /// Create a new edge scan, optionally filtered to a single edge type.
+    ///
+    /// Passing `None` scans every edge; passing `Some(type)` yields only edges
+    /// of that type (or nothing, if the type was never interned).
+    pub fn new(edge_type: Option<String>, current: Arc<CurrentStorage>) -> Self {
+        // Resolve the requested type to an interned id exactly once. An unknown
+        // type short-circuits to `None` so the scan yields nothing rather than
+        // degrading to an unfiltered scan.
+        let filter = match edge_type {
+            Option::None => EdgeScanFilter::All,
+            Some(ref t) => match GLOBAL_INTERNER.get_id(t) {
+                Some(id) => EdgeScanFilter::Type(id),
+                Option::None => EdgeScanFilter::None,
+            },
+        };
+
+        // Snapshot the live edge id set once. For an unknown type the snapshot
+        // is skipped entirely (no edge can match), so the scan drains
+        // immediately without touching storage.
+        let edge_ids = if matches!(filter, EdgeScanFilter::None) {
+            Vec::new()
+        } else {
+            current.get_all_edge_ids()
+        };
+
+        EdgeScanIterator {
+            filter,
+            edge_ids: edge_ids.into_iter(),
+            current,
+        }
+    }
+}
+
+impl ResultIterator for EdgeScanIterator {
+    fn next(&mut self) -> Option<Result<QueryRow>> {
+        // An edge type that was never interned can match no edge.
+        if matches!(self.filter, EdgeScanFilter::None) {
+            return None;
+        }
+
+        loop {
+            let id = self.edge_ids.next()?;
+
+            match self.current.get_edge(id) {
+                Ok(edge) => {
+                    // Apply the edge-type filter on the fully-loaded edge.
+                    if let EdgeScanFilter::Type(type_id) = self.filter
+                        && edge.label != type_id
+                    {
+                        continue;
+                    }
+                    return Some(Ok(QueryRow::from_entity(EntityResult::Edge(edge))));
+                }
+                // The id was live when the snapshot was taken but was deleted
+                // before this load; skip it (relaxed snapshot semantics).
+                Err(crate::core::error::Error::Storage(
+                    crate::core::error::StorageError::EdgeNotFound(_),
+                )) => continue,
+                Err(e) => return Some(Err(e)),
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if matches!(self.filter, EdgeScanFilter::None) {
+            return (0, Some(0));
+        }
+        // Upper bound only: a type filter or a concurrent deletion may drop ids.
+        (0, Some(self.edge_ids.len()))
     }
 }
 
@@ -4945,6 +5068,92 @@ mod tests {
         iter.next();
         // After consuming one id the remaining upper bound shrinks.
         assert_eq!(iter.size_hint(), (0, Some(3)));
+    }
+
+    // ==================== EdgeScanIterator Tests ====================
+
+    /// Build a small graph (2 nodes, 2 KNOWS edges + 1 FOLLOWS edge) for edge
+    /// scan tests. Returns the storage and the count of KNOWS edges (2).
+    fn edge_scan_fixture() -> Arc<CurrentStorage> {
+        let current = Arc::new(CurrentStorage::new());
+        let a = current
+            .create_node("Person", PropertyMapBuilder::new().insert("n", "a").build())
+            .unwrap();
+        let b = current
+            .create_node("Person", PropertyMapBuilder::new().insert("n", "b").build())
+            .unwrap();
+        current
+            .create_edge(a, b, "KNOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+        current
+            .create_edge(b, a, "KNOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+        current
+            .create_edge(a, b, "FOLLOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+        current
+    }
+
+    fn drain(mut iter: EdgeScanIterator) -> Vec<crate::core::graph::Edge> {
+        let mut edges = Vec::new();
+        while let Some(item) = iter.next() {
+            edges.push(item.unwrap().entity.as_edge().unwrap().clone());
+        }
+        edges
+    }
+
+    #[test]
+    fn test_edge_scan_iterator_all_edges() {
+        // `edge_type: None` scans every edge regardless of type.
+        let current = edge_scan_fixture();
+        let edges = drain(EdgeScanIterator::new(None, current));
+        assert_eq!(edges.len(), 3, "unfiltered scan yields all 3 edges");
+    }
+
+    #[test]
+    fn test_edge_scan_iterator_type_filter_matches_only_that_type() {
+        // `edge_type: Some("KNOWS")` yields only the two KNOWS edges.
+        let current = edge_scan_fixture();
+        let edges = drain(EdgeScanIterator::new(Some("KNOWS".to_string()), current));
+        assert_eq!(edges.len(), 2, "type filter must yield only KNOWS edges");
+        assert!(
+            edges.iter().all(|e| e.has_label_str("KNOWS")),
+            "every yielded edge must be a KNOWS edge"
+        );
+    }
+
+    #[test]
+    fn test_edge_scan_iterator_unknown_type_yields_nothing() {
+        // A type filter whose type was never interned must yield zero rows,
+        // NOT degrade into an unfiltered full scan (mirrors NodeScan).
+        let current = edge_scan_fixture();
+        let mut iter = EdgeScanIterator::new(Some("NONEXISTENT".to_string()), current);
+        assert!(
+            iter.next().is_none(),
+            "unknown edge type must match no edges, not all of them"
+        );
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+    }
+
+    #[test]
+    fn test_edge_scan_iterator_empty_storage() {
+        let current = Arc::new(CurrentStorage::new());
+        let mut iter = EdgeScanIterator::new(None, current);
+        assert!(iter.next().is_none(), "no edges -> no rows");
+    }
+
+    #[test]
+    fn test_edge_scan_iterator_yields_edge_entities() {
+        // Every yielded row must be an Edge entity (not a Node).
+        let current = edge_scan_fixture();
+        let mut iter = EdgeScanIterator::new(None, current);
+        while let Some(item) = iter.next() {
+            let row = item.unwrap();
+            assert!(
+                row.entity.as_edge().is_some(),
+                "edge scan must yield Edge entities"
+            );
+        }
     }
 
     // ==================== VectorResultIterator Tests ====================

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -18,6 +18,8 @@ use crate::storage::historical::HistoricalStorage;
 use super::planner::physical::{PhysicalOp, PhysicalPlan};
 
 #[doc(hidden)]
+pub use iterators::EdgeScanIterator;
+#[doc(hidden)]
 pub use iterators::NodeScanIterator;
 pub use iterators::ResultIterator;
 #[doc(hidden)]
@@ -298,276 +300,285 @@ impl QueryExecutor {
         });
 
         let child_depth = depth + 1;
-        let iter: Box<dyn ResultIterator> = match op {
-            PhysicalOp::NodeLookup { node_ids } => Box::new(iterators::NodeLookupIterator::new(
-                node_ids.clone(),
-                Arc::clone(&self.current),
-            )),
+        let iter: Box<dyn ResultIterator> =
+            match op {
+                PhysicalOp::NodeLookup { node_ids } => Box::new(
+                    iterators::NodeLookupIterator::new(node_ids.clone(), Arc::clone(&self.current)),
+                ),
 
-            PhysicalOp::NodeScan { label, .. } => Box::new(iterators::NodeScanIterator::new(
-                label.clone(),
-                Arc::clone(&self.current),
-            )),
+                PhysicalOp::NodeScan { label, .. } => Box::new(iterators::NodeScanIterator::new(
+                    label.clone(),
+                    Arc::clone(&self.current),
+                )),
 
-            PhysicalOp::HnswSearch {
-                embedding,
-                k,
-                label_filter,
-                property_key,
-            } => self.execute_hnsw_search(
-                embedding,
-                *k,
-                label_filter.as_deref(),
-                property_key.as_deref(),
-            )?,
+                // Full edge scan (SQL `SELECT * FROM edges`). Mirrors `NodeScan`.
+                // Yields `EntityResult::Edge` rows; note these survive `collect_all`
+                // / `count_all` / direct iteration but are dropped by the
+                // node-centric `collect_structured`/`collect_nodes` helpers, which
+                // remain node-only by design (see `results.rs`).
+                PhysicalOp::EdgeScan { edge_type, .. } => Box::new(
+                    iterators::EdgeScanIterator::new(edge_type.clone(), Arc::clone(&self.current)),
+                ),
 
-            PhysicalOp::TemporalNodeLookup {
-                node_ids,
-                valid_time,
-                transaction_time,
-                use_batch,
-            } => {
-                if *use_batch {
-                    // Use batch iterator for large queries (holds lock across all iterations)
-                    Box::new(iterators::BatchTemporalNodeIterator::new(
-                        node_ids.clone(),
-                        *valid_time,
-                        *transaction_time,
-                        Arc::clone(&self.historical),
-                    )?)
-                } else {
-                    // Use per-node iterator for small queries (lock per node)
-                    Box::new(iterators::TemporalNodeIterator::new(
-                        node_ids.clone(),
-                        *valid_time,
-                        *transaction_time,
-                        Arc::clone(&self.historical),
-                    ))
+                PhysicalOp::HnswSearch {
+                    embedding,
+                    k,
+                    label_filter,
+                    property_key,
+                } => self.execute_hnsw_search(
+                    embedding,
+                    *k,
+                    label_filter.as_deref(),
+                    property_key.as_deref(),
+                )?,
+
+                PhysicalOp::TemporalNodeLookup {
+                    node_ids,
+                    valid_time,
+                    transaction_time,
+                    use_batch,
+                } => {
+                    if *use_batch {
+                        // Use batch iterator for large queries (holds lock across all iterations)
+                        Box::new(iterators::BatchTemporalNodeIterator::new(
+                            node_ids.clone(),
+                            *valid_time,
+                            *transaction_time,
+                            Arc::clone(&self.historical),
+                        )?)
+                    } else {
+                        // Use per-node iterator for small queries (lock per node)
+                        Box::new(iterators::TemporalNodeIterator::new(
+                            node_ids.clone(),
+                            *valid_time,
+                            *transaction_time,
+                            Arc::clone(&self.historical),
+                        ))
+                    }
                 }
-            }
 
-            PhysicalOp::TemporalNodeScan {
-                label,
-                valid_time,
-                transaction_time,
-            } => {
-                // Point-in-time label scan (`AS OF`, Issues #550/#551). Enumerate
-                // every ever-versioned node (mirroring the AS OF node-find oracle
-                // `AletheiaDB::find_nodes_at_time`) and reconstruct each at the
-                // requested bi-temporal point, filtering by label; candidates that
-                // did not exist at that instant are skipped, not errors.
-                let node_ids = self.temporal_scan_candidates();
-                Box::new(
-                    iterators::TemporalNodeScanIterator::new(
+                PhysicalOp::TemporalNodeScan {
+                    label,
+                    valid_time,
+                    transaction_time,
+                } => {
+                    // Point-in-time label scan (`AS OF`, Issues #550/#551). Enumerate
+                    // every ever-versioned node (mirroring the AS OF node-find oracle
+                    // `AletheiaDB::find_nodes_at_time`) and reconstruct each at the
+                    // requested bi-temporal point, filtering by label; candidates that
+                    // did not exist at that instant are skipped, not errors.
+                    let node_ids = self.temporal_scan_candidates();
+                    Box::new(
+                        iterators::TemporalNodeScanIterator::new(
+                            node_ids,
+                            *valid_time,
+                            *transaction_time,
+                            Arc::clone(&self.historical),
+                            label.clone(),
+                        )
+                        .skipping_missing(),
+                    )
+                }
+
+                PhysicalOp::TemporalNodeRangeScan {
+                    label,
+                    valid_from,
+                    valid_to,
+                    transaction_time,
+                } => {
+                    // Valid-time range label scan (`BETWEEN`, Issue #552). Same
+                    // candidate enumeration; the iterator emits each node's
+                    // believed-at-`transaction_time` version whose valid interval
+                    // overlaps the range (at most one row per node -- multiple rows
+                    // only across distinct nodes).
+                    let node_ids = self.temporal_scan_candidates();
+                    Box::new(iterators::TemporalNodeRangeScanIterator::new(
                         node_ids,
-                        *valid_time,
+                        *valid_from,
+                        *valid_to,
                         *transaction_time,
                         Arc::clone(&self.historical),
                         label.clone(),
-                    )
-                    .skipping_missing(),
-                )
-            }
+                    ))
+                }
 
-            PhysicalOp::TemporalNodeRangeScan {
-                label,
-                valid_from,
-                valid_to,
-                transaction_time,
-            } => {
-                // Valid-time range label scan (`BETWEEN`, Issue #552). Same
-                // candidate enumeration; the iterator emits each node's
-                // believed-at-`transaction_time` version whose valid interval
-                // overlaps the range (at most one row per node -- multiple rows
-                // only across distinct nodes).
-                let node_ids = self.temporal_scan_candidates();
-                Box::new(iterators::TemporalNodeRangeScanIterator::new(
-                    node_ids,
-                    *valid_from,
-                    *valid_to,
-                    *transaction_time,
-                    Arc::clone(&self.historical),
+                PhysicalOp::TemporalVectorSearch {
+                    embedding,
+                    k,
+                    timestamp,
+                    property_key,
+                } => {
+                    // Always use the multi-property-aware method with explicit property name.
+                    // This ensures correctness in multi-property setups instead of relying on
+                    // the default-property resolution (alphabetically first temporal index).
+                    let prop = property_key.as_deref().unwrap_or("embedding");
+                    let results = self
+                        .current
+                        .find_similar_as_of_in(prop, embedding, *k, *timestamp)?;
+
+                    Box::new(iterators::VectorResultIterator::new(
+                        results,
+                        Arc::clone(&self.current),
+                    ))
+                }
+
+                PhysicalOp::IndexedTraversal {
+                    input,
+                    direction,
+                    label,
+                    min_depth,
+                    depth: traversal_depth,
+                    temporal_context,
+                } => {
+                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    Box::new(iterators::TraversalIterator::new(
+                        input_iter,
+                        *direction,
+                        label.clone(),
+                        *min_depth,
+                        *traversal_depth,
+                        Arc::clone(&self.current),
+                        Arc::clone(&self.historical),
+                        *temporal_context,
+                    ))
+                }
+
+                PhysicalOp::PropertyScan {
+                    label, key, value, ..
+                } => Box::new(iterators::PropertyScanIterator::new(
                     label.clone(),
-                ))
-            }
-
-            PhysicalOp::TemporalVectorSearch {
-                embedding,
-                k,
-                timestamp,
-                property_key,
-            } => {
-                // Always use the multi-property-aware method with explicit property name.
-                // This ensures correctness in multi-property setups instead of relying on
-                // the default-property resolution (alphabetically first temporal index).
-                let prop = property_key.as_deref().unwrap_or("embedding");
-                let results = self
-                    .current
-                    .find_similar_as_of_in(prop, embedding, *k, *timestamp)?;
-
-                Box::new(iterators::VectorResultIterator::new(
-                    results,
+                    key.clone(),
+                    value,
                     Arc::clone(&self.current),
-                ))
-            }
+                )),
 
-            PhysicalOp::IndexedTraversal {
-                input,
-                direction,
-                label,
-                min_depth,
-                depth: traversal_depth,
-                temporal_context,
-            } => {
-                let input_iter = self.build_op(input, profile, child_depth)?;
-                Box::new(iterators::TraversalIterator::new(
-                    input_iter,
-                    *direction,
-                    label.clone(),
-                    *min_depth,
-                    *traversal_depth,
-                    Arc::clone(&self.current),
-                    Arc::clone(&self.historical),
-                    *temporal_context,
-                ))
-            }
+                PhysicalOp::Filter { input, predicate } => {
+                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    // Pass historical storage so a `Predicate::Provenance` leaf
+                    // (Issue #3354a) can resolve each row entity's write-time
+                    // provenance; property-only filters never touch it.
+                    Box::new(iterators::FilterIterator::with_historical(
+                        input_iter,
+                        predicate.clone(),
+                        Arc::clone(&self.historical),
+                    ))
+                }
 
-            PhysicalOp::PropertyScan {
-                label, key, value, ..
-            } => Box::new(iterators::PropertyScanIterator::new(
-                label.clone(),
-                key.clone(),
-                value,
-                Arc::clone(&self.current),
-            )),
+                PhysicalOp::VectorRerank {
+                    input,
+                    embedding,
+                    k,
+                    property_key,
+                    metric,
+                    threshold,
+                    score_alias,
+                } => {
+                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    Box::new(iterators::VectorRerankIterator::with_options(
+                        input_iter,
+                        embedding.clone(),
+                        *k,
+                        Arc::clone(&self.current),
+                        property_key.clone(),
+                        *metric,
+                        *threshold,
+                        score_alias.clone(),
+                    ))
+                }
 
-            PhysicalOp::Filter { input, predicate } => {
-                let input_iter = self.build_op(input, profile, child_depth)?;
-                // Pass historical storage so a `Predicate::Provenance` leaf
-                // (Issue #3354a) can resolve each row entity's write-time
-                // provenance; property-only filters never touch it.
-                Box::new(iterators::FilterIterator::with_historical(
-                    input_iter,
-                    predicate.clone(),
-                    Arc::clone(&self.historical),
-                ))
-            }
+                PhysicalOp::Limit {
+                    input,
+                    count,
+                    offset,
+                } => {
+                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    Box::new(iterators::LimitIterator::new(input_iter, *offset, *count))
+                }
 
-            PhysicalOp::VectorRerank {
-                input,
-                embedding,
-                k,
-                property_key,
-                metric,
-                threshold,
-                score_alias,
-            } => {
-                let input_iter = self.build_op(input, profile, child_depth)?;
-                Box::new(iterators::VectorRerankIterator::with_options(
-                    input_iter,
-                    embedding.clone(),
+                PhysicalOp::Project { input, properties } => {
+                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    Box::new(iterators::ProjectIterator::new(
+                        input_iter,
+                        properties.clone(),
+                    ))
+                }
+
+                PhysicalOp::OptionalApply { input, steps } => {
+                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    Box::new(iterators::OptionalApplyIterator::new(
+                        input_iter,
+                        steps.clone(),
+                        Arc::clone(&self.current),
+                        Arc::clone(&self.historical),
+                    ))
+                }
+
+                PhysicalOp::Aggregate {
+                    input,
+                    group_keys,
+                    aggregates,
+                } => {
+                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    Box::new(iterators::AggregateIterator::new(
+                        input_iter,
+                        group_keys.clone(),
+                        aggregates.clone(),
+                    ))
+                }
+
+                PhysicalOp::Distinct { input } => {
+                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    Box::new(iterators::DistinctIterator::new(input_iter))
+                }
+
+                PhysicalOp::Sort { input, keys } => {
+                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    // Pass historical storage so a `SortKey::Provenance` key
+                    // (Issue #3354) can resolve each row entity's write-time
+                    // provenance; property/score sorts never touch it.
+                    Box::new(iterators::SortIterator::with_historical(
+                        input_iter,
+                        keys.clone(),
+                        Arc::clone(&self.historical),
+                    ))
+                }
+
+                PhysicalOp::ProjectProvenance { input, projection } => {
+                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    Box::new(iterators::ProvenanceProjectIterator::new(
+                        input_iter,
+                        projection.clone(),
+                        Arc::clone(&self.historical),
+                    ))
+                }
+
+                PhysicalOp::Count { input } => {
+                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    Box::new(iterators::CountIterator::new(input_iter))
+                }
+
+                PhysicalOp::Empty => Box::new(iterators::EmptyIterator),
+                PhysicalOp::SimilarToNode {
+                    source_node,
+                    property_key,
+                    k,
+                    label_filter,
+                } => self.execute_similar_to_node(
+                    *source_node,
+                    property_key,
                     *k,
-                    Arc::clone(&self.current),
-                    property_key.clone(),
-                    *metric,
-                    *threshold,
-                    score_alias.clone(),
-                ))
-            }
+                    label_filter.as_deref(),
+                )?,
 
-            PhysicalOp::Limit {
-                input,
-                count,
-                offset,
-            } => {
-                let input_iter = self.build_op(input, profile, child_depth)?;
-                Box::new(iterators::LimitIterator::new(input_iter, *offset, *count))
-            }
-
-            PhysicalOp::Project { input, properties } => {
-                let input_iter = self.build_op(input, profile, child_depth)?;
-                Box::new(iterators::ProjectIterator::new(
-                    input_iter,
-                    properties.clone(),
-                ))
-            }
-
-            PhysicalOp::OptionalApply { input, steps } => {
-                let input_iter = self.build_op(input, profile, child_depth)?;
-                Box::new(iterators::OptionalApplyIterator::new(
-                    input_iter,
-                    steps.clone(),
-                    Arc::clone(&self.current),
-                    Arc::clone(&self.historical),
-                ))
-            }
-
-            PhysicalOp::Aggregate {
-                input,
-                group_keys,
-                aggregates,
-            } => {
-                let input_iter = self.build_op(input, profile, child_depth)?;
-                Box::new(iterators::AggregateIterator::new(
-                    input_iter,
-                    group_keys.clone(),
-                    aggregates.clone(),
-                ))
-            }
-
-            PhysicalOp::Distinct { input } => {
-                let input_iter = self.build_op(input, profile, child_depth)?;
-                Box::new(iterators::DistinctIterator::new(input_iter))
-            }
-
-            PhysicalOp::Sort { input, keys } => {
-                let input_iter = self.build_op(input, profile, child_depth)?;
-                // Pass historical storage so a `SortKey::Provenance` key
-                // (Issue #3354) can resolve each row entity's write-time
-                // provenance; property/score sorts never touch it.
-                Box::new(iterators::SortIterator::with_historical(
-                    input_iter,
-                    keys.clone(),
-                    Arc::clone(&self.historical),
-                ))
-            }
-
-            PhysicalOp::ProjectProvenance { input, projection } => {
-                let input_iter = self.build_op(input, profile, child_depth)?;
-                Box::new(iterators::ProvenanceProjectIterator::new(
-                    input_iter,
-                    projection.clone(),
-                    Arc::clone(&self.historical),
-                ))
-            }
-
-            PhysicalOp::Count { input } => {
-                let input_iter = self.build_op(input, profile, child_depth)?;
-                Box::new(iterators::CountIterator::new(input_iter))
-            }
-
-            PhysicalOp::Empty => Box::new(iterators::EmptyIterator),
-            PhysicalOp::SimilarToNode {
-                source_node,
-                property_key,
-                k,
-                label_filter,
-            } => self.execute_similar_to_node(
-                *source_node,
-                property_key,
-                *k,
-                label_filter.as_deref(),
-            )?,
-
-            // For unsupported operations, return error
-            _ => {
-                return Err(crate::core::error::Error::Query(
-                    crate::core::error::QueryError::SyntaxError {
-                        message: format!("Unsupported physical operator: {:?}", op.name()),
-                    },
-                ));
-            }
-        };
+                // For unsupported operations, return error
+                _ => {
+                    return Err(crate::core::error::Error::Query(
+                        crate::core::error::QueryError::SyntaxError {
+                            message: format!("Unsupported physical operator: {:?}", op.name()),
+                        },
+                    ));
+                }
+            };
 
         // Instrument this operator when profiling.
         Ok(match handle {

--- a/src/sql/converter.rs
+++ b/src/sql/converter.rs
@@ -133,8 +133,32 @@ impl SqlConverter {
         // Convert FROM clause
         self.convert_from(&select.from, &mut ops)?;
 
+        // Detect an edge scan (`FROM edges`). Edge property WHERE/ORDER BY are
+        // rejected below because they would otherwise be silent no-ops (the
+        // shared FilterIterator passes non-provenance property leaves through on
+        // edge rows, and the Sort iterator extracts sort keys from nodes only).
+        // SQL's WHERE lowering can only emit property predicates -- never a
+        // `Predicate::Provenance` -- so an edge WHERE is always silently ignored
+        // rather than filtered; likewise an edge property ORDER BY never sorts.
+        // Rather than return silently-wrong results we reject them explicitly.
+        // Real edge-property filtering/sorting is a tracked follow-up that
+        // requires shared-iterator work (which would change AQL/Cypher
+        // semantics), so it is deliberately confined out of the SQL lane here.
+        let scans_edges = ops.iter().any(|op| matches!(op, QueryOp::ScanEdges { .. }));
+
         // Convert WHERE clause
         if let Some(ref selection) = select.selection {
+            if scans_edges {
+                return Err(SqlError::UnsupportedFeature(
+                    "filtering `FROM edges` by a property is not yet supported. \
+                     An edge-property WHERE clause would be silently ignored \
+                     (every edge would be returned), so it is rejected rather \
+                     than producing a wrong result. Query `FROM nodes` with a \
+                     WHERE clause, or drop the WHERE and filter edges in the \
+                     caller. Real edge-property filtering is a tracked follow-up."
+                        .to_string(),
+                ));
+            }
             let predicate = self.convert_expr_to_predicate(selection)?;
             ops.push(QueryOp::Filter(predicate));
         }
@@ -144,7 +168,7 @@ impl SqlConverter {
 
         // Convert ORDER BY
         for order_by in &query.order_by {
-            self.convert_order_by(order_by, &mut ops)?;
+            self.convert_order_by(order_by, scans_edges, &mut ops)?;
         }
 
         // Convert OFFSET (must come before LIMIT for correct SQL semantics:
@@ -263,9 +287,15 @@ impl SqlConverter {
     }
 
     /// Convert ORDER BY clause.
+    ///
+    /// `scans_edges` is `true` when the query sources rows from `FROM edges`.
+    /// In that case a property-key `ORDER BY` is rejected: the Sort iterator
+    /// extracts sort keys from nodes only, so sorting edge rows by a property
+    /// would silently no-op. `ORDER BY score`/`timestamp` are unaffected.
     fn convert_order_by(
         &self,
         order_by: &OrderByExpr,
+        scans_edges: bool,
         ops: &mut Vec<QueryOp>,
     ) -> Result<(), SqlError> {
         let key = match &order_by.expr {
@@ -290,6 +320,17 @@ impl SqlConverter {
                 ));
             }
         };
+
+        if scans_edges && matches!(key, SortKey::Property(_)) {
+            return Err(SqlError::UnsupportedFeature(
+                "ordering `FROM edges` by a property is not yet supported. \
+                 Sorting edge rows by a property key would be silently ignored \
+                 (edges would be returned in scan order), so it is rejected \
+                 rather than producing an unsorted result. Real edge-property \
+                 sorting is a tracked follow-up."
+                    .to_string(),
+            ));
+        }
 
         let descending = order_by.asc.map(|asc| !asc).unwrap_or(false);
 

--- a/src/sql/tests.rs
+++ b/src/sql/tests.rs
@@ -1210,15 +1210,32 @@ mod phase3_graph {
     }
 
     #[test]
-    fn test_parse_select_from_edges_with_filter() {
-        let query = parse_sql("SELECT * FROM edges WHERE type = 'KNOWS'").unwrap();
+    fn test_parse_select_from_edges_with_filter_is_rejected() {
+        // An edge-property WHERE would be silently ignored (SQL can only emit
+        // property predicates, which the FilterIterator passes through on edge
+        // rows), so the converter rejects it rather than returning all edges.
+        let err = parse_sql("SELECT * FROM edges WHERE type = 'KNOWS'")
+            .expect_err("edge-property WHERE must be rejected");
+        assert!(matches!(err, SqlError::UnsupportedFeature(_)));
+        let msg = err.to_string();
         assert!(
-            query
-                .ops
-                .iter()
-                .any(|op| matches!(op, QueryOp::ScanEdges { .. }))
+            msg.contains("filtering `FROM edges`"),
+            "unexpected error message: {msg}"
         );
-        assert!(query.ops.iter().any(|op| matches!(op, QueryOp::Filter(_))));
+    }
+
+    #[test]
+    fn test_parse_select_from_edges_with_property_order_by_is_rejected() {
+        // Symmetric to the WHERE rejection: an edge-property ORDER BY would
+        // silently no-op (the Sort iterator reads keys from nodes only).
+        let err = parse_sql("SELECT * FROM edges ORDER BY weight DESC")
+            .expect_err("edge-property ORDER BY must be rejected");
+        assert!(matches!(err, SqlError::UnsupportedFeature(_)));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ordering `FROM edges`"),
+            "unexpected error message: {msg}"
+        );
     }
 
     #[test]

--- a/tests/sql_integration.rs
+++ b/tests/sql_integration.rs
@@ -12,11 +12,13 @@
 //! so nodes must be created with lowercase labels to match SQL label-filtered queries.
 //! Use `FROM nodes` (no label filter) to query nodes regardless of label case.
 //!
-//! # Executor Limitations
+//! # Executor Support
 //!
-//! The query executor does not yet support `Sort` or `EdgeScan` physical operators.
-//! Tests for ORDER BY and edge scanning verify parsing succeeds and document the
-//! expected execution error as a known limitation.
+//! The query executor executes `Sort` (ORDER BY) and `EdgeScan` (`FROM edges`)
+//! physical operators end-to-end. `SELECT * FROM edges` yields edge rows
+//! consumed via `collect_all()` (the node-centric `collect_structured()` /
+//! `collect_nodes()` helpers remain node-only, see the v1 limitation note in
+//! the `select_edges` module); ORDER BY returns rows in sorted order.
 
 #![cfg(feature = "sql")]
 
@@ -475,11 +477,34 @@ mod limit_and_offset {
 }
 
 // =============================================================================
-// Part 5: ORDER BY -- Parse succeeds, execution not yet supported
+// Part 5: ORDER BY -- Parse succeeds AND executes with sorted output
 // =============================================================================
 
 mod order_by {
     use super::*;
+    use aletheiadb::PropertyValue;
+
+    /// Extract the integer `age` property from a node row, in row order.
+    fn ages(rows: &[aletheiadb::query::executor::QueryRow]) -> Vec<i64> {
+        rows.iter()
+            .filter_map(|row| row.entity.as_node())
+            .filter_map(|node| match node.get_property("age") {
+                Some(PropertyValue::Int(age)) => Some(*age),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Extract the string `name` property from a node row, in row order.
+    fn names(rows: &[aletheiadb::query::executor::QueryRow]) -> Vec<String> {
+        rows.iter()
+            .filter_map(|row| row.entity.as_node())
+            .filter_map(|node| match node.get_property("name") {
+                Some(PropertyValue::String(name)) => Some(name.to_string()),
+                _ => None,
+            })
+            .collect()
+    }
 
     #[test]
     fn order_by_asc_parses_successfully() {
@@ -503,26 +528,60 @@ mod order_by {
     }
 
     #[test]
-    fn order_by_execution_returns_error() {
-        // The Sort physical operator is not yet implemented in the executor.
-        // This test documents this as a known limitation.
+    fn order_by_age_asc_returns_ascending_rows() {
+        // The Sort physical operator executes end-to-end: rows come back sorted
+        // by the requested key, ascending.
+        let db = setup_person_db();
+        let query = parse_sql("SELECT * FROM nodes ORDER BY age ASC").expect("Failed to parse SQL");
+        let results = db.execute_query(query).expect("ORDER BY should execute");
+        let rows = results.collect_all().expect("Failed to collect results");
+
+        assert_eq!(
+            ages(&rows),
+            vec![25, 30, 35],
+            "ORDER BY age ASC must return ages in ascending order (Bob, Alice, Carol)"
+        );
+    }
+
+    #[test]
+    fn order_by_name_desc_returns_descending_rows() {
         let db = setup_person_db();
         let query =
-            parse_sql("SELECT * FROM nodes ORDER BY name ASC").expect("Failed to parse SQL");
-        let result = db.execute_query(query);
-        assert!(
-            result.is_err(),
-            "ORDER BY execution should return an error (Sort operator not yet supported)"
+            parse_sql("SELECT * FROM nodes ORDER BY name DESC").expect("Failed to parse SQL");
+        let results = db.execute_query(query).expect("ORDER BY should execute");
+        let rows = results.collect_all().expect("Failed to collect results");
+
+        assert_eq!(
+            names(&rows),
+            vec!["Carol".to_string(), "Bob".to_string(), "Alice".to_string()],
+            "ORDER BY name DESC must return names in descending order"
         );
     }
 }
 
 // =============================================================================
-// Part 6: Edge Scanning -- Parse succeeds, execution not yet supported
+// Part 6: Edge Scanning -- Parse succeeds AND executes, yielding edge rows
 // =============================================================================
-
+//
+// ## v1 limitations
+//
+// `SELECT * FROM edges` yields `EntityResult::Edge` rows that are consumed via
+// `collect_all()` / `count_all()` / direct iteration (the paths these tests
+// use). The node-centric structured helpers `collect_structured()` /
+// `collect_nodes()` intentionally remain node-only (they populate a
+// `Vec<NodeId>`), so they silently drop edge rows -- a pre-existing shape that
+// this change deliberately does not widen (that would ripple into the
+// node-oriented structured-result consumers). Consume edge scans via
+// `collect_all()`.
+//
+// A `WHERE` predicate over *edge property* leaves does not yet filter edge rows
+// (the FilterIterator's single-entity AQL edge pipeline passes non-provenance
+// property leaves through -- Issue #3354a). That is a separate pre-existing gap,
+// not part of #311's EdgeScan execution; see
+// `select_edges_where_passes_through_edge_rows`.
 mod select_edges {
     use super::*;
+    use aletheiadb::PropertyValue;
 
     #[test]
     fn select_edges_parses_successfully() {
@@ -534,16 +593,198 @@ mod select_edges {
     }
 
     #[test]
-    fn select_edges_execution_returns_error() {
-        // The EdgeScan physical operator is not yet implemented in the executor.
-        // This test documents this as a known limitation.
+    fn select_edges_returns_all_edges() {
+        // The EdgeScan physical operator executes end-to-end and yields one
+        // Edge row per stored edge.
         let db = setup_graph_db();
         let query = parse_sql("SELECT * FROM edges").expect("Failed to parse SQL");
-        let result = db.execute_query(query);
-        assert!(
-            result.is_err(),
-            "Edge scan execution should return an error (EdgeScan operator not yet supported)"
+        let results = db.execute_query(query).expect("Edge scan should execute");
+        let rows = results.collect_all().expect("Failed to collect results");
+
+        assert_eq!(rows.len(), 2, "setup_graph_db has exactly 2 KNOWS edges");
+        for row in &rows {
+            let edge = row
+                .entity
+                .as_edge()
+                .expect("each row should be an Edge entity");
+            assert!(
+                edge.has_label_str("KNOWS"),
+                "every edge should carry the KNOWS label"
+            );
+        }
+    }
+
+    #[test]
+    fn select_edges_preserves_endpoints() {
+        // The two KNOWS edges are Alice->Bob and Bob->Carol. Verify the exact
+        // (source, target) endpoint pairs round-trip through the scan.
+        let db = setup_graph_db();
+
+        // Resolve node ids by name so the assertion does not depend on id order.
+        let node_query = parse_sql("SELECT * FROM nodes").expect("Failed to parse SQL");
+        let node_rows = db
+            .execute_query(node_query)
+            .expect("node scan should execute")
+            .collect_all()
+            .expect("Failed to collect node rows");
+        let id_of = |name: &str| {
+            node_rows
+                .iter()
+                .filter_map(|r| r.entity.as_node())
+                .find(|n| n.get_property("name") == Some(&PropertyValue::String(name.into())))
+                .map(|n| n.id)
+                .unwrap_or_else(|| panic!("node named {name} should exist"))
+        };
+        let (alice, bob, carol) = (id_of("Alice"), id_of("Bob"), id_of("Carol"));
+
+        let query = parse_sql("SELECT * FROM edges").expect("Failed to parse SQL");
+        let rows = db
+            .execute_query(query)
+            .expect("Edge scan should execute")
+            .collect_all()
+            .expect("Failed to collect results");
+
+        let mut endpoints: Vec<(u64, u64)> = rows
+            .iter()
+            .filter_map(|r| r.entity.as_edge())
+            .map(|e| (e.source.as_u64(), e.target.as_u64()))
+            .collect();
+        endpoints.sort_unstable();
+
+        let mut expected = vec![
+            (alice.as_u64(), bob.as_u64()),
+            (bob.as_u64(), carol.as_u64()),
+        ];
+        expected.sort_unstable();
+
+        assert_eq!(
+            endpoints, expected,
+            "edge rows must carry the correct (source, target) endpoints"
         );
+    }
+
+    #[test]
+    fn select_edges_carries_properties() {
+        // Edge properties must round-trip through the scan. Build a local
+        // fixture with a distinctive edge property and assert it survives.
+        let db = AletheiaDB::new().expect("Failed to create database");
+        let a = db
+            .create_node("Person", PropertyMapBuilder::new().insert("n", "a").build())
+            .expect("create a");
+        let b = db
+            .create_node("Person", PropertyMapBuilder::new().insert("n", "b").build())
+            .expect("create b");
+        db.create_edge(
+            a,
+            b,
+            "FOLLOWS",
+            PropertyMapBuilder::new().insert("weight", 42).build(),
+        )
+        .expect("create edge");
+
+        let query = parse_sql("SELECT * FROM edges").expect("Failed to parse SQL");
+        let rows = db
+            .execute_query(query)
+            .expect("Edge scan should execute")
+            .collect_all()
+            .expect("Failed to collect results");
+
+        assert_eq!(rows.len(), 1, "exactly one edge was created");
+        let edge = rows[0]
+            .entity
+            .as_edge()
+            .expect("row should be an Edge entity");
+        assert!(edge.has_label_str("FOLLOWS"));
+        assert_eq!(
+            edge.get_property("weight"),
+            Some(&PropertyValue::Int(42)),
+            "edge property must round-trip through the scan"
+        );
+    }
+
+    #[test]
+    fn select_edges_where_passes_through_edge_rows() {
+        // v1 limitation: a WHERE predicate over *edge property* leaves does NOT
+        // filter edge rows. The shared FilterIterator sits above the EdgeScan,
+        // but its single-entity AQL edge pipeline deliberately passes
+        // non-provenance property leaves through on edge rows (Issue #3354a,
+        // covered by `edge_non_provenance_leaf_is_pass_through` in
+        // `src/query/executor/iterators.rs`). EdgeScan surfaces the edges; edge
+        // *property* filtering is a separate, pre-existing gap tracked outside
+        // #311. This test pins the current behavior so a future edge-predicate
+        // implementation flips it deliberately rather than by accident.
+        let db = setup_graph_db(); // edges have `since` = 2020 and 2021
+        let query =
+            parse_sql("SELECT * FROM edges WHERE since = 2021").expect("Failed to parse SQL");
+        let rows = db
+            .execute_query(query)
+            .expect("Edge scan should execute")
+            .collect_all()
+            .expect("Failed to collect results");
+
+        // Both edges are returned: the edge-property predicate is a pass-through.
+        assert_eq!(
+            rows.len(),
+            2,
+            "edge-property WHERE leaves pass through in v1 (pre-existing FilterIterator limitation)"
+        );
+        assert!(
+            rows.iter().all(|r| r.entity.as_edge().is_some()),
+            "every returned row is still an Edge entity"
+        );
+        // Sanity: the property values are intact on the returned edge rows.
+        let mut since: Vec<i64> = rows
+            .iter()
+            .filter_map(|r| r.entity.as_edge())
+            .filter_map(|e| match e.get_property("since") {
+                Some(PropertyValue::Int(v)) => Some(*v),
+                _ => None,
+            })
+            .collect();
+        since.sort_unstable();
+        assert_eq!(since, vec![2020, 2021]);
+    }
+
+    #[test]
+    fn select_edges_limit_restricts_count() {
+        let db = setup_graph_db();
+        let query = parse_sql("SELECT * FROM edges LIMIT 1").expect("Failed to parse SQL");
+        let rows = db
+            .execute_query(query)
+            .expect("Edge scan should execute")
+            .collect_all()
+            .expect("Failed to collect results");
+
+        assert_eq!(rows.len(), 1, "LIMIT 1 should cap the edge scan to 1 row");
+    }
+
+    #[test]
+    fn select_edges_empty_database_returns_ok_zero_rows() {
+        // A database with no edges yields zero rows and does NOT error.
+        let db = setup_person_db(); // nodes only, no edges
+        let query = parse_sql("SELECT * FROM edges").expect("Failed to parse SQL");
+        let results = db.execute_query(query).expect("Edge scan should execute");
+        let count = results.count_all().expect("Failed to count results");
+        assert_eq!(count, 0, "a db with no edges must return zero edge rows");
+    }
+
+    #[test]
+    fn select_edges_collect_all_is_the_consumption_path() {
+        // Explicitly assert the primary consumption path (collect_all) surfaces
+        // edge rows -- the node-centric collect_nodes()/collect_structured()
+        // helpers remain node-only by design (see the module v1-limitation note).
+        let db = setup_graph_db();
+        let query = parse_sql("SELECT * FROM edges").expect("Failed to parse SQL");
+        let rows = db
+            .execute_query(query)
+            .expect("Edge scan should execute")
+            .collect_all()
+            .expect("Failed to collect results");
+        assert!(
+            rows.iter().all(|r| r.entity.as_edge().is_some()),
+            "collect_all must surface every row as an Edge entity"
+        );
+        assert_eq!(rows.len(), 2);
     }
 }
 

--- a/tests/sql_integration.rs
+++ b/tests/sql_integration.rs
@@ -574,11 +574,15 @@ mod order_by {
 // node-oriented structured-result consumers). Consume edge scans via
 // `collect_all()`.
 //
-// A `WHERE` predicate over *edge property* leaves does not yet filter edge rows
+// A `WHERE` predicate over *edge property* leaves cannot yet filter edge rows
 // (the FilterIterator's single-entity AQL edge pipeline passes non-provenance
-// property leaves through -- Issue #3354a). That is a separate pre-existing gap,
-// not part of #311's EdgeScan execution; see
-// `select_edges_where_passes_through_edge_rows`.
+// property leaves through -- Issue #3354a), and an `ORDER BY` over an edge
+// property cannot yet sort them (the Sort iterator reads keys from nodes only).
+// Rather than silently ignore them, the SQL converter rejects an edge-property
+// `WHERE`/`ORDER BY` with a structured "not yet supported" error; see
+// `select_edges_where_property_is_rejected` /
+// `select_edges_order_by_property_is_rejected`. The supported edge form is
+// `SELECT * FROM edges [LIMIT n]`.
 mod select_edges {
     use super::*;
     use aletheiadb::PropertyValue;
@@ -703,46 +707,51 @@ mod select_edges {
     }
 
     #[test]
-    fn select_edges_where_passes_through_edge_rows() {
-        // v1 limitation: a WHERE predicate over *edge property* leaves does NOT
-        // filter edge rows. The shared FilterIterator sits above the EdgeScan,
-        // but its single-entity AQL edge pipeline deliberately passes
-        // non-provenance property leaves through on edge rows (Issue #3354a,
-        // covered by `edge_non_provenance_leaf_is_pass_through` in
-        // `src/query/executor/iterators.rs`). EdgeScan surfaces the edges; edge
-        // *property* filtering is a separate, pre-existing gap tracked outside
-        // #311. This test pins the current behavior so a future edge-predicate
-        // implementation flips it deliberately rather than by accident.
-        let db = setup_graph_db(); // edges have `since` = 2020 and 2021
-        let query =
-            parse_sql("SELECT * FROM edges WHERE since = 2021").expect("Failed to parse SQL");
-        let rows = db
+    fn select_edges_where_property_is_rejected() {
+        // A WHERE predicate over an *edge property* would be silently ignored:
+        // the shared FilterIterator sits above the EdgeScan but its
+        // single-entity AQL edge pipeline passes non-provenance property leaves
+        // through on edge rows (covered by `edge_non_provenance_leaf_is_pass_through`
+        // in `src/query/executor/iterators.rs`), and SQL's WHERE lowering can
+        // only ever emit property predicates. So every SQL edge-WHERE would
+        // return ALL edges unfiltered -- a silent wrong result. The SQL lane
+        // therefore rejects it at conversion time rather than executing.
+        let err = parse_sql("SELECT * FROM edges WHERE since = 2021")
+            .expect_err("edge-property WHERE must be rejected, not silently ignored");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("filtering `FROM edges`") && msg.contains("not yet supported"),
+            "error must explain edge-property filtering is unsupported, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn select_edges_order_by_property_is_rejected() {
+        // Symmetric to the WHERE rejection: ordering edge rows by a property key
+        // would silently no-op (the Sort iterator extracts sort keys from nodes
+        // only), so the SQL lane rejects it at conversion time.
+        let err = parse_sql("SELECT * FROM edges ORDER BY since ASC")
+            .expect_err("edge-property ORDER BY must be rejected, not silently ignored");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ordering `FROM edges`") && msg.contains("not yet supported"),
+            "error must explain edge-property ordering is unsupported, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn select_edges_count_all_non_empty() {
+        // Non-empty `count_all()` over an edge scan: the fixture has exactly 2
+        // KNOWS edges, so counting the stream yields 2 (complements the
+        // empty-database zero-count case).
+        let db = setup_graph_db();
+        let query = parse_sql("SELECT * FROM edges").expect("Failed to parse SQL");
+        let count = db
             .execute_query(query)
             .expect("Edge scan should execute")
-            .collect_all()
-            .expect("Failed to collect results");
-
-        // Both edges are returned: the edge-property predicate is a pass-through.
-        assert_eq!(
-            rows.len(),
-            2,
-            "edge-property WHERE leaves pass through in v1 (pre-existing FilterIterator limitation)"
-        );
-        assert!(
-            rows.iter().all(|r| r.entity.as_edge().is_some()),
-            "every returned row is still an Edge entity"
-        );
-        // Sanity: the property values are intact on the returned edge rows.
-        let mut since: Vec<i64> = rows
-            .iter()
-            .filter_map(|r| r.entity.as_edge())
-            .filter_map(|e| match e.get_property("since") {
-                Some(PropertyValue::Int(v)) => Some(*v),
-                _ => None,
-            })
-            .collect();
-        since.sort_unstable();
-        assert_eq!(since, vec![2020, 2021]);
+            .count_all()
+            .expect("Failed to count results");
+        assert_eq!(count, 2, "setup_graph_db has exactly 2 edges");
     }
 
     #[test]


### PR DESCRIPTION
Closes the "#311 residue": SQL `FROM edges` (`EdgeScan`) execution, plus a positive end-to-end assertion for SQL `ORDER BY`.

Reference: issue #311.

## Before / After

**EdgeScan (`SELECT * FROM edges`)**
- **Before:** The SQL → IR → logical → physical path already produced `PhysicalOp::EdgeScan`, but `QueryExecutor::build_op` had no arm for it, so execution hit the catch-all and errored: `Unsupported physical operator: "EdgeScan"`.
- **After:** `SELECT * FROM edges` returns one edge row per stored edge (label, source/target, and properties intact), consumable via `collect_all()` / `count_all()`.

**ORDER BY**
- **Before:** The Sort pipeline already executed (wired by the provenance merge), so the stale test `order_by_execution_returns_error` — which asserted an error that no longer happens — was *failing on trunk*. There was no positive proof that rows come back sorted.
- **After:** The stale error-test is removed and replaced with positive assertions that rows are returned in the requested sorted order (ascending by `age`, descending by `name`). The stale file-header comment (claiming the executor supports neither Sort nor EdgeScan) is corrected.

## How

- **`EdgeScanIterator`** (`src/query/executor/iterators.rs`) — the edge counterpart to `NodeScanIterator`. Edges have no id high-water mark analogous to `get_max_node_id`, so the node sweep does not apply: the iterator snapshots the live edge id set once via `CurrentStorage::get_all_edge_ids()` (ids only — does **not** clone the edges) and materializes each `Edge` lazily with `get_edge()` as `next()` is pulled. An optional `edge_type` is resolved to its interned id once (via `GLOBAL_INTERNER.get_id`); an unknown type yields nothing (mirroring NodeScan's unknown-label semantics, **not** an unfiltered scan). Ids deleted after the snapshot surface as `EdgeNotFound` and are skipped (relaxed snapshot semantics). No storage lock is held across a yield.
- **Executor wiring** — added the `PhysicalOp::EdgeScan { edge_type, .. }` arm in `QueryExecutor::build_op` (before the catch-all, which is retained for genuinely-unhandled variants), and re-exported `EdgeScanIterator`.
- **ORDER BY** — no production change; ORDER BY already executes through the shared `SortIterator` pipeline. Test-only: flipped to a positive sorted-output assertion.

Note: adding the arm tips rustfmt into wrapping `let iter = match op {` onto its own line, which mechanically re-indents the whole match block by one level in `mod.rs` (trunk was fmt-clean; this is pure `cargo fmt` output, no logic change).

## Adversarial-review follow-up (edge-property WHERE / ORDER BY now rejected, not silent-wrong)

Review found that surfacing edge rows exposed two **silent-wrong-result** paths that were previously latent (no execution path reached them):

1. **`SELECT * FROM edges WHERE <prop>` silently returned ALL edges.** The shared `FilterIterator` passes non-provenance property leaves through on edge rows (intentional AQL edge behavior, pinned by `edge_non_provenance_leaf_is_pass_through`), and SQL's WHERE lowering can only ever emit **property** predicates — never a `Predicate::Provenance` — so every SQL edge-WHERE was silently ignored.
2. **`SELECT * FROM edges ORDER BY <edge prop>` silently did not sort.** The Sort iterator extracts sort keys from nodes only, so an edge-property `ORDER BY` was a silent no-op.

**Fix (confined to the SQL lane, `src/sql/converter.rs`):** when a query scans edges and carries a WHERE, or a property-key `ORDER BY`, the converter now returns a structured `SqlError::UnsupportedFeature("... not yet supported")` **before any execution**, instead of returning wrong/unsorted results. `ORDER BY score`/`timestamp` over edges is unaffected. Because SQL provably cannot emit provenance predicates, this has **zero false positives** and does not touch node WHERE/ORDER BY. Crucially, **no change** is made to the shared `FilterIterator`/`SortIterator` or the MCP lane, so AQL/Cypher edge semantics (and the pinned `edge_non_provenance_leaf_is_pass_through` test) are untouched.

## v1 limitations / supported forms

- **Supported edge form:** `SELECT * FROM edges [LIMIT n]` (optionally with `ORDER BY score`/`timestamp`).
- **Edge-property `WHERE` and `ORDER BY` return a structured "not yet supported" error** (`SqlError::UnsupportedFeature`) — **not** a silent-wrong result. Real edge-property filtering/sorting is a follow-up that requires shared-iterator work (a dedicated edge-predicate path in `FilterIterator` and edge sort-key extraction in `SortIterator`), which would change AQL/Cypher edge semantics and so is deliberately kept out of the SQL lane for now.
- **`collect_structured()` / `collect_nodes()` stay node-only.** `QueryResult.nodes` is `Vec<NodeId>`; those helpers silently drop edge rows (pre-existing). Edge rows *do* survive `collect_all()` / `count_all()` / direct iteration — the paths the tests use. This PR deliberately does **not** widen the structured-results struct (that risks an MCP ripple and is out of scope). Consume edge scans via `collect_all()`.

### Scaling follow-up

`EdgeScanIterator` snapshots **all** edge ids resident in a `Vec<EdgeId>` at construction (via `get_all_edge_ids()`), unlike the paged, high-water-mark `NodeScanIterator` (Issue #3422). Only 8-byte ids are held (edge payloads are still materialized lazily one at a time), so this is acceptable for v1, but on very large edge sets the id buffer is O(edge-count) memory. Follow-up: add a `get_max_edge_id` high-water mark (enabling the dense `[0, max)` paged sweep the node scan uses) or a paged/streaming edge enumeration so the id set need not be fully resident.

## AC-evidence table

| #311 deliverable | Evidence (test names) |
|---|---|
| **(A) SQL EdgeScan execution** | `tests/sql_integration.rs`: `select_edges::select_edges_returns_all_edges`, `select_edges_preserves_endpoints`, `select_edges_carries_properties`, `select_edges_limit_restricts_count`, `select_edges_empty_database_returns_ok_zero_rows`, `select_edges_count_all_non_empty` (non-empty count), `select_edges_collect_all_is_the_consumption_path` · `src/query/executor/iterators.rs`: `test_edge_scan_iterator_all_edges`, `test_edge_scan_iterator_type_filter_matches_only_that_type`, `test_edge_scan_iterator_unknown_type_yields_nothing`, `test_edge_scan_iterator_empty_storage`, `test_edge_scan_iterator_yields_edge_entities`, `test_edge_scan_iterator_skips_edge_deleted_after_snapshot` (deleted-after-snapshot skip arm), `test_edge_scan_iterator_size_hint_reports_edge_count` (populated `size_hint`) |
| **(B) ORDER BY end-to-end** | `tests/sql_integration.rs`: `order_by::order_by_age_asc_returns_ascending_rows`, `order_by::order_by_name_desc_returns_descending_rows` (positive sorted-output) |
| **(C) Edge WHERE/ORDER BY rejected (not silent-wrong)** | `tests/sql_integration.rs`: `select_edges::select_edges_where_property_is_rejected`, `select_edges::select_edges_order_by_property_is_rejected` · `src/sql/tests.rs`: `phase3_graph::test_parse_select_from_edges_with_filter_is_rejected`, `phase3_graph::test_parse_select_from_edges_with_property_order_by_is_rejected` |

## Test evidence

`cargo test --features sql --test sql_integration` → **63 passed; 0 failed**. Full suite (default and `--features sql`) → only the two known-acceptable uid-0 havoc failures (`test_flush_deadlock_on_io_error`, `test_metadata_corruption_on_error`). `cargo fmt --all` applied; clippy `--all-targets --features "config-toml,mcp-server,sharding-rpc,simulation"` (and with `sql`) `-- -D warnings` is clean. `--all-features` clippy fails only on 8 pre-existing `result_large_err` warnings in `src/mcp/server.rs` (verified on clean trunk), untouched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_014BhzWPXAxWQ8mhivodKYos)_