### PR TITLE
fix(encryption): add manifest-body decrypt probe to `encryption verify` (#3618)

### DIFF
--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -856,14 +856,16 @@ fn encryption_status(args: &[String]) -> Result<(), String> {
 ///   (encrypted) WAL through the configured cipher; a wrong or missing key
 ///   fails the open with an authentication error. A successful open therefore
 ///   *proves* the WAL actually AEAD-decrypts.
-/// * **Index — a header classification, NOT a body decrypt.** On success we
-///   additionally *classify* every persisted index file by reading its 10-byte
-///   `AEIX` header key-version and matching it against the live keyring
-///   (`at_current` / `at_old` / `unknown` / `plaintext`). This reads only the
-///   header bytes; it does **not** AEAD-decrypt the index bodies. A genuine
-///   index-body decrypt happens only when `persistence.load_on_startup = true`
-///   (which the durable `open()` path enables), where the load itself would
-///   fail on a bad key.
+/// * **Index — header classification AND a body decrypt probe.** On success we
+///   *classify* every persisted index file by reading its 10-byte `AEIX` header
+///   key-version and matching it against the live keyring (`at_current` /
+///   `at_old` / `unknown` / `plaintext`). Header classification alone can
+///   false-PASS when a wrong key shares the same key-version number, so we
+///   additionally run an *active* body decrypt probe (Issue #3618): the manifest
+///   body plus one representative encrypted file per distinct key generation are
+///   AEAD-decrypted through the keyring. A wrong key (or a corrupted body) fails
+///   the AEAD auth tag here even when the header matches, turning what was a
+///   false-PASS into a FAIL. No key bytes or file paths are ever printed.
 ///
 /// Operates on the ambient configuration only (`ALETHEIADB_CONFIG` /
 /// `ALETHEIADB_DATA_DIR`); it does not accept `--key-file` / `--env-var`, which
@@ -911,6 +913,22 @@ fn encryption_verify(_args: &[String]) -> Result<(), String> {
                     s.unknown
                 ));
             }
+            // Header classification alone can FALSE-PASS: a wrong key that shares
+            // the same key_version number matches the header while decrypting
+            // nothing (Issue #3618). Actively probe that index bodies AEAD-decrypt
+            // under the live keyring — a wrong key or a corrupted body fails here.
+            let probe = db
+                .verify_index_decryptable()
+                .map_err(|e| format!("encryption verify FAILED: {e}"))?;
+            if !probe.decrypt_failed.is_empty() {
+                // Report a count and a generic reason only — never a path or key
+                // material that could leak secrets.
+                return Err(format!(
+                    "encryption verify FAILED: {} index file(s) present a body that does \
+                     NOT decrypt with the configured key material (wrong key or corruption)",
+                    probe.decrypt_failed.len()
+                ));
+            }
             let stats = db.stats();
             println!("encryption verify: PASS");
             println!(
@@ -922,6 +940,10 @@ fn encryption_verify(_args: &[String]) -> Result<(), String> {
                  by AEIX header ({} plaintext)",
                 s.at_current + s.at_old,
                 s.plaintext
+            );
+            println!(
+                "  Index: {} encrypted file(s) body-decrypted with the live keyring",
+                probe.decrypted_ok
             );
         }
         Err(e) if rotation_status_not_enabled(&e) => {

--- a/src/db/rotation.rs
+++ b/src/db/rotation.rs
@@ -63,6 +63,7 @@ use crate::encryption::config::{EncryptionConfig, KeyProviderConfig};
 use crate::encryption::factory::create_cipher;
 use crate::encryption::key_derivation::KeyDerivation;
 use crate::storage::index_persistence::common::ENC_INDEX_KEY_VERSION_V1;
+use crate::storage::index_persistence::reencrypt::DecryptProbeReport;
 use crate::storage::index_persistence::{
     IndexKeyRotation, IndexPersistenceManager, RotationError, RotationStatus,
 };
@@ -193,6 +194,45 @@ impl AletheiaDB {
             cipher,
         );
         engine.status().map_err(rotation_err)
+    }
+
+    /// Actively probe that persisted index bodies decrypt under the live keyring
+    /// (Issue #3618).
+    ///
+    /// [`index_rotation_status`](Self::index_rotation_status) classifies files by
+    /// their `AEIX` header `key_version` only, which false-PASSes when a wrong key
+    /// shares the same version number. This probe AEAD-decrypts representative
+    /// index bodies (the manifest plus one file per distinct key generation) and
+    /// reports which authenticated, so `encryption verify` fails on wrong key
+    /// material or a corrupted body rather than trusting the header.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if index persistence or encryption is not configured, or
+    /// if the index directory cannot be read. A body that does not decrypt is
+    /// NOT an error here — it is recorded in
+    /// [`DecryptProbeReport::decrypt_failed`] for the caller to act on.
+    pub fn verify_index_decryptable(&self) -> Result<DecryptProbeReport> {
+        let manager = self.require_rotation_prereqs()?;
+        let keyring = manager
+            .keyring()
+            .cloned()
+            .ok_or_else(|| rotation_err(RotationError::NotConfigured))?;
+        let cipher = keyring
+            .current_cipher()
+            .ok_or_else(|| rotation_err(RotationError::NotConfigured))?;
+        let version = keyring.current_version();
+        // The probe only reads/decrypts bodies; a single-generation engine
+        // (mirroring index_rotation_status) suffices.
+        let engine = IndexKeyRotation::new(
+            manager.indexes_path(),
+            keyring,
+            version,
+            cipher.clone(),
+            version,
+            cipher,
+        );
+        engine.verify_decryptable().map_err(rotation_err)
     }
 
     /// Rotate the index-encryption key to a new key source, re-encrypting every

