### PR TITLE
test(server): full-surface parity + AC-evidence sweep (#3524 PR8)

### DIFF
--- a/crates/aletheia-server/tests/full_surface_parity_sweep.rs
+++ b/crates/aletheia-server/tests/full_surface_parity_sweep.rs
@@ -103,7 +103,7 @@ async fn live_mcp_catalog(client: &TestClient) -> BTreeSet<String> {
         .send()
         .await;
     assert_eq!(resp.status.as_u16(), 200, "tools/list must succeed");
-    let body: Value = serde_json::from_str(&resp.text()).expect("tools/list json");
+    let body: Value = resp.json();
     body["result"]["tools"]
         .as_array()
         .expect("tools array")

--- a/crates/aletheia-server/tests/full_surface_parity_sweep.rs
+++ b/crates/aletheia-server/tests/full_surface_parity_sweep.rs
@@ -1,0 +1,393 @@
+//! Full-surface parity + completeness sweep (Issue #3524 PR8, the COMPLETING
+//! slice of the autumn-web migration).
+//!
+//! Every prior slice ported one cluster of the AletheiaDB surface onto the
+//! unified autumn-web `#[api_doc(mcp)]` handlers and pinned it byte-for-byte
+//! against the legacy 0.4 HTTP router / legacy MCP server. This file is the
+//! consolidating sweep: it asserts, from the LIVE assembled app, that the
+//! **whole** surface is now complete and matches the cross-lane source of
+//! truth `tests/parity/inventory.json` — no tool missing, none extra, every
+//! access class in lockstep, all five HTTP routes routed, `/openapi.json`
+//! served and covering the tool routes, and the budgetable/cursorable behavior
+//! sets exactly as inventory documents.
+//!
+//! It intentionally holds NO production code of its own — it only reads the
+//! inventory and drives the same `build_server_client` app the parity suites
+//! drive. A failure here is a REAL gap in the merged surface (a tool that
+//! silently dropped off `/mcp`, a class drift, an unrouted HTTP route), which
+//! is exactly what a completing sweep exists to catch.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use aletheia_server::build_server_client;
+use aletheia_server::edge_tools::{ALL_DISPATCH_ROUTED, DISPATCH_ROUTED_READ_TOOLS};
+use aletheia_server::security::rbac;
+use aletheiadb::auth::{AccessClass, AuthMode, AuthStore, Role};
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+use autumn_web::test::TestClient;
+use serde_json::{Value, json};
+
+const ADMIN_TOKEN: &str = "admin-token-abcdefghijklmnop";
+
+/// The repo-root inventory, located relative to this crate's manifest dir so the
+/// test is CWD-independent (mirrors `tests/security_rbac.rs`).
+const INVENTORY_JSON: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../tests/parity/inventory.json"
+));
+
+/// The five #3360 cursorable tools (CLAUDE.md "Cursor continuation for large
+/// scans"): `list_nodes`, `find_nodes_at_time`, `get_outgoing_edges`,
+/// `get_incoming_edges`, `traverse`. Inventory carries a `budgetable` flag but
+/// no `cursorable` flag, so the cursorable set is pinned here and cross-checked
+/// against the live surface (each must be routable and — since cursoring is a
+/// slow-read behavior — budgetable).
+const CURSORABLE_TOOLS: &[&str] = &[
+    "list_nodes",
+    "find_nodes_at_time",
+    "get_outgoing_edges",
+    "get_incoming_edges",
+    "traverse",
+];
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+/// A minimal DB (one `Person` node with a vector) + an auth store carrying an
+/// admin key (Admin passes every RBAC class, so one token exercises the whole
+/// surface).
+fn fixture() -> (Arc<AletheiaDB>, Arc<AuthStore>) {
+    let db = Arc::new(AletheiaDB::new().expect("create db"));
+    db.create_node(
+        "Person",
+        PropertyMapBuilder::new()
+            .insert("name", "Alice")
+            .insert_vector("embedding", &[0.1_f32, 0.2, 0.3, 0.4])
+            .build(),
+    )
+    .expect("create node");
+
+    let store = Arc::new(AuthStore::new());
+    store
+        .insert_bootstrap_key("admin", Role::Admin, ADMIN_TOKEN)
+        .expect("insert admin key");
+    (db, store)
+}
+
+/// Map an inventory `access_class` string to the typed [`AccessClass`] (panics
+/// on any value outside the known four — an unexpected class fails loudly).
+/// Mirrors `tests/security_rbac.rs::class_from_inventory`.
+fn class_from_inventory(s: &str) -> AccessClass {
+    match s {
+        "read" => AccessClass::Read,
+        "write" => AccessClass::Write,
+        "metrics" => AccessClass::Metrics,
+        "admin" => AccessClass::Admin,
+        other => panic!("unexpected access_class {other:?} in inventory.json"),
+    }
+}
+
+/// Parse the pinned inventory document.
+fn inventory() -> Value {
+    serde_json::from_str(INVENTORY_JSON).expect("inventory.json parses")
+}
+
+/// The live set of tool names the assembled app actually routes on `/mcp`
+/// (the JSON-RPC `tools/list` catalog).
+async fn live_mcp_catalog(client: &TestClient) -> BTreeSet<String> {
+    let rpc = json!({ "jsonrpc": "2.0", "id": 1, "method": "tools/list" });
+    let resp = client
+        .post("/mcp")
+        .header("authorization", &format!("Bearer {ADMIN_TOKEN}"))
+        .json(&rpc)
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200, "tools/list must succeed");
+    let body: Value = serde_json::from_str(&resp.text()).expect("tools/list json");
+    body["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .map(|t| t["name"].as_str().expect("tool name").to_string())
+        .collect()
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// (1) MCP catalog == inventory — EXACT set equality across all 46 tools.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn mcp_catalog_equals_inventory_exactly() {
+    let (db, store) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+
+    let live = live_mcp_catalog(&client).await;
+
+    let doc = inventory();
+    let inv: BTreeSet<String> = doc["mcp"]["tools"]
+        .as_array()
+        .expect("mcp.tools array")
+        .iter()
+        .map(|t| t["name"].as_str().expect("tool name").to_string())
+        .collect();
+
+    assert_eq!(
+        inv.len(),
+        46,
+        "inventory must advertise exactly 46 MCP tools"
+    );
+
+    // Symmetric difference, reported precisely so a drift names the culprits.
+    let missing: BTreeSet<&String> = inv.difference(&live).collect();
+    let extra: BTreeSet<&String> = live.difference(&inv).collect();
+    assert!(
+        missing.is_empty() && extra.is_empty(),
+        "live /mcp catalog must EQUAL inventory.json mcp.tools[] exactly.\n  \
+         missing from live (in inventory, not routed): {missing:?}\n  \
+         extra on live   (routed, not in inventory):  {extra:?}"
+    );
+    assert_eq!(
+        live.len(),
+        46,
+        "the live catalog must be exactly 46 tools (got {})",
+        live.len()
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// (2) Access-class conformance for all 46 (belt-and-suspenders full-set check;
+//     `tests/security_rbac.rs::registry_matches_inventory_exactly` pins the
+//     static registry, this pins the *live-catalog-anchored* class per tool).
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn access_class_conformance_for_all_46() {
+    let (db, store) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+    let live = live_mcp_catalog(&client).await;
+
+    let doc = inventory();
+    for t in doc["mcp"]["tools"].as_array().expect("mcp.tools array") {
+        let name = t["name"].as_str().expect("tool name");
+        let expected = class_from_inventory(t["access_class"].as_str().expect("access_class"));
+        // Every inventory tool is routed live...
+        assert!(
+            live.contains(name),
+            "inventory tool {name:?} is not routed on the live /mcp catalog"
+        );
+        // ...and its RBAC-registry class equals inventory exactly.
+        assert_eq!(
+            rbac::tool_access_class(name),
+            Some(expected),
+            "RBAC class for {name:?} must equal inventory access_class ({expected:?})"
+        );
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// (3) All five HTTP routes are served (routed, not the autumn no-route 404).
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn all_five_http_routes_are_served() {
+    let (db, store) = fixture();
+    // Anonymous mode: the synthetic principal is Admin, so every route's class
+    // gate passes and a non-404 status positively proves the method+path is
+    // routed (a 401/403 could otherwise mask an unrouted path).
+    let client = build_server_client(db, store.clone(), AuthMode::Anonymous);
+
+    // Pre-mint a key so the revoke route hits an existing id (its own semantic
+    // 404-on-unknown-id would otherwise be indistinguishable from unrouted).
+    let (principal, _key) = store
+        .create_key("sweep-revoke", Role::Reader)
+        .expect("mint key");
+
+    let doc = inventory();
+    let routes = doc["http"]["routes"].as_array().expect("http.routes array");
+    assert_eq!(routes.len(), 5, "inventory must list exactly 5 HTTP routes");
+
+    for route in routes {
+        let method = route["method"].as_str().expect("method");
+        let path = route["path"].as_str().expect("path");
+
+        let status = match (method, path) {
+            ("GET", p) => client.get(p).send().await.status.as_u16(),
+            ("POST", "/admin/keys") => client
+                .post(path)
+                .json(&json!({ "name": "sweep-create", "role": "reader" }))
+                .send()
+                .await
+                .status
+                .as_u16(),
+            ("POST", "/admin/keys/revoke") => client
+                .post(path)
+                .json(&json!({ "id": principal.id }))
+                .send()
+                .await
+                .status
+                .as_u16(),
+            ("POST", "/query") => {
+                // An empty body deserializes into the all-optional QueryBody;
+                // the query tool returns its structured payload in-band. Routed
+                // either way — we only assert non-404.
+                client
+                    .post(path)
+                    .json(&json!({}))
+                    .send()
+                    .await
+                    .status
+                    .as_u16()
+            }
+            (m, p) => panic!("unexpected inventory route {m} {p}"),
+        };
+
+        assert_ne!(
+            status, 404,
+            "{method} {path} must be routed (got the no-route 404)"
+        );
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// (4) /openapi.json is served and covers the MCP-projection routes for the
+//     tools — one representative route from every ported cluster.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn openapi_served_and_covers_representative_tool_routes() {
+    let (db, store) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+
+    let resp = client.get("/openapi.json").send().await;
+    assert_eq!(resp.status.as_u16(), 200, "/openapi.json must be served");
+    let spec: Value = resp.json();
+    let paths = &spec["paths"];
+    assert!(paths.is_object(), "openapi spec must carry a paths object");
+
+    // (path, method, cluster) — at least one representative per ported cluster,
+    // plus the two HTTP admin/status routes, all of which the api_doc surface
+    // projects into `paths`.
+    let representatives: &[(&str, &str, &str)] = &[
+        ("/nodes/{id}", "get", "node reads"),
+        ("/nodes", "post", "node writes"),
+        ("/edges/{id}", "get", "edge reads"),
+        ("/nodes/{node_id}/edges/outgoing", "get", "edge adjacency"),
+        ("/traverse", "get", "traverse/temporal"),
+        ("/nodes/diff", "post", "temporal diff"),
+        ("/find_similar", "post", "vector"),
+        ("/query", "post", "query"),
+        ("/schema", "get", "schema"),
+        ("/batch", "post", "batch"),
+        ("/constraints/unique", "post", "constraints"),
+        ("/lineage/upstream", "post", "lineage"),
+        ("/chain/head", "get", "audit/chain"),
+        ("/status", "get", "http status"),
+        ("/admin/keys", "post", "http admin"),
+    ];
+
+    for (path, method, cluster) in representatives {
+        let op = &paths[path][method];
+        assert!(
+            !op.is_null(),
+            "openapi must document {method} {path} ({cluster} cluster): available paths = {:?}",
+            paths.as_object().map(|o| o.keys().collect::<Vec<_>>())
+        );
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// (5) Budgetable / cursorable behavior sets match inventory.
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn budgetable_and_cursorable_sets_match_inventory() {
+    let (db, store) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+    let live = live_mcp_catalog(&client).await;
+
+    let doc = inventory();
+
+    // inventory `budgetable:true` set.
+    let inv_budgetable: BTreeSet<String> = doc["mcp"]["tools"]
+        .as_array()
+        .expect("mcp.tools array")
+        .iter()
+        .filter(|t| t["budgetable"].as_bool() == Some(true))
+        .map(|t| t["name"].as_str().expect("tool name").to_string())
+        .collect();
+    assert_eq!(
+        inv_budgetable.len(),
+        13,
+        "inventory must mark exactly 13 budgetable read tools"
+    );
+    // Cross-check against the totals block too.
+    assert_eq!(
+        doc["totals"]["mcp_budgetable_read_tools"].as_u64(),
+        Some(13),
+        "totals.mcp_budgetable_read_tools must be 13"
+    );
+
+    // The crate's DISPATCH_ROUTED_READ_TOOLS is precisely the budgetable set:
+    // every budgetable tool forwards raw args through dispatch_tool_json so the
+    // #3353 budget shaper runs. Assert EXACT equality (both directions).
+    let dispatch_budgetable: BTreeSet<String> = DISPATCH_ROUTED_READ_TOOLS
+        .iter()
+        .map(|(n, _)| (*n).to_string())
+        .collect();
+    assert_eq!(
+        dispatch_budgetable, inv_budgetable,
+        "DISPATCH_ROUTED_READ_TOOLS must equal inventory's budgetable:true set exactly \
+         (every budgetable tool is dispatch-routed so the token budget applies)"
+    );
+
+    // Every budgetable tool is live-routable and read-class.
+    for name in &inv_budgetable {
+        assert!(
+            live.contains(name),
+            "budgetable tool {name:?} must be routed on /mcp"
+        );
+        assert_eq!(
+            rbac::tool_access_class(name),
+            Some(AccessClass::Read),
+            "budgetable tool {name:?} must be Read class"
+        );
+    }
+
+    // ALL_DISPATCH_ROUTED is the budgetable set plus the three non-budgetable
+    // provenance-hash-chain tools — the superset covering every dispatch site.
+    let all_dispatch: BTreeSet<String> = ALL_DISPATCH_ROUTED
+        .iter()
+        .map(|(n, _)| (*n).to_string())
+        .collect();
+    assert!(
+        dispatch_budgetable.is_subset(&all_dispatch),
+        "DISPATCH_ROUTED_READ_TOOLS must be a subset of ALL_DISPATCH_ROUTED"
+    );
+    let chain_extra: BTreeSet<String> = all_dispatch
+        .difference(&dispatch_budgetable)
+        .cloned()
+        .collect();
+    assert_eq!(
+        chain_extra,
+        ["audit_export", "export_chain_head", "verify_chain"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<BTreeSet<String>>(),
+        "ALL_DISPATCH_ROUTED beyond the budgetable set must be exactly the 3 chain tools"
+    );
+
+    // Cursorable set (#3360): each is routable and — cursoring being a slow-read
+    // behavior — also budgetable, so it composes with the token budget.
+    let cursorable: BTreeSet<String> = CURSORABLE_TOOLS.iter().map(|s| s.to_string()).collect();
+    assert_eq!(cursorable.len(), 5, "there are exactly 5 cursorable tools");
+    for name in &cursorable {
+        assert!(
+            live.contains(name),
+            "cursorable tool {name:?} must be routed on /mcp"
+        );
+        assert!(
+            inv_budgetable.contains(name),
+            "cursorable tool {name:?} must also be budgetable (cursorable ⊆ budgetable)"
+        );
+    }
+}


### PR DESCRIPTION
## Autumn-web migration PR8 (COMPLETING slice): full-surface parity + AC-evidence sweep (Issue #3524)

This is the consolidating slice of the autumn-web migration. Every prior PR (PR1–PR7) ported one cluster of the surface onto the unified `#[api_doc(mcp)]` handlers and pinned it byte-for-byte against the legacy 0.4 HTTP router / legacy MCP server. This PR adds a single **live-app sweep** asserting the WHOLE surface is complete and matches the cross-lane source of truth `tests/parity/inventory.json`, plus the 51-row AC-evidence table proving every tool/route is covered.

**No production code changes** — verification-only slice. One new test file: `crates/aletheia-server/tests/full_surface_parity_sweep.rs`.

### Before / After

- **Before:** the surface was maintained as **5 HTTP routes + 46 MCP tools across two separate stacks** — a string-match rmcp dispatcher on one side, a polymorphic `/query` enum on the other, two error shapes, two auth-classification tables kept in sync only by conformance tests. Completeness of the port was pinned slice-by-slice but never asserted as one whole-surface set-equality from the live app.
- **After:** the migration is **complete** — one crate (`aletheia-server`) serves all **46 MCP tools + 5 HTTP routes** from single handler definitions, projected to HTTP + MCP-over-HTTP (`/mcp`) + OpenAPI (`/openapi.json`). The sweep asserts, from the live `.mount_mcp` catalog, that the routed tool set EQUALS inventory's 46 exactly (zero missing, zero extra), every access class is in lockstep, all 5 routes are routed, `/openapi.json` covers the tool routes, and the budgetable/cursorable behavior sets match inventory.

### The sweep (5 assertions, all live-app)

1. **MCP catalog == inventory (exact set equality):** the live `/mcp` `tools/list` catalog equals EXACTLY the 46 names in `inventory.json` `mcp.tools` — symmetric difference reported on failure. **Result: PASS — 46 == 46, ∅ missing, ∅ extra.**
2. **Access-class conformance for all 46:** every inventory tool is live-routable AND its `rbac::tool_access_class` equals inventory `access_class`. Belt-and-suspenders over the static `registry_matches_inventory_exactly` (`tests/security_rbac.rs`), anchored to the *live* catalog.
3. **All 5 HTTP routes routed:** each `http.routes` row (method+path) responds non-404 in anonymous mode (Admin principal so a 401/403 cannot mask an unrouted path; revoke pre-mints a real key id).
4. **/openapi.json served + covers tools:** `/openapi.json` is 200 and its `paths` include a representative MCP-projection route from every ported cluster (node reads/writes, edge reads/adjacency, traverse/temporal/diff, vector, query, schema, batch, constraints, lineage, audit/chain) plus the HTTP status/admin routes.
5. **budgetable/cursorable sets match inventory:** `DISPATCH_ROUTED_READ_TOOLS` equals inventory's `budgetable:true` set EXACTLY (13 tools); `ALL_DISPATCH_ROUTED` beyond that is exactly the 3 chain tools; every budgetable tool is live-routable + Read-class; the 5 cursorable tools (#3360) are all routable and budgetable (cursorable ⊆ budgetable).

### Note on `POST /query` (polymorphic → typed decomposition)

Inventory's 5th HTTP route, `POST /query`, is the legacy polymorphic handler dispatching 10 ops (`find_node`, `get_node`, `bulk_get_nodes`, `find_neighbors`, `execute_query`, `bulk_*`, `create_node`). Per the migration plan (`docs/plans/2026-07-12-autumn-migration.md` open-question #4, recommendation **typed routes**), those ops are decomposed into the individual typed tool routes across PR2–PR6 (`get_node` → `GET /nodes/{id}`, etc.). `POST /query` in the autumn surface is served by the **`query` tool** (`execute_query`, read-only Cypher/AQL — `vector_query_tools.rs`). The route is present/routed; per-op byte-parity is proven per-tool by the slice suites, not by a single polymorphic-endpoint replay.

### Full AC-evidence table (51 rows) — tool/route → access_class → slice module → covering parity test(s)

#### 46 MCP tools

| tool | access_class | slice module | covering parity test(s) | budgetable | cursorable |
|------|--------------|--------------|-------------------------|:----------:|:----------:|
| `get_node` | read | `node_tools.rs` | `server_parity::get_node_byte_parity_with_legacy_mcp`, `::get_node_include_vectors_parity`, `::mcp_tools_call_get_node_matches_http`; `node_reads_budget_cursor::get_node_token_budget_parity`, `::get_node_budget_is_honored_not_silently_dropped` | ✅ | — |
| `create_node` | write | `node_tools.rs` | `node_writes_parity::create_node_byte_parity_with_legacy_mcp`, `::create_node_backdated_valid_time_honored`, `::mcp_tools_call_create_node_matches_http` | — | — |
| `update_node` | write | `node_tools.rs` | `node_writes_parity::update_node_byte_parity_with_legacy_mcp` | — | — |
| `delete_node` | write | `node_tools.rs` | `node_writes_parity::delete_node_refuses_without_detach_reports_connected_edges`, `::delete_node_detach_removes_edges`, `::delete_node_clean_when_no_edges` | — | — |
| `retract_node` | write | `node_tools.rs` | `node_writes_parity::retract_node_refuses_without_detach`, `::retract_node_detach_and_idempotent`, `::retract_node_idempotent_byte_parity` | — | — |
| `retract_edge` | write | `edge_tools.rs` | `edge_parity::retract_edge_idempotent_byte_parity` | — | — |
| `delete_node_cascade` | write | `node_tools.rs` | `node_writes_parity::delete_node_cascade_byte_parity` | — | — |
| `list_nodes` | read | `node_tools.rs` | `server_parity::list_nodes_byte_parity_with_legacy_mcp`; `node_reads_budget_cursor::list_nodes_token_budget_shapes_response_and_matches_legacy`, `::list_nodes_cursor_paging_snapshot_anchored`, `::list_nodes_budget_is_honored_not_silently_dropped` | ✅ | ✅ |
| `count_nodes` | read | `node_tools.rs` | `server_parity::count_nodes_byte_parity_with_legacy_mcp` | — | — |
| `get_edge` | read | `edge_tools.rs` | `edge_parity::get_edge_byte_parity_and_temporal_block`, `::get_edge_vector_elided_by_default_and_full_with_flag`, `::get_edge_missing_returns_not_found_in_band`, `::get_edge_token_budget_parity`, `::mcp_tools_call_get_edge_matches_http` | ✅ | — |
| `create_edge` | write | `edge_tools.rs` | `edge_parity::create_edge_byte_parity_with_legacy_mcp`, `::create_edge_backdated_valid_time_honored`, `::mcp_tools_call_create_edge_matches_http` | — | — |
| `update_edge` | write | `edge_tools.rs` | `edge_parity::update_edge_byte_parity_with_legacy_mcp` | — | — |
| `delete_edge` | write | `edge_tools.rs` | `edge_parity::delete_edge_byte_parity` | — | — |
| `apply_batch` | write | `schema_batch_tools.rs` | `schema_batch_parity::apply_batch_success_multi_op_with_ref_map_and_input_order`, `::apply_batch_per_op_failure_reports_failed_op_index`, `::apply_batch_over_cap_is_rejected_with_null_failed_op_index`, `::apply_batch_in_batch_detach_delete_contract` | — | — |
| `list_edges` | read | `edge_tools.rs` | `edge_parity::list_edges_byte_parity` | ✅ | — |
| `count_edges` | read | `edge_tools.rs` | `edge_parity::count_edges_byte_parity` | — | — |
| `get_outgoing_edges` | read | `edge_tools.rs` | `edge_parity::get_outgoing_edges_byte_parity_and_elision`, `::get_outgoing_edges_include_vectors`, `::get_outgoing_edges_token_budget_shapes_response`, `::get_outgoing_edges_cursor_paging_snapshot_anchored` | ✅ | ✅ |
| `get_incoming_edges` | read | `edge_tools.rs` | `edge_parity::get_incoming_edges_byte_parity` | ✅ | ✅ |
| `traverse` | read | `traverse_temporal_tools.rs` | `traverse_temporal_parity::traverse_behavior_pinned`, `::traverse_token_budget_shapes_response_and_matches_legacy`, `::traverse_cursor_paging_snapshot_anchored`, `::traverse_unauthenticated_401` | ✅ | ✅ |
| `find_similar` | read | `vector_query_tools.rs` | `vector_query_parity::all_four_byte_parity_required_mode`/`_anonymous_mode`, `::find_similar_elides_vectors_by_default_and_preserves_score`, `::find_similar_budget_shapes_without_dropping_results_and_matches_legacy` | ✅ | — |
| `enable_vector_index` | write | `constraints_lineage_audit_tools.rs` | `constraints_lineage_audit_parity::enable_vector_index_twin_db_parity_and_idempotent`, `::write_auth_gating_reader_denied_on_enables` | — | — |
| `list_vector_indexes` | read | `vector_query_tools.rs` | `vector_query_parity::all_four_byte_parity_required_mode`/`_anonymous_mode` | — | — |
| `enable_unique_constraint` | write | `constraints_lineage_audit_tools.rs` | `constraints_lineage_audit_parity::enable_unique_constraint_twin_db_parity_and_idempotent`, `::write_auth_gating_reader_denied_on_enables` | — | — |
| `list_unique_constraints` | read | `constraints_lineage_audit_tools.rs` | `constraints_lineage_audit_parity::reads_byte_parity_required_mode`/`_anonymous_mode` | — | — |
| `get_node_at_time` | read | `traverse_temporal_tools.rs` | `traverse_temporal_parity::all_twelve_byte_parity_required_mode`/`_anonymous_mode` | — | — |
| `get_edge_at_time` | read | `traverse_temporal_tools.rs` | `traverse_temporal_parity::all_twelve_byte_parity_required_mode`/`_anonymous_mode` | — | — |
| `find_nodes_at_time` | read | `node_tools.rs` | `node_writes_parity::find_nodes_at_time_byte_parity_and_elision`, `::find_nodes_at_time_include_vectors`; `node_reads_budget_cursor::find_nodes_at_time_token_budget_shapes_response_and_matches_legacy`, `::find_nodes_at_time_cursor_paging_snapshot_anchored`, `::find_nodes_at_time_budget_is_honored_not_silently_dropped` | ✅ | ✅ |
| `list_changes` | read | `traverse_temporal_tools.rs` | `traverse_temporal_parity::all_twelve_byte_parity_required_mode`/`_anonymous_mode` | — | — |
| `get_node_at_valid_time` | read | `traverse_temporal_tools.rs` | `traverse_temporal_parity::all_twelve_byte_parity_required_mode`/`_anonymous_mode` | — | — |
| `get_node_at_transaction_time` | read | `traverse_temporal_tools.rs` | `traverse_temporal_parity::all_twelve_byte_parity_required_mode`/`_anonymous_mode` | — | — |
| `get_node_history` | read | `traverse_temporal_tools.rs` | `traverse_temporal_parity::all_twelve_byte_parity_*`, `::get_node_history_token_budget_shapes_response_and_matches_legacy` | ✅ | — |
| `diff_node_versions` | read | `traverse_temporal_tools.rs` | `traverse_temporal_parity::all_twelve_byte_parity_*`, `::openapi_diff_node_versions_has_typed_request_schema` | — | — |
| `get_edge_at_valid_time` | read | `traverse_temporal_tools.rs` | `traverse_temporal_parity::all_twelve_byte_parity_required_mode`/`_anonymous_mode` | — | — |
| `get_edge_at_transaction_time` | read | `traverse_temporal_tools.rs` | `traverse_temporal_parity::all_twelve_byte_parity_required_mode`/`_anonymous_mode` | — | — |
| `get_edge_history` | read | `traverse_temporal_tools.rs` | `traverse_temporal_parity::all_twelve_byte_parity_required_mode`/`_anonymous_mode` | — | — |
| `diff_edge_versions` | read | `traverse_temporal_tools.rs` | `traverse_temporal_parity::all_twelve_byte_parity_required_mode`/`_anonymous_mode` | — | — |
| `hybrid_query` | read | `vector_query_tools.rs` | `vector_query_parity::all_four_byte_parity_required_mode`/`_anonymous_mode` | ✅ | — |
| `query` | read | `vector_query_tools.rs` | `vector_query_parity::all_four_byte_parity_*`, `::query_budget_shapes_response_and_matches_legacy`, `::query_read_only_violation_kind_preserved`, `::query_parse_error_kind_preserved`, `::query_cursor_request_is_unsupported_construct`, `::query_cypher_language_unavailable_when_feature_off` | ✅ | — |
| `get_schema` | read | `schema_batch_tools.rs` | `schema_batch_parity::reads_byte_parity_*`, `::get_schema_as_of_matches_legacy`, `::get_schema_budget_shapes_response_and_matches_legacy` | ✅ | — |
| `temporal_extent` | read | `schema_batch_tools.rs` | `schema_batch_parity::reads_byte_parity_*`, `::temporal_extent_empty_db_returns_explicit_nulls`, `::temporal_extent_by_label_matches_legacy` | — | — |
| `lineage_upstream` | read | `constraints_lineage_audit_tools.rs` | `constraints_lineage_audit_parity::reads_byte_parity_*`, `::lineage_upstream_pagination_has_more_and_next_offset`, `::lineage_upstream_bad_entity_kind_is_invalid_argument` | — | — |
| `lineage_downstream` | read | `constraints_lineage_audit_tools.rs` | `constraints_lineage_audit_parity::reads_byte_parity_required_mode`/`_anonymous_mode` | — | — |
| `audit_export` | read | `constraints_lineage_audit_tools.rs` | `constraints_lineage_audit_parity::audit_export_roundtrip_signs_and_redacts`, `::audit_export_without_signing_key_is_failed_precondition` | — | — |
| `verify_chain` | read | `constraints_lineage_audit_tools.rs` | `constraints_lineage_audit_parity::verify_and_export_chain_parity_on_enabled_chain`, `::verify_and_export_chain_disabled_is_failed_precondition` | — | — |
| `export_chain_head` | read | `constraints_lineage_audit_tools.rs` | `constraints_lineage_audit_parity::verify_and_export_chain_parity_on_enabled_chain` | — | — |
| `database_stats` | metrics | `schema_batch_tools.rs` | `schema_batch_parity::database_stats_snapshot_shape`, `::database_stats_is_metrics_class_gated_not_read` | — | — |

Full-set coverage for every tool row above: `full_surface_parity_sweep::mcp_catalog_equals_inventory_exactly` + `::access_class_conformance_for_all_46`. Catalog-advertisement per cluster: `node_writes_parity::mcp_catalog_advertises_the_six_node_write_tools`, `edge_parity::mcp_catalog_advertises_the_nine_edge_tools`, `constraints_lineage_audit_parity::all_eight_tools_routable_on_mcp_with_correct_class`, `server_parity::mcp_routable_tools_are_all_classified`.

#### 5 HTTP routes

| route | access_class | slice module | covering parity test(s) |
|-------|--------------|--------------|-------------------------|
| `GET /status` | metrics | `http_routes.rs` | `server_parity::status_success_byte_parity_required_mode`, `::status_unauthenticated_401_byte_parity`, `::status_success_anonymous_mode`; `full_surface_parity_sweep::all_five_http_routes_are_served` |
| `POST /query` | per-op (query tool = read) | `vector_query_tools.rs` | `vector_query_parity::all_four_byte_parity_*` + the `query_*` suite (see `query` row); `full_surface_parity_sweep::all_five_http_routes_are_served` |
| `POST /admin/keys` | admin | `http_routes.rs` | `server_parity::admin_create_key_success_shape`, `::admin_create_key_unauthenticated_401_byte_parity`; `full_surface_parity_sweep::all_five_http_routes_are_served` |
| `GET /admin/keys` | admin | `http_routes.rs` | `server_parity::admin_list_keys_byte_parity_with_shared_store`, `::admin_list_keys_unauthenticated_401_byte_parity`; `full_surface_parity_sweep::all_five_http_routes_are_served` |
| `POST /admin/keys/revoke` | admin | `http_routes.rs` | `server_parity::admin_revoke_key_behavior`; `full_surface_parity_sweep::all_five_http_routes_are_served` |

**No row lacks a covering test.**

### Main-crate widenings: none

This slice touches only `crates/aletheia-server/tests/` (one new test file). No `aletheiadb` (main crate) code changed; no `pub` widening; no `src/security/**` change.

### Deferred: envelope unification

Per the design doc, HTTP↔MCP error-envelope unification (#3234's nested `{error:{code,message,retriable,details?}}` everywhere) is an OPEN, user-sign-off-gated BREAKING change. **It is NOT implemented here.** Current state is **parity-exact**: HTTP keeps the flat `{success:false, error:<string>, code?, retriable?, details?}` envelope (code/retriable/details additive only on auth + resource-limit variants) and MCP keeps the nested `{error:{code,message,retriable,details?}}` envelope, each byte-identical to the legacy surface. Unifying them is a separate breaking follow-up pending explicit user approval; the asymmetry is documented in `inventory.json` `http.error_envelope.vocabulary_asymmetry_vs_mcp`.

### Codecov

Coverage delta is non-blocking for this PR: it adds only a test file (no new production lines), so line/function/region coverage of the shipped crate is unchanged — any codecov movement is measurement noise on the test target, not a regression.

### Gate output (verbatim, all six green — 0 warnings, 0 errors)

```
########## GATE clippy-server EXIT=0        # cargo clippy -p aletheia-server --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 23s

########## GATE test-server EXIT=0          # cargo test -p aletheia-server
     Running tests/full_surface_parity_sweep.rs
running 5 tests
test mcp_catalog_equals_inventory_exactly ... ok
test budgetable_and_cursorable_sets_match_inventory ... ok
test all_five_http_routes_are_served ... ok
test access_class_conformance_for_all_46 ... ok
test openapi_served_and_covers_representative_tool_routes ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s
    (+ all other aletheia-server suites: server_parity 15, edge_parity 24, node_writes_parity 18,
     traverse_temporal_parity 10, vector_query_parity 11, schema_batch_parity 15,
     constraints_lineage_audit_parity 17, node_reads_budget_cursor 12, security_* … — all ok, 0 failed)

########## GATE fmt-check EXIT=0            # cargo fmt --all -- --check

########## GATE check-main-http EXIT=0      # cargo check -p aletheiadb --no-default-features --tests --features http-server
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 53s

########## GATE test-legacy-goldens EXIT=0  # cargo test --features http-server,mcp-server --test parity_http --test parity_mcp
     Running tests/parity_http.rs
test result: ok. 33 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.12s
     Running tests/parity_mcp.rs
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.13s

########## GATE clippy-main EXIT=0          # cargo clippy -p aletheiadb --features "config-toml,mcp-server,sharding-rpc,simulation" --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 53.89s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEwJg2bDPZ7DzcHebqwZVK

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEwJg2bDPZ7DzcHebqwZVK)_