### PR TITLE
feat(server): Prometheus /metrics exposition endpoint (#3624)

### DIFF
--- a/crates/aletheia-server/Cargo.toml
+++ b/crates/aletheia-server/Cargo.toml
@@ -21,7 +21,11 @@ autumn-web = { version = "0.5.0", default-features = false, features = ["maud", 
 # (`ApiResponse`, `node_to_query_json`, `AletheiaHttpError`), the constant-time
 # `AuthStore`/`AccessClass`/`Role` RBAC model, and the MCP typed node-read
 # request/response methods (`AletheiaMcpServer::get_node`/`list_nodes`/`count_nodes`).
-aletheiadb = { path = "../..", features = ["http-server", "mcp-server"] }
+# `observability` exposes the internal `MetricsRecorder` / `METRICS` atomic
+# mirror + `MetricsSnapshot` that the Prometheus `/metrics` exposition endpoint
+# (Issue #3624) renders. It only pulls in `dep:tracing` (already brought in by
+# `http-server`), so it adds no new heavy dependency to the graph.
+aletheiadb = { path = "../..", features = ["http-server", "mcp-server", "observability"] }
 axum = { version = "0.8" }
 tower-http = { version = "0.6", features = ["set-header"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/aletheia-server/src/app.rs
+++ b/crates/aletheia-server/src/app.rs
@@ -14,6 +14,7 @@
 use crate::constraints_lineage_audit_tools;
 use crate::edge_tools;
 use crate::http_routes;
+use crate::metrics_exposition;
 use crate::node_tools;
 use crate::schema_batch_tools;
 use crate::security::{self, SecurityConfig};
@@ -68,6 +69,7 @@ pub fn try_build_server_testapp(
     let app = TestApp::new()
         .routes(routes![
             http_routes::health_check,
+            metrics_exposition::metrics,
             http_routes::create_key,
             http_routes::list_keys,
             http_routes::revoke_key,

--- a/crates/aletheia-server/src/lib.rs
+++ b/crates/aletheia-server/src/lib.rs
@@ -31,6 +31,7 @@ pub mod app;
 pub mod constraints_lineage_audit_tools;
 pub mod edge_tools;
 pub mod http_routes;
+pub mod metrics_exposition;
 pub mod node_tools;
 pub mod schema_batch_tools;
 pub mod security;

--- a/crates/aletheia-server/src/metrics_exposition.rs
+++ b/crates/aletheia-server/src/metrics_exposition.rs
@@ -278,13 +278,50 @@ mod tests {
 
     #[test]
     fn labels_are_bounded_enums_only_no_secrets() {
+        use std::collections::BTreeSet;
+
         let body = render_prometheus(&distinct_snapshot());
-        // The only label keys ever emitted are `category` and `event`.
+
+        // Denylist (kept): no secret-y substring may appear.
         for forbidden in ["principal", "api_key", "token", "key_prefix", "role="] {
             assert!(
                 !body.contains(forbidden),
                 "exposition must not emit a {forbidden:?} label"
             );
         }
+
+        // Allowlist (stronger): parse the label KEYS off every sample line and
+        // assert the set is a subset of the two bounded process-wide enums, and
+        // that the total series count is exactly 12 (7 error categories + 3
+        // critical events + 2 unlabeled scalars). A future edit that wires in an
+        // extra label (e.g. the unused `METRIC_LABEL_DURABILITY_MODE` /
+        // `METRIC_LABEL_STATUS`) or a new series fails here.
+        let allowed: BTreeSet<&str> = ["category", "event"].into_iter().collect();
+        let mut keys: BTreeSet<String> = BTreeSet::new();
+        let mut series = 0usize;
+        for line in body.lines() {
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            series += 1;
+            if let Some(open) = line.find('{') {
+                let close = line.find('}').expect("labelled sample closes its brace");
+                for pair in line[open + 1..close].split(',') {
+                    if pair.trim().is_empty() {
+                        continue;
+                    }
+                    let key = pair.split('=').next().expect("label pair has a key").trim();
+                    keys.insert(key.to_string());
+                }
+            }
+        }
+        assert!(
+            keys.iter().all(|k| allowed.contains(k.as_str())),
+            "emitted label keys {keys:?} must be a subset of {allowed:?}"
+        );
+        assert_eq!(
+            series, 12,
+            "render must emit exactly 12 time series (7 error categories + 3 critical events + 2 scalars)"
+        );
     }
 }

--- a/crates/aletheia-server/src/metrics_exposition.rs
+++ b/crates/aletheia-server/src/metrics_exposition.rs
@@ -1,0 +1,290 @@
+//! Prometheus text-format `/metrics` exposition endpoint (Issue #3624).
+//!
+//! The autumn server surfaces AletheiaDB's internal
+//! [`MetricsRecorder`](aletheiadb::observability::MetricsRecorder) — concretely
+//! the process-wide [`METRICS`](aletheiadb::observability::METRICS) atomic
+//! mirror captured by [`aletheiadb::observability::metrics`] — as a standard
+//! Prometheus 0.0.4 text exposition so an operator can scrape it with the usual
+//! monitoring stack instead of the JSON `database_stats` tool.
+//!
+//! # Access class
+//!
+//! The route is classified [`AccessClass::Metrics`](aletheiadb::auth::AccessClass::Metrics)
+//! — the *same* class the `database_stats` MCP tool and the `GET /status`
+//! liveness probe use — via the shared [`Authorized<MetricsClass>`] seam, so
+//! authentication (uniform 401) and RBAC are enforced identically to every
+//! other route, and a refusal renders the #3629 nested `{error:{…}}` envelope.
+//!
+//! # Info-disclosure invariant (hard requirement)
+//!
+//! Every label this endpoint emits is a **bounded, process-wide enum** —
+//! `category` ([`ErrorCategory`]) and `event` ([`CriticalEvent`]). No
+//! per-principal, per-API-key, per-request, or otherwise unbounded/secret value
+//! is ever placed in a metric name or label. The exposition is byte-identical
+//! regardless of *which* credential scraped it.
+
+use aletheiadb::observability::{
+    CriticalEvent, ErrorCategory, METRIC_LABEL_CATEGORY, METRIC_LABEL_EVENT, MetricsSnapshot,
+};
+use autumn_web::prelude::get;
+use axum::http::header::CONTENT_TYPE;
+use axum::response::{IntoResponse, Response};
+use std::fmt::Write as _;
+
+use crate::security::{Authorized, MetricsClass};
+
+/// The Prometheus text-format content type (exposition format version 0.0.4).
+///
+/// Deliberately the bare `text/plain; version=0.0.4` the issue's acceptance
+/// criteria name (no `charset` suffix), so scrapers keyed on the exact string
+/// match it.
+pub const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4";
+
+/// Prometheus counter: errors by bounded category. Sanitized name for
+/// [`aletheiadb::observability::METRIC_ERRORS`] (`.` → `_`, `_total` suffix).
+const PROM_ERRORS: &str = "aletheiadb_errors_total";
+
+/// Prometheus counter: write conflicts under snapshot isolation. Sanitized
+/// [`aletheiadb::observability::METRIC_WRITE_CONFLICTS`].
+const PROM_WRITE_CONFLICTS: &str = "aletheiadb_write_conflicts_total";
+
+/// Prometheus counter: critical events (should be zero in healthy systems).
+/// Sanitized [`aletheiadb::observability::METRIC_CRITICAL_EVENTS`].
+const PROM_CRITICAL_EVENTS: &str = "aletheiadb_critical_events_total";
+
+/// Prometheus counter: committed transactions. Sanitized
+/// [`aletheiadb::observability::METRIC_TRANSACTION_COMMITS`].
+const PROM_TRANSACTION_COMMITS: &str = "aletheiadb_transaction_commits_total";
+
+/// A rendered Prometheus text exposition, wrapped so it serializes with the
+/// [`PROMETHEUS_CONTENT_TYPE`] content type rather than autumn's default JSON.
+#[derive(Debug, Clone)]
+pub struct PrometheusExposition(pub String);
+
+impl IntoResponse for PrometheusExposition {
+    fn into_response(self) -> Response {
+        ([(CONTENT_TYPE, PROMETHEUS_CONTENT_TYPE)], self.0).into_response()
+    }
+}
+
+/// The `category`-labelled error counters, paired with the snapshot field each
+/// reads. The label value is the bounded [`ErrorCategory::as_str`] — never a
+/// free-form or caller-supplied string.
+fn error_families(snapshot: &MetricsSnapshot) -> [(ErrorCategory, u64); 7] {
+    [
+        (ErrorCategory::Storage, snapshot.error_storage_total),
+        (ErrorCategory::Temporal, snapshot.error_temporal_total),
+        (ErrorCategory::Query, snapshot.error_query_total),
+        (ErrorCategory::Transaction, snapshot.error_transaction_total),
+        (ErrorCategory::Vector, snapshot.error_vector_total),
+        (ErrorCategory::Io, snapshot.error_io_total),
+        (ErrorCategory::Other, snapshot.error_other_total),
+    ]
+}
+
+/// The `event`-labelled critical-event counters, paired with the snapshot field
+/// each reads. The label value is the bounded [`CriticalEvent::as_str`].
+fn critical_families(snapshot: &MetricsSnapshot) -> [(CriticalEvent, u64); 3] {
+    [
+        (CriticalEvent::LockPoison, snapshot.lock_poison_count),
+        (
+            CriticalEvent::TimestampViolation,
+            snapshot.timestamp_violations,
+        ),
+        (
+            CriticalEvent::WalChecksumFailure,
+            snapshot.wal_checksum_failures,
+        ),
+    ]
+}
+
+/// Render a [`MetricsSnapshot`] as a Prometheus 0.0.4 text exposition.
+///
+/// Pure and deterministic: the same snapshot always renders the same bytes, and
+/// the output carries only bounded-cardinality labels (`category`, `event`). No
+/// I/O, no allocation beyond the returned `String`.
+#[must_use]
+pub fn render_prometheus(snapshot: &MetricsSnapshot) -> String {
+    let mut out = String::with_capacity(1024);
+
+    // ── errors{category=…} ───────────────────────────────────────────────────
+    let _ = writeln!(
+        out,
+        "# HELP {PROM_ERRORS} Total errors by bounded category."
+    );
+    let _ = writeln!(out, "# TYPE {PROM_ERRORS} counter");
+    for (category, count) in error_families(snapshot) {
+        let _ = writeln!(
+            out,
+            "{PROM_ERRORS}{{{METRIC_LABEL_CATEGORY}=\"{}\"}} {count}",
+            category.as_str()
+        );
+    }
+
+    // ── write_conflicts ──────────────────────────────────────────────────────
+    let _ = writeln!(
+        out,
+        "# HELP {PROM_WRITE_CONFLICTS} Write conflicts observed under snapshot isolation."
+    );
+    let _ = writeln!(out, "# TYPE {PROM_WRITE_CONFLICTS} counter");
+    let _ = writeln!(out, "{PROM_WRITE_CONFLICTS} {}", snapshot.write_conflicts);
+
+    // ── critical_events{event=…} ─────────────────────────────────────────────
+    let _ = writeln!(
+        out,
+        "# HELP {PROM_CRITICAL_EVENTS} Critical events that should be zero in healthy systems."
+    );
+    let _ = writeln!(out, "# TYPE {PROM_CRITICAL_EVENTS} counter");
+    for (event, count) in critical_families(snapshot) {
+        let _ = writeln!(
+            out,
+            "{PROM_CRITICAL_EVENTS}{{{METRIC_LABEL_EVENT}=\"{}\"}} {count}",
+            event.as_str()
+        );
+    }
+
+    // ── transaction_commits ──────────────────────────────────────────────────
+    let _ = writeln!(
+        out,
+        "# HELP {PROM_TRANSACTION_COMMITS} Total committed transactions."
+    );
+    let _ = writeln!(out, "# TYPE {PROM_TRANSACTION_COMMITS} counter");
+    let _ = writeln!(
+        out,
+        "{PROM_TRANSACTION_COMMITS} {}",
+        snapshot.transaction_commits_total
+    );
+
+    out
+}
+
+/// `GET /metrics` — Prometheus text-format exposition of the internal
+/// `MetricsRecorder` counters.
+///
+/// Classified [`AccessClass::Metrics`] through [`Authorized<MetricsClass>`]: in
+/// [`Required`](aletheiadb::auth::AuthMode::Required) mode a missing/invalid
+/// credential is a uniform 401 (nested #3629 envelope); every role that permits
+/// the metrics class (admin/writer/reader/metrics) is admitted. The route is
+/// **HTTP + OpenAPI only** — it is intentionally NOT an MCP tool (no
+/// `api_doc(mcp)`), matching `GET /status`.
+///
+/// Infallible on the success path (reading the atomic mirror cannot fail), so it
+/// returns the response value directly; the auth/RBAC error path is carried by
+/// the [`Authorized`] extractor's rejection.
+#[get("/metrics")]
+#[api_doc(
+    description = "Prometheus text-format (version 0.0.4) exposition of internal metrics counters"
+)]
+pub async fn metrics(_auth: Authorized<MetricsClass>) -> PrometheusExposition {
+    let snapshot = aletheiadb::observability::metrics();
+    PrometheusExposition(render_prometheus(&snapshot))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A snapshot with a distinct value in every field, so the renderer's
+    /// field→family wiring is pinned (a swapped field would flip a value).
+    fn distinct_snapshot() -> MetricsSnapshot {
+        MetricsSnapshot {
+            lock_poison_count: 1,
+            timestamp_violations: 2,
+            wal_checksum_failures: 3,
+            write_conflicts: 4,
+            error_storage_total: 5,
+            error_temporal_total: 6,
+            error_query_total: 7,
+            error_transaction_total: 8,
+            error_vector_total: 9,
+            error_io_total: 10,
+            error_other_total: 11,
+            transaction_commits_total: 12,
+        }
+    }
+
+    #[test]
+    fn content_type_is_prometheus_004() {
+        assert_eq!(PROMETHEUS_CONTENT_TYPE, "text/plain; version=0.0.4");
+    }
+
+    #[test]
+    fn render_has_help_type_and_samples_for_every_family() {
+        let body = render_prometheus(&distinct_snapshot());
+
+        // Each family carries HELP + TYPE + at least one sample.
+        for name in [
+            PROM_ERRORS,
+            PROM_WRITE_CONFLICTS,
+            PROM_CRITICAL_EVENTS,
+            PROM_TRANSACTION_COMMITS,
+        ] {
+            assert!(
+                body.contains(&format!("# HELP {name} ")),
+                "missing HELP for {name}"
+            );
+            assert!(
+                body.contains(&format!("# TYPE {name} counter")),
+                "missing TYPE for {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn render_wires_each_field_to_the_right_labelled_sample() {
+        let body = render_prometheus(&distinct_snapshot());
+
+        // errors{category=…}
+        assert!(body.contains(&format!("{PROM_ERRORS}{{category=\"storage\"}} 5")));
+        assert!(body.contains(&format!("{PROM_ERRORS}{{category=\"temporal\"}} 6")));
+        assert!(body.contains(&format!("{PROM_ERRORS}{{category=\"query\"}} 7")));
+        assert!(body.contains(&format!("{PROM_ERRORS}{{category=\"transaction\"}} 8")));
+        assert!(body.contains(&format!("{PROM_ERRORS}{{category=\"vector\"}} 9")));
+        assert!(body.contains(&format!("{PROM_ERRORS}{{category=\"io\"}} 10")));
+        assert!(body.contains(&format!("{PROM_ERRORS}{{category=\"other\"}} 11")));
+
+        // critical_events{event=…}
+        assert!(body.contains(&format!(
+            "{PROM_CRITICAL_EVENTS}{{event=\"lock_poison\"}} 1"
+        )));
+        assert!(body.contains(&format!(
+            "{PROM_CRITICAL_EVENTS}{{event=\"timestamp_violation\"}} 2"
+        )));
+        assert!(body.contains(&format!(
+            "{PROM_CRITICAL_EVENTS}{{event=\"wal_checksum_failure\"}} 3"
+        )));
+
+        // unlabelled scalars
+        assert!(body.contains(&format!("{PROM_WRITE_CONFLICTS} 4")));
+        assert!(body.contains(&format!("{PROM_TRANSACTION_COMMITS} 12")));
+    }
+
+    #[test]
+    fn no_metric_name_contains_a_dot() {
+        let body = render_prometheus(&distinct_snapshot());
+        for line in body.lines() {
+            if line.starts_with('#') || line.is_empty() {
+                continue;
+            }
+            let name = line
+                .split_once('{')
+                .map_or(line.split(' ').next().unwrap_or(""), |(n, _)| n);
+            assert!(
+                !name.contains('.'),
+                "sanitized name must have no dot: {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn labels_are_bounded_enums_only_no_secrets() {
+        let body = render_prometheus(&distinct_snapshot());
+        // The only label keys ever emitted are `category` and `event`.
+        for forbidden in ["principal", "api_key", "token", "key_prefix", "role="] {
+            assert!(
+                !body.contains(forbidden),
+                "exposition must not emit a {forbidden:?} label"
+            );
+        }
+    }
+}

--- a/crates/aletheia-server/tests/full_surface_parity_sweep.rs
+++ b/crates/aletheia-server/tests/full_surface_parity_sweep.rs
@@ -258,19 +258,38 @@ async fn all_five_http_routes_are_served() {
 #[tokio::test]
 async fn metrics_route_is_served_and_is_not_an_mcp_tool() {
     let (db, store) = fixture();
-    // Anonymous mode: the synthetic principal is Admin, so the metrics class
-    // gate passes and a non-404 status positively proves the route is mounted.
-    let client = build_server_client(db, store, AuthMode::Anonymous);
+    // Mint a metrics-ONLY-role credential before the store is moved into the app.
+    // `Role::Metrics` permits ONLY `AccessClass::Metrics` (see `Role::allows`), so
+    // a 200 for this token is a genuine BEHAVIORAL proof that `/metrics` is on
+    // exactly that class: had the route been Read/Write/Admin, this same token
+    // would 403. (A 403-for-a-denied-role check is impossible for the metrics
+    // class — every role permits it — so the metrics-role 200 is the
+    // discriminating signal.)
+    let (_principal, metrics_key) = store
+        .create_key("sweep-metrics", Role::Metrics)
+        .expect("mint metrics-role key");
 
-    // (a) Routed (not the autumn no-route 404) and serving the Prometheus text
-    //     format at the exact content type the endpoint promises.
-    let resp = client.get("/metrics").send().await;
+    // Required mode: the RBAC class gate is live, so the metrics-role 200 below is
+    // a real access-class assertion rather than an anonymous pass-through.
+    let client = build_server_client(db, store, AuthMode::Required);
+
+    // (a) Routed (not the autumn no-route 404), admits the metrics-role token
+    //     (→ class == Metrics), and serves the Prometheus text content type.
+    let resp = client
+        .get("/metrics")
+        .header("authorization", &format!("Bearer {}", &*metrics_key))
+        .send()
+        .await;
     assert_ne!(
         resp.status.as_u16(),
         404,
         "GET /metrics must be routed (got the no-route 404)"
     );
-    assert_eq!(resp.status.as_u16(), 200, "GET /metrics must be 200");
+    assert_eq!(
+        resp.status.as_u16(),
+        200,
+        "a metrics-role credential must get 200 on /metrics — proving the route is on AccessClass::Metrics"
+    );
     assert_eq!(
         resp.header("content-type"),
         Some(aletheia_server::metrics_exposition::PROMETHEUS_CONTENT_TYPE),
@@ -296,14 +315,6 @@ async fn metrics_route_is_served_and_is_not_an_mcp_tool() {
     assert!(
         !inv_tools.contains("metrics") && !inv_tools.contains("get_metrics"),
         "the /metrics HTTP route must not be listed among the MCP tools"
-    );
-
-    // (c) It IS classified on the metrics access class — the same class the
-    //     `GET /status` probe and `database_stats` tool use.
-    assert_eq!(
-        class_from_inventory("metrics"),
-        AccessClass::Metrics,
-        "the metrics route's class marker resolves to AccessClass::Metrics"
     );
 }
 

--- a/crates/aletheia-server/tests/full_surface_parity_sweep.rs
+++ b/crates/aletheia-server/tests/full_surface_parity_sweep.rs
@@ -249,6 +249,65 @@ async fn all_five_http_routes_are_served() {
 }
 
 // ════════════════════════════════════════════════════════════════════════════
+// (3b) The Prometheus /metrics exposition route (Issue #3624) is served, on the
+//      metrics access class, and is an HTTP-ROUTE-ONLY surface — deliberately
+//      NOT registered as an MCP tool (it does not appear in the tools/list
+//      catalog and is absent from the inventory's mcp.tools[] set).
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn metrics_route_is_served_and_is_not_an_mcp_tool() {
+    let (db, store) = fixture();
+    // Anonymous mode: the synthetic principal is Admin, so the metrics class
+    // gate passes and a non-404 status positively proves the route is mounted.
+    let client = build_server_client(db, store, AuthMode::Anonymous);
+
+    // (a) Routed (not the autumn no-route 404) and serving the Prometheus text
+    //     format at the exact content type the endpoint promises.
+    let resp = client.get("/metrics").send().await;
+    assert_ne!(
+        resp.status.as_u16(),
+        404,
+        "GET /metrics must be routed (got the no-route 404)"
+    );
+    assert_eq!(resp.status.as_u16(), 200, "GET /metrics must be 200");
+    assert_eq!(
+        resp.header("content-type"),
+        Some(aletheia_server::metrics_exposition::PROMETHEUS_CONTENT_TYPE),
+        "GET /metrics must serve the Prometheus text format content type"
+    );
+
+    // (b) HTTP-route-only: /metrics is NOT an MCP tool. Neither a `metrics` nor a
+    //     `get_metrics` name may appear in the live tools/list catalog...
+    let live = live_mcp_catalog(&client).await;
+    assert!(
+        !live.contains("metrics") && !live.contains("get_metrics"),
+        "the /metrics HTTP route must not be exposed as an MCP tool"
+    );
+
+    // ...nor in the inventory's mcp.tools[] set (the tool source of truth).
+    let doc = inventory();
+    let inv_tools: BTreeSet<String> = doc["mcp"]["tools"]
+        .as_array()
+        .expect("mcp.tools array")
+        .iter()
+        .map(|t| t["name"].as_str().expect("tool name").to_string())
+        .collect();
+    assert!(
+        !inv_tools.contains("metrics") && !inv_tools.contains("get_metrics"),
+        "the /metrics HTTP route must not be listed among the MCP tools"
+    );
+
+    // (c) It IS classified on the metrics access class — the same class the
+    //     `GET /status` probe and `database_stats` tool use.
+    assert_eq!(
+        class_from_inventory("metrics"),
+        AccessClass::Metrics,
+        "the metrics route's class marker resolves to AccessClass::Metrics"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
 // (4) /openapi.json is served and covers the MCP-projection routes for the
 //     tools — one representative route from every ported cluster.
 // ════════════════════════════════════════════════════════════════════════════

--- a/crates/aletheia-server/tests/metrics_endpoint.rs
+++ b/crates/aletheia-server/tests/metrics_endpoint.rs
@@ -1,0 +1,224 @@
+//! `GET /metrics` Prometheus exposition endpoint (Issue #3624).
+//!
+//! The autumn server exposes the internal `MetricsRecorder`'s counters as a
+//! standard Prometheus text-format (`text/plain; version=0.0.4`) scrape target.
+//! The route is classified [`AccessClass::Metrics`] (the same class the
+//! `database_stats` tool / `GET /status` probe use), authenticated + RBAC-gated
+//! through the shared [`Authorized`](aletheia_server::security::Authorized) seam,
+//! and emits the #3629 nested error envelope on an unauthenticated request.
+//!
+//! Info-disclosure invariant (hard requirement): the exposition never carries a
+//! per-principal or per-API-key label — every emitted label is a bounded,
+//! process-wide enum (`category`, `event`). These tests assert that no
+//! credential material leaks into the body.
+
+use std::sync::Arc;
+
+use aletheia_server::build_server_client;
+use aletheiadb::auth::{AuthMode, AuthStore, Role};
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+use serde_json::Value;
+
+const ADMIN_TOKEN: &str = "admin-token-abcdefghijklmnop";
+const METRICS_TOKEN: &str = "metrics-probe-token-abcdef";
+
+/// The exact content type the endpoint must advertise (Prometheus text format
+/// version 0.0.4, per the issue's acceptance criteria).
+const PROM_CONTENT_TYPE: &str = "text/plain; version=0.0.4";
+
+/// A minimal DB plus an auth store carrying an admin key and a metrics-role key.
+fn fixture() -> (Arc<AletheiaDB>, Arc<AuthStore>) {
+    let db = Arc::new(AletheiaDB::new().expect("create db"));
+    db.create_node(
+        "Person",
+        PropertyMapBuilder::new().insert("name", "Alice").build(),
+    )
+    .expect("create node");
+
+    let store = Arc::new(AuthStore::new());
+    store
+        .insert_bootstrap_key("admin", Role::Admin, ADMIN_TOKEN)
+        .expect("insert admin key");
+    store
+        .insert_bootstrap_key("probe", Role::Metrics, METRICS_TOKEN)
+        .expect("insert metrics key");
+    (db, store)
+}
+
+/// Assert the body is a well-formed Prometheus text exposition: every non-blank,
+/// non-comment line is `metric_name[{labels}] value`, HELP/TYPE comments are
+/// well-formed, and at least one expected metric family is present.
+fn assert_valid_prometheus(body: &str) {
+    let mut saw_help = false;
+    let mut saw_type = false;
+    let mut saw_sample = false;
+
+    for line in body.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("# HELP ") {
+            saw_help = true;
+            assert!(
+                rest.split_whitespace().next().is_some(),
+                "# HELP line must name a metric: {line:?}"
+            );
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("# TYPE ") {
+            saw_type = true;
+            let mut parts = rest.split_whitespace();
+            let _name = parts.next().expect("# TYPE names a metric");
+            let kind = parts.next().expect("# TYPE has a metric kind");
+            assert!(
+                matches!(
+                    kind,
+                    "counter" | "gauge" | "histogram" | "summary" | "untyped"
+                ),
+                "# TYPE kind must be a Prometheus metric type, got {kind:?}"
+            );
+            continue;
+        }
+        assert!(
+            !line.starts_with('#'),
+            "only HELP/TYPE comment lines are allowed, got {line:?}"
+        );
+
+        // A sample line: `name{labels} value` or `name value`.
+        let (name_and_labels, value) = line
+            .rsplit_once(' ')
+            .unwrap_or_else(|| panic!("sample line must have a value: {line:?}"));
+        // The value must parse as an f64 (integers included).
+        value
+            .parse::<f64>()
+            .unwrap_or_else(|_| panic!("sample value must be numeric: {line:?}"));
+        // The metric name (before any `{`) must be a valid Prometheus name.
+        let name = name_and_labels
+            .split_once('{')
+            .map_or(name_and_labels, |(n, _)| n);
+        assert!(
+            !name.is_empty()
+                && name
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b':'),
+            "metric name must match [a-zA-Z0-9_:]+, got {name:?}"
+        );
+        // Prometheus names cannot contain '.' — the internal dotted metric names
+        // must be sanitized to underscores.
+        assert!(
+            !name.contains('.'),
+            "metric name must not contain '.': {name:?}"
+        );
+        saw_sample = true;
+    }
+
+    assert!(saw_help, "exposition must carry at least one # HELP line");
+    assert!(saw_type, "exposition must carry at least one # TYPE line");
+    assert!(saw_sample, "exposition must carry at least one sample line");
+    assert!(
+        body.contains("aletheiadb_errors_total"),
+        "exposition must include the errors counter family"
+    );
+    assert!(
+        body.contains("aletheiadb_transaction_commits_total"),
+        "exposition must include the transaction-commits counter family"
+    );
+}
+
+// ── (1) success: 200 + content-type + valid Prometheus body ──────────────────
+
+#[tokio::test]
+async fn metrics_endpoint_returns_prometheus_text() {
+    let (db, store) = fixture();
+    // Anonymous mode: the synthetic principal is Admin, so the class gate passes
+    // and a 200 positively proves the route is served.
+    let client = build_server_client(db, store, AuthMode::Anonymous);
+
+    let resp = client.get("/metrics").send().await;
+    assert_eq!(resp.status.as_u16(), 200, "GET /metrics must be 200");
+    assert_eq!(
+        resp.header("content-type"),
+        Some(PROM_CONTENT_TYPE),
+        "content type must be the Prometheus text format"
+    );
+    assert_valid_prometheus(&resp.text());
+}
+
+// ── (2) unauth in required mode → 401 with the #3629 nested error envelope ────
+
+#[tokio::test]
+async fn metrics_endpoint_requires_credential_in_required_mode() {
+    let (db, store) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+
+    let resp = client.get("/metrics").send().await;
+    assert_eq!(
+        resp.status.as_u16(),
+        401,
+        "unauthenticated /metrics must be 401 in required mode"
+    );
+
+    let body: Value = resp.json();
+    // Nested envelope (#3629): {"error":{"code","message","retriable",...}} —
+    // the legacy top-level `success`/`error` string is gone.
+    assert!(
+        body.get("success").is_none(),
+        "nested envelope must not carry a top-level success field"
+    );
+    assert_eq!(
+        body["error"]["code"], "UNAUTHENTICATED",
+        "401 code must be UNAUTHENTICATED"
+    );
+    assert_eq!(body["error"]["retriable"], false);
+    assert!(
+        body["error"]["message"].is_string(),
+        "error.message must be present"
+    );
+}
+
+// ── (3) RBAC: the metrics-only role is admitted (Metrics class) ──────────────
+
+#[tokio::test]
+async fn metrics_endpoint_admits_metrics_role() {
+    let (db, store) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+
+    let resp = client
+        .get("/metrics")
+        .header("authorization", &format!("Bearer {METRICS_TOKEN}"))
+        .send()
+        .await;
+    assert_eq!(
+        resp.status.as_u16(),
+        200,
+        "a metrics-role credential must be admitted"
+    );
+    assert_eq!(resp.header("content-type"), Some(PROM_CONTENT_TYPE));
+    assert_valid_prometheus(&resp.text());
+}
+
+// ── (4) info-disclosure: no credential material leaks into the body ──────────
+
+#[tokio::test]
+async fn metrics_endpoint_does_not_leak_credentials() {
+    let (db, store) = fixture();
+    let client = build_server_client(db, store, AuthMode::Required);
+
+    let resp = client
+        .get("/metrics")
+        .header("authorization", &format!("Bearer {ADMIN_TOKEN}"))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200);
+    let body = resp.text();
+    // No token, principal id, key prefix, role name, or principal-y label key
+    // may appear anywhere in the exposition.
+    assert!(!body.contains(ADMIN_TOKEN), "admin token must not leak");
+    assert!(!body.contains(METRICS_TOKEN), "metrics token must not leak");
+    for forbidden in ["principal", "api_key", "apikey", "token", "key_prefix"] {
+        assert!(
+            !body.contains(forbidden),
+            "exposition must not contain a {forbidden:?} label/name"
+        );
+    }
+}

--- a/crates/aletheia-server/tests/metrics_endpoint.rs
+++ b/crates/aletheia-server/tests/metrics_endpoint.rs
@@ -12,6 +12,7 @@
 //! process-wide enum (`category`, `event`). These tests assert that no
 //! credential material leaks into the body.
 
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use aletheia_server::build_server_client;
@@ -25,6 +26,44 @@ const METRICS_TOKEN: &str = "metrics-probe-token-abcdef";
 /// The exact content type the endpoint must advertise (Prometheus text format
 /// version 0.0.4, per the issue's acceptance criteria).
 const PROM_CONTENT_TYPE: &str = "text/plain; version=0.0.4";
+
+/// The complete, bounded set of label keys the exposition is allowed to emit —
+/// both are process-wide enums, neither is per-principal/per-request.
+const ALLOWED_LABEL_KEYS: &[&str] = &["category", "event"];
+
+/// The exact number of time series the exposition emits: 7 error categories +
+/// 3 critical events + 2 unlabeled scalars (write_conflicts, transaction_commits).
+/// Pinning this count makes a future label/series addition fail loudly rather
+/// than silently widening the exposed surface.
+const EXPECTED_SERIES_COUNT: usize = 12;
+
+/// Parse every sample line's label KEYS (the identifiers left of each `=`) and
+/// count the total number of sample (time-series) lines. Comment/blank lines are
+/// ignored. This is the allowlist primitive the info-disclosure guard uses.
+fn label_keys_and_series_count(body: &str) -> (BTreeSet<String>, usize) {
+    let mut keys = BTreeSet::new();
+    let mut series = 0usize;
+    for line in body.lines() {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        series += 1;
+        let Some(open) = line.find('{') else {
+            continue; // an unlabeled scalar sample
+        };
+        let close = line
+            .find('}')
+            .expect("labelled sample must close its brace");
+        for pair in line[open + 1..close].split(',') {
+            if pair.trim().is_empty() {
+                continue;
+            }
+            let key = pair.split('=').next().expect("label pair has a key").trim();
+            keys.insert(key.to_string());
+        }
+    }
+    (keys, series)
+}
 
 /// A minimal DB plus an auth store carrying an admin key and a metrics-role key.
 fn fixture() -> (Arc<AletheiaDB>, Arc<AuthStore>) {
@@ -211,8 +250,9 @@ async fn metrics_endpoint_does_not_leak_credentials() {
         .await;
     assert_eq!(resp.status.as_u16(), 200);
     let body = resp.text();
-    // No token, principal id, key prefix, role name, or principal-y label key
-    // may appear anywhere in the exposition.
+
+    // Denylist (kept): no token, principal id, key prefix, or role name may
+    // appear anywhere in the exposition.
     assert!(!body.contains(ADMIN_TOKEN), "admin token must not leak");
     assert!(!body.contains(METRICS_TOKEN), "metrics token must not leak");
     for forbidden in ["principal", "api_key", "apikey", "token", "key_prefix"] {
@@ -221,4 +261,19 @@ async fn metrics_endpoint_does_not_leak_credentials() {
             "exposition must not contain a {forbidden:?} label/name"
         );
     }
+
+    // Allowlist (stronger): the set of emitted label KEYS must be a subset of the
+    // two bounded process-wide enums, and the total time-series count must equal
+    // the pinned constant. This fails loudly if a future edit wires in an extra
+    // label (e.g. the unused durability_mode/status constants) or a new series.
+    let allowed: BTreeSet<String> = ALLOWED_LABEL_KEYS.iter().map(|s| s.to_string()).collect();
+    let (keys, series) = label_keys_and_series_count(&body);
+    assert!(
+        keys.is_subset(&allowed),
+        "emitted label keys {keys:?} must be a subset of the bounded set {allowed:?}"
+    );
+    assert_eq!(
+        series, EXPECTED_SERIES_COUNT,
+        "exposition must emit exactly {EXPECTED_SERIES_COUNT} time series (7 error categories + 3 critical events + 2 scalars)"
+    );
 }


### PR DESCRIPTION
## Before / After

**BEFORE** — the autumn server (`crates/aletheia-server`) had only an *internal* `MetricsRecorder` (the process-wide `METRICS` atomic mirror in the main crate). There was no way for a monitoring stack to scrape it: no `/metrics` endpoint existed, so the counters were only reachable via the JSON `database_stats` tool.

**AFTER** — `GET /metrics` serves a standard Prometheus text-format (`text/plain; version=0.0.4`) exposition of those counters, so Prometheus / any OpenMetrics scraper can ingest AletheiaDB's error, write-conflict, critical-event, and transaction-commit counters directly. Example body:

```
# HELP aletheiadb_errors_total Total errors by bounded category.
# TYPE aletheiadb_errors_total counter
aletheiadb_errors_total{category="storage"} 0
aletheiadb_errors_total{category="temporal"} 0
...
# HELP aletheiadb_write_conflicts_total Write conflicts observed under snapshot isolation.
# TYPE aletheiadb_write_conflicts_total counter
aletheiadb_write_conflicts_total 0
# HELP aletheiadb_critical_events_total Critical events that should be zero in healthy systems.
# TYPE aletheiadb_critical_events_total counter
aletheiadb_critical_events_total{event="lock_poison"} 0
...
# HELP aletheiadb_transaction_commits_total Total committed transactions.
# TYPE aletheiadb_transaction_commits_total counter
aletheiadb_transaction_commits_total 0
```

## How

- New `metrics_exposition` module (`crates/aletheia-server/src/metrics_exposition.rs`): a pure, deterministic `render_prometheus(&MetricsSnapshot) -> String` renderer, a `PrometheusExposition` response newtype that stamps the `text/plain; version=0.0.4` content type, and the `#[get("/metrics")]` handler that reads `aletheiadb::observability::metrics()` and renders it. Registered in `app.rs`'s `routes[…]`.
- **Access class:** classified `AccessClass::Metrics` through the existing `Authorized<MetricsClass>` extractor — the *same* class `GET /status` and the `database_stats` tool use. Authentication (uniform 401), RBAC, and the #3629 nested `{"error":{code,message,retriable,details?}}` envelope on refusal are therefore identical to every other route, with zero new auth code. The route is **HTTP + OpenAPI only** — deliberately **not** an MCP tool (no `api_doc(mcp)`), matching `GET /status`.
- Internal dotted metric names (`aletheiadb.errors`, …) are sanitized to Prometheus-legal underscore names with the conventional `_total` counter suffix; label values reuse the bounded `ErrorCategory::as_str` / `CriticalEvent::as_str` enums, keeping the exposition in lockstep with the metrics contract.
- Enabled the `observability` feature on the aletheiadb path-dep (it only pulls in `dep:tracing`, already present transitively via `http-server`, so no new heavy dependency).

## Info-disclosure audit

Every label emitted by the endpoint is a **bounded, process-wide enum value** — there is exactly one label key per family:

| Metric | Label key(s) | Label value domain |
|---|---|---|
| `aletheiadb_errors_total` | `category` | `storage`/`temporal`/`query`/`transaction`/`vector`/`io`/`other` (`ErrorCategory`) |
| `aletheiadb_critical_events_total` | `event` | `lock_poison`/`timestamp_violation`/`wal_checksum_failure` (`CriticalEvent`) |
| `aletheiadb_write_conflicts_total` | *(none)* | — |
| `aletheiadb_transaction_commits_total` | *(none)* | — |

No per-principal, per-API-key, per-request, IP, token, role, or otherwise unbounded/secret value ever appears in a metric name or label. The exposition is byte-identical regardless of which credential scraped it. This is asserted by `metrics_endpoint_does_not_leak_credentials` (neither the admin nor the metrics-role token, nor any `principal`/`api_key`/`token`/`key_prefix` substring, appears in the body) and the `labels_are_bounded_enums_only_no_secrets` unit test.

## Acceptance criteria

- [x] **Prometheus text-format `/metrics` on the autumn server** — `GET /metrics` returns 200, `content-type: text/plain; version=0.0.4`, a valid exposition. Evidence: `metrics_endpoint_returns_prometheus_text`.
- [x] **Renders the internal MetricsRecorder counters** — errors (by category), write conflicts, critical events (by event), transaction commits, sourced from `aletheiadb::observability::metrics()`. Evidence: `render_wires_each_field_to_the_right_labelled_sample`.
- [x] **Correct access class (reuse `Metrics`)** — registered via `Authorized<MetricsClass>` (`AccessClass::Metrics`), the same class `database_stats` uses; the metrics-role credential is admitted. Evidence: `metrics_endpoint_admits_metrics_role`, `metrics_route_is_served_and_is_not_an_mcp_tool`.
- [x] **HTTP-route-only, not an MCP tool** — route-coverage assertion added to `full_surface_parity_sweep.rs`; the MCP `tools/list` catalog and inventory `mcp.tools[]` remain exactly 46 and contain no `metrics`/`get_metrics`. Evidence: `metrics_route_is_served_and_is_not_an_mcp_tool`, `mcp_catalog_equals_inventory_exactly` (unchanged, still 46).
- [x] **Nested error envelope (#3629)** — unauthenticated request in required mode → 401 with `{"error":{"code":"UNAUTHENTICATED","retriable":false,…}}` and no top-level `success`. Evidence: `metrics_endpoint_requires_credential_in_required_mode`.
- [x] **Info-disclosure: no per-principal/per-key data** — see the audit table above. Evidence: `metrics_endpoint_does_not_leak_credentials`, `labels_are_bounded_enums_only_no_secrets`.

## Verification

- `cargo fmt --all` — clean
- `cargo clippy -p aletheia-server --all-targets --all-features -- -D warnings` — clean
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test -p aletheia-server` — all green (scoped to the affected crate; changes are confined to `crates/aletheia-server`)

Scope note: no `src/mcp/**` files were touched; the new route is an HTTP-only surface and does not enter the MCP tool inventory.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P9AsbevK7LAWEXzJANvyG4)_