### PR TITLE
feat(http)!: unify HTTP error envelope to nested {error:{code,message,retriable,details}} (#3234)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,6 +385,13 @@ Recovery loop: `retriable: true` -> retry with backoff; `INVALID_ARGUMENT` /
 `message` + `details` and re-issue; otherwise escalate. Codes may be added
 over time but never change meaning; treat unknown codes as non-retriable. See
 [docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md#structured-error-codes-and-the-retriable-contract).
+**The HTTP surface now shares this exact nested envelope (breaking change):**
+`AletheiaHttpError` emits `{"error":{"code","message","retriable","details"?}}`
+(with `trace_id`, when present, a **top-level** sibling of `error`) — the legacy
+flat HTTP body (`{"success":false,"error":"<msg>","code":…}`, top-level
+`success`/`error`/`code`/`retriable`/`details`) has been **removed**, so HTTP and
+MCP error bodies are byte-shape-identical. Success responses are unchanged
+(`{"success":true,"data":…}`).
 
 **Database stats (Issue #3222)**: `database_stats` (no arguments) returns a
 holistic snapshot in one call so an LLM/operator can orient itself before
@@ -630,7 +637,11 @@ per call (revocation is immediate); auth failures are a uniform
 `UNAUTHENTICATED` (never distinguishing missing/unknown/revoked), role
 denials are `PERMISSION_DENIED` with `details.required_class` /
 `details.principal_role` — both additive to the #3234 enum, both
-`retriable: false`. Authenticated writes stamp the principal's name into
+`retriable: false`. Since the #3234 HTTP error-envelope unification these
+denials render identically on **both** surfaces as the nested
+`{"error":{"code","message","retriable","details"}}` body (the HTTP surface no
+longer emits the legacy flat `{"success":false,…}` shape, and its 403 now carries
+`error.details.{required_class,principal_role}` too). Authenticated writes stamp the principal's name into
 version provenance (`provenance.principal`, composing with the
 caller-supplied `source`) on the structured create/update node/edge
 paths of both surfaces — deletes/retracts and HTTP AQL-statement writes

--- a/crates/aletheia-server/src/security/auth.rs
+++ b/crates/aletheia-server/src/security/auth.rs
@@ -214,10 +214,14 @@ impl RateLimitSettings {
 ///
 /// **Unified 403 envelope (Issue #3234):** the HTTP-surface 403 now carries the
 /// same nested `{error: {code, message, retriable, details}}` envelope as the
-/// MCP surface, including `details: {required_class, principal_role}`. The
-/// legacy message-only body has been retired in the breaking HTTP error-envelope
-/// unification; the `required_class` / `principal_role` are threaded through the
-/// [`AletheiaHttpError::PermissionDenied`] variant.
+/// MCP surface, including `details: {required_class, principal_role}`.
+/// Single-shape 403 (supersedes cross-lane ruling F4 (two-shape 403), per the
+/// user-approved #3234 unification): HTTP 403 carries
+/// `details:{required_class, principal_role}` identically to the MCP surface —
+/// no NEW disclosure (MCP already surfaced these via the same shared enums).
+/// The legacy message-only body has been retired in the breaking HTTP
+/// error-envelope unification; the `required_class` / `principal_role` are
+/// threaded through the [`AletheiaHttpError::PermissionDenied`] variant.
 ///
 /// # Errors
 ///

--- a/crates/aletheia-server/src/security/auth.rs
+++ b/crates/aletheia-server/src/security/auth.rs
@@ -209,15 +209,15 @@ impl RateLimitSettings {
 /// The per-request RBAC decision. On refusal returns
 /// [`AletheiaHttpError::PermissionDenied`] (HTTP 403 / `PERMISSION_DENIED`,
 /// non-retriable) with the **byte-identical** legacy message
-/// `"role '{role}' does not permit {class} access"`, so 403 bodies stay
+/// `"role '{role}' does not permit {class} access"`, so 403 messages stay
 /// identical to the existing `/query` surface.
 ///
-/// **Two-shape 403 contract (coordinator #8a / ruling F4):** this HTTP-surface
-/// 403 is deliberately **message-only** — it carries no `details` block, exactly
-/// mirroring the legacy `src/http/auth.rs`. Only the MCP-surface 403
-/// ([`crate::security::mcp_permission_denied_response`]) carries
-/// `details: {required_class, principal_role}`. The asymmetry is intentional;
-/// do not add `details` here.
+/// **Unified 403 envelope (Issue #3234):** the HTTP-surface 403 now carries the
+/// same nested `{error: {code, message, retriable, details}}` envelope as the
+/// MCP surface, including `details: {required_class, principal_role}`. The
+/// legacy message-only body has been retired in the breaking HTTP error-envelope
+/// unification; the `required_class` / `principal_role` are threaded through the
+/// [`AletheiaHttpError::PermissionDenied`] variant.
 ///
 /// # Errors
 ///
@@ -227,10 +227,10 @@ pub fn authorize_class(principal: &Principal, class: AccessClass) -> Result<(), 
     if principal.role.allows(class) {
         Ok(())
     } else {
-        Err(AletheiaHttpError::PermissionDenied(format!(
-            "role '{}' does not permit {} access",
-            principal.role, class
-        )))
+        Err(AletheiaHttpError::PermissionDenied {
+            required_class: class,
+            principal_role: principal.role,
+        })
     }
 }
 

--- a/crates/aletheia-server/src/security/mcp_gate.rs
+++ b/crates/aletheia-server/src/security/mcp_gate.rs
@@ -60,9 +60,13 @@
 //! HTTP-surface 403 ([`crate::security::authorize_class`] →
 //! [`AletheiaHttpError::PermissionDenied`]) emit the **same** nested
 //! `{error:{code, message, retriable, details}}` envelope, including
-//! `details: {required_class, principal_role}`. The legacy asymmetry (a
-//! message-only HTTP 403) was retired in the breaking HTTP error-envelope
-//! unification, so the two surfaces are now byte-shape-identical. Because the
+//! `details: {required_class, principal_role}`. Single-shape 403 (supersedes
+//! cross-lane ruling F4 (two-shape 403), per the user-approved #3234
+//! unification): HTTP 403 now carries `details:{required_class, principal_role}`
+//! identically to the MCP surface — no NEW disclosure (MCP already surfaced
+//! these via the same shared enums). The legacy message-only HTTP 403 was
+//! retired in the breaking HTTP error-envelope unification, so the two surfaces
+//! are now byte-shape-identical. Because the
 //! gate fails closed on every tool-executing frame it cannot identify (point 4),
 //! no MCP tools/call reaches the dispatch handler's 403 path without first
 //! passing the gate's detail-carrying precheck.

--- a/crates/aletheia-server/src/security/mcp_gate.rs
+++ b/crates/aletheia-server/src/security/mcp_gate.rs
@@ -35,7 +35,8 @@
 //!    and [`rbac::authorize_tool`] consulted. A role that does not permit the
 //!    tool's class is refused **before dispatch** with a `403 PERMISSION_DENIED`
 //!    envelope carrying `details: {required_class, principal_role}` — the same
-//!    shape the legacy MCP `permission_denied_error` emits. (The replayed
+//!    nested `{error:{code, message, retriable, details}}` shape the HTTP surface
+//!    and the MCP tool dispatch emit (Issue #3234). (The replayed
 //!    dispatch handler's own `Authorized<C>` gate remains as defense-in-depth;
 //!    see the crate/README notes on the tools/call replay boundary.)
 //! 4. **Fails closed** on frames it cannot RBAC-precheck (#6): an oversize
@@ -53,17 +54,18 @@
 //!    while guaranteeing the losing/unverified header never survives. Only the
 //!    credential the layer actually verified is normalized.
 //!
-//! # Two-shape 403 contract (ruling F4 / coordinator #8a)
+//! # Unified 403 envelope (ruling F4 / Issue #3234)
 //!
-//! The MCP-surface 403 ([`mcp_permission_denied_response`]) **carries**
-//! `details: {required_class, principal_role}`; the HTTP-surface 403
-//! ([`crate::security::authorize_class`] →
-//! [`AletheiaHttpError::PermissionDenied`]) stays **message-only**, matching the
-//! legacy `src/http/auth.rs`. The two shapes are intentional and asymmetric — do
-//! not add `details` to the HTTP surface. Because the gate now fails closed on
-//! every tool-executing frame it cannot identify (point 4), no MCP tools/call
-//! reaches the dispatch handler's message-only 403 path without first passing
-//! the gate's detail-carrying precheck.
+//! Both the MCP-surface 403 ([`mcp_permission_denied_response`]) and the
+//! HTTP-surface 403 ([`crate::security::authorize_class`] →
+//! [`AletheiaHttpError::PermissionDenied`]) emit the **same** nested
+//! `{error:{code, message, retriable, details}}` envelope, including
+//! `details: {required_class, principal_role}`. The legacy asymmetry (a
+//! message-only HTTP 403) was retired in the breaking HTTP error-envelope
+//! unification, so the two surfaces are now byte-shape-identical. Because the
+//! gate fails closed on every tool-executing frame it cannot identify (point 4),
+//! no MCP tools/call reaches the dispatch handler's 403 path without first
+//! passing the gate's detail-carrying precheck.
 //!
 //! In [`AuthMode::Anonymous`] the layer inserts [`Principal::anonymous`] and
 //! passes through unconditionally (catalog reachable — matching the legacy
@@ -105,28 +107,50 @@ pub fn mcp_unauthenticated_response() -> Response<Body> {
     AletheiaHttpError::Unauthorized.into_response()
 }
 
+/// Build the unified nested error envelope `{error:{code, message, retriable,
+/// details}}` (Issue #3234) shared with the HTTP surface
+/// ([`AletheiaHttpError::into_response`]), so the `/mcp` gate's hand-built
+/// refusals stay byte-shape-identical to the rest of the surface.
+fn mcp_error_envelope(
+    status: StatusCode,
+    code: &str,
+    message: String,
+    retriable: bool,
+    details: serde_json::Value,
+) -> Response<Body> {
+    let body = json!({
+        "error": {
+            "code": code,
+            "message": message,
+            "retriable": retriable,
+            "details": details,
+        }
+    });
+    (status, Json(body)).into_response()
+}
+
 /// The `403 PERMISSION_DENIED` envelope for a `/mcp` per-tool RBAC refusal,
 /// carrying `details: {required_class, principal_role}` (ruling F4). The
-/// `error` message and `details` shape mirror the legacy MCP
-/// `permission_denied_error` exactly, so an LLM/caller branches on `code` +
-/// `details` without substring matching; `retriable` is `false` (a caller-fault
-/// authorization denial is never retriable).
+/// `error` message and `details` shape mirror the MCP tool dispatch and the
+/// HTTP surface exactly (the unified nested envelope, Issue #3234), so an
+/// LLM/caller branches on `code` + `details` without substring matching;
+/// `retriable` is `false` (a caller-fault authorization denial is never
+/// retriable).
 #[must_use]
 pub fn mcp_permission_denied_response(denied: Denied) -> Response<Body> {
-    let body = json!({
-        "success": false,
-        "error": format!(
+    mcp_error_envelope(
+        StatusCode::FORBIDDEN,
+        "PERMISSION_DENIED",
+        format!(
             "role '{}' does not permit {} access",
             denied.principal_role, denied.required_class
         ),
-        "code": "PERMISSION_DENIED",
-        "retriable": false,
-        "details": {
+        false,
+        json!({
             "required_class": denied.required_class.to_string(),
             "principal_role": denied.principal_role.to_string(),
-        },
-    });
-    (StatusCode::FORBIDDEN, Json(body)).into_response()
+        }),
+    )
 }
 
 /// The `413 RESOURCE_EXHAUSTED` envelope for an over-limit buffered `/mcp` body
@@ -136,19 +160,16 @@ pub fn mcp_permission_denied_response(denied: Denied) -> Response<Body> {
 /// fault), mirroring the shared `ResultBytes` 413.
 #[must_use]
 pub fn mcp_payload_too_large_response() -> Response<Body> {
-    let body = json!({
-        "success": false,
-        "error": format!(
-            "request body exceeds the {MAX_MCP_REQUEST_BYTES}-byte /mcp limit"
-        ),
-        "code": "RESOURCE_EXHAUSTED",
-        "retriable": false,
-        "details": {
+    mcp_error_envelope(
+        StatusCode::PAYLOAD_TOO_LARGE,
+        "RESOURCE_EXHAUSTED",
+        format!("request body exceeds the {MAX_MCP_REQUEST_BYTES}-byte /mcp limit"),
+        false,
+        json!({
             "reason": "request_body_too_large",
             "limit": MAX_MCP_REQUEST_BYTES,
-        },
-    });
-    (StatusCode::PAYLOAD_TOO_LARGE, Json(body)).into_response()
+        }),
+    )
 }
 
 /// The `400 INVALID_ARGUMENT` envelope for a tool-executing frame the gate
@@ -158,14 +179,13 @@ pub fn mcp_payload_too_large_response() -> Response<Body> {
 /// refuses it fail-closed. Non-retriable.
 #[must_use]
 pub fn mcp_unroutable_tool_call_response(reason: &'static str) -> Response<Body> {
-    let body = json!({
-        "success": false,
-        "error": format!("unroutable tools/call frame refused: {reason}"),
-        "code": "INVALID_ARGUMENT",
-        "retriable": false,
-        "details": { "reason": reason },
-    });
-    (StatusCode::BAD_REQUEST, Json(body)).into_response()
+    mcp_error_envelope(
+        StatusCode::BAD_REQUEST,
+        "INVALID_ARGUMENT",
+        format!("unroutable tools/call frame refused: {reason}"),
+        false,
+        json!({ "reason": reason }),
+    )
 }
 
 /// The classification of a buffered `/mcp` JSON-RPC frame for RBAC prechecking.

--- a/crates/aletheia-server/src/security/rate_limit.rs
+++ b/crates/aletheia-server/src/security/rate_limit.rs
@@ -70,24 +70,28 @@ type SpikeGovernorConfig = GovernorConfig<PeerIpKeyExtractor, NoOpMiddleware>;
 /// [`GovernorLayer::error_handler`] — the clean tower_governor 0.8 hook (a
 /// `Fn(GovernorError) -> Response<Body>`), so no extra tower layer is needed.
 ///
-/// Only the `TooManyRequests` (429) case is rewritten, into the legacy
-/// `ResourceLimitExceeded` shape — `code: "RESOURCE_EXHAUSTED"`, `retriable:
-/// true` (rate-limit throttling is transient) — preserving governor's
+/// Only the `TooManyRequests` (429) case is rewritten, into the unified nested
+/// `{error:{code, message, retriable, details}}` envelope (Issue #3234) —
+/// `code: "RESOURCE_EXHAUSTED"`, `retriable: true` (rate-limit throttling is
+/// transient) — preserving governor's
 /// `retry-after` header so a client still learns when to retry. Non-throttle
 /// governor errors (`UnableToExtractKey` → 500, custom `Other`) fall through to
 /// governor's default rendering unchanged.
 fn wrap_governor_error(error: GovernorError) -> Response<Body> {
     match error {
         GovernorError::TooManyRequests { wait_time, headers } => {
+            // Unified nested error envelope (Issue #3234), byte-shape-identical to
+            // the HTTP surface's `AletheiaHttpError::into_response`.
             let body = json!({
-                "success": false,
-                "error": format!("rate limit exceeded; retry after {wait_time}s"),
-                "code": "RESOURCE_EXHAUSTED",
-                "retriable": true,
-                "details": {
-                    "reason": "rate_limit",
-                    "retry_after_secs": wait_time,
-                },
+                "error": {
+                    "code": "RESOURCE_EXHAUSTED",
+                    "message": format!("rate limit exceeded; retry after {wait_time}s"),
+                    "retriable": true,
+                    "details": {
+                        "reason": "rate_limit",
+                        "retry_after_secs": wait_time,
+                    },
+                }
             });
             let mut resp = (StatusCode::TOO_MANY_REQUESTS, Json(body)).into_response();
             // Preserve governor's advisory headers (retry-after / x-ratelimit-*)

--- a/crates/aletheia-server/tests/constraints_lineage_audit_parity.rs
+++ b/crates/aletheia-server/tests/constraints_lineage_audit_parity.rs
@@ -411,7 +411,10 @@ async fn write_auth_gating_reader_denied_on_enables() {
     )
     .await;
     assert_eq!(s, 403, "reader denied enable_vector_index: {body}");
-    assert_eq!(body["code"], "PERMISSION_DENIED", "denial code: {body}");
+    assert_eq!(
+        body["error"]["code"], "PERMISSION_DENIED",
+        "denial code: {body}"
+    );
 
     let (s, body) = post(
         &client,
@@ -421,7 +424,10 @@ async fn write_auth_gating_reader_denied_on_enables() {
     )
     .await;
     assert_eq!(s, 403, "reader denied enable_unique_constraint: {body}");
-    assert_eq!(body["code"], "PERMISSION_DENIED", "denial code: {body}");
+    assert_eq!(
+        body["error"]["code"], "PERMISSION_DENIED",
+        "denial code: {body}"
+    );
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/crates/aletheia-server/tests/schema_batch_parity.rs
+++ b/crates/aletheia-server/tests/schema_batch_parity.rs
@@ -420,7 +420,10 @@ async fn database_stats_is_metrics_class_gated_not_read() {
     // Read.
     let (s, body) = get(&client, "/schema", Some(METRICS_TOKEN)).await;
     assert_eq!(s, 403, "metrics token denied on a ReadClass tool: {body}");
-    assert_eq!(body["code"], "PERMISSION_DENIED", "denial code: {body}");
+    assert_eq!(
+        body["error"]["code"], "PERMISSION_DENIED",
+        "denial code: {body}"
+    );
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/crates/aletheia-server/tests/security_acceptance.rs
+++ b/crates/aletheia-server/tests/security_acceptance.rs
@@ -189,9 +189,9 @@ async fn rbac_reader_reads_ok_but_admin_route_forbidden() {
     // Admin route: reader (denies Admin) → 403 PERMISSION_DENIED.
     let (status, body) = get_bearer(&client, "/admin/keys", Some(READER_TOKEN)).await;
     assert_eq!(status, 403, "reader may not reach the admin surface");
-    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert_eq!(body["error"]["code"], "PERMISSION_DENIED");
     assert_ne!(
-        body["retriable"],
+        body["error"]["retriable"],
         json!(true),
         "authz denial is not retriable"
     );
@@ -209,7 +209,7 @@ async fn rbac_metrics_token_only_reaches_metrics_class() {
     // /nodes is ReadClass → metrics (denies Read) 403.
     let (status, body) = get_bearer(&client, "/nodes", Some(METRICS_TOKEN)).await;
     assert_eq!(status, 403, "metrics may not read graph data");
-    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert_eq!(body["error"]["code"], "PERMISSION_DENIED");
 
     // /admin/keys is AdminClass → metrics 403.
     let (status, _) = get_bearer(&client, "/admin/keys", Some(METRICS_TOKEN)).await;
@@ -228,10 +228,10 @@ async fn rbac_metrics_token_denied_read_tool_over_mcp_with_details() {
     let (status, body) = mcp_post(&client, &rpc, Some(METRICS_TOKEN)).await;
 
     assert_eq!(status, 403, "metrics→get_node over /mcp is refused: {body}");
-    assert_eq!(body["code"], "PERMISSION_DENIED");
-    assert_eq!(body["retriable"], false);
-    assert_eq!(body["details"]["required_class"], "read");
-    assert_eq!(body["details"]["principal_role"], "metrics");
+    assert_eq!(body["error"]["code"], "PERMISSION_DENIED");
+    assert_eq!(body["error"]["retriable"], false);
+    assert_eq!(body["error"]["details"]["required_class"], "read");
+    assert_eq!(body["error"]["details"]["principal_role"], "metrics");
 }
 
 /// Extractor-class ↔ inventory conformance (load-bearing): for every routable
@@ -282,7 +282,7 @@ async fn rbac_routable_tool_extractor_class_matches_registry() {
             deny_status, 403,
             "{tool}: metrics denied {registry_class} → 403 (enforced class matches registry)"
         );
-        assert_eq!(deny_body["code"], "PERMISSION_DENIED");
+        assert_eq!(deny_body["error"]["code"], "PERMISSION_DENIED");
     }
 }
 
@@ -465,9 +465,16 @@ async fn error_contract_http_401_shape() {
     let client = build_server_client(db, store, AuthMode::Required);
     let (status, body) = get_bearer(&client, "/nodes", None).await;
     assert_eq!(status, 401);
-    assert_eq!(body["code"], "UNAUTHENTICATED");
-    assert_eq!(body["success"], false);
-    assert_ne!(body["retriable"], json!(true), "auth failure not retriable");
+    assert_eq!(body["error"]["code"], "UNAUTHENTICATED");
+    assert!(
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
+    assert_ne!(
+        body["error"]["retriable"],
+        json!(true),
+        "auth failure not retriable"
+    );
 }
 
 #[tokio::test]
@@ -476,9 +483,9 @@ async fn error_contract_http_403_shape() {
     let client = build_server_client(db, store, AuthMode::Required);
     let (status, body) = get_bearer(&client, "/admin/keys", Some(READER_TOKEN)).await;
     assert_eq!(status, 403);
-    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert_eq!(body["error"]["code"], "PERMISSION_DENIED");
     assert_ne!(
-        body["retriable"],
+        body["error"]["retriable"],
         json!(true),
         "authz failure not retriable"
     );
@@ -498,10 +505,10 @@ async fn error_contract_http_413_byte_cap() {
         status, 413,
         "8-byte budget forces a payload-too-large: {body}"
     );
-    assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
-    assert_eq!(body["retriable"], false);
-    assert_eq!(body["details"]["dimension"], "result_bytes");
-    assert_eq!(body["details"]["limit"], 8);
+    assert_eq!(body["error"]["code"], "RESOURCE_EXHAUSTED");
+    assert_eq!(body["error"]["retriable"], false);
+    assert_eq!(body["error"]["details"]["dimension"], "result_bytes");
+    assert_eq!(body["error"]["details"]["limit"], 8);
 }
 
 #[tokio::test]
@@ -511,10 +518,13 @@ async fn error_contract_mcp_401_shape() {
     let (status, body) = mcp_post(&client, &rpc_tools_list(), None).await;
     assert_eq!(status, 401);
     assert_eq!(
-        body["code"], "UNAUTHENTICATED",
+        body["error"]["code"], "UNAUTHENTICATED",
         "/mcp 401 is enveloped: {body}"
     );
-    assert_eq!(body["success"], false);
+    assert!(
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
 }
 
 #[tokio::test]
@@ -524,10 +534,10 @@ async fn error_contract_mcp_403_shape_with_details() {
     let rpc = rpc_tools_call("get_node", json!({ "id": node_id.as_u64() }));
     let (status, body) = mcp_post(&client, &rpc, Some(METRICS_TOKEN)).await;
     assert_eq!(status, 403);
-    assert_eq!(body["code"], "PERMISSION_DENIED");
-    assert_eq!(body["retriable"], false);
-    assert_eq!(body["details"]["required_class"], "read");
-    assert_eq!(body["details"]["principal_role"], "metrics");
+    assert_eq!(body["error"]["code"], "PERMISSION_DENIED");
+    assert_eq!(body["error"]["retriable"], false);
+    assert_eq!(body["error"]["details"]["required_class"], "read");
+    assert_eq!(body["error"]["details"]["principal_role"], "metrics");
 }
 
 /// The transient-vs-fault `retriable` matrix on the shared envelope both
@@ -540,22 +550,28 @@ async fn error_contract_retriable_matrix_on_shared_envelope() {
 
     let (s, b) = render_error(timeout_error(Duration::from_millis(100), false)).await;
     assert_eq!(s, 429);
-    assert_eq!(b["code"], "RESOURCE_EXHAUSTED");
-    assert_eq!(b["retriable"], true, "read timeout is retriable");
+    assert_eq!(b["error"]["code"], "RESOURCE_EXHAUSTED");
+    assert_eq!(b["error"]["retriable"], true, "read timeout is retriable");
 
     let (s, b) = render_error(timeout_error(Duration::from_millis(100), true)).await;
     assert_eq!(s, 429);
-    assert_eq!(b["retriable"], false, "write timeout is NOT retriable");
+    assert_eq!(
+        b["error"]["retriable"], false,
+        "write timeout is NOT retriable"
+    );
 
     let (s, b) = render_error(byte_cap_error(1024, 4096)).await;
     assert_eq!(s, 413);
-    assert_eq!(b["code"], "RESOURCE_EXHAUSTED");
-    assert_eq!(b["retriable"], false);
+    assert_eq!(b["error"]["code"], "RESOURCE_EXHAUSTED");
+    assert_eq!(b["error"]["retriable"], false);
 
     let (s, b) = render_error(AletheiaHttpError::InFlightCapacityExceeded { cap: 4 }).await;
     assert_eq!(s, 503);
-    assert_eq!(b["code"], "UNAVAILABLE");
-    assert_eq!(b["retriable"], true, "capacity overload is retriable");
+    assert_eq!(b["error"]["code"], "UNAVAILABLE");
+    assert_eq!(
+        b["error"]["retriable"], true,
+        "capacity overload is retriable"
+    );
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -581,7 +597,7 @@ async fn revocation_takes_effect_on_the_next_request() {
     assert!(store.revoke(&principal.id).expect("revoke"));
     let (status, body) = get_bearer(&client, &uri, Some(&key)).await;
     assert_eq!(status, 401, "revoked key is rejected immediately: {body}");
-    assert_eq!(body["code"], "UNAUTHENTICATED");
+    assert_eq!(body["error"]["code"], "UNAUTHENTICATED");
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -605,7 +621,7 @@ async fn attack_right_token_wrong_class_is_403() {
     // Writer may write/read but not administer keys.
     let (status, body) = get_bearer(&client, "/admin/keys", Some(WRITER_TOKEN)).await;
     assert_eq!(status, 403);
-    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert_eq!(body["error"]["code"], "PERMISSION_DENIED");
 }
 
 #[tokio::test]
@@ -629,6 +645,6 @@ async fn attack_in_flight_cap_exhaustion_is_503() {
         .expect_err("second slot rejected at cap");
     let (status, body) = render_error(err).await;
     assert_eq!(status, 503);
-    assert_eq!(body["code"], "UNAVAILABLE");
-    assert_eq!(body["retriable"], true);
+    assert_eq!(body["error"]["code"], "UNAVAILABLE");
+    assert_eq!(body["error"]["retriable"], true);
 }

--- a/crates/aletheia-server/tests/security_mcp_gate.rs
+++ b/crates/aletheia-server/tests/security_mcp_gate.rs
@@ -274,8 +274,11 @@ async fn oversize_mcp_body_is_413_envelope() {
     let status = resp.status.as_u16();
     let body: Value = serde_json::from_str(&resp.text()).unwrap_or(Value::Null);
     assert_eq!(status, 413, "oversize body → 413: {body}");
-    assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
-    assert_eq!(body["success"], json!(false));
+    assert_eq!(body["error"]["code"], "RESOURCE_EXHAUSTED");
+    assert!(
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -307,7 +310,7 @@ async fn batch_with_tools_call_is_failclosed() {
         status, 400,
         "batched tools/call is refused fail-closed: {text}"
     );
-    assert_eq!(body["code"], "INVALID_ARGUMENT");
+    assert_eq!(body["error"]["code"], "INVALID_ARGUMENT");
     assert!(
         !text.contains("\"name\":\"Alice\"") && !text.contains("Alice"),
         "the tool must NOT have executed (no node data leaked): {text}"
@@ -338,7 +341,7 @@ async fn tools_call_missing_name_is_failclosed() {
         status, 400,
         "malformed tools/call → fail-closed 400: {body}"
     );
-    assert_eq!(body["code"], "INVALID_ARGUMENT");
+    assert_eq!(body["error"]["code"], "INVALID_ARGUMENT");
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -389,7 +392,7 @@ async fn x_api_key_metrics_read_tool_denied_403_with_details() {
     let status = resp.status.as_u16();
     let body: Value = serde_json::from_str(&resp.text()).unwrap_or(Value::Null);
     assert_eq!(status, 403, "metrics denied read over x-api-key: {body}");
-    assert_eq!(body["code"], "PERMISSION_DENIED");
-    assert_eq!(body["details"]["required_class"], "read");
-    assert_eq!(body["details"]["principal_role"], "metrics");
+    assert_eq!(body["error"]["code"], "PERMISSION_DENIED");
+    assert_eq!(body["error"]["details"]["required_class"], "read");
+    assert_eq!(body["error"]["details"]["principal_role"], "metrics");
 }

--- a/crates/aletheia-server/tests/security_rate_limit.rs
+++ b/crates/aletheia-server/tests/security_rate_limit.rs
@@ -323,15 +323,18 @@ async fn over_limit_429_is_structured_envelope_not_raw_text() {
         .expect("read body");
     let v: Value = serde_json::from_slice(&bytes)
         .expect("wrapped 429 body must be structured JSON, not raw governor text");
-    assert_eq!(v["success"], json!(false));
-    assert_eq!(v["code"], "RESOURCE_EXHAUSTED", "8b code: {v}");
+    assert!(
+        v.get("success").is_none(),
+        "flat `success` field dropped: {v}"
+    );
+    assert_eq!(v["error"]["code"], "RESOURCE_EXHAUSTED", "8b code: {v}");
     assert_eq!(
-        v["retriable"],
+        v["error"]["retriable"],
         json!(true),
         "rate-limit 429 is retriable: {v}"
     );
     assert!(
-        v["error"].is_string(),
+        v["error"]["message"].is_string(),
         "carries a human-readable message: {v}"
     );
     let raw = String::from_utf8_lossy(&bytes);

--- a/crates/aletheia-server/tests/security_rbac.rs
+++ b/crates/aletheia-server/tests/security_rbac.rs
@@ -266,17 +266,26 @@ fn permission_denied_message_is_byte_identical() {
 
     // via authorize_class
     let err = authorize_class(&reader, AccessClass::Write).expect_err("reader denied write");
-    let AletheiaHttpError::PermissionDenied(msg) = err else {
-        panic!("expected PermissionDenied");
-    };
-    assert_eq!(msg, "role 'reader' does not permit write access");
+    assert!(
+        matches!(err, AletheiaHttpError::PermissionDenied { .. }),
+        "expected PermissionDenied"
+    );
+    // The Display free text is byte-identical to the legacy message.
+    assert_eq!(
+        err.to_string(),
+        "role 'reader' does not permit write access"
+    );
 
     // via the marker-generic authorize::<C> (the shape Authorized<C> calls)
     let err = authorize::<WriteClass>(&reader).expect_err("reader denied write class");
-    let AletheiaHttpError::PermissionDenied(msg) = err else {
-        panic!("expected PermissionDenied");
-    };
-    assert_eq!(msg, "role 'reader' does not permit write access");
+    assert!(
+        matches!(err, AletheiaHttpError::PermissionDenied { .. }),
+        "expected PermissionDenied"
+    );
+    assert_eq!(
+        err.to_string(),
+        "role 'reader' does not permit write access"
+    );
 
     // A permitted class does not error.
     assert!(authorize::<ReadClass>(&reader).is_ok());
@@ -285,10 +294,14 @@ fn permission_denied_message_is_byte_identical() {
     // matrix guarantees: metrics role denied read.
     let metrics = principal_with_role(Role::Metrics);
     let err = authorize::<ReadClass>(&metrics).expect_err("metrics denied read");
-    let AletheiaHttpError::PermissionDenied(msg) = err else {
-        panic!("expected PermissionDenied");
-    };
-    assert_eq!(msg, "role 'metrics' does not permit read access");
+    assert!(
+        matches!(err, AletheiaHttpError::PermissionDenied { .. }),
+        "expected PermissionDenied"
+    );
+    assert_eq!(
+        err.to_string(),
+        "role 'metrics' does not permit read access"
+    );
     assert!(authorize::<MetricsClass>(&metrics).is_ok());
 }
 

--- a/crates/aletheia-server/tests/server_parity.rs
+++ b/crates/aletheia-server/tests/server_parity.rs
@@ -166,7 +166,7 @@ async fn status_unauthenticated_401_byte_parity() {
     let (l_status, l_body) = legacy_request(router, "GET", "/status", None, None).await;
     assert_eq!(s_status, 401);
     assert_eq!(s_status, l_status);
-    assert_eq!(s_body["code"], "UNAUTHENTICATED");
+    assert_eq!(s_body["error"]["code"], "UNAUTHENTICATED");
     assert_eq!(s_body, l_body, "uniform 401 must equal legacy");
 }
 
@@ -292,7 +292,11 @@ async fn admin_revoke_key_behavior() {
     )
     .await;
     assert_eq!(status, 404);
-    assert_eq!(body["success"], false);
+    assert!(
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
+    assert_eq!(body["error"]["code"], "NOT_FOUND");
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/crates/autumn-spike/src/auth.rs
+++ b/crates/autumn-spike/src/auth.rs
@@ -82,10 +82,10 @@ impl SpikeAuth {
                 if p.role.allows(class) {
                     Ok(())
                 } else {
-                    Err(AletheiaHttpError::PermissionDenied(format!(
-                        "role '{}' does not permit {} access",
-                        p.role, class
-                    )))
+                    Err(AletheiaHttpError::PermissionDenied {
+                        required_class: class,
+                        principal_role: p.role,
+                    })
                 }
             }
         }

--- a/crates/autumn-spike/src/handler.rs
+++ b/crates/autumn-spike/src/handler.rs
@@ -120,7 +120,7 @@ fn error_code(e: &AletheiaHttpError) -> &'static str {
         AletheiaHttpError::BadRequest(_) => "INVALID_ARGUMENT",
         AletheiaHttpError::NotFound(_) => "NOT_FOUND",
         AletheiaHttpError::Unauthorized => "UNAUTHENTICATED",
-        AletheiaHttpError::PermissionDenied(_) => "PERMISSION_DENIED",
+        AletheiaHttpError::PermissionDenied { .. } => "PERMISSION_DENIED",
         _ => "INTERNAL",
     }
 }

--- a/crates/autumn-spike/tests/autumn_spike_parity.rs
+++ b/crates/autumn-spike/tests/autumn_spike_parity.rs
@@ -124,7 +124,7 @@ async fn case_a_unauthenticated_returns_401_parity() {
     let (q_status, q_body) = query_get_node(db, store, node_id.as_u64(), None).await;
     assert_eq!(s_status, 401);
     assert_eq!(s_status, q_status);
-    assert_eq!(s_body["code"], "UNAUTHENTICATED");
+    assert_eq!(s_body["error"]["code"], "UNAUTHENTICATED");
     assert_eq!(
         s_body, q_body,
         "unauth error body must be byte-identical to POST /query"
@@ -165,7 +165,7 @@ async fn case_c_metrics_forbidden_parity() {
     let (q_status, q_body) = query_get_node(db, store, node_id.as_u64(), Some(METRICS_TOKEN)).await;
     assert_eq!(s_status, 403);
     assert_eq!(s_status, q_status);
-    assert_eq!(s_body["code"], "PERMISSION_DENIED");
+    assert_eq!(s_body["error"]["code"], "PERMISSION_DENIED");
     // HTTP's flat envelope carries NO `details` (it is thinner than MCP's #3234
     // envelope — see the spike doc). Parity holds by construction.
     assert!(s_body.get("details").is_none());
@@ -185,7 +185,10 @@ async fn case_d_missing_node_not_found_parity() {
     let (q_status, q_body) = query_get_node(db, store, 999_999, Some(READER_TOKEN)).await;
     assert_eq!(s_status, 404);
     assert_eq!(s_status, q_status);
-    assert_eq!(s_body["success"], false);
+    assert!(
+        s_body.get("success").is_none(),
+        "flat `success` field dropped: {s_body}"
+    );
     assert_eq!(
         s_body, q_body,
         "404 error body must be byte-identical to POST /query"
@@ -218,9 +221,15 @@ async fn case_e2_non_numeric_id_structured_envelope() {
     let (status, body) = spike_get(&client, "abc", Some(READER_TOKEN)).await;
     assert_eq!(status, 400);
     // Flat envelope, not axum's plain-text default.
-    assert_eq!(body["success"], false);
     assert!(
-        body["error"].as_str().unwrap().contains("invalid node id"),
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("invalid node id"),
         "structured body expected: {body}"
     );
 }
@@ -346,11 +355,11 @@ async fn case_h_mcp_tools_call_auth_failure_reflected() {
     let text = body["result"]["content"][0]["text"]
         .as_str()
         .expect("tool text");
-    // Text is `handler returned HTTP 403: {<flat error body>}` — parse the JSON.
+    // Text is `handler returned HTTP 403: {<nested error body>}` — parse the JSON.
     let start = text.find('{').expect("embedded error json");
     let inner: Value = serde_json::from_str(&text[start..]).expect("inner error json");
     assert_eq!(
-        inner["code"], "PERMISSION_DENIED",
+        inner["error"]["code"], "PERMISSION_DENIED",
         "tool error must carry the #3234 code, not a substring: {text}"
     );
 

--- a/docs/guides/access-control-matrix.md
+++ b/docs/guides/access-control-matrix.md
@@ -29,26 +29,36 @@ Defined by `Role::allows(AccessClass)` in `src/auth/role.rs`.
 
 ## Error contract
 
+> **Breaking change (HTTP error-envelope unification, Issue #3234):** the HTTP
+> error body is now the **same nested `{"error":{"code","message","retriable",
+> "details"?}}` envelope** the MCP surface emits, with `trace_id` (when present)
+> as a top-level sibling of `error`. The legacy flat body
+> (`{"success":false,"error":"<msg>","code":…}`) — the top-level `success` and
+> the flat `error` string — has been **removed**. Read `error.code` /
+> `error.message` / `error.retriable` / `error.details` instead of the old
+> top-level fields.
+
 - **Unauthenticated** (missing/unknown/revoked credential, `required` mode):
-  - HTTP: `401`, body `{"success":false,"error":"authentication required","code":"UNAUTHENTICATED"}` — byte-identical regardless of why authentication failed (no key-existence oracle).
+  - HTTP: `401`, body `{"error":{"code":"UNAUTHENTICATED","message":"authentication required","retriable":false}}` — byte-identical regardless of why authentication failed (no key-existence oracle).
   - MCP: structured error `{"error":{"code":"UNAUTHENTICATED","message":"authentication required","retriable":false}}` — uniform for **every** tool, including unknown tool names (the tool inventory is not revealed to unauthenticated callers). Never echoes the presented credential.
 - **Permission denied** (authenticated, role does not allow the class):
-  - HTTP: `403`, body `{"success":false,"error":"role '<role>' does not permit <class> access","code":"PERMISSION_DENIED"}`.
-  - MCP: `{"error":{"code":"PERMISSION_DENIED","message":"role '<role>' does not permit <class> access","retriable":false,"details":{"required_class":"<class>","principal_role":"<role>"}}}`.
+  - HTTP: `403`, body `{"error":{"code":"PERMISSION_DENIED","message":"role '<role>' does not permit <class> access","retriable":false,"details":{"required_class":"<class>","principal_role":"<role>"}}}`.
+  - MCP: `{"error":{"code":"PERMISSION_DENIED","message":"role '<role>' does not permit <class> access","retriable":false,"details":{"required_class":"<class>","principal_role":"<role>"}}}` — now identical to the HTTP body.
 
 Both codes are additive to the #3234 enum and are never retriable: obtain a
 valid credential / a sufficient role, then re-issue.
 
 - **Resource limit exceeded** (per-query limits, HTTP `/query`, Issue #3368):
   authentication and authorization run **first**, so these are only reachable
-  by an already-authorized caller.
-  - HTTP `429`, `code:"RESOURCE_EXHAUSTED"`, `retriable:true`,
-    `details:{dimension:"wall_clock_timeout", limit_ms}` — wall-clock timeout.
-  - HTTP `413`, `code:"RESOURCE_EXHAUSTED"`, `retriable:false`,
-    `details:{dimension:"result_rows"|"result_bytes", limit, consumed}` — result
+  by an already-authorized caller. All fields below live under the nested
+  `error` object (e.g. `error.code`, `error.details.dimension`).
+  - HTTP `429`, `error.code:"RESOURCE_EXHAUSTED"`, `error.retriable:true`,
+    `error.details:{dimension:"wall_clock_timeout", limit_ms}` — wall-clock timeout.
+  - HTTP `413`, `error.code:"RESOURCE_EXHAUSTED"`, `error.retriable:false`,
+    `error.details:{dimension:"result_rows"|"result_bytes", limit, consumed}` — result
     too large (row `Reject` policy / byte cap).
-  - HTTP `422`, `code:"INVALID_ARGUMENT"`, `retriable:false`,
-    `details:{dimension, requested, ceiling}` — a per-call `limits` override
+  - HTTP `422`, `error.code:"INVALID_ARGUMENT"`, `error.retriable:false`,
+    `error.details:{dimension, requested, ceiling}` — a per-call `limits` override
     exceeded the operator ceiling.
   - See [HTTP Per-Query Resource Limits](http-query-limits.md) for the full
     contract. (MCP parity is deferred to the MCP lane.)

--- a/docs/guides/http-query-limits.md
+++ b/docs/guides/http-query-limits.md
@@ -150,9 +150,12 @@ The merge is a single tested function
 
 ## Error contract
 
-All limit errors keep the existing `{success:false, error:"…"}` body and add the
-`code` / `retriable` / `details` fields (aligning the HTTP surface toward the MCP
-`#3234` contract). Existing non-limit error bodies are unchanged.
+Since the #3234 HTTP error-envelope unification, all limit errors render the
+nested `{"error":{"code","message","retriable","details"}}` body (byte-shape-
+identical to the MCP surface), with the active trace id carried additively as a
+top-level `trace_id` sibling of `error`. The legacy flat
+`{"success":false,"error":"…"}` body has been removed. Existing non-limit error
+bodies now use this same nested shape.
 
 ### `429` — wall-clock timeout
 

--- a/docs/guides/http-query-limits.md
+++ b/docs/guides/http-query-limits.md
@@ -160,13 +160,18 @@ Carries a `Retry-After: 1` response header. `retriable` is `true` for a read
 timeout and `false` for a write timeout (a committed write must not be
 duplicated — see [Write operations are exempt](#write-operations-are-exempt-from-the-result-caps)).
 
+Since the #3234 HTTP error-envelope unification the body is the nested
+`{"error":{…}}` shape (byte-shape-identical to MCP); the legacy flat
+`{"success":false,…}` body has been removed.
+
 ```json
 {
-  "success": false,
-  "error": "query exceeded the wall-clock timeout of 30000 ms",
-  "code": "RESOURCE_EXHAUSTED",
-  "retriable": true,
-  "details": { "dimension": "wall_clock_timeout", "limit_ms": 30000 }
+  "error": {
+    "code": "RESOURCE_EXHAUSTED",
+    "message": "query exceeded the wall-clock timeout of 30000 ms",
+    "retriable": true,
+    "details": { "dimension": "wall_clock_timeout", "limit_ms": 30000 }
+  }
 }
 ```
 
@@ -174,11 +179,12 @@ duplicated — see [Write operations are exempt](#write-operations-are-exempt-fr
 
 ```json
 {
-  "success": false,
-  "error": "query response exceeded the byte limit of 1048576 (serialized 2400512)",
-  "code": "RESOURCE_EXHAUSTED",
-  "retriable": false,
-  "details": { "dimension": "result_bytes", "limit": 1048576, "consumed": 2400512 }
+  "error": {
+    "code": "RESOURCE_EXHAUSTED",
+    "message": "query response exceeded the byte limit of 1048576 (serialized 2400512)",
+    "retriable": false,
+    "details": { "dimension": "result_bytes", "limit": 1048576, "consumed": 2400512 }
+  }
 }
 ```
 
@@ -203,11 +209,12 @@ pre-#3368 responses.
 
 ```json
 {
-  "success": false,
-  "error": "limit override for 'result_rows' (1000) exceeds the maximum allowed (100)",
-  "code": "INVALID_ARGUMENT",
-  "retriable": false,
-  "details": { "dimension": "result_rows", "requested": 1000, "ceiling": 100 }
+  "error": {
+    "code": "INVALID_ARGUMENT",
+    "message": "limit override for 'result_rows' (1000) exceeds the maximum allowed (100)",
+    "retriable": false,
+    "details": { "dimension": "result_rows", "requested": 1000, "ceiling": 100 }
+  }
 }
 ```
 

--- a/docs/guides/otel-tracing-guide.md
+++ b/docs/guides/otel-tracing-guide.md
@@ -133,9 +133,15 @@ middleware.
 
 Failures expose the active trace id for direct lookup in your backend: error
 responses carry a `trace_id` body field **and** an `x-trace-id` response header.
+Since the #3234 HTTP error-envelope unification the error is the nested
+`{"error":{…}}` shape, and `trace_id` remains a **top-level** sibling of `error`
+(the SDK reads it top-level):
 
 ```json
-{ "success": false, "error": "Node 999 not found", "trace_id": "0af7651916cd43dd8448eb211c80319c" }
+{
+  "error": { "code": "NOT_FOUND", "message": "Node 999 not found", "retriable": false },
+  "trace_id": "0af7651916cd43dd8448eb211c80319c"
+}
 ```
 
 ## Overhead

--- a/docs/guides/security-quickstart.md
+++ b/docs/guides/security-quickstart.md
@@ -157,6 +157,16 @@ can act on — see the
 [error-code contract](mcp-query-tool.md#structured-error-codes-and-the-retriable-contract)
 (`UNAUTHENTICATED` / `PERMISSION_DENIED`, both `retriable: false`).
 
+> **Breaking change (Issue #3234):** the **HTTP** error body now uses the same
+> nested envelope as the MCP surface —
+> `{"error":{"code","message","retriable","details"?}}`, with `trace_id` (when
+> present) a top-level sibling of `error`. The legacy flat HTTP body
+> (`{"success":false,"error":"<msg>","code":…}`) has been removed; read
+> `error.code` / `error.message` / `error.retriable` / `error.details`. A
+> `403 PERMISSION_DENIED` now also carries
+> `error.details:{required_class, principal_role}` on the HTTP surface, matching
+> MCP exactly. Success responses are unchanged (`{"success":true,"data":…}`).
+
 ## Step 4 — Audit and revoke
 
 Listing is **masked by construction** — the response can only carry the

--- a/src/http/auth.rs
+++ b/src/http/auth.rs
@@ -83,10 +83,10 @@ impl AuthContext {
                 if p.role.allows(class) {
                     Ok(())
                 } else {
-                    Err(AletheiaHttpError::PermissionDenied(format!(
-                        "role '{}' does not permit {} access",
-                        p.role, class
-                    )))
+                    Err(AletheiaHttpError::PermissionDenied {
+                        required_class: class,
+                        principal_role: p.role,
+                    })
                 }
             }
         }

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -4,6 +4,7 @@
 //! `Result<Json<ApiResponse>, AletheiaHttpError>` and get the right status
 //! code + JSON error body for free.
 
+use crate::auth::{AccessClass, Role};
 use crate::http::config::{LimitDimension, LimitOverrideError};
 use axum::Json;
 use axum::http::StatusCode;
@@ -110,8 +111,19 @@ pub enum AletheiaHttpError {
     Unauthorized,
 
     /// The authenticated principal's role does not allow this operation.
-    #[error("{0}")]
-    PermissionDenied(String),
+    ///
+    /// Carries the operation's required [`AccessClass`] and the principal's
+    /// [`Role`] so the error body can surface a structured
+    /// `details: {required_class, principal_role}` block (matching the MCP
+    /// surface, Issue #3234). The `Display` free text is byte-identical to the
+    /// legacy `"role '{role}' does not permit {class} access"` message.
+    #[error("role '{principal_role}' does not permit {required_class} access")]
+    PermissionDenied {
+        /// The access class the operation required.
+        required_class: AccessClass,
+        /// The authenticated principal's role.
+        principal_role: Role,
+    },
 
     /// A per-query resource limit (timeout / rows / bytes) was exceeded
     /// (Issue #3368). Renders `429` (timeout) or `413` (rows/bytes).
@@ -147,7 +159,7 @@ impl AletheiaHttpError {
             Self::NotFound(_) => StatusCode::NOT_FOUND,
             Self::Internal(_) | Self::StateMissing => StatusCode::INTERNAL_SERVER_ERROR,
             Self::Unauthorized => StatusCode::UNAUTHORIZED,
-            Self::PermissionDenied(_) => StatusCode::FORBIDDEN,
+            Self::PermissionDenied { .. } => StatusCode::FORBIDDEN,
             Self::InvalidLimitOverride(_) => StatusCode::UNPROCESSABLE_ENTITY,
             // Transient overload → 503 Service Unavailable (retriable).
             Self::InFlightCapacityExceeded { .. } => StatusCode::SERVICE_UNAVAILABLE,
@@ -162,38 +174,38 @@ impl AletheiaHttpError {
         }
     }
 
-    /// Stable machine-readable code (additive: present for auth errors since
-    /// Issue #3350 and for resource-limit errors since Issue #3368).
-    fn code(&self) -> Option<&'static str> {
+    /// Whether a caller may usefully retry. `true` only for transient failure
+    /// classes: a read-class wall-clock timeout (carried on the
+    /// [`ResourceLimitExceeded`] itself) and a full in-flight worker pool
+    /// (transient overload). A write-class timeout is not retriable (a
+    /// committed write must not be duplicated), and every caller-fault class
+    /// (bad-request, not-found, auth, override, row/byte caps) is `false`.
+    ///
+    /// Mirrors the MCP surface's explicit per-error classification (Issue
+    /// #3234): the nested error envelope always carries a concrete `retriable`
+    /// boolean.
+    fn retriable(&self) -> bool {
         match self {
-            Self::Unauthorized => Some("UNAUTHENTICATED"),
-            Self::PermissionDenied(_) => Some("PERMISSION_DENIED"),
-            Self::ResourceLimitExceeded(_) => Some("RESOURCE_EXHAUSTED"),
-            Self::InvalidLimitOverride(_) => Some("INVALID_ARGUMENT"),
-            Self::InFlightCapacityExceeded { .. } => Some("UNAVAILABLE"),
-            _ => None,
-        }
-    }
-
-    /// Whether a caller may usefully retry (additive; Issue #3368). The flag is
-    /// carried on the [`ResourceLimitExceeded`] itself: a read-class wall-clock
-    /// timeout is transient (`true`), a write-class timeout is not (a committed
-    /// write must not be duplicated), and row/byte caps are never retriable.
-    /// `None` where the flag does not apply (existing variants keep their
-    /// pre-#3368 body shape).
-    fn retriable(&self) -> Option<bool> {
-        match self {
-            Self::ResourceLimitExceeded(e) => Some(e.retriable),
-            Self::InvalidLimitOverride(_) => Some(false),
+            Self::ResourceLimitExceeded(e) => e.retriable,
             // Transient overload: backing off and retrying can succeed.
-            Self::InFlightCapacityExceeded { .. } => Some(true),
-            _ => None,
+            Self::InFlightCapacityExceeded { .. } => true,
+            _ => false,
         }
     }
 
-    /// Structured, per-code metadata (additive; Issue #3368).
+    /// Structured, per-code metadata (additive; Issue #3368 and, for
+    /// `PermissionDenied`, Issue #3234). Rendered under `error.details`.
     fn details(&self) -> Option<Value> {
         match self {
+            // A role denial names the required class and the principal's role,
+            // mirroring the MCP-surface 403 details (Issue #3234).
+            Self::PermissionDenied {
+                required_class,
+                principal_role,
+            } => Some(json!({
+                "required_class": required_class.to_string(),
+                "principal_role": principal_role.to_string(),
+            })),
             Self::ResourceLimitExceeded(e) => {
                 let mut d = json!({
                     "dimension": e.dimension.as_str(),
@@ -225,51 +237,46 @@ impl AletheiaHttpError {
     }
 
     /// Stable machine-readable code for *every* variant, using the Issue #3234
-    /// vocabulary. Used to stamp `aletheiadb.error.code` onto the trace span
-    /// (Issue #3376); the response body still only carries [`code`](Self::code)
-    /// for auth errors so the existing wire shape is unchanged.
+    /// vocabulary. Rendered as `error.code` in the response body (unified with
+    /// the MCP surface) and stamped as `aletheiadb.error.code` onto the trace
+    /// span (Issue #3376).
     #[must_use]
-    // Only consumed by the tracing span-stamping path, which is compiled out
-    // when `observability` is disabled; keep it available without warning.
-    #[cfg_attr(not(feature = "observability"), allow(dead_code))]
     pub(crate) fn code_str(&self) -> &'static str {
         match self {
             Self::BadRequest(_) | Self::QueryParse(_) => "INVALID_ARGUMENT",
             Self::NotFound(_) => "NOT_FOUND",
             Self::Internal(_) | Self::StateMissing => "INTERNAL",
             Self::Unauthorized => "UNAUTHENTICATED",
-            Self::PermissionDenied(_) => "PERMISSION_DENIED",
+            Self::PermissionDenied { .. } => "PERMISSION_DENIED",
             Self::ResourceLimitExceeded(_) => "RESOURCE_EXHAUSTED",
             Self::InvalidLimitOverride(_) => "INVALID_ARGUMENT",
             Self::InFlightCapacityExceeded { .. } => "UNAVAILABLE",
         }
     }
 
-    /// Convert to a response, additively including the active trace id
-    /// (Issue #3376) as a `trace_id` body field and `x-trace-id` header when
+    /// Convert to a response with the unified nested error envelope (Issue
+    /// #3234): `{"error": {"code", "message", "retriable", "details"?}}`,
+    /// byte-shape-identical to the MCP surface. The active trace id (Issue
+    /// #3376) is carried additively as a **top-level** `trace_id` sibling of
+    /// `error` (the SDK reads it top-level) and as an `x-trace-id` header when
     /// one is available, so a failing call can be looked up in the trace
     /// backend directly.
     #[must_use]
     pub(crate) fn into_response_with_trace(self, trace_id: Option<String>) -> Response {
         let status = self.status();
-        let mut body = json!({
-            "success": false,
-            "error": self.to_string(),
-        });
-        // Additive fields — only inserted when the variant defines them, so
-        // existing error bodies (bad-request, not-found, internal) are byte
-        // identical to their pre-#3368 shape.
-        if let Some(code) = self.code() {
-            body["code"] = json!(code);
-        }
-        if let Some(retriable) = self.retriable() {
-            body["retriable"] = json!(retriable);
-        }
+        // Build the nested `error` object, mirroring `McpError::to_json`'s
+        // field order: code, message, retriable, then optional details.
+        let mut error_obj = serde_json::Map::new();
+        error_obj.insert("code".to_string(), json!(self.code_str()));
+        error_obj.insert("message".to_string(), json!(self.to_string()));
+        error_obj.insert("retriable".to_string(), json!(self.retriable()));
         if let Some(details) = self.details() {
-            body["details"] = details;
+            error_obj.insert("details".to_string(), details);
         }
-        // Additively carry the active trace id (Issue #3376) as a `trace_id`
-        // body field so a failing call can be correlated in the trace backend.
+        let mut body = json!({ "error": Value::Object(error_obj) });
+        // Additively carry the active trace id (Issue #3376) as a *top-level*
+        // `trace_id` field (sibling of `error`, not nested) so a failing call
+        // can be correlated in the trace backend and the SDK can read it.
         if let (Some(map), Some(tid)) = (body.as_object_mut(), trace_id.as_deref()) {
             map.insert("trace_id".to_string(), json!(tid));
         }
@@ -338,12 +345,20 @@ mod tests {
         ))
         .await;
         assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
-        assert_eq!(body["success"], false);
-        assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
-        assert_eq!(body["retriable"], true);
-        assert_eq!(body["details"]["dimension"], "wall_clock_timeout");
-        assert_eq!(body["details"]["limit_ms"], 100);
-        assert!(body["error"].as_str().unwrap().contains("timeout"));
+        assert!(
+            body.get("success").is_none(),
+            "flat `success` field dropped"
+        );
+        assert_eq!(body["error"]["code"], "RESOURCE_EXHAUSTED");
+        assert_eq!(body["error"]["retriable"], true);
+        assert_eq!(body["error"]["details"]["dimension"], "wall_clock_timeout");
+        assert_eq!(body["error"]["details"]["limit_ms"], 100);
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("timeout")
+        );
     }
 
     #[tokio::test]
@@ -358,11 +373,11 @@ mod tests {
         ))
         .await;
         assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
-        assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
-        assert_eq!(body["retriable"], false);
-        assert_eq!(body["details"]["dimension"], "result_bytes");
-        assert_eq!(body["details"]["limit"], 1024);
-        assert_eq!(body["details"]["consumed"], 4096);
+        assert_eq!(body["error"]["code"], "RESOURCE_EXHAUSTED");
+        assert_eq!(body["error"]["retriable"], false);
+        assert_eq!(body["error"]["details"]["dimension"], "result_bytes");
+        assert_eq!(body["error"]["details"]["limit"], 1024);
+        assert_eq!(body["error"]["details"]["consumed"], 4096);
     }
 
     #[tokio::test]
@@ -377,8 +392,8 @@ mod tests {
         ))
         .await;
         assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
-        assert_eq!(body["details"]["dimension"], "result_rows");
-        assert_eq!(body["details"]["consumed"], 25);
+        assert_eq!(body["error"]["details"]["dimension"], "result_rows");
+        assert_eq!(body["error"]["details"]["consumed"], 25);
     }
 
     /// A write-class wall-clock timeout renders `429` but `retriable: false`
@@ -396,12 +411,12 @@ mod tests {
         ))
         .await;
         assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
-        assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
+        assert_eq!(body["error"]["code"], "RESOURCE_EXHAUSTED");
         assert_eq!(
-            body["retriable"], false,
+            body["error"]["retriable"], false,
             "a write timeout must not invite a duplicate retry"
         );
-        assert_eq!(body["details"]["dimension"], "wall_clock_timeout");
+        assert_eq!(body["error"]["details"]["dimension"], "wall_clock_timeout");
     }
 
     #[tokio::test]
@@ -415,11 +430,11 @@ mod tests {
         ))
         .await;
         assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
-        assert_eq!(body["code"], "INVALID_ARGUMENT");
-        assert_eq!(body["retriable"], false);
-        assert_eq!(body["details"]["dimension"], "wall_clock_timeout");
-        assert_eq!(body["details"]["requested"], 999);
-        assert_eq!(body["details"]["ceiling"], 100);
+        assert_eq!(body["error"]["code"], "INVALID_ARGUMENT");
+        assert_eq!(body["error"]["retriable"], false);
+        assert_eq!(body["error"]["details"]["dimension"], "wall_clock_timeout");
+        assert_eq!(body["error"]["details"]["requested"], 999);
+        assert_eq!(body["error"]["details"]["ceiling"], 100);
     }
 
     /// The in-flight-capacity guard renders `503 UNAVAILABLE`, `retriable:
@@ -439,33 +454,49 @@ mod tests {
         );
         let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
         let body: Value = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(body["success"], false);
-        assert_eq!(body["code"], "UNAVAILABLE");
-        assert_eq!(body["retriable"], true);
-        assert_eq!(body["details"]["reason"], "in_flight_query_cap");
-        assert_eq!(body["details"]["max_in_flight_queries"], 64);
-        assert!(body["error"].as_str().unwrap().contains("cap of 64"));
+        assert!(
+            body.get("success").is_none(),
+            "flat `success` field dropped"
+        );
+        assert_eq!(body["error"]["code"], "UNAVAILABLE");
+        assert_eq!(body["error"]["retriable"], true);
+        assert_eq!(body["error"]["details"]["reason"], "in_flight_query_cap");
+        assert_eq!(body["error"]["details"]["max_in_flight_queries"], 64);
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("cap of 64")
+        );
     }
 
     #[tokio::test]
-    async fn existing_variants_keep_minimal_body_shape() {
-        // No `code`/`retriable`/`details` for a plain bad-request (unchanged).
+    async fn bad_request_renders_nested_invalid_argument() {
+        // The nested envelope now always carries code/message/retriable; a
+        // plain bad-request has no `details` and is never retriable.
         let (status, body) = body_json(AletheiaHttpError::BadRequest("nope".into())).await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
-        assert_eq!(body["success"], false);
-        assert_eq!(body["error"], "nope");
-        assert!(body.get("code").is_none());
-        assert!(body.get("retriable").is_none());
-        assert!(body.get("details").is_none());
+        assert!(
+            body.get("success").is_none(),
+            "flat `success` field dropped"
+        );
+        assert_eq!(body["error"]["code"], "INVALID_ARGUMENT");
+        assert_eq!(body["error"]["message"], "nope");
+        assert_eq!(body["error"]["retriable"], false);
+        assert!(body["error"].get("details").is_none());
     }
 
     #[tokio::test]
-    async fn auth_error_body_unchanged_still_has_code_only() {
+    async fn auth_error_renders_nested_unauthenticated() {
         let (status, body) = body_json(AletheiaHttpError::Unauthorized).await;
         assert_eq!(status, StatusCode::UNAUTHORIZED);
-        assert_eq!(body["code"], "UNAUTHENTICATED");
-        // Auth variants deliberately keep their pre-#3368 shape (no retriable).
-        assert!(body.get("retriable").is_none());
-        assert!(body.get("details").is_none());
+        assert!(
+            body.get("success").is_none(),
+            "flat `success` field dropped"
+        );
+        assert_eq!(body["error"]["code"], "UNAUTHENTICATED");
+        assert_eq!(body["error"]["message"], "authentication required");
+        assert_eq!(body["error"]["retriable"], false);
+        assert!(body["error"].get("details").is_none());
     }
 }

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -243,13 +243,14 @@ impl AletheiaHttpError {
     #[must_use]
     pub(crate) fn code_str(&self) -> &'static str {
         match self {
-            Self::BadRequest(_) | Self::QueryParse(_) => "INVALID_ARGUMENT",
+            Self::BadRequest(_) | Self::QueryParse(_) | Self::InvalidLimitOverride(_) => {
+                "INVALID_ARGUMENT"
+            }
             Self::NotFound(_) => "NOT_FOUND",
             Self::Internal(_) | Self::StateMissing => "INTERNAL",
             Self::Unauthorized => "UNAUTHENTICATED",
             Self::PermissionDenied { .. } => "PERMISSION_DENIED",
             Self::ResourceLimitExceeded(_) => "RESOURCE_EXHAUSTED",
-            Self::InvalidLimitOverride(_) => "INVALID_ARGUMENT",
             Self::InFlightCapacityExceeded { .. } => "UNAVAILABLE",
         }
     }

--- a/tests/http_api.rs
+++ b/tests/http_api.rs
@@ -303,9 +303,13 @@ async fn bulk_execute_query_enforces_total_row_budget() {
     .await;
 
     assert_eq!(status, 400, "expected request-level row budget rejection");
-    assert_eq!(body["success"], false);
     assert!(
-        body["error"]
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
+    assert_eq!(body["error"]["code"], "INVALID_ARGUMENT");
+    assert!(
+        body["error"]["message"]
             .as_str()
             .unwrap_or_default()
             .contains("result budget exceeded")

--- a/tests/http_auth.rs
+++ b/tests/http_auth.rs
@@ -83,9 +83,17 @@ async fn missing_credential_returns_401_with_uniform_body() {
     assert_eq!(www, "Bearer");
 
     let body: Value = serde_json::from_slice(&resp.body).expect("json body");
-    assert_eq!(body["success"], false);
-    assert_eq!(body["code"], "UNAUTHENTICATED");
-    assert!(!body["error"].as_str().expect("error string").is_empty());
+    assert!(
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
+    assert_eq!(body["error"]["code"], "UNAUTHENTICATED");
+    assert!(
+        !body["error"]["message"]
+            .as_str()
+            .expect("error string")
+            .is_empty()
+    );
 }
 
 #[tokio::test]
@@ -192,7 +200,7 @@ async fn malformed_authorization_shadows_valid_x_api_key() {
         "a malformed Authorization header must not fall back to x-api-key"
     );
     let body: Value = serde_json::from_slice(&resp.body).expect("json body");
-    assert_eq!(body["code"], "UNAUTHENTICATED");
+    assert_eq!(body["error"]["code"], "UNAUTHENTICATED");
 }
 
 /// When BOTH headers carry valid keys, `Authorization` wins. Observable via
@@ -217,9 +225,9 @@ async fn authorization_header_wins_over_x_api_key_when_both_valid() {
         "Authorization (reader) must win over x-api-key (writer)"
     );
     let body: Value = serde_json::from_slice(&resp.body).expect("json body");
-    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert_eq!(body["error"]["code"], "PERMISSION_DENIED");
     assert!(
-        body["error"]
+        body["error"]["message"]
             .as_str()
             .expect("error string")
             .contains("reader"),
@@ -311,7 +319,7 @@ async fn every_registered_route_returns_uniform_401_without_credential() {
             route.path
         );
         let body: Value = serde_json::from_slice(&resp.body).expect("json 401 body");
-        assert_eq!(body["code"], "UNAUTHENTICATED");
+        assert_eq!(body["error"]["code"], "UNAUTHENTICATED");
         match &reference_body {
             None => reference_body = Some(resp.body.clone()),
             Some(reference) => assert_eq!(
@@ -368,9 +376,9 @@ async fn non_admin_roles_get_403_on_every_admin_route() {
                 route.path
             );
             let body: Value = serde_json::from_slice(&resp.body).expect("json 403 body");
-            assert_eq!(body["code"], "PERMISSION_DENIED");
+            assert_eq!(body["error"]["code"], "PERMISSION_DENIED");
             assert!(
-                body["error"]
+                body["error"]["message"]
                     .as_str()
                     .expect("error string")
                     .contains(role_name),
@@ -414,8 +422,11 @@ async fn reader_can_read_but_not_write() {
     // create_node: 403 PERMISSION_DENIED.
     let (status, body) = post_query_with_key(&client, &key, &create_node_op()).await;
     assert_eq!(status, 403);
-    assert_eq!(body["success"], false);
-    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert!(
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
+    assert_eq!(body["error"]["code"], "PERMISSION_DENIED");
 
     // bulk_delete_nodes: 403 PERMISSION_DENIED.
     let (status, body) = post_query_with_key(
@@ -425,7 +436,7 @@ async fn reader_can_read_but_not_write() {
     )
     .await;
     assert_eq!(status, 403);
-    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert_eq!(body["error"]["code"], "PERMISSION_DENIED");
 
     // The node must still exist (authorization happened before any DB work).
     assert!(db.get_node(node_id).is_ok());
@@ -449,7 +460,7 @@ async fn metrics_role_can_probe_status_but_not_read_data() {
     // /query read: 403.
     let (status, body) = post_query_with_key(&client, &key, &find_node_op()).await;
     assert_eq!(status, 403);
-    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert_eq!(body["error"]["code"], "PERMISSION_DENIED");
 }
 
 #[tokio::test]
@@ -494,7 +505,7 @@ async fn writer_can_read_and_write_but_not_admin() {
         .await;
     assert_eq!(revoke.status.as_u16(), 403);
     let body: Value = serde_json::from_slice(&revoke.body).expect("json");
-    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert_eq!(body["error"]["code"], "PERMISSION_DENIED");
 }
 
 #[tokio::test]
@@ -550,7 +561,7 @@ async fn reader_gets_403_for_mutating_execute_query() {
     )
     .await;
     assert_eq!(status, 403, "mutating statement must need Write: {body}");
-    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert_eq!(body["error"]["code"], "PERMISSION_DENIED");
 }
 
 // ---------------------------------------------------------------------------
@@ -624,7 +635,7 @@ async fn admin_key_lifecycle_end_to_end() {
     // 5. The same key is now rejected with the uniform 401.
     let (status, body) = post_query_with_key(&client, &reader_key, &find_node_op()).await;
     assert_eq!(status, 401);
-    assert_eq!(body["code"], "UNAUTHENTICATED");
+    assert_eq!(body["error"]["code"], "UNAUTHENTICATED");
 }
 
 /// Invalid create-key input (empty or overlong name) is a 400 BadRequest,
@@ -648,7 +659,10 @@ async fn create_key_with_invalid_name_returns_400() {
             name.len()
         );
         let body: Value = serde_json::from_slice(&resp.body).expect("json body");
-        assert_eq!(body["success"], false);
+        assert!(
+            body.get("success").is_none(),
+            "flat `success` field dropped: {body}"
+        );
     }
 
     // No key was minted by the rejected requests.

--- a/tests/http_provenance_where.rs
+++ b/tests/http_provenance_where.rs
@@ -124,5 +124,12 @@ async fn provenance_type_mismatch_fails_closed_over_http() {
         "type-misused accessor must be a structured error, not a silent empty result: \
          status={status} body={body}"
     );
-    assert_eq!(body["success"], false, "{body}");
+    assert!(
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
+    assert!(
+        body["error"]["code"].is_string(),
+        "structured nested error envelope expected: {body}"
+    );
 }

--- a/tests/http_query_limits.rs
+++ b/tests/http_query_limits.rs
@@ -154,12 +154,15 @@ async fn row_cap_reject_returns_413_with_details() {
         status, 413,
         "reject policy must error, not truncate: {body}"
     );
-    assert_eq!(body["success"], false);
-    assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
-    assert_eq!(body["retriable"], false);
-    assert_eq!(body["details"]["dimension"], "result_rows");
-    assert_eq!(body["details"]["limit"], 2);
-    assert_eq!(body["details"]["consumed"], 5);
+    assert!(
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
+    assert_eq!(body["error"]["code"], "RESOURCE_EXHAUSTED");
+    assert_eq!(body["error"]["retriable"], false);
+    assert_eq!(body["error"]["details"]["dimension"], "result_rows");
+    assert_eq!(body["error"]["details"]["limit"], 2);
+    assert_eq!(body["error"]["details"]["consumed"], 5);
 }
 
 // ---------------------------------------------------------------------------
@@ -184,13 +187,16 @@ async fn byte_cap_exceeded_returns_413_with_details() {
 
     let (status, body) = post_query(&client, &find_people()).await;
     assert_eq!(status, 413, "oversized response must be rejected: {body}");
-    assert_eq!(body["success"], false);
-    assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
-    assert_eq!(body["retriable"], false);
-    assert_eq!(body["details"]["dimension"], "result_bytes");
-    assert_eq!(body["details"]["limit"], 16);
     assert!(
-        body["details"]["consumed"].as_u64().unwrap() > 16,
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
+    assert_eq!(body["error"]["code"], "RESOURCE_EXHAUSTED");
+    assert_eq!(body["error"]["retriable"], false);
+    assert_eq!(body["error"]["details"]["dimension"], "result_bytes");
+    assert_eq!(body["error"]["details"]["limit"], 16);
+    assert!(
+        body["error"]["details"]["consumed"].as_u64().unwrap() > 16,
         "consumed must report the actual serialized size"
     );
 }
@@ -262,12 +268,15 @@ async fn override_above_ceiling_returns_422() {
         status, 422,
         "over-ceiling override must be rejected: {body}"
     );
-    assert_eq!(body["success"], false);
-    assert_eq!(body["code"], "INVALID_ARGUMENT");
-    assert_eq!(body["retriable"], false);
-    assert_eq!(body["details"]["dimension"], "result_rows");
-    assert_eq!(body["details"]["requested"], 1000);
-    assert_eq!(body["details"]["ceiling"], 100);
+    assert!(
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
+    assert_eq!(body["error"]["code"], "INVALID_ARGUMENT");
+    assert_eq!(body["error"]["retriable"], false);
+    assert_eq!(body["error"]["details"]["dimension"], "result_rows");
+    assert_eq!(body["error"]["details"]["requested"], 1000);
+    assert_eq!(body["error"]["details"]["ceiling"], 100);
 }
 
 /// A timeout override above the ceiling is likewise rejected 422 (dimension =
@@ -286,8 +295,8 @@ async fn timeout_override_above_ceiling_returns_422() {
     )
     .await;
     assert_eq!(status, 422);
-    assert_eq!(body["code"], "INVALID_ARGUMENT");
-    assert_eq!(body["details"]["dimension"], "wall_clock_timeout");
+    assert_eq!(body["error"]["code"], "INVALID_ARGUMENT");
+    assert_eq!(body["error"]["details"]["dimension"], "wall_clock_timeout");
 }
 
 // ---------------------------------------------------------------------------
@@ -381,7 +390,7 @@ async fn authenticated_request_gets_same_limit_behavior() {
         status, 422,
         "authenticated over-ceiling override → 422: {body}"
     );
-    assert_eq!(body["code"], "INVALID_ARGUMENT");
+    assert_eq!(body["error"]["code"], "INVALID_ARGUMENT");
 }
 
 /// An unauthenticated request that ALSO breaches a limit is rejected 401 —
@@ -413,7 +422,7 @@ async fn unauthenticated_over_limit_request_is_401_not_422() {
     )
     .await;
     assert_eq!(status, 401, "auth must reject before limit logic: {body}");
-    assert_eq!(body["code"], "UNAUTHENTICATED");
+    assert_eq!(body["error"]["code"], "UNAUTHENTICATED");
 }
 
 // ---------------------------------------------------------------------------
@@ -671,11 +680,11 @@ async fn concurrent_requests_with_distinct_overrides_are_isolated() {
 
     // B: byte-cap 413.
     assert_eq!(b.0, 413, "B: {}", b.1);
-    assert_eq!(b.1["details"]["dimension"], "result_bytes");
+    assert_eq!(b.1["error"]["details"]["dimension"], "result_bytes");
 
     // C: over-ceiling 422.
     assert_eq!(c.0, 422, "C: {}", c.1);
-    assert_eq!(c.1["details"]["dimension"], "result_rows");
+    assert_eq!(c.1["error"]["details"]["dimension"], "result_rows");
 
     // D: full, untruncated.
     assert_eq!(d.0, 200, "D: {}", d.1);
@@ -721,5 +730,5 @@ async fn authorized_check_precedes_limit_validation() {
         status, 403,
         "role denial must precede limit validation: {body}"
     );
-    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert_eq!(body["error"]["code"], "PERMISSION_DENIED");
 }

--- a/tests/parity_http.rs
+++ b/tests/parity_http.rs
@@ -192,8 +192,11 @@ async fn status_requires_credential_in_required_mode() {
     assert_eq!(resp.status.as_u16(), 401);
     assert_eq!(resp.header("www-authenticate"), Some("Bearer"));
     let body: Value = serde_json::from_slice(&resp.body).expect("json");
-    assert_eq!(body["success"], false);
-    assert_eq!(body["code"], "UNAUTHENTICATED");
+    assert!(
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
+    assert_eq!(body["error"]["code"], "UNAUTHENTICATED");
 }
 
 // ===========================================================================
@@ -218,9 +221,10 @@ async fn query_success_envelope_shape() {
     );
 }
 
-/// PARITY: a not-found lookup is a 404 whose body keeps the MINIMAL error
-/// envelope — `{success:false, error:<string>}` with NO additive
-/// `code`/`retriable`/`details` fields (those are auth/limit-only).
+/// PARITY: a not-found lookup is a 404 whose body carries the unified nested
+/// error envelope — `{error:{code, message, retriable, details?}}` (Issue
+/// #3234), byte-shape-identical to the MCP surface. `code = NOT_FOUND`,
+/// `retriable = false`, no `details`, and the flat `success` field is gone.
 #[tokio::test]
 async fn query_not_found_minimal_error_envelope() {
     let (client, _db) = anon_client();
@@ -230,25 +234,26 @@ async fn query_not_found_minimal_error_envelope() {
     )
     .await;
     assert_eq!(status, 404);
-    assert_eq!(body["success"], false);
     assert!(
-        body["error"].as_str().is_some_and(|s| !s.is_empty()),
-        "error must be a non-empty string: {body}"
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
     );
-    assert!(body.get("code").is_none(), "404 carries no `code`: {body}");
+    assert_eq!(body["error"]["code"], "NOT_FOUND");
     assert!(
-        body.get("retriable").is_none(),
-        "404 carries no `retriable`: {body}"
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()),
+        "error.message must be a non-empty string: {body}"
     );
+    assert_eq!(body["error"]["retriable"], false);
     assert!(
-        body.get("details").is_none(),
+        body["error"].get("details").is_none(),
         "404 carries no `details`: {body}"
     );
 
-    // Exact top-level key-set pin: the minimal error envelope is EXACTLY
-    // `{success, error}` — an ADDED field (e.g. a leaked `code`/`trace_id`)
-    // is caught here. Additive fields (code/details/retriable) are
-    // deliberately kept off this path so this exact-key-set pin is valid.
+    // Exact top-level key-set pin: the unified error envelope is EXACTLY
+    // `{error}` (no `trace_id` without the observability feature). An ADDED
+    // top-level field (e.g. a leaked flat `code`/`success`) is caught here.
     let keys: std::collections::BTreeSet<&str> = body
         .as_object()
         .expect("error body is an object")
@@ -257,16 +262,16 @@ async fn query_not_found_minimal_error_envelope() {
         .collect();
     assert_eq!(
         keys,
-        std::collections::BTreeSet::from(["success", "error"]),
-        "minimal 404 error envelope must carry exactly {{success, error}}: {body}"
+        std::collections::BTreeSet::from(["error"]),
+        "unified 404 error envelope must carry exactly {{error}} at top level: {body}"
     );
 }
 
 /// PARITY: a malformed operation payload is a clean 400 client error (never a
 /// 500). A nested-object property is rejected before any DB work (BadRequest →
-/// 400) and keeps the MINIMAL `{success:false, error:<string>}` envelope with
-/// NO additive `code`/`retriable`/`details` (consistent with the not-found
-/// case; those additive fields are auth/limit-only).
+/// 400) and carries the unified nested envelope `{error:{code, message,
+/// retriable}}` with `code = INVALID_ARGUMENT`, `retriable = false`, and no
+/// `details` (consistent with the not-found case).
 #[tokio::test]
 async fn query_malformed_payload_is_400_not_500() {
     let (client, _db) = anon_client();
@@ -283,18 +288,20 @@ async fn query_malformed_payload_is_400_not_500() {
         status, 400,
         "nested property must be a 400 client error, got {status}: {body}"
     );
-    assert_eq!(body["success"], false);
     assert!(
-        body["error"].as_str().is_some_and(|s| !s.is_empty()),
-        "error must be a non-empty string: {body}"
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
     );
-    assert!(body.get("code").is_none(), "400 carries no `code`: {body}");
+    assert_eq!(body["error"]["code"], "INVALID_ARGUMENT");
     assert!(
-        body.get("retriable").is_none(),
-        "400 carries no `retriable`: {body}"
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()),
+        "error.message must be a non-empty string: {body}"
     );
+    assert_eq!(body["error"]["retriable"], false);
     assert!(
-        body.get("details").is_none(),
+        body["error"].get("details").is_none(),
         "400 carries no `details`: {body}"
     );
 }
@@ -330,11 +337,16 @@ async fn query_missing_credential_is_uniform_401() {
     assert_eq!(resp.status.as_u16(), 401);
     assert_eq!(resp.header("www-authenticate"), Some("Bearer"));
     let body: Value = serde_json::from_slice(&resp.body).expect("json");
-    assert_eq!(body["success"], false);
-    assert_eq!(body["code"], "UNAUTHENTICATED");
     assert!(
-        body["error"].as_str().is_some_and(|s| !s.is_empty()),
-        "uniform 401 keeps a non-empty error string: {body}"
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
+    assert_eq!(body["error"]["code"], "UNAUTHENTICATED");
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()),
+        "uniform 401 keeps a non-empty error.message string: {body}"
     );
 }
 
@@ -350,8 +362,11 @@ async fn query_reader_write_is_403_permission_denied() {
     )
     .await;
     assert_eq!(status, 403, "reader may not write: {body}");
-    assert_eq!(body["success"], false);
-    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert!(
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
+    assert_eq!(body["error"]["code"], "PERMISSION_DENIED");
 }
 
 // --- /query resource limits (Issue #3368) ---
@@ -377,12 +392,15 @@ async fn query_row_cap_reject_is_413_resource_exhausted() {
 
     let (status, body) = post_query(&client, &find_people()).await;
     assert_eq!(status, 413, "reject policy over cap → 413: {body}");
-    assert_eq!(body["success"], false);
-    assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
-    assert_eq!(body["retriable"], false);
-    assert_eq!(body["details"]["dimension"], "result_rows");
-    assert_eq!(body["details"]["limit"], 2);
-    assert_eq!(body["details"]["consumed"], 5);
+    assert!(
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
+    assert_eq!(body["error"]["code"], "RESOURCE_EXHAUSTED");
+    assert_eq!(body["error"]["retriable"], false);
+    assert_eq!(body["error"]["details"]["dimension"], "result_rows");
+    assert_eq!(body["error"]["details"]["limit"], 2);
+    assert_eq!(body["error"]["details"]["consumed"], 5);
 }
 
 /// PARITY: result-byte cap → 413 with `details.dimension = result_bytes` and a
@@ -405,15 +423,18 @@ async fn query_byte_cap_is_413_resource_exhausted() {
 
     let (status, body) = post_query(&client, &find_people()).await;
     assert_eq!(status, 413, "oversized response → 413: {body}");
-    assert_eq!(body["success"], false);
-    assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
+    assert!(
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
+    assert_eq!(body["error"]["code"], "RESOURCE_EXHAUSTED");
     assert_eq!(
-        body["retriable"], false,
+        body["error"]["retriable"], false,
         "a byte cap is never retriable (symmetry with the row cap): {body}"
     );
-    assert_eq!(body["details"]["dimension"], "result_bytes");
-    assert_eq!(body["details"]["limit"], 16);
-    assert!(body["details"]["consumed"].as_u64().unwrap() > 16);
+    assert_eq!(body["error"]["details"]["dimension"], "result_bytes");
+    assert_eq!(body["error"]["details"]["limit"], 16);
+    assert!(body["error"]["details"]["consumed"].as_u64().unwrap() > 16);
 }
 
 /// PARITY: a per-call limit override above the operator ceiling is rejected
@@ -444,12 +465,15 @@ async fn query_over_ceiling_override_is_422_invalid_argument() {
     )
     .await;
     assert_eq!(status, 422, "over-ceiling override → 422: {body}");
-    assert_eq!(body["success"], false);
-    assert_eq!(body["code"], "INVALID_ARGUMENT");
-    assert_eq!(body["retriable"], false);
-    assert_eq!(body["details"]["dimension"], "result_rows");
-    assert_eq!(body["details"]["requested"], 1000);
-    assert_eq!(body["details"]["ceiling"], 100);
+    assert!(
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
+    assert_eq!(body["error"]["code"], "INVALID_ARGUMENT");
+    assert_eq!(body["error"]["retriable"], false);
+    assert_eq!(body["error"]["details"]["dimension"], "result_rows");
+    assert_eq!(body["error"]["details"]["requested"], 1000);
+    assert_eq!(body["error"]["details"]["ceiling"], 100);
 }
 
 /// PARITY: auth is evaluated BEFORE limit validation — an unauthenticated
@@ -485,7 +509,7 @@ async fn query_auth_precedes_limit_validation() {
     )
     .await;
     assert_eq!(status, 401, "auth rejects before limit logic: {body}");
-    assert_eq!(body["code"], "UNAUTHENTICATED");
+    assert_eq!(body["error"]["code"], "UNAUTHENTICATED");
 }
 
 // ===========================================================================
@@ -530,7 +554,7 @@ async fn admin_create_key_non_admin_is_403() {
         .await;
     assert_eq!(resp.status.as_u16(), 403);
     let body: Value = serde_json::from_slice(&resp.body).expect("json");
-    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert_eq!(body["error"]["code"], "PERMISSION_DENIED");
 }
 
 /// PARITY: invalid create-key input (empty name) is a 400 (repairable client
@@ -547,7 +571,10 @@ async fn admin_create_key_invalid_name_is_400() {
         .await;
     assert_eq!(resp.status.as_u16(), 400);
     let body: Value = serde_json::from_slice(&resp.body).expect("json");
-    assert_eq!(body["success"], false);
+    assert!(
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
 }
 
 // ===========================================================================
@@ -614,7 +641,7 @@ async fn admin_list_keys_non_admin_is_403() {
         .await;
     assert_eq!(resp.status.as_u16(), 403);
     let body: Value = serde_json::from_slice(&resp.body).expect("json");
-    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert_eq!(body["error"]["code"], "PERMISSION_DENIED");
 }
 
 // ===========================================================================
@@ -652,12 +679,11 @@ async fn admin_revoke_key_success_and_immediate_effect() {
     // Immediate revocation: the key is now a uniform 401.
     let (status, body) = post_query_key(&client, &victim_key, &find_people()).await;
     assert_eq!(status, 401);
-    assert_eq!(body["code"], "UNAUTHENTICATED");
+    assert_eq!(body["error"]["code"], "UNAUTHENTICATED");
 }
 
-/// PARITY: revoking an unknown id → 404 with the MINIMAL
-/// `{success:false, error:<string>}` envelope (NotFound → no additive
-/// `code`/`retriable`/`details`).
+/// PARITY: revoking an unknown id → 404 with the unified nested envelope
+/// `{error:{code:NOT_FOUND, message, retriable:false}}` (Issue #3234).
 #[tokio::test]
 async fn admin_revoke_unknown_id_is_404() {
     let (client, store, _db) = required_client();
@@ -670,16 +696,18 @@ async fn admin_revoke_unknown_id_is_404() {
         .await;
     assert_eq!(resp.status.as_u16(), 404);
     let body: Value = serde_json::from_slice(&resp.body).expect("json");
-    assert_eq!(body["success"], false);
     assert!(
-        body["error"].as_str().is_some_and(|s| !s.is_empty()),
-        "error must be a non-empty string: {body}"
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
     );
-    assert!(body.get("code").is_none(), "404 carries no `code`: {body}");
+    assert_eq!(body["error"]["code"], "NOT_FOUND");
     assert!(
-        body.get("retriable").is_none(),
-        "404 carries no `retriable`: {body}"
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()),
+        "error.message must be a non-empty string: {body}"
     );
+    assert_eq!(body["error"]["retriable"], false);
 }
 
 /// PARITY: a non-admin role → 403 on the revoke route.
@@ -695,7 +723,7 @@ async fn admin_revoke_non_admin_is_403() {
         .await;
     assert_eq!(resp.status.as_u16(), 403);
     let body: Value = serde_json::from_slice(&resp.body).expect("json");
-    assert_eq!(body["code"], "PERMISSION_DENIED");
+    assert_eq!(body["error"]["code"], "PERMISSION_DENIED");
 }
 
 // ===========================================================================
@@ -957,9 +985,16 @@ async fn find_node_invalid_confidence_is_400() {
     )
     .await;
     assert_eq!(status, 400);
-    assert_eq!(body["success"].as_bool(), Some(false));
     assert!(
-        body["error"].as_str().unwrap().contains("min_confidence"),
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
+    assert_eq!(body["error"]["code"], "INVALID_ARGUMENT");
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("min_confidence"),
         "error must name the field: {body}"
     );
 }
@@ -977,7 +1012,7 @@ async fn find_node_empty_source_list_is_400() {
     .await;
     assert_eq!(status, 400);
     assert!(
-        body["error"]
+        body["error"]["message"]
             .as_str()
             .unwrap()
             .contains("provenance_sources")
@@ -1189,9 +1224,16 @@ async fn find_neighbors_invalid_confidence_is_400() {
     )
     .await;
     assert_eq!(status, 400, "out-of-range confidence must be a 400: {body}");
-    assert_eq!(body["success"].as_bool(), Some(false));
     assert!(
-        body["error"].as_str().unwrap().contains("min_confidence"),
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
+    assert_eq!(body["error"]["code"], "INVALID_ARGUMENT");
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("min_confidence"),
         "error must name the field: {body}"
     );
 }

--- a/tests/warden_http_panic.rs
+++ b/tests/warden_http_panic.rs
@@ -114,9 +114,13 @@ async fn find_neighbors_overflow_pagination_rejected() {
         "overflow attempt must be rejected"
     );
     let body: serde_json::Value = serde_json::from_slice(&resp.body).unwrap();
-    assert_eq!(body["success"], false);
     assert!(
-        body["error"]
+        body.get("success").is_none(),
+        "flat `success` field dropped: {body}"
+    );
+    assert_eq!(body["error"]["code"], "INVALID_ARGUMENT");
+    assert!(
+        body["error"]["message"]
             .as_str()
             .unwrap()
             .contains("Pagination limit exceeded"),


### PR DESCRIPTION
## Before / After

**BEFORE** — an HTTP error returned a **flat** body:

```json
{ "success": false, "error": "role 'reader' does not permit write access", "code": "PERMISSION_DENIED", "retriable": false, "details": { ... } }
```

**AFTER** — it returns the **nested** envelope, with `trace_id` (when present) as a **top-level** sibling of `error` — identical in shape to the MCP surface (Issue #3234):

```json
{
  "error": {
    "code": "PERMISSION_DENIED",
    "message": "role 'reader' does not permit write access",
    "retriable": false,
    "details": { "required_class": "write", "principal_role": "reader" }
  },
  "trace_id": "0af7651916cd43dd8448eb211c80319c"
}
```

The top-level `success` and the flat `error` string are **gone**. `error.message` preserves the exact pre-existing free text — only the shape changes. Success responses (`{"success":true,"data":…}`) and MCP tool in-band responses are unchanged.

## ⚠️ BREAKING CHANGE

This is a **breaking change to the HTTP error body shape**. Clients that read top-level `success` / `error` / `code` / `retriable` / `details` must switch to the nested `error.*` fields. It was done at the **user's explicit sign-off** authorizing this deliberate deviation from the legacy-HTTP-freeze ("let's do the breaking unification").

## How

- Rewrote `AletheiaHttpError::into_response_with_trace` (`src/http/error.rs`) to emit the nested `{error:{code,message,retriable,details?}}` object, mirroring the MCP error's serde field order; `trace_id` stays a top-level sibling.
- **Restructured the `PermissionDenied` variant** to carry `required_class` (`AccessClass`) and `principal_role` (`Role`) so the 403 now surfaces `error.details:{required_class, principal_role}` matching MCP. Fixed the three construction sites: `src/http/auth.rs`, `crates/autumn-spike/src/auth.rs`, `crates/aletheia-server/src/security/auth.rs`.
- **Widened `retriable()`** to return `bool` for every variant (was `Option`); dropped the now-unused `code()` Option accessor (the always-present `code_str()` feeds the body).
- Kept aletheia-server's hand-built `/mcp`-gate refusals and rate-limit 429 consistent by nesting them too (`mcp_permission_denied_response` / `mcp_payload_too_large_response` / `mcp_unroutable_tool_call_response`, `wrap_governor_error`), preserving the gate's own "byte-identical to the HTTP surface" contract.
- **Regenerated ~55 pinned goldens** across the HTTP + security test suites (main crate: `parity_http`, `http_query_limits`, `http_auth`, `http_api`, `http_provenance_where`, `warden_http_panic`, `http_otel_*`; aletheia-server: `security_acceptance`, `security_mcp_gate`, `security_rate_limit`, `security_rbac`, `server_parity`, `constraints_lineage_audit_parity`, `schema_batch_parity`; autumn-spike parity) and updated the docs.

## Verification

- `cargo fmt --all` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- Main-crate HTTP goldens + otel — all green
- `cargo test -p aletheia-server` / `-p aletheia-autumn-spike` — all green
- `cargo test --test parity_mcp` — still green (untouched sanity)

## Lane B files touched (for post-hoc audit)

Each file below is a **FORCED, content-preserving flat→nested consequence** of the unification. There is **no auth/rate-limit behavior change** — status codes, headers, and refusal conditions are identical; only the body shape changed.

**Source:**
- `crates/aletheia-server/src/security/auth.rs` — `PermissionDenied` construction site (struct-variant fixup; `Display` message byte-identical).
- `crates/aletheia-server/src/security/mcp_gate.rs` — 403/413/400 gate refusals nested via the new `mcp_error_envelope` helper (the byte-parity-with-HTTP-surface contract required it).
- `crates/aletheia-server/src/security/rate_limit.rs` — 429 body nested; `code`/`retriable`/`details` content unchanged.

**Tests:**
- `crates/aletheia-server/tests/security_acceptance.rs`, `security_mcp_gate.rs`, `security_rate_limit.rs`, `security_rbac.rs` — goldens updated to the nested shape; `security_rbac` destructures the now-struct `PermissionDenied`.

Note: this **supersedes cross-lane ruling F4 (two-shape 403), per the user-approved #3234 unification** — HTTP 403 now carries `details:{required_class, principal_role}` exactly as MCP already did; no NEW disclosure. Coordinator-acknowledged.

## Follow-up

- The `clients/typescript` fixtures may need re-recording, but the TS SDK's `parseHttpError` already copes with **both** shapes — **the SDK is intentionally not modified in this PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEwJg2bDPZ7DzcHebqwZVK

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEwJg2bDPZ7DzcHebqwZVK)_