### PR TITLE
feat(db): named snapshots for reproducible reads (#3370)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -875,11 +875,16 @@ already-recorded), all non-retriable. Durable persistence of lineage is a
 Pins a human-readable name to a bi-temporal coordinate
 `(valid_time, transaction_time)`; reads through the resulting handle resolve
 via the deterministic historical (`*_at_time`) path, so the same handle returns
-**byte-for-byte identical results regardless of later writes**. A snapshot is a
-**coordinate, not a held resource**: it pins no storage, blocks no writers, and
-adds **zero overhead to the write path** (the registry is off the data write
-path). **Rust API:** `create_snapshot(name, description)` (defaults both
-dimensions to the commit frontier under `current_timestamp`, so post-pin
+**identical results regardless of later writes**. A snapshot is a **coordinate,
+not a held resource**: it pins no storage and adds no lasting write-path
+overhead (the registry is off the data write path). Creation takes the
+commit-clock lock just long enough to copy one `Timestamp` (nanosecond-scale,
+not literally zero); a snapshot created racing an in-flight commit inherits the
+engine's standard committed-but-not-yet-applied visibility window (same caveat
+as #3225/#3236). **Rust API:** `create_snapshot(name, description)` defaults
+**valid-time = wallclock `time::now()`** (the engine's "now" convention, so
+facts actually valid at creation are not dropped) and **transaction-time = the
+commit frontier under `current_timestamp`** (race-free monotonic, so post-pin
 commits are invisible and pre-pin commits visible) / `create_snapshot_at(name,
 vt, tt, description)` (explicit/backdated, not extent-checked) /
 `snapshot(name) -> Snapshot` / `get_snapshot` / `list_snapshots` (stable order:
@@ -888,9 +893,15 @@ created_at, then name) / `delete_snapshot`. The `Snapshot<'_>` handle pins
 (`get_outgoing_edges`/`get_incoming_edges`), and a pre-pinned `query()` builder
 (traversal at the pin). Errors reuse the #3234 codes (dup name → `CONFLICT`,
 missing → `NOT_FOUND` with the name). Durably persisted (atomic
-temp+rename+fsync, coordinates as i64 micros) to `{data_dir}/snapshots.json`
-when index persistence is enabled — survives restart; in-memory-only for
-ephemeral `AletheiaDB::new()`. Caveats mirror `temporal_extent` (#3238) /
+temp+rename+fsync, coordinates as the **full HLC** `{wallclock, logical}` so a
+same-microsecond supersession pin resolves correctly after restart; sidecar
+`version: 2`, a legacy `version: 1` bare-i64 file still loads as logical 0)
+**inside** the persistence dir at `{persistence.data_dir}/snapshots.json`
+(`{data_dir}/indexes/snapshots.json` under the durable config) when index
+persistence is enabled — survives restart; in-memory-only for ephemeral
+`AletheiaDB::new()`. A corrupt/unparseable sidecar does **not** brick startup
+(unlike the auth key store): it is quarantined aside (`*.corrupt`) and startup
+proceeds with an empty registry. Caveats mirror `temporal_extent` (#3238) /
 point-in-time reads: cold-tier/truncation eviction can make a pinned version
 unreadable, and pinning "now" excludes future-valid facts. MCP exposure and an
 `AS OF SNAPSHOT <name>` query DDL are a coordinated follow-up (this wave is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -870,6 +870,32 @@ already-recorded), all non-retriable. Durable persistence of lineage is a
 #3413 follow-up; the #3427 attribution caveat applies. See
 [docs/guides/derivation-lineage.md](docs/guides/derivation-lineage.md).
 
+### Named Snapshots — Reproducible Reads (Issue #3370)
+
+Pins a human-readable name to a bi-temporal coordinate
+`(valid_time, transaction_time)`; reads through the resulting handle resolve
+via the deterministic historical (`*_at_time`) path, so the same handle returns
+**byte-for-byte identical results regardless of later writes**. A snapshot is a
+**coordinate, not a held resource**: it pins no storage, blocks no writers, and
+adds **zero overhead to the write path** (the registry is off the data write
+path). **Rust API:** `create_snapshot(name, description)` (defaults both
+dimensions to the commit frontier under `current_timestamp`, so post-pin
+commits are invisible and pre-pin commits visible) / `create_snapshot_at(name,
+vt, tt, description)` (explicit/backdated, not extent-checked) /
+`snapshot(name) -> Snapshot` / `get_snapshot` / `list_snapshots` (stable order:
+created_at, then name) / `delete_snapshot`. The `Snapshot<'_>` handle pins
+`get_node`/`get_edge`/`find_nodes`/`find_nodes_by_property`, adjacency
+(`get_outgoing_edges`/`get_incoming_edges`), and a pre-pinned `query()` builder
+(traversal at the pin). Errors reuse the #3234 codes (dup name → `CONFLICT`,
+missing → `NOT_FOUND` with the name). Durably persisted (atomic
+temp+rename+fsync, coordinates as i64 micros) to `{data_dir}/snapshots.json`
+when index persistence is enabled — survives restart; in-memory-only for
+ephemeral `AletheiaDB::new()`. Caveats mirror `temporal_extent` (#3238) /
+point-in-time reads: cold-tier/truncation eviction can make a pinned version
+unreadable, and pinning "now" excludes future-valid facts. MCP exposure and an
+`AS OF SNAPSHOT <name>` query DDL are a coordinated follow-up (this wave is
+Rust-API-only). See [docs/guides/snapshot-pin.md](docs/guides/snapshot-pin.md).
+
 ### Feature Flags: Stable vs Experimental
 
 Semantic features are split between a stable cohort and four experimental

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -510,6 +510,13 @@ harness = false
 path = "benches/historical_storage.rs"
 required-features = []
 
+# Named snapshots / reproducible reads (Issue #3370)
+[[bench]]
+name = "snapshot_pin"
+harness = false
+path = "benches/snapshot_pin.rs"
+required-features = []
+
 # High-level API - includes transaction overhead and API layer
 [[bench]]
 name = "aletheiadb"

--- a/benches/snapshot_pin.rs
+++ b/benches/snapshot_pin.rs
@@ -1,0 +1,80 @@
+//! Benchmarks for named snapshots / reproducible reads (Issue #3370).
+//!
+//! Success metric: **snapshot-name resolution < 100µs p99**. Resolving a name
+//! to a pinned coordinate is a single `RwLock` read + clone, so it should be
+//! well under budget. We compare:
+//!
+//! - `resolve`: `db.snapshot(name)` — name -> borrowed handle.
+//! - `resolve_and_read`: resolve + one pinned `get_node` at the coordinate.
+//! - `raw_as_of_read`: the equivalent `get_node_at_time` with raw timestamps
+//!   (the baseline the pin adds naming convenience on top of).
+//!
+//! These are intentionally cheap to sample so CI/local runs stay fast; the
+//! numeric p99 target is validated on the performance rig, not gated here.
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::core::PropertyMapBuilder;
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+fn bench_snapshot_pin(c: &mut Criterion) {
+    let db = AletheiaDB::new().expect("db init");
+
+    // Seed a small graph so the pinned reads resolve real versions.
+    let mut node = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .expect("seed node");
+    for i in 0..64 {
+        node = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("name", format!("P{i}"))
+                    .build(),
+            )
+            .expect("seed node");
+    }
+
+    let snap = db.create_snapshot("bench", None).expect("snapshot");
+    let (vt, tt) = snap.coordinate();
+
+    c.bench_function("snapshot_resolve", |b| {
+        b.iter(|| {
+            let handle = db.snapshot(black_box("bench")).expect("resolve");
+            black_box(handle.coordinate());
+        });
+    });
+
+    c.bench_function("snapshot_resolve_and_read", |b| {
+        b.iter(|| {
+            let handle = db.snapshot(black_box("bench")).expect("resolve");
+            black_box(handle.get_node(black_box(node)).expect("pinned read"));
+        });
+    });
+
+    c.bench_function("snapshot_raw_as_of_read", |b| {
+        b.iter(|| {
+            black_box(
+                db.get_node_at_time(black_box(node), black_box(vt), black_box(tt))
+                    .expect("as-of read"),
+            );
+        });
+    });
+
+    c.bench_function("snapshot_create", |b| {
+        let mut n = 0u64;
+        b.iter(|| {
+            n += 1;
+            black_box(
+                db.create_snapshot(format!("bench-create-{n}"), None)
+                    .expect("create"),
+            );
+        });
+    });
+}
+
+criterion_group!(benches, bench_snapshot_pin);
+criterion_main!(benches);

--- a/docs/guides/snapshot-pin.md
+++ b/docs/guides/snapshot-pin.md
@@ -1,0 +1,110 @@
+# Named Snapshots — Reproducible Reads (Issue #3370)
+
+A **named snapshot** pins a human-readable name to a bi-temporal coordinate
+`(valid_time, transaction_time)`. Reads issued through the resulting handle are
+evaluated at that coordinate via the deterministic historical (`*_at_time`)
+read path, so the **same handle returns byte-for-byte identical results no
+matter how the database mutates afterward**. This is the reproducibility
+primitive behind "run this analysis against exactly the state I saw a moment
+ago".
+
+> **Scope.** This wave ships the **Rust API only**. Surfacing named snapshots
+> through the MCP server and an `AS OF SNAPSHOT <name>` query DDL clause is a
+> deliberately coordinated follow-up.
+
+## Quick start
+
+```rust
+use aletheiadb::AletheiaDB;
+
+let db = AletheiaDB::open("data/mydb")?;
+// ... writes ...
+
+// Pin "the world as of right now".
+let snap = db.create_snapshot("nightly-run", Some("2026-07-15 report".into()))?;
+
+// Resolve to a read-only, borrowed handle and read at the pin.
+let view = db.snapshot("nightly-run")?;
+let alice = view.get_node(alice_id)?;          // as of the pin
+let people = view.find_nodes("Person")?;       // as of the pin
+let out    = view.get_outgoing_edges(alice_id); // adjacency as of the pin
+
+// A pre-pinned query builder (traversal, filtering, vector ranking):
+let results = view.query().start(alice_id).traverse("KNOWS").execute(&db)?;
+```
+
+## API
+
+| Method | Purpose |
+|--------|---------|
+| `create_snapshot(name, description)` | Pin the current commit frontier for both dimensions. |
+| `create_snapshot_at(name, valid_time, transaction_time, description)` | Pin an explicit (possibly backdated) coordinate. |
+| `snapshot(name) -> Snapshot` | Resolve a name to a borrowed read handle. |
+| `get_snapshot(name) -> NamedSnapshot` | Fetch the coordinate/metadata without a handle. |
+| `list_snapshots() -> Vec<NamedSnapshot>` | List all pins (stable order: created_at, then name). |
+| `delete_snapshot(name)` | Remove a pin. |
+
+The `Snapshot<'_>` handle exposes `get_node`, `get_edge`, `find_nodes`,
+`find_nodes_by_property`, `get_outgoing_edges` / `get_incoming_edges` (adjacency
+at the pin), and `query()` (a `QueryBuilder` already pinned via
+`as_of(valid_time, transaction_time)` — use it for multi-hop traversal at the
+pin). Every read routes through the historical `*_at_time` path, never the
+current-state hot path.
+
+Errors use the project's structured codes (Issue #3234): a duplicate name is a
+**CONFLICT**, an unknown name is a **NOT_FOUND** (with the name in the message).
+
+## A snapshot is a coordinate, not a held resource
+
+Creating a snapshot records two timestamps in a small sidecar registry. It
+
+- **pins no storage** — there is no retention obligation and nothing is kept
+  alive on your behalf;
+- **blocks no writers** — snapshots never participate in the write path;
+- **adds zero overhead to `create_node` / `create_edge`** — the registry is
+  entirely off the data write path.
+
+This mirrors the #3360 cursor, which likewise captures a `(vt, tt)` pair once
+and re-reads deterministically.
+
+## Defaulting the coordinate ("now")
+
+`create_snapshot` captures the database's authoritative commit frontier — the
+value guarded by `current_timestamp` — for **both** dimensions. The commit
+path advances that frontier strictly monotonically under the same lock, so:
+
+- every transaction **committed before** the snapshot has a transaction-time
+  start `≤` the frontier → **visible** through the pin;
+- every transaction **committed after** the snapshot has a start strictly `>`
+  the frontier → **invisible** through the pin.
+
+The result is a deterministic "as of the moment of creation" pin: a node
+created after the pin is invisible, a node updated after the pin reads as its
+pre-update version, and a node deleted after the pin is still visible.
+
+## Caveats (shared with `temporal_extent` / point-in-time reads)
+
+- **Cold-tier / truncation visibility.** A snapshot enjoys no retention
+  guarantee. If the versions it observes are later evicted (cold tier not
+  configured, or history truncated) a read through the handle can return
+  "not found" for a fact that was visible at creation — exactly the
+  visibility caveat that governs `temporal_extent` (Issue #3238) and every
+  other point-in-time read. Keep history (or a configured cold tier) for as
+  long as you intend a snapshot to remain readable.
+- **Future-valid facts.** Pinning "now" excludes facts whose `valid_from` lies
+  in the future of the pin — the same tradeoff documented for #3236 /
+  point-in-time reads. Use `create_snapshot_at` with an explicit future
+  `valid_time` if you need to observe forward-dated facts.
+- **Backdated pins.** `create_snapshot_at` does **not** reject coordinates
+  outside the current temporal extent; a coordinate before any recorded
+  history simply resolves to an empty world.
+
+## Durability
+
+When index persistence is enabled (e.g. via `AletheiaDB::open(path)`), the
+registry is persisted atomically (temp file + rename + parent fsync, mirroring
+the auth key store) to `{data_dir}/snapshots.json`, so named snapshots survive
+a restart. Coordinates are stored as `i64` microseconds since the Unix epoch
+(the HLC logical counter is dropped — snapshot coordinates are
+microsecond-granular on disk, which is sufficient for point-in-time reads).
+Ephemeral databases (`AletheiaDB::new()`) keep the registry in memory only.

--- a/docs/guides/snapshot-pin.md
+++ b/docs/guides/snapshot-pin.md
@@ -3,10 +3,9 @@
 A **named snapshot** pins a human-readable name to a bi-temporal coordinate
 `(valid_time, transaction_time)`. Reads issued through the resulting handle are
 evaluated at that coordinate via the deterministic historical (`*_at_time`)
-read path, so the **same handle returns byte-for-byte identical results no
-matter how the database mutates afterward**. This is the reproducibility
-primitive behind "run this analysis against exactly the state I saw a moment
-ago".
+read path, so the **same handle returns identical results regardless of writes
+that land afterward**. This is the reproducibility primitive behind "run this
+analysis against exactly the state I saw a moment ago".
 
 > **Scope.** This wave ships the **Rust API only**. Surfacing named snapshots
 > through the MCP server and an `AS OF SNAPSHOT <name>` query DDL clause is a
@@ -37,7 +36,7 @@ let results = view.query().start(alice_id).traverse("KNOWS").execute(&db)?;
 
 | Method | Purpose |
 |--------|---------|
-| `create_snapshot(name, description)` | Pin the current commit frontier for both dimensions. |
+| `create_snapshot(name, description)` | Pin "now": valid-time = wallclock now, transaction-time = the commit frontier. |
 | `create_snapshot_at(name, valid_time, transaction_time, description)` | Pin an explicit (possibly backdated) coordinate. |
 | `snapshot(name) -> Snapshot` | Resolve a name to a borrowed read handle. |
 | `get_snapshot(name) -> NamedSnapshot` | Fetch the coordinate/metadata without a handle. |
@@ -60,27 +59,42 @@ Creating a snapshot records two timestamps in a small sidecar registry. It
 
 - **pins no storage** — there is no retention obligation and nothing is kept
   alive on your behalf;
-- **blocks no writers** — snapshots never participate in the write path;
-- **adds zero overhead to `create_node` / `create_edge`** — the registry is
-  entirely off the data write path.
+- **adds no lasting write-path overhead** — the registry is entirely off the
+  data write path (`create_node` / `create_edge` never touch it).
 
-This mirrors the #3360 cursor, which likewise captures a `(vt, tt)` pair once
-and re-reads deterministically.
+Creation is effectively free but **not literally a no-op** against concurrent
+committers: it takes the commit-clock lock (`current_timestamp`) just long
+enough to copy a single `Timestamp` — nanosecond-scale contention on the hot
+commit path, released immediately. This mirrors the #3360 cursor, which
+likewise captures a `(vt, tt)` pair once and re-reads deterministically.
+
+A snapshot **created at an instant racing an in-flight commit** inherits the
+engine's standard committed-but-not-yet-applied visibility window — the same
+caveat #3225 / #3236 point-in-time reads carry. Once created, the coordinate is
+fixed and every read through it is deterministic.
 
 ## Defaulting the coordinate ("now")
 
-`create_snapshot` captures the database's authoritative commit frontier — the
-value guarded by `current_timestamp` — for **both** dimensions. The commit
-path advances that frontier strictly monotonically under the same lock, so:
+`create_snapshot` defaults the two dimensions **differently**, each to the
+correct notion of "now":
 
-- every transaction **committed before** the snapshot has a transaction-time
-  start `≤` the frontier → **visible** through the pin;
-- every transaction **committed after** the snapshot has a start strictly `>`
-  the frontier → **invisible** through the pin.
+- **transaction time = the commit frontier** (the value guarded by
+  `current_timestamp`). The commit path advances that frontier strictly
+  monotonically under the same lock, so every transaction committed **before**
+  the snapshot has a transaction-time start `≤` the frontier (**visible**) and
+  every transaction committed **after** has a start strictly `>` it
+  (**invisible**). The frontier equals "now" for all committed data, but is
+  chosen over wallclock precisely for this race-free monotonicity.
+- **valid time = wallclock `time::now()`**, matching the engine's "now"
+  convention (`get_node_at_valid_time`, `find_nodes_at_time`). Defaulting valid
+  time to the (idle-lagging) frontier would silently **exclude** facts that are
+  genuinely valid at creation — including #3221 future-dated facts already valid
+  by now.
 
-The result is a deterministic "as of the moment of creation" pin: a node
-created after the pin is invisible, a node updated after the pin reads as its
-pre-update version, and a node deleted after the pin is still visible.
+So "as of the moment of creation" is precise: valid-time-now = wallclock-now,
+transaction-time-now = the commit frontier. A node created after the pin is
+invisible, a node updated after the pin reads as its pre-update version, and a
+node deleted after the pin is still visible.
 
 ## Caveats (shared with `temporal_extent` / point-in-time reads)
 
@@ -102,9 +116,26 @@ pre-update version, and a node deleted after the pin is still visible.
 ## Durability
 
 When index persistence is enabled (e.g. via `AletheiaDB::open(path)`), the
-registry is persisted atomically (temp file + rename + parent fsync, mirroring
-the auth key store) to `{data_dir}/snapshots.json`, so named snapshots survive
-a restart. Coordinates are stored as `i64` microseconds since the Unix epoch
-(the HLC logical counter is dropped — snapshot coordinates are
-microsecond-granular on disk, which is sufficient for point-in-time reads).
+registry is persisted atomically (temp file + rename + parent fsync) **inside**
+the persistence directory, at `{persistence.data_dir}/snapshots.json` — under
+the canonical durable config that is `{data_dir}/indexes/snapshots.json`. Keeping
+the sidecar inside the data dir (rather than a stripped-parent sibling) means a
+power user who points `data_dir` at their data root never gets a file written
+outside it.
+
+Coordinates are stored as the **full HLC timestamp** (`{wallclock, logical}`),
+not bare microseconds. Persisting the logical counter is required for
+restart-fidelity: two commits within one wallclock microsecond receive distinct
+logical counters, so a pin at `(W, 1)` that dropped its logical counter would
+collapse to `(W, 0)` on reload and resolve the **wrong** (superseded) version.
+The sidecar is versioned (`version: 2`); a legacy `version: 1` file (bare-integer
+timestamps) still loads, reconstructed with logical `0`.
+
+A corrupt, unparseable, or unknown-future-version `snapshots.json` does **not**
+brick startup (unlike the security-critical auth key store, which correctly
+hard-fails): the database logs a warning, quarantines the bad file aside
+(`snapshots.json.corrupt`, preserving the bytes), and starts with an empty
+registry — snapshots are non-critical bookmarks whose loss costs at most a
+re-created pin.
+
 Ephemeral databases (`AletheiaDB::new()`) keep the registry in memory only.

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -477,6 +477,13 @@ impl AletheiaDB {
             let enable_cold_storage = config.historical.enable_cold_storage;
             let cold_storage_path = config.historical.cold_storage_path.clone();
 
+            // Named-snapshot registry (Issue #3370): durable sidecar at
+            // `{data_dir}/snapshots.json` when index persistence is enabled,
+            // in-memory-only otherwise. Loaded here so pins survive restart.
+            let snapshots = Arc::new(crate::db::snapshot::SnapshotRegistry::open(
+                crate::db::snapshot::registry_path_for(&config.persistence),
+            )?);
+
             let mut db = AletheiaDB {
                 current: Arc::new(CurrentStorage::new()),
                 historical: Arc::new(RwLock::new(HistoricalStorage::from_unified_config(
@@ -503,6 +510,7 @@ impl AletheiaDB {
                 encryption_config: encryption_config_stored,
                 constraint_registry: Arc::new(crate::core::constraint::ConstraintRegistry::new()),
                 lineage: Arc::new(crate::core::lineage::LineageStore::new()),
+                snapshots,
                 chain: None,
                 _tempdir: None,
             };
@@ -877,6 +885,8 @@ impl AletheiaDB {
                 encryption_config: None,
                 constraint_registry: Arc::new(crate::core::constraint::ConstraintRegistry::new()),
                 lineage: Arc::new(crate::core::lineage::LineageStore::new()),
+                // Ephemeral (no index persistence): in-memory-only registry.
+                snapshots: Arc::new(crate::db::snapshot::SnapshotRegistry::in_memory()),
                 chain: None,
                 _tempdir: None,
             };

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -48,6 +48,8 @@ pub mod rotation;
 pub mod schema;
 /// Unified vector similarity query builder.
 pub mod similarity_query;
+/// Named snapshots for reproducible reads (Issue #3370).
+pub mod snapshot;
 /// Database-wide statistics snapshot (Issue #3222).
 pub mod stats;
 /// Temporal query operations.
@@ -70,6 +72,7 @@ pub use ops::NodesAtTime;
 pub use pitr::{PitrCoord, PitrPlan, PitrTarget};
 pub use schema::{EdgeTypeSchema, GraphSchema, LabelSchema, SchemaInstant};
 pub use similarity_query::{SimilarityQuery, SimilaritySource};
+pub use snapshot::{NamedSnapshot, Snapshot};
 pub use stats::{
     ColdStorageDetails, ColdStorageTierStats, CurrentStateStats, DatabaseStats,
     HistoricalDepthStats, TierAccessStats, WalStateStats,
@@ -214,6 +217,15 @@ pub struct AletheiaDB {
     /// in-memory (does not survive restart) to keep the WAL format untouched
     /// (Issue #3413); see [`crate::core::lineage`].
     pub(crate) lineage: Arc<crate::core::lineage::LineageStore>,
+    /// Named-snapshot registry for reproducible reads (Issue #3370).
+    ///
+    /// Maps a human-readable name to a pinned bi-temporal coordinate. Entirely
+    /// off the data write path (creating a snapshot never touches
+    /// current/historical storage, the WAL, or `current_timestamp`), so it
+    /// adds zero overhead to `create_node`/`create_edge`. Durably persisted to
+    /// a `{data_dir}/snapshots.json` sidecar when index persistence is enabled;
+    /// in-memory-only for ephemeral databases. See [`crate::db::snapshot`].
+    pub(crate) snapshots: Arc<snapshot::SnapshotRegistry>,
     /// Opt-in tamper-evident provenance hash chain (Issue #3351).
     ///
     /// `None` unless `config.chain.enabled`. When present, each committed

--- a/src/db/snapshot.rs
+++ b/src/db/snapshot.rs
@@ -66,6 +66,7 @@ use crate::db::ops::NodesAtTime;
 use crate::query::QueryBuilder;
 use crate::query::builder::state::Initial;
 use parking_lot::RwLock;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -80,6 +81,10 @@ use std::path::PathBuf;
 /// microsecond) must not collapse onto its same-microsecond neighbor on reload.
 /// The [`ts_hlc`] deserializer still accepts the legacy bare-integer form
 /// (reconstructing it as logical 0), so v1 files load without a hard failure.
+///
+/// Only referenced by the serde-gated persistence path; the in-memory registry
+/// needs no on-disk format version.
+#[cfg(feature = "serde")]
 const PERSIST_FORMAT_VERSION: u32 = 2;
 
 /// serde adapter: (de)serialize a [`Timestamp`] (an HLC `HybridTimestamp`)
@@ -95,6 +100,10 @@ const PERSIST_FORMAT_VERSION: u32 = 2;
 ///
 /// The deserializer is tolerant of the **legacy** v1 shape — a bare integer is
 /// accepted and reconstructed with logical `0` — so an old sidecar still loads.
+///
+/// Only compiled when the `serde` feature is enabled (persistence is a no-op
+/// otherwise); the snapshot registry itself works in-memory regardless.
+#[cfg(feature = "serde")]
 mod ts_hlc {
     use super::Timestamp;
     use crate::core::hlc::HybridTimestamp;
@@ -159,16 +168,20 @@ mod ts_hlc {
 /// This value is immutable and cheaply cloneable. It records the pin's name,
 /// the `(valid_time, transaction_time)` coordinate reads resolve at, when the
 /// snapshot was created, and an optional human description.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NamedSnapshot {
     name: String,
-    #[serde(with = "ts_hlc")]
+    #[cfg_attr(feature = "serde", serde(with = "ts_hlc"))]
     valid_time: Timestamp,
-    #[serde(with = "ts_hlc")]
+    #[cfg_attr(feature = "serde", serde(with = "ts_hlc"))]
     transaction_time: Timestamp,
-    #[serde(with = "ts_hlc")]
+    #[cfg_attr(feature = "serde", serde(with = "ts_hlc"))]
     created_at: Timestamp,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
     description: Option<String>,
 }
 
@@ -211,6 +224,10 @@ impl NamedSnapshot {
 }
 
 /// The on-disk registry envelope (versioned, mirrors the auth key store).
+///
+/// Only compiled with the `serde` feature; without it the registry is
+/// in-memory-only and never (de)serialized.
+#[cfg(feature = "serde")]
 #[derive(Serialize, Deserialize)]
 struct PersistedRegistry {
     version: u32,
@@ -273,6 +290,10 @@ impl SnapshotRegistry {
             persist_path: path.clone(),
             save_lock: parking_lot::Mutex::new(()),
         };
+        // Loading the sidecar requires serde; without it the registry is
+        // in-memory-only (persistence is compiled out) and `path` is retained
+        // solely so a later save is a clean no-op.
+        #[cfg(feature = "serde")]
         if let Some(path) = path {
             match std::fs::read_to_string(&path) {
                 Ok(contents) => match serde_json::from_str::<PersistedRegistry>(&contents) {
@@ -421,6 +442,25 @@ impl SnapshotRegistry {
             return Ok(());
         };
 
+        // Durable persistence requires serde. Without it the registry is
+        // in-memory-only: nothing is written (the sidecar path is still tracked
+        // so behavior is otherwise identical).
+        #[cfg(not(feature = "serde"))]
+        {
+            let _ = path;
+            return Ok(());
+        }
+
+        #[cfg(feature = "serde")]
+        {
+            self.save_serialized(path)
+        }
+    }
+
+    /// Serialize the registry to `path` (temp file + rename + parent fsync).
+    /// Split out so the serde-gated body lives in one place.
+    #[cfg(feature = "serde")]
+    fn save_serialized(&self, path: &std::path::Path) -> Result<()> {
         let mut snapshots: Vec<NamedSnapshot> = self.entries.read().values().cloned().collect();
         snapshots.sort_by(|a, b| {
             a.created_at
@@ -465,6 +505,9 @@ impl SnapshotRegistry {
 /// Emit a warning about the snapshot registry under either logging
 /// configuration, matching the crate's `observability`-gated logging style
 /// (mirrors `log_scan_warning` in `src/storage/wal/segment_reader.rs`).
+///
+/// Only used by the serde-gated sidecar load path.
+#[cfg(feature = "serde")]
 fn log_registry_warning(message: &str) {
     #[cfg(feature = "observability")]
     tracing::warn!("{}", message);
@@ -478,6 +521,9 @@ fn log_registry_warning(message: &str) {
 /// bad file is the interesting one). Failure to quarantine is itself logged but
 /// never fatal: the in-memory registry is already empty, and a later `save()`
 /// overwrites the file atomically.
+///
+/// Only used by the serde-gated sidecar load path.
+#[cfg(feature = "serde")]
 fn quarantine_corrupt_registry(path: &std::path::Path) {
     let mut corrupt = path.as_os_str().to_owned();
     corrupt.push(".corrupt");
@@ -861,6 +907,7 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn named_snapshot_serde_round_trips_full_hlc() {
         use crate::core::hlc::HybridTimestamp;
@@ -887,6 +934,7 @@ mod tests {
         assert_eq!(back.transaction_time().logical(), 3);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn ts_hlc_reconstructs_exact_wallclock_and_logical() {
         use crate::core::hlc::HybridTimestamp;
@@ -901,6 +949,7 @@ mod tests {
         assert_eq!(back.0.logical(), 42);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn ts_hlc_accepts_legacy_bare_integer_as_logical_zero() {
         // A legacy v1 sidecar stored bare-integer micros. The tolerant
@@ -921,6 +970,7 @@ mod tests {
         assert_eq!(s.transaction_time.logical(), 0);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn open_quarantines_corrupt_sidecar_and_starts_empty() {
         let dir = tempfile::tempdir().unwrap();
@@ -943,6 +993,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn open_quarantines_future_version_and_starts_empty() {
         let dir = tempfile::tempdir().unwrap();
@@ -977,6 +1028,7 @@ mod tests {
     // shares the parse-failure quarantine path, which the corrupt-sidecar and
     // future-version tests already cover.
 
+    #[cfg(feature = "serde")]
     #[test]
     fn insert_rolls_back_on_save_failure() {
         // Point the sidecar at a path whose parent is a *file*, so directory

--- a/src/db/snapshot.rs
+++ b/src/db/snapshot.rs
@@ -258,40 +258,57 @@ impl SnapshotRegistry {
     /// database startup**. On such a file we log a warning, quarantine it aside
     /// (rename to `*.corrupt`, preserving the bytes for inspection), and start
     /// with an empty registry. Legacy v1 files (bare-integer timestamps) still
-    /// load normally via the [`ts_hlc`] tolerant deserializer. Only a genuine
-    /// read I/O error (e.g. permissions) is surfaced, since that is an operator
-    /// problem the empty-registry fallback cannot paper over.
+    /// load normally via the [`ts_hlc`] tolerant deserializer.
+    ///
+    /// The load is driven off a single `read_to_string` (no `exists()`
+    /// pre-check, so no TOCTOU gap): a `NotFound` error is the normal first-run
+    /// case and silently yields an empty registry, while **any other** read I/O
+    /// error (permissions, a sharing violation, on-disk corruption surfacing as
+    /// an I/O error) is treated exactly like a parse failure — warn, quarantine,
+    /// start empty — so an operator problem still cannot brick startup for a
+    /// non-critical bookmark file.
     pub(crate) fn open(path: Option<PathBuf>) -> Result<Self> {
         let registry = Self {
             entries: RwLock::new(HashMap::new()),
             persist_path: path.clone(),
             save_lock: parking_lot::Mutex::new(()),
         };
-        if let Some(path) = path
-            && path.exists()
-        {
-            let contents = std::fs::read_to_string(&path)?;
-            match serde_json::from_str::<PersistedRegistry>(&contents) {
-                Ok(parsed) if parsed.version <= PERSIST_FORMAT_VERSION => {
-                    let mut entries = registry.entries.write();
-                    for snapshot in parsed.snapshots {
-                        entries.insert(snapshot.name.clone(), snapshot);
+        if let Some(path) = path {
+            match std::fs::read_to_string(&path) {
+                Ok(contents) => match serde_json::from_str::<PersistedRegistry>(&contents) {
+                    Ok(parsed) if parsed.version <= PERSIST_FORMAT_VERSION => {
+                        let mut entries = registry.entries.write();
+                        for snapshot in parsed.snapshots {
+                            entries.insert(snapshot.name.clone(), snapshot);
+                        }
                     }
-                }
-                Ok(parsed) => {
-                    log_registry_warning(&format!(
-                        "snapshot registry at {} has unsupported future version {} (this build \
-                         understands up to {}); quarantining it and starting with an empty \
-                         registry",
-                        path.display(),
-                        parsed.version,
-                        PERSIST_FORMAT_VERSION
-                    ));
-                    quarantine_corrupt_registry(&path);
-                }
+                    Ok(parsed) => {
+                        log_registry_warning(&format!(
+                            "snapshot registry at {} has unsupported future version {} (this \
+                             build understands up to {}); quarantining it and starting with an \
+                             empty registry",
+                            path.display(),
+                            parsed.version,
+                            PERSIST_FORMAT_VERSION
+                        ));
+                        quarantine_corrupt_registry(&path);
+                    }
+                    Err(e) => {
+                        log_registry_warning(&format!(
+                            "failed to parse snapshot registry at {} ({e}); quarantining it and \
+                             starting with an empty registry",
+                            path.display()
+                        ));
+                        quarantine_corrupt_registry(&path);
+                    }
+                },
+                // Missing file is the normal first-run case: start empty, no warning.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                // Any other read I/O error (permissions, sharing violation,
+                // corruption) must not brick startup: warn, quarantine, empty.
                 Err(e) => {
                     log_registry_warning(&format!(
-                        "failed to parse snapshot registry at {} ({e}); quarantining it and \
+                        "failed to read snapshot registry at {} ({e}); quarantining it and \
                          starting with an empty registry",
                         path.display()
                     ));
@@ -308,6 +325,15 @@ impl SnapshotRegistry {
     /// [`StorageError::DuplicateId`](crate::core::error::StorageError::DuplicateId),
     /// which maps to the #3234 `CONFLICT` code) if the name is already taken.
     pub(crate) fn insert(&self, snapshot: NamedSnapshot) -> Result<()> {
+        // Serialize the whole mutate+save under `save_lock` (outermost). Two
+        // concurrent inserts must not interleave such that the later save wins
+        // on disk while the earlier one rolls back its in-memory entry, leaving
+        // an on-disk entry absent from RAM. Holding `save_lock` across the
+        // conflict-check, insert, and save closes that observable divergence
+        // window. No deadlock: the `entries` write guard is dropped before
+        // `save_locked()` (which only takes `entries.read()`), and the rollback
+        // re-takes `entries.write()` only after `save_locked()` returns.
+        let _guard = self.save_lock.lock();
         let name = {
             let mut entries = self.entries.write();
             if entries.contains_key(&snapshot.name) {
@@ -319,7 +345,7 @@ impl SnapshotRegistry {
         };
         // Roll back the in-memory insert if the disk save fails, so RAM and disk
         // never diverge (the caller sees Err *and* the entry is not registered).
-        if let Err(e) = self.save() {
+        if let Err(e) = self.save_locked() {
             self.entries.write().remove(&name);
             return Err(e);
         }
@@ -346,6 +372,12 @@ impl SnapshotRegistry {
     ///
     /// Returns a `NOT_FOUND`-classed error if the name is absent.
     pub(crate) fn remove(&self, name: &str) -> Result<()> {
+        // Serialize the whole mutate+save under `save_lock` (outermost),
+        // symmetric to `insert`, so a concurrent remove/insert cannot leave RAM
+        // and disk diverged. Same no-deadlock argument: the `entries` write
+        // guard is dropped before `save_locked()`, and the re-insert on failure
+        // re-takes `entries.write()` only after it returns.
+        let _guard = self.save_lock.lock();
         let removed = {
             let mut entries = self.entries.write();
             match entries.remove(name) {
@@ -355,7 +387,7 @@ impl SnapshotRegistry {
         };
         // Re-insert the removed entry if the disk save fails, so RAM and disk
         // never diverge (the caller sees Err *and* the entry is still present).
-        if let Err(e) = self.save() {
+        if let Err(e) = self.save_locked() {
             self.entries.write().insert(removed.name.clone(), removed);
             return Err(e);
         }
@@ -365,11 +397,29 @@ impl SnapshotRegistry {
     /// Atomically persist the registry to its sidecar file (temp file +
     /// rename + parent fsync), mirroring the auth key store. A no-op for
     /// in-memory-only registries.
+    ///
+    /// Acquires `save_lock` and delegates to [`save_locked`](Self::save_locked).
+    /// Callers already holding `save_lock` (the `insert`/`remove` mutate+save
+    /// critical sections) must call `save_locked` directly instead — this
+    /// `Mutex` is not reentrant. Retained as the standalone lock-acquiring save
+    /// entry point (both current callers hold `save_lock` and use `save_locked`,
+    /// so this is currently unused).
+    #[allow(dead_code)]
     fn save(&self) -> Result<()> {
+        let _guard = self.save_lock.lock();
+        self.save_locked()
+    }
+
+    /// The durable-write body of [`save`](Self::save), **assuming `save_lock`
+    /// is already held** by the caller. A no-op for in-memory-only registries.
+    ///
+    /// Only ever takes `entries.read()` (to snapshot the map for serialization),
+    /// never `save_lock`, so it composes safely inside the `insert`/`remove`
+    /// critical sections that hold `save_lock` across the whole mutate+save.
+    fn save_locked(&self) -> Result<()> {
         let Some(path) = &self.persist_path else {
             return Ok(());
         };
-        let _guard = self.save_lock.lock();
 
         let mut snapshots: Vec<NamedSnapshot> = self.entries.read().values().cloned().collect();
         snapshots.sort_by(|a, b| {
@@ -892,6 +942,40 @@ mod tests {
             "quarantined file exists"
         );
     }
+
+    #[test]
+    fn open_quarantines_future_version_and_starts_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("snapshots.json");
+        // A well-formed sidecar whose version is NEWER than this build
+        // understands must be treated exactly like corruption: quarantine and
+        // start empty, never brick startup or misread newer-format entries.
+        let future = format!(
+            r#"{{ "version": {}, "snapshots": [] }}"#,
+            PERSIST_FORMAT_VERSION + 1
+        );
+        std::fs::write(&path, future.as_bytes()).unwrap();
+
+        let reg = SnapshotRegistry::open(Some(path.clone())).unwrap();
+        assert!(
+            reg.list().is_empty(),
+            "future-version registry starts empty"
+        );
+        // The unsupported file is preserved aside for inspection.
+        assert!(!path.exists(), "future-version file was moved aside");
+        assert!(
+            dir.path().join("snapshots.json.corrupt").exists(),
+            "quarantined file exists"
+        );
+    }
+
+    // NOTE: an unreadable-file (non-NotFound I/O error) `open` case — e.g. a
+    // `chmod 000` sidecar exercising the generic `Err(e)` quarantine arm — is
+    // deliberately NOT tested here: the suite frequently runs as root (in CI
+    // containers), and root bypasses Unix permission bits, so `read_to_string`
+    // would succeed and the test could not reliably provoke the error. The arm
+    // shares the parse-failure quarantine path, which the corrupt-sidecar and
+    // future-version tests already cover.
 
     #[test]
     fn insert_rolls_back_on_save_failure() {

--- a/src/db/snapshot.rs
+++ b/src/db/snapshot.rs
@@ -3,34 +3,52 @@
 //! A *named snapshot* pins a human-readable name to a bi-temporal coordinate
 //! `(valid_time, transaction_time)`. Reads issued through the resulting
 //! [`Snapshot`] handle are evaluated at that coordinate via the deterministic
-//! historical (`*_at_time`) read path, so the same handle returns
-//! byte-for-byte identical results no matter how the database mutates
-//! afterward.
+//! historical (`*_at_time`) read path, so the same handle returns identical
+//! results regardless of writes that land afterward.
 //!
 //! # A snapshot is a coordinate, not a held resource
 //!
 //! Creating a snapshot records two timestamps in a small sidecar registry. It
-//! **pins no storage**, blocks no writers, and imposes **zero overhead on the
-//! write path** (`create_node`/`create_edge` never touch the registry). This
-//! mirrors the #3360 cursor, which likewise captures a `(vt, tt)` pair once
-//! and re-reads deterministically. The tradeoff is that a snapshot enjoys no
-//! retention guarantee: if the versions it observes are later evicted (cold
-//! tier not configured, or history truncated) a read through the handle can
-//! return "not found" for a fact that was visible at creation. This is the
-//! same visibility caveat that governs `temporal_extent` (#3238) and every
-//! other point-in-time read.
+//! **pins no storage** and adds no lasting overhead to the write path
+//! (`create_node`/`create_edge` never touch the registry). Creation itself
+//! takes the commit-clock lock (`current_timestamp`) just long enough to copy a
+//! single `Timestamp` — nanosecond-scale contention on the hot commit path, not
+//! literally zero — so it is effectively free but not a true no-op against
+//! concurrent committers. This mirrors the #3360 cursor, which likewise
+//! captures a `(vt, tt)` pair once and re-reads deterministically. The tradeoff
+//! is that a snapshot enjoys no retention guarantee: if the versions it observes
+//! are later evicted (cold tier not configured, or history truncated) a read
+//! through the handle can return "not found" for a fact that was visible at
+//! creation. This is the same visibility caveat that governs `temporal_extent`
+//! (#3238) and every other point-in-time read.
+//!
+//! A snapshot **created at an instant that races an in-flight commit** inherits
+//! the engine's standard committed-but-not-yet-applied visibility window: the
+//! same caveat that #3225 / #3236 point-in-time reads carry. Once created, the
+//! coordinate is fixed and every read through it is deterministic.
 //!
 //! # Defaulting the coordinate ("now")
 //!
-//! [`AletheiaDB::create_snapshot`] captures the database's authoritative
-//! commit frontier — the value under `current_timestamp` — for **both**
-//! dimensions. Because the commit path advances that frontier strictly
-//! monotonically under the same lock, every already-committed transaction has
-//! a transaction-time start `<=` the frontier (so it is visible) and every
-//! future commit has a start strictly `>` the frontier (so it is invisible).
-//! The result is a deterministic "as of the moment of creation" pin. Note the
-//! same future-valid caveat point-in-time reads carry: a fact whose
-//! `valid_from` lies in the future of the pin is not visible through it.
+//! [`AletheiaDB::create_snapshot`] defaults the two dimensions **differently**,
+//! each to the correct notion of "now":
+//!
+//! - **transaction time** = the database's authoritative commit frontier (the
+//!   value under `current_timestamp`). Because the commit path advances that
+//!   frontier strictly monotonically under the same lock, every already-committed
+//!   transaction has a transaction-time start `<=` the frontier (visible) and
+//!   every future commit a start strictly `>` it (invisible) — a race-free
+//!   monotonic pin. The frontier equals "now" for all committed data but is
+//!   chosen over wallclock precisely for that race-safety.
+//! - **valid time** = wallclock `time::now()`, matching the engine's "now"
+//!   convention (`get_node_at_valid_time`, `find_nodes_at_time`). This ensures a
+//!   default "now" snapshot sees every fact actually valid at creation, rather
+//!   than silently excluding facts the (idle-lagging) frontier has not yet
+//!   reached.
+//!
+//! So "as of the moment of creation" is precise: valid-time-now =
+//! wallclock-now, transaction-time-now = the commit frontier. Note the same
+//! future-valid caveat point-in-time reads carry: a fact whose `valid_from`
+//! lies in the future of the pinned valid time is not visible through it.
 //!
 //! # Scope (this wave is Rust-API-only)
 //!
@@ -54,22 +72,85 @@ use std::path::PathBuf;
 
 /// Persisted-format version for the snapshot registry sidecar file. Bumped
 /// only on an incompatible on-disk change (mirrors the auth key store).
-const PERSIST_FORMAT_VERSION: u32 = 1;
+///
+/// v1 stored each timestamp as a bare `i64` (wallclock micros only, HLC logical
+/// counter dropped). v2 stores the **full** [`HybridTimestamp`] as
+/// `{wallclock, logical}` so a pin round-trips losslessly across restart — a
+/// coordinate with a nonzero logical counter (two commits in the same
+/// microsecond) must not collapse onto its same-microsecond neighbor on reload.
+/// The [`ts_hlc`] deserializer still accepts the legacy bare-integer form
+/// (reconstructing it as logical 0), so v1 files load without a hard failure.
+const PERSIST_FORMAT_VERSION: u32 = 2;
 
-/// serde adapter: (de)serialize a [`Timestamp`] as `i64` microseconds since
-/// the Unix epoch, exactly as the #3360 cursor persists its coordinates. The
-/// logical HLC counter is intentionally dropped — snapshot coordinates are
-/// microsecond-granular on disk, which is sufficient for point-in-time reads.
-mod ts_micros {
+/// serde adapter: (de)serialize a [`Timestamp`] (an HLC `HybridTimestamp`)
+/// **losslessly** as a `{wallclock, logical}` object.
+///
+/// Dropping the logical counter (as the pre-#3370-review format did) is not
+/// safe for snapshot coordinates: two commits within one wallclock microsecond
+/// receive the same wallclock but distinct logical counters (`0`, `1`, …), so a
+/// pin at `(W, 1)` that collapses to `(W, 0)` on reload lands on the *wrong*
+/// side of the supersession and returns the superseded version. Persisting both
+/// components mirrors the version store's on-disk 12-byte
+/// `[wallclock:8][logical:4]` timestamp (`src/core/temporal.rs`).
+///
+/// The deserializer is tolerant of the **legacy** v1 shape — a bare integer is
+/// accepted and reconstructed with logical `0` — so an old sidecar still loads.
+mod ts_hlc {
     use super::Timestamp;
-    use serde::{Deserialize, Deserializer, Serializer};
+    use crate::core::hlc::HybridTimestamp;
+    use serde::de::{self, MapAccess, Visitor};
+    use serde::ser::SerializeStruct;
+    use serde::{Deserializer, Serializer};
+    use std::fmt;
 
     pub fn serialize<S: Serializer>(ts: &Timestamp, s: S) -> Result<S::Ok, S::Error> {
-        s.serialize_i64(ts.wallclock())
+        let mut st = s.serialize_struct("HybridTimestamp", 2)?;
+        st.serialize_field("wallclock", &ts.wallclock())?;
+        st.serialize_field("logical", &ts.logical())?;
+        st.end()
     }
 
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Timestamp, D::Error> {
-        Ok(Timestamp::from(i64::deserialize(d)?))
+        struct TsVisitor;
+
+        impl<'de> Visitor<'de> for TsVisitor {
+            type Value = Timestamp;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("a {wallclock, logical} object or a legacy integer (micros)")
+            }
+
+            // Legacy v1 form: bare integer micros -> logical 0.
+            fn visit_i64<E: de::Error>(self, v: i64) -> Result<Timestamp, E> {
+                Ok(HybridTimestamp::new_unchecked(v, 0))
+            }
+
+            fn visit_u64<E: de::Error>(self, v: u64) -> Result<Timestamp, E> {
+                Ok(HybridTimestamp::new_unchecked(v as i64, 0))
+            }
+
+            // Current v2 form: {wallclock, logical}.
+            fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Timestamp, A::Error> {
+                let mut wallclock: Option<i64> = None;
+                let mut logical: Option<u32> = None;
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "wallclock" => wallclock = Some(map.next_value()?),
+                        "logical" => logical = Some(map.next_value()?),
+                        _ => {
+                            let _: de::IgnoredAny = map.next_value()?;
+                        }
+                    }
+                }
+                let wallclock = wallclock.ok_or_else(|| de::Error::missing_field("wallclock"))?;
+                Ok(HybridTimestamp::new_unchecked(
+                    wallclock,
+                    logical.unwrap_or(0),
+                ))
+            }
+        }
+
+        d.deserialize_any(TsVisitor)
     }
 }
 
@@ -81,11 +162,11 @@ mod ts_micros {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NamedSnapshot {
     name: String,
-    #[serde(with = "ts_micros")]
+    #[serde(with = "ts_hlc")]
     valid_time: Timestamp,
-    #[serde(with = "ts_micros")]
+    #[serde(with = "ts_hlc")]
     transaction_time: Timestamp,
-    #[serde(with = "ts_micros")]
+    #[serde(with = "ts_hlc")]
     created_at: Timestamp,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     description: Option<String>,
@@ -165,10 +246,21 @@ impl SnapshotRegistry {
     /// Open a registry, loading any existing sidecar at `path`.
     ///
     /// `path` is `None` for an in-memory-only registry. A missing file yields
-    /// an empty registry (first run). A present-but-unreadable or corrupt file
-    /// is surfaced as an error, matching how the auth key store treats its
-    /// persisted file — a durable store that cannot be parsed is a
-    /// configuration problem the operator should see, not silently discarded.
+    /// an empty registry (first run).
+    ///
+    /// # Tolerant load (deliberate divergence from the auth key store)
+    ///
+    /// Snapshots are non-critical *bookmarks*: they pin no data and losing them
+    /// costs at most a re-created pin. So — unlike the **security-critical** auth
+    /// key store (`src/auth/store.rs`), which correctly hard-fails on a corrupt
+    /// file rather than silently start with no credentials — a corrupt,
+    /// unparseable, or unknown-future-version `snapshots.json` must **not brick
+    /// database startup**. On such a file we log a warning, quarantine it aside
+    /// (rename to `*.corrupt`, preserving the bytes for inspection), and start
+    /// with an empty registry. Legacy v1 files (bare-integer timestamps) still
+    /// load normally via the [`ts_hlc`] tolerant deserializer. Only a genuine
+    /// read I/O error (e.g. permissions) is surfaced, since that is an operator
+    /// problem the empty-registry fallback cannot paper over.
     pub(crate) fn open(path: Option<PathBuf>) -> Result<Self> {
         let registry = Self {
             entries: RwLock::new(HashMap::new()),
@@ -179,21 +271,32 @@ impl SnapshotRegistry {
             && path.exists()
         {
             let contents = std::fs::read_to_string(&path)?;
-            let parsed: PersistedRegistry = serde_json::from_str(&contents).map_err(|e| {
-                Error::Other(format!(
-                    "failed to parse snapshot registry at {}: {e}",
-                    path.display()
-                ))
-            })?;
-            if parsed.version != PERSIST_FORMAT_VERSION {
-                return Err(Error::Other(format!(
-                    "unsupported snapshot registry version {} (expected {})",
-                    parsed.version, PERSIST_FORMAT_VERSION
-                )));
-            }
-            let mut entries = registry.entries.write();
-            for snapshot in parsed.snapshots {
-                entries.insert(snapshot.name.clone(), snapshot);
+            match serde_json::from_str::<PersistedRegistry>(&contents) {
+                Ok(parsed) if parsed.version <= PERSIST_FORMAT_VERSION => {
+                    let mut entries = registry.entries.write();
+                    for snapshot in parsed.snapshots {
+                        entries.insert(snapshot.name.clone(), snapshot);
+                    }
+                }
+                Ok(parsed) => {
+                    log_registry_warning(&format!(
+                        "snapshot registry at {} has unsupported future version {} (this build \
+                         understands up to {}); quarantining it and starting with an empty \
+                         registry",
+                        path.display(),
+                        parsed.version,
+                        PERSIST_FORMAT_VERSION
+                    ));
+                    quarantine_corrupt_registry(&path);
+                }
+                Err(e) => {
+                    log_registry_warning(&format!(
+                        "failed to parse snapshot registry at {} ({e}); quarantining it and \
+                         starting with an empty registry",
+                        path.display()
+                    ));
+                    quarantine_corrupt_registry(&path);
+                }
             }
         }
         Ok(registry)
@@ -205,14 +308,22 @@ impl SnapshotRegistry {
     /// [`StorageError::DuplicateId`](crate::core::error::StorageError::DuplicateId),
     /// which maps to the #3234 `CONFLICT` code) if the name is already taken.
     pub(crate) fn insert(&self, snapshot: NamedSnapshot) -> Result<()> {
-        {
+        let name = {
             let mut entries = self.entries.write();
             if entries.contains_key(&snapshot.name) {
                 return Err(conflict(&snapshot.name));
             }
-            entries.insert(snapshot.name.clone(), snapshot);
+            let name = snapshot.name.clone();
+            entries.insert(name.clone(), snapshot);
+            name
+        };
+        // Roll back the in-memory insert if the disk save fails, so RAM and disk
+        // never diverge (the caller sees Err *and* the entry is not registered).
+        if let Err(e) = self.save() {
+            self.entries.write().remove(&name);
+            return Err(e);
         }
-        self.save()
+        Ok(())
     }
 
     /// Fetch a snapshot by name.
@@ -235,13 +346,20 @@ impl SnapshotRegistry {
     ///
     /// Returns a `NOT_FOUND`-classed error if the name is absent.
     pub(crate) fn remove(&self, name: &str) -> Result<()> {
-        {
+        let removed = {
             let mut entries = self.entries.write();
-            if entries.remove(name).is_none() {
-                return Err(not_found(name));
+            match entries.remove(name) {
+                Some(removed) => removed,
+                None => return Err(not_found(name)),
             }
+        };
+        // Re-insert the removed entry if the disk save fails, so RAM and disk
+        // never diverge (the caller sees Err *and* the entry is still present).
+        if let Err(e) = self.save() {
+            self.entries.write().insert(removed.name.clone(), removed);
+            return Err(e);
         }
-        self.save()
+        Ok(())
     }
 
     /// Atomically persist the registry to its sidecar file (temp file +
@@ -294,26 +412,53 @@ impl SnapshotRegistry {
     }
 }
 
+/// Emit a warning about the snapshot registry under either logging
+/// configuration, matching the crate's `observability`-gated logging style
+/// (mirrors `log_scan_warning` in `src/storage/wal/segment_reader.rs`).
+fn log_registry_warning(message: &str) {
+    #[cfg(feature = "observability")]
+    tracing::warn!("{}", message);
+    #[cfg(not(feature = "observability"))]
+    eprintln!("WARNING: {}", message);
+}
+
+/// Move a corrupt/unreadable sidecar aside so startup can proceed with an empty
+/// registry while preserving the bad bytes for inspection. Renames `path` to
+/// `path.corrupt` (overwriting a prior quarantine, which is fine — the current
+/// bad file is the interesting one). Failure to quarantine is itself logged but
+/// never fatal: the in-memory registry is already empty, and a later `save()`
+/// overwrites the file atomically.
+fn quarantine_corrupt_registry(path: &std::path::Path) {
+    let mut corrupt = path.as_os_str().to_owned();
+    corrupt.push(".corrupt");
+    let corrupt = PathBuf::from(corrupt);
+    if let Err(e) = std::fs::rename(path, &corrupt) {
+        log_registry_warning(&format!(
+            "could not quarantine corrupt snapshot registry {} -> {}: {e}",
+            path.display(),
+            corrupt.display()
+        ));
+    }
+}
+
 /// Build the sidecar path for a database's snapshot registry, or `None` when
 /// the database is ephemeral (persistence disabled).
 ///
-/// The file lives at `{data_dir}/snapshots.json`, alongside the auth store's
-/// `{data_dir}/auth/`. The canonical durable config
-/// ([`crate::config::durable_config_for_data_dir`]) sets
-/// `persistence.data_dir = {data_dir}/indexes`, so the top-level data dir is
-/// that path's parent.
+/// The file lives **inside** the configured persistence directory, at
+/// `{persistence.data_dir}/snapshots.json`. Under the canonical durable config
+/// ([`crate::config::durable_config_for_data_dir`], which sets
+/// `persistence.data_dir = {data_dir}/indexes`) that is
+/// `{data_dir}/indexes/snapshots.json`. Keeping it inside `data_dir` — rather
+/// than stripping a parent path component — means a power user who points
+/// `data_dir` straight at their data root gets the sidecar contained within
+/// that root, never a sibling written outside it that could collide.
 pub(crate) fn registry_path_for(
     persistence: &crate::storage::index_persistence::PersistenceConfig,
 ) -> Option<PathBuf> {
     if !persistence.enabled {
         return None;
     }
-    let indexes_dir = &persistence.data_dir;
-    let root = indexes_dir
-        .parent()
-        .map(std::path::Path::to_path_buf)
-        .unwrap_or_else(|| indexes_dir.clone());
-    Some(root.join("snapshots.json"))
+    Some(persistence.data_dir.join("snapshots.json"))
 }
 
 /// A read-only, borrowed handle that pins every read to a
@@ -470,15 +615,28 @@ fn not_found(name: &str) -> Error {
 }
 
 impl AletheiaDB {
-    /// Create a named snapshot pinned to the database's current commit frontier
-    /// (Issue #3370).
+    /// Create a named snapshot pinned to "the moment of creation" (Issue #3370).
     ///
-    /// Both temporal dimensions default to the value under `current_timestamp`
-    /// (the authoritative, monotonically advancing commit clock), so the
-    /// snapshot sees exactly the state committed at creation and nothing
-    /// after: every already-committed transaction is visible and every future
-    /// commit is not. See the [module docs](crate::db::snapshot) for the
-    /// determinism argument and the future-valid caveat.
+    /// The two dimensions are defaulted **differently**, each to the correct
+    /// notion of "now":
+    ///
+    /// - **transaction time** = the commit frontier under `current_timestamp`
+    ///   (the authoritative, monotonically advancing commit clock). Because the
+    ///   commit path advances that frontier strictly monotonically under the
+    ///   same lock, every already-committed transaction has a transaction-time
+    ///   start `<=` the frontier (visible) and every future commit a start
+    ///   strictly `>` it (invisible) — a race-free monotonic pin.
+    /// - **valid time** = wallclock `time::now()`, matching the engine's "now"
+    ///   convention for `get_node_at_valid_time` / `find_nodes_at_time`. Using
+    ///   the (possibly lagging) commit frontier for valid time would silently
+    ///   *exclude* facts that are genuinely valid at creation — the frontier
+    ///   trails wallclock during write-idle periods, and a #3221 future-dated
+    ///   fact already valid by now would be dropped.
+    ///
+    /// Both coordinates are captured **once** here and stored, so reads through
+    /// the resulting handle remain fully deterministic. See the
+    /// [module docs](crate::db::snapshot) for the determinism argument and the
+    /// future-valid caveat.
     ///
     /// # Errors
     ///
@@ -489,11 +647,15 @@ impl AletheiaDB {
         name: impl Into<String>,
         description: Option<String>,
     ) -> Result<NamedSnapshot> {
-        // Capture the commit frontier under its own lock (lock class 1) and
-        // release immediately — we hold no later-class lock, so the ordering
-        // contract is preserved. The commit path advances this value strictly
-        // monotonically under the same lock, which is what makes the pin
-        // deterministic (future commits are strictly greater, hence invisible).
+        // Valid-time "now" is wallclock now (the engine's convention). Captured
+        // outside the lock (class-1 lock discipline holds nothing else).
+        let valid_now = crate::core::temporal::time::now();
+        // Transaction-time "now" is the commit frontier: captured under its own
+        // lock (lock class 1) and released immediately — we hold no later-class
+        // lock, so the ordering contract is preserved. The frontier advances
+        // strictly monotonically under the same lock, which is what makes the
+        // transaction-time pin deterministic (future commits are strictly
+        // greater, hence invisible).
         let frontier = {
             let ts = self.current_timestamp.lock().map_err(|_| {
                 Error::from(crate::core::error::TransactionError::LockPoisoned {
@@ -502,7 +664,7 @@ impl AletheiaDB {
             })?;
             *ts
         };
-        self.create_snapshot_at(name, frontier, frontier, description)
+        self.create_snapshot_at(name, valid_now, frontier, description)
     }
 
     /// Create a named snapshot pinned to an explicit bi-temporal coordinate
@@ -591,10 +753,26 @@ mod tests {
     }
 
     #[test]
-    fn registry_path_is_data_dir_sibling_of_indexes() {
+    fn registry_path_is_inside_data_dir() {
         let cfg = crate::storage::index_persistence::PersistenceConfig {
             enabled: true,
             data_dir: PathBuf::from("/var/lib/aletheia/indexes"),
+            ..Default::default()
+        };
+        // The sidecar lives INSIDE data_dir, never a sibling written outside it.
+        assert_eq!(
+            registry_path_for(&cfg),
+            Some(PathBuf::from("/var/lib/aletheia/indexes/snapshots.json"))
+        );
+    }
+
+    #[test]
+    fn registry_path_is_inside_data_dir_root() {
+        // A power user who points data_dir at their data root gets the sidecar
+        // contained within that root (not a sibling that could collide).
+        let cfg = crate::storage::index_persistence::PersistenceConfig {
+            enabled: true,
+            data_dir: PathBuf::from("/var/lib/aletheia"),
             ..Default::default()
         };
         assert_eq!(
@@ -634,19 +812,111 @@ mod tests {
     }
 
     #[test]
-    fn named_snapshot_serde_round_trips_as_micros() {
+    fn named_snapshot_serde_round_trips_full_hlc() {
+        use crate::core::hlc::HybridTimestamp;
+        // Coordinates with NONZERO logical counters (two commits in the same
+        // wallclock microsecond) must round-trip losslessly — dropping logical
+        // would collapse a pin onto its same-microsecond neighbor.
         let snap = NamedSnapshot {
             name: "s".to_string(),
-            valid_time: Timestamp::from(111),
-            transaction_time: Timestamp::from(222),
-            created_at: Timestamp::from(333),
+            valid_time: HybridTimestamp::new_unchecked(111, 7),
+            transaction_time: HybridTimestamp::new_unchecked(222, 3),
+            created_at: HybridTimestamp::new_unchecked(333, 0),
             description: None,
         };
         let json = serde_json::to_string(&snap).unwrap();
-        // Timestamps serialize as bare integer micros, not nested objects.
-        assert!(json.contains("\"valid_time\":111"), "json was {json}");
-        assert!(json.contains("\"transaction_time\":222"), "json was {json}");
+        // Timestamps serialize as {wallclock, logical} objects (lossless).
+        assert!(json.contains("\"wallclock\":111"), "json was {json}");
+        assert!(json.contains("\"logical\":7"), "json was {json}");
+        assert!(json.contains("\"wallclock\":222"), "json was {json}");
+        assert!(json.contains("\"logical\":3"), "json was {json}");
         let back: NamedSnapshot = serde_json::from_str(&json).unwrap();
         assert_eq!(back, snap);
+        // The logical counter specifically survives (the regression guard).
+        assert_eq!(back.valid_time().logical(), 7);
+        assert_eq!(back.transaction_time().logical(), 3);
+    }
+
+    #[test]
+    fn ts_hlc_reconstructs_exact_wallclock_and_logical() {
+        use crate::core::hlc::HybridTimestamp;
+        // Direct serde round-trip of a single timestamp with logical > 0.
+        #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+        struct Wrap(#[serde(with = "ts_hlc")] Timestamp);
+        let ts = HybridTimestamp::new_unchecked(1_700_000_000_000_000, 42);
+        let json = serde_json::to_string(&Wrap(ts)).unwrap();
+        let back: Wrap = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.0, ts);
+        assert_eq!(back.0.wallclock(), 1_700_000_000_000_000);
+        assert_eq!(back.0.logical(), 42);
+    }
+
+    #[test]
+    fn ts_hlc_accepts_legacy_bare_integer_as_logical_zero() {
+        // A legacy v1 sidecar stored bare-integer micros. The tolerant
+        // deserializer must still load it (reconstructed with logical 0), so an
+        // old file loads instead of hard-failing.
+        let legacy = r#"{
+            "version": 1,
+            "snapshots": [
+                { "name": "old", "valid_time": 111, "transaction_time": 222, "created_at": 333 }
+            ]
+        }"#;
+        let parsed: PersistedRegistry = serde_json::from_str(legacy).unwrap();
+        assert_eq!(parsed.version, 1);
+        let s = &parsed.snapshots[0];
+        assert_eq!(s.valid_time.wallclock(), 111);
+        assert_eq!(s.valid_time.logical(), 0);
+        assert_eq!(s.transaction_time.wallclock(), 222);
+        assert_eq!(s.transaction_time.logical(), 0);
+    }
+
+    #[test]
+    fn open_quarantines_corrupt_sidecar_and_starts_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("snapshots.json");
+        std::fs::write(&path, b"this is not valid json {{{").unwrap();
+
+        // A corrupt sidecar must NOT brick startup: it quarantines and yields an
+        // empty registry (unlike the security-critical auth store).
+        let reg = SnapshotRegistry::open(Some(path.clone())).unwrap();
+        assert!(
+            reg.list().is_empty(),
+            "registry starts empty after corruption"
+        );
+
+        // The bad bytes are preserved aside for inspection.
+        assert!(!path.exists(), "corrupt file was moved aside");
+        assert!(
+            dir.path().join("snapshots.json.corrupt").exists(),
+            "quarantined file exists"
+        );
+    }
+
+    #[test]
+    fn insert_rolls_back_on_save_failure() {
+        // Point the sidecar at a path whose parent is a *file*, so directory
+        // creation / the atomic write cannot succeed and save() returns Err.
+        let dir = tempfile::tempdir().unwrap();
+        let blocking_file = dir.path().join("not_a_dir");
+        std::fs::write(&blocking_file, b"x").unwrap();
+        let bad_path = blocking_file.join("nested").join("snapshots.json");
+
+        let reg = SnapshotRegistry::open(Some(bad_path)).unwrap();
+        let snap = NamedSnapshot {
+            name: "run1".to_string(),
+            valid_time: Timestamp::from(1000),
+            transaction_time: Timestamp::from(1000),
+            created_at: Timestamp::from(1000),
+            description: None,
+        };
+        let err = reg.insert(snap);
+        assert!(err.is_err(), "save failure surfaces as Err");
+        // RAM did not diverge from disk: the failed insert left no entry.
+        assert!(
+            reg.get("run1").is_none(),
+            "in-memory insert rolled back on save failure"
+        );
+        assert!(reg.list().is_empty());
     }
 }

--- a/src/db/snapshot.rs
+++ b/src/db/snapshot.rs
@@ -1,0 +1,652 @@
+//! Named snapshots for reproducible reads (Issue #3370).
+//!
+//! A *named snapshot* pins a human-readable name to a bi-temporal coordinate
+//! `(valid_time, transaction_time)`. Reads issued through the resulting
+//! [`Snapshot`] handle are evaluated at that coordinate via the deterministic
+//! historical (`*_at_time`) read path, so the same handle returns
+//! byte-for-byte identical results no matter how the database mutates
+//! afterward.
+//!
+//! # A snapshot is a coordinate, not a held resource
+//!
+//! Creating a snapshot records two timestamps in a small sidecar registry. It
+//! **pins no storage**, blocks no writers, and imposes **zero overhead on the
+//! write path** (`create_node`/`create_edge` never touch the registry). This
+//! mirrors the #3360 cursor, which likewise captures a `(vt, tt)` pair once
+//! and re-reads deterministically. The tradeoff is that a snapshot enjoys no
+//! retention guarantee: if the versions it observes are later evicted (cold
+//! tier not configured, or history truncated) a read through the handle can
+//! return "not found" for a fact that was visible at creation. This is the
+//! same visibility caveat that governs `temporal_extent` (#3238) and every
+//! other point-in-time read.
+//!
+//! # Defaulting the coordinate ("now")
+//!
+//! [`AletheiaDB::create_snapshot`] captures the database's authoritative
+//! commit frontier — the value under `current_timestamp` — for **both**
+//! dimensions. Because the commit path advances that frontier strictly
+//! monotonically under the same lock, every already-committed transaction has
+//! a transaction-time start `<=` the frontier (so it is visible) and every
+//! future commit has a start strictly `>` the frontier (so it is invisible).
+//! The result is a deterministic "as of the moment of creation" pin. Note the
+//! same future-valid caveat point-in-time reads carry: a fact whose
+//! `valid_from` lies in the future of the pin is not visible through it.
+//!
+//! # Scope (this wave is Rust-API-only)
+//!
+//! Surfacing named snapshots through MCP and an `AS OF SNAPSHOT <name>` query
+//! DDL clause is a deliberately coordinated follow-up; this module adds only
+//! the Rust API, registry, and durable persistence.
+
+use crate::core::error::{Error, Result};
+use crate::core::graph::{Edge, Node};
+use crate::core::id::{EdgeId, NodeId};
+use crate::core::property::PropertyValue;
+use crate::core::temporal::Timestamp;
+use crate::db::AletheiaDB;
+use crate::db::ops::NodesAtTime;
+use crate::query::QueryBuilder;
+use crate::query::builder::state::Initial;
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Persisted-format version for the snapshot registry sidecar file. Bumped
+/// only on an incompatible on-disk change (mirrors the auth key store).
+const PERSIST_FORMAT_VERSION: u32 = 1;
+
+/// serde adapter: (de)serialize a [`Timestamp`] as `i64` microseconds since
+/// the Unix epoch, exactly as the #3360 cursor persists its coordinates. The
+/// logical HLC counter is intentionally dropped — snapshot coordinates are
+/// microsecond-granular on disk, which is sufficient for point-in-time reads.
+mod ts_micros {
+    use super::Timestamp;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(ts: &Timestamp, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_i64(ts.wallclock())
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Timestamp, D::Error> {
+        Ok(Timestamp::from(i64::deserialize(d)?))
+    }
+}
+
+/// A named, reproducible bi-temporal snapshot coordinate (Issue #3370).
+///
+/// This value is immutable and cheaply cloneable. It records the pin's name,
+/// the `(valid_time, transaction_time)` coordinate reads resolve at, when the
+/// snapshot was created, and an optional human description.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NamedSnapshot {
+    name: String,
+    #[serde(with = "ts_micros")]
+    valid_time: Timestamp,
+    #[serde(with = "ts_micros")]
+    transaction_time: Timestamp,
+    #[serde(with = "ts_micros")]
+    created_at: Timestamp,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+}
+
+impl NamedSnapshot {
+    /// The snapshot's unique name.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The valid-time coordinate reads resolve at.
+    #[must_use]
+    pub fn valid_time(&self) -> Timestamp {
+        self.valid_time
+    }
+
+    /// The transaction-time coordinate reads resolve at.
+    #[must_use]
+    pub fn transaction_time(&self) -> Timestamp {
+        self.transaction_time
+    }
+
+    /// The `(valid_time, transaction_time)` coordinate pair.
+    #[must_use]
+    pub fn coordinate(&self) -> (Timestamp, Timestamp) {
+        (self.valid_time, self.transaction_time)
+    }
+
+    /// When the snapshot was created (transaction-time of the create call).
+    #[must_use]
+    pub fn created_at(&self) -> Timestamp {
+        self.created_at
+    }
+
+    /// The optional human-readable description.
+    #[must_use]
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+}
+
+/// The on-disk registry envelope (versioned, mirrors the auth key store).
+#[derive(Serialize, Deserialize)]
+struct PersistedRegistry {
+    version: u32,
+    snapshots: Vec<NamedSnapshot>,
+}
+
+/// In-process registry of named snapshots, optionally persisted to a sidecar
+/// JSON file.
+///
+/// The registry is entirely off the data write path: mutating it never touches
+/// current/historical storage, the WAL, or `current_timestamp`, so creating a
+/// snapshot adds zero overhead to `create_node`/`create_edge`.
+pub(crate) struct SnapshotRegistry {
+    entries: RwLock<HashMap<String, NamedSnapshot>>,
+    /// Sidecar file path when persistence is enabled; `None` for ephemeral,
+    /// in-memory-only registries (`AletheiaDB::new()`).
+    persist_path: Option<PathBuf>,
+    /// Serializes concurrent disk saves (the in-memory map has its own
+    /// `RwLock`; this guards the temp-file+rename dance).
+    save_lock: parking_lot::Mutex<()>,
+}
+
+impl SnapshotRegistry {
+    /// Create an empty, memory-only registry (no file is ever written).
+    pub(crate) fn in_memory() -> Self {
+        Self {
+            entries: RwLock::new(HashMap::new()),
+            persist_path: None,
+            save_lock: parking_lot::Mutex::new(()),
+        }
+    }
+
+    /// Open a registry, loading any existing sidecar at `path`.
+    ///
+    /// `path` is `None` for an in-memory-only registry. A missing file yields
+    /// an empty registry (first run). A present-but-unreadable or corrupt file
+    /// is surfaced as an error, matching how the auth key store treats its
+    /// persisted file — a durable store that cannot be parsed is a
+    /// configuration problem the operator should see, not silently discarded.
+    pub(crate) fn open(path: Option<PathBuf>) -> Result<Self> {
+        let registry = Self {
+            entries: RwLock::new(HashMap::new()),
+            persist_path: path.clone(),
+            save_lock: parking_lot::Mutex::new(()),
+        };
+        if let Some(path) = path
+            && path.exists()
+        {
+            let contents = std::fs::read_to_string(&path)?;
+            let parsed: PersistedRegistry = serde_json::from_str(&contents).map_err(|e| {
+                Error::Other(format!(
+                    "failed to parse snapshot registry at {}: {e}",
+                    path.display()
+                ))
+            })?;
+            if parsed.version != PERSIST_FORMAT_VERSION {
+                return Err(Error::Other(format!(
+                    "unsupported snapshot registry version {} (expected {})",
+                    parsed.version, PERSIST_FORMAT_VERSION
+                )));
+            }
+            let mut entries = registry.entries.write();
+            for snapshot in parsed.snapshots {
+                entries.insert(snapshot.name.clone(), snapshot);
+            }
+        }
+        Ok(registry)
+    }
+
+    /// Insert a snapshot if its name is free.
+    ///
+    /// Returns a `CONFLICT`-classed error (reusing
+    /// [`StorageError::DuplicateId`](crate::core::error::StorageError::DuplicateId),
+    /// which maps to the #3234 `CONFLICT` code) if the name is already taken.
+    pub(crate) fn insert(&self, snapshot: NamedSnapshot) -> Result<()> {
+        {
+            let mut entries = self.entries.write();
+            if entries.contains_key(&snapshot.name) {
+                return Err(conflict(&snapshot.name));
+            }
+            entries.insert(snapshot.name.clone(), snapshot);
+        }
+        self.save()
+    }
+
+    /// Fetch a snapshot by name.
+    pub(crate) fn get(&self, name: &str) -> Option<NamedSnapshot> {
+        self.entries.read().get(name).cloned()
+    }
+
+    /// List all snapshots in a stable order (created_at, then name).
+    pub(crate) fn list(&self) -> Vec<NamedSnapshot> {
+        let mut all: Vec<NamedSnapshot> = self.entries.read().values().cloned().collect();
+        all.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        all
+    }
+
+    /// Remove a snapshot by name.
+    ///
+    /// Returns a `NOT_FOUND`-classed error if the name is absent.
+    pub(crate) fn remove(&self, name: &str) -> Result<()> {
+        {
+            let mut entries = self.entries.write();
+            if entries.remove(name).is_none() {
+                return Err(not_found(name));
+            }
+        }
+        self.save()
+    }
+
+    /// Atomically persist the registry to its sidecar file (temp file +
+    /// rename + parent fsync), mirroring the auth key store. A no-op for
+    /// in-memory-only registries.
+    fn save(&self) -> Result<()> {
+        let Some(path) = &self.persist_path else {
+            return Ok(());
+        };
+        let _guard = self.save_lock.lock();
+
+        let mut snapshots: Vec<NamedSnapshot> = self.entries.read().values().cloned().collect();
+        snapshots.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.name.cmp(&b.name))
+        });
+
+        let serialized = serde_json::to_vec_pretty(&PersistedRegistry {
+            version: PERSIST_FORMAT_VERSION,
+            snapshots,
+        })
+        .map_err(|e| Error::Other(format!("failed to serialize snapshot registry: {e}")))?;
+
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let tmp_path = path.with_extension("tmp");
+        let _ = std::fs::remove_file(&tmp_path);
+        {
+            use std::io::Write as _;
+            let mut options = std::fs::OpenOptions::new();
+            options.write(true).create(true).truncate(true);
+            let mut file = options.open(&tmp_path)?;
+            file.write_all(&serialized)?;
+            file.sync_all()?;
+        }
+        std::fs::rename(&tmp_path, path)?;
+        // Make the rename durable: fsync the parent directory (unix only).
+        #[cfg(unix)]
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::File::open(parent)?.sync_all()?;
+        }
+        Ok(())
+    }
+}
+
+/// Build the sidecar path for a database's snapshot registry, or `None` when
+/// the database is ephemeral (persistence disabled).
+///
+/// The file lives at `{data_dir}/snapshots.json`, alongside the auth store's
+/// `{data_dir}/auth/`. The canonical durable config
+/// ([`crate::config::durable_config_for_data_dir`]) sets
+/// `persistence.data_dir = {data_dir}/indexes`, so the top-level data dir is
+/// that path's parent.
+pub(crate) fn registry_path_for(
+    persistence: &crate::storage::index_persistence::PersistenceConfig,
+) -> Option<PathBuf> {
+    if !persistence.enabled {
+        return None;
+    }
+    let indexes_dir = &persistence.data_dir;
+    let root = indexes_dir
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_else(|| indexes_dir.clone());
+    Some(root.join("snapshots.json"))
+}
+
+/// A read-only, borrowed handle that pins every read to a
+/// [`NamedSnapshot`]'s bi-temporal coordinate (Issue #3370).
+///
+/// All reads delegate to the historical (`*_at_time`) path — never the
+/// current-state hot path — so results are deterministic and reproducible
+/// regardless of concurrent or subsequent writes.
+///
+/// # Adjacency and traversal
+///
+/// [`Snapshot::get_outgoing_edges`] / [`Snapshot::get_incoming_edges`] resolve
+/// adjacency at the pin via the temporal adjacency index. Multi-hop traversal
+/// is available through the pre-pinned [`Snapshot::query`] builder (its
+/// `as_of` context is already set); there is no separate storage-layer
+/// traversal for snapshots.
+pub struct Snapshot<'a> {
+    db: &'a AletheiaDB,
+    snapshot: NamedSnapshot,
+}
+
+impl std::fmt::Debug for Snapshot<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Snapshot")
+            .field("snapshot", &self.snapshot)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> Snapshot<'a> {
+    fn new(db: &'a AletheiaDB, snapshot: NamedSnapshot) -> Self {
+        Self { db, snapshot }
+    }
+
+    /// The pinned snapshot's name.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        self.snapshot.name()
+    }
+
+    /// The pinned valid-time coordinate.
+    #[must_use]
+    pub fn valid_time(&self) -> Timestamp {
+        self.snapshot.valid_time()
+    }
+
+    /// The pinned transaction-time coordinate.
+    #[must_use]
+    pub fn transaction_time(&self) -> Timestamp {
+        self.snapshot.transaction_time()
+    }
+
+    /// The pinned `(valid_time, transaction_time)` coordinate pair.
+    #[must_use]
+    pub fn coordinate(&self) -> (Timestamp, Timestamp) {
+        self.snapshot.coordinate()
+    }
+
+    /// The pinned snapshot's optional description.
+    #[must_use]
+    pub fn description(&self) -> Option<&str> {
+        self.snapshot.description()
+    }
+
+    /// The underlying [`NamedSnapshot`] value.
+    #[must_use]
+    pub fn named(&self) -> &NamedSnapshot {
+        &self.snapshot
+    }
+
+    /// Read a node as it existed at the pinned coordinate.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn get_node(&self, node_id: NodeId) -> Result<Node> {
+        let (vt, tt) = self.snapshot.coordinate();
+        self.db.get_node_at_time(node_id, vt, tt)
+    }
+
+    /// Read an edge as it existed at the pinned coordinate.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn get_edge(&self, edge_id: EdgeId) -> Result<Edge> {
+        let (vt, tt) = self.snapshot.coordinate();
+        self.db.get_edge_at_time(edge_id, vt, tt)
+    }
+
+    /// Find nodes by label as they existed at the pinned coordinate.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn find_nodes(&self, label: &str) -> Result<NodesAtTime> {
+        let (vt, tt) = self.snapshot.coordinate();
+        self.db.find_nodes_at_time(label, vt, tt)
+    }
+
+    /// Find nodes by label and exact property value at the pinned coordinate.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn find_nodes_by_property(
+        &self,
+        label: &str,
+        property_key: &str,
+        property_value: &PropertyValue,
+    ) -> Result<NodesAtTime> {
+        let (vt, tt) = self.snapshot.coordinate();
+        self.db
+            .find_nodes_by_property_at(label, property_key, property_value, vt, tt)
+    }
+
+    /// Outgoing edges from `source` valid at the pinned coordinate.
+    #[must_use]
+    pub fn get_outgoing_edges(&self, source: NodeId) -> Vec<EdgeId> {
+        let (vt, tt) = self.snapshot.coordinate();
+        self.db.get_outgoing_edges_at_time(source, vt, tt)
+    }
+
+    /// Incoming edges to `target` valid at the pinned coordinate.
+    #[must_use]
+    pub fn get_incoming_edges(&self, target: NodeId) -> Vec<EdgeId> {
+        let (vt, tt) = self.snapshot.coordinate();
+        self.db.get_incoming_edges_at_time(target, vt, tt)
+    }
+
+    /// A query builder pre-pinned to the snapshot's coordinate.
+    ///
+    /// The returned builder already has its `as_of(valid_time,
+    /// transaction_time)` context set, so multi-hop traversal, filtering, and
+    /// vector ranking all execute at the pin. Executing it reproduces the same
+    /// world every time.
+    #[must_use]
+    pub fn query(&self) -> QueryBuilder<Initial> {
+        let (vt, tt) = self.snapshot.coordinate();
+        self.db.query().as_of(vt, tt)
+    }
+}
+
+/// Reuse [`StorageError::DuplicateId`] for a duplicate snapshot name so the
+/// error maps to the #3234 `CONFLICT` code (and is non-retriable) when the
+/// MCP surface is added later. The name is carried in the `id` field.
+fn conflict(name: &str) -> Error {
+    Error::Storage(crate::core::error::StorageError::DuplicateId {
+        id: name.to_string(),
+        kind: "snapshot".to_string(),
+    })
+}
+
+/// Reuse [`StorageError::PropertyNotFound`] (a string-carrying storage
+/// not-found) for a missing snapshot name so the error maps to the #3234
+/// `NOT_FOUND` code. The name is embedded in the message ("the details").
+///
+/// There is no dedicated string-based not-found variant on the top-level
+/// `Error` enum that maps to `NOT_FOUND`, and adding one would require editing
+/// the (exhaustive) MCP error classifier — out of scope for this Rust-only
+/// wave — so we reuse the closest existing variant.
+fn not_found(name: &str) -> Error {
+    Error::Storage(crate::core::error::StorageError::PropertyNotFound(format!(
+        "snapshot '{name}'"
+    )))
+}
+
+impl AletheiaDB {
+    /// Create a named snapshot pinned to the database's current commit frontier
+    /// (Issue #3370).
+    ///
+    /// Both temporal dimensions default to the value under `current_timestamp`
+    /// (the authoritative, monotonically advancing commit clock), so the
+    /// snapshot sees exactly the state committed at creation and nothing
+    /// after: every already-committed transaction is visible and every future
+    /// commit is not. See the [module docs](crate::db::snapshot) for the
+    /// determinism argument and the future-valid caveat.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `CONFLICT`-classed error if `name` is already registered.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn create_snapshot(
+        &self,
+        name: impl Into<String>,
+        description: Option<String>,
+    ) -> Result<NamedSnapshot> {
+        // Capture the commit frontier under its own lock (lock class 1) and
+        // release immediately — we hold no later-class lock, so the ordering
+        // contract is preserved. The commit path advances this value strictly
+        // monotonically under the same lock, which is what makes the pin
+        // deterministic (future commits are strictly greater, hence invisible).
+        let frontier = {
+            let ts = self.current_timestamp.lock().map_err(|_| {
+                Error::from(crate::core::error::TransactionError::LockPoisoned {
+                    resource: "current_timestamp".to_string(),
+                })
+            })?;
+            *ts
+        };
+        self.create_snapshot_at(name, frontier, frontier, description)
+    }
+
+    /// Create a named snapshot pinned to an explicit bi-temporal coordinate
+    /// (Issue #3370).
+    ///
+    /// Unlike [`create_snapshot`](Self::create_snapshot), the caller supplies
+    /// the `(valid_time, transaction_time)` coordinate directly. Backdated
+    /// coordinates are permitted and are **not** rejected for falling outside
+    /// the current temporal extent — the coordinate is stored as given, and a
+    /// coordinate before any recorded history simply resolves to an empty
+    /// world.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `CONFLICT`-classed error if `name` is already registered.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn create_snapshot_at(
+        &self,
+        name: impl Into<String>,
+        valid_time: Timestamp,
+        transaction_time: Timestamp,
+        description: Option<String>,
+    ) -> Result<NamedSnapshot> {
+        let snapshot = NamedSnapshot {
+            name: name.into(),
+            valid_time,
+            transaction_time,
+            created_at: crate::core::temporal::time::now(),
+            description,
+        };
+        self.snapshots.insert(snapshot.clone())?;
+        Ok(snapshot)
+    }
+
+    /// Resolve a named snapshot to a borrowed, read-only [`Snapshot`] handle.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `NOT_FOUND`-classed error (with `name` in the message) if no
+    /// snapshot with that name is registered.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn snapshot(&self, name: &str) -> Result<Snapshot<'_>> {
+        let snapshot = self.snapshots.get(name).ok_or_else(|| not_found(name))?;
+        Ok(Snapshot::new(self, snapshot))
+    }
+
+    /// Fetch a named snapshot's coordinate/metadata without a borrowed handle.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `NOT_FOUND`-classed error (with `name` in the message) if
+    /// absent.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn get_snapshot(&self, name: &str) -> Result<NamedSnapshot> {
+        self.snapshots.get(name).ok_or_else(|| not_found(name))
+    }
+
+    /// List all registered snapshots in a stable order (creation time, then
+    /// name).
+    #[must_use]
+    pub fn list_snapshots(&self) -> Vec<NamedSnapshot> {
+        self.snapshots.list()
+    }
+
+    /// Delete a named snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `NOT_FOUND`-classed error (with `name` in the message) if no
+    /// snapshot with that name is registered.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn delete_snapshot(&self, name: &str) -> Result<()> {
+        self.snapshots.remove(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_path_is_none_when_persistence_disabled() {
+        let cfg = crate::storage::index_persistence::PersistenceConfig::default();
+        assert!(!cfg.enabled);
+        assert_eq!(registry_path_for(&cfg), None);
+    }
+
+    #[test]
+    fn registry_path_is_data_dir_sibling_of_indexes() {
+        let cfg = crate::storage::index_persistence::PersistenceConfig {
+            enabled: true,
+            data_dir: PathBuf::from("/var/lib/aletheia/indexes"),
+            ..Default::default()
+        };
+        assert_eq!(
+            registry_path_for(&cfg),
+            Some(PathBuf::from("/var/lib/aletheia/snapshots.json"))
+        );
+    }
+
+    #[test]
+    fn in_memory_registry_insert_get_conflict_remove() {
+        let reg = SnapshotRegistry::in_memory();
+        let snap = NamedSnapshot {
+            name: "run1".to_string(),
+            valid_time: Timestamp::from(1000),
+            transaction_time: Timestamp::from(1000),
+            created_at: Timestamp::from(1000),
+            description: Some("first".to_string()),
+        };
+        reg.insert(snap.clone()).unwrap();
+        assert_eq!(reg.get("run1"), Some(snap.clone()));
+
+        // Duplicate -> CONFLICT (DuplicateId).
+        let err = reg.insert(snap).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::Storage(crate::core::error::StorageError::DuplicateId { .. })
+        ));
+
+        // Remove -> gone; second remove -> NOT_FOUND.
+        reg.remove("run1").unwrap();
+        assert_eq!(reg.get("run1"), None);
+        let err = reg.remove("run1").unwrap_err();
+        assert!(matches!(
+            err,
+            Error::Storage(crate::core::error::StorageError::PropertyNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn named_snapshot_serde_round_trips_as_micros() {
+        let snap = NamedSnapshot {
+            name: "s".to_string(),
+            valid_time: Timestamp::from(111),
+            transaction_time: Timestamp::from(222),
+            created_at: Timestamp::from(333),
+            description: None,
+        };
+        let json = serde_json::to_string(&snap).unwrap();
+        // Timestamps serialize as bare integer micros, not nested objects.
+        assert!(json.contains("\"valid_time\":111"), "json was {json}");
+        assert!(json.contains("\"transaction_time\":222"), "json was {json}");
+        let back: NamedSnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, snap);
+    }
+}

--- a/tests/snapshot_pin.rs
+++ b/tests/snapshot_pin.rs
@@ -9,8 +9,15 @@ use aletheiadb::core::graph::{Edge, Node};
 use aletheiadb::core::id::{EdgeId, NodeId};
 use aletheiadb::core::temporal::time;
 use aletheiadb::db::snapshot::Snapshot;
-use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+use aletheiadb::{AletheiaDB, PropertyMapBuilder, WriteOps};
 use serde_json::json;
+
+/// The canonical durable config places the snapshot sidecar inside the index
+/// persistence dir: `{data_dir}/indexes/snapshots.json` (Issue #3370, review
+/// M6 — never a sibling written outside the data dir).
+fn sidecar_path(data_dir: &std::path::Path) -> std::path::PathBuf {
+    data_dir.join("indexes").join("snapshots.json")
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -454,8 +461,13 @@ fn snapshot_survives_restart() {
         (snap.coordinate(), node_id)
     };
 
-    // A sidecar file was actually written.
-    assert!(dir.path().join("snapshots.json").exists(), "sidecar exists");
+    // A sidecar file was actually written (inside the data dir, M6).
+    assert!(sidecar_path(dir.path()).exists(), "sidecar exists");
+    // And nothing was written OUTSIDE the data dir as a sibling.
+    assert!(
+        !dir.path().join("snapshots.json").exists(),
+        "no sibling sidecar outside the data dir"
+    );
 
     // Reopen the same directory.
     let db = AletheiaDB::open(dir.path()).unwrap();
@@ -502,25 +514,28 @@ fn persisted_registry_file_is_valid_json_shape() {
         db.create_snapshot("s2", None).unwrap();
     }
 
-    let path = dir.path().join("snapshots.json");
+    let path = sidecar_path(dir.path());
     let contents = std::fs::read_to_string(&path).unwrap();
     let value: serde_json::Value = serde_json::from_str(&contents).unwrap();
 
-    assert_eq!(value["version"], 1);
+    // v2 persists the full HLC (wallclock + logical), not bare micros (M1).
+    assert_eq!(value["version"], 2);
     let arr = value["snapshots"].as_array().unwrap();
     assert_eq!(arr.len(), 2);
-    // Timestamps are bare integer micros (mirrors the #3360 cursor).
-    assert!(arr[0]["valid_time"].is_i64(), "valid_time is i64 micros");
-    assert!(arr[0]["transaction_time"].is_i64());
-    assert!(arr[0]["created_at"].is_i64());
+    // Timestamps are {wallclock, logical} objects (lossless HLC).
+    assert!(
+        arr[0]["valid_time"].is_object(),
+        "valid_time is a {{wallclock, logical}} object"
+    );
+    assert!(arr[0]["valid_time"]["wallclock"].is_i64());
+    assert!(arr[0]["valid_time"]["logical"].is_u64());
+    assert!(arr[0]["transaction_time"]["wallclock"].is_i64());
+    assert!(arr[0]["created_at"]["wallclock"].is_i64());
     let names: Vec<&str> = arr.iter().map(|e| e["name"].as_str().unwrap()).collect();
     assert!(names.contains(&"s1") && names.contains(&"s2"));
 
     // No leftover temp file after the atomic rename.
-    assert!(
-        !dir.path().join("snapshots.tmp").exists(),
-        "no stale temp file"
-    );
+    assert!(!path.with_extension("tmp").exists(), "no stale temp file");
 }
 
 #[test]
@@ -592,4 +607,331 @@ fn pinned_adjacency_reflects_the_coordinate() {
     assert_eq!(out, vec![e], "only the pre-pin outgoing edge at the pin");
     let inc = handle.get_incoming_edges(b);
     assert_eq!(inc, vec![e], "pre-pin incoming edge at the pin");
+}
+
+// ---------------------------------------------------------------------------
+// M3. Retraction AFTER the pin of a PRE-pin tracked entity must not disturb it
+// ---------------------------------------------------------------------------
+
+#[test]
+fn retraction_after_pin_preserves_pre_pin_tracked_entity() {
+    let db = AletheiaDB::new().unwrap();
+    // Seed n1 (+ edge e1 to n2) BEFORE the pin so they are genuinely in the
+    // tracked read set (the review noted the determinism loop only retracted a
+    // throwaway node created AFTER the pin, which proves nothing).
+    let n1 = db.create_node("Person", person("Alice", 30)).unwrap();
+    let n2 = db.create_node("Person", person("Bob", 40)).unwrap();
+    let e1 = db
+        .create_edge(
+            n1,
+            n2,
+            "KNOWS",
+            PropertyMapBuilder::new().insert("since", 2020).build(),
+        )
+        .unwrap();
+
+    // Pin now — after seeding, before any retraction.
+    db.create_snapshot("pre", None).unwrap();
+    let handle = db.snapshot("pre").unwrap();
+
+    let n1_before = handle.get_node(n1).unwrap();
+    let persons_before = handle.find_nodes("Person").unwrap().nodes.len();
+    assert_eq!(persons_before, 2);
+
+    // Retract n1 (detach co-retracts the connected edge e1) AFTER the pin.
+    let res = db.retract_node_detach(n1, time::now()).unwrap();
+    assert_eq!(res.edges_retracted, 1, "e1 co-retracted with n1");
+
+    // The pin STILL returns n1's pre-retraction version, byte-identical.
+    let n1_after = handle.get_node(n1).unwrap();
+    assert_eq!(
+        n1_after.properties, n1_before.properties,
+        "pinned n1 unchanged by post-pin retraction"
+    );
+    assert_eq!(
+        n1_after.properties.get("name").and_then(|v| v.as_str()),
+        Some("Alice")
+    );
+
+    // find_nodes count unchanged through the pin, and e1 still visible.
+    assert_eq!(
+        handle.find_nodes("Person").unwrap().nodes.len(),
+        persons_before,
+        "find count unchanged through the pin after retraction"
+    );
+    assert!(
+        handle.get_edge(e1).is_ok(),
+        "co-retracted edge still visible at the pin"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// m8. The pre-pinned Snapshot::query() builder traverses AS OF the pin (AC4)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pinned_query_builder_traverses_at_the_coordinate() {
+    use aletheiadb::query::QueryBuilder;
+
+    let db = AletheiaDB::new().unwrap();
+    let a = db.create_node("Person", person("A", 1)).unwrap();
+    let b = db.create_node("Person", person("B", 2)).unwrap();
+    db.create_edge(a, b, "KNOWS", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    db.create_snapshot("q", None).unwrap();
+
+    // A post-pin edge to a fresh node C (must be excluded by the pinned query).
+    let c = db.create_node("Person", person("C", 3)).unwrap();
+    db.create_edge(a, c, "KNOWS", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    let handle = db.snapshot("q").unwrap();
+    // The builder returned by handle.query() is already `as_of(pin)`.
+    let builder: QueryBuilder<_> = handle.query();
+    let nodes = builder
+        .start(a)
+        .traverse("KNOWS")
+        .execute(&db)
+        .unwrap()
+        .collect_nodes()
+        .unwrap();
+    let ids: Vec<NodeId> = nodes.iter().map(|n| n.id).collect();
+    assert!(
+        ids.contains(&b),
+        "pinned traversal reaches the pre-pin neighbor B, got {ids:?}"
+    );
+    assert!(
+        !ids.contains(&c),
+        "pinned traversal excludes the post-pin neighbor C, got {ids:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// m9. Future-valid exclusion by a default (valid=now) snapshot; included when
+//     pinned to the future valid coord (ties to M2: default valid = now())
+// ---------------------------------------------------------------------------
+
+#[test]
+fn future_valid_fact_excluded_by_default_snapshot_included_when_pinned_to_future() {
+    let db = AletheiaDB::new().unwrap();
+    let now = time::now();
+    // A fact that only becomes valid 10s in the future.
+    let future: aletheiadb::core::temporal::Timestamp = (now.wallclock() + 10_000_000).into();
+    let fnode = db
+        .create_node_with_valid_time("Person", person("Future", 1), Some(future))
+        .unwrap();
+
+    // Default snapshot pins valid-time = wallclock-now (M2), so the future-dated
+    // fact is invisible through it.
+    db.create_snapshot("now", None).unwrap();
+    let now_handle = db.snapshot("now").unwrap();
+    assert!(
+        now_handle.get_node(fnode).is_err(),
+        "future-valid fact excluded by the default (valid=now) snapshot"
+    );
+    assert!(
+        now_handle
+            .find_nodes("Person")
+            .unwrap()
+            .nodes
+            .iter()
+            .all(|n| n.id != fnode),
+        "future-valid fact not in find_nodes at the default pin"
+    );
+
+    // A snapshot pinned to the fact's future valid coordinate DOES see it.
+    let tt = db.get_snapshot("now").unwrap().transaction_time();
+    db.create_snapshot_at("fut", future, tt, None).unwrap();
+    let fut_handle = db.snapshot("fut").unwrap();
+    assert!(
+        fut_handle.get_node(fnode).is_ok(),
+        "future-valid fact visible when the snapshot valid coord is the future"
+    );
+    assert_eq!(
+        fut_handle
+            .get_node(fnode)
+            .unwrap()
+            .properties
+            .get("name")
+            .and_then(|v| v.as_str()),
+        Some("Future")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// m7. Multithreaded determinism: a writer thread mutates the graph while the
+//     main thread repeatedly reads through the handle; every read batch must be
+//     byte-identical to the pre-write fingerprint.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn determinism_under_concurrent_writer() {
+    let db = AletheiaDB::new().unwrap();
+
+    let n1 = db.create_node("Person", person("Alice", 30)).unwrap();
+    let n2 = db.create_node("Person", person("Bob", 40)).unwrap();
+    let e1 = db
+        .create_edge(
+            n1,
+            n2,
+            "KNOWS",
+            PropertyMapBuilder::new().insert("since", 2020).build(),
+        )
+        .unwrap();
+
+    // Create the snapshot FIRST, before spawning the writer, so creation does
+    // not race a commit (this keeps the test deterministic and sidesteps the
+    // known committed-but-not-yet-applied visibility window).
+    db.create_snapshot("mt", None).unwrap();
+
+    let labels = ["Person", "Other"];
+    let fingerprint = {
+        let handle = db.snapshot("mt").unwrap();
+        read_batch(&handle, &[n1, n2], &[e1], &labels)
+    };
+
+    std::thread::scope(|scope| {
+        // Writer thread: many create/update/delete ops against the live db.
+        scope.spawn(|| {
+            for i in 0..300 {
+                match i % 4 {
+                    0 => {
+                        db.create_node("Person", person(&format!("W{i}"), i as i64))
+                            .unwrap();
+                    }
+                    1 => {
+                        db.update_node_with_valid_time(n1, person("Mutated", 99), None)
+                            .unwrap();
+                    }
+                    2 => {
+                        let tmp = db
+                            .create_node("Other", person(&format!("T{i}"), 1))
+                            .unwrap();
+                        db.delete_node_with_valid_time(tmp, None).unwrap();
+                    }
+                    _ => {
+                        let a = db
+                            .create_node("Other", person(&format!("A{i}"), 1))
+                            .unwrap();
+                        let b = db
+                            .create_node("Other", person(&format!("B{i}"), 2))
+                            .unwrap();
+                        db.create_edge(a, b, "LINK", PropertyMapBuilder::new().build())
+                            .unwrap();
+                    }
+                }
+            }
+        });
+
+        // Reader: hammer the handle; every batch must match the pre-write value.
+        let handle = db.snapshot("mt").unwrap();
+        for _ in 0..500 {
+            let batch = read_batch(&handle, &[n1, n2], &[e1], &labels);
+            assert_eq!(
+                batch, fingerprint,
+                "snapshot read diverged under a concurrent writer"
+            );
+        }
+    });
+
+    // A final read after all writes are joined must still match.
+    let handle = db.snapshot("mt").unwrap();
+    assert_eq!(
+        read_batch(&handle, &[n1, n2], &[e1], &labels),
+        fingerprint,
+        "snapshot read diverged after the writer finished"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// M1. Same-microsecond supersession must resolve the correct version AFTER a
+//     restart: the pin's HLC logical counter must round-trip through the
+//     sidecar. With the logical counter dropped, the pin at (W, L2) collapses
+//     to (W, 0) and resolves the WRONG (superseded / absent) version.
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "simulation")]
+#[test]
+fn snapshot_resolves_correct_version_across_restart_same_microsecond() {
+    use aletheiadb::simulation::SimulatedClock;
+
+    let dir = tempfile::tempdir().unwrap();
+
+    // Freeze the clock so both commits land in ONE wallclock microsecond and
+    // differ only in their HLC logical counter.
+    let clock = SimulatedClock::new(1_700_000_000_000_000);
+
+    let (node_id, vt2, tt2) = {
+        let _guard = clock.inject();
+        let db = AletheiaDB::open(dir.path()).unwrap();
+
+        // v1
+        let node_id = {
+            let mut tx = db.write_transaction().unwrap();
+            let id = tx.create_node("Person", person("V1", 1)).unwrap();
+            tx.commit_with_timestamp().unwrap();
+            id
+        };
+        // v2 supersedes v1 in the SAME frozen microsecond.
+        let ts2 = {
+            let mut tx = db.write_transaction().unwrap();
+            tx.update_node(node_id, person("V2", 2)).unwrap();
+            tx.commit_with_timestamp().unwrap()
+        };
+        assert!(
+            ts2.logical() > 0,
+            "v2 tx-time must carry a nonzero logical counter, got {ts2:?}"
+        );
+
+        // Pin exactly at v2's bi-temporal coordinate.
+        let snap = db.create_snapshot_at("pin", ts2, ts2, None).unwrap();
+
+        // BEFORE restart: the handle resolves v2.
+        let handle = db.snapshot("pin").unwrap();
+        assert_eq!(
+            handle
+                .get_node(node_id)
+                .unwrap()
+                .properties
+                .get("name")
+                .and_then(|v| v.as_str()),
+            Some("V2"),
+            "pre-restart handle resolves v2"
+        );
+        (node_id, snap.valid_time(), snap.transaction_time())
+    };
+
+    assert!(tt2.logical() > 0, "pinned tx-time has a nonzero logical");
+
+    // Reopen from the same data dir (clock guard dropped — reads use the pinned
+    // coordinate, not wallclock now).
+    let db = AletheiaDB::open(dir.path()).unwrap();
+
+    // The FULL HLC coordinate survives the sidecar round-trip.
+    let reloaded = db.get_snapshot("pin").unwrap();
+    assert_eq!(
+        reloaded.transaction_time(),
+        tt2,
+        "tx-time logical counter survives restart"
+    );
+    assert_eq!(
+        reloaded.valid_time(),
+        vt2,
+        "valid-time logical counter survives restart"
+    );
+
+    // AND a read through the reopened handle STILL returns v2 — not the
+    // superseded v1, not absent (which is what a collapsed (W,0) pin yields).
+    let handle = db.snapshot("pin").unwrap();
+    assert_eq!(
+        handle
+            .get_node(node_id)
+            .unwrap()
+            .properties
+            .get("name")
+            .and_then(|v| v.as_str()),
+        Some("V2"),
+        "restart resolves v2 via the full-HLC pin, not v1"
+    );
 }

--- a/tests/snapshot_pin.rs
+++ b/tests/snapshot_pin.rs
@@ -1,0 +1,595 @@
+//! Integration tests for named snapshots / reproducible reads (Issue #3370).
+//!
+//! Named snapshots pin a human name to a bi-temporal coordinate; reads through
+//! the resulting handle are deterministic and reproducible regardless of any
+//! writes that land afterward.
+
+use aletheiadb::core::error::Error;
+use aletheiadb::core::graph::{Edge, Node};
+use aletheiadb::core::id::{EdgeId, NodeId};
+use aletheiadb::core::temporal::time;
+use aletheiadb::db::snapshot::Snapshot;
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+use serde_json::json;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn person(name: &str, age: i64) -> aletheiadb::core::PropertyMap {
+    PropertyMapBuilder::new()
+        .insert("name", name)
+        .insert("age", age)
+        .build()
+}
+
+/// Canonical, stable JSON for a node (property order normalized).
+fn node_json(n: &Node) -> serde_json::Value {
+    let mut props: Vec<(String, String)> = n
+        .properties
+        .iter()
+        .map(|(k, v)| (format!("{k:?}"), format!("{v:?}")))
+        .collect();
+    props.sort();
+    json!({
+        "id": format!("{}", n.id),
+        "label": format!("{}", n.label),
+        "props": props,
+    })
+}
+
+/// Canonical, stable JSON for an edge.
+fn edge_json(e: &Edge) -> serde_json::Value {
+    let mut props: Vec<(String, String)> = e
+        .properties
+        .iter()
+        .map(|(k, v)| (format!("{k:?}"), format!("{v:?}")))
+        .collect();
+    props.sort();
+    json!({
+        "id": format!("{}", e.id),
+        "source": format!("{}", e.source),
+        "target": format!("{}", e.target),
+        "label": format!("{}", e.label),
+        "props": props,
+    })
+}
+
+/// Serialize a batch of reads through the snapshot handle to a byte-stable
+/// string. This is the reproducibility fingerprint the determinism test
+/// compares across arbitrary interleaved writes.
+fn read_batch(s: &Snapshot, node_ids: &[NodeId], edge_ids: &[EdgeId], labels: &[&str]) -> String {
+    let mut nodes = serde_json::Map::new();
+    for id in node_ids {
+        let v = match s.get_node(*id) {
+            Ok(n) => node_json(&n),
+            Err(_) => json!("absent"),
+        };
+        nodes.insert(format!("{id}"), v);
+    }
+
+    let mut edges = serde_json::Map::new();
+    for id in edge_ids {
+        let v = match s.get_edge(*id) {
+            Ok(e) => edge_json(&e),
+            Err(_) => json!("absent"),
+        };
+        edges.insert(format!("{id}"), v);
+    }
+
+    let mut finds = serde_json::Map::new();
+    for label in labels {
+        let result = s.find_nodes(label).expect("find_nodes should not error");
+        let arr: Vec<serde_json::Value> = result.nodes.iter().map(node_json).collect();
+        finds.insert(
+            (*label).to_string(),
+            json!({ "sampled": result.sampled, "nodes": arr }),
+        );
+    }
+
+    serde_json::to_string(&json!({
+        "nodes": nodes,
+        "edges": edges,
+        "finds": finds,
+    }))
+    .expect("serialization must succeed")
+}
+
+// ---------------------------------------------------------------------------
+// 1. create default -> both coords ~= now; a read through the handle works
+// ---------------------------------------------------------------------------
+
+#[test]
+fn create_default_snapshot_reflects_committed_state() {
+    let db = AletheiaDB::new().unwrap();
+    let before = time::now().wallclock();
+    let alice = db.create_node("Person", person("Alice", 30)).unwrap();
+
+    let snap = db
+        .create_snapshot("now", Some("default coord".to_string()))
+        .unwrap();
+    let after = time::now().wallclock();
+
+    // Both coordinates land within [before, after].
+    let (vt, tt) = snap.coordinate();
+    assert!(
+        vt.wallclock() >= before && vt.wallclock() <= after,
+        "vt in range"
+    );
+    assert!(
+        tt.wallclock() >= before && tt.wallclock() <= after,
+        "tt in range"
+    );
+    assert_eq!(snap.description(), Some("default coord"));
+
+    // A read through the handle returns the node.
+    let handle = db.snapshot("now").unwrap();
+    let node = handle.get_node(alice).unwrap();
+    assert_eq!(
+        node.properties.get("name").and_then(|v| v.as_str()),
+        Some("Alice")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. explicit backdated coords within extent -> handle reflects that world
+// ---------------------------------------------------------------------------
+
+#[test]
+fn create_snapshot_at_explicit_backdated_coord() {
+    let db = AletheiaDB::new().unwrap();
+    let alice = db.create_node("Person", person("Alice", 30)).unwrap();
+
+    // Capture the world-with-only-Alice via a default snapshot.
+    let world_a = db.create_snapshot("world_a", None).unwrap();
+    let (vt_a, tt_a) = world_a.coordinate();
+
+    // Now add Bob.
+    let bob = db.create_node("Person", person("Bob", 40)).unwrap();
+
+    // A backdated snapshot pinned to Alice-only coords must NOT see Bob.
+    let back = db
+        .create_snapshot_at(
+            "backdated",
+            vt_a,
+            tt_a,
+            Some("as of Alice-only".to_string()),
+        )
+        .unwrap();
+    let handle = db.snapshot(back.name()).unwrap();
+
+    assert!(
+        handle.get_node(alice).is_ok(),
+        "Alice visible at backdated pin"
+    );
+    assert!(
+        handle.get_node(bob).is_err(),
+        "Bob invisible at backdated pin"
+    );
+
+    let persons = handle.find_nodes("Person").unwrap();
+    assert_eq!(persons.nodes.len(), 1, "only Alice at backdated pin");
+}
+
+// ---------------------------------------------------------------------------
+// 3. duplicate name -> CONFLICT structured error
+// ---------------------------------------------------------------------------
+
+#[test]
+fn duplicate_name_is_conflict() {
+    let db = AletheiaDB::new().unwrap();
+    db.create_node("Person", person("Alice", 30)).unwrap();
+    db.create_snapshot("dup", None).unwrap();
+
+    let err = db.create_snapshot("dup", None).unwrap_err();
+    // Reuses StorageError::DuplicateId, which maps to the #3234 CONFLICT code.
+    match err {
+        Error::Storage(aletheiadb::core::error::StorageError::DuplicateId { ref id, ref kind }) => {
+            assert_eq!(id, "dup");
+            assert_eq!(kind, "snapshot");
+        }
+        other => panic!("expected DuplicateId conflict, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 4. list returns name/coord/created_at/description in stable order
+// ---------------------------------------------------------------------------
+
+#[test]
+fn list_returns_metadata_in_stable_order() {
+    let db = AletheiaDB::new().unwrap();
+    db.create_node("Person", person("Alice", 30)).unwrap();
+
+    // Explicit created-at ordering via distinct coordinates + names.
+    let s_a = db
+        .create_snapshot_at("a", time::now(), time::now(), Some("first".into()))
+        .unwrap();
+    let s_b = db
+        .create_snapshot_at("b", time::now(), time::now(), None)
+        .unwrap();
+    let s_c = db
+        .create_snapshot_at("c", time::now(), time::now(), Some("third".into()))
+        .unwrap();
+
+    let list = db.list_snapshots();
+    assert_eq!(list.len(), 3);
+
+    // Stable order: created_at, then name. All fields are present.
+    let names: Vec<&str> = list.iter().map(|s| s.name()).collect();
+    assert_eq!(names, vec!["a", "b", "c"]);
+    assert_eq!(list[0].description(), Some("first"));
+    assert_eq!(list[1].description(), None);
+    assert_eq!(list[2].description(), Some("third"));
+    assert_eq!(list[0].coordinate(), s_a.coordinate());
+    assert_eq!(list[1].coordinate(), s_b.coordinate());
+    assert_eq!(list[2].coordinate(), s_c.coordinate());
+    // created_at is populated and monotonic non-decreasing.
+    assert!(list[0].created_at().wallclock() <= list[2].created_at().wallclock());
+
+    // Listing is repeatable (same order every call).
+    let names2: Vec<String> = db
+        .list_snapshots()
+        .iter()
+        .map(|s| s.name().to_string())
+        .collect();
+    assert_eq!(names2, vec!["a", "b", "c"]);
+}
+
+// ---------------------------------------------------------------------------
+// 5. delete removes it; subsequent resolve -> NOT_FOUND with name in details
+// ---------------------------------------------------------------------------
+
+#[test]
+fn delete_removes_and_resolve_is_not_found() {
+    let db = AletheiaDB::new().unwrap();
+    db.create_node("Person", person("Alice", 30)).unwrap();
+    db.create_snapshot("temp", None).unwrap();
+
+    db.delete_snapshot("temp").unwrap();
+
+    // snapshot(name) -> NOT_FOUND, name in message.
+    let err = db.snapshot("temp").unwrap_err();
+    assert_not_found_with_name(&err, "temp");
+
+    // get_snapshot -> NOT_FOUND, name in message.
+    let err = db.get_snapshot("temp").unwrap_err();
+    assert_not_found_with_name(&err, "temp");
+
+    // second delete -> NOT_FOUND.
+    let err = db.delete_snapshot("temp").unwrap_err();
+    assert_not_found_with_name(&err, "temp");
+}
+
+// ---------------------------------------------------------------------------
+// 6. resolve nonexistent -> NOT_FOUND with name in details
+// ---------------------------------------------------------------------------
+
+#[test]
+fn resolve_nonexistent_is_not_found() {
+    let db = AletheiaDB::new().unwrap();
+    let err = db.snapshot("nope").unwrap_err();
+    assert_not_found_with_name(&err, "nope");
+    let err = db.get_snapshot("nope").unwrap_err();
+    assert_not_found_with_name(&err, "nope");
+}
+
+fn assert_not_found_with_name(err: &Error, name: &str) {
+    // Reuses StorageError::PropertyNotFound, which maps to the #3234 NOT_FOUND
+    // code; the name is carried in the message ("the details").
+    match err {
+        Error::Storage(aletheiadb::core::error::StorageError::PropertyNotFound(msg)) => {
+            assert!(msg.contains(name), "name '{name}' missing from '{msg}'");
+        }
+        other => panic!("expected NOT_FOUND (PropertyNotFound) for '{name}', got {other:?}"),
+    }
+    // And the Display carries the name too.
+    assert!(
+        err.to_string().contains(name),
+        "Display should contain the name"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 7. DETERMINISM CORE (the falsifiable AC)
+// ---------------------------------------------------------------------------
+
+fn run_determinism(iterations: usize) {
+    let db = AletheiaDB::new().unwrap();
+
+    // Seed a small graph.
+    let n1 = db.create_node("Person", person("Alice", 30)).unwrap();
+    let n2 = db.create_node("Person", person("Bob", 40)).unwrap();
+    let e1 = db
+        .create_edge(
+            n1,
+            n2,
+            "KNOWS",
+            PropertyMapBuilder::new().insert("since", 2020).build(),
+        )
+        .unwrap();
+
+    let s = db.create_snapshot("run1", None).unwrap();
+    let handle = db.snapshot("run1").unwrap();
+
+    let labels = ["Person", "Other"];
+    let r0 = read_batch(&handle, &[n1, n2], &[e1], &labels);
+
+    // Interleave arbitrary writes; the snapshot reads must never budge.
+    let mut n2_deleted = false;
+    let mut n1_updated = false;
+    for i in 0..iterations {
+        match i % 7 {
+            0 => {
+                // create a node that appears after the pin (must stay invisible)
+                db.create_node("Person", person(&format!("New{i}"), i as i64))
+                    .unwrap();
+            }
+            1 => {
+                // update n1 after the pin (pin must keep the old version)
+                db.update_node_with_valid_time(n1, person("AliceChanged", 99), None)
+                    .unwrap();
+                n1_updated = true;
+            }
+            2 => {
+                // create then update a throwaway edge (exercise the edge
+                // write/update path without touching the pinned e1, whose
+                // endpoint n2 may already be deleted below)
+                let a = db
+                    .create_node("Other", person(&format!("Ea{i}"), 1))
+                    .unwrap();
+                let b = db
+                    .create_node("Other", person(&format!("Eb{i}"), 2))
+                    .unwrap();
+                let te = db
+                    .create_edge(
+                        a,
+                        b,
+                        "LINK",
+                        PropertyMapBuilder::new().insert("w", 1).build(),
+                    )
+                    .unwrap();
+                db.update_edge_with_valid_time(
+                    te,
+                    PropertyMapBuilder::new().insert("w", 2 + i as i64).build(),
+                    None,
+                )
+                .unwrap();
+            }
+            3 => {
+                // delete n2 (once) after the pin (pin must keep it visible)
+                if !n2_deleted {
+                    db.delete_node_with_valid_time(n2, None).unwrap();
+                    n2_deleted = true;
+                }
+            }
+            4 => {
+                // create + retract an isolated throwaway node
+                let tmp = db
+                    .create_node("Ghost", person(&format!("G{i}"), 1))
+                    .unwrap();
+                db.retract_node(tmp, time::now()).unwrap();
+            }
+            5 => {
+                // create a throwaway edge between two fresh nodes
+                let a = db
+                    .create_node("Other", person(&format!("A{i}"), 1))
+                    .unwrap();
+                let b = db
+                    .create_node("Other", person(&format!("B{i}"), 2))
+                    .unwrap();
+                db.create_edge(a, b, "LINK", PropertyMapBuilder::new().build())
+                    .unwrap();
+            }
+            _ => {
+                // create + delete a throwaway node
+                let tmp = db
+                    .create_node("Other", person(&format!("T{i}"), 3))
+                    .unwrap();
+                db.delete_node_with_valid_time(tmp, None).unwrap();
+            }
+        }
+
+        let ri = read_batch(&handle, &[n1, n2], &[e1], &labels);
+        assert_eq!(ri, r0, "snapshot reads diverged at iteration {i}");
+    }
+
+    // We really exercised the three required scenarios.
+    assert!(n1_updated, "n1 was updated after the pin");
+    assert!(n2_deleted, "n2 was deleted after the pin");
+
+    // Explicitly: a node created after the pin is invisible through it.
+    let post = db.create_node("Person", person("AfterPin", 1)).unwrap();
+    assert!(handle.get_node(post).is_err(), "post-pin node invisible");
+    let persons = handle.find_nodes("Person").unwrap();
+    assert_eq!(
+        persons.nodes.len(),
+        2,
+        "only the two pre-pin Persons at the pin"
+    );
+
+    // A node updated after the pin reads as-of the pin (original value).
+    let alice_at_pin = handle.get_node(n1).unwrap();
+    assert_eq!(
+        alice_at_pin.properties.get("name").and_then(|v| v.as_str()),
+        Some("Alice")
+    );
+
+    // A node deleted after the pin is still visible through the pin.
+    assert!(
+        handle.get_node(n2).is_ok(),
+        "deleted node still visible at the pin"
+    );
+
+    // The coordinate is what we claim.
+    let (vt, tt) = s.coordinate();
+    assert_eq!(handle.valid_time(), vt);
+    assert_eq!(handle.transaction_time(), tt);
+}
+
+#[test]
+fn determinism_core_60_iterations() {
+    run_determinism(60);
+}
+
+#[test]
+fn determinism_heavy_1000_iterations() {
+    run_determinism(1000);
+}
+
+// ---------------------------------------------------------------------------
+// 8. Restart durability
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_survives_restart() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let (coord, node_id) = {
+        let db = AletheiaDB::open(dir.path()).unwrap();
+        let node_id = db.create_node("Person", person("Alice", 30)).unwrap();
+        let snap = db
+            .create_snapshot("persisted", Some("across restart".to_string()))
+            .unwrap();
+        (snap.coordinate(), node_id)
+    };
+
+    // A sidecar file was actually written.
+    assert!(dir.path().join("snapshots.json").exists(), "sidecar exists");
+
+    // Reopen the same directory.
+    let db = AletheiaDB::open(dir.path()).unwrap();
+    let reloaded = db.get_snapshot("persisted").unwrap();
+    assert_eq!(reloaded.coordinate(), coord, "coordinate survives restart");
+    assert_eq!(reloaded.description(), Some("across restart"));
+
+    // Reads through the reopened snapshot still work (history is available).
+    let handle = db.snapshot("persisted").unwrap();
+    let node = handle.get_node(node_id).unwrap();
+    assert_eq!(
+        node.properties.get("name").and_then(|v| v.as_str()),
+        Some("Alice")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 9. Registry persistence is atomic; ephemeral new() keeps it in-memory
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ephemeral_db_writes_no_sidecar_but_resolves_in_process() {
+    let db = AletheiaDB::new().unwrap();
+    db.create_node("Person", person("Alice", 30)).unwrap();
+    let snap = db.create_snapshot("mem", None).unwrap();
+
+    // Resolves within the process.
+    assert_eq!(
+        db.get_snapshot("mem").unwrap().coordinate(),
+        snap.coordinate()
+    );
+    // But nothing was persisted anywhere reachable (ephemeral tempdir has no
+    // snapshots.json at its root; there is no configured data dir).
+    assert_eq!(db.list_snapshots().len(), 1);
+}
+
+#[test]
+fn persisted_registry_file_is_valid_json_shape() {
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let db = AletheiaDB::open(dir.path()).unwrap();
+        db.create_node("Person", person("Alice", 30)).unwrap();
+        db.create_snapshot("s1", Some("one".to_string())).unwrap();
+        db.create_snapshot("s2", None).unwrap();
+    }
+
+    let path = dir.path().join("snapshots.json");
+    let contents = std::fs::read_to_string(&path).unwrap();
+    let value: serde_json::Value = serde_json::from_str(&contents).unwrap();
+
+    assert_eq!(value["version"], 1);
+    let arr = value["snapshots"].as_array().unwrap();
+    assert_eq!(arr.len(), 2);
+    // Timestamps are bare integer micros (mirrors the #3360 cursor).
+    assert!(arr[0]["valid_time"].is_i64(), "valid_time is i64 micros");
+    assert!(arr[0]["transaction_time"].is_i64());
+    assert!(arr[0]["created_at"].is_i64());
+    let names: Vec<&str> = arr.iter().map(|e| e["name"].as_str().unwrap()).collect();
+    assert!(names.contains(&"s1") && names.contains(&"s2"));
+
+    // No leftover temp file after the atomic rename.
+    assert!(
+        !dir.path().join("snapshots.tmp").exists(),
+        "no stale temp file"
+    );
+}
+
+#[test]
+fn deletion_persists_across_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let db = AletheiaDB::open(dir.path()).unwrap();
+        db.create_node("Person", person("Alice", 30)).unwrap();
+        db.create_snapshot("keep", None).unwrap();
+        db.create_snapshot("drop", None).unwrap();
+        db.delete_snapshot("drop").unwrap();
+    }
+    let db = AletheiaDB::open(dir.path()).unwrap();
+    assert!(db.get_snapshot("keep").is_ok());
+    assert!(
+        db.get_snapshot("drop").is_err(),
+        "deletion survived restart"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 10. No write-path overhead: creating a snapshot does not change writes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_creation_does_not_disturb_writes() {
+    let db = AletheiaDB::new().unwrap();
+    let n1 = db.create_node("Person", person("Alice", 30)).unwrap();
+
+    // Interleave snapshot creation with writes; ids/counts are unaffected.
+    db.create_snapshot("s0", None).unwrap();
+    let n2 = db.create_node("Person", person("Bob", 40)).unwrap();
+    db.create_snapshot("s1", None).unwrap();
+    let e1 = db
+        .create_edge(n1, n2, "KNOWS", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // The graph is exactly what the writes produced.
+    assert!(db.get_node(n1).is_ok());
+    assert!(db.get_node(n2).is_ok());
+    assert!(db.get_edge(e1).is_ok());
+    assert_ne!(format!("{n1}"), format!("{n2}"));
+}
+
+// ---------------------------------------------------------------------------
+// Pinned adjacency at the snapshot coordinate
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pinned_adjacency_reflects_the_coordinate() {
+    let db = AletheiaDB::new().unwrap();
+    let a = db.create_node("Person", person("A", 1)).unwrap();
+    let b = db.create_node("Person", person("B", 2)).unwrap();
+    let e = db
+        .create_edge(a, b, "KNOWS", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    let handle_name = "adj";
+    db.create_snapshot(handle_name, None).unwrap();
+
+    // Add another edge AFTER the pin.
+    let c = db.create_node("Person", person("C", 3)).unwrap();
+    let _e2 = db
+        .create_edge(a, c, "KNOWS", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    let handle = db.snapshot(handle_name).unwrap();
+    let out = handle.get_outgoing_edges(a);
+    assert_eq!(out, vec![e], "only the pre-pin outgoing edge at the pin");
+    let inc = handle.get_incoming_edges(b);
+    assert_eq!(inc, vec![e], "pre-pin incoming edge at the pin");
+}


### PR DESCRIPTION
**Before/After.** Before, every caller had to carry two raw bi-temporal timestamps and re-supply them on every read; across a multi-step agent run it was easy to mix coordinates (one read at `now`, the next backdated) and silently assemble an answer from two different worlds. After, a caller creates a named snapshot once and pins any sequence of reads to it by name, so every read in a run, eval, or audit replay is deterministic and mutually consistent no matter what writes land concurrently:

```rust
let snap = db.create_snapshot("incident-postmortem", None)?; // pins (valid=now, tx=commit-frontier)
let s = db.snapshot("incident-postmortem")?;
let alice = s.get_node(alice_id)?;          // reads the frozen world
let friends = s.query().start(alice_id).traverse("KNOWS").execute(&db)?;
// arbitrary inserts/updates/deletes/retractions may occur here …
assert_eq!(s.get_node(alice_id)?, alice);   // … the pinned read is unchanged
```

**Scope (this wave is Rust-API-only).** Per the Wave-7 Lane 2 boundary, this PR adds the Rust API only. The MCP `snapshot` parameter on the `as_of_*` read tools and the AQL/Cypher `AS OF SNAPSHOT 'name'` DDL form (issue #3370 ACs 3 and the query-language half of AC 4) are a coordinated Lane 1 follow-up and are documented as deferred, not dropped.

**How.** New `src/db/snapshot.rs`:
- `NamedSnapshot` — a named, frozen `(valid_time, transaction_time)` coordinate plus `created_at` and optional description. Serialized with the FULL HybridTimestamp `{wallclock, logical}` (lossless — dropping the logical counter would let a restart flip a pinned read across a same-microsecond supersession), tolerantly loading the legacy bare-integer form as logical 0.
- `SnapshotRegistry` — durable atomic sidecar at `{persistence.data_dir}/snapshots.json` (temp-write + fsync + rename + parent-dir fsync, mirroring the auth key store), unique-name enforcement, in-memory-only for ephemeral `AletheiaDB::new()`. A corrupt sidecar is quarantined (renamed aside) and the DB opens with an empty registry rather than failing startup (snapshots are non-critical bookmarks, unlike the security-critical key store).
- `Snapshot<'a>` — a borrowed handle whose every read (`get_node`, `get_edge`, `get_outgoing_edges`/`get_incoming_edges`, `find_nodes`/`find_nodes_by_property`, and a pre-pinned `query()` builder) routes ONLY through the deterministic historical `*_at_time` path, never the hot current-state path.
- API on `AletheiaDB`: `create_snapshot` (defaults valid-time = wallclock now, transaction-time = the commit frontier read under the class-1 `current_timestamp` lock — race-safe monotonic), `create_snapshot_at`, `snapshot`, `get_snapshot`, `list_snapshots`, `delete_snapshot`. Errors reuse the existing structured codes (duplicate → CONFLICT, missing → NOT_FOUND with the name).
- No WAL format change. Registry mutation is off the data write path (zero data-write overhead; creating a snapshot touches only the class-1 commit clock for a single Timestamp copy).

**Tests & bench.** 18 integration tests (`tests/snapshot_pin.rs`) + 9 lib tests. Highlights: the falsifiable determinism core (60- and 1000-iteration byte-identical reads under interleaved create/update/delete/retract/edge ops), a multithreaded writer-vs-pinned-reader determinism test, same-microsecond supersession across restart, retraction-after-pin on a pre-pin tracked entity, future-valid exclusion, backdated pins, restart durability, corrupt-sidecar quarantine, and full-HLC serde round-trip. Criterion bench (`benches/snapshot_pin.rs`) measures name-resolution overhead against the <100µs p99 target.

**Acceptance criteria evidence (issue #3370):**
- AC1 (default→now both dims; explicit + backdated accepted) — `create_default_snapshot_reflects_committed_state`, `create_snapshot_at_explicit_backdated_coord`.
- AC2 (unique names→CONFLICT; listable; deletable) — `duplicate_name_is_conflict`, `list_returns_metadata_in_stable_order`, `delete_removes_and_resolve_is_not_found`.
- AC3 (MCP snapshot param; snapshot+as_of→INVALID_ARGUMENT) — DEFERRED to Lane 1 (documented).
- AC4 (Rust API + query reference by name) — Rust: `db.snapshot(name)` + handle reads + `pinned_query_builder_traverses_at_the_coordinate`; AQL/Cypher DDL DEFERRED.
- AC5 (byte-identical under interleaved writes — the falsifiable core) — `determinism_core_60_iterations`, `determinism_heavy_1000_iterations`, `determinism_under_concurrent_writer`.
- AC6 (nonexistent→NOT_FOUND with name) — `resolve_nonexistent_is_not_found`.
- AC7 (survive restart; cold-tier caveat documented like #3238) — `snapshot_survives_restart`, `deletion_persists_across_restart`, `snapshot_resolves_correct_version_across_restart_same_microsecond`; caveat in `docs/guides/snapshot-pin.md`.
- AC8 (self-describing: echo name + resolved coordinate) — handle exposes `name()`/`coordinate()`/`valid_time()`/`transaction_time()`; per-response envelope echo is the deferred MCP layer.
- AC9 (no write-path overhead; no retention obligation, documented) — `snapshot_creation_does_not_disturb_writes`; documented in the guide; bench for resolution overhead.

**Gates:** `cargo test --test snapshot_pin` 18/18, `cargo test --lib db::snapshot` 9/9, `cargo clippy --all-targets` clean under both the CI feature set (`config-toml,mcp-server,sharding-rpc,simulation`) and `--all-features` (`-D warnings`), `cargo fmt --all --check` clean. No `src/mcp/**` or server-crate changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GF8ApFzNTUEEa2rAQq5Jon)_