### PR TITLE
feat(query): temporal aggregation windows over entity history in AQL (#3363)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -481,6 +481,14 @@ harness = false
 path = "benches/performance_targets.rs"
 required-features = []
 
+# Temporal aggregation windows (Issue #3363): 12-window monthly aggregation
+# over ~1,000 historical versions, targeting < 50ms end-to-end.
+[[bench]]
+name = "temporal_window"
+harness = false
+path = "benches/temporal_window.rs"
+required-features = []
+
 # OpenTelemetry tracing overhead gate (Issue #3376): disabled vs enabled.
 [[bench]]
 name = "otel_overhead"

--- a/benches/temporal_window.rs
+++ b/benches/temporal_window.rs
@@ -1,0 +1,68 @@
+//! Benchmark for AQL temporal aggregation windows (Issue #3363).
+//!
+//! Success metric: a 12-window (monthly, 1 year) aggregation over an entity
+//! with <=1,000 historical versions completes in **< 50ms** end-to-end. This
+//! bench builds a single Product with ~1,000 monotonic valid-time versions and
+//! times a 12-window monthly `AVG`/`MIN`/`MAX`/`CHANGES` query end-to-end
+//! through `execute_aql`. The numeric target is validated on the performance
+//! rig, not gated here; this keeps a cheap, representative sample.
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::PropertyMapBuilder;
+use aletheiadb::api::transaction::WriteRequestOptions;
+use aletheiadb::core::temporal::Timestamp;
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+/// Microseconds since epoch for 2023-01-01T00:00:00Z (a fixed, past anchor).
+const YEAR_START_MICROS: i64 = 1_672_531_200_000_000;
+const MICROS_PER_DAY: i64 = 86_400_000_000;
+
+/// Build a Product whose price is updated `versions` times at successive
+/// valid-time instants, roughly one every few hours across ~2023.
+fn build_versioned_product(versions: usize) -> AletheiaDB {
+    let db = AletheiaDB::new().expect("db init");
+    let id = db
+        .create_node_with_options(
+            "Product",
+            PropertyMapBuilder::new().insert("price", 100i64).build(),
+            WriteRequestOptions::new().with_valid_from(Timestamp::from(YEAR_START_MICROS)),
+        )
+        .expect("create");
+    // Spread `versions` updates over ~360 days so all land inside the query range.
+    let step = (360 * MICROS_PER_DAY) / versions.max(1) as i64;
+    for i in 1..versions {
+        let vf = YEAR_START_MICROS + step * i as i64;
+        db.update_node_with_options(
+            id,
+            PropertyMapBuilder::new()
+                .insert("price", 100i64 + i as i64)
+                .build(),
+            WriteRequestOptions::new().with_valid_from(Timestamp::from(vf)),
+        )
+        .expect("update");
+    }
+    db
+}
+
+fn bench_monthly_window_1000_versions(c: &mut Criterion) {
+    let db = build_versioned_product(1_000);
+    let query = "MATCH (p:Product) \
+         WINDOW 1 month OVER VALID_TIME FROM '2023-01-01T00:00:00Z' TO '2024-01-01T00:00:00Z' \
+         RETURN AVG(p.price) AS avg_price, MIN(p.price) AS lo, MAX(p.price) AS hi, \
+                CHANGES(p.price) AS changes";
+
+    c.bench_function("temporal_window/monthly_1y_1000_versions", |b| {
+        b.iter(|| {
+            let results = db
+                .execute_aql(black_box(query))
+                .expect("query")
+                .collect_all()
+                .expect("collect");
+            black_box(results.len())
+        });
+    });
+}
+
+criterion_group!(benches, bench_monthly_window_1000_versions);
+criterion_main!(benches);

--- a/docs/plans/2026-07-15-temporal-aggregation-windows.md
+++ b/docs/plans/2026-07-15-temporal-aggregation-windows.md
@@ -1,0 +1,190 @@
+# Plan: Temporal Aggregation Windows over Entity History in AQL (Issue #3363)
+
+Complexity tier: **L**. Lane: `src/query/**` (+ `src/cypher`, `src/sql` owned but
+untouched — Cypher aggregation is explicitly out of scope per the issue).
+Constraint: **must not** edit `src/mcp/**` or `crates/aletheia-server`.
+
+## 1. Problem restatement
+
+AletheiaDB can reconstruct any entity at any bi-temporal coordinate but cannot
+*summarize across time*. This adds a one-statement AQL construct that buckets a
+matched entity's (or matched set's) **valid-time** history into fixed
+(tumbling) windows and computes per-window aggregates, replacing O(windows)
+client-side `AS OF` round-trips.
+
+## 2. Acceptance criteria (verbatim from #3363)
+
+1. AQL grammar supports a windowed temporal aggregation construct over a
+   valid-time range — match pattern → declare window granularity (`1 hour`,
+   `1 day`, `1 month`) over an explicit `[start, end)` valid-time range →
+   `RETURN` per-window aggregates. Keyword syntax is Engineering's choice;
+   documented in the AQL grammar reference.
+2. Supported aggregates v1: `COUNT`, `SUM`, `AVG`, `MIN`, `MAX` over numeric
+   properties, plus `CHANGES` (number of distinct versions of the matched
+   entity/property whose valid intervals start within the window).
+3. Window semantics documented and falsifiable: value attributed to a window =
+   value as of a documented sampling rule (at minimum: value at window start).
+   Fixture with hand-computed values per window passes exactly.
+4. Interval-edge correctness: a version whose valid interval starts exactly at
+   a window boundary is counted in exactly one window (boundary rule
+   documented); open-ended intervals handled through the final window; windows
+   with no valid data return an explicit empty/`null` row, not dropped.
+5. Transaction-time dimension respected: results reflect history as recorded at
+   a caller-supplied `AS OF SYSTEM_TIME` (default now).
+6. Works through the MCP `query` tool (read-only path, existing error
+   contract): a malformed window spec returns a structured
+   `parse_error`/`invalid_params`, never a panic or empty success.
+7. Result rows include window start/end (RFC 3339) alongside the aggregates.
+8. Documentation includes ≥2 worked examples (monthly `AVG` of a price; weekly
+   `CHANGES` volatility) with expected output.
+
+Success metric: 12-window monthly aggregation over ≤1,000 versions < 50ms
+(benchmark). Window-edge fixture passes 100% vs hand-computed values.
+
+## 3. Chosen grammar
+
+```
+MATCH (v:Label {prop: value})
+WINDOW <n> <unit> OVER VALID_TIME FROM <ts> TO <ts>
+[ AS OF SYSTEM_TIME <ts> ]
+RETURN <agg>(v.prop | *) [AS alias] [, ...]
+```
+
+- `<unit>` ∈ `MINUTE(S) | HOUR(S) | DAY(S) | WEEK(S) | MONTH(S) | YEAR(S)`
+  (also `QUARTER(S)` = 3 months). MINUTE/HOUR/DAY/WEEK are fixed-duration;
+  MONTH/QUARTER/YEAR are calendar-based (chrono month arithmetic, UTC).
+- `<ts>` = RFC 3339/ISO-8601 string, or integer/string microseconds since
+  epoch (superset of existing AQL timestamp handling; existing AQL only did
+  micros, so this is strictly additive).
+- The WINDOW clause sits after the source (MATCH) and before RETURN. The
+  tx-time coordinate lives *inside* the window clause (`AS OF SYSTEM_TIME`) to
+  avoid ambiguity with the pre-MATCH `AS OF <valid>[, <tx>]` temporal clause.
+
+### Sampling & boundary rules (documented, falsifiable)
+
+- **Boundary rule:** windows are half-open `[b_k, b_{k+1})`, `b_0 = start`,
+  `b_{k+1} = step(b_k)`, generated until `b_k >= end`; the final window's end is
+  **clamped to `end`**. Union of windows == exactly `[start, end)`, no
+  overlap/gap. A version whose `valid_from` equals a boundary belongs to the
+  window it *starts* (`b_k <= valid_from < b_{k+1}`).
+- **Value sampling (SUM/AVG/MIN/MAX/COUNT):** value attributed to window `k` =
+  the entity's property value **as of window start** `(valid = b_k,
+  tx = as_of_system_time)`, reconstructed via
+  `find_node_version_at_time` + `reconstruct_node_properties`. One sample per
+  matched entity per window.
+  - `SUM/AVG/MIN/MAX(v.prop)` aggregate the numeric samples across the matched
+    set (non-numeric/absent samples skipped, mirroring #558 leniency).
+  - `COUNT(v.prop)` = number of matched entities with a defined numeric sample
+    at window start. `COUNT(*)` = number of matched entities that exist (any
+    version valid) at window start.
+- **CHANGES:** `CHANGES(v)`/`CHANGES(*)` = number of entity versions (across the
+  matched set) whose `valid_from ∈ [b_k, b_{k+1})`, counting only versions
+  believed as-of `as_of_system_time` (transaction interval contains the
+  tx coordinate). `CHANGES(v.prop)` = of those in-window versions, the count
+  whose value for `prop` differs from the immediately-preceding (by valid
+  order) believed version's value (genuine property change).
+- **Empty window:** row always emitted. `COUNT`/`CHANGES` → `0` (Int);
+  `SUM/AVG/MIN/MAX` → `Null`.
+
+## 4. Implementation approaches considered
+
+- **A. New terminal `QueryOp` + executor iterator (CHOSEN).** Lower
+  `MATCH…WINDOW…RETURN` into `[ScanNodes/Filter…, TemporalWindowAggregate(spec)]`.
+  Mirror the existing `Aggregate` op through `plan.rs` (`UnaryOp`),
+  `planner/{mod,physical,cost}.rs`, `executor/mod.rs` dispatch, and a new
+  `TemporalWindowAggregateIterator`. Pure window math factored into
+  `src/query/temporal_window.rs` for unit testing.
+  *Cost:* ~8 files, mostly mechanical one-arm additions. *Wins:* stays entirely
+  in `src/query`; `execute_aql`, the MCP `query` tool, EXPLAIN/PROFILE all keep
+  working with zero edits outside the lane; reuses MATCH source + property
+  filters; errors already map (SyntaxError→`parse_error`,
+  InvalidParameter→`invalid_params`, UnsupportedFeature→`unsupported_construct`).
+- **B. Dedicated evaluator routed from `execute_aql`** (like Cypher
+  MultiPattern/Mutation). *Cost:* smaller query-internal surface but requires
+  editing `src/db/query.rs::execute_aql`, outside the owned lane, and would
+  bypass planner EXPLAIN/PROFILE.
+- **C. Overload existing `Aggregate` op with a window field.** *Cost:* pollutes
+  the streaming single-coordinate aggregator with a fundamentally different
+  history-reading execution model; rejected as muddying a hot path.
+
+**Pick: A.** Idiomatic (every AQL/Cypher feature lowers to `QueryOp`), fully
+in-lane, no MCP/server/db edits, structured errors for free.
+
+## 5. Reverse brainstorm — how could this silently produce wrong results?
+
+Each becomes a test:
+- Off-by-one at window boundary (version at `valid_from == b_k` double-counted
+  or dropped). → boundary fixture.
+- Last window extends past `end`, double-counting versions in `[end, b_last)`.
+  → clamp test.
+- Calendar month treated as 30 days → Feb/31-day drift. → monthly fixture with
+  hand-computed month starts.
+- AS OF SYSTEM_TIME ignored → later corrections rewrite past analytics. →
+  bi-temporal test: correct a value, re-run with old tx time, expect old result.
+- Empty window silently dropped → caller sees 11 rows for 12 months. → empty
+  window test asserts row present with null/0.
+- Open-ended (still-valid) version not sampled in windows after its start. →
+  open-interval test.
+- Overflow of i64 sum → wrap. → reuse #558 i128/float-promote accumulator.
+- Non-numeric property fed to SUM → panic or garbage. → skip + test.
+- Malformed spec (end<=start, zero count, unknown unit, unparseable ts) →
+  panic/empty success. → structured-error tests.
+- RFC3339 vs micros parsing divergence between FROM and TO. → parity test.
+
+## 6. Six-hats (condensed)
+
+- White (facts): history APIs `find_node_version_at_time`,
+  `reconstruct_node_properties`, `get_node_history` exist; chrono is a
+  non-optional dep; column rows already surface through MCP (server.rs:5719).
+- Red (gut): the correctness risk is all in interval math — isolate & fixture it.
+- Black (caution): don't perturb the streaming aggregator or planner cost of
+  existing queries; new op only.
+- Yellow (benefit): one query replaces ≥12 round-trips; falsifiable fixture.
+- Green (creative): factor pure boundary/step math into its own module so it is
+  testable without a DB.
+- Blue (process): TDD — parser tests, boundary unit tests, then end-to-end
+  bi-temporal fixtures, then bench.
+
+## 7. Risks / edge cases as concrete test cases
+
+1. `window_boundary_start_counted_once` — version at exact boundary in one bucket.
+2. `last_window_clamped_to_end` — no double count past `end`.
+3. `monthly_calendar_windows_hand_computed` — 12 monthly AVG rows exact.
+4. `weekly_changes_volatility_hand_computed` — CHANGES per week exact.
+5. `as_of_system_time_respects_correction` — old tx time yields pre-correction.
+6. `empty_window_emits_null_row` — 0/null, not dropped.
+7. `open_ended_interval_sampled_through_final_window`.
+8. `sum_overflow_promotes_to_float`.
+9. `non_numeric_property_skipped`.
+10. `malformed_spec_structured_error` (end<=start, count 0, unknown unit).
+11. `rfc3339_and_micros_boundaries_parity`.
+12. `aql_equiv_micros_vs_rfc3339` (AQL≡AQL parity for two timestamp encodings).
+13. AQL≡Cypher parity note: Cypher temporal windows are **out of scope** (#558
+    follow-up); parity here is between the two AQL timestamp encodings and
+    between value-sampling done two ways. Documented explicitly.
+14. `multi_entity_avg_across_set` — matched set averaging.
+15. Bench: `bench_monthly_window_1000_versions < 50ms`.
+
+## 8. Deliverables
+
+- Grammar: lexer tokens (`WINDOW/OVER/VALID_TIME/SYSTEM_TIME/FROM/CHANGES` +
+  unit words as contextual identifiers), parser clause, AST `WindowClause`.
+- IR: `QueryOp::TemporalWindowAggregate(TemporalWindowSpec)` + supporting types.
+- Converter: lower MATCH+WINDOW+RETURN, with semantic validation → structured
+  errors.
+- Pure math module `src/query/temporal_window.rs` (boundary gen, calendar step,
+  ts parse/format) with unit tests.
+- Executor `TemporalWindowAggregateIterator`.
+- Planner/physical/cost plumbing.
+- Docs: AQL grammar reference section + 2 worked examples.
+- Benchmark.
+
+## 9. v1 limitations (documented)
+
+- Windowed variable must bind a **node** (v1). Edge windows return a structured
+  `UnsupportedFeature` error (documented follow-up) unless cheap to add.
+- Matched candidate set is resolved from the pattern at current state (entity
+  must currently exist for its history to be windowed); windowing history of
+  since-deleted entities is a follow-up.
+- Tumbling (fixed, non-overlapping) windows only — no sliding/hopping/session
+  (explicitly out of scope in #3363).

--- a/docs/query-language-design.md
+++ b/docs/query-language-design.md
@@ -25,17 +25,34 @@ AletheiaDB's query language (AQL - Aletheia Query Language) extends the Cypher g
 (* Top-level query *)
 query           = [ temporal_clause ]
                   ( match_clause | vector_clause )
-                  { where_clause }
-                  [ return_clause ]
-                  [ order_clause ]
-                  [ skip_clause ]
-                  [ limit_clause ] ;
+                  ( window_clause
+                  | ( { where_clause }
+                      [ return_clause ]
+                      [ order_clause ]
+                      [ skip_clause ]
+                      [ limit_clause ] ) ) ;
 
 (* Temporal Clauses *)
 temporal_clause = as_of_clause | between_clause ;
 as_of_clause    = "AS" "OF" timestamp [ "," timestamp ] ;
 between_clause  = "BETWEEN" timestamp "AND" timestamp ;
 timestamp       = string_literal | integer_literal ;
+
+(* Temporal Aggregation Window Clause - Issue #3363 *)
+(* A self-contained terminal clause: it carries its own aggregate RETURN and
+   may not be combined with WHERE/ORDER/SKIP/LIMIT. It buckets the matched
+   node's valid-time history into fixed tumbling windows over an explicit
+   [start, end) valid-time range and returns one row per window. *)
+window_clause   = "WINDOW" integer_literal window_unit
+                  "OVER" "VALID_TIME" "FROM" timestamp "TO" timestamp
+                  [ "AS" "OF" "SYSTEM_TIME" timestamp ]
+                  "RETURN" window_agg { "," window_agg } ;
+window_unit     = "MINUTE" | "MINUTES" | "HOUR" | "HOURS" | "DAY" | "DAYS"
+                | "WEEK" | "WEEKS" | "MONTH" | "MONTHS"
+                | "QUARTER" | "QUARTERS" | "YEAR" | "YEARS" ;
+window_agg      = window_func "(" window_arg ")" [ "AS" identifier ] ;
+window_func     = "COUNT" | "SUM" | "AVG" | "MIN" | "MAX" | "CHANGES" ;
+window_arg      = "*" | identifier [ "." identifier ] ;
 
 (* Match Clause - Graph Pattern Matching *)
 match_clause    = "MATCH" pattern { "," pattern } ;
@@ -182,6 +199,95 @@ MATCH (n:Person {name: "Alice"})
 RETURN n
 ```
 