--- a/src/storage/index_persistence/reencrypt.rs
+++ b/src/storage/index_persistence/reencrypt.rs
@@ -134,6 +134,37 @@ impl RotationStatus {
     }
 }
 
+/// Result of the manifest-/index-body decrypt probe (Issue #3618).
+///
+/// [`RotationStatus`] classifies files by their 10-byte `AEIX` header
+/// `key_version` ONLY; it never AEAD-decrypts the body. A wrong key that happens
+/// to share the same `key_version` number therefore passes header classification
+/// (`unknown == 0`) even though it cannot actually decrypt anything — a
+/// false-PASS for `encryption verify`. This report captures an *active* decrypt
+/// probe: it attempts to AEAD-decrypt representative index bodies with the live
+/// keyring and records what actually authenticated.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DecryptProbeReport {
+    /// Number of encrypted files whose body the probe actually attempted to
+    /// decrypt (bounded — see [`IndexKeyRotation::verify_decryptable`]).
+    pub probed: usize,
+    /// Probed files whose body AEAD-decrypted successfully under the keyring.
+    pub decrypted_ok: usize,
+    /// Plaintext (non-`AEIX`) files encountered — skipped, NOT a failure.
+    pub plaintext: usize,
+    /// Paths of probed files whose body did NOT decrypt (wrong key material or
+    /// corruption). Path only — never any key bytes.
+    pub decrypt_failed: Vec<PathBuf>,
+}
+
+impl DecryptProbeReport {
+    /// True when the probe attempted at least one decrypt and none failed.
+    #[must_use]
+    pub fn all_decrypted(&self) -> bool {
+        self.decrypt_failed.is_empty()
+    }
+}
+
 /// Per-file outcome of the byte-level re-encryption primitive.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FileOutcome {
@@ -205,6 +236,75 @@ impl IndexKeyRotation {
             }
         }
         Ok(status)
