### PR TITLE
⚡ Bolt: Pre-allocate vector in SortIterator::drain

### DIFF
--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -3295,7 +3295,9 @@ impl SortIterator {
             Some(i) => i,
             None => return Ok(()),
         };
-        let mut rows: Vec<QueryRow> = Vec::new();
+        // ⚡ Bolt Optimization: Pre-allocates vector based on iterator's lower size bound
+        // to reduce heap allocations during iterator drain.
+        let mut rows: Vec<QueryRow> = Vec::with_capacity(input.size_hint().0);
         while let Some(row) = input.next() {
             rows.push(row?);
         }


### PR DESCRIPTION
💡 What: Switched `Vec::new()` to `Vec::with_capacity(input.size_hint().0)` in `SortIterator::drain`.
🎯 Why: To avoid unnecessary heap allocations while reading from the query iterator stream.
📊 Impact: Reduces heap reallocations when draining query iterators for sorting.
🔬 Measurement: Run bench `cargo test --lib query`.

---
*PR created automatically by Jules for task [8762667217320661101](https://jules.google.com/task/8762667217320661101) started by @madmax983*