+### Temporal Aggregation Windows (Issue #3363)
+
+Bucket a matched node's **valid-time history** into fixed, non-overlapping
+(tumbling) windows over an explicit `[start, end)` valid-time range and compute
+per-window aggregates in a single statement — instead of issuing one `AS OF`
+query per window boundary and aggregating client-side.
+
+**Supported aggregates (v1):** `COUNT`, `SUM`, `AVG`, `MIN`, `MAX` over numeric
+properties, plus `CHANGES` (version-start volatility).
+
+**Semantics (documented, falsifiable):**
+
+- **Boundary rule.** Windows are half-open `[b_k, b_{k+1})` with `b_0 = start`
+  and each next boundary produced by advancing one granularity step; generation
+  stops once a boundary reaches `end`, and the final window's end is **clamped
+  to `end`**. The union of all windows equals exactly `[start, end)` — no gaps,
+  no overlaps. A version whose `valid_from` equals a boundary belongs to the
+  window it *starts*.
+- **Value sampling rule.** For `SUM`/`AVG`/`MIN`/`MAX`/`COUNT`, the value
+  attributed to a window is the entity's property value **as of the window
+  start** `(valid = window_start, transaction = AS OF SYSTEM_TIME)`. One sample
+  per matched entity per window; non-numeric or absent samples are skipped
+  (they do not corrupt the aggregate). If the entity is not valid at the window
+  start it contributes nothing to that window.
+- **`COUNT`.** `COUNT(v.prop)` counts entities with a defined numeric sample at
+  the window start; `COUNT(*)` counts matched entities present at the window
+  start.
+- **`CHANGES`.** `CHANGES(v)` / `CHANGES(*)` counts entity versions whose valid
+  interval *starts within* the window. `CHANGES(v.prop)` counts only versions
+  whose value for `prop` differs from the immediately-preceding version's value
+  (a genuine change; re-asserting the same value is not counted).
+- **Transaction-time.** `AS OF SYSTEM_TIME <ts>` (default: now) fixes the belief
+  the history is read at, so later corrections never silently rewrite previously
+  computed analytics.
+- **Empty windows** are never dropped: they emit an explicit row with `NULL`
+  value aggregates and `0` counts.
+- **Timestamps** accept RFC 3339 / ISO-8601 (`'2024-01-01T00:00:00Z'`,
+  `'2024-01-01'`) or microseconds since the Unix epoch.
+- **Output** rows carry `window_start` and `window_end` (RFC 3339 UTC strings)
+  alongside each aggregate column, so results are self-describing.
+
+**Worked example 1 — monthly average price:**
+
+```cypher
+-- Product created at $100 (Jan 1), raised to $200 (Feb 15), to $300 (Apr 1).
+MATCH (p:Product {sku: "ABC"})
+WINDOW 1 month OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-05-01T00:00:00Z'
+RETURN AVG(p.price) AS avg_price
+```
+
+| window_start | window_end | avg_price |
+|--------------|------------|-----------|
+| 2024-01-01T00:00:00.000000Z | 2024-02-01T00:00:00.000000Z | 100.0 |
+| 2024-02-01T00:00:00.000000Z | 2024-03-01T00:00:00.000000Z | 100.0 |
+| 2024-03-01T00:00:00.000000Z | 2024-04-01T00:00:00.000000Z | 200.0 |
+| 2024-04-01T00:00:00.000000Z | 2024-05-01T00:00:00.000000Z | 300.0 |
+
+(The Feb-15 change does not affect February, whose sample instant is Feb 1; the
+Apr-1 change lands exactly on the April boundary and is sampled by that window.)
+This replaces four separate `AS OF VALID_TIME '<month-start>'` round-trips with
+one query.
+
+**Worked example 2 — weekly change volatility:**
+
+```cypher
+-- How often did the price change each week?
+MATCH (p:Product {sku: "ABC"})
+WINDOW 1 week OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-01-29T00:00:00Z'
+RETURN CHANGES(p.price) AS price_changes
+```
+
+| window_start | window_end | price_changes |
+|--------------|------------|---------------|
+| 2024-01-01T00:00:00.000000Z | 2024-01-08T00:00:00.000000Z | 1 |
+| 2024-01-08T00:00:00.000000Z | 2024-01-15T00:00:00.000000Z | 2 |
+| 2024-01-15T00:00:00.000000Z | 2024-01-22T00:00:00.000000Z | 0 |
+| 2024-01-22T00:00:00.000000Z | 2024-01-29T00:00:00.000000Z | 0 |
+
+(Week 4 re-asserts the same price, which is not a genuine change.)
+
+**v1 limitations.** Windows a single bound **node** pattern (edge/traversal and
+multi-pattern windows are rejected with a structured error); the matched entity
+must currently exist for its history to be windowed; only fixed tumbling
+windows (no sliding/hopping/session windows or gap-filling). Malformed specs
+(backwards range, zero size, unknown unit/function, unparseable timestamp,
+mismatched aggregate variable) are rejected with a structured
+`invalid_params` / `unsupported_construct` error, never a panic or empty
+success.
+
 ### Temporal + Vector Queries
 
 ```cypher
@@ -293,6 +399,7 @@ RETURN n
 | `RANK BY SIMILARITY` | `QueryOp::RankBySimilarity { ... }` |
 | `AS OF T1, T2` | `QueryOp::AsOf { valid_time: T1, transaction_time: T2 }` |
 | `BETWEEN T1 AND T2` | `QueryOp::Between { time_range: ... }` |
+| `WINDOW N unit OVER VALID_TIME FROM T1 TO T2 ... RETURN aggs` | `QueryOp::TemporalWindowAggregate(TemporalWindowSpec { ... })` |
 | `WHERE pred` | `QueryOp::Filter(Predicate)` |
 | `LIMIT N` | `QueryOp::Limit(N)` |
 | `SKIP N` | `QueryOp::Skip(N)` |

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -27,6 +27,11 @@ pub struct QueryAst {
     pub skip: Option<usize>,
     /// LIMIT clause
     pub limit: Option<usize>,
+    /// Temporal aggregation window clause (Issue #3363). When present, the query
+    /// buckets the matched entity's valid-time history into tumbling windows and
+    /// computes per-window aggregates; the window clause carries its own
+    /// aggregate `RETURN` list, so `return_clause` is unused.
+    pub window: Option<WindowClause>,
 }
 
 impl QueryAst {
@@ -41,6 +46,7 @@ impl QueryAst {
             order: None,
             skip: None,
             limit: None,
+            window: None,
         }
     }
 
@@ -93,6 +99,13 @@ impl QueryAst {
         self
     }
 
+    /// Add a temporal aggregation window clause to the query.
+    #[must_use]
+    pub fn with_window(mut self, window: WindowClause) -> Self {
+        self.window = Some(window);
+        self
+    }
+
     /// Check if this query has temporal context.
     pub fn is_temporal(&self) -> bool {
         self.temporal.is_some()
@@ -123,6 +136,66 @@ pub enum TemporalClause {
         start: TimestampLiteral,
         /// End time
         end: TimestampLiteral,
+    },
+}
+
+/// A temporal aggregation window clause (Issue #3363).
+///
+/// Syntax:
+/// ```text
+/// WINDOW <count> <unit> OVER VALID_TIME FROM <ts> TO <ts>
+/// [ AS OF SYSTEM_TIME <ts> ]
+/// RETURN <agg>(<arg>) [AS alias] [, ...]
+/// ```
+///
+/// The unit word and aggregate function names are kept as raw strings and
+/// validated in the converter, where a bad unit/function maps to a structured
+/// [`crate::core::error::QueryError`] the MCP `query` tool surfaces as
+/// `invalid_params` / `unsupported_construct`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WindowClause {
+    /// The positive window-size multiplier (`3` in `3 months`).
+    pub count: i64,
+    /// The raw unit word (e.g. `"month"`, `"days"`), validated in the converter.
+    pub unit: String,
+    /// Inclusive start of the valid-time range.
+    pub range_start: TimestampLiteral,
+    /// Exclusive end of the valid-time range.
+    pub range_end: TimestampLiteral,
+    /// Optional `AS OF SYSTEM_TIME` transaction-time coordinate (default: now).
+    pub as_of_system_time: Option<TimestampLiteral>,
+    /// The per-window aggregate return items.
+    pub aggregates: Vec<WindowReturnItem>,
+}
+
+/// One aggregate item in a window `RETURN` list (Issue #3363).
+#[derive(Debug, Clone, PartialEq)]
+pub struct WindowReturnItem {
+    /// The raw aggregate function name (`COUNT`/`SUM`/`AVG`/`MIN`/`MAX`/`CHANGES`),
+    /// validated in the converter.
+    pub func: String,
+    /// The aggregate argument.
+    pub arg: WindowAggArg,
+    /// Optional output-column alias (`AS foo`).
+    pub alias: Option<String>,
+}
+
+/// The argument of a window aggregate (Issue #3363).
+#[derive(Debug, Clone, PartialEq)]
+pub enum WindowAggArg {
+    /// `*` (valid for `COUNT(*)` and `CHANGES(*)`).
+    Star,
+    /// A bare variable `v` (valid for `CHANGES(v)`; counts entity versions).
+    Entity {
+        /// The matched variable name.
+        var: String,
+    },
+    /// A property access `v.key`.
+    Property {
+        /// The matched variable name.
+        var: String,
+        /// The property key.
+        key: String,
     },
 }
 

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -179,14 +179,16 @@ use super::ast::{
     ComparisonOp, DepthSpec, EmbeddingRef, Expression, NodePattern, NodeRef, OrderClause, Pattern,
     PatternElement, PredicateExpr, PropertyValue, QueryAst, RelationshipDirection,
     RelationshipPattern, ReturnClause, SourceClause, TemporalClause, TimestampLiteral,
+    WindowClause, WindowReturnItem,
 };
 use super::builder::Query;
 use super::ir::{
     Predicate, PredicateValue, ProvenanceCmp, ProvenanceField, ProvenanceOperand,
     ProvenancePredicate, ProvenanceProjection, ProvenanceProjectionItem, QueryOp, SortKey,
-    TraversalDepth,
+    TemporalWindowSpec, TraversalDepth, WindowAggFunc, WindowAggregateSpec,
 };
 use super::plan::{QueryHints, TemporalContext};
+use super::temporal_window::{self, WindowError, WindowGranularity, WindowUnit};
 
 /// Map a provenance accessor function name to its [`ProvenanceField`]
 /// (case-insensitive), or `None` if the name is not a provenance accessor