+    }
+
+    /// Actively probe that index bodies decrypt under the live keyring
+    /// (Issue #3618).
+    ///
+    /// [`status`](Self::status) classifies files by their `AEIX` header
+    /// `key_version` alone and cannot catch a wrong key that shares the same
+    /// version number (the body is never touched). This probe closes that hole:
+    /// it AEAD-decrypts representative index *bodies* through the keyring and
+    /// reports which authenticated. A wrong key (or a corrupted body) fails the
+    /// AEAD auth tag — the header is AAD — so `decrypt_failed` becomes non-empty.
+    ///
+    /// **Bounded cost.** `verify` is an operator command, not a hot path, and
+    /// decrypting every file of a huge database would be wasteful. The probe
+    /// therefore decrypts the manifest body (the small canonical file every
+    /// encrypted database writes) plus ONE representative encrypted file per
+    /// distinct `key_version` actually present on disk. That fully catches a
+    /// uniformly-wrong configured key — the Issue #3618 scenario — since a wrong
+    /// key fails on the very first file of each generation.
+    ///
+    /// Plaintext (non-`AEIX`) files are counted under `plaintext` and skipped;
+    /// they are not decrypt failures. Recorded failure paths never carry key
+    /// material.
+    pub fn verify_decryptable(&self) -> Result<DecryptProbeReport, RotationError> {
+        use std::collections::HashSet;
+
+        let mut report = DecryptProbeReport::default();
+        let mut probed_versions: HashSet<u32> = HashSet::new();
+        let manifest_path = self.indexes_dir.join("manifest.idx");
+
+        // Walk EVERY non-scratch file (not just encrypted ones) so plaintext
+        // files are counted rather than silently invisible. Sorted for a
+        // deterministic representative per key-version.
+        let mut files = Vec::new();
+        if self.indexes_dir.exists() {
+            collect_all_files(&self.indexes_dir, &mut files)?;
+        }
+        files.sort();
+
+        for path in files {
+            // verify may run against a LIVE db: a file listed a moment ago can be
+            // removed/renamed by a concurrent writer's atomic_write between the
+            // scan and this read. A vanished file is benign — skip it rather than
+            // fail the probe; any OTHER io error still propagates.
+            let bytes = match std::fs::read(&path) {
+                Ok(b) => b,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => return Err(e.into()),
+            };
+            let Some(key_version) = index_file_key_version(&bytes) else {
+                // Not an AEIX-encrypted file: plaintext, skip (not a failure).
+                report.plaintext += 1;
+                continue;
+            };
+            // Bounded cost: always probe the manifest body; otherwise probe only
+            // the first file seen for each distinct key_version.
+            let is_manifest = path == manifest_path;
+            let first_of_version = probed_versions.insert(key_version);
+            if !is_manifest && !first_of_version {
+                continue;
+            }
+            report.probed += 1;
+            match decrypt_index_bytes_with_keyring(&bytes, &path, Some(&self.keyring)) {
+                Ok(_) => report.decrypted_ok += 1,
+                // Path only — never any key bytes.
+                Err(_) => report.decrypt_failed.push(path),
+            }
+        }
+        Ok(report)
     }
 
     /// Re-encrypt every old-key file to the new key (forward pass).
