### PR TITLE
fix(vector): de-index temporal vectors on node update (#3621)

### DIFF
--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -1563,6 +1563,20 @@ impl WriteOps for WriteTransaction {
             // Build the final merged property map
             let merged_properties = builder.build();
 
+            // A PATCH may drop or downgrade a vector (e.g. overwrite the
+            // embedding key with a scalar, or remove it): mark the buffer so
+            // the temporal vector index snapshots on commit if EITHER the
+            // existing node or the merged map carries a vector. `WriteBuffer::add`
+            // only inspects the merged map, so without this a vector-removing
+            // PATCH leaves `has_vector_operations` false and no snapshot fires,
+            // leaking the phantom as-of-now (Issue #3621). Mirrors
+            // `buffer_node_replace`.
+            if !self.buffer.has_vector_operations()
+                && (node.properties.contains_vector() || merged_properties.contains_vector())
+            {
+                self.buffer.mark_has_vector_operations();
+            }
+
             // Get timestamp: use provided valid_from or default to transaction start time
             let timestamp = self.start_timestamp;
             let valid_from = options.valid_from.unwrap_or(timestamp);

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -765,12 +765,17 @@ impl CurrentStorage {
         // NOTE: with multiple vector/temporal indexes enabled, a mid-fan-out
         // failure returns Err with indexes visited earlier already updated
         // (partial work); the node update itself is not applied.
+        // Update every enabled current-state AND temporal vector index using the
+        // old properties, so a removed/overwritten embedding is de-indexed (not
+        // just re-added) on both. Without the old props (node not previously in
+        // storage — e.g. a replay create routed here) fall back to the add-only
+        // path, which is correct because there is no prior vector to remove.
         if let Some(old_p) = old_props {
             self.update_vector_index(node.id, &node.properties, &old_p)?;
+            self.update_temporal_vector_index(node.id, &node.properties, &old_p, timestamp)?;
+        } else {
+            self.try_index_temporal_vector(node.id, &node.properties, timestamp)?;
         }
-
-        // Update every enabled temporal vector index
-        self.try_index_temporal_vector(node.id, &node.properties, timestamp)?;
 
         // Finally, insert node into main indexes. This avoids node.clone().
         self.indexes.insert_node(node);
@@ -1951,6 +1956,65 @@ impl CurrentStorage {
         Ok(())
     }
 
+    /// Update every enabled temporal vector index for a node whose properties
+    /// changed, mirroring [`update_vector_index`](Self::update_vector_index) for
+    /// the current-state HNSW.
+    ///
+    /// For each indexed property this diffs the old vs new vector and applies the
+    /// matching temporal operation:
+    ///
+    /// - `(None, None)` — property absent before and after: no-op.
+    /// - `(None, Some)` — vector added: [`TemporalVectorIndex::add`].
+    /// - `(Some, None)` — vector removed: [`TemporalVectorIndex::remove`], which
+    ///   drops the embedding from the live HNSW **and** from `current_state.vectors`
+    ///   so it no longer leaks into the next snapshot.
+    /// - `(Some, Some)` — vector overwritten: only re-`add` (an upsert) when the
+    ///   value actually changed, avoiding needless HNSW churn.
+    ///
+    /// # Bi-temporal tombstone semantics
+    ///
+    /// `remove`/overwrite CLOSE the vector's interval at `timestamp` — the change
+    /// is reflected in any snapshot taken **after** it — but they never erase
+    /// snapshots taken **before** it. History is therefore preserved: a
+    /// `find_similar_as_of` anchored before the change still returns the old
+    /// embedding, while an as-of-now query no longer returns the stale phantom
+    /// (Issue #3621). Because this is the exact method the WAL-replay
+    /// `update_node_direct` invokes, crash recovery reconstructs the same
+    /// corrected point-in-time state.
+    ///
+    /// Fan-out matches [`try_index_temporal_vector`](Self::try_index_temporal_vector):
+    /// on the first failing index this returns `Err` with earlier indexes already
+    /// updated (partial work); the node update itself is not applied by the caller.
+    fn update_temporal_vector_index(
+        &self,
+        node_id: NodeId,
+        new_props: &PropertyMap,
+        old_props: &PropertyMap,
+        timestamp: Timestamp,
+    ) -> Result<()> {
+        for (property_name, index) in self.collect_temporal_vector_indexes() {
+            let old_vec = old_props.get(&property_name).and_then(|v| v.as_vector());
+            let new_vec = new_props.get(&property_name).and_then(|v| v.as_vector());
+
+            match (old_vec, new_vec) {
+                (None, None) => {}
+                (None, Some(v)) => {
+                    index.add(node_id, v, timestamp)?;
+                }
+                (Some(_), None) => {
+                    index.remove(node_id, timestamp)?;
+                }
+                (Some(o), Some(n)) => {
+                    if o != n {
+                        // add() is an upsert (remove + add) on the temporal index.
+                        index.add(node_id, n, timestamp)?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Helper to remove a node's vectors from every enabled temporal vector index.
     ///
     /// Mirrors [`try_remove_from_index`](Self::try_remove_from_index): removal is
@@ -2649,5 +2713,175 @@ mod coverage_tests {
         let result = storage.find_similar_in("embedding", node_id, 5);
         assert!(result.is_err());
         assert!(format!("{}", result.unwrap_err()).contains("Vector index not found"));
+    }
+}
+
+/// Issue #3621: WAL replay reruns `update_node_direct`, so the corrected
+/// temporal de-indexing must reconstruct the right point-in-time state after a
+/// crash-recovery replay. These tests drive `insert_node_direct` /
+/// `update_node_direct` — the exact entry points recovery calls at
+/// `storage/recovery.rs` (`current.insert_node_direct` / `current.update_node_direct`)
+/// — with a temporal vector index enabled, then trigger snapshots via
+/// `on_temporal_vector_transaction` (the same hook the commit path fires). A
+/// true open→reopen test cannot cover this: the temporal vector index is an
+/// in-memory index whose config is not persisted, so replay only repopulates it
+/// when it is re-enabled beforehand — which is precisely what exercising the
+/// replay entry points here simulates.
+#[cfg(test)]
+mod deindex_replay_tests {
+    use super::*;
+    use crate::core::property::PropertyMapBuilder;
+    use crate::core::temporal::time;
+    use crate::index::vector::DistanceMetric;
+
+    fn temporal_config() -> TemporalVectorConfig {
+        use crate::index::vector::temporal::{RetentionPolicy, SnapshotStrategy};
+        TemporalVectorConfig {
+            snapshot_strategy: SnapshotStrategy::TransactionInterval(1),
+            retention_policy: RetentionPolicy::KeepN(100),
+            max_snapshots: 100,
+            full_snapshot_interval: 5,
+            hnsw_config: Some(HnswConfig::new(4, DistanceMetric::Cosine)),
+        }
+    }
+
+    fn node(id: u64, version: u64, props: PropertyMap) -> Node {
+        let label = GLOBAL_INTERNER.intern("Doc").unwrap();
+        Node::new(
+            NodeId::new(id).unwrap(),
+            label,
+            props,
+            VersionId::new(version).unwrap(),
+        )
+    }
+
+    fn advance() {
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+
+    /// Replaying a create followed by a vector-property removal through the
+    /// direct (WAL-replay) methods leaves the temporal index de-indexed at the
+    /// current time while an earlier snapshot still finds the vector.
+    #[test]
+    fn replay_remove_vector_deindexes_current_but_preserves_history() {
+        let storage = CurrentStorage::new();
+        storage
+            .enable_temporal_vector_index("embedding", temporal_config())
+            .unwrap();
+
+        // Replay: create a node with an embedding (recovery.rs -> insert_node_direct).
+        let target_id = NodeId::new(1).unwrap();
+        let create_props = PropertyMapBuilder::new()
+            .insert("name", "target")
+            .insert_vector("embedding", &[1.0f32, 0.0, 0.0, 0.0])
+            .build();
+        let t1 = time::now();
+        storage
+            .insert_node_direct(node(1, 1, create_props), t1)
+            .unwrap();
+        storage.on_temporal_vector_transaction().unwrap();
+
+        advance();
+        let t_before_remove = time::now();
+        advance();
+
+        // Replay: update the node, dropping the embedding (recovery.rs -> update_node_direct).
+        let removed_props = PropertyMapBuilder::new().insert("name", "target").build();
+        let t2 = time::now();
+        storage
+            .update_node_direct(node(1, 2, removed_props), t2)
+            .unwrap();
+        storage.on_temporal_vector_transaction().unwrap();
+
+        advance();
+        let t_after_remove = time::now();
+
+        let query = [1.0f32, 0.0, 0.0, 0.0];
+
+        // History preserved: the pre-removal snapshot still finds the target.
+        let historical = storage
+            .find_similar_as_of(&query, 10, t_before_remove)
+            .unwrap();
+        assert!(
+            historical.iter().any(|(id, _)| *id == target_id),
+            "replay must preserve the pre-removal snapshot, got {historical:?}"
+        );
+
+        // De-indexed now: the post-removal snapshot must NOT return the phantom.
+        let current = storage
+            .find_similar_as_of(&query, 10, t_after_remove)
+            .unwrap();
+        assert!(
+            !current.iter().any(|(id, _)| *id == target_id),
+            "replay through update_node_direct must de-index the removed vector, got {current:?}"
+        );
+    }
+
+    /// Replaying a create then an embedding overwrite reconstructs the new
+    /// vector at the current time and the old vector as-of the earlier snapshot.
+    #[test]
+    fn replay_overwrite_vector_reconstructs_corrected_state() {
+        let storage = CurrentStorage::new();
+        storage
+            .enable_temporal_vector_index("embedding", temporal_config())
+            .unwrap();
+
+        let target_id = NodeId::new(1).unwrap();
+        let create_props = PropertyMapBuilder::new()
+            .insert_vector("embedding", &[1.0f32, 0.0, 0.0, 0.0])
+            .build();
+        storage
+            .insert_node_direct(node(1, 1, create_props), time::now())
+            .unwrap();
+        storage.on_temporal_vector_transaction().unwrap();
+
+        advance();
+        let t_before = time::now();
+        advance();
+
+        let overwrite_props = PropertyMapBuilder::new()
+            .insert_vector("embedding", &[0.0f32, 1.0, 0.0, 0.0])
+            .build();
+        storage
+            .update_node_direct(node(1, 2, overwrite_props), time::now())
+            .unwrap();
+        storage.on_temporal_vector_transaction().unwrap();
+
+        advance();
+        let t_after = time::now();
+
+        // As-of before: old embedding ~identical to old query.
+        let before = storage
+            .find_similar_as_of(&[1.0f32, 0.0, 0.0, 0.0], 10, t_before)
+            .unwrap();
+        assert!(
+            before
+                .iter()
+                .find(|(id, _)| *id == target_id)
+                .is_some_and(|(_, s)| *s > 0.99),
+            "replay must reconstruct the old embedding as-of before, got {before:?}"
+        );
+
+        // As-of after: new embedding ~identical to new query; old region no longer matches.
+        let after_new = storage
+            .find_similar_as_of(&[0.0f32, 1.0, 0.0, 0.0], 10, t_after)
+            .unwrap();
+        assert!(
+            after_new
+                .iter()
+                .find(|(id, _)| *id == target_id)
+                .is_some_and(|(_, s)| *s > 0.99),
+            "replay must reconstruct the new embedding as-of after, got {after_new:?}"
+        );
+        let after_old = storage
+            .find_similar_as_of(&[1.0f32, 0.0, 0.0, 0.0], 10, t_after)
+            .unwrap();
+        assert!(
+            after_old
+                .iter()
+                .find(|(id, _)| *id == target_id)
+                .is_none_or(|(_, s)| *s < 0.1),
+            "replay must drop the old embedding region after overwrite, got {after_old:?}"
+        );
     }
 }

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -1983,8 +1983,16 @@ impl CurrentStorage {
     /// is reflected in any snapshot taken **after** it — but they never erase
     /// snapshots taken **before** it. History is therefore preserved: a
     /// `find_similar_as_of` anchored before the change still returns the old
-    /// embedding, while an as-of-now query no longer returns the stale phantom
-    /// (Issue #3621). Because this is the exact method the WAL-replay
+    /// embedding (Issue #3621). The de-index is also applied to the live
+    /// current-state HNSW **immediately** (via `current_state.vectors`), so a
+    /// current-state `find_similar` stops returning the stale phantom right away.
+    /// The as-of-now temporal side, by contrast, is only as fresh as the last
+    /// snapshot: between this de-index and the next snapshot a
+    /// `find_similar_as_of(now)` still reads the prior snapshot and returns the
+    /// old embedding — inherent snapshot cadence, symmetric with how newly added
+    /// vectors only appear in an as-of-now query once the next snapshot is taken.
+    /// Once a snapshot is taken after the change, the as-of-now query no longer
+    /// returns the phantom. Because this is the exact method the WAL-replay
     /// `update_node_direct` invokes, crash recovery reconstructs the same
     /// corrected point-in-time state.
     ///
@@ -2008,6 +2016,14 @@ impl CurrentStorage {
                     index.add(node_id, v, timestamp)?;
                 }
                 (Some(_), None) => {
+                    // Propagate the error via `?` on purpose: unlike the
+                    // current-state `update_vector_index` (which swallows removal
+                    // errors with `let _ =`), a fault from the temporal index is a
+                    // real bi-temporal-bookkeeping failure the caller must see so
+                    // the node update aborts rather than committing a stale phantom.
+                    // Safe because `HnswIndex::remove` returns `Ok(())` for a
+                    // missing id — enabling an index after the node already exists
+                    // (so the id was never added) is a no-op, not a spurious abort.
                     index.remove(node_id, timestamp)?;
                 }
                 (Some(o), Some(n)) => {
@@ -2026,10 +2042,12 @@ impl CurrentStorage {
     /// Mirrors [`try_remove_from_index`](Self::try_remove_from_index): removal is
     /// attempted on ALL indexes even when one fails, so a per-index error never
     /// leaves stale entries behind in the remaining indexes. The first error
-    /// encountered is returned after every index has been attempted. Note that
-    /// `remove` may fail for an index that never contained the node; callers
-    /// treating removal as best-effort (e.g. `delete_node_direct`) ignore the
-    /// returned error for this reason.
+    /// encountered is returned after every index has been attempted. A missing
+    /// id is **not** an error — `HnswIndex::remove` returns `Ok(())` when the
+    /// node was never indexed — so an index that never contained the node does
+    /// not contribute a spurious failure here. Any error returned therefore
+    /// reflects a genuine index fault; callers treating removal as best-effort
+    /// (e.g. `delete_node_direct`) may still ignore it.
     fn try_remove_temporal_vector(&self, node_id: NodeId, timestamp: Timestamp) -> Result<()> {
         let mut first_err = None;
         for (_, index) in self.collect_temporal_vector_indexes() {
@@ -2825,6 +2843,12 @@ mod deindex_replay_tests {
 
     /// Replaying a create then an embedding overwrite reconstructs the new
     /// vector at the current time and the old vector as-of the earlier snapshot.
+    ///
+    /// Regression lock, not a fix discriminator: this `Some -> Some` overwrite
+    /// already reconstructs correctly on trunk (the add-only temporal helper
+    /// upserted on overwrite). The fix-discriminating replay guard is
+    /// `replay_remove_vector_deindexes_current_but_preserves_history` above (the
+    /// `Some -> None` removal that trunk's add-only helper leaked).
     #[test]
     fn replay_overwrite_vector_reconstructs_corrected_state() {
         let storage = CurrentStorage::new();

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -767,13 +767,19 @@ impl CurrentStorage {
         // (partial work); the node update itself is not applied.
         // Update every enabled current-state AND temporal vector index using the
         // old properties, so a removed/overwritten embedding is de-indexed (not
-        // just re-added) on both. Without the old props (node not previously in
-        // storage — e.g. a replay create routed here) fall back to the add-only
-        // path, which is correct because there is no prior vector to remove.
+        // just re-added) on both. Without the old props the node is not yet in
+        // current storage — e.g. WAL replay applying an `UpdateNode` against a
+        // lagging index snapshot that never saw the node's create (recovery.rs
+        // applies these idempotently to converge). In that case there is no
+        // prior vector to remove, so we ADD to both the current-state HNSW and
+        // the temporal index, exactly mirroring `insert_node_direct`; indexing
+        // only the temporal side would leave the vector invisible to
+        // current-state `find_similar`.
         if let Some(old_p) = old_props {
             self.update_vector_index(node.id, &node.properties, &old_p)?;
             self.update_temporal_vector_index(node.id, &node.properties, &old_p, timestamp)?;
         } else {
+            self.try_index_vector(node.id, &node.properties)?;
             self.try_index_temporal_vector(node.id, &node.properties, timestamp)?;
         }
 
@@ -2882,6 +2888,48 @@ mod deindex_replay_tests {
                 .find(|(id, _)| *id == target_id)
                 .is_none_or(|(_, s)| *s < 0.1),
             "replay must drop the old embedding region after overwrite, got {after_old:?}"
+        );
+    }
+
+    /// Regression for the Gemini review on PR #3632: an `UpdateNode` replayed
+    /// against a node ABSENT from the (lagging) current-state index — the
+    /// `old_props == None` create-through-update branch of `update_node_direct`
+    /// — must index the vector into the current-state HNSW too, not only the
+    /// temporal index. Otherwise the vector is invisible to current-state
+    /// `find_similar` after recovery. Mirrors `insert_node_direct`, which
+    /// indexes both.
+    #[test]
+    fn update_create_path_indexes_current_state_hnsw() {
+        let storage = CurrentStorage::new();
+        // Current-state (non-temporal) vector index enabled; temporal one too,
+        // to exercise the exact fan-out the create-through-update branch runs.
+        storage
+            .enable_vector_index("embedding", HnswConfig::new(4, DistanceMetric::Cosine))
+            .unwrap();
+        storage
+            .enable_temporal_vector_index("embedding", temporal_config())
+            .unwrap();
+
+        // Drive update_node_direct on a node that was NEVER inserted, so
+        // old_props resolves to None (the create-through-update / lagging-replay
+        // path). This is exactly `current.update_node_direct(...)` at
+        // recovery.rs when the create was already truncated past the snapshot.
+        let target_id = NodeId::new(1).unwrap();
+        let props = PropertyMapBuilder::new()
+            .insert("name", "target")
+            .insert_vector("embedding", &[1.0f32, 0.0, 0.0, 0.0])
+            .build();
+        storage
+            .update_node_direct(node(1, 1, props), time::now())
+            .unwrap();
+
+        // The node must now be findable via the CURRENT-STATE HNSW.
+        let results = storage
+            .find_similar_by_embedding(&[1.0f32, 0.0, 0.0, 0.0], 10)
+            .unwrap();
+        assert!(
+            results.iter().any(|(id, _)| *id == target_id),
+            "create-through-update must index the current-state HNSW, got {results:?}"
         );
     }
 }

--- a/tests/temporal_vector_deindex.rs
+++ b/tests/temporal_vector_deindex.rs
@@ -221,6 +221,104 @@ fn overwrite_vector_property_deindexes_old_but_preserves_history() {
     );
 }
 
+/// A plain PATCH `update_node` that overwrites the embedding key with a
+/// NON-vector value (and carries no other vector property) must fire a temporal
+/// snapshot so the phantom is de-indexed as-of-now — not left stale until an
+/// unrelated future vector transaction happens to snapshot.
+///
+/// Fix discriminator for the snapshot-gating gap (Issue #3621, PATCH path):
+/// `WriteBuffer::add` sets `has_vector_operations` only from the merged/new
+/// property map, so a PATCH that turns `embedding` from a vector into a scalar
+/// leaves the flag false → `on_temporal_vector_transaction` never fires → no
+/// snapshot at t2 → `find_similar_as_of(now)` keeps returning the phantom
+/// (unbounded staleness). The `update_node_with_options` gate on the EXISTING
+/// node's vector — mirroring `buffer_node_replace` — closes it. The storage
+/// layer already de-indexes the LIVE temporal index; only the snapshot was
+/// missing.
+#[test]
+fn patch_overwriting_vector_with_scalar_deindexes_current_but_preserves_history() {
+    let db = temporal_db();
+
+    // A decoy keeps the temporal index non-empty across the change so a
+    // snapshot is always materialized (orthogonal to the query so it never
+    // masks the target assertion).
+    let decoy = db
+        .create_node(
+            "Doc",
+            PropertyMapBuilder::new()
+                .insert("name", "decoy")
+                .insert_vector("embedding", &[0.0f32, 0.0, 0.0, 1.0])
+                .build(),
+        )
+        .expect("create decoy");
+
+    let target = db
+        .create_node(
+            "Doc",
+            PropertyMapBuilder::new()
+                .insert("name", "target")
+                .insert_vector("embedding", &[1.0f32, 0.0, 0.0, 0.0])
+                .build(),
+        )
+        .expect("create target");
+
+    advance();
+    let t_before: Timestamp = time::now();
+    advance();
+
+    // PLAIN PATCH `update_node` (routes through `update_node_with_options`, the
+    // ungated path — NOT `replace_node`): overwrite the vector-typed key with a
+    // scalar, with NO other vector property in the patch. The merged map has no
+    // vector, so `WriteBuffer::add` leaves `has_vector_operations` false.
+    db.write(|tx| {
+        tx.update_node(
+            target,
+            PropertyMapBuilder::new()
+                .insert("embedding", "not-a-vector")
+                .build(),
+        )?;
+        Ok::<_, Error>(())
+    })
+    .expect("PATCH overwrites embedding with scalar");
+
+    advance();
+    let t_after: Timestamp = time::now();
+
+    // NO further/unrelated vector transaction is issued after this point.
+
+    let query = [1.0f32, 0.0, 0.0, 0.0];
+
+    // History preserved: as-of BEFORE the change, the target is still found.
+    let historical = as_of(&db, &query, 10, t_before);
+    assert!(
+        contains(&historical, target),
+        "target must remain findable as-of before the PATCH (history preserved), got {historical:?}"
+    );
+
+    // De-indexed now: as-of AFTER the change, the phantom must be gone — this is
+    // what fails without the snapshot-gating fix (no snapshot fired at t2).
+    let current = as_of(&db, &query, 10, t_after);
+    assert!(
+        !contains(&current, target),
+        "target must NOT be returned by temporal similarity as-of after the PATCH (Issue #3621 snapshot-gating phantom), got {current:?}"
+    );
+
+    // The decoy survives — the change only de-indexed the target.
+    assert!(
+        contains(&current, decoy),
+        "decoy must remain indexed after the target's PATCH, got {current:?}"
+    );
+
+    // Current-state index must also exclude the target.
+    let live = db
+        .similarity_search(SimilarityQuery::from_embedding(query.to_vec()).k(10))
+        .expect("current-state search");
+    assert!(
+        !contains(&live, target),
+        "target must be gone from the current-state index too, got {live:?}"
+    );
+}
+
 /// Sanity: without touching the vector (a non-vector-property update that
 /// re-supplies the same embedding), the embedding stays indexed — the fix must
 /// not over-remove.

--- a/tests/temporal_vector_deindex.rs
+++ b/tests/temporal_vector_deindex.rs
@@ -1,0 +1,247 @@
+//! Regression tests for Issue #3621: the transactional node-update path must
+//! de-index vectors from the TEMPORAL vector index, not only add to it.
+//!
+//! Before the fix, `CurrentStorage::update_node_direct` fanned vector updates
+//! into the current-state HNSW correctly (add/remove/upsert) but drove the
+//! temporal vector index through an ADD-ONLY helper. Removing a vector property
+//! (Some -> None) therefore left the stale embedding in the temporal index's
+//! `current_state.vectors`, and it leaked into the next snapshot, so
+//! `find_similar_as_of(now)` returned a phantom hit for a fact whose embedding
+//! had been deleted.
+//!
+//! The bi-temporal contract these tests pin down: removing/overwriting an
+//! embedding CLOSES the interval at the current time (a snapshot taken AFTER the
+//! change no longer contains the old vector), while snapshots taken BEFORE the
+//! change still retain it (history is preserved, never erased).
+
+use aletheiadb::core::temporal::{Timestamp, time};
+use aletheiadb::db::SimilarityQuery;
+use aletheiadb::index::vector::temporal::{
+    RetentionPolicy, SnapshotStrategy, TemporalVectorConfig,
+};
+use aletheiadb::{
+    AletheiaDB, DistanceMetric, Error, HnswConfig, NodeId, PropertyMapBuilder, WriteOps,
+};
+
+/// Build a DB with a temporal vector index that snapshots on EVERY committed
+/// transaction (the proven deterministic mechanism used by the existing
+/// `find_similar_as_of` tests): each `create_node`/`update_node` commit calls
+/// `on_temporal_vector_transaction`, which — with `TransactionInterval(1)` —
+/// materializes a snapshot keyed at that commit's wallclock.
+fn temporal_db() -> AletheiaDB {
+    let db = AletheiaDB::new().expect("db");
+    let hnsw = HnswConfig::new(4, DistanceMetric::Cosine);
+    let config = TemporalVectorConfig {
+        snapshot_strategy: SnapshotStrategy::TransactionInterval(1),
+        retention_policy: RetentionPolicy::KeepN(100),
+        max_snapshots: 100,
+        full_snapshot_interval: 5,
+        hnsw_config: Some(hnsw),
+    };
+    db.enable_temporal_vector_index("embedding", config)
+        .expect("enable temporal vector index");
+    db
+}
+
+/// Small wall-clock advance so distinct commits land in distinct, ordered
+/// snapshot buckets (snapshots are keyed by wallclock at commit time).
+fn advance() {
+    std::thread::sleep(std::time::Duration::from_millis(25));
+}
+
+/// Point-in-time similarity via the current public API (`similarity_search`
+/// with `.at_time(..)`), which routes to the temporal vector index.
+fn as_of(db: &AletheiaDB, query: &[f32], k: usize, ts: Timestamp) -> Vec<(NodeId, f32)> {
+    db.similarity_search(
+        SimilarityQuery::from_embedding(query.to_vec())
+            .k(k)
+            .at_time(ts),
+    )
+    .expect("as-of similarity search")
+}
+
+fn contains(results: &[(NodeId, f32)], id: NodeId) -> bool {
+    results.iter().any(|(nid, _)| *nid == id)
+}
+
+fn score_of(results: &[(NodeId, f32)], id: NodeId) -> Option<f32> {
+    results.iter().find(|(nid, _)| *nid == id).map(|(_, s)| *s)
+}
+
+/// Removing a vector property de-indexes it from the temporal index at the
+/// current time, while an earlier snapshot still finds it (history preserved).
+#[test]
+fn remove_vector_property_deindexes_current_but_preserves_history() {
+    let db = temporal_db();
+
+    // A decoy keeps the temporal index non-empty across the removal so a
+    // snapshot is always materialized (and its embedding is orthogonal to the
+    // query, so it never masks the target assertion).
+    let decoy = db
+        .create_node(
+            "Doc",
+            PropertyMapBuilder::new()
+                .insert("name", "decoy")
+                .insert_vector("embedding", &[0.0f32, 0.0, 0.0, 1.0])
+                .build(),
+        )
+        .expect("create decoy");
+
+    let target = db
+        .create_node(
+            "Doc",
+            PropertyMapBuilder::new()
+                .insert("name", "target")
+                .insert_vector("embedding", &[1.0f32, 0.0, 0.0, 0.0])
+                .build(),
+        )
+        .expect("create target");
+
+    advance();
+    let t_before_remove: Timestamp = time::now();
+    advance();
+
+    // Remove the embedding (Some -> None) via a full-map replace that drops it.
+    db.replace_node(
+        target,
+        "Doc",
+        PropertyMapBuilder::new().insert("name", "target").build(),
+    )
+    .expect("replace removes vector");
+
+    advance();
+    let t_after_remove: Timestamp = time::now();
+
+    let query = [1.0f32, 0.0, 0.0, 0.0];
+
+    // History preserved: as-of BEFORE the removal, the target is still found.
+    let historical = as_of(&db, &query, 10, t_before_remove);
+    assert!(
+        contains(&historical, target),
+        "target must remain findable as-of before the removal (history preserved), got {historical:?}"
+    );
+
+    // De-indexed now: as-of AFTER the removal, the phantom must be gone.
+    let current = as_of(&db, &query, 10, t_after_remove);
+    assert!(
+        !contains(&current, target),
+        "target must NOT be returned by temporal similarity as-of after removal (Issue #3621 phantom), got {current:?}"
+    );
+
+    // The decoy survives — the removal only de-indexed the target.
+    assert!(
+        contains(&current, decoy),
+        "decoy must remain indexed after target's removal, got {current:?}"
+    );
+
+    // Current-state index must also exclude the target (covered by #3596, kept
+    // here as a cross-check that both indexes agree post-fix).
+    let live = db
+        .similarity_search(SimilarityQuery::from_embedding(query.to_vec()).k(10))
+        .expect("current-state search");
+    assert!(
+        !contains(&live, target),
+        "target must be gone from the current-state index too, got {live:?}"
+    );
+}
+
+/// Overwriting a vector property replaces the old embedding at the current time
+/// (nearest to the NEW vector, no longer to the old region), while an earlier
+/// snapshot still returns it nearest to the OLD vector.
+#[test]
+fn overwrite_vector_property_deindexes_old_but_preserves_history() {
+    let db = temporal_db();
+
+    let target = db
+        .create_node(
+            "Doc",
+            PropertyMapBuilder::new()
+                .insert("name", "target")
+                .insert_vector("embedding", &[1.0f32, 0.0, 0.0, 0.0])
+                .build(),
+        )
+        .expect("create target");
+
+    advance();
+    let t_before: Timestamp = time::now();
+    advance();
+
+    // Overwrite with a very different embedding (Some -> Some, changed).
+    db.write(|tx| {
+        tx.update_node(
+            target,
+            PropertyMapBuilder::new()
+                .insert("name", "target")
+                .insert_vector("embedding", &[0.0f32, 1.0, 0.0, 0.0])
+                .build(),
+        )
+    })
+    .expect("overwrite embedding");
+
+    advance();
+    let t_after: Timestamp = time::now();
+
+    let old_region = [1.0f32, 0.0, 0.0, 0.0];
+    let new_region = [0.0f32, 1.0, 0.0, 0.0];
+
+    // As-of BEFORE the overwrite: nearest to the OLD region.
+    let before = as_of(&db, &old_region, 10, t_before);
+    assert!(
+        score_of(&before, target).is_some_and(|s| s > 0.99),
+        "as-of before overwrite, target must be ~identical to the old embedding, got {before:?}"
+    );
+
+    // As-of AFTER the overwrite: nearest to the NEW region.
+    let after_new = as_of(&db, &new_region, 10, t_after);
+    assert!(
+        score_of(&after_new, target).is_some_and(|s| s > 0.99),
+        "as-of after overwrite, target must be ~identical to the new embedding, got {after_new:?}"
+    );
+
+    // As-of AFTER the overwrite: the OLD region no longer matches the target
+    // (the stale embedding is gone from the current snapshot).
+    let after_old = as_of(&db, &old_region, 10, t_after);
+    assert!(
+        score_of(&after_old, target).is_none_or(|s| s < 0.1),
+        "as-of after overwrite, the OLD embedding must no longer match the target, got {after_old:?}"
+    );
+}
+
+/// Sanity: without touching the vector (a non-vector-property update), the
+/// embedding stays indexed — the fix must not over-remove.
+#[test]
+fn unrelated_update_keeps_vector_indexed() {
+    let db = temporal_db();
+
+    let target = db
+        .create_node(
+            "Doc",
+            PropertyMapBuilder::new()
+                .insert("name", "target")
+                .insert_vector("embedding", &[1.0f32, 0.0, 0.0, 0.0])
+                .build(),
+        )
+        .expect("create target");
+
+    // Update a non-vector property while re-supplying the same embedding.
+    db.write(|tx| {
+        tx.update_node(
+            target,
+            PropertyMapBuilder::new()
+                .insert("name", "renamed")
+                .insert_vector("embedding", &[1.0f32, 0.0, 0.0, 0.0])
+                .build(),
+        )?;
+        Ok::<_, Error>(())
+    })
+    .expect("update non-vector property");
+
+    advance();
+    let now: Timestamp = time::now();
+
+    let results = as_of(&db, &[1.0f32, 0.0, 0.0, 0.0], 10, now);
+    assert!(
+        contains(&results, target),
+        "target must remain indexed after an unrelated update, got {results:?}"
+    );
+}

--- a/tests/temporal_vector_deindex.rs
+++ b/tests/temporal_vector_deindex.rs
@@ -9,10 +9,19 @@
 //! `find_similar_as_of(now)` returned a phantom hit for a fact whose embedding
 //! had been deleted.
 //!
-//! The bi-temporal contract these tests pin down: removing/overwriting an
+//! The bi-temporal contract these tests exercise: removing/overwriting an
 //! embedding CLOSES the interval at the current time (a snapshot taken AFTER the
 //! change no longer contains the old vector), while snapshots taken BEFORE the
 //! change still retain it (history is preserved, never erased).
+//!
+//! Fix-discriminating vs regression-lock: only the REMOVAL case (`Some -> None`)
+//! actually fails on trunk before the fix — that is what the add-only temporal
+//! helper mishandled — so `remove_vector_property_deindexes_current_but_preserves_history`
+//! is the guard that pins the fix. The overwrite (`Some -> Some`) and
+//! unrelated-update tests below PASS on trunk too (trunk's add-only helper
+//! already upserted on `Some -> Some` via `HnswIndex::add`); they are kept as
+//! regression locks that the de-index change did not break overwrite or
+//! over-remove on an unrelated update.
 
 use aletheiadb::core::temporal::{Timestamp, time};
 use aletheiadb::db::SimilarityQuery;
@@ -148,6 +157,11 @@ fn remove_vector_property_deindexes_current_but_preserves_history() {
 /// Overwriting a vector property replaces the old embedding at the current time
 /// (nearest to the NEW vector, no longer to the old region), while an earlier
 /// snapshot still returns it nearest to the OLD vector.
+///
+/// Regression lock, not a fix discriminator: this `Some -> Some` overwrite
+/// already passes on trunk (the add-only temporal helper upserted on overwrite
+/// via `HnswIndex::add`). It guards that the #3621 de-index change did not
+/// regress the overwrite path.
 #[test]
 fn overwrite_vector_property_deindexes_old_but_preserves_history() {
     let db = temporal_db();
@@ -207,8 +221,19 @@ fn overwrite_vector_property_deindexes_old_but_preserves_history() {
     );
 }
 
-/// Sanity: without touching the vector (a non-vector-property update), the
-/// embedding stays indexed — the fix must not over-remove.
+/// Sanity: without touching the vector (a non-vector-property update that
+/// re-supplies the same embedding), the embedding stays indexed — the fix must
+/// not over-remove.
+///
+/// Regression lock, not a fix discriminator: this passes on trunk too (the
+/// `Some -> Some` unchanged case was already a no-op via the `if o != n` guard).
+/// It guards that the de-index change did not over-remove on an unrelated
+/// update. (A no-churn assertion — that re-supplying the same embedding does
+/// not redundantly re-add — is intentionally omitted: the temporal index's
+/// change-tracking is `HashSet<NodeId>`-keyed, so a single node re-supplying the
+/// same vector yields the identical count whether or not the guard fires, and
+/// snapshot counts grow per commit regardless; no reachable, non-fragile
+/// observable discriminates the guard.)
 #[test]
 fn unrelated_update_keeps_vector_indexed() {
     let db = temporal_db();


### PR DESCRIPTION
Fixes #3621.

## Before

Removing (or overwriting) a vector/embedding property on a node left a **phantom vector** in the temporal vector index. A point-in-time similarity query anchored at the current time (`find_similar_as_of` / `similarity_search(...).at_time(now)`) would still return the node for an embedding that had been deleted or replaced.

Root cause: `CurrentStorage::update_node_direct` updated the **current-state** HNSW correctly via `update_vector_index` (a full `match (old_vec, new_vec)` handling add / remove / upsert), but drove the **temporal** vector index through the **add-only** `try_index_temporal_vector` helper. That helper never removes and never handles overwrite, so a `Some -&gt; None` removal left the stale embedding in the temporal index&#39;s `current_state.vectors`, and it leaked into the next snapshot.

## After

Removing or overwriting an embedding now **closes the vector&#39;s interval at the update timestamp**: a snapshot taken *after* the change no longer contains the old vector, so as-of-now similarity no longer returns the phantom — while a snapshot taken *before* the change still retains it. History is preserved (interval-close, **not** a history erase); an as-of-earlier query still finds the old embedding.

## How

- New `CurrentStorage::update_temporal_vector_index`, mirroring `update_vector_index` for the temporal path: per enabled temporal index property it diffs old vs new and applies `(None,None)` no-op / `(None,Some)` add / `(Some,None)` `remove` / `(Some,Some)` upsert-if-changed. `TemporalVectorIndex::remove` drops the embedding from the live HNSW **and** `current_state.vectors`, so it no longer leaks into the next snapshot, and records the change without erasing prior snapshots.
- Wired into `update_node_direct` alongside `update_vector_index`, guarded on the old properties being present. The add-only path is retained only for the no-old-props case (a create routed through the update path), where there is nothing to remove.
- Because `update_node_direct` is the exact entry point WAL replay calls during crash recovery, replay reconstructs the same corrected point-in-time state through this method — no WAL format change.
- Respects the CLAUDE.md lock order; reuses the existing `add`/`remove` on `TemporalVectorIndex`.
- **Snapshot-gating completion (a second hunk, outside `src/storage/`, in `src/api/transaction/write/mod.rs` — coordinated with Lane 2):** the storage-layer de-index above correctly updates the LIVE temporal HNSW, but the plain PATCH `update_node` path did not always TRIGGER a temporal snapshot. `WriteBuffer::add` sets `has_vector_operations` only from the merged/new property map, so a PATCH that overwrites a vector-typed key with a scalar (or drops the embedding) when no other property is a vector left the flag false → `on_temporal_vector_transaction` never fired → no snapshot at the update time, so `find_similar_as_of(now)` kept returning the phantom until an *unrelated future* vector transaction happened to snapshot (unbounded staleness). `update_node_with_options` now gates on the **existing** node&#39;s vector too — `node.properties.contains_vector() || merged_properties.contains_vector()` — mirroring the already-correct `buffer_node_replace` / `delete_node` gating, so a vector-dropping/downgrading PATCH de-indexes **as-of-now, not just eventually**. The gate stays tied to the existing node actually having had a vector, so a PATCH that touches no vector on a never-vector node does not newly fire the hook.

## Testing

TDD, red -&gt; green:

- **RED**: `remove_vector_property_deindexes_current_but_preserves_history` failed with the phantom still present — `target must NOT be returned by temporal similarity as-of after removal (Issue #3621 phantom), got [(NodeId(1), 1.0), (NodeId(0), 0.0)]`. The replay unit test failed the same way (`got [(NodeId(1), 1.0)]`).
- **RED (snapshot-gating hunk)**: `patch_overwriting_vector_with_scalar_deindexes_current_but_preserves_history` failed with the phantom still returned as-of-after because no snapshot fired — `target must NOT be returned by temporal similarity as-of after the PATCH (Issue #3621 snapshot-gating phantom), got [(NodeId(1), 1.0), (NodeId(0), 0.0)]`.
- **GREEN** after the fix:
  - `tests/temporal_vector_deindex.rs` (4 tests): `remove_vector_property_deindexes_current_but_preserves_history`, `overwrite_vector_property_deindexes_old_but_preserves_history`, `unrelated_update_keeps_vector_indexed`, and the new `patch_overwriting_vector_with_scalar_deindexes_current_but_preserves_history` (plain PATCH overwriting the embedding key with a scalar: as-of-after excludes the phantom, as-of-before still finds it, current-state excludes it).
  - `src/storage/current/mod.rs` `deindex_replay_tests` (2 tests): `replay_remove_vector_deindexes_current_but_preserves_history`, `replay_overwrite_vector_reconstructs_corrected_state` — drive `insert_node_direct` / `update_node_direct` (the WAL-replay entry points) directly.
- Regression: `temporal_vector`, `temporal_vector_tests`, `temporal_vector_integration`, `replace_tombstone`, `recovery`, and the `api::transaction` lib unit tests all green after the snapshot-gating hunk.
- `cargo fmt --all` clean; `cargo clippy --all-targets` clean on both the CI feature set (`config-toml,mcp-server,sharding-rpc,simulation`) and `--all-features` with `-D warnings`.

The bi-temporal contract these tests pin down: a removed/overwritten embedding is de-indexed at the current time while snapshots taken before the change still find it.

## Scope notes

Fix is confined to the transactional update path (the filed bug). The snapshot-gating hunk lives in `src/api/transaction/write/mod.rs` (the write-transaction layer, **outside `src/storage/`**), coordinated with Lane 2 to avoid collision. The non-transactional `CurrentStorage::create_node` (mod.rs ~499) and `delete_node` (mod.rs ~695) still lack temporal-index maintenance, but those paths have no timestamp/temporal semantics by design (see their existing comments) and are out of scope for #3621; left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qYdwtZEgefPNdKbv5sax8

---
_Generated by [Claude Code](https://claude.ai/code/session_018qYdwtZEgefPNdKbv5sax8)_