@@ -589,6 +591,21 @@ impl AstConverter {
         // 2. Convert source clause (MATCH or vector search)
         self.convert_source(&ast.source, &mut ops)?;
 
+        // 2b. Temporal aggregation window (Issue #3363). A self-contained
+        //     terminal op: it consumes the matched-entity stream produced above
+        //     (scan + inline property filters) and emits per-window aggregate
+        //     rows. No further read clauses apply (the parser already rejects
+        //     trailing WHERE/ORDER/etc. after a WINDOW ... RETURN).
+        if let Some(ref window) = ast.window {
+            let spec = self.convert_window_clause(window, &ast.source)?;
+            ops.push(QueryOp::TemporalWindowAggregate(spec));
+            return Ok(Query {
+                ops,
+                temporal_context,
+                hints,
+            });
+        }
+
         // 3. Convert WHERE clause to filter operations
         if let Some(ref where_clause) = ast.where_clause {
             self.convert_where_clause(where_clause, &mut ops)?;
@@ -753,6 +770,222 @@ impl AstConverter {
             return None;
         };
         node.variable.clone()
+    }
+
+    /// Validate and lower a raw AST [`WindowClause`] into a resolved
+    /// [`TemporalWindowSpec`] (Issue #3363).
+    ///
+    /// All caller-fault failures are structured [`QueryError`]s (the MCP `query`
+    /// tool renders them as `invalid_params` / `unsupported_construct`), never a
+    /// panic or silent success: an unknown unit or function, a non-positive
+    /// window size, an empty/backwards range, an unparseable boundary, or an
+    /// aggregate argument referencing a variable other than the single matched
+    /// node.
+    fn convert_window_clause(
+        &self,
+        window: &WindowClause,
+        source: &SourceClause,
+    ) -> Result<TemporalWindowSpec> {
+        // The windowed entity must be the single bound MATCH node (v1: nodes
+        // only; edge-history windows are a documented follow-up).
+        let match_var = Self::sole_match_node_var(source).ok_or_else(|| {
+            Error::Query(QueryError::UnsupportedFeature {
+                feature: "temporal aggregation windows require a single bound node pattern \
+                          (e.g. MATCH (v:Label) WINDOW ...); windowing edges, traversals, or \
+                          multi-pattern matches is not supported (v1)"
+                    .to_string(),
+            })
+        })?;
+
+        // Window size must be a positive integer that fits a u32 multiplier.
+        let count = u32::try_from(window.count)
+            .ok()
+            .filter(|c| *c > 0)
+            .ok_or_else(|| {
+                Error::Query(QueryError::InvalidParameter {
+                    parameter: "window size".to_string(),
+                    reason: format!(
+                        "window size must be a positive integer, got {}",
+                        window.count
+                    ),
+                })
+            })?;
+
+        let unit = WindowUnit::parse(&window.unit).ok_or_else(|| {
+            Error::Query(QueryError::InvalidParameter {
+                parameter: "window unit".to_string(),
+                reason: format!(
+                    "unknown window unit '{}' (expected minute/hour/day/week/month/quarter/year)",
+                    window.unit
+                ),
+            })
+        })?;
+        let granularity = WindowGranularity { count, unit };
+
+        let range_start_micros = self.window_timestamp_micros(&window.range_start)?;
+        let range_end_micros = self.window_timestamp_micros(&window.range_end)?;
+
+        // Validate the range/granularity now (empty range, too many windows)
+        // so a malformed spec fails at convert time with a structured error.
+        temporal_window::generate_windows(range_start_micros, range_end_micros, granularity)
+            .map_err(Self::window_error_to_query_error)?;
+
+        let as_of_system_time = match &window.as_of_system_time {
+            Some(ts) => Timestamp::from(self.window_timestamp_micros(ts)?),
+            None => time::now(),
+        };
+
+        let aggregates = window
+            .aggregates
+            .iter()
+            .map(|item| self.convert_window_agg_item(item, &match_var))
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(TemporalWindowSpec {
+            granularity,
+            range_start_micros,
+            range_end_micros,
+            as_of_system_time,
+            aggregates,
+        })
+    }
+
+    /// Resolve a window boundary [`TimestampLiteral`] to microseconds since
+    /// epoch, accepting RFC 3339 / ISO-8601 strings as well as the existing
+    /// integer/microsecond forms.
+    fn window_timestamp_micros(&self, ts: &TimestampLiteral) -> Result<i64> {
+        match ts {
+            TimestampLiteral::Integer(micros) => Ok(*micros),
+            TimestampLiteral::String(s) => {
+                temporal_window::parse_boundary_micros(s).map_err(Self::window_error_to_query_error)
+            }
+        }
+    }
+
+    /// Validate one window aggregate item, resolving its function and argument
+    /// and rejecting incompatible combinations with structured errors.
+    fn convert_window_agg_item(
+        &self,
+        item: &WindowReturnItem,
+        match_var: &str,
+    ) -> Result<WindowAggregateSpec> {
+        use crate::query::ast::WindowAggArg as AstArg;
+        use crate::query::ir::WindowAggArg as IrArg;
+
+        let func = match item.func.to_ascii_uppercase().as_str() {
+            "COUNT" => WindowAggFunc::Count,
+            "SUM" => WindowAggFunc::Sum,
+            "AVG" => WindowAggFunc::Avg,
+            "MIN" => WindowAggFunc::Min,
+            "MAX" => WindowAggFunc::Max,
+            "CHANGES" => WindowAggFunc::Changes,
+            other => {
+                return Err(Error::Query(QueryError::UnsupportedFeature {
+                    feature: format!(
+                        "temporal window aggregate function '{other}' (supported: \
+                         COUNT, SUM, AVG, MIN, MAX, CHANGES)"
+                    ),
+                }));
+            }
+        };
+
+        // Any variable named in the argument must be the single matched node.
+        let referenced_var = match &item.arg {
+            AstArg::Star => None,
+            AstArg::Entity { var } | AstArg::Property { var, .. } => Some(var.as_str()),
+        };
+        if let Some(var) = referenced_var
+            && var != match_var
+        {
+            return Err(Error::Query(QueryError::InvalidParameter {
+                parameter: "window aggregate argument".to_string(),
+                reason: format!(
+                    "aggregate references variable '{var}' but the matched entity is \
+                     '{match_var}'"
+                ),
+            }));
+        }
+
+        // Resolve the IR argument, enforcing per-function argument shapes.
+        let ir_arg = match (func, &item.arg) {
+            // Value aggregates require a numeric property argument.
+            (
+                WindowAggFunc::Sum | WindowAggFunc::Avg | WindowAggFunc::Min | WindowAggFunc::Max,
+                AstArg::Property { key, .. },
+            ) => IrArg::Property(key.clone()),
+            (
+                WindowAggFunc::Sum | WindowAggFunc::Avg | WindowAggFunc::Min | WindowAggFunc::Max,
+                _,
+            ) => {
+                return Err(Error::Query(QueryError::InvalidParameter {
+                    parameter: "window aggregate argument".to_string(),
+                    reason: format!(
+                        "{} requires a property argument (e.g. {}({}.price))",
+                        item.func.to_ascii_uppercase(),
+                        item.func.to_ascii_uppercase(),
+                        match_var
+                    ),
+                }));
+            }
+            // COUNT(*) / COUNT(v) count entities present; COUNT(v.prop) counts
+            // defined samples.
+            (WindowAggFunc::Count, AstArg::Property { key, .. }) => IrArg::Property(key.clone()),
+            (WindowAggFunc::Count, _) => IrArg::Star,
+            // CHANGES(*) / CHANGES(v) count entity versions; CHANGES(v.prop)
+            // counts genuine property changes.
+            (WindowAggFunc::Changes, AstArg::Property { key, .. }) => IrArg::Property(key.clone()),
+            (WindowAggFunc::Changes, _) => IrArg::Star,
+        };
+
+        let output_name = item
+            .alias
+            .clone()
+            .unwrap_or_else(|| Self::default_window_output_name(&item.func, &item.arg));
+
+        Ok(WindowAggregateSpec {
+            func,
+            arg: ir_arg,
+            output_name,
+        })
+    }
+
+    /// Default output column name for an unaliased window aggregate, e.g.
+    /// `avg(v.price)` or `count(*)`.
+    fn default_window_output_name(func: &str, arg: &crate::query::ast::WindowAggArg) -> String {
+        use crate::query::ast::WindowAggArg as AstArg;
+        let f = func.to_ascii_lowercase();
+        match arg {
+            AstArg::Star => format!("{f}(*)"),
+            AstArg::Entity { var } => format!("{f}({var})"),
+            AstArg::Property { var, key } => format!("{f}({var}.{key})"),
+        }
+    }
+
+    /// Map a [`WindowError`] to the structured [`QueryError`] the MCP surface
+    /// renders (`invalid_params`).
+    fn window_error_to_query_error(err: WindowError) -> Error {
+        let reason = match err {
+            WindowError::ZeroCount => "window size must be positive".to_string(),
+            WindowError::EmptyRange => {
+                "the valid-time range end must be strictly after the start".to_string()
+            }
+            WindowError::TooManyWindows(n) => format!(
+                "the window granularity and range would generate {n} windows, exceeding the \
+                 limit of {}",
+                temporal_window::MAX_WINDOWS
+            ),
+            WindowError::BadTimestamp(s) => format!(
+                "could not parse timestamp '{s}' (expected RFC 3339 / ISO-8601 or microseconds \
+                 since epoch)"
+            ),
+            WindowError::CalendarOverflow => {
+                "the window range overflowed the representable timestamp range".to_string()
+            }
+        };
+        Error::Query(QueryError::InvalidParameter {
+            parameter: "temporal window".to_string(),
+            reason,
+        })
     }
 
     fn convert_where_clause(

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -21,7 +21,7 @@ use crate::core::{EdgeId, NodeId, Timestamp};
 use crate::query::ir::{
     AggregateArg, AggregateFunc, AggregateGroupKey, AggregateSpec, Direction, Predicate,
     PredicateValue, ProvenanceField, ProvenancePredicate, ProvenanceProjection, ScoreThreshold,
-    SortKey,
+    SortKey, TemporalWindowSpec, WindowAggArg, WindowAggFunc,
 };
 use crate::storage::current::CurrentStorage;
 use crate::storage::historical::HistoricalStorage;
@@ -3228,6 +3228,352 @@ impl AggregateIterator {
 }
 
 impl ResultIterator for AggregateIterator {
+    fn next(&mut self) -> Option<Result<QueryRow>> {
+        if !self.drained {
+            self.drained = true;
+            if let Err(e) = self.drain() {
+                return Some(Err(e));
+            }
+        }
+        self.output.next().map(Ok)
+    }
+}
+
+/// One change-point in an entity's reconstructed valid-time timeline, as
+/// believed at the query's transaction-time coordinate (Issue #3363). The
+/// version's value holds from `valid_from` until the next change-point (or
+/// forever, for the last one).
+struct BelievedVersion {
+    /// Valid-time interval start, microseconds since epoch.
+    valid_from: i64,
+    /// The version's reconstructed properties.
+    properties: crate::core::property::PropertyMap,
+}
+
+/// Per-window, per-aggregate accumulator for temporal window aggregation.
+struct WindowAcc {
+    func: WindowAggFunc,
+    /// COUNT: entities/samples present; CHANGES: version-start count.
+    count: i64,
+    /// Count of numeric samples folded (value aggregates).
+    numeric_count: i64,
+    sum_i: i128,
+    sum_f: f64,
+    saw_float: bool,
+    min: Option<PropertyValue>,
+    max: Option<PropertyValue>,
+}
+
+impl WindowAcc {
+    fn new(func: WindowAggFunc) -> Self {
+        WindowAcc {
+            func,
+            count: 0,
+            numeric_count: 0,
+            sum_i: 0,
+            sum_f: 0.0,
+            saw_float: false,
+            min: None,
+            max: None,
+        }
+    }
+
+    /// Fold one numeric value sample (SUM/AVG/MIN/MAX/COUNT-of-property).
+    fn fold_value(&mut self, v: &PropertyValue) {
+        if let Some(f) = property_as_f64(v) {
+            self.numeric_count += 1;
+            self.sum_f += f;
+            match v {
+                PropertyValue::Int(i) => self.sum_i += i128::from(*i),
+                PropertyValue::Float(_) => self.saw_float = true,
+                _ => {}
+            }
+            match &self.min {
+                Some(m) if compare_property(v, m) != std::cmp::Ordering::Less => {}
+                _ => self.min = Some(v.clone()),
+            }
+            match &self.max {
+                Some(m) if compare_property(v, m) != std::cmp::Ordering::Greater => {}
+                _ => self.max = Some(v.clone()),
+            }
+        }
+    }
+
+    /// Produce the final [`PropertyValue`] for this window/aggregate. Value
+    /// aggregates over an empty/absent sample set yield `Null` (an explicit
+    /// "no data" marker per the #3363 contract); COUNT/CHANGES yield `0`.
+    fn finalize(self) -> PropertyValue {
+        match self.func {
+            WindowAggFunc::Count | WindowAggFunc::Changes => PropertyValue::Int(self.count),
+            WindowAggFunc::Sum => {
+                if self.numeric_count == 0 {
+                    PropertyValue::Null
+                } else if self.saw_float {
+                    PropertyValue::Float(self.sum_f)
+                } else {
+                    // All-integer sum; promote to float only if it overflows i64.
+                    i64::try_from(self.sum_i)
+                        .map(PropertyValue::Int)
+                        .unwrap_or(PropertyValue::Float(self.sum_f))
+                }
+            }
+            WindowAggFunc::Avg => {
+                if self.numeric_count == 0 {
+                    PropertyValue::Null
+                } else {
+                    PropertyValue::Float(self.sum_f / self.numeric_count as f64)
+                }
+            }
+            WindowAggFunc::Min => self.min.unwrap_or(PropertyValue::Null),
+            WindowAggFunc::Max => self.max.unwrap_or(PropertyValue::Null),
+        }
+    }
+}
+
+/// Temporal aggregation window iterator (Issue #3363).
+///
+/// On the first `next()` it drains the upstream matched-entity stream to a set
+/// of node ids, reconstructs each entity's valid-time history as believed at the
+/// spec's transaction-time coordinate, buckets that history into the spec's
+/// tumbling windows, and emits one computed-column [`QueryRow`] per window
+/// carrying `window_start`/`window_end` (RFC 3339) followed by each aggregate.
+/// See [`crate::query::temporal_window`] for the boundary contract and the
+/// crate guide for the sampling rules.
+pub struct TemporalWindowAggregateIterator {
+    input: Option<Box<dyn ResultIterator>>,
+    spec: TemporalWindowSpec,
+    historical: Arc<RwLock<HistoricalStorage>>,
+    output: std::vec::IntoIter<QueryRow>,
+    drained: bool,
+}
+
+impl TemporalWindowAggregateIterator {
+    /// Create a new temporal window aggregation iterator.
+    pub fn new(
+        input: Box<dyn ResultIterator>,
+        spec: TemporalWindowSpec,
+        historical: Arc<RwLock<HistoricalStorage>>,
+    ) -> Self {
+        TemporalWindowAggregateIterator {
+            input: Some(input),
+            spec,
+            historical,
+            output: Vec::new().into_iter(),
+            drained: false,
+        }
+    }
+
+    fn drain(&mut self) -> Result<()> {
+        let mut input = match self.input.take() {
+            Some(i) => i,
+            None => return Ok(()),
+        };
+
+        // Collect distinct matched node ids, preserving discovery order. v1
+        // windows nodes only (the converter rejects edge/traversal windows).
+        let mut node_ids: Vec<NodeId> = Vec::new();
+        let mut seen: HashSet<NodeId> = HashSet::new();
+        while let Some(row) = input.next() {
+            let row = row?;
+            if let Some(EntityId::Node(id)) = row.entity.id()
+                && seen.insert(id)
+            {
+                node_ids.push(id);
+            }
+        }
+
+        // Generate the tumbling windows (validated at convert time; re-run here
+        // to obtain the boundaries). A structured error would already have been
+        // raised during conversion, so this is effectively infallible.
+        let windows = crate::query::temporal_window::generate_windows(
+            self.spec.range_start_micros,
+            self.spec.range_end_micros,
+            self.spec.granularity,
+        )
+        .map_err(|e| {
+            crate::core::error::Error::Query(crate::core::error::QueryError::InvalidParameter {
+                parameter: "temporal window".to_string(),
+                reason: format!("{e:?}"),
+            })
+        })?;
+
+        let as_of = self.spec.as_of_system_time;
+        let naggs = self.spec.aggregates.len();
+        // accs[window_index][aggregate_index]
+        let mut accs: Vec<Vec<WindowAcc>> = windows
+            .iter()
+            .map(|_| {
+                self.spec
+                    .aggregates
+                    .iter()
+                    .map(|a| WindowAcc::new(a.func))
+                    .collect()
+            })
+            .collect();
+
+        {
+            let hist = self.historical.read();
+            for node_id in &node_ids {
+                // Reconstruct the entity's valid-time timeline as believed at
+                // the transaction-time coordinate (#3363 AC: later corrections
+                // must not rewrite past analytics). Every version *recorded by*
+                // `as_of` (`transaction_from <= as_of`) contributes a
+                // change-point at its `valid_from`; versions recorded later are
+                // invisible. Multiple versions sharing a `valid_from` are a
+                // same-instant correction, so we keep the one with the latest
+                // belief (greatest `transaction_from <= as_of`). Both value
+                // sampling and CHANGES read from this single, consistent source.
+                // Entities absent from current state (e.g. deleted) cannot be
+                // walked in v1 and are skipped (documented).
+                let believed: Vec<BelievedVersion> = match hist.get_node_history(*node_id) {
+                    Ok(h) => {
+                        let mut by_vf: std::collections::HashMap<
+                            i64,
+                            (Timestamp, crate::core::property::PropertyMap),
+                        > = std::collections::HashMap::new();
+                        for ver in h.versions {
+                            let tx_from = ver.temporal.transaction_time().start();
+                            if tx_from > as_of {
+                                continue;
+                            }
+                            let vf = ver.temporal.valid_time().start().wallclock();
+                            match by_vf.get(&vf) {
+                                Some((existing_tx, _)) if *existing_tx >= tx_from => {}
+                                _ => {
+                                    by_vf.insert(vf, (tx_from, ver.properties));
+                                }
+                            }
+                        }
+                        let mut v: Vec<BelievedVersion> = by_vf
+                            .into_iter()
+                            .map(|(valid_from, (_, properties))| BelievedVersion {
+                                valid_from,
+                                properties,
+                            })
+                            .collect();
+                        v.sort_by_key(|b| b.valid_from);
+                        v
+                    }
+                    Err(_) => continue,
+                };
+
+                for (w_idx, window) in windows.iter().enumerate() {
+                    // Value sample: the value in effect at the window start --
+                    // the change-point with the greatest `valid_from <= start`.
+                    // `None` => the entity did not yet exist at the window start.
+                    let sample = believed
+                        .iter()
+                        .rev()
+                        .find(|b| b.valid_from <= window.start_micros);
+
+                    for (a_idx, agg) in self.spec.aggregates.iter().enumerate() {
+                        let acc = &mut accs[w_idx][a_idx];
+                        match (agg.func, &agg.arg) {
+                            (WindowAggFunc::Changes, arg) => {
+                                acc.count += changes_in_window(&believed, window, arg);
+                            }
+                            (WindowAggFunc::Count, WindowAggArg::Star) => {
+                                if sample.is_some() {
+                                    acc.count += 1;
+                                }
+                            }
+                            (WindowAggFunc::Count, WindowAggArg::Property(key)) => {
+                                if let Some(v) = sample.and_then(|b| b.properties.get(key.as_str()))
+                                    && property_as_f64(v).is_some()
+                                {
+                                    acc.count += 1;
+                                }
+                            }
+                            // Value aggregates (SUM/AVG/MIN/MAX) over a property.
+                            (_, WindowAggArg::Property(key)) => {
+                                if let Some(v) = sample.and_then(|b| b.properties.get(key.as_str()))
+                                {
+                                    acc.fold_value(v);
+                                }
+                            }
+                            // SUM/AVG/MIN/MAX with a `*` argument is rejected at
+                            // convert time; nothing to fold if it slips through.
+                            (_, WindowAggArg::Star) => {}
+                        }
+                    }
+                }
+            }
+        }
+
+        // Emit one row per window: window_start, window_end, then aggregates.
+        let mut rows = Vec::with_capacity(windows.len());
+        for (w_idx, window) in windows.iter().enumerate() {
+            let mut columns: Vec<(String, PropertyValue)> = Vec::with_capacity(2 + naggs);
+            columns.push((
+                "window_start".to_string(),
+                PropertyValue::String(Arc::from(
+                    crate::query::temporal_window::format_rfc3339(window.start_micros).as_str(),
+                )),
+            ));
+            columns.push((
+                "window_end".to_string(),
+                PropertyValue::String(Arc::from(
+                    crate::query::temporal_window::format_rfc3339(window.end_micros).as_str(),
+                )),
+            ));
+            let window_accs = std::mem::take(&mut accs[w_idx]);
+            for (agg, acc) in self.spec.aggregates.iter().zip(window_accs) {
+                columns.push((agg.output_name.clone(), acc.finalize()));
+            }
+            rows.push(QueryRow::from_columns(columns));
+        }
+        self.output = rows.into_iter();
+        Ok(())
+    }
+}
+
+/// Count the versions whose valid interval *starts* within `window`
+/// (`[start, end)`), among the believed versions, for a `CHANGES` aggregate.
+///
+/// - `CHANGES(*)` / `CHANGES(v)` counts every entity version starting in the
+///   window.
+/// - `CHANGES(v.prop)` counts only versions whose value for `prop` differs from
+///   the immediately-preceding believed version's value (a genuine property
+///   change; the first believed version counts as a change from "absent").
+fn changes_in_window(
+    believed: &[BelievedVersion],
+    window: &crate::query::temporal_window::Window,
+    arg: &WindowAggArg,
+) -> i64 {
+    let in_window = |vf: i64| vf >= window.start_micros && vf < window.end_micros;
+    match arg {
+        WindowAggArg::Star => believed.iter().filter(|b| in_window(b.valid_from)).count() as i64,
+        WindowAggArg::Property(key) => {
+            let mut count = 0i64;
+            for (i, b) in believed.iter().enumerate() {
+                if !in_window(b.valid_from) {
+                    continue;
+                }
+                let cur = b.properties.get(key.as_str());
+                let prev = if i == 0 {
+                    None
+                } else {
+                    believed[i - 1].properties.get(key.as_str())
+                };
+                if !property_values_equal(cur, prev) {
+                    count += 1;
+                }
+            }
+            count
+        }
+    }
+}
+
+/// Equality of two optional property values for property-change detection.
+fn property_values_equal(a: Option<&PropertyValue>, b: Option<&PropertyValue>) -> bool {
+    match (a, b) {
+        (None, None) => true,
+        (Some(x), Some(y)) => x == y,
+        _ => false,
+    }
+}
+
+impl ResultIterator for TemporalWindowAggregateIterator {
     fn next(&mut self) -> Option<Result<QueryRow>> {
         if !self.drained {
             self.drained = true;

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -526,6 +526,17 @@ impl QueryExecutor {
                     ))
                 }
 
+                PhysicalOp::TemporalWindowAggregate { input, spec } => {
+                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    // Historical storage is required to reconstruct each matched
+                    // entity's valid-time history per window (Issue #3363).
+                    Box::new(iterators::TemporalWindowAggregateIterator::new(
+                        input_iter,
+                        spec.clone(),
+                        Arc::clone(&self.historical),
+                    ))
+                }
+
                 PhysicalOp::Distinct { input } => {
                     let input_iter = self.build_op(input, profile, child_depth)?;
                     Box::new(iterators::DistinctIterator::new(input_iter))

--- a/src/query/ir.rs
+++ b/src/query/ir.rs
@@ -207,6 +207,16 @@ pub enum QueryOp {
         aggregates: Vec<AggregateSpec>,
     },
 
+    /// Temporal aggregation window (Issue #3363).
+    ///
+    /// A terminal operation that consumes the upstream matched-entity stream,
+    /// buckets each entity's **valid-time** history into fixed tumbling windows
+    /// over `[range_start, range_end)`, and emits one output row per window
+    /// carrying the window's `window_start`/`window_end` (RFC 3339 columns)
+    /// followed by each per-window aggregate. Reads history at the belief
+    /// recorded as of `as_of_system_time` (the transaction-time dimension).
+    TemporalWindowAggregate(TemporalWindowSpec),
+
     /// Collect unique values
     Distinct,
 
@@ -292,6 +302,61 @@ impl ScoreThreshold {
             ScoreComparison::Le => score <= self.value,
         }
     }
+}
+
+/// The fully-resolved plan for a [`QueryOp::TemporalWindowAggregate`]
+/// (Issue #3363). Produced by the converter after validating the raw AST window
+/// clause (unit word, aggregate functions, timestamp boundaries).
+#[derive(Debug, Clone, PartialEq)]
+pub struct TemporalWindowSpec {
+    /// The window granularity (count + unit).
+    pub granularity: crate::query::temporal_window::WindowGranularity,
+    /// Inclusive start of the valid-time range (microseconds since epoch).
+    pub range_start_micros: i64,
+    /// Exclusive end of the valid-time range (microseconds since epoch).
+    pub range_end_micros: i64,
+    /// Transaction-time coordinate the history is read as-of.
+    pub as_of_system_time: Timestamp,
+    /// The per-window aggregates to compute, in `RETURN` order.
+    pub aggregates: Vec<WindowAggregateSpec>,
+}
+
+/// A single resolved window aggregate (Issue #3363).
+#[derive(Debug, Clone, PartialEq)]
+pub struct WindowAggregateSpec {
+    /// The aggregate function.
+    pub func: WindowAggFunc,
+    /// The aggregate argument.
+    pub arg: WindowAggArg,
+    /// The output column name (alias if given, else a rendered default).
+    pub output_name: String,
+}
+
+/// A temporal-window aggregate function (Issue #3363).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowAggFunc {
+    /// Count of samples/entities present in the window.
+    Count,
+    /// Sum of numeric samples at window start.
+    Sum,
+    /// Mean of numeric samples at window start.
+    Avg,
+    /// Minimum numeric sample at window start.
+    Min,
+    /// Maximum numeric sample at window start.
+    Max,
+    /// Number of entity/property versions whose valid interval starts in the
+    /// window.
+    Changes,
+}
+
+/// The argument to a temporal-window aggregate (Issue #3363).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WindowAggArg {
+    /// `*` — the matched entity itself (no property).
+    Star,
+    /// A property key `v.key`.
+    Property(String),
 }
 
 /// A grouping key in a [`QueryOp::Aggregate`] (a non-aggregate projection

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -99,6 +99,7 @@ pub mod planner;
 pub mod read_only;
 pub mod result;
 pub mod semantic_pathfinding;