@@ -371,6 +471,32 @@ fn peek_key_version(path: &Path) -> Result<Option<u32>, RotationError> {
 /// A temp/scratch file the rotation engine must never treat as an index file.
 fn is_scratch_file(name: &str) -> bool {
     name.ends_with(".tmp") || name.contains(".tmp.") || name.starts_with(".aeix-usearch-tmp-")
+}
+
+/// Recursively collect every regular, non-scratch file under `dir` — encrypted
+/// AND plaintext. Unlike [`collect_index_files`], this does NOT filter to files
+/// carrying the `AEIX` header, so the decrypt probe (Issue #3618) can count
+/// plaintext files instead of treating them as absent.
+fn collect_all_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), RotationError> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_all_files(&path, out)?;
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if is_scratch_file(&name) {
+            continue;
+        }
+        out.push(path);
+    }
+    Ok(())
 }
 
 fn collect_index_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), RotationError> {
@@ -707,6 +833,271 @@ mod tests {
             std::fs::read(&plain).unwrap(),
             b"\x00plaintext-not-encrypted"
         );
+    }
+
+    // ── Issue #3618: manifest-/index-body decrypt probe ──────────────
+
+    #[test]
+    fn verify_decryptable_passes_with_correct_key() {
+        // Files written and probed with the SAME key: every probed body
+        // authenticates, nothing fails.
+        let dir = tempfile::tempdir().unwrap();
+        let indexes = dir.path().join("indexes");
+        let good = cipher_from_seed(0x11);
+
+        write_enc(
+            &indexes.join("manifest.idx"),
+            &good,
+            OLD_V,
+            b"MANIFEST-body-0",
+        );
+        write_enc(
+            &indexes.join("graph").join("adjacency.idx"),
+            &good,
+            OLD_V,
+            b"graph-body-1",
+        );
+
+        let ring = IndexKeyring::single_versioned(good.clone(), OLD_V);
+        let eng = IndexKeyRotation::new(&indexes, ring, OLD_V, good.clone(), OLD_V, good.clone());
+
+        let report = eng.verify_decryptable().unwrap();
+        assert!(
+            report.decrypt_failed.is_empty(),
+            "correct key must decrypt every probed body: {report:?}"
+        );
+        assert!(
+            report.decrypted_ok > 0,
+            "at least one body must be probed and decrypt: {report:?}"
+        );
+        assert!(report.all_decrypted());
+    }
+
+    #[test]
+    fn verify_decryptable_catches_same_version_wrong_key() {
+        // THE core red test (Issue #3618): a wrong key that shares the SAME
+        // key_version number passes header classification (status()) but MUST be
+        // caught by the body decrypt probe.
+        let dir = tempfile::tempdir().unwrap();
+        let indexes = dir.path().join("indexes");
+        let good = cipher_from_seed(0x11); // key material X
+        let wrong = cipher_from_seed(0x99); // DIFFERENT key material Y
+
+        // Bodies written by the GOOD key at key_version 1.
+        write_enc(
+            &indexes.join("manifest.idx"),
+            &good,
+            OLD_V,
+            b"MANIFEST-body",
+        );
+        write_enc(
+            &indexes.join("graph").join("adjacency.idx"),
+            &good,
+            OLD_V,
+            b"graph-body",
+        );
+
+        // Engine holds the WRONG key at the SAME version 1.
+        let wrong_ring = IndexKeyring::single_versioned(wrong.clone(), OLD_V);
+        let eng = IndexKeyRotation::new(
+            &indexes,
+            wrong_ring,
+            OLD_V,
+            wrong.clone(),
+            OLD_V,
+            wrong.clone(),
+        );
+
+        // (a) Header classification PASSES — this is the bug: the version number
+        // matches, so status() sees only "current" files and nothing unknown.
+        let status = eng.status().unwrap();
+        assert!(
+            status.at_current > 0,
+            "header classification should see current-version files: {status:?}"
+        );
+        assert_eq!(
+            status.unknown, 0,
+            "header classification cannot detect the wrong key: {status:?}"
+        );
+
+        // (b) The body decrypt probe CATCHES it: nothing authenticates under the
+        // wrong key.
+        let report = eng.verify_decryptable().unwrap();
+        assert!(
+            !report.decrypt_failed.is_empty(),
+            "decrypt probe must flag the wrong key: {report:?}"
+        );
+        assert_eq!(
+            report.decrypted_ok, 0,
+            "no body can decrypt under the wrong key: {report:?}"
+        );
+        assert!(!report.all_decrypted());
+    }
+
+    #[test]
+    fn verify_decryptable_ignores_plaintext_files() {
+        // A legacy plaintext (non-AEIX) file is counted as plaintext, never as a
+        // decrypt failure.
+        let dir = tempfile::tempdir().unwrap();
+        let indexes = dir.path().join("indexes");
+        let good = cipher_from_seed(0x11);
+
+        write_enc(
+            &indexes.join("manifest.idx"),
+            &good,
+            OLD_V,
+            b"MANIFEST-body",
+        );
+        std::fs::create_dir_all(&indexes).unwrap();
+        std::fs::write(indexes.join("legacy.idx"), b"\x00plaintext-not-encrypted").unwrap();
+
+        let ring = IndexKeyring::single_versioned(good.clone(), OLD_V);
+        let eng = IndexKeyRotation::new(&indexes, ring, OLD_V, good.clone(), OLD_V, good.clone());
+
+        let report = eng.verify_decryptable().unwrap();
+        assert_eq!(
+            report.plaintext, 1,
+            "the plaintext file must be counted as plaintext: {report:?}"
+        );
+        assert!(
+            report.decrypt_failed.is_empty(),
+            "a plaintext file is not a decrypt failure: {report:?}"
+        );
+        assert!(
+            report.decrypted_ok >= 1,
+            "the encrypted manifest must still be probed and decrypt: {report:?}"
+        );
+    }
+
+    #[test]
+    fn verify_decryptable_catches_wrong_key_in_one_of_multiple_generations() {
+        // Multi-generation coverage: bodies exist at BOTH key_version 1 and 2.
+        // The keyring holds the CORRECT v1 cipher but a WRONG v2 cipher (same
+        // version slot, different key bytes). The per-key-version dedup probes one
+        // representative body per generation, so the v1 files decrypt while the v2
+        // representative fails — exactly what would happen if a later generation's
+        // configured key were wrong.
+        let dir = tempfile::tempdir().unwrap();
+        let indexes = dir.path().join("indexes");
+        let good_v1 = cipher_from_seed(0x11); // correct v1 key material
+        let good_v2 = cipher_from_seed(0x22); // the key that actually wrote v2 files
+        let wrong_v2 = cipher_from_seed(0x99); // different bytes, same version slot
+
+        // v1 bodies (manifest + one file) written by the good v1 key.
+        write_enc(
+            &indexes.join("manifest.idx"),
+            &good_v1,
+            OLD_V,
+            b"MANIFEST-v1",
+        );
+        write_enc(
+            &indexes.join("graph").join("adjacency.idx"),
+            &good_v1,
+            OLD_V,
+            b"graph-v1",
+        );
+        // v2 bodies written by the good v2 key (a later generation on disk).
+        write_enc(
+            &indexes.join("vector").join("emb").join("meta.idx"),
+            &good_v2,
+            NEW_V,
+            b"vector-v2",
+        );
+
+        // Keyring: correct v1, WRONG v2.
+        let ring = IndexKeyring::single_versioned(good_v1.clone(), OLD_V);
+        ring.add_generation(NEW_V, wrong_v2.clone());
+        let eng = IndexKeyRotation::new(
+            &indexes,
+            ring,
+            OLD_V,
+            good_v1.clone(),
+            NEW_V,
+            wrong_v2.clone(),
+        );
+
+        let report = eng.verify_decryptable().unwrap();
+        assert!(
+            !report.decrypt_failed.is_empty(),
+            "the v2 representative under the wrong key must fail: {report:?}"
+        );
+        assert!(
+            report.decrypted_ok >= 1,
+            "the v1 files must still decrypt under the correct v1 key: {report:?}"
+        );
+    }
+
+    #[test]
+    fn verify_decryptable_always_probes_manifest() {
+        // Bounded-cost design: the manifest is ALWAYS probed, plus the first file
+        // (sorted) of each distinct key_version. With three same-version files —
+        // one sorting before `manifest.idx`, the manifest, one sorting after —
+        // the probe hits exactly two: `aaa.idx` (first-of-version) and the
+        // always-probed manifest; `zzz.idx` (a third same-version body) is
+        // intentionally NOT probed.
+        let dir = tempfile::tempdir().unwrap();
+        let indexes = dir.path().join("indexes");
+        let good = cipher_from_seed(0x11);
+
+        write_enc(&indexes.join("aaa.idx"), &good, OLD_V, b"aaa-body");
+        write_enc(
+            &indexes.join("manifest.idx"),
+            &good,
+            OLD_V,
+            b"MANIFEST-body",
+        );
+        write_enc(&indexes.join("zzz.idx"), &good, OLD_V, b"zzz-body");
+
+        let ring = IndexKeyring::single_versioned(good.clone(), OLD_V);
+        let eng = IndexKeyRotation::new(&indexes, ring, OLD_V, good.clone(), OLD_V, good.clone());
+
+        let report = eng.verify_decryptable().unwrap();
+        assert_eq!(
+            report.probed, 2,
+            "expected manifest + aaa.idx probed, zzz.idx skipped: {report:?}"
+        );
+        assert!(
+            report.all_decrypted(),
+            "all probed bodies decrypt: {report:?}"
+        );
+    }
+
+    #[test]
+    fn verify_decryptable_empty_or_missing_manifest_is_pass() {
+        let good = cipher_from_seed(0x11);
+
+        // (a) Non-existent indexes dir: the exists() guard means nothing is
+        // walked; the probe returns a clean pass (no panic).
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist");
+        let ring = IndexKeyring::single_versioned(good.clone(), OLD_V);
+        let eng = IndexKeyRotation::new(&missing, ring, OLD_V, good.clone(), OLD_V, good.clone());
+        let report = eng.verify_decryptable().unwrap();
+        assert_eq!(
+            report.probed, 0,
+            "nothing to probe in a missing dir: {report:?}"
+        );
+        assert!(report.decrypt_failed.is_empty());
+        assert!(report.all_decrypted());
+
+        // (b) Encrypted non-manifest files but NO manifest.idx: still a pass — the
+        // first-of-version representative is probed and decrypts.
+        let dir2 = tempfile::tempdir().unwrap();
+        let indexes = dir2.path().join("indexes");
+        write_enc(
+            &indexes.join("graph").join("adjacency.idx"),
+            &good,
+            OLD_V,
+            b"graph-body",
+        );
+        let ring2 = IndexKeyring::single_versioned(good.clone(), OLD_V);
+        let eng2 = IndexKeyRotation::new(&indexes, ring2, OLD_V, good.clone(), OLD_V, good.clone());
+        let report2 = eng2.verify_decryptable().unwrap();
+        assert!(
+            report2.decrypt_failed.is_empty(),
+            "no manifest present is not a failure: {report2:?}"
+        );
+        assert!(report2.all_decrypted());
     }
 
     #[test]