+pub mod temporal_window;
 /// Query execution traits.
 pub mod traits;
 

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -195,6 +195,24 @@ impl Parser {
             query = query.with_temporal(t);
         }
 
+        // Parse an optional temporal aggregation window clause (Issue #3363).
+        // When present it is self-contained (it carries its own aggregate
+        // `RETURN`), so no further read clauses are parsed and the query must
+        // end after it.
+        if self.check_kw("WINDOW") {
+            let window = self.parse_window_clause()?;
+            query = query.with_window(window);
+            if !self.is_at_end() {
+                return Err(self.error(
+                    "Unexpected tokens after WINDOW ... RETURN (WHERE/ORDER/SKIP/LIMIT \
+                     are not supported with a temporal aggregation window)"
+                        .to_string(),
+                    Some("end of query".to_string()),
+                ));
+            }
+            return Ok(query);
+        }
+
         // Parse optional RANK BY SIMILARITY clause
         if let Some(rank) = self.parse_rank_clause()? {
             query = query.with_rank(rank);
@@ -291,6 +309,125 @@ impl Parser {
         let end = self.parse_timestamp()?;
 
         Ok(TemporalClause::Between { start, end })
+    }
+
+    // =========================================================
+    // Temporal Aggregation Window Clause (Issue #3363)
+    // =========================================================
+
+    /// Parse a temporal aggregation window clause.
+    ///
+    /// # Grammar
+    /// ```text
+    /// window_clause ::= "WINDOW" integer unit
+    ///                   "OVER" "VALID_TIME" "FROM" timestamp "TO" timestamp
+    ///                   ("AS" "OF" "SYSTEM_TIME" timestamp)?
+    ///                   "RETURN" window_agg ("," window_agg)*
+    /// unit          ::= identifier   (minute|hour|day|week|month|quarter|year, +s)
+    /// window_agg    ::= func "(" agg_arg ")" ("AS" identifier)?
+    /// func          ::= "COUNT" | identifier   (SUM|AVG|MIN|MAX|CHANGES)
+    /// agg_arg       ::= "*" | identifier ("." identifier)?
+    /// ```
+    fn parse_window_clause(&mut self) -> Result<WindowClause, ParseError> {
+        self.expect_kw("WINDOW")?;
+
+        // <count> <unit>
+        let count = match self.current() {
+            Some(Token::IntegerLiteral(n)) => {
+                let n = *n;
+                self.advance();
+                n
+            }
+            _ => {
+                return Err(self.error(
+                    "Expected an integer window size after WINDOW".to_string(),
+                    Some("integer".to_string()),
+                ));
+            }
+        };
+        let unit = self.parse_identifier().map_err(|_| {
+            self.error(
+                "Expected a window unit (e.g. day, week, month) after the window size".to_string(),
+                Some("unit".to_string()),
+            )
+        })?;
+
+        // OVER VALID_TIME FROM <ts> TO <ts>
+        self.expect_kw("OVER")?;
+        self.expect_kw("VALID_TIME")?;
+        self.expect_kw("FROM")?;
+        let range_start = self.parse_timestamp()?;
+        self.expect(&Token::To)?;
+        let range_end = self.parse_timestamp()?;
+
+        // Optional AS OF SYSTEM_TIME <ts>
+        let as_of_system_time = if self.check(&Token::As) {
+            self.advance(); // AS
+            self.expect(&Token::Of)?;
+            self.expect_kw("SYSTEM_TIME")?;
+            Some(self.parse_timestamp()?)
+        } else {
+            None
+        };
+
+        // RETURN <agg> [, <agg>]*
+        self.expect(&Token::Return)?;
+        let mut aggregates = vec![self.parse_window_agg_item()?];
+        while self.check(&Token::Comma) {
+            self.advance();
+            aggregates.push(self.parse_window_agg_item()?);
+        }
+
+        Ok(WindowClause {
+            count,
+            unit,
+            range_start,
+            range_end,
+            as_of_system_time,
+            aggregates,
+        })
+    }
+
+    /// Parse one `func(arg) [AS alias]` window aggregate item.
+    fn parse_window_agg_item(&mut self) -> Result<WindowReturnItem, ParseError> {
+        // Function name: COUNT is a reserved token; the rest are identifiers.
+        let func = if self.check(&Token::Count) {
+            self.advance();
+            "COUNT".to_string()
+        } else {
+            self.parse_identifier().map_err(|_| {
+                self.error(
+                    "Expected an aggregate function name (COUNT/SUM/AVG/MIN/MAX/CHANGES)"
+                        .to_string(),
+                    Some("aggregate function".to_string()),
+                )
+            })?
+        };
+
+        self.expect(&Token::LeftParen)?;
+        let arg = if self.check(&Token::Star) {
+            self.advance();
+            WindowAggArg::Star
+        } else {
+            let var = self.parse_identifier()?;
+            if self.check(&Token::Dot) {
+                self.advance();
+                let key = self.parse_identifier()?;
+                WindowAggArg::Property { var, key }
+            } else {
+                WindowAggArg::Entity { var }
+            }
+        };
+        self.expect(&Token::RightParen)?;
+
+        let alias = if self.check(&Token::As) {
+            self.advance();
+            Some(self.parse_identifier()?)
+        } else {
+            None
+        };
+
+        Ok(WindowReturnItem { func, arg, alias })
     }
 
     fn parse_timestamp(&mut self) -> Result<TimestampLiteral, ParseError> {
@@ -1466,6 +1603,32 @@ impl Parser {
             position: self.position,
             expected,
             found: self.current().cloned(),
+        }
+    }
+
+    // =========================================================
+    // Contextual keyword helpers (Issue #3363)
+    //
+    // The temporal aggregation window clause introduces several words
+    // (`WINDOW`, `OVER`, `VALID_TIME`, `SYSTEM_TIME`, `FROM`) that are matched
+    // *contextually* against `Token::Identifier` rather than being reserved in
+    // the lexer, so existing queries whose labels/variables happen to use those
+    // words keep parsing unchanged.
+    // =========================================================
+
+    /// True if the current token is an identifier equal (case-insensitively) to
+    /// `kw`.
+    fn check_kw(&self, kw: &str) -> bool {
+        matches!(self.current(), Some(Token::Identifier(s)) if s.eq_ignore_ascii_case(kw))
+    }
+
+    /// Consume a contextual keyword, or error.
+    fn expect_kw(&mut self, kw: &str) -> Result<(), ParseError> {
+        if self.check_kw(kw) {
+            self.advance();
+            Ok(())
+        } else {
+            Err(self.error(format!("Expected `{}`", kw), Some(kw.to_uppercase())))
         }
     }
 }

--- a/src/query/plan.rs
+++ b/src/query/plan.rs
@@ -308,6 +308,12 @@ pub enum UnaryOp {
         aggregates: Vec<super::ir::AggregateSpec>,
     },
 
+    /// Temporal aggregation window (Issue #3363). Mirrors
+    /// [`super::ir::QueryOp::TemporalWindowAggregate`]: buckets each upstream
+    /// entity's valid-time history into tumbling windows and emits per-window
+    /// aggregate rows.
+    TemporalWindowAggregate(super::ir::TemporalWindowSpec),
+
     /// Left-outer application of an optional sub-pattern (`OPTIONAL MATCH`).
     ///
     /// For each input row, the `steps` sub-pipeline runs seeded from that row;

--- a/src/query/planner/cost.rs
+++ b/src/query/planner/cost.rs
@@ -469,6 +469,7 @@ impl CostModel {
             | PhysicalOp::Distinct { input }
             | PhysicalOp::Count { input }
             | PhysicalOp::Aggregate { input, .. }
+            | PhysicalOp::TemporalWindowAggregate { input, .. }
             | PhysicalOp::Materialize { input }
             | PhysicalOp::TemporalTrack { input, .. } => self.estimate(input, stats),
 
@@ -582,6 +583,17 @@ impl CostModel {
             PhysicalOp::Except { left, .. } => self.estimate_cardinality(left, stats),
             PhysicalOp::Materialize { input } | PhysicalOp::TemporalTrack { input, .. } => {
                 self.estimate_cardinality(input, stats)
+            }
+            PhysicalOp::TemporalWindowAggregate { spec, .. } => {
+                // One output row per tumbling window; estimate the window count
+                // directly from the spec (cheap, storage-free).
+                crate::query::temporal_window::generate_windows(
+                    spec.range_start_micros,
+                    spec.range_end_micros,
+                    spec.granularity,
+                )
+                .map(|w| w.len().max(1))
+                .unwrap_or(1)
             }
             PhysicalOp::SimilarToNode { k, .. } => *k,
             PhysicalOp::OptionalApply { input, .. } => {

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -485,6 +485,11 @@ impl QueryPlanner {
                 input,
             )),
 
+            QueryOp::TemporalWindowAggregate(spec) => Ok(LogicalOp::unary(
+                UnaryOp::TemporalWindowAggregate(spec.clone()),
+                input,
+            )),
+
             QueryOp::Distinct => Ok(LogicalOp::unary(UnaryOp::Distinct, input)),
 
             QueryOp::Project(props) => Ok(LogicalOp::unary(UnaryOp::Project(props.clone()), input)),
@@ -532,6 +537,7 @@ impl QueryPlanner {
             QueryOp::Skip(_) => "Skip",
             QueryOp::Count => "Count",
             QueryOp::Aggregate { .. } => "Aggregate",
+            QueryOp::TemporalWindowAggregate(_) => "TemporalWindowAggregate",
             QueryOp::Distinct => "Distinct",
             QueryOp::Project(_) => "Project",
             QueryOp::ProjectProvenance(_) => "ProjectProvenance",
@@ -973,6 +979,11 @@ impl QueryPlanner {
             UnaryOp::TemporalTrack { time_range } => Ok(PhysicalOp::TemporalTrack {
                 input: Box::new(input),
                 time_range: *time_range,
+            }),
+
+            UnaryOp::TemporalWindowAggregate(spec) => Ok(PhysicalOp::TemporalWindowAggregate {
+                input: Box::new(input),
+                spec: spec.clone(),
             }),
 
             UnaryOp::OptionalApply { steps } => {

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -360,6 +360,7 @@ impl PhysicalPlan {
             | PhysicalOp::Distinct { input, .. }
             | PhysicalOp::Count { input, .. }
             | PhysicalOp::Aggregate { input, .. }
+            | PhysicalOp::TemporalWindowAggregate { input, .. }
             | PhysicalOp::Materialize { input, .. }
             | PhysicalOp::TemporalTrack { input, .. }
             | PhysicalOp::IndexedTraversal { input, .. }
@@ -722,6 +723,16 @@ pub enum PhysicalOp {
         time_range: TimeRange,
     },
 
+    /// Temporal aggregation window (Issue #3363). Consumes the upstream
+    /// matched-entity stream and emits one computed-column row per tumbling
+    /// window. Maps 1:1 to the executor's `TemporalWindowAggregateIterator`.
+    TemporalWindowAggregate {
+        /// Input operator providing the matched entities.
+        input: Box<PhysicalOp>,
+        /// The resolved window specification.
+        spec: crate::query::ir::TemporalWindowSpec,
+    },
+
     /// Materialize results into memory
     Materialize {
         /// Input operator
@@ -805,6 +816,7 @@ impl PhysicalOp {
             PhysicalOp::Distinct { .. } => "Distinct",
             PhysicalOp::Count { .. } => "Count",
             PhysicalOp::Aggregate { .. } => "Aggregate",
+            PhysicalOp::TemporalWindowAggregate { .. } => "TemporalWindowAggregate",
             PhysicalOp::TemporalTrack { .. } => "TemporalTrack",
             PhysicalOp::Materialize { .. } => "Materialize",
             PhysicalOp::OptionalApply { .. } => "OptionalApply",
@@ -857,6 +869,7 @@ impl PhysicalOp {
             | PhysicalOp::Distinct { input, .. }
             | PhysicalOp::Count { input, .. }
             | PhysicalOp::Aggregate { input, .. }
+            | PhysicalOp::TemporalWindowAggregate { input, .. }
             | PhysicalOp::TemporalTrack { input, .. }
             | PhysicalOp::Materialize { input, .. }
             | PhysicalOp::OptionalApply { input, .. } => 1 + input.depth(),
@@ -1066,6 +1079,7 @@ impl PhysicalOp {
             | PhysicalOp::Distinct { input, .. }
             | PhysicalOp::Count { input, .. }
             | PhysicalOp::Aggregate { input, .. }
+            | PhysicalOp::TemporalWindowAggregate { input, .. }
             | PhysicalOp::TemporalTrack { input, .. }
             | PhysicalOp::Materialize { input, .. }
             | PhysicalOp::OptionalApply { input, .. } => Some(input),

--- a/src/query/temporal_window.rs
+++ b/src/query/temporal_window.rs
@@ -1,0 +1,455 @@
+//! Pure interval math for temporal aggregation windows (Issue #3363).
+//!
+//! This module holds the *storage-free* logic behind AQL temporal aggregation
+//! windows: parsing a window boundary timestamp, formatting a boundary back to
+//! RFC 3339, and generating the sequence of tumbling `[start, end)` windows for
+//! a given granularity. Keeping it separate from the executor iterator lets the
+//! subtle interval-edge and calendar arithmetic be unit-tested without a
+//! database.
+//!
+//! # Window semantics (falsifiable contract)
+//!
+//! Windows are half-open `[b_k, b_{k+1})` with `b_0 = start` and
+//! `b_{k+1} = step(b_k)`, generated until `b_k >= end`. The final window's end
+//! is **clamped to `end`**, so the union of all windows equals exactly
+//! `[start, end)` with no overlap and no gap. A version whose `valid_from`
+//! equals a boundary belongs to the window it *starts*
+//! (`b_k <= valid_from < b_{k+1}`).
+//!
+//! Fixed-duration units (minute/hour/day/week) advance by a constant
+//! microsecond delta. Calendar units (month/quarter/year) advance by
+//! chrono UTC calendar arithmetic, so month lengths (28/29/30/31) and leap
+//! years are honored exactly.
+
+use chrono::{DateTime, Months, TimeZone, Utc};
+
+use crate::core::temporal::Timestamp;
+
+/// Microseconds in one minute.
+const MICROS_PER_MINUTE: i64 = 60 * 1_000_000;
+/// Microseconds in one hour.
+const MICROS_PER_HOUR: i64 = 60 * MICROS_PER_MINUTE;
+/// Microseconds in one day.
+const MICROS_PER_DAY: i64 = 24 * MICROS_PER_HOUR;
+/// Microseconds in one week.
+const MICROS_PER_WEEK: i64 = 7 * MICROS_PER_DAY;
+
+/// Hard cap on the number of windows a single query may generate, guarding
+/// against a caller pairing a huge range with a tiny granularity (which would
+/// otherwise allocate unbounded rows and reconstruct history per window).
+pub const MAX_WINDOWS: usize = 100_000;
+
+/// A window granularity: a positive multiplier and a time unit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WindowGranularity {
+    /// The positive multiplier (e.g. `3` in `3 months`).
+    pub count: u32,
+    /// The time unit.
+    pub unit: WindowUnit,
+}
+
+/// A temporal window unit. Fixed-duration units advance by a constant
+/// microsecond delta; calendar units advance via chrono month arithmetic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowUnit {
+    /// A minute (fixed 60s).
+    Minute,
+    /// An hour (fixed 3600s).
+    Hour,
+    /// A day (fixed 86400s).
+    Day,
+    /// A week (fixed 7 days).
+    Week,
+    /// A calendar month.
+    Month,
+    /// A calendar quarter (3 calendar months).
+    Quarter,
+    /// A calendar year (12 calendar months).
+    Year,
+}
+
+impl WindowUnit {
+    /// Parse a unit word (case-insensitive, singular or plural). Returns `None`
+    /// for an unknown unit so the caller can raise a structured error.
+    pub fn parse(word: &str) -> Option<Self> {
+        match word.to_ascii_lowercase().as_str() {
+            "minute" | "minutes" => Some(WindowUnit::Minute),
+            "hour" | "hours" => Some(WindowUnit::Hour),
+            "day" | "days" => Some(WindowUnit::Day),
+            "week" | "weeks" => Some(WindowUnit::Week),
+            "month" | "months" => Some(WindowUnit::Month),
+            "quarter" | "quarters" => Some(WindowUnit::Quarter),
+            "year" | "years" => Some(WindowUnit::Year),
+            _ => None,
+        }
+    }
+
+    /// The fixed microsecond delta for one unit, or `None` for calendar units.
+    fn fixed_micros(self) -> Option<i64> {
+        match self {
+            WindowUnit::Minute => Some(MICROS_PER_MINUTE),
+            WindowUnit::Hour => Some(MICROS_PER_HOUR),
+            WindowUnit::Day => Some(MICROS_PER_DAY),
+            WindowUnit::Week => Some(MICROS_PER_WEEK),
+            _ => None,
+        }
+    }
+
+    /// The number of calendar months per unit, or `None` for fixed units.
+    fn calendar_months(self) -> Option<u32> {
+        match self {
+            WindowUnit::Month => Some(1),
+            WindowUnit::Quarter => Some(3),
+            WindowUnit::Year => Some(12),
+            _ => None,
+        }
+    }
+}
+
+/// A single tumbling window: half-open `[start, end)` in microseconds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Window {
+    /// Inclusive start (microseconds since epoch).
+    pub start_micros: i64,
+    /// Exclusive end (microseconds since epoch), clamped to the range end.
+    pub end_micros: i64,
+}
+
+/// Errors from window construction. Kept as a small enum so the converter can
+/// map each to the right structured [`crate::core::error::QueryError`] variant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WindowError {
+    /// The multiplier was zero.
+    ZeroCount,
+    /// `end <= start`.
+    EmptyRange,
+    /// The granularity/range pair would generate more than [`MAX_WINDOWS`].
+    TooManyWindows(usize),
+    /// A boundary timestamp could not be parsed.
+    BadTimestamp(String),
+    /// Calendar arithmetic overflowed the representable timestamp range.
+    CalendarOverflow,
+}
+
+/// Parse a window boundary timestamp: RFC 3339 / ISO-8601 string, or an integer
+/// (or digit string) of microseconds since the Unix epoch. This is a superset
+/// of the existing AQL timestamp handling (which accepted only microseconds),
+/// so previously valid queries are unaffected.
+pub fn parse_boundary_micros(raw: &str) -> Result<i64, WindowError> {
+    let trimmed = raw.trim();
+    // Integer microseconds since epoch (matches existing AQL convention).
+    if let Ok(micros) = trimmed.parse::<i64>() {
+        return Ok(micros);
+    }
+    // RFC 3339 / ISO-8601 with an explicit offset (e.g. `...Z`, `...+00:00`).
+    if let Ok(dt) = DateTime::parse_from_rfc3339(trimmed) {
+        return Ok(dt.with_timezone(&Utc).timestamp_micros());
+    }
+    // Bare date `YYYY-MM-DD` interpreted as UTC midnight.
+    if let Ok(date) = chrono::NaiveDate::parse_from_str(trimmed, "%Y-%m-%d")
+        && let Some(dt) = date.and_hms_opt(0, 0, 0)
+    {
+        return Ok(Utc.from_utc_datetime(&dt).timestamp_micros());
+    }
+    // Naive date-time `YYYY-MM-DDTHH:MM:SS` interpreted as UTC.
+    for fmt in ["%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S"] {
+        if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(trimmed, fmt) {
+            return Ok(Utc.from_utc_datetime(&dt).timestamp_micros());
+        }
+    }
+    Err(WindowError::BadTimestamp(raw.to_string()))
+}
+
+/// Format a microsecond timestamp as an RFC 3339 UTC string (`Z` suffix,
+/// microsecond precision), mirroring the MCP surface's convention. Falls back to
+/// a `<micros>us` token if the value is outside chrono's representable range.
+pub fn format_rfc3339(micros: i64) -> String {
+    DateTime::<Utc>::from_timestamp_micros(micros)
+        .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Micros, true))
+        .unwrap_or_else(|| format!("{micros}us"))
+}
+
+/// Advance a boundary by one granularity step. Fixed units add a constant
+/// microsecond delta; calendar units add whole months via chrono UTC
+/// arithmetic (clamping to the last valid day of the target month, chrono's
+/// documented behavior).
+fn step(boundary_micros: i64, gran: WindowGranularity) -> Result<i64, WindowError> {
+    if let Some(delta) = gran.unit.fixed_micros() {
+        return boundary_micros
+            .checked_add(
+                delta
+                    .checked_mul(i64::from(gran.count))
+                    .ok_or(WindowError::CalendarOverflow)?,
+            )
+            .ok_or(WindowError::CalendarOverflow);
+    }
+    let months_per = gran
+        .unit
+        .calendar_months()
+        .expect("non-fixed unit has months");
+    let total_months = months_per
+        .checked_mul(gran.count)
+        .ok_or(WindowError::CalendarOverflow)?;
+    let dt = DateTime::<Utc>::from_timestamp_micros(boundary_micros)
+        .ok_or(WindowError::CalendarOverflow)?;
+    // Preserve the sub-second/day-of-month position; chrono clamps day-of-month
+    // to the target month's length (e.g. Jan 31 + 1 month -> Feb 28/29).
+    let advanced = dt
+        .checked_add_months(Months::new(total_months))
+        .ok_or(WindowError::CalendarOverflow)?;
+    Ok(advanced.timestamp_micros())
+}
+
+/// Generate the tumbling windows tiling `[start_micros, end_micros)` at the
+/// given granularity. See the module docs for the half-open boundary contract.
+pub fn generate_windows(
+    start_micros: i64,
+    end_micros: i64,
+    gran: WindowGranularity,
+) -> Result<Vec<Window>, WindowError> {
+    if gran.count == 0 {
+        return Err(WindowError::ZeroCount);
+    }
+    if end_micros <= start_micros {
+        return Err(WindowError::EmptyRange);
+    }
+    // Sanity pre-check for fixed units: cheap upper-bound on window count so a
+    // pathological range/granularity fails fast with a structured error rather
+    // than looping to allocate millions of rows.
+    if let Some(delta) = gran.unit.fixed_micros() {
+        let span = (end_micros - start_micros) as i128;
+        let step_span = delta as i128 * i128::from(gran.count);
+        let approx = (span / step_span) + 1;
+        if approx > MAX_WINDOWS as i128 {
+            return Err(WindowError::TooManyWindows(approx as usize));
+        }
+    }
+
+    let mut windows = Vec::new();
+    let mut b = start_micros;
+    while b < end_micros {
+        let next = step(b, gran)?;
+        // Guard against a non-advancing step (should be impossible given
+        // count>0, but defend against any degenerate calendar edge).
+        if next <= b {
+            return Err(WindowError::CalendarOverflow);
+        }
+        let clamped_end = next.min(end_micros);
+        windows.push(Window {
+            start_micros: b,
+            end_micros: clamped_end,
+        });
+        if windows.len() > MAX_WINDOWS {
+            return Err(WindowError::TooManyWindows(windows.len()));
+        }
+        b = next;
+    }
+    Ok(windows)
+}
+
+/// Convenience: window start as a [`Timestamp`] for point-in-time reads.
+pub fn window_start_timestamp(w: &Window) -> Timestamp {
+    Timestamp::from(w.start_micros)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn micros_of(rfc: &str) -> i64 {
+        parse_boundary_micros(rfc).unwrap()
+    }
+
+    #[test]
+    fn parse_rfc3339_and_micros_agree() {
+        // 2024-01-01T00:00:00Z == 1704067200 seconds == 1704067200_000_000 us.
+        let a = parse_boundary_micros("2024-01-01T00:00:00Z").unwrap();
+        let b = parse_boundary_micros("1704067200000000").unwrap();
+        assert_eq!(a, b);
+        assert_eq!(a, 1_704_067_200_000_000);
+    }
+
+    #[test]
+    fn parse_bare_date_is_utc_midnight() {
+        let a = parse_boundary_micros("2024-01-01").unwrap();
+        assert_eq!(a, 1_704_067_200_000_000);
+    }
+
+    #[test]
+    fn parse_rejects_garbage() {
+        assert!(matches!(
+            parse_boundary_micros("not-a-time"),
+            Err(WindowError::BadTimestamp(_))
+        ));
+    }
+
+    #[test]
+    fn format_round_trips_rfc3339() {
+        let m = 1_704_067_200_000_000;
+        assert_eq!(format_rfc3339(m), "2024-01-01T00:00:00.000000Z");
+    }
+
+    #[test]
+    fn fixed_day_windows_tile_exactly() {
+        let start = micros_of("2024-01-01T00:00:00Z");
+        let end = micros_of("2024-01-04T00:00:00Z");
+        let gran = WindowGranularity {
+            count: 1,
+            unit: WindowUnit::Day,
+        };
+        let ws = generate_windows(start, end, gran).unwrap();
+        assert_eq!(ws.len(), 3);
+        assert_eq!(ws[0].start_micros, start);
+        assert_eq!(ws[0].end_micros, micros_of("2024-01-02T00:00:00Z"));
+        assert_eq!(ws[2].end_micros, end);
+        // Union == [start, end): contiguous, no gap/overlap.
+        for pair in ws.windows(2) {
+            assert_eq!(pair[0].end_micros, pair[1].start_micros);
+        }
+    }
+
+    #[test]
+    fn last_window_clamped_to_end() {
+        // 2.5 days at 1-day granularity -> last window is a half day, clamped.
+        let start = micros_of("2024-01-01T00:00:00Z");
+        let end = micros_of("2024-01-03T12:00:00Z");
+        let gran = WindowGranularity {
+            count: 1,
+            unit: WindowUnit::Day,
+        };
+        let ws = generate_windows(start, end, gran).unwrap();
+        assert_eq!(ws.len(), 3);
+        let last = ws.last().unwrap();
+        assert_eq!(last.start_micros, micros_of("2024-01-03T00:00:00Z"));
+        assert_eq!(last.end_micros, end);
+        assert!(last.end_micros - last.start_micros < MICROS_PER_DAY);
+    }
+
+    #[test]
+    fn calendar_months_have_variable_length() {
+        // Jan, Feb (leap 2024), Mar starts.
+        let start = micros_of("2024-01-01T00:00:00Z");
+        let end = micros_of("2024-04-01T00:00:00Z");
+        let gran = WindowGranularity {
+            count: 1,
+            unit: WindowUnit::Month,
+        };
+        let ws = generate_windows(start, end, gran).unwrap();
+        assert_eq!(ws.len(), 3);
+        assert_eq!(ws[0].start_micros, micros_of("2024-01-01T00:00:00Z"));
+        assert_eq!(ws[0].end_micros, micros_of("2024-02-01T00:00:00Z"));
+        assert_eq!(ws[1].end_micros, micros_of("2024-03-01T00:00:00Z"));
+        assert_eq!(ws[2].end_micros, end);
+        // January has 31 days, February 2024 has 29 (leap).
+        assert_eq!(ws[0].end_micros - ws[0].start_micros, 31 * MICROS_PER_DAY);
+        assert_eq!(ws[1].end_micros - ws[1].start_micros, 29 * MICROS_PER_DAY);
+    }
+
+    #[test]
+    fn quarter_is_three_months() {
+        let start = micros_of("2024-01-01T00:00:00Z");
+        let end = micros_of("2024-07-01T00:00:00Z");
+        let gran = WindowGranularity {
+            count: 1,
+            unit: WindowUnit::Quarter,
+        };
+        let ws = generate_windows(start, end, gran).unwrap();
+        assert_eq!(ws.len(), 2);
+        assert_eq!(ws[0].end_micros, micros_of("2024-04-01T00:00:00Z"));
+    }
+
+    #[test]
+    fn year_end_of_month_clamps() {
+        // Jan 31 + 1 month clamps to Feb 29 (2024 leap year), chrono behavior.
+        let start = micros_of("2024-01-31T00:00:00Z");
+        let next = step(
+            start,
+            WindowGranularity {
+                count: 1,
+                unit: WindowUnit::Month,
+            },
+        )
+        .unwrap();
+        assert_eq!(next, micros_of("2024-02-29T00:00:00Z"));
+    }
+
+    #[test]
+    fn zero_count_and_empty_range_rejected() {
+        let s = micros_of("2024-01-01T00:00:00Z");
+        let e = micros_of("2024-02-01T00:00:00Z");
+        assert_eq!(
+            generate_windows(
+                s,
+                e,
+                WindowGranularity {
+                    count: 0,
+                    unit: WindowUnit::Day
+                }
+            ),
+            Err(WindowError::ZeroCount)
+        );
+        assert_eq!(
+            generate_windows(
+                e,
+                s,
+                WindowGranularity {
+                    count: 1,
+                    unit: WindowUnit::Day
+                }
+            ),
+            Err(WindowError::EmptyRange)
+        );
+        assert_eq!(
+            generate_windows(
+                s,
+                s,
+                WindowGranularity {
+                    count: 1,
+                    unit: WindowUnit::Day
+                }
+            ),
+            Err(WindowError::EmptyRange)
+        );
+    }
+
+    #[test]
+    fn too_many_windows_rejected() {
+        let s = 0i64;
+        let e = MICROS_PER_DAY * (MAX_WINDOWS as i64 + 10);
+        let err = generate_windows(
+            s,
+            e,
+            WindowGranularity {
+                count: 1,
+                unit: WindowUnit::Day,
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(err, WindowError::TooManyWindows(_)));
+    }
+
+    #[test]
+    fn multi_count_units() {
+        let s = micros_of("2024-01-01T00:00:00Z");
+        let e = micros_of("2024-01-01T06:00:00Z");
+        let ws = generate_windows(
+            s,
+            e,
+            WindowGranularity {
+                count: 2,
+                unit: WindowUnit::Hour,
+            },
+        )
+        .unwrap();
+        assert_eq!(ws.len(), 3);
+        assert_eq!(ws[0].end_micros, micros_of("2024-01-01T02:00:00Z"));
+    }
+
+    #[test]
+    fn unit_parse_singular_plural_case_insensitive() {
+        assert_eq!(WindowUnit::parse("Month"), Some(WindowUnit::Month));
+        assert_eq!(WindowUnit::parse("months"), Some(WindowUnit::Month));
+        assert_eq!(WindowUnit::parse("HOURS"), Some(WindowUnit::Hour));
+        assert_eq!(WindowUnit::parse("fortnight"), None);
+    }
+}

--- a/src/query/temporal_window.rs
+++ b/src/query/temporal_window.rs
@@ -452,4 +452,45 @@ mod tests {
         assert_eq!(WindowUnit::parse("HOURS"), Some(WindowUnit::Hour));
         assert_eq!(WindowUnit::parse("fortnight"), None);
     }
+
+    #[test]
+    fn parse_naive_datetime_forms_are_utc() {
+        // Naive date-times (no explicit offset) are interpreted as UTC, in both
+        // the `T`-separated and space-separated forms, and must agree with the
+        // equivalent RFC 3339 `Z` instant.
+        let expected = micros_of("2024-03-04T05:06:07Z");
+        assert_eq!(
+            parse_boundary_micros("2024-03-04T05:06:07").unwrap(),
+            expected
+        );
+        assert_eq!(
+            parse_boundary_micros("2024-03-04 05:06:07").unwrap(),
+            expected
+        );
+        // Whitespace around the token is tolerated.
+        assert_eq!(
+            parse_boundary_micros("  2024-03-04T05:06:07  ").unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn format_rfc3339_falls_back_for_out_of_range_micros() {
+        // `i64::MAX` microseconds is far outside chrono's representable range,
+        // so formatting falls back to the `<micros>us` token rather than
+        // panicking.
+        assert_eq!(format_rfc3339(i64::MAX), format!("{}us", i64::MAX));
+    }
+
+    #[test]
+    fn window_start_timestamp_matches_start_micros() {
+        let w = Window {
+            start_micros: 1_704_067_200_000_000,
+            end_micros: 1_704_070_800_000_000,
+        };
+        assert_eq!(
+            window_start_timestamp(&w),
+            Timestamp::from(1_704_067_200_000_000)
+        );
+    }
 }

--- a/tests/aql_temporal_window.rs
+++ b/tests/aql_temporal_window.rs
@@ -1,0 +1,675 @@
+//! End-to-end tests for AQL temporal aggregation windows (Issue #3363).
+//!
+//! These exercise the full pipeline (`execute_aql` -> parser -> converter ->
+//! planner -> executor) and assert hand-computed per-window values, the
+//! documented boundary/sampling rules, bi-temporal `AS OF SYSTEM_TIME`
+//! correctness, empty-window handling, and structured errors for malformed
+//! specs. The pure interval math has its own unit tests in
+//! `src/query/temporal_window.rs`; these cover semantics that require real
+//! history.
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::PropertyMapBuilder;
+use aletheiadb::api::transaction::WriteRequestOptions;
+use aletheiadb::core::NodeId;
+use aletheiadb::core::error::{Error, QueryError};
+use aletheiadb::core::property::PropertyValue;
+use aletheiadb::core::temporal::Timestamp;
+use aletheiadb::query::executor::QueryRow;
+use aletheiadb::query::temporal_window::parse_boundary_micros;
+
+/// Microseconds since epoch for an RFC 3339 instant (test convenience).
+fn micros(rfc: &str) -> i64 {
+    parse_boundary_micros(rfc).expect("valid rfc3339")
+}
+
+/// A `Timestamp` at an RFC 3339 instant.
+fn ts(rfc: &str) -> Timestamp {
+    Timestamp::from(micros(rfc))
+}
+
+fn rows(db: &AletheiaDB, aql: &str) -> Vec<QueryRow> {
+    db.execute_aql(aql)
+        .expect("query executes")
+        .collect_all()
+        .expect("collect rows")
+}
+
+/// Look up a projected column value by name in a row.
+fn col<'a>(row: &'a QueryRow, name: &str) -> Option<&'a PropertyValue> {
+    row.columns
+        .as_ref()
+        .and_then(|cols| cols.iter().find(|(k, _)| k == name).map(|(_, v)| v))
+}
+
+fn col_f64(row: &QueryRow, name: &str) -> Option<f64> {
+    match col(row, name) {
+        Some(PropertyValue::Float(f)) => Some(*f),
+        Some(PropertyValue::Int(i)) => Some(*i as f64),
+        _ => None,
+    }
+}
+
+fn col_i64(row: &QueryRow, name: &str) -> Option<i64> {
+    match col(row, name) {
+        Some(PropertyValue::Int(i)) => Some(*i),
+        _ => None,
+    }
+}
+
+fn col_str(row: &QueryRow, name: &str) -> Option<String> {
+    match col(row, name) {
+        Some(PropertyValue::String(s)) => Some(s.to_string()),
+        _ => None,
+    }
+}
+
+fn is_null(row: &QueryRow, name: &str) -> bool {
+    matches!(col(row, name), Some(PropertyValue::Null))
+}
+
+/// Create a `Product` node with an initial price valid from `valid_from`.
+fn create_product(db: &AletheiaDB, price: i64, valid_from: Timestamp) -> NodeId {
+    db.create_node_with_options(
+        "Product",
+        PropertyMapBuilder::new().insert("price", price).build(),
+        WriteRequestOptions::new().with_valid_from(valid_from),
+    )
+    .expect("create product")
+}
+
+/// Update a `Product`'s price valid from `valid_from`.
+fn update_price(db: &AletheiaDB, id: NodeId, price: i64, valid_from: Timestamp) {
+    db.update_node_with_options(
+        id,
+        PropertyMapBuilder::new().insert("price", price).build(),
+        WriteRequestOptions::new().with_valid_from(valid_from),
+    )
+    .expect("update price");
+}
+
+// ---------------------------------------------------------------------------
+// AC 3 + 4: hand-computed monthly value fixture, boundary & sampling rules.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn monthly_avg_hand_computed_with_boundary_and_clamp() {
+    let db = AletheiaDB::new().expect("db");
+    let id = create_product(&db, 100, ts("2024-01-01T00:00:00Z"));
+    // Mid-February change (does not affect the Feb window, whose start is Feb 1).
+    update_price(&db, id, 200, ts("2024-02-15T00:00:00Z"));
+    // Change exactly at a window boundary -> counted in the April window.
+    update_price(&db, id, 300, ts("2024-04-01T00:00:00Z"));
+
+    let result = rows(
+        &db,
+        "MATCH (p:Product) \
+         WINDOW 1 month OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-05-01T00:00:00Z' \
+         RETURN AVG(p.price) AS avg_price, MIN(p.price) AS lo, MAX(p.price) AS hi, \
+                COUNT(p.price) AS n, COUNT(*) AS present",
+    );
+
+    // Four windows: Jan, Feb, Mar, Apr.
+    assert_eq!(result.len(), 4, "one row per monthly window");
+
+    // Self-describing window bounds (RFC 3339).
+    assert_eq!(
+        col_str(&result[0], "window_start").as_deref(),
+        Some("2024-01-01T00:00:00.000000Z")
+    );
+    assert_eq!(
+        col_str(&result[0], "window_end").as_deref(),
+        Some("2024-02-01T00:00:00.000000Z")
+    );
+    // Last window's end is clamped to the range end (May 1).
+    assert_eq!(
+        col_str(&result[3], "window_end").as_deref(),
+        Some("2024-05-01T00:00:00.000000Z")
+    );
+
+    // Value-at-window-start sampling: [Jan=100, Feb=100, Mar=200, Apr=300].
+    let expected = [100.0, 100.0, 200.0, 300.0];
+    for (i, want) in expected.iter().enumerate() {
+        assert_eq!(
+            col_f64(&result[i], "avg_price"),
+            Some(*want),
+            "avg window {i}"
+        );
+        assert_eq!(col_f64(&result[i], "lo"), Some(*want), "min window {i}");
+        assert_eq!(col_f64(&result[i], "hi"), Some(*want), "max window {i}");
+        assert_eq!(col_i64(&result[i], "n"), Some(1), "count(price) window {i}");
+        assert_eq!(
+            col_i64(&result[i], "present"),
+            Some(1),
+            "count(*) window {i}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AC 4: empty windows emit an explicit null/zero row, never dropped.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_window_emits_null_and_zero_row() {
+    let db = AletheiaDB::new().expect("db");
+    // Product only exists from mid-February onward.
+    let _id = create_product(&db, 50, ts("2024-02-10T00:00:00Z"));
+
+    let result = rows(
+        &db,
+        "MATCH (p:Product) \
+         WINDOW 1 month OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-04-01T00:00:00Z' \
+         RETURN AVG(p.price) AS avg_price, COUNT(*) AS present, CHANGES(p) AS changes",
+    );
+
+    assert_eq!(result.len(), 3, "three windows, none dropped");
+    // January: entity does not exist at all -> null value aggregate, zero counts.
+    assert!(is_null(&result[0], "avg_price"), "empty window avg is null");
+    assert_eq!(col_i64(&result[0], "present"), Some(0));
+    assert_eq!(col_i64(&result[0], "changes"), Some(0));
+    // February: the entity is created on Feb-10, i.e. AFTER the window start
+    // (Feb-01). Under the "value at window start" sampling rule it is not yet
+    // present at the sample instant, so the value aggregate is null and
+    // COUNT(*) is 0 -- but a version *starts* inside the window, so CHANGES is 1.
+    assert!(
+        is_null(&result[1], "avg_price"),
+        "not present at Feb-01 window start"
+    );
+    assert_eq!(col_i64(&result[1], "present"), Some(0));
+    assert_eq!(
+        col_i64(&result[1], "changes"),
+        Some(1),
+        "create starts in February"
+    );
+    // March: the entity is valid at the March-01 window start (open interval)
+    // -> sampled through the final window.
+    assert_eq!(col_f64(&result[2], "avg_price"), Some(50.0));
+    assert_eq!(col_i64(&result[2], "present"), Some(1));
+    assert_eq!(
+        col_i64(&result[2], "changes"),
+        Some(0),
+        "no new version in March"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC 2: CHANGES volatility (weekly), hand-computed.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn weekly_changes_volatility_hand_computed() {
+    let db = AletheiaDB::new().expect("db");
+    // Create in week 1, two changes in week 2, none in week 3, one in week 4.
+    let id = create_product(&db, 10, ts("2024-01-01T00:00:00Z")); // week 1
+    update_price(&db, id, 11, ts("2024-01-08T12:00:00Z")); // week 2
+    update_price(&db, id, 12, ts("2024-01-10T00:00:00Z")); // week 2
+    update_price(&db, id, 12, ts("2024-01-22T00:00:00Z")); // week 4 (value unchanged)
+
+    let result = rows(
+        &db,
+        "MATCH (p:Product) \
+         WINDOW 1 week OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-01-29T00:00:00Z' \
+         RETURN CHANGES(p) AS versions, CHANGES(p.price) AS price_changes",
+    );
+
+    assert_eq!(result.len(), 4, "four weekly windows");
+    // Entity-version starts per week: [1, 2, 0, 1].
+    assert_eq!(col_i64(&result[0], "versions"), Some(1));
+    assert_eq!(col_i64(&result[1], "versions"), Some(2));
+    assert_eq!(col_i64(&result[2], "versions"), Some(0));
+    assert_eq!(col_i64(&result[3], "versions"), Some(1));
+    // Genuine price changes per week: week1 create (absent->10) counts; week2
+    // both are genuine changes (10->11->12); week4 re-set to same 12 is NOT a
+    // change.
+    assert_eq!(col_i64(&result[0], "price_changes"), Some(1));
+    assert_eq!(col_i64(&result[1], "price_changes"), Some(2));
+    assert_eq!(col_i64(&result[2], "price_changes"), Some(0));
+    assert_eq!(
+        col_i64(&result[3], "price_changes"),
+        Some(0),
+        "same value is not a change"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC 5: transaction-time dimension (AS OF SYSTEM_TIME) is respected.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn as_of_system_time_respects_correction() {
+    use std::thread::sleep;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    let now_micros = || -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("after epoch")
+            .as_micros() as i64
+    };
+
+    let db = AletheiaDB::new().expect("db");
+    // v1: price 100, valid from Jan 1 (open-ended in valid time).
+    let id = create_product(&db, 100, ts("2024-01-01T00:00:00Z"));
+
+    sleep(Duration::from_millis(20));
+    let tx_between = now_micros();
+    sleep(Duration::from_millis(20));
+
+    // v2 (recorded later): price 200 valid from March 1.
+    update_price(&db, id, 200, ts("2024-03-01T00:00:00Z"));
+
+    let q = |as_of: Option<i64>| -> Vec<QueryRow> {
+        let clause = match as_of {
+            Some(t) => format!(" AS OF SYSTEM_TIME {t}"),
+            None => String::new(),
+        };
+        rows(
+            &db,
+            &format!(
+                "MATCH (p:Product) \
+                 WINDOW 1 month OVER VALID_TIME FROM '2024-01-01T00:00:00Z' \
+                 TO '2024-05-01T00:00:00Z'{clause} RETURN AVG(p.price) AS avg_price"
+            ),
+        )
+    };
+
+    // As of NOW: the March-onward correction is visible; March window samples 200.
+    let now_rows = q(None);
+    assert_eq!(now_rows.len(), 4);
+    assert_eq!(
+        col_f64(&now_rows[2], "avg_price"),
+        Some(200.0),
+        "March, now"
+    );
+
+    // As of BEFORE the correction: only v1 believed; March still samples 100.
+    let past_rows = q(Some(tx_between));
+    assert_eq!(
+        col_f64(&past_rows[2], "avg_price"),
+        Some(100.0),
+        "March, as-of past"
+    );
+    // January is unaffected either way.
+    assert_eq!(col_f64(&now_rows[0], "avg_price"), Some(100.0));
+    assert_eq!(col_f64(&past_rows[0], "avg_price"), Some(100.0));
+}
+
+// ---------------------------------------------------------------------------
+// Multi-entity aggregation across a matched set.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn avg_across_matched_set() {
+    let db = AletheiaDB::new().expect("db");
+    create_product(&db, 100, ts("2024-01-01T00:00:00Z"));
+    create_product(&db, 300, ts("2024-01-01T00:00:00Z"));
+
+    let result = rows(
+        &db,
+        "MATCH (p:Product) \
+         WINDOW 1 month OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' \
+         RETURN AVG(p.price) AS avg_price, SUM(p.price) AS total, COUNT(*) AS n",
+    );
+    assert_eq!(result.len(), 1);
+    assert_eq!(col_f64(&result[0], "avg_price"), Some(200.0));
+    assert_eq!(col_i64(&result[0], "total"), Some(400));
+    assert_eq!(col_i64(&result[0], "n"), Some(2));
+}
+
+// ---------------------------------------------------------------------------
+// AQL timestamp-encoding parity: RFC 3339 boundaries == microsecond boundaries.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rfc3339_and_micros_boundaries_agree() {
+    let db = AletheiaDB::new().expect("db");
+    let id = create_product(&db, 100, ts("2024-01-01T00:00:00Z"));
+    update_price(&db, id, 200, ts("2024-02-01T00:00:00Z"));
+
+    let start = micros("2024-01-01T00:00:00Z");
+    let end = micros("2024-03-01T00:00:00Z");
+
+    let with_rfc = rows(
+        &db,
+        "MATCH (p:Product) \
+         WINDOW 1 month OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-03-01T00:00:00Z' \
+         RETURN AVG(p.price) AS avg_price",
+    );
+    let with_micros = rows(
+        &db,
+        &format!(
+            "MATCH (p:Product) \
+             WINDOW 1 month OVER VALID_TIME FROM {start} TO {end} RETURN AVG(p.price) AS avg_price"
+        ),
+    );
+
+    assert_eq!(with_rfc.len(), with_micros.len());
+    for (a, b) in with_rfc.iter().zip(with_micros.iter()) {
+        assert_eq!(col_f64(a, "avg_price"), col_f64(b, "avg_price"));
+        assert_eq!(col_str(a, "window_start"), col_str(b, "window_start"));
+    }
+    assert_eq!(col_f64(&with_rfc[0], "avg_price"), Some(100.0));
+    assert_eq!(col_f64(&with_rfc[1], "avg_price"), Some(200.0));
+}
+
+// ---------------------------------------------------------------------------
+// AC 6: malformed specs return structured errors (never panic / empty success).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn malformed_specs_return_structured_errors() {
+    let db = AletheiaDB::new().expect("db");
+    let _ = create_product(&db, 100, ts("2024-01-01T00:00:00Z"));
+
+    // Backwards range.
+    assert!(
+        db.execute_aql(
+            "MATCH (p:Product) WINDOW 1 day OVER VALID_TIME \
+             FROM '2024-05-01T00:00:00Z' TO '2024-01-01T00:00:00Z' RETURN AVG(p.price)"
+        )
+        .is_err()
+    );
+
+    // Zero window size.
+    assert!(
+        db.execute_aql(
+            "MATCH (p:Product) WINDOW 0 day OVER VALID_TIME \
+             FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN AVG(p.price)"
+        )
+        .is_err()
+    );
+
+    // Unknown unit.
+    assert!(
+        db.execute_aql(
+            "MATCH (p:Product) WINDOW 1 fortnight OVER VALID_TIME \
+             FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN AVG(p.price)"
+        )
+        .is_err()
+    );
+
+    // Unparseable boundary.
+    assert!(
+        db.execute_aql(
+            "MATCH (p:Product) WINDOW 1 day OVER VALID_TIME \
+             FROM 'not-a-time' TO '2024-02-01T00:00:00Z' RETURN AVG(p.price)"
+        )
+        .is_err()
+    );
+
+    // Unknown aggregate function.
+    assert!(
+        db.execute_aql(
+            "MATCH (p:Product) WINDOW 1 day OVER VALID_TIME \
+             FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN MEDIAN(p.price)"
+        )
+        .is_err()
+    );
+
+    // SUM without a property argument.
+    assert!(
+        db.execute_aql(
+            "MATCH (p:Product) WINDOW 1 day OVER VALID_TIME \
+             FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN SUM(*)"
+        )
+        .is_err()
+    );
+
+    // Aggregate references a different variable than the matched entity.
+    assert!(
+        db.execute_aql(
+            "MATCH (p:Product) WINDOW 1 day OVER VALID_TIME \
+             FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN AVG(q.price)"
+        )
+        .is_err()
+    );
+
+    // Windowing an edge / traversal (v1: nodes only) is rejected.
+    assert!(
+        db.execute_aql(
+            "MATCH (p:Product)-[r:SELLS]->(q) WINDOW 1 day OVER VALID_TIME \
+             FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN AVG(r.price)"
+        )
+        .is_err()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC 6: malformed specs map to the exact structured QueryError variants that the
+// MCP `query` tool renders as parse_error / invalid_params / unsupported_construct.
+//
+// This test lives at the query-executor level (execute_aql) rather than the MCP
+// surface: the MCP `query` tool forwards the AQL string to this executor and
+// then maps each QueryError variant one-to-one to a structured error kind
+// (src/mcp/server.rs::map_query_error -- SyntaxError->parse_error,
+// InvalidParameter->invalid_params, UnsupportedFeature->unsupported_construct).
+// Proving the executor emits the right variant is therefore proof that the MCP
+// path returns the right kind, without editing src/mcp. It also proves a valid
+// window query returns rows carrying window_start/window_end.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn malformed_specs_map_to_structured_query_error_variants() {
+    let db = AletheiaDB::new().expect("db");
+    let _ = create_product(&db, 100, ts("2024-01-01T00:00:00Z"));
+
+    // Backwards range -> InvalidParameter -> MCP `invalid_params`.
+    assert!(
+        matches!(
+            db.execute_aql(
+                "MATCH (p:Product) WINDOW 1 day OVER VALID_TIME \
+                 FROM '2024-05-01T00:00:00Z' TO '2024-01-01T00:00:00Z' RETURN AVG(p.price)"
+            ),
+            Err(Error::Query(QueryError::InvalidParameter { .. }))
+        ),
+        "backwards range must be InvalidParameter"
+    );
+
+    // Zero window size -> InvalidParameter.
+    assert!(
+        matches!(
+            db.execute_aql(
+                "MATCH (p:Product) WINDOW 0 day OVER VALID_TIME \
+                 FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN AVG(p.price)"
+            ),
+            Err(Error::Query(QueryError::InvalidParameter { .. }))
+        ),
+        "zero window size must be InvalidParameter"
+    );
+
+    // Unknown unit -> InvalidParameter.
+    assert!(
+        matches!(
+            db.execute_aql(
+                "MATCH (p:Product) WINDOW 1 fortnight OVER VALID_TIME \
+                 FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN AVG(p.price)"
+            ),
+            Err(Error::Query(QueryError::InvalidParameter { .. }))
+        ),
+        "unknown unit must be InvalidParameter"
+    );
+
+    // Unparseable boundary -> InvalidParameter.
+    assert!(
+        matches!(
+            db.execute_aql(
+                "MATCH (p:Product) WINDOW 1 day OVER VALID_TIME \
+                 FROM 'not-a-time' TO '2024-02-01T00:00:00Z' RETURN AVG(p.price)"
+            ),
+            Err(Error::Query(QueryError::InvalidParameter { .. }))
+        ),
+        "unparseable boundary must be InvalidParameter"
+    );
+
+    // Unknown aggregate function -> UnsupportedFeature -> `unsupported_construct`.
+    assert!(
+        matches!(
+            db.execute_aql(
+                "MATCH (p:Product) WINDOW 1 day OVER VALID_TIME \
+                 FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN MEDIAN(p.price)"
+            ),
+            Err(Error::Query(QueryError::UnsupportedFeature { .. }))
+        ),
+        "unknown aggregate must be UnsupportedFeature"
+    );
+
+    // Windowing an edge/traversal (v1: nodes only) -> UnsupportedFeature.
+    assert!(
+        matches!(
+            db.execute_aql(
+                "MATCH (p:Product)-[r:SELLS]->(q) WINDOW 1 day OVER VALID_TIME \
+                 FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN AVG(r.price)"
+            ),
+            Err(Error::Query(QueryError::UnsupportedFeature { .. }))
+        ),
+        "edge/traversal window must be UnsupportedFeature"
+    );
+
+    // Grammatically malformed WINDOW clause -> SyntaxError -> `parse_error`.
+    assert!(
+        matches!(
+            db.execute_aql(
+                "MATCH (p:Product) WINDOW day OVER VALID_TIME \
+                 FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN AVG(p.price)"
+            ),
+            Err(Error::Query(QueryError::SyntaxError { .. }))
+        ),
+        "missing window size must be a SyntaxError"
+    );
+
+    // A valid query returns rows carrying self-describing window bounds.
+    let ok = rows(
+        &db,
+        "MATCH (p:Product) \
+         WINDOW 1 month OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-03-01T00:00:00Z' \
+         RETURN AVG(p.price) AS avg_price",
+    );
+    assert_eq!(ok.len(), 2, "two monthly windows");
+    assert_eq!(
+        col_str(&ok[0], "window_start").as_deref(),
+        Some("2024-01-01T00:00:00.000000Z")
+    );
+    assert_eq!(
+        col_str(&ok[0], "window_end").as_deref(),
+        Some("2024-02-01T00:00:00.000000Z")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Success metric: a 12-window monthly aggregation over ~1,000 valid-time
+// versions completes end-to-end well within budget (AC target: < 50ms on the
+// release perf rig). Correctness is asserted unconditionally; the wallclock
+// bound is enforced strictly only in optimized builds (`cargo test --release`),
+// where the 50ms target applies, and loosely in unoptimized debug builds to
+// still catch a pathological (e.g. accidental O(versions^2)) regression without
+// flaking on the ~10x-slower debug reconstruction path.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn monthly_12_window_over_1000_versions_within_budget() {
+    use std::time::Instant;
+
+    let db = AletheiaDB::new().expect("db");
+    let year_start = ts("2023-01-01T00:00:00Z");
+    let id = create_product(&db, 100, year_start);
+    // ~1,000 versions spread across 2023 so all land inside the query range.
+    let micros_per_day = 86_400_000_000i64;
+    let step = (360 * micros_per_day) / 1000;
+    for i in 1..1000i64 {
+        update_price(
+            &db,
+            id,
+            100 + i,
+            Timestamp::from(micros("2023-01-01T00:00:00Z") + step * i),
+        );
+    }
+
+    let query = "MATCH (p:Product) \
+         WINDOW 1 month OVER VALID_TIME FROM '2023-01-01T00:00:00Z' TO '2024-01-01T00:00:00Z' \
+         RETURN AVG(p.price) AS avg_price, MIN(p.price) AS lo, MAX(p.price) AS hi, \
+                CHANGES(p.price) AS changes";
+
+    // Warm once (build caches), then take the best of three timed runs.
+    let _ = rows(&db, query);
+    let mut best = std::time::Duration::from_secs(3600);
+    let mut last: Vec<QueryRow> = Vec::new();
+    for _ in 0..3 {
+        let t0 = Instant::now();
+        last = rows(&db, query);
+        best = best.min(t0.elapsed());
+    }
+
+    // Correctness: exactly 12 monthly windows, all with data (monotonic prices).
+    assert_eq!(last.len(), 12, "twelve monthly windows");
+    for (i, row) in last.iter().enumerate() {
+        assert!(col_f64(row, "avg_price").is_some(), "window {i} has data");
+        assert!(col_i64(row, "changes").is_some(), "window {i} changes");
+    }
+
+    let budget = if cfg!(debug_assertions) {
+        // Loose bound for the unoptimized reconstruction path; a genuine
+        // algorithmic regression blows far past this, a 50ms target does not.
+        std::time::Duration::from_millis(2000)
+    } else {
+        // The AC success metric: < 50ms end-to-end for 12 windows / ~1,000
+        // versions on an optimized build.
+        std::time::Duration::from_millis(50)
+    };
+    assert!(
+        best <= budget,
+        "12-window monthly aggregation over ~1,000 versions took {best:?}, exceeding {budget:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scope: the temporal WINDOW construct is AQL-only in v1 (Issue #3363 scopes
+// Cypher/SQL out). The Cypher surface must *reject* it with a structured error
+// rather than mis-parse it into a silently-wrong result. `WINDOW` is not a
+// Cypher clause keyword, so the Cypher parser errors out; this test pins that
+// (no silent fallback, no accidental acceptance).
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "cypher")]
+#[test]
+fn cypher_surface_rejects_temporal_window_construct() {
+    let db = AletheiaDB::new().expect("db");
+    let _ = create_product(&db, 100, ts("2024-01-01T00:00:00Z"));
+
+    let res = db.execute_cypher(
+        "MATCH (p:Product) \
+         WINDOW 1 month OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-05-01T00:00:00Z' \
+         RETURN AVG(p.price)",
+    );
+    assert!(
+        res.is_err(),
+        "the AQL-only WINDOW construct must be rejected by the Cypher surface, not mis-parsed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Non-numeric properties are skipped by value aggregates (never garbage).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn non_numeric_property_skipped() {
+    let db = AletheiaDB::new().expect("db");
+    db.create_node_with_options(
+        "Product",
+        PropertyMapBuilder::new().insert("name", "widget").build(),
+        WriteRequestOptions::new().with_valid_from(ts("2024-01-01T00:00:00Z")),
+    )
+    .expect("create");
+
+    let result = rows(
+        &db,
+        "MATCH (p:Product) \
+         WINDOW 1 month OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' \
+         RETURN AVG(p.name) AS avg_name, COUNT(p.name) AS numeric_n, COUNT(*) AS present",
+    );
+    assert_eq!(result.len(), 1);
+    // Non-numeric -> no numeric sample -> null value aggregate, zero numeric count,
+    // but the entity is still present.
+    assert!(is_null(&result[0], "avg_name"));
+    assert_eq!(col_i64(&result[0], "numeric_n"), Some(0));
+    assert_eq!(col_i64(&result[0], "present"), Some(1));
+}

--- a/tests/aql_temporal_window.rs
+++ b/tests/aql_temporal_window.rs
@@ -673,3 +673,169 @@ fn non_numeric_property_skipped() {
     assert_eq!(col_i64(&result[0], "numeric_n"), Some(0));
     assert_eq!(col_i64(&result[0], "present"), Some(1));
 }
+
+// ---------------------------------------------------------------------------
+// Grammar error paths: every structurally-malformed WINDOW clause is rejected
+// as a SyntaxError (never a panic or a silently-wrong parse). Each line below
+// exercises a distinct `expect`/`expect_kw`/`parse_identifier` failure branch in
+// the window-clause parser. A trailing clause after `WINDOW ... RETURN` is also
+// rejected (the window clause is self-terminating).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn window_clause_grammar_errors_are_syntax_errors() {
+    let db = AletheiaDB::new().expect("db");
+    let _ = create_product(&db, 100, ts("2024-01-01T00:00:00Z"));
+
+    let bad_queries = [
+        // Unit is not an identifier (an integer follows the window size).
+        "MATCH (p:Product) WINDOW 1 2 OVER VALID_TIME \
+         FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN AVG(p.price)",
+        // Missing OVER.
+        "MATCH (p:Product) WINDOW 1 day VALID_TIME \
+         FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN AVG(p.price)",
+        // Missing VALID_TIME.
+        "MATCH (p:Product) WINDOW 1 day OVER \
+         FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN AVG(p.price)",
+        // Missing FROM.
+        "MATCH (p:Product) WINDOW 1 day OVER VALID_TIME \
+         '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN AVG(p.price)",
+        // Missing TO (two timestamps in a row).
+        "MATCH (p:Product) WINDOW 1 day OVER VALID_TIME \
+         FROM '2024-01-01T00:00:00Z' '2024-02-01T00:00:00Z' RETURN AVG(p.price)",
+        // AS without OF (partial AS OF SYSTEM_TIME).
+        "MATCH (p:Product) WINDOW 1 day OVER VALID_TIME \
+         FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' AS SYSTEM_TIME 0 \
+         RETURN AVG(p.price)",
+        // AS OF without SYSTEM_TIME.
+        "MATCH (p:Product) WINDOW 1 day OVER VALID_TIME \
+         FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' AS OF WALLCLOCK 0 \
+         RETURN AVG(p.price)",
+        // Aggregate function name missing (opens straight into a paren).
+        "MATCH (p:Product) WINDOW 1 day OVER VALID_TIME \
+         FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN (p.price)",
+        // Missing '(' after the aggregate function.
+        "MATCH (p:Product) WINDOW 1 day OVER VALID_TIME \
+         FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN AVG p.price",
+        // Missing ')' closing the aggregate argument (runs to end of query).
+        "MATCH (p:Product) WINDOW 1 day OVER VALID_TIME \
+         FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN AVG(p.price",
+        // Trailing clause after a self-terminating WINDOW ... RETURN.
+        "MATCH (p:Product) WINDOW 1 day OVER VALID_TIME \
+         FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN AVG(p.price) LIMIT 10",
+    ];
+
+    for q in bad_queries {
+        assert!(
+            matches!(
+                db.execute_aql(q),
+                Err(Error::Query(QueryError::SyntaxError { .. }))
+            ),
+            "expected a SyntaxError for malformed window query:\n{q}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A granularity/range pair that would generate an enormous number of windows is
+// rejected with a structured InvalidParameter (the TooManyWindows guard), rather
+// than allocating unbounded rows.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn too_many_windows_rejected_with_structured_error() {
+    let db = AletheiaDB::new().expect("db");
+    let _ = create_product(&db, 100, ts("2024-01-01T00:00:00Z"));
+
+    // 24 years at 1-minute granularity is ~12.6M windows, far over the cap.
+    assert!(
+        matches!(
+            db.execute_aql(
+                "MATCH (p:Product) WINDOW 1 minute OVER VALID_TIME \
+                 FROM '2000-01-01T00:00:00Z' TO '2024-01-01T00:00:00Z' RETURN COUNT(*)"
+            ),
+            Err(Error::Query(QueryError::InvalidParameter { .. }))
+        ),
+        "an over-cap window count must be InvalidParameter"
+    );
+
+    // A window multiplier exceeding u32 is likewise an InvalidParameter.
+    assert!(
+        matches!(
+            db.execute_aql(
+                "MATCH (p:Product) WINDOW 5000000000 day OVER VALID_TIME \
+                 FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' RETURN COUNT(*)"
+            ),
+            Err(Error::Query(QueryError::InvalidParameter { .. }))
+        ),
+        "a window size exceeding u32 must be InvalidParameter"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Value aggregates over float-valued properties keep float arithmetic (SUM/AVG
+// stay floats; the all-integer promotion path is not taken).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn float_property_value_aggregates() {
+    let db = AletheiaDB::new().expect("db");
+    db.create_node_with_options(
+        "Gadget",
+        PropertyMapBuilder::new().insert("price", 100.5f64).build(),
+        WriteRequestOptions::new().with_valid_from(ts("2024-01-01T00:00:00Z")),
+    )
+    .expect("create");
+    db.create_node_with_options(
+        "Gadget",
+        PropertyMapBuilder::new().insert("price", 200.25f64).build(),
+        WriteRequestOptions::new().with_valid_from(ts("2024-01-01T00:00:00Z")),
+    )
+    .expect("create");
+
+    let result = rows(
+        &db,
+        "MATCH (g:Gadget) \
+         WINDOW 1 month OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' \
+         RETURN SUM(g.price) AS total, AVG(g.price) AS avg_price, \
+                MIN(g.price) AS lo, MAX(g.price) AS hi",
+    );
+    assert_eq!(result.len(), 1);
+    // Floating sum/avg over {100.5, 200.25}.
+    assert_eq!(col_f64(&result[0], "total"), Some(300.75));
+    assert_eq!(col_f64(&result[0], "avg_price"), Some(150.375));
+    assert_eq!(col_f64(&result[0], "lo"), Some(100.5));
+    assert_eq!(col_f64(&result[0], "hi"), Some(200.25));
+}
+
+// ---------------------------------------------------------------------------
+// Bare-entity (`COUNT(v)` / `CHANGES(v)`) and `CHANGES(*)` argument forms, plus
+// the default (unaliased) output-column naming for each argument shape.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bare_entity_and_star_aggregates_with_default_names() {
+    let db = AletheiaDB::new().expect("db");
+    let id = create_product(&db, 100, ts("2024-01-01T00:00:00Z"));
+    // A second version starting inside the window is one entity change-point.
+    update_price(&db, id, 150, ts("2024-01-15T00:00:00Z"));
+
+    let result = rows(
+        &db,
+        "MATCH (p:Product) \
+         WINDOW 1 month OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' \
+         RETURN COUNT(p), COUNT(*), CHANGES(p), CHANGES(*)",
+    );
+    assert_eq!(result.len(), 1);
+
+    // Default output names follow `func(arg)` (lower-cased), for entity and star.
+    assert_eq!(
+        col_i64(&result[0], "count(p)"),
+        Some(1),
+        "entity present once"
+    );
+    assert_eq!(col_i64(&result[0], "count(*)"), Some(1));
+    // Two version-starts inside January (Jan 1 and Jan 15).
+    assert_eq!(col_i64(&result[0], "changes(p)"), Some(2));
+    assert_eq!(col_i64(&result[0], "changes(*)"), Some(2));
+}


### PR DESCRIPTION
## Before

AletheiaDB could reconstruct any entity at any point in time, but it could not
_summarize a fact across time_. To answer "what was the average price each
month last year?" a caller had to issue one point-in-time (`AS OF`) query per
month boundary and stitch the results together client-side — twelve
round-trips, all the bucketing and interval math done by hand, and no built-in
way to ask "how volatile was this value?"

## After

A single AQL statement buckets a matched node's **valid-time history** into
fixed, non-overlapping (tumbling) windows over an explicit `[start, end)` range
and returns one self-describing row per window:

```cypher
MATCH (p:Product {sku: "ABC"})
WINDOW 1 month OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-05-01T00:00:00Z'
RETURN AVG(p.price) AS avg_price
```

| window_start | window_end | avg_price |
|--------------|------------|-----------|
| 2024-01-01T00:00:00.000000Z | 2024-02-01T00:00:00.000000Z | 100.0 |
| 2024-02-01T00:00:00.000000Z | 2024-03-01T00:00:00.000000Z | 100.0 |
| 2024-03-01T00:00:00.000000Z | 2024-04-01T00:00:00.000000Z | 200.0 |
| 2024-04-01T00:00:00.000000Z | 2024-05-01T00:00:00.000000Z | 300.0 |

- **Aggregates (v1):** `COUNT`, `SUM`, `AVG`, `MIN`, `MAX` over numeric
  properties, plus `CHANGES` — version-start volatility, where
  `CHANGES(p.price)` counts only genuine value changes (re-asserting the same
  value is not a change).
- **Falsifiable boundary rule:** windows are half-open `[b_k, b_{k+1})`, the
  final window's end is clamped to the range end, and a version whose
  `valid_from` sits exactly on a boundary is counted in exactly one window. The
  union of windows equals exactly `[start, end)`.
- **Bi-temporal:** an optional `AS OF SYSTEM_TIME <ts>` (default: now) fixes the
  belief the history is read at, so a correction recorded later never silently
  rewrites previously computed analytics.
- **Empty windows are never dropped** — they emit an explicit row with `NULL`
  value aggregates and `0` counts, so a caller always gets one row per bucket.
- Result rows carry `window_start` / `window_end` as RFC 3339 UTC strings.
- Calendar units (`month`/`quarter`/`year`) honor real month lengths and leap
  years; fixed units (`minute`/`hour`/`day`/`week`) advance by a constant delta.
- Timestamps accept RFC 3339 / ISO-8601 or microseconds since the epoch.

Malformed specs (backwards range, zero window size, unknown unit/function,
unparseable timestamp, an aggregate referencing a different variable, or
windowing an edge/traversal) are rejected with a structured error and never
produce a panic or a silently-empty success. Through the read-only MCP `query`
tool these surface as `parse_error` / `invalid_params` / `unsupported_construct`.
Cypher and SQL are out of scope for v1 and reject the construct rather than
mis-parsing it.

## How

The `WINDOW … RETURN` clause is parsed into a self-contained AST node (its unit
and function words matched contextually, so existing queries that use those
words as labels/variables are unaffected) and lowered by the converter — with
full semantic validation — into a new terminal `QueryOp::TemporalWindowAggregate`.
That op flows through the existing planner → physical → cost pipeline to a
`TemporalWindowAggregateIterator`, so `execute_aql`, `EXPLAIN`/`PROFILE`, and the
MCP query tool all keep working with no changes outside the query lane (nothing
under `src/mcp/**` was touched — the MCP tool already maps the emitted
`QueryError` variants to its structured error kinds). The iterator reconstructs
each matched entity's valid-time timeline as believed at the transaction-time
coordinate, then buckets it: value aggregates sample the value in effect at each
window start, and `CHANGES` counts versions whose valid interval starts inside
the window. All the subtle interval/calendar arithmetic is factored into a
storage-free `src/query/temporal_window.rs` module so it can be unit-tested
without a database.

**Tests & metric:** 13 pure-math unit tests; 11 end-to-end tests asserting
hand-computed monthly/weekly fixtures, boundary + clamp rules, empty-window
rows, bi-temporal correction correctness, RFC-3339-vs-microseconds parity, the
exact structured-error variants, the Cypher-surface rejection, and a
12-window / 1-year over ~1,000-versions performance test. A criterion benchmark
covers the `< 50 ms` success metric on the perf rig. `cargo fmt --check` clean;
clippy clean on both the targeted feature set and `--all-features`; the full
`sql,cypher` suite passes (6,563 passed; the only failures are pre-existing
uid-0 IO-error-injection tests unrelated to this change).

## Documented v1 limitations

Windows a single bound **node** pattern (edges/traversals/multi-pattern
rejected); the matched entity must currently exist for its history to be
windowed; tumbling windows only (no sliding/hopping/session/gap-filling); the
lineage/Cypher/SQL surfaces are follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MM68sFWVTxKbBRnCq1VTrD)_