--- a/src/storage/index_persistence/reencrypt.rs
+++ b/src/storage/index_persistence/reencrypt.rs
@@ -279,16 +279,19 @@ impl IndexKeyRotation {
             // verify may run against a LIVE db: a file listed a moment ago can be
             // removed/renamed by a concurrent writer's atomic_write between the
             // scan and this read. A vanished file is benign — skip it rather than
-            // fail the probe; any OTHER io error still propagates.
-            let bytes = match std::fs::read(&path) {
-                Ok(b) => b,
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
-                Err(e) => return Err(e.into()),
-            };
-            let Some(key_version) = index_file_key_version(&bytes) else {
+            // fail the probe; any OTHER io error still propagates. Peek only the
+            // 10-byte header first (index files can be up to ~100GB, so reading a
+            // whole body just to read its key_version would risk OOM); the full
+            // body is read ONLY for a file we actually decrypt-probe.
+            let key_version = match peek_key_version(&path) {
+                Ok(Some(v)) => v,
                 // Not an AEIX-encrypted file: plaintext, skip (not a failure).
-                report.plaintext += 1;
-                continue;
+                Ok(None) => {
+                    report.plaintext += 1;
+                    continue;
+                }
+                Err(RotationError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => return Err(e),
             };
             // Bounded cost: always probe the manifest body; otherwise probe only
             // the first file seen for each distinct key_version.
@@ -297,6 +300,13 @@ impl IndexKeyRotation {
             if !is_manifest && !first_of_version {
                 continue;
             }
+            // Only now read the full body — the file we will actually
+            // decrypt-probe (bounded to the manifest + one file per key_version).
+            let bytes = match std::fs::read(&path) {
+                Ok(b) => b,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => return Err(e.into()),
+            };
             report.probed += 1;
             match decrypt_index_bytes_with_keyring(&bytes, &path, Some(&self.keyring)) {
                 Ok(_) => report.decrypted_ok += 1,

--- a/tests/cli_encryption.rs
+++ b/tests/cli_encryption.rs
@@ -604,6 +604,120 @@ mod encrypted {
         walk(indexes_dir, version).expect("no AEIX-headed index file found to tamper")
     }
 
+    /// Corrupt the encrypted BODY of the named `AEIX`-headed index file under
+    /// `indexes_dir` while leaving its 10-byte plaintext header (magic, format,
+    /// algorithm, `key_version`) byte-for-byte intact: flip the final byte (the
+    /// AES-GCM tag), guaranteeing the AEAD auth check fails on decrypt even
+    /// though header classification still passes. Returns the tampered path.
+    fn corrupt_index_body_named(indexes_dir: &Path, file_name: &str) -> std::path::PathBuf {
+        fn walk(dir: &Path, file_name: &str) -> Option<std::path::PathBuf> {
+            for e in std::fs::read_dir(dir).ok()?.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    if let Some(hit) = walk(&p, file_name) {
+                        return Some(hit);
+                    }
+                    continue;
+                }
+                if p.file_name().and_then(|n| n.to_str()) != Some(file_name) {
+                    continue;
+                }
+                let mut bytes = match std::fs::read(&p) {
+                    Ok(b) => b,
+                    Err(_) => continue,
+                };
+                // Header intact (>=10 bytes, AEIX magic); flip the last body byte.
+                if bytes.len() > 10 && &bytes[..4] == b"AEIX" {
+                    let last = bytes.len() - 1;
+                    bytes[last] ^= 0xFF;
+                    std::fs::write(&p, &bytes).unwrap();
+                    return Some(p);
+                }
+            }
+            None
+        }
+        walk(indexes_dir, file_name).expect("named AEIX-headed index file not found to corrupt")
+    }
+
+    /// Author a TOML config for the fixture's data dir/key but with index
+    /// persistence `load_on_startup = false`, so a corrupted index BODY does not
+    /// fail the `open()` (the index files are not force-loaded) — the exact
+    /// window in which header-only classification would false-PASS (Issue #3618).
+    fn no_load_toml(f: &EncryptedFixture) -> std::path::PathBuf {
+        let root = f.toml_path.parent().unwrap();
+        let config = AletheiaDBConfig::builder()
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(root.join("wal"))
+                    .durability_mode(DurabilityMode::GroupCommit {
+                        max_delay_ms: 5,
+                        max_batch_size: 64,
+                    })
+                    .build(),
+            )
+            .persistence(PersistenceConfig {
+                enabled: true,
+                data_dir: root.join("data"),
+                load_on_startup: false,
+                ..Default::default()
+            })
+            .encryption(EncryptionConfig::file_based(&f.key_path))
+            .build();
+        let toml_path = root.join("no-load.toml");
+        config.to_toml_file(&toml_path).unwrap();
+        toml_path
+    }
+
+    #[test]
+    fn encryption_verify_same_version_undecryptable_body_fails() {
+        // Issue #3618: the false-PASS the old header-only classifier could not
+        // catch. Corrupt one index file's BODY (AES-GCM tag) while leaving its
+        // AEIX header/key_version intact, and open with load_on_startup=false so
+        // the corrupted body is NOT force-loaded at open(). Under the OLD code
+        // path, header classification finds version 1 held by the keyring and
+        // `encryption verify` would PASS. The #3618 decrypt probe attempts a real
+        // body decrypt, the AEAD auth tag fails, and verify now FAILS instead.
+        //
+        // Why corruption, not a fully-wrong configured KEY, is the constructible
+        // end-to-end probe trigger: WAL and index share one MEK, so a wrong
+        // configured key aborts at open_db() during WAL replay BEFORE the index
+        // probe ever runs — it cannot be reached via the CLI. Corrupting one index
+        // body (header intact, load_on_startup=false so it is not force-loaded at
+        // open) is the only way to drive the probe to a FAIL end-to-end. The
+        // body-level wrong-key path is covered by the multi-generation unit test
+        // (verify_decryptable_catches_wrong_key_in_one_of_multiple_generations).
+        let f = make_encrypted_db();
+        let indexes_dir = f.toml_path.parent().unwrap().join("data").join("indexes");
+        // Corrupt the manifest body (always probed by verify_decryptable).
+        let tampered = corrupt_index_body_named(&indexes_dir, "manifest.idx");
+        assert!(tampered.exists(), "the manifest should have been corrupted");
+
+        let toml = no_load_toml(&f);
+        let r = run_with(
+            &["encryption", "verify"],
+            &[("ALETHEIADB_CONFIG", toml.display().to_string())],
+        );
+        assert_ne!(
+            r.code, 0,
+            "verify with an undecryptable index body must FAIL; stdout={:?} stderr={:?}",
+            r.stdout, r.stderr
+        );
+        let c = r.combined_lower();
+        assert!(c.contains("failed"), "verify must report FAILED; got={c:?}");
+        assert!(
+            !c.contains("verify: pass"),
+            "verify must NOT false-PASS on an undecryptable body; got={c:?}"
+        );
+        // The probe's FAIL wording: wrong key / corruption, does not decrypt.
+        assert!(
+            c.contains("does not decrypt") || c.contains("wrong key") || c.contains("corruption"),
+            "failure should name the undecryptable body; got={c:?}"
+        );
+        assert!(!c.contains("panicked"), "must not panic; got={c:?}");
+        // No key bytes leak on stdout or stderr.
+        assert_no_key_leak(&r, &[f.key_path.as_path()]);
+    }
+
     #[test]
     fn encryption_verify_foreign_key_version_index_file_fails() {
         // Re-stamp one persisted index file's AEIX header with a key version the


### PR DESCRIPTION
## Before / After

**Before:** `aletheia encryption verify` classified persisted index files by their 10-byte `AEIX` header only. A *wrong* key that happened to share the same header `key_version` number passed classification (`unknown == 0`) even though it could not actually decrypt a single byte — a silent false-PASS.

**After:** verify additionally AEAD-decrypts representative index *bodies* through the live keyring — the `manifest.idx` body plus one representative file per distinct `key_version` present on disk. Because the header is authenticated as AAD, wrong key material or a corrupted body fails the AEAD auth tag, so `encryption verify` now FAILs (non-zero exit) on undecryptable bodies instead of trusting the header. No key bytes or paths are ever leaked in the failure message (count + generic reason only).

## How

- `IndexKeyRotation::verify_decryptable()` (`src/storage/index_persistence/reencrypt.rs`) walks every non-scratch file under `indexes/`, counts plaintext (non-`AEIX`) files, and decrypts a **bounded** set of bodies: the manifest is always probed, plus the first (sorted) file of each distinct `key_version`. This fully catches a uniformly-wrong configured key while keeping `verify` (an operator command, not a hot path) cheap on large databases. Results are returned as `DecryptProbeReport { probed, decrypted_ok, plaintext, decrypt_failed }`.
- `AletheiaDB::verify_index_decryptable()` (`src/db/rotation.rs`) wraps the engine probe behind the same prerequisite checks as `index_rotation_status`.
- `src/bin/aletheia.rs`: `encryption verify` runs the body probe after header classification and FAILs when `decrypt_failed` is non-empty; on PASS it additionally reports the count of bodies decrypted under the live keyring.
- **Robustness:** the per-file read tolerates a file vanishing mid-scan (`ErrorKind::NotFound` → skip) so `verify` against a *live* DB does not turn a concurrent writer's atomic rename into a hard FAIL; any other io error still propagates. Decrypt-auth failures are never swallowed.

## Testing

**Unit (`reencrypt.rs`):**
- `verify_decryptable_passes_with_correct_key`
- `verify_decryptable_catches_same_version_wrong_key` (core false-PASS regression)
- `verify_decryptable_ignores_plaintext_files`
- `verify_decryptable_catches_wrong_key_in_one_of_multiple_generations` (multi-generation: correct v1 + wrong v2 keyring; v1 bodies decrypt, the v2 representative fails)
- `verify_decryptable_always_probes_manifest` (pins the bounded-cost design: manifest + first-of-version probed, a third same-version body skipped)
- `verify_decryptable_empty_or_missing_manifest_is_pass` (non-existent dir guard + missing-manifest case)

**CLI (`tests/cli_encryption.rs`):**
- `encryption_verify_same_version_undecryptable_body_fails` — drives the probe end-to-end via a corrupted manifest body. (A fully-wrong configured *key* is not a constructible end-to-end trigger: WAL and index share one MEK, so a wrong key aborts at `open_db()` during WAL replay *before* the index probe runs; corruption is the only way to reach the probe via the CLI. The body-level wrong-key path is covered by the multi-generation unit test.)
- `encryption_verify_foreign_key_version_index_file_fails`, `encryption_verify_good_encrypted_passes`, `encryption_verify_missing_key_fails_clearly`

**Gates (isolated target dir):**
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings` — 0 warnings
- `cargo clippy --all-targets --all-features -- -D warnings` — 0 warnings
- `cargo test --features "config-toml,mcp-server,sharding-rpc,simulation"` — all new unit tests, the 4 CLI encryption tests, and the AEIX guard `encrypted_persist_writes_no_plaintext_index_files` pass (only pre-existing known-noise uid-0 havoc test fails)
- Standalone: `cargo check --no-default-features --features encryption` / `encryption-aws-kms` / `encryption-vault` — all pass

Closes #3618.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRMi3NFi3FwGqXoon9Fqga)_