### PR TITLE
feat(query): temporal joins aligning entities at matching valid times (#3379)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -489,6 +489,14 @@ harness = false
 path = "benches/temporal_window.rs"
 required-features = []
 
+# Temporal joins (Issue #3379): event-aligned join over ~100 alignment instants
+# across 2 entities, targeting < 50ms p99 end-to-end.
+[[bench]]
+name = "temporal_join"
+harness = false
+path = "benches/temporal_join.rs"
+required-features = []
+
 # OpenTelemetry tracing overhead gate (Issue #3376): disabled vs enabled.
 [[bench]]
 name = "otel_overhead"

--- a/benches/temporal_join.rs
+++ b/benches/temporal_join.rs
@@ -1,0 +1,101 @@
+//! Benchmark for AQL temporal joins (Issue #3379).
+//!
+//! Success metric: an event-aligned join over a range containing ~100 alignment
+//! instants across 2 entities completes in **< 50ms** end-to-end (each
+//! alignment point is bounded by the < 10ms temporal-reconstruction target; the
+//! engine amortizes history reconstruction across instants, beating 100 × naive
+//! `AS OF` round-trips). This bench builds a driver (Order) with ~100
+//! valid-time versions joined via an edge to a Customer with its own tier
+//! history, and times the event-aligned join end-to-end through `execute_aql`.
+//! The numeric target is validated on the performance rig, not gated here.
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::PropertyMapBuilder;
+use aletheiadb::api::transaction::WriteRequestOptions;
+use aletheiadb::core::temporal::Timestamp;
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+/// Microseconds since epoch for 2023-01-01T00:00:00Z (a fixed, past anchor).
+const YEAR_START_MICROS: i64 = 1_672_531_200_000_000;
+const MICROS_PER_DAY: i64 = 86_400_000_000;
+
+/// Build a driver Order with `events` valid-time versions, joined to a Customer
+/// (with a handful of tier changes) via a PLACED_BY edge valid all year.
+fn build_scenario(events: usize) -> AletheiaDB {
+    let db = AletheiaDB::new().expect("db init");
+
+    // Customer with 12 monthly tier changes.
+    let customer = db
+        .create_node_with_options(
+            "Customer",
+            PropertyMapBuilder::new().insert("tier", 1i64).build(),
+            WriteRequestOptions::new().with_valid_from(Timestamp::from(YEAR_START_MICROS)),
+        )
+        .expect("create customer");
+    for m in 1..12 {
+        let vf = YEAR_START_MICROS + 30 * MICROS_PER_DAY * m as i64;
+        db.update_node_with_options(
+            customer,
+            PropertyMapBuilder::new()
+                .insert("tier", 1i64 + m as i64)
+                .build(),
+            WriteRequestOptions::new().with_valid_from(Timestamp::from(vf)),
+        )
+        .expect("update tier");
+    }
+
+    // Driver Order with `events` valid-time versions spread across ~360 days.
+    let order = db
+        .create_node_with_options(
+            "Purchase",
+            PropertyMapBuilder::new().insert("total", 10i64).build(),
+            WriteRequestOptions::new().with_valid_from(Timestamp::from(YEAR_START_MICROS)),
+        )
+        .expect("create order");
+    let step = (360 * MICROS_PER_DAY) / events.max(1) as i64;
+    for i in 1..events {
+        let vf = YEAR_START_MICROS + step * i as i64;
+        db.update_node_with_options(
+            order,
+            PropertyMapBuilder::new()
+                .insert("total", 10i64 + i as i64)
+                .build(),
+            WriteRequestOptions::new().with_valid_from(Timestamp::from(vf)),
+        )
+        .expect("update order");
+    }
+
+    db.create_edge_with_options(
+        order,
+        customer,
+        "PLACED_BY",
+        PropertyMapBuilder::new().build(),
+        WriteRequestOptions::new().with_valid_from(Timestamp::from(YEAR_START_MICROS)),
+    )
+    .expect("create edge");
+
+    db
+}
+
+fn bench_event_join_100_instants(c: &mut Criterion) {
+    let db = build_scenario(100);
+    let query = "MATCH (o:Purchase)-[:PLACED_BY]->(c:Customer) \
+         ALIGN EVENTS DRIVER o \
+         OVER VALID_TIME FROM '2023-01-01T00:00:00Z' TO '2024-01-01T00:00:00Z' \
+         RETURN o.total, c.tier AS tier";
+
+    c.bench_function("temporal_join/event_align_100_instants_2_entities", |b| {
+        b.iter(|| {
+            let results = db
+                .execute_aql(black_box(query))
+                .expect("query")
+                .collect_all()
+                .expect("collect");
+            black_box(results.len())
+        });
+    });
+}
+
+criterion_group!(benches, bench_event_join_100_instants);
+criterion_main!(benches);

--- a/docs/guides/temporal-joins.md
+++ b/docs/guides/temporal-joins.md
@@ -1,0 +1,144 @@
+# Correlated Point-in-Time Analysis: Temporal Joins (Issue #3379)
+
+AletheiaDB can answer *"what did entity X look like AS OF T?"* for a single `T`
+(`AS OF`, `#3225`, `#3236`). The questions analysts actually pay a temporal
+database for are **correlative**:
+
+- *"What was each customer's tier **at the moment** each of their orders was placed?"*
+- *"Who was the account manager **when** the complaint was filed?"*
+- *"Compare a product's price and its supplier's rating **at the same instants** across last year."*
+
+Answering these without a temporal join forces the caller — human or LLM — into
+a loop: enumerate one entity's version timeline, issue one `AS OF` lookup per
+version for the other entity, then zip the results in application code with
+hand-rolled interval-boundary logic. That is `O(versions)` round-trips, trivially
+wrong at interval boundaries, and hopeless over MCP where each round-trip costs
+tokens.
+
+A **temporal join** (`ALIGN`) turns that loop into one declarative AQL statement
+with correct-by-default half-open boundary semantics and bi-temporal pinning.
+
+## Two modes
+
+### Event-aligned (`ALIGN EVENTS`) — the SQL `ASOF JOIN` analog
+
+For each **version-change instant** of a *driver* entity within the range,
+evaluate every participant at *its most recent state at or before that instant*.
+One output row per driver event.
+
+```aql
+MATCH (o:Purchase)-[:PLACED_BY]->(c:Customer)
+ALIGN EVENTS DRIVER o
+  OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2025-01-01T00:00:00Z'
+RETURN o.total, c.tier AS tier
+```
+
+Each output row carries `align_valid_time` (RFC 3339) plus the `RETURN` columns:
+
+| align_valid_time            | o.total | tier |
+|-----------------------------|---------|------|
+| 2024-02-01T00:00:00.000000Z | 10      | 1    |
+| 2024-09-01T00:00:00.000000Z | 20      | 2    |
+
+*(The Feb order sees the customer's tier-1 state; the Sep order sees the tier-2
+state after a June upgrade — the tier is aligned to each order's placement
+instant.)*
+
+### Interval-overlap (`ALIGN OVERLAP`)
+
+Return the piecewise maximal sub-intervals over the range during which **all**
+participant states (and any gating edge) co-held — the intersection of the
+participating valid intervals. One row per non-empty sub-interval.
+
+```aql
+MATCH (p:Product)-[:SUPPLIED_BY]->(s:Supplier)
+ALIGN OVERLAP
+  OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-06-01T00:00:00Z'
+RETURN p.price AS price, s.rating AS rating
+```
+
+Each output row carries `overlap_from` / `overlap_to` (RFC 3339) plus the
+`RETURN` columns. Sub-intervals where any participant is absent (a gap) are
+dropped — never a row pairing states that did not co-hold.
+
+| overlap_from | overlap_to | price | rating |
+|--------------|------------|-------|--------|
+| 2024-02-01…  | 2024-04-01…| 100   | 5      |
+| 2024-04-01…  | 2024-05-01…| 150   | 5      |
+| 2024-05-01…  | 2024-06-01…| 150   | 4      |
+
+*(January is dropped because the supplier record did not yet exist — an empty
+overlap.)*
+
+## The client-side loop it replaces
+
+The event-aligned example above, done by hand, is roughly:
+
+```text
+versions = get_node_history(order_id)                 # 1 call
+for v in versions:                                     # ~N calls
+    if v.valid_from in [from, to):
+        cust = get_node_at_time(customer_id,
+                                valid_time=v.valid_from,
+                                transaction_time=now)   # 1 call each
+        emit(v.valid_from, v.total, cust.tier)
+        # ...and you still hand-roll: which timestamp wins at a boundary?
+        # open or closed ends? what if the customer didn't exist yet?
+```
+
+For 1 driver with 100 versions and 1 joined entity that is **~101 calls**; the
+`ALIGN` form is **one** query — a ≥ 99% round-trip reduction, and over MCP the
+difference between one `< 30ms` response and 100+ sequential calls.
+
+## Boundary and dimension semantics (the falsifiable contract)
+
+- **Half-open `[from, to)`**, consistent with the storage model and the `#3363`
+  temporal-window convention. A version whose `valid_from` **equals** an
+  alignment instant *starts* that instant and is **included** there; a version at
+  exactly `to` is **excluded**.
+- **Transaction-time pinning.** History is read as believed at the transaction
+  time; it defaults to *now* and is independently pinnable with
+  `AS OF SYSTEM_TIME <ts>` on the clause. A correction recorded **after** the pin
+  never rewrites the pinned analytics (later corrections do not change the past).
+  Same-`valid_from` corrections keep the latest belief `≤` the pin.
+- **Edge validity is honored at each instant.** When a participant is bound via a
+  relationship, that edge's validity gates the pairing: at an instant where the
+  edge is not valid, the participant is treated as absent (its columns are `null`
+  in event mode; the sub-interval is dropped in overlap mode).
+- **Absent participants.** A participant with no state at/before the alignment
+  instant (e.g. an order placed before the customer existed) yields `null`
+  columns in event mode and drops the sub-interval in overlap mode.
+
+## Composition and access
+
+- **Graph patterns.** `ALIGN` composes with a `MATCH` traversal — the joined
+  entities may be bound via an edge (`order → customer`), not only by explicit
+  ids. The pattern binding resolves at current state (or the outer `AS OF`), then
+  the alignment reconstructs each bound entity's history over the range.
+- **MCP `query` tool.** Available read-only through the MCP `query` tool (AQL
+  path); results ride the existing row/limit contracts, and over-large ranges
+  respect the standard result caps.
+
+## v1 limitations
+
+- **Supported pattern shapes:** a single bound node (`MATCH (v:Label)`) or a
+  single-hop traversal (`MATCH (a)-[:R]->(b)`, both directions). Multi-hop,
+  variable-length, and comma-separated patterns return a structured
+  `UnsupportedFeature` error. Every node in the pattern must be named.
+- **Fully retracted / deleted edges cannot be re-bound by a `MATCH`.** Like
+  `#3225` AS OF traversal, candidate edges are enumerated from the *current*
+  adjacency index, so an edge whose validity is entirely in the past (retracted)
+  is not found by the pattern — anchor the binding with an outer `AS OF` at a
+  point where the edge still held (both dimensions, per `#3225`). The gating math
+  itself handles closed intervals; only candidate discovery is current-state.
+- **Range cap.** A range that would generate more than `MAX_ALIGN_INSTANTS`
+  (100,000) alignment instants / boundaries is rejected with a structured
+  `InvalidParameter` error.
+
+## Out of scope (tracked elsewhere)
+
+- SQL:2011 surface for the same semantics — `#311` owns SQL syntax.
+- Temporal aggregation (windowed `COUNT`/`AVG`) over the aligned output — `#3363`.
+- Alignment across more than one time dimension simultaneously beyond pinning.
+- Allen's-interval-algebra predicate library (`MEETS`, `DURING`, …).
+- Streaming / continuous evaluation of temporal joins — `#3375`.

--- a/docs/guides/temporal-joins.md
+++ b/docs/guides/temporal-joins.md
@@ -100,14 +100,34 @@ difference between one `< 30ms` response and 100+ sequential calls.
   time; it defaults to *now* and is independently pinnable with
   `AS OF SYSTEM_TIME <ts>` on the clause. A correction recorded **after** the pin
   never rewrites the pinned analytics (later corrections do not change the past).
-  Same-`valid_from` corrections keep the latest belief `≤` the pin.
+  *v1 pinning scope:* the pin is exact for **same-`valid_from` corrections** — a
+  restatement of a fact's value at an already-recorded `valid_from`, recorded
+  after the pin, is correctly excluded. It is **not** a full as-of-transaction-time
+  snapshot across the whole valid axis: a participant's believed timeline is
+  reconstructed from every version with `transaction_from ≤ pin` (mirroring the
+  `#3363` window reconstruction), so a distinct-`valid_from` fact whose
+  transaction interval was later closed is still included. Full
+  transaction-interval-`contains` scoping is a tracked follow-up (it is
+  deliberately *not* used here because, under the append-only supersession model
+  where a superseded version keeps its valid interval open, it would drop
+  genuinely-held earlier history).
 - **Edge validity is honored at each instant.** When a participant is bound via a
   relationship, that edge's validity gates the pairing: at an instant where the
   edge is not valid, the participant is treated as absent (its columns are `null`
   in event mode; the sub-interval is dropped in overlap mode).
+- **Valid-time closure is honored.** A participant whose covering version's valid
+  interval has **closed** — a retraction (`#3230`), a delete, or a valid-time gap
+  before a later version — is treated as **absent** from the close instant onward,
+  symmetric with the edge-gate path: its columns are `null` in event mode and the
+  sub-interval ends (or is dropped) in overlap mode. A retracted or deleted
+  participant is *not* presumed present forever.
 - **Absent participants.** A participant with no state at/before the alignment
   instant (e.g. an order placed before the customer existed) yields `null`
   columns in event mode and drops the sub-interval in overlap mode.
+- **Event-aligned driver.** The driver is **always present at its own event** by
+  construction — it is ungated even when it is the far node of a traversal
+  (`ALIGN EVENTS DRIVER <far-node>`), so a driver event never emits a row with
+  the driver's own column `null`.
 
 ## Composition and access
 
@@ -125,12 +145,18 @@ difference between one `< 30ms` response and 100+ sequential calls.
   single-hop traversal (`MATCH (a)-[:R]->(b)`, both directions). Multi-hop,
   variable-length, and comma-separated patterns return a structured
   `UnsupportedFeature` error. Every node in the pattern must be named.
-- **Fully retracted / deleted edges cannot be re-bound by a `MATCH`.** Like
-  `#3225` AS OF traversal, candidate edges are enumerated from the *current*
-  adjacency index, so an edge whose validity is entirely in the past (retracted)
-  is not found by the pattern — anchor the binding with an outer `AS OF` at a
-  point where the edge still held (both dimensions, per `#3225`). The gating math
-  itself handles closed intervals; only candidate discovery is current-state.
+- **Fully retracted / deleted edges (and nodes) cannot be re-bound by a
+  `MATCH`.** Like `#3225` AS OF traversal, candidate entities are enumerated from
+  the *current* adjacency / label index, so an edge or node whose validity is
+  entirely in the past (retracted / deleted) is not found by the pattern — anchor
+  the binding with an outer `AS OF` at a point where it still held (both
+  dimensions, per `#3225`). This is a **candidate-discovery** limitation only:
+  once an entity *is* bound, the alignment fully honors **closed valid intervals**
+  on both the participant node timeline (a mid-range retraction / delete / gap
+  makes it absent from the close instant) and the gating edge — so a participant
+  that is retracted *within* the range while still bindable is correctly nulled
+  (event mode) or ends its co-hold sub-interval (overlap mode) at the retraction
+  instant.
 - **Range cap.** A range that would generate more than `MAX_ALIGN_INSTANTS`
   (100,000) alignment instants / boundaries is rejected with a structured
   `InvalidParameter` error.

--- a/docs/query-language-design.md
+++ b/docs/query-language-design.md
@@ -26,6 +26,7 @@ AletheiaDB's query language (AQL - Aletheia Query Language) extends the Cypher g
 query           = [ temporal_clause ]
                   ( match_clause | vector_clause )
                   ( window_clause
+                  | align_clause
                   | ( { where_clause }
                       [ return_clause ]
                       [ order_clause ]
@@ -53,6 +54,19 @@ window_unit     = "MINUTE" | "MINUTES" | "HOUR" | "HOURS" | "DAY" | "DAYS"
 window_agg      = window_func "(" window_arg ")" [ "AS" identifier ] ;
 window_func     = "COUNT" | "SUM" | "AVG" | "MIN" | "MAX" | "CHANGES" ;
 window_arg      = "*" | identifier [ "." identifier ] ;
+
+(* Temporal Join / Align Clause - Issue #3379 *)
+(* A self-contained terminal clause: it carries its own RETURN and may not be
+   combined with WHERE/ORDER/SKIP/LIMIT. It aligns the matched participants at
+   matching valid-time coordinates over an explicit [from, to) range, in either
+   event-aligned (ASOF) or interval-overlap mode. See
+   docs/guides/temporal-joins.md. *)
+align_clause    = "ALIGN" align_mode
+                  "OVER" "VALID_TIME" "FROM" timestamp "TO" timestamp
+                  [ "AS" "OF" "SYSTEM_TIME" timestamp ]
+                  "RETURN" align_item { "," align_item } ;
+align_mode      = "EVENTS" "DRIVER" identifier | "OVERLAP" ;
+align_item      = identifier [ "." identifier ] [ "AS" identifier ] ;
 
 (* Match Clause - Graph Pattern Matching *)
 match_clause    = "MATCH" pattern { "," pattern } ;
@@ -400,6 +414,8 @@ RETURN n
 | `AS OF T1, T2` | `QueryOp::AsOf { valid_time: T1, transaction_time: T2 }` |
 | `BETWEEN T1 AND T2` | `QueryOp::Between { time_range: ... }` |
 | `WINDOW N unit OVER VALID_TIME FROM T1 TO T2 ... RETURN aggs` | `QueryOp::TemporalWindowAggregate(TemporalWindowSpec { ... })` |
+| `ALIGN EVENTS DRIVER v OVER VALID_TIME FROM T1 TO T2 ... RETURN items` | `QueryOp::TemporalAlign(TemporalAlignSpec { ... })` |
+| `ALIGN OVERLAP OVER VALID_TIME FROM T1 TO T2 ... RETURN items` | `QueryOp::TemporalAlign(TemporalAlignSpec { ... })` |
 | `WHERE pred` | `QueryOp::Filter(Predicate)` |
 | `LIMIT N` | `QueryOp::Limit(N)` |
 | `SKIP N` | `QueryOp::Skip(N)` |

--- a/src/db/rotation.rs
+++ b/src/db/rotation.rs
@@ -64,7 +64,6 @@ use crate::encryption::factory::Algorithm;
 use crate::encryption::factory::create_cipher;
 use crate::encryption::key_derivation::KeyDerivation;
 use crate::storage::index_persistence::common::{ENC_INDEX_KEY_VERSION_V1, IndexKeyring};
-use crate::storage::index_persistence::common::ENC_INDEX_KEY_VERSION_V1;
 use crate::storage::index_persistence::reencrypt::DecryptProbeReport;
 use crate::storage::index_persistence::{
     IndexKeyRotation, IndexPersistenceManager, RotationError, RotationProgress, RotationStatus,

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -32,6 +32,11 @@ pub struct QueryAst {
     /// computes per-window aggregates; the window clause carries its own
     /// aggregate `RETURN` list, so `return_clause` is unused.
     pub window: Option<WindowClause>,
+    /// Temporal join / align clause (Issue #3379). When present, the query
+    /// aligns the matched entities at matching valid-time coordinates over a
+    /// range; the align clause carries its own `RETURN` list, so
+    /// `return_clause` is unused.
+    pub align: Option<AlignClause>,
 }
 
 impl QueryAst {
@@ -47,6 +52,7 @@ impl QueryAst {
             skip: None,
             limit: None,
             window: None,
+            align: None,
         }
     }
 
@@ -103,6 +109,13 @@ impl QueryAst {
     #[must_use]
     pub fn with_window(mut self, window: WindowClause) -> Self {
         self.window = Some(window);
+        self
+    }
+
+    /// Add a temporal join / align clause to the query.
+    #[must_use]
+    pub fn with_align(mut self, align: AlignClause) -> Self {
+        self.align = Some(align);
         self
     }
 
@@ -197,6 +210,63 @@ pub enum WindowAggArg {
         /// The property key.
         key: String,
     },
+}
+
+/// A temporal join / align clause (Issue #3379).
+///
+/// Syntax:
+/// ```text
+/// ALIGN EVENTS DRIVER <var>                 -- event-aligned (ASOF analog)
+///   OVER VALID_TIME FROM <ts> TO <ts>
+///   [ AS OF SYSTEM_TIME <ts> ]
+///   RETURN <item> [AS alias] [, ...]
+///
+/// ALIGN OVERLAP                             -- interval-overlap
+///   OVER VALID_TIME FROM <ts> TO <ts> [ AS OF SYSTEM_TIME <ts> ]
+///   RETURN <item> [, ...]
+/// ```
+///
+/// The mode and return-item variables are validated in the converter, where a
+/// bad reference or unsupported pattern maps to a structured
+/// [`crate::core::error::QueryError`] the MCP `query` tool surfaces.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AlignClause {
+    /// The alignment mode.
+    pub mode: AlignMode,
+    /// The driving-entity variable (event-aligned mode only; `None` for
+    /// interval-overlap).
+    pub driver: Option<String>,
+    /// Inclusive start of the valid-time range.
+    pub range_start: TimestampLiteral,
+    /// Exclusive end of the valid-time range.
+    pub range_end: TimestampLiteral,
+    /// Optional `AS OF SYSTEM_TIME` transaction-time coordinate (default: now).
+    pub as_of_system_time: Option<TimestampLiteral>,
+    /// The aligned `RETURN` items.
+    pub items: Vec<AlignReturnItem>,
+}
+
+/// The temporal-join alignment mode (Issue #3379).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlignMode {
+    /// `EVENTS` — event-aligned (ASOF): sample participants at each driver
+    /// change-point.
+    Events,
+    /// `OVERLAP` — interval-overlap: piecewise sub-intervals where states
+    /// co-held.
+    Overlap,
+}
+
+/// One item in an align `RETURN` list (Issue #3379): a bound variable, or one
+/// of its properties, with an optional output alias.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AlignReturnItem {
+    /// The matched variable name.
+    pub var: String,
+    /// The property key, or `None` to return the entity id.
+    pub key: Option<String>,
+    /// Optional output-column alias (`AS foo`).
+    pub alias: Option<String>,
 }
 
 /// A timestamp literal (string or integer).

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -801,7 +801,7 @@ impl AstConverter {
         source: &SourceClause,
     ) -> Result<TemporalAlignSpec> {
         // Build the participant plan from the (supported) pattern shape.
-        let participants = Self::align_participants(source)?;
+        let mut participants = Self::align_participants(source)?;
         let index_of =
             |var: &str| -> Option<usize> { participants.iter().position(|p| p.var == var) };
 
@@ -875,6 +875,19 @@ impl AstConverter {
                 })
             })
             .collect::<Result<Vec<_>>>()?;
+
+        // The event-aligned driver must be **present at its own event** by
+        // definition, so it is ungated by construction: if the user names the
+        // FAR node of a traversal as DRIVER, the connecting edge would
+        // otherwise gate the driver and null the driver's OWN column at a
+        // change-point where the edge is not valid — contradicting the
+        // invariant (Issue #3379 review finding). Removing the driver's gate
+        // makes its events fire with the driver present regardless of the
+        // connecting edge's validity. (Done after `index_of` is no longer
+        // borrowed.)
+        if mode == JoinAlignMode::Events {
+            participants[driver_index].edge_gate_path_index = None;
+        }
 
         Ok(TemporalAlignSpec {
             mode,

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -176,18 +176,20 @@ use crate::core::temporal::{TimeRange, Timestamp, time};
 use crate::index::vector::DistanceMetric;
 
 use super::ast::{
-    ComparisonOp, DepthSpec, EmbeddingRef, Expression, NodePattern, NodeRef, OrderClause, Pattern,
-    PatternElement, PredicateExpr, PropertyValue, QueryAst, RelationshipDirection,
-    RelationshipPattern, ReturnClause, SourceClause, TemporalClause, TimestampLiteral,
-    WindowClause, WindowReturnItem,
+    AlignClause, AlignMode as AstAlignMode, ComparisonOp, DepthSpec, EmbeddingRef, Expression,
+    NodePattern, NodeRef, OrderClause, Pattern, PatternElement, PredicateExpr, PropertyValue,
+    QueryAst, RelationshipDirection, RelationshipPattern, ReturnClause, SourceClause,
+    TemporalClause, TimestampLiteral, WindowClause, WindowReturnItem,
 };
 use super::builder::Query;
 use super::ir::{
-    Predicate, PredicateValue, ProvenanceCmp, ProvenanceField, ProvenanceOperand,
-    ProvenancePredicate, ProvenanceProjection, ProvenanceProjectionItem, QueryOp, SortKey,
-    TemporalWindowSpec, TraversalDepth, WindowAggFunc, WindowAggregateSpec,
+    AlignNodeSource, AlignOutputItem, AlignParticipant, Predicate, PredicateValue, ProvenanceCmp,
+    ProvenanceField, ProvenanceOperand, ProvenancePredicate, ProvenanceProjection,
+    ProvenanceProjectionItem, QueryOp, SortKey, TemporalAlignSpec, TemporalWindowSpec,
+    TraversalDepth, WindowAggFunc, WindowAggregateSpec,
 };
 use super::plan::{QueryHints, TemporalContext};
+use super::temporal_join::AlignMode as JoinAlignMode;
 use super::temporal_window::{self, WindowError, WindowGranularity, WindowUnit};
 
 /// Map a provenance accessor function name to its [`ProvenanceField`]
@@ -606,6 +608,20 @@ impl AstConverter {
             });
         }
 
+        // 2c. Temporal join / align (Issue #3379). Also a self-contained
+        //     terminal op: it consumes the matched-participant stream and emits
+        //     per-alignment-coordinate rows. The parser rejects trailing
+        //     read clauses after ALIGN ... RETURN.
+        if let Some(ref align) = ast.align {
+            let spec = self.convert_align_clause(align, &ast.source)?;
+            ops.push(QueryOp::TemporalAlign(spec));
+            return Ok(Query {
+                ops,
+                temporal_context,
+                hints,
+            });
+        }
+
         // 3. Convert WHERE clause to filter operations
         if let Some(ref where_clause) = ast.where_clause {
             self.convert_where_clause(where_clause, &mut ops)?;
@@ -770,6 +786,177 @@ impl AstConverter {
             return None;
         };
         node.variable.clone()
+    }
+
+    /// Validate and lower a raw AST [`AlignClause`] into a resolved
+    /// [`TemporalAlignSpec`] (Issue #3379).
+    ///
+    /// v1 supports a single MATCH pattern that is either one bound node, or a
+    /// single-hop `(a)-[:R]->(b)` traversal (both directions). All caller-fault
+    /// failures are structured [`QueryError`]s (unsupported pattern, unknown
+    /// return/driver variable, unparseable/empty range).
+    fn convert_align_clause(
+        &self,
+        align: &AlignClause,
+        source: &SourceClause,
+    ) -> Result<TemporalAlignSpec> {
+        // Build the participant plan from the (supported) pattern shape.
+        let participants = Self::align_participants(source)?;
+        let index_of =
+            |var: &str| -> Option<usize> { participants.iter().position(|p| p.var == var) };
+
+        // Resolve range boundaries (reusing the RFC 3339 / micros boundary
+        // parser) and validate the range is non-empty.
+        let range_start_micros = self.window_timestamp_micros(&align.range_start)?;
+        let range_end_micros = self.window_timestamp_micros(&align.range_end)?;
+        if range_end_micros <= range_start_micros {
+            return Err(Error::Query(QueryError::InvalidParameter {
+                parameter: "temporal join range".to_string(),
+                reason: "the valid-time range end must be strictly after the start".to_string(),
+            }));
+        }
+
+        let as_of_system_time = match &align.as_of_system_time {
+            Some(ts) => Timestamp::from(self.window_timestamp_micros(ts)?),
+            None => time::now(),
+        };
+
+        // Resolve mode + driver.
+        let (mode, driver_index) = match align.mode {
+            AstAlignMode::Events => {
+                let driver = align.driver.as_deref().ok_or_else(|| {
+                    Error::Query(QueryError::InvalidParameter {
+                        parameter: "align driver".to_string(),
+                        reason: "event-aligned ALIGN requires DRIVER <var>".to_string(),
+                    })
+                })?;
+                let idx = index_of(driver).ok_or_else(|| {
+                    Error::Query(QueryError::InvalidParameter {
+                        parameter: "align driver".to_string(),
+                        reason: format!(
+                            "driver variable '{driver}' is not a bound participant in the pattern"
+                        ),
+                    })
+                })?;
+                (JoinAlignMode::Events, idx)
+            }
+            AstAlignMode::Overlap => (JoinAlignMode::Overlap, 0),
+        };
+
+        // Resolve the RETURN items against the participants.
+        if align.items.is_empty() {
+            return Err(Error::Query(QueryError::InvalidParameter {
+                parameter: "align return".to_string(),
+                reason: "ALIGN requires at least one RETURN item".to_string(),
+            }));
+        }
+        let output_items = align
+            .items
+            .iter()
+            .map(|item| {
+                let participant_index = index_of(&item.var).ok_or_else(|| {
+                    Error::Query(QueryError::InvalidParameter {
+                        parameter: "align return".to_string(),
+                        reason: format!(
+                            "RETURN references variable '{}' but it is not a bound participant \
+                             in the pattern",
+                            item.var
+                        ),
+                    })
+                })?;
+                let output_name = item.alias.clone().unwrap_or_else(|| match &item.key {
+                    Some(key) => format!("{}.{}", item.var, key),
+                    None => item.var.clone(),
+                });
+                Ok(AlignOutputItem {
+                    participant_index,
+                    key: item.key.clone(),
+                    output_name,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(TemporalAlignSpec {
+            mode,
+            driver_index,
+            range_start_micros,
+            range_end_micros,
+            as_of_system_time,
+            participants,
+            output_items,
+        })
+    }
+
+    /// Build the participant extraction plan from a MATCH source, enforcing the
+    /// v1 supported pattern shapes (one bound node, or a single-hop traversal).
+    fn align_participants(source: &SourceClause) -> Result<Vec<AlignParticipant>> {
+        let unsupported = || {
+            Error::Query(QueryError::UnsupportedFeature {
+                feature: "temporal joins require a single MATCH pattern that is either one bound \
+                          node (e.g. MATCH (v:Label)) or a single-hop traversal (e.g. \
+                          MATCH (a)-[:R]->(b)); multi-hop, variable-length, and comma-separated \
+                          patterns are not supported (v1)"
+                    .to_string(),
+            })
+        };
+
+        let SourceClause::Match(patterns) = source else {
+            return Err(unsupported());
+        };
+        let [pattern] = patterns.as_slice() else {
+            return Err(unsupported());
+        };
+
+        // Collect nodes (in order) and reject variable-length relationships.
+        let mut nodes: Vec<&NodePattern> = Vec::new();
+        let mut rel_count = 0usize;
+        for element in &pattern.elements {
+            match element {
+                PatternElement::Node(node) => nodes.push(node),
+                PatternElement::Relationship(rel) => {
+                    if rel.depth.is_some() {
+                        return Err(unsupported());
+                    }
+                    rel_count += 1;
+                }
+            }
+        }
+
+        // v1: exactly one node (no rel) or exactly two nodes (one rel).
+        match (nodes.len(), rel_count) {
+            (1, 0) => {}
+            (2, 1) => {}
+            _ => return Err(unsupported()),
+        }
+
+        let num_nodes = nodes.len();
+        let mut participants = Vec::with_capacity(num_nodes);
+        for (k, node) in nodes.iter().enumerate() {
+            let var = node.variable.clone().ok_or_else(|| {
+                Error::Query(QueryError::InvalidParameter {
+                    parameter: "align pattern".to_string(),
+                    reason: "every node in a temporal-join pattern must be named \
+                             (e.g. (a)-[:R]->(b))"
+                        .to_string(),
+                })
+            })?;
+            // The last node of the traversal is the row's primary entity; earlier
+            // nodes live at even path indices (node position k -> path[2k]).
+            let node_source = if k + 1 == num_nodes {
+                AlignNodeSource::Entity
+            } else {
+                AlignNodeSource::PathIndex(2 * k)
+            };
+            // A non-anchor node is reached via the relationship immediately
+            // before it (path[2k-1]); its validity gates the participant.
+            let edge_gate_path_index = if k == 0 { None } else { Some(2 * k - 1) };
+            participants.push(AlignParticipant {
+                var,
+                node_source,
+                edge_gate_path_index,
+            });
+        }
+        Ok(participants)
     }
 
     /// Validate and lower a raw AST [`WindowClause`] into a resolved

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -3642,72 +3642,102 @@ impl TemporalJoinIterator {
 
     /// Reconstruct a node's believed valid-time timeline as of `as_of`: every
     /// version recorded by `as_of` (`transaction_from <= as_of`) contributes a
-    /// change-point at its `valid_from`; same-`valid_from` corrections keep the
-    /// latest belief (mirrors the #3363 believed-version reconstruction).
+    /// change-point over its half-open valid interval `[valid_from, valid_to)`;
+    /// same-`valid_from` corrections keep the latest belief (mirrors the #3363
+    /// believed-version reconstruction). A retraction (#3230) / delete closes
+    /// the covering version's `valid_to`, so the entity becomes **absent** at/
+    /// after it rather than presumed present forever (Issue #3379 correctness,
+    /// symmetric with the edge-gate path).
+    ///
+    /// A genuinely missing node (`NodeNotFound`) yields an **empty** timeline
+    /// (a legitimate "absent" — the participant is simply null everywhere); any
+    /// **other** storage error is a real failure and is propagated so it can
+    /// surface as a structured `QueryError` rather than being silently read as
+    /// "not found" (Issue #3379 review finding).
     fn node_timeline(
         hist: &HistoricalStorage,
         node_id: NodeId,
         as_of: Timestamp,
-    ) -> crate::query::temporal_join::Timeline {
+    ) -> Result<crate::query::temporal_join::Timeline> {
+        use crate::core::error::{Error, StorageError};
         use crate::query::temporal_join::{ChangePoint, Timeline};
+        let h = match hist.get_node_history(node_id) {
+            Ok(h) => h,
+            Err(Error::Storage(StorageError::NodeNotFound(_))) => {
+                return Ok(Timeline::default());
+            }
+            Err(e) => return Err(e),
+        };
+        // valid_from -> (latest believed tx_from, properties, valid_to).
         let mut by_vf: std::collections::HashMap<
             i64,
-            (Timestamp, crate::core::property::PropertyMap),
+            (Timestamp, crate::core::property::PropertyMap, i64),
         > = std::collections::HashMap::new();
-        if let Ok(h) = hist.get_node_history(node_id) {
-            for ver in h.versions {
-                let tx_from = ver.temporal.transaction_time().start();
-                if tx_from > as_of {
-                    continue;
-                }
-                let vf = ver.temporal.valid_time().start().wallclock();
-                match by_vf.get(&vf) {
-                    Some((existing_tx, _)) if *existing_tx >= tx_from => {}
-                    _ => {
-                        by_vf.insert(vf, (tx_from, ver.properties));
-                    }
+        for ver in h.versions {
+            let tx_from = ver.temporal.transaction_time().start();
+            if tx_from > as_of {
+                continue;
+            }
+            let vf = ver.temporal.valid_time().start().wallclock();
+            let vt = ver.temporal.valid_time().end().wallclock();
+            match by_vf.get(&vf) {
+                Some((existing_tx, _, _)) if *existing_tx >= tx_from => {}
+                _ => {
+                    by_vf.insert(vf, (tx_from, ver.properties, vt));
                 }
             }
         }
         let changes = by_vf
             .into_iter()
-            .map(|(valid_from, (_, properties))| ChangePoint {
+            .map(|(valid_from, (_, properties, valid_to))| ChangePoint {
                 valid_from,
+                valid_to,
                 properties,
             })
             .collect();
-        Timeline::from_changes(changes)
+        Ok(Timeline::from_changes(changes))
     }
 
     /// Reconstruct an edge's believed presence intervals as of `as_of`: each
     /// believed version contributes its half-open valid interval
     /// `[valid_from, valid_to)` (an open interval ends at `i64::MAX`).
+    ///
+    /// As with [`node_timeline`](Self::node_timeline), a missing edge
+    /// (`EdgeNotFound`) yields **empty** presence intervals (a gate that is
+    /// never open); any other storage error is propagated (Issue #3379 review
+    /// finding — do not conflate a genuine error with not-found).
     fn edge_presence(
         hist: &HistoricalStorage,
         edge_id: EdgeId,
         as_of: Timestamp,
-    ) -> crate::query::temporal_join::PresenceIntervals {
+    ) -> Result<crate::query::temporal_join::PresenceIntervals> {
+        use crate::core::error::{Error, StorageError};
         use crate::query::temporal_join::PresenceIntervals;
+        let h = match hist.get_edge_history(edge_id) {
+            Ok(h) => h,
+            Err(Error::Storage(StorageError::EdgeNotFound(_))) => {
+                return Ok(PresenceIntervals::default());
+            }
+            Err(e) => return Err(e),
+        };
         let mut by_vf: std::collections::HashMap<i64, (Timestamp, i64)> =
             std::collections::HashMap::new();
-        if let Ok(h) = hist.get_edge_history(edge_id) {
-            for ver in h.versions {
-                let tx_from = ver.temporal.transaction_time().start();
-                if tx_from > as_of {
-                    continue;
-                }
-                let vf = ver.temporal.valid_time().start().wallclock();
-                let vt = ver.temporal.valid_time().end().wallclock();
-                match by_vf.get(&vf) {
-                    Some((existing_tx, _)) if *existing_tx >= tx_from => {}
-                    _ => {
-                        by_vf.insert(vf, (tx_from, vt));
-                    }
+        for ver in h.versions {
+            let tx_from = ver.temporal.transaction_time().start();
+            if tx_from > as_of {
+                continue;
+            }
+            let vf = ver.temporal.valid_time().start().wallclock();
+            let vt = ver.temporal.valid_time().end().wallclock();
+            match by_vf.get(&vf) {
+                Some((existing_tx, _)) if *existing_tx >= tx_from => {}
+                _ => {
+                    by_vf.insert(vf, (tx_from, vt));
                 }
             }
         }
         let intervals = by_vf.into_iter().map(|(vf, (_, vt))| (vf, vt)).collect();
-        PresenceIntervals { intervals }
+        Ok(PresenceIntervals { intervals })
     }
 
     fn drain(&mut self) -> Result<()> {
@@ -3715,7 +3745,7 @@ impl TemporalJoinIterator {
             self, AlignCoordinate, AlignMode, Participant, PresenceIntervals,
         };
 
-        let mut input = match self.input.take() {
+        let input = match self.input.take() {
             Some(i) => i,
             None => return Ok(()),
         };
@@ -3723,34 +3753,65 @@ impl TemporalJoinIterator {
         let as_of = self.spec.as_of_system_time;
         let from = self.spec.range_start_micros;
         let to = self.spec.range_end_micros;
-        let mut rows: Vec<QueryRow> = Vec::new();
 
-        let hist = self.historical.read();
-        while let Some(row) = input.next() {
-            let row = row?;
-
-            // Resolve each participant's node id + gating edge for this row.
-            // A participant whose node id cannot be located in the row is
-            // skipped for the whole matched row (the pattern shape guarantees
-            // it, but we defend against a null/optional binding).
-            let mut node_ids: Vec<NodeId> = Vec::with_capacity(self.spec.participants.len());
-            let mut participants: Vec<Participant> =
-                Vec::with_capacity(self.spec.participants.len());
-            let mut incomplete = false;
-            for p in &self.spec.participants {
-                let Some(nid) = Self::participant_node_id(&row, p.node_source) else {
-                    incomplete = true;
-                    break;
-                };
-                node_ids.push(nid);
-                let timeline = Self::node_timeline(&hist, nid, as_of);
-                let gate: Option<PresenceIntervals> = p.edge_gate_path_index.and_then(|idx| {
-                    Self::gate_edge_id(&row, idx).map(|eid| Self::edge_presence(&hist, eid, as_of))
-                });
-                participants.push(Participant { timeline, gate });
+        // Phase 1: fully drain the upstream matched-participant stream into a
+        // Vec of per-row resolved (node id + gating edge id) tuples, THEN drop
+        // the input iterator, all BEFORE acquiring the `historical` read guard.
+        // Holding a parking_lot read guard across `input.next()` risks a
+        // recursive-read deadlock (an upstream iterator may itself take the
+        // same lock) and starves writers; mirror the #3363 sibling which drains
+        // first (Issue #3379 review finding — BLOCKER). A row whose participant
+        // node id cannot be located is skipped whole (defensive against a
+        // null/optional binding; the pattern shape normally guarantees it).
+        struct ResolvedParticipant {
+            node_id: NodeId,
+            gate_edge_id: Option<EdgeId>,
+        }
+        let mut resolved_rows: Vec<Vec<ResolvedParticipant>> = Vec::new();
+        {
+            let mut input = input;
+            while let Some(row) = input.next() {
+                let row = row?;
+                let mut resolved: Vec<ResolvedParticipant> =
+                    Vec::with_capacity(self.spec.participants.len());
+                let mut incomplete = false;
+                for p in &self.spec.participants {
+                    let Some(nid) = Self::participant_node_id(&row, p.node_source) else {
+                        incomplete = true;
+                        break;
+                    };
+                    let gate_edge_id = p
+                        .edge_gate_path_index
+                        .and_then(|idx| Self::gate_edge_id(&row, idx));
+                    resolved.push(ResolvedParticipant {
+                        node_id: nid,
+                        gate_edge_id,
+                    });
+                }
+                if !incomplete {
+                    resolved_rows.push(resolved);
+                }
             }
-            if incomplete {
-                continue;
+        }
+
+        // Phase 2: acquire the `historical` read guard in a scoped block and
+        // reconstruct each participant's believed timeline / gating-edge
+        // presence, run the storage-free alignment, and materialize rows. No
+        // `input.next()` runs while this guard is held.
+        let mut rows: Vec<QueryRow> = Vec::new();
+        let hist = self.historical.read();
+        for resolved in &resolved_rows {
+            let mut node_ids: Vec<NodeId> = Vec::with_capacity(resolved.len());
+            let mut participants: Vec<Participant> = Vec::with_capacity(resolved.len());
+            for (p, r) in self.spec.participants.iter().zip(resolved) {
+                node_ids.push(r.node_id);
+                let timeline = Self::node_timeline(&hist, r.node_id, as_of)?;
+                let gate: Option<PresenceIntervals> = match (p.edge_gate_path_index, r.gate_edge_id)
+                {
+                    (Some(_), Some(eid)) => Some(Self::edge_presence(&hist, eid, as_of)?),
+                    _ => None,
+                };
+                participants.push(Participant { timeline, gate });
             }
 
             // Run the storage-free alignment for the requested mode.
@@ -3760,12 +3821,7 @@ impl TemporalJoinIterator {
                 }
                 AlignMode::Overlap => temporal_join::align_overlap(&participants, from, to),
             }
-            .map_err(|e| {
-                crate::core::error::Error::Query(crate::core::error::QueryError::InvalidParameter {
-                    parameter: "temporal join".to_string(),
-                    reason: format!("{e:?}"),
-                })
-            })?;
+            .map_err(temporal_join::align_error_to_query_error)?;
 
             // Materialize each aligned coordinate into a computed-column row.
             for arow in aligned {

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -23,6 +23,7 @@ use crate::query::ir::{
     PredicateValue, ProvenanceField, ProvenancePredicate, ProvenanceProjection, ScoreThreshold,
     SortKey, TemporalWindowSpec, WindowAggArg, WindowAggFunc,
 };
+use crate::query::ir::{AlignNodeSource, TemporalAlignSpec};
 use crate::storage::current::CurrentStorage;
 use crate::storage::historical::HistoricalStorage;
 use std::cell::RefCell;
@@ -3574,6 +3575,254 @@ fn property_values_equal(a: Option<&PropertyValue>, b: Option<&PropertyValue>) -
 }
 
 impl ResultIterator for TemporalWindowAggregateIterator {
+    fn next(&mut self) -> Option<Result<QueryRow>> {
+        if !self.drained {
+            self.drained = true;
+            if let Err(e) = self.drain() {
+                return Some(Err(e));
+            }
+        }
+        self.output.next().map(Ok)
+    }
+}
+
+/// Temporal join / align iterator (Issue #3379).
+///
+/// On the first `next()` it drains the upstream matched-participant stream. For
+/// each matched row it extracts each participant's node id (and any gating edge
+/// id) per the spec, reconstructs each participant's believed valid-time
+/// timeline (and gating-edge presence intervals) as of the spec's
+/// transaction-time coordinate, and runs the storage-free
+/// [`crate::query::temporal_join`] alignment for the requested mode. Each
+/// resulting alignment coordinate becomes one computed-column [`QueryRow`]
+/// carrying the coordinate (RFC 3339) followed by the resolved `RETURN` items.
+pub struct TemporalJoinIterator {
+    input: Option<Box<dyn ResultIterator>>,
+    spec: TemporalAlignSpec,
+    historical: Arc<RwLock<HistoricalStorage>>,
+    output: std::vec::IntoIter<QueryRow>,
+    drained: bool,
+}
+
+impl TemporalJoinIterator {
+    /// Create a new temporal join iterator.
+    pub fn new(
+        input: Box<dyn ResultIterator>,
+        spec: TemporalAlignSpec,
+        historical: Arc<RwLock<HistoricalStorage>>,
+    ) -> Self {
+        TemporalJoinIterator {
+            input: Some(input),
+            spec,
+            historical,
+            output: Vec::new().into_iter(),
+            drained: false,
+        }
+    }
+
+    /// Extract the node id for a participant from a matched row, per its
+    /// configured [`AlignNodeSource`].
+    fn participant_node_id(row: &QueryRow, source: AlignNodeSource) -> Option<NodeId> {
+        match source {
+            AlignNodeSource::Entity => row.entity.node_id(),
+            AlignNodeSource::PathIndex(i) => match row.path.as_ref()?.get(i)? {
+                EntityId::Node(id) => Some(*id),
+                EntityId::Edge(_) => None,
+            },
+        }
+    }
+
+    /// Extract the gating edge id for a participant from a matched row.
+    fn gate_edge_id(row: &QueryRow, path_index: usize) -> Option<EdgeId> {
+        match row.path.as_ref()?.get(path_index)? {
+            EntityId::Edge(id) => Some(*id),
+            EntityId::Node(_) => None,
+        }
+    }
+
+    /// Reconstruct a node's believed valid-time timeline as of `as_of`: every
+    /// version recorded by `as_of` (`transaction_from <= as_of`) contributes a
+    /// change-point at its `valid_from`; same-`valid_from` corrections keep the
+    /// latest belief (mirrors the #3363 believed-version reconstruction).
+    fn node_timeline(
+        hist: &HistoricalStorage,
+        node_id: NodeId,
+        as_of: Timestamp,
+    ) -> crate::query::temporal_join::Timeline {
+        use crate::query::temporal_join::{ChangePoint, Timeline};
+        let mut by_vf: std::collections::HashMap<
+            i64,
+            (Timestamp, crate::core::property::PropertyMap),
+        > = std::collections::HashMap::new();
+        if let Ok(h) = hist.get_node_history(node_id) {
+            for ver in h.versions {
+                let tx_from = ver.temporal.transaction_time().start();
+                if tx_from > as_of {
+                    continue;
+                }
+                let vf = ver.temporal.valid_time().start().wallclock();
+                match by_vf.get(&vf) {
+                    Some((existing_tx, _)) if *existing_tx >= tx_from => {}
+                    _ => {
+                        by_vf.insert(vf, (tx_from, ver.properties));
+                    }
+                }
+            }
+        }
+        let changes = by_vf
+            .into_iter()
+            .map(|(valid_from, (_, properties))| ChangePoint {
+                valid_from,
+                properties,
+            })
+            .collect();
+        Timeline::from_changes(changes)
+    }
+
+    /// Reconstruct an edge's believed presence intervals as of `as_of`: each
+    /// believed version contributes its half-open valid interval
+    /// `[valid_from, valid_to)` (an open interval ends at `i64::MAX`).
+    fn edge_presence(
+        hist: &HistoricalStorage,
+        edge_id: EdgeId,
+        as_of: Timestamp,
+    ) -> crate::query::temporal_join::PresenceIntervals {
+        use crate::query::temporal_join::PresenceIntervals;
+        let mut by_vf: std::collections::HashMap<i64, (Timestamp, i64)> =
+            std::collections::HashMap::new();
+        if let Ok(h) = hist.get_edge_history(edge_id) {
+            for ver in h.versions {
+                let tx_from = ver.temporal.transaction_time().start();
+                if tx_from > as_of {
+                    continue;
+                }
+                let vf = ver.temporal.valid_time().start().wallclock();
+                let vt = ver.temporal.valid_time().end().wallclock();
+                match by_vf.get(&vf) {
+                    Some((existing_tx, _)) if *existing_tx >= tx_from => {}
+                    _ => {
+                        by_vf.insert(vf, (tx_from, vt));
+                    }
+                }
+            }
+        }
+        let intervals = by_vf.into_iter().map(|(vf, (_, vt))| (vf, vt)).collect();
+        PresenceIntervals { intervals }
+    }
+
+    fn drain(&mut self) -> Result<()> {
+        use crate::query::temporal_join::{
+            self, AlignCoordinate, AlignMode, Participant, PresenceIntervals,
+        };
+
+        let mut input = match self.input.take() {
+            Some(i) => i,
+            None => return Ok(()),
+        };
+
+        let as_of = self.spec.as_of_system_time;
+        let from = self.spec.range_start_micros;
+        let to = self.spec.range_end_micros;
+        let mut rows: Vec<QueryRow> = Vec::new();
+
+        let hist = self.historical.read();
+        while let Some(row) = input.next() {
+            let row = row?;
+
+            // Resolve each participant's node id + gating edge for this row.
+            // A participant whose node id cannot be located in the row is
+            // skipped for the whole matched row (the pattern shape guarantees
+            // it, but we defend against a null/optional binding).
+            let mut node_ids: Vec<NodeId> = Vec::with_capacity(self.spec.participants.len());
+            let mut participants: Vec<Participant> =
+                Vec::with_capacity(self.spec.participants.len());
+            let mut incomplete = false;
+            for p in &self.spec.participants {
+                let Some(nid) = Self::participant_node_id(&row, p.node_source) else {
+                    incomplete = true;
+                    break;
+                };
+                node_ids.push(nid);
+                let timeline = Self::node_timeline(&hist, nid, as_of);
+                let gate: Option<PresenceIntervals> = p.edge_gate_path_index.and_then(|idx| {
+                    Self::gate_edge_id(&row, idx).map(|eid| Self::edge_presence(&hist, eid, as_of))
+                });
+                participants.push(Participant { timeline, gate });
+            }
+            if incomplete {
+                continue;
+            }
+
+            // Run the storage-free alignment for the requested mode.
+            let aligned = match self.spec.mode {
+                AlignMode::Events => {
+                    temporal_join::align_events(&participants, self.spec.driver_index, from, to)
+                }
+                AlignMode::Overlap => temporal_join::align_overlap(&participants, from, to),
+            }
+            .map_err(|e| {
+                crate::core::error::Error::Query(crate::core::error::QueryError::InvalidParameter {
+                    parameter: "temporal join".to_string(),
+                    reason: format!("{e:?}"),
+                })
+            })?;
+
+            // Materialize each aligned coordinate into a computed-column row.
+            for arow in aligned {
+                let mut columns: Vec<(String, PropertyValue)> = Vec::new();
+                match arow.coordinate {
+                    AlignCoordinate::Instant(t) => columns.push((
+                        "align_valid_time".to_string(),
+                        PropertyValue::String(Arc::from(
+                            crate::query::temporal_window::format_rfc3339(t).as_str(),
+                        )),
+                    )),
+                    AlignCoordinate::Interval { from: s, to: e } => {
+                        columns.push((
+                            "overlap_from".to_string(),
+                            PropertyValue::String(Arc::from(
+                                crate::query::temporal_window::format_rfc3339(s).as_str(),
+                            )),
+                        ));
+                        columns.push((
+                            "overlap_to".to_string(),
+                            PropertyValue::String(Arc::from(
+                                crate::query::temporal_window::format_rfc3339(e).as_str(),
+                            )),
+                        ));
+                    }
+                }
+
+                for item in &self.spec.output_items {
+                    let pidx = item.participant_index;
+                    let value = match arow.sample_index.get(pidx).copied().flatten() {
+                        None => PropertyValue::Null,
+                        Some(sample_idx) => match &item.key {
+                            None => {
+                                // `RETURN v` (no key) -> the participant's node id.
+                                PropertyValue::Int(node_ids[pidx].as_u64() as i64)
+                            }
+                            Some(key) => participants[pidx].timeline.changes[sample_idx]
+                                .properties
+                                .get(key.as_str())
+                                .cloned()
+                                .unwrap_or(PropertyValue::Null),
+                        },
+                    };
+                    columns.push((item.output_name.clone(), value));
+                }
+
+                rows.push(QueryRow::from_columns(columns));
+            }
+        }
+        drop(hist);
+
+        self.output = rows.into_iter();
+        Ok(())
+    }
+}
+
+impl ResultIterator for TemporalJoinIterator {
     fn next(&mut self) -> Option<Result<QueryRow>> {
         if !self.drained {
             self.drained = true;

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -537,6 +537,18 @@ impl QueryExecutor {
                     ))
                 }
 
+                PhysicalOp::TemporalAlign { input, spec } => {
+                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    // Historical storage is required to reconstruct each matched
+                    // participant's valid-time history (and gating edge validity)
+                    // at the alignment coordinates (Issue #3379).
+                    Box::new(iterators::TemporalJoinIterator::new(
+                        input_iter,
+                        spec.clone(),
+                        Arc::clone(&self.historical),
+                    ))
+                }
+
                 PhysicalOp::Distinct { input } => {
                     let input_iter = self.build_op(input, profile, child_depth)?;
                     Box::new(iterators::DistinctIterator::new(input_iter))

--- a/src/query/ir.rs
+++ b/src/query/ir.rs
@@ -217,6 +217,15 @@ pub enum QueryOp {
     /// recorded as of `as_of_system_time` (the transaction-time dimension).
     TemporalWindowAggregate(TemporalWindowSpec),
 
+    /// Temporal join / align (Issue #3379).
+    ///
+    /// A terminal operation that consumes the upstream matched-entity stream and
+    /// aligns the bound participants at matching **valid-time** coordinates over
+    /// `[range_start, range_end)`, in either event-aligned or interval-overlap
+    /// mode, emitting one computed-column row per alignment coordinate. Reads
+    /// history at the belief recorded as of `as_of_system_time`.
+    TemporalAlign(TemporalAlignSpec),
+
     /// Collect unique values
     Distinct,
 
@@ -357,6 +366,64 @@ pub enum WindowAggArg {
     Star,
     /// A property key `v.key`.
     Property(String),
+}
+
+/// The fully-resolved plan for a [`QueryOp::TemporalAlign`] (Issue #3379).
+/// Produced by the converter after validating the raw AST align clause (mode,
+/// pattern shape, driver/return variables, timestamp boundaries).
+#[derive(Debug, Clone, PartialEq)]
+pub struct TemporalAlignSpec {
+    /// The alignment mode.
+    pub mode: crate::query::temporal_join::AlignMode,
+    /// Index into `participants` of the driving entity (event-aligned mode).
+    /// Ignored for interval-overlap.
+    pub driver_index: usize,
+    /// Inclusive start of the valid-time range (microseconds since epoch).
+    pub range_start_micros: i64,
+    /// Exclusive end of the valid-time range (microseconds since epoch).
+    pub range_end_micros: i64,
+    /// Transaction-time coordinate the history is read as-of.
+    pub as_of_system_time: Timestamp,
+    /// The participants, in declaration order (their index is referenced by
+    /// `driver_index` and each [`AlignOutputItem`]).
+    pub participants: Vec<AlignParticipant>,
+    /// The aligned output items, in `RETURN` order.
+    pub output_items: Vec<AlignOutputItem>,
+}
+
+/// One participant in a temporal join (Issue #3379): a bound variable, how to
+/// extract its node id from each matched row, and an optional gating edge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlignParticipant {
+    /// The bound variable name.
+    pub var: String,
+    /// Where the participant's node id is read from in the matched row.
+    pub node_source: AlignNodeSource,
+    /// The path index of the connecting edge that gates this participant's
+    /// presence (its validity must contain the alignment instant), or `None`
+    /// for an ungated participant (the pattern anchor / a single bound node).
+    pub edge_gate_path_index: Option<usize>,
+}
+
+/// How a participant's node id is located within a matched [`QueryRow`]
+/// (Issue #3379).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlignNodeSource {
+    /// The row's primary `entity` (the far/final node of the traversal).
+    Entity,
+    /// The node at this index in the row's `path` (`path[0]` is the anchor).
+    PathIndex(usize),
+}
+
+/// One resolved align output item (Issue #3379).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlignOutputItem {
+    /// Index into [`TemporalAlignSpec::participants`] of the referenced variable.
+    pub participant_index: usize,
+    /// The property key to read, or `None` to return the entity id.
+    pub key: Option<String>,
+    /// The output column name (alias if given, else a rendered default).
+    pub output_name: String,
 }
 
 /// A grouping key in a [`QueryOp::Aggregate`] (a non-aggregate projection

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -99,6 +99,7 @@ pub mod planner;
 pub mod read_only;
 pub mod result;
 pub mod semantic_pathfinding;
+pub mod temporal_join;
 pub mod temporal_window;
 /// Query execution traits.
 pub mod traits;

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -213,6 +213,23 @@ impl Parser {
             return Ok(query);
         }
 
+        // Parse an optional temporal join / align clause (Issue #3379). Like
+        // WINDOW it is self-contained (carries its own `RETURN`), so no further
+        // read clauses are parsed and the query must end after it.
+        if self.check_kw("ALIGN") {
+            let align = self.parse_align_clause()?;
+            query = query.with_align(align);
+            if !self.is_at_end() {
+                return Err(self.error(
+                    "Unexpected tokens after ALIGN ... RETURN (WHERE/ORDER/SKIP/LIMIT \
+                     are not supported with a temporal join)"
+                        .to_string(),
+                    Some("end of query".to_string()),
+                ));
+            }
+            return Ok(query);
+        }
+
         // Parse optional RANK BY SIMILARITY clause
         if let Some(rank) = self.parse_rank_clause()? {
             query = query.with_rank(rank);
@@ -428,6 +445,106 @@ impl Parser {
         };
 
         Ok(WindowReturnItem { func, arg, alias })
+    }
+
+    // =========================================================
+    // Temporal Join / Align Clause (Issue #3379)
+    // =========================================================
+
+    /// Parse a temporal join / align clause.
+    ///
+    /// # Grammar
+    /// ```text
+    /// align_clause ::= "ALIGN" mode
+    ///                  "OVER" "VALID_TIME" "FROM" timestamp "TO" timestamp
+    ///                  ("AS" "OF" "SYSTEM_TIME" timestamp)?
+    ///                  "RETURN" align_item ("," align_item)*
+    /// mode         ::= "EVENTS" "DRIVER" identifier
+    ///                | "OVERLAP"
+    /// align_item   ::= identifier ("." identifier)? ("AS" identifier)?
+    /// ```
+    fn parse_align_clause(&mut self) -> Result<AlignClause, ParseError> {
+        self.expect_kw("ALIGN")?;
+
+        // mode: EVENTS DRIVER <var> | OVERLAP
+        let (mode, driver) = if self.check_kw("EVENTS") {
+            self.advance();
+            self.expect_kw("DRIVER")?;
+            let var = self.parse_identifier().map_err(|_| {
+                self.error(
+                    "Expected the driving-entity variable after DRIVER".to_string(),
+                    Some("variable".to_string()),
+                )
+            })?;
+            (AlignMode::Events, Some(var))
+        } else if self.check_kw("OVERLAP") {
+            self.advance();
+            (AlignMode::Overlap, None)
+        } else {
+            return Err(self.error(
+                "Expected an alignment mode (EVENTS DRIVER <var> | OVERLAP) after ALIGN"
+                    .to_string(),
+                Some("EVENTS or OVERLAP".to_string()),
+            ));
+        };
+
+        // OVER VALID_TIME FROM <ts> TO <ts>
+        self.expect_kw("OVER")?;
+        self.expect_kw("VALID_TIME")?;
+        self.expect_kw("FROM")?;
+        let range_start = self.parse_timestamp()?;
+        self.expect(&Token::To)?;
+        let range_end = self.parse_timestamp()?;
+
+        // Optional AS OF SYSTEM_TIME <ts>
+        let as_of_system_time = if self.check(&Token::As) {
+            self.advance(); // AS
+            self.expect(&Token::Of)?;
+            self.expect_kw("SYSTEM_TIME")?;
+            Some(self.parse_timestamp()?)
+        } else {
+            None
+        };
+
+        // RETURN <item> [, <item>]*
+        self.expect(&Token::Return)?;
+        let mut items = vec![self.parse_align_item()?];
+        while self.check(&Token::Comma) {
+            self.advance();
+            items.push(self.parse_align_item()?);
+        }
+
+        Ok(AlignClause {
+            mode,
+            driver,
+            range_start,
+            range_end,
+            as_of_system_time,
+            items,
+        })
+    }
+
+    /// Parse one `var[.key] [AS alias]` align return item.
+    fn parse_align_item(&mut self) -> Result<AlignReturnItem, ParseError> {
+        let var = self.parse_identifier().map_err(|_| {
+            self.error(
+                "Expected a bound variable in the ALIGN RETURN list".to_string(),
+                Some("variable".to_string()),
+            )
+        })?;
+        let key = if self.check(&Token::Dot) {
+            self.advance();
+            Some(self.parse_identifier()?)
+        } else {
+            None
+        };
+        let alias = if self.check(&Token::As) {
+            self.advance();
+            Some(self.parse_identifier()?)
+        } else {
+            None
+        };
+        Ok(AlignReturnItem { var, key, alias })
     }
 
     fn parse_timestamp(&mut self) -> Result<TimestampLiteral, ParseError> {
@@ -2601,5 +2718,71 @@ mod sentry_tests {
 
         // Element 1 is the relationship
         assert_eq!(patterns[0].elements[1], expected_rel);
+    }
+
+    // =====================================================
+    // Temporal Join / Align Clause Tests (Issue #3379)
+    // =====================================================
+
+    #[test]
+    fn test_parse_align_events_mode() {
+        let query = Parser::parse(
+            "MATCH (o:Purchase)-[:PLACED_BY]->(c:Customer) \
+             ALIGN EVENTS DRIVER o \
+             OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2025-01-01T00:00:00Z' \
+             AS OF SYSTEM_TIME '2024-06-01T00:00:00Z' \
+             RETURN o.total, c.tier AS tier",
+        )
+        .expect("parses");
+        let align = query.align.expect("has align clause");
+        assert_eq!(align.mode, AlignMode::Events);
+        assert_eq!(align.driver.as_deref(), Some("o"));
+        assert!(align.as_of_system_time.is_some());
+        assert_eq!(align.items.len(), 2);
+        assert_eq!(align.items[0].var, "o");
+        assert_eq!(align.items[0].key.as_deref(), Some("total"));
+        assert_eq!(align.items[1].var, "c");
+        assert_eq!(align.items[1].alias.as_deref(), Some("tier"));
+        // A terminal clause: no separate RETURN clause is parsed.
+        assert!(query.return_clause.is_none());
+    }
+
+    #[test]
+    fn test_parse_align_overlap_mode_no_driver() {
+        let query = Parser::parse(
+            "MATCH (p:Product) ALIGN OVERLAP \
+             OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-06-01T00:00:00Z' \
+             RETURN p.price",
+        )
+        .expect("parses");
+        let align = query.align.expect("has align clause");
+        assert_eq!(align.mode, AlignMode::Overlap);
+        assert!(align.driver.is_none());
+        assert!(align.as_of_system_time.is_none());
+        assert_eq!(align.items.len(), 1);
+        assert_eq!(align.items[0].var, "p");
+        assert_eq!(align.items[0].key.as_deref(), Some("price"));
+    }
+
+    #[test]
+    fn test_parse_align_rejects_trailing_clause_and_bad_mode() {
+        // No trailing read clauses after ALIGN ... RETURN.
+        assert!(
+            Parser::parse(
+                "MATCH (p:Product) ALIGN OVERLAP \
+             OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-06-01T00:00:00Z' \
+             RETURN p.price LIMIT 5",
+            )
+            .is_err()
+        );
+        // Unknown mode word.
+        assert!(
+            Parser::parse(
+                "MATCH (p:Product) ALIGN SIDEWAYS \
+             OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-06-01T00:00:00Z' \
+             RETURN p.price",
+            )
+            .is_err()
+        );
     }
 }

--- a/src/query/plan.rs
+++ b/src/query/plan.rs
@@ -314,6 +314,12 @@ pub enum UnaryOp {
     /// aggregate rows.
     TemporalWindowAggregate(super::ir::TemporalWindowSpec),
 
+    /// Temporal join / align (Issue #3379). Mirrors
+    /// [`super::ir::QueryOp::TemporalAlign`]: aligns the upstream matched
+    /// participants at matching valid-time coordinates and emits per-coordinate
+    /// computed-column rows.
+    TemporalAlign(super::ir::TemporalAlignSpec),
+
     /// Left-outer application of an optional sub-pattern (`OPTIONAL MATCH`).
     ///
     /// For each input row, the `steps` sub-pipeline runs seeded from that row;

--- a/src/query/planner/cost.rs
+++ b/src/query/planner/cost.rs
@@ -470,6 +470,7 @@ impl CostModel {
             | PhysicalOp::Count { input }
             | PhysicalOp::Aggregate { input, .. }
             | PhysicalOp::TemporalWindowAggregate { input, .. }
+            | PhysicalOp::TemporalAlign { input, .. }
             | PhysicalOp::Materialize { input }
             | PhysicalOp::TemporalTrack { input, .. } => self.estimate(input, stats),
 
@@ -594,6 +595,13 @@ impl CostModel {
                 )
                 .map(|w| w.len().max(1))
                 .unwrap_or(1)
+            }
+            PhysicalOp::TemporalAlign { input, .. } => {
+                // Alignment fans each matched participant pairing out into one
+                // row per driver event / overlap sub-interval; the exact count
+                // is data-dependent (needs history), so use the input
+                // cardinality as a cheap storage-free proxy.
+                self.estimate_cardinality(input, stats).max(1)
             }
             PhysicalOp::SimilarToNode { k, .. } => *k,
             PhysicalOp::OptionalApply { input, .. } => {

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -490,6 +490,11 @@ impl QueryPlanner {
                 input,
             )),
 
+            QueryOp::TemporalAlign(spec) => Ok(LogicalOp::unary(
+                UnaryOp::TemporalAlign(spec.clone()),
+                input,
+            )),
+
             QueryOp::Distinct => Ok(LogicalOp::unary(UnaryOp::Distinct, input)),
 
             QueryOp::Project(props) => Ok(LogicalOp::unary(UnaryOp::Project(props.clone()), input)),
@@ -538,6 +543,7 @@ impl QueryPlanner {
             QueryOp::Count => "Count",
             QueryOp::Aggregate { .. } => "Aggregate",
             QueryOp::TemporalWindowAggregate(_) => "TemporalWindowAggregate",
+            QueryOp::TemporalAlign(_) => "TemporalAlign",
             QueryOp::Distinct => "Distinct",
             QueryOp::Project(_) => "Project",
             QueryOp::ProjectProvenance(_) => "ProjectProvenance",
@@ -982,6 +988,11 @@ impl QueryPlanner {
             }),
 
             UnaryOp::TemporalWindowAggregate(spec) => Ok(PhysicalOp::TemporalWindowAggregate {
+                input: Box::new(input),
+                spec: spec.clone(),
+            }),
+
+            UnaryOp::TemporalAlign(spec) => Ok(PhysicalOp::TemporalAlign {
                 input: Box::new(input),
                 spec: spec.clone(),
             }),

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -361,6 +361,7 @@ impl PhysicalPlan {
             | PhysicalOp::Count { input, .. }
             | PhysicalOp::Aggregate { input, .. }
             | PhysicalOp::TemporalWindowAggregate { input, .. }
+            | PhysicalOp::TemporalAlign { input, .. }
             | PhysicalOp::Materialize { input, .. }
             | PhysicalOp::TemporalTrack { input, .. }
             | PhysicalOp::IndexedTraversal { input, .. }
@@ -733,6 +734,16 @@ pub enum PhysicalOp {
         spec: crate::query::ir::TemporalWindowSpec,
     },
 
+    /// Temporal join / align (Issue #3379). Consumes the upstream matched
+    /// participant stream and emits one computed-column row per alignment
+    /// coordinate. Maps 1:1 to the executor's `TemporalJoinIterator`.
+    TemporalAlign {
+        /// Input operator providing the matched participants.
+        input: Box<PhysicalOp>,
+        /// The resolved temporal-align specification.
+        spec: crate::query::ir::TemporalAlignSpec,
+    },
+
     /// Materialize results into memory
     Materialize {
         /// Input operator
@@ -817,6 +828,7 @@ impl PhysicalOp {
             PhysicalOp::Count { .. } => "Count",
             PhysicalOp::Aggregate { .. } => "Aggregate",
             PhysicalOp::TemporalWindowAggregate { .. } => "TemporalWindowAggregate",
+            PhysicalOp::TemporalAlign { .. } => "TemporalAlign",
             PhysicalOp::TemporalTrack { .. } => "TemporalTrack",
             PhysicalOp::Materialize { .. } => "Materialize",
             PhysicalOp::OptionalApply { .. } => "OptionalApply",
@@ -870,6 +882,7 @@ impl PhysicalOp {
             | PhysicalOp::Count { input, .. }
             | PhysicalOp::Aggregate { input, .. }
             | PhysicalOp::TemporalWindowAggregate { input, .. }
+            | PhysicalOp::TemporalAlign { input, .. }
             | PhysicalOp::TemporalTrack { input, .. }
             | PhysicalOp::Materialize { input, .. }
             | PhysicalOp::OptionalApply { input, .. } => 1 + input.depth(),
@@ -1080,6 +1093,7 @@ impl PhysicalOp {
             | PhysicalOp::Count { input, .. }
             | PhysicalOp::Aggregate { input, .. }
             | PhysicalOp::TemporalWindowAggregate { input, .. }
+            | PhysicalOp::TemporalAlign { input, .. }
             | PhysicalOp::TemporalTrack { input, .. }
             | PhysicalOp::Materialize { input, .. }
             | PhysicalOp::OptionalApply { input, .. } => Some(input),

--- a/src/query/temporal_join.rs
+++ b/src/query/temporal_join.rs
@@ -1,0 +1,581 @@
+//! Pure interval math for AQL temporal joins (Issue #3379).
+//!
+//! This module holds the *storage-free* semantic core behind AQL temporal
+//! joins: given each participating entity's reconstructed **valid-time**
+//! timeline (as believed at a pinned transaction time), it aligns them at
+//! matching valid-time coordinates over a range, in one of two modes:
+//!
+//! * **event-aligned** ([`AlignMode::Events`]) — the SQL `ASOF JOIN` analog.
+//!   For each version-change instant of a *driver* entity within the range,
+//!   every participant is sampled at "its most recent state at or before that
+//!   instant". One output row per driver event.
+//! * **interval-overlap** ([`AlignMode::Overlap`]) — the piecewise maximal
+//!   sub-intervals over the range during which *all* participants' states (and
+//!   any gating edge) co-held constant, i.e. the intersection of the
+//!   participating valid intervals. One output row per non-empty sub-interval.
+//!
+//! Keeping this logic separate from the executor iterator lets the subtle
+//! half-open interval-boundary rules be exhaustively unit-tested without a
+//! database — the CI correctness fixture (Issue #3379 AC6) lives in this
+//! module's tests.
+//!
+//! # Boundary contract (falsifiable)
+//!
+//! All ranges and presence intervals are **half-open** `[from, to)`, matching
+//! the storage model and the #3363 temporal-window convention. A change-point
+//! or edge interval whose `valid_from` equals an alignment instant *starts*
+//! that instant and is therefore **included** at it (a version does not
+//! contribute to an instant strictly before its `valid_from`). A version at
+//! exactly `to` is excluded from the range. No output row ever pairs states
+//! that did not co-hold under this rule.
+
+use crate::core::property::PropertyMap;
+
+/// Hard cap on the number of alignment instants (event mode) or sub-interval
+/// boundaries (overlap mode) a single join may generate, guarding against a
+/// caller pairing a huge range with highly volatile entities.
+pub const MAX_ALIGN_INSTANTS: usize = 100_000;
+
+/// The temporal-join alignment mode (Issue #3379).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlignMode {
+    /// Event-aligned (ASOF): sample participants at each driver change-point.
+    Events,
+    /// Interval-overlap: piecewise sub-intervals where all states co-held.
+    Overlap,
+}
+
+/// One believed change-point in an entity's valid-time timeline: the entity's
+/// reconstructed state (`properties`) holds from `valid_from` until the next
+/// change-point (or forever, for the last one).
+#[derive(Debug, Clone)]
+pub struct ChangePoint {
+    /// Valid-time interval start, microseconds since epoch.
+    pub valid_from: i64,
+    /// The version's reconstructed properties at this change-point.
+    pub properties: PropertyMap,
+}
+
+/// A believed valid-time timeline for one participant entity: its change-points
+/// sorted ascending and deduplicated by `valid_from` (latest belief wins — the
+/// caller resolves same-instant supersession before constructing this).
+#[derive(Debug, Clone, Default)]
+pub struct Timeline {
+    /// Ascending, `valid_from`-deduplicated change-points.
+    pub changes: Vec<ChangePoint>,
+}
+
+impl Timeline {
+    /// Build a timeline from unsorted change-points, sorting ascending by
+    /// `valid_from`. Callers must have already resolved same-`valid_from`
+    /// supersession (see the executor's believed-version reconstruction).
+    #[must_use]
+    pub fn from_changes(mut changes: Vec<ChangePoint>) -> Self {
+        changes.sort_by_key(|c| c.valid_from);
+        Timeline { changes }
+    }
+
+    /// Index of the most recent change-point at or before `instant`
+    /// (`valid_from <= instant`), or `None` if the entity did not yet exist.
+    #[must_use]
+    pub fn sample_index_at(&self, instant: i64) -> Option<usize> {
+        // changes is ascending; find the last one with valid_from <= instant.
+        self.changes.iter().rposition(|c| c.valid_from <= instant)
+    }
+}
+
+/// A set of believed half-open valid intervals `[from, to)` during which a
+/// gating edge is present (`to == i64::MAX` for an open interval). Used to gate
+/// a participant that is reached via a relationship whose own validity changes
+/// over the range (Issue #3379 AC2: edge validity honored at each instant).
+#[derive(Debug, Clone, Default)]
+pub struct PresenceIntervals {
+    /// Half-open `[from, to)` intervals; may overlap/abut (union semantics).
+    pub intervals: Vec<(i64, i64)>,
+}
+
+impl PresenceIntervals {
+    /// Whether the gate is open at `instant` (some interval contains it).
+    #[must_use]
+    pub fn present_at(&self, instant: i64) -> bool {
+        self.intervals
+            .iter()
+            .any(|(s, e)| instant >= *s && instant < *e)
+    }
+}
+
+/// A participant in a temporal join: its own state timeline plus an optional
+/// connecting-edge presence gate. The participant is considered *present* at an
+/// instant iff it has a state sample there **and** its gate (if any) is open.
+#[derive(Debug, Clone)]
+pub struct Participant {
+    /// The participant's believed valid-time state timeline.
+    pub timeline: Timeline,
+    /// Optional connecting-edge validity gate. `None` means ungated (e.g. the
+    /// driver itself, or a participant bound by explicit id).
+    pub gate: Option<PresenceIntervals>,
+}
+
+impl Participant {
+    /// Construct an ungated participant from a timeline.
+    #[must_use]
+    pub fn ungated(timeline: Timeline) -> Self {
+        Participant {
+            timeline,
+            gate: None,
+        }
+    }
+
+    /// Whether the gate (if any) is open at `instant`.
+    fn gate_open_at(&self, instant: i64) -> bool {
+        self.gate.as_ref().is_none_or(|g| g.present_at(instant))
+    }
+
+    /// The sampled change-point index at `instant`, honoring the gate: `None`
+    /// if the entity has no state at/before `instant` or the gate is closed.
+    #[must_use]
+    pub fn sample_index_at(&self, instant: i64) -> Option<usize> {
+        if self.gate_open_at(instant) {
+            self.timeline.sample_index_at(instant)
+        } else {
+            None
+        }
+    }
+
+    /// Whether the participant is present (state + gate) at `instant`.
+    #[must_use]
+    pub fn present_at(&self, instant: i64) -> bool {
+        self.sample_index_at(instant).is_some()
+    }
+}
+
+/// The alignment coordinate stamped on each output row (Issue #3379 AC4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlignCoordinate {
+    /// Event-aligned: the single valid-time instant (microseconds since epoch).
+    Instant(i64),
+    /// Interval-overlap: the half-open `[from, to)` sub-interval it holds over.
+    Interval {
+        /// Inclusive start (microseconds since epoch).
+        from: i64,
+        /// Exclusive end (microseconds since epoch).
+        to: i64,
+    },
+}
+
+/// One aligned output row: the alignment coordinate plus, for each participant
+/// (in participant order), the index of its sampled change-point, or `None`
+/// when the participant was absent at that coordinate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlignedRow {
+    /// The valid-time coordinate this row corresponds to.
+    pub coordinate: AlignCoordinate,
+    /// Per-participant sampled change-point index (`None` == absent).
+    pub sample_index: Vec<Option<usize>>,
+}
+
+/// Errors from alignment. Mapped by the converter/executor to structured
+/// [`crate::core::error::QueryError`]s.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AlignError {
+    /// `to <= from`.
+    EmptyRange,
+    /// No participants were supplied.
+    NoParticipants,
+    /// The driver index is out of range for event-aligned mode.
+    DriverOutOfRange,
+    /// The range/volatility pair would generate more than
+    /// [`MAX_ALIGN_INSTANTS`] instants or boundaries.
+    TooManyInstants(usize),
+}
+
+/// Event-aligned join (Issue #3379, [`AlignMode::Events`]).
+///
+/// Emits one row per distinct driver change-point instant `T` with
+/// `from <= T < to`, sampling every participant at its most recent state at or
+/// before `T` (`None` == absent). The driver is always present at its own
+/// event. Rows are in ascending instant order.
+pub fn align_events(
+    participants: &[Participant],
+    driver: usize,
+    from: i64,
+    to: i64,
+) -> Result<Vec<AlignedRow>, AlignError> {
+    if participants.is_empty() {
+        return Err(AlignError::NoParticipants);
+    }
+    if driver >= participants.len() {
+        return Err(AlignError::DriverOutOfRange);
+    }
+    if to <= from {
+        return Err(AlignError::EmptyRange);
+    }
+
+    // Distinct driver change-point instants in [from, to), ascending. The
+    // driver timeline is already sorted+deduped, so a linear pass suffices.
+    let mut instants: Vec<i64> = Vec::new();
+    for cp in &participants[driver].timeline.changes {
+        if cp.valid_from >= from && cp.valid_from < to {
+            if instants.last() != Some(&cp.valid_from) {
+                instants.push(cp.valid_from);
+            }
+            if instants.len() > MAX_ALIGN_INSTANTS {
+                return Err(AlignError::TooManyInstants(instants.len()));
+            }
+        }
+    }
+
+    let rows = instants
+        .into_iter()
+        .map(|t| AlignedRow {
+            coordinate: AlignCoordinate::Instant(t),
+            sample_index: participants.iter().map(|p| p.sample_index_at(t)).collect(),
+        })
+        .collect();
+    Ok(rows)
+}
+
+/// Interval-overlap join (Issue #3379, [`AlignMode::Overlap`]).
+///
+/// Computes the piecewise maximal sub-intervals tiling `[from, to)` at the
+/// union of all participants' change-points and gating-edge boundaries within
+/// the range, and emits one row per sub-interval **over which every participant
+/// (state + gate) co-held** — sub-intervals where any participant is absent are
+/// the empty-overlap gaps and are dropped. Each participant is sampled at the
+/// sub-interval's left endpoint (constant across it by construction). Rows are
+/// in ascending interval order.
+pub fn align_overlap(
+    participants: &[Participant],
+    from: i64,
+    to: i64,
+) -> Result<Vec<AlignedRow>, AlignError> {
+    if participants.is_empty() {
+        return Err(AlignError::NoParticipants);
+    }
+    if to <= from {
+        return Err(AlignError::EmptyRange);
+    }
+
+    // Boundary set: `from`, every participant change-point in [from, to), and
+    // every gating-edge interval boundary in (from, to). A BTreeSet keeps them
+    // sorted and unique.
+    let mut boundaries: std::collections::BTreeSet<i64> = std::collections::BTreeSet::new();
+    boundaries.insert(from);
+    for p in participants {
+        for cp in &p.timeline.changes {
+            if cp.valid_from >= from && cp.valid_from < to {
+                boundaries.insert(cp.valid_from);
+            }
+        }
+        if let Some(gate) = &p.gate {
+            for (s, e) in &gate.intervals {
+                if *s > from && *s < to {
+                    boundaries.insert(*s);
+                }
+                if *e > from && *e < to {
+                    boundaries.insert(*e);
+                }
+            }
+        }
+        if boundaries.len() > MAX_ALIGN_INSTANTS {
+            return Err(AlignError::TooManyInstants(boundaries.len()));
+        }
+    }
+
+    // Consecutive boundaries form sub-intervals [b_j, b_{j+1}); the final
+    // sub-interval's end is `to`.
+    let starts: Vec<i64> = boundaries.into_iter().collect();
+    let mut rows = Vec::new();
+    for (j, &s) in starts.iter().enumerate() {
+        let e = starts.get(j + 1).copied().unwrap_or(to);
+        // Sample every participant at the left endpoint; keep the sub-interval
+        // only if ALL are present (co-hold), per the overlap contract.
+        let sample_index: Vec<Option<usize>> =
+            participants.iter().map(|p| p.sample_index_at(s)).collect();
+        if sample_index.iter().all(Option::is_some) {
+            rows.push(AlignedRow {
+                coordinate: AlignCoordinate::Interval { from: s, to: e },
+                sample_index,
+            });
+        }
+    }
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::property::PropertyMapBuilder;
+    use crate::query::temporal_window::parse_boundary_micros;
+
+    fn t(rfc: &str) -> i64 {
+        parse_boundary_micros(rfc).unwrap()
+    }
+
+    /// Build a timeline of `(valid_from_rfc, tier_int)` change-points.
+    fn timeline(points: &[(&str, i64)]) -> Timeline {
+        let changes = points
+            .iter()
+            .map(|(vf, tier)| ChangePoint {
+                valid_from: t(vf),
+                properties: PropertyMapBuilder::new().insert("v", *tier).build(),
+            })
+            .collect();
+        Timeline::from_changes(changes)
+    }
+
+    fn v_at(p: &Participant, idx: Option<usize>) -> Option<i64> {
+        let i = idx?;
+        match p.timeline.changes[i].properties.get("v") {
+            Some(crate::core::property::PropertyValue::Int(n)) => Some(*n),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn sample_index_is_most_recent_at_or_before() {
+        let tl = timeline(&[("2024-01-01", 1), ("2024-03-01", 2), ("2024-06-01", 3)]);
+        // Before first change-point: absent.
+        assert_eq!(tl.sample_index_at(t("2023-12-31")), None);
+        // Exactly at a change-point: included (half-open start rule).
+        assert_eq!(tl.sample_index_at(t("2024-03-01")), Some(1));
+        // Between change-points: the earlier one holds.
+        assert_eq!(tl.sample_index_at(t("2024-04-15")), Some(1));
+        // After the last: the last holds forever.
+        assert_eq!(tl.sample_index_at(t("2030-01-01")), Some(2));
+    }
+
+    #[test]
+    fn events_one_row_per_driver_change_point_in_range() {
+        // Driver (order) has placements; customer tier changes independently.
+        let driver = Participant::ungated(timeline(&[
+            ("2024-02-01", 10),
+            ("2024-05-01", 20),
+            ("2024-09-01", 30),
+        ]));
+        let customer = Participant::ungated(timeline(&[
+            ("2024-01-01", 1), // tier 1
+            ("2024-06-01", 2), // upgraded to tier 2
+        ]));
+        let parts = vec![driver, customer];
+        let rows = align_events(&parts, 0, t("2024-01-01"), t("2025-01-01")).unwrap();
+        // 3 driver events.
+        assert_eq!(rows.len(), 3);
+        assert_eq!(
+            rows[0].coordinate,
+            AlignCoordinate::Instant(t("2024-02-01"))
+        );
+        assert_eq!(
+            rows[1].coordinate,
+            AlignCoordinate::Instant(t("2024-05-01"))
+        );
+        assert_eq!(
+            rows[2].coordinate,
+            AlignCoordinate::Instant(t("2024-09-01"))
+        );
+        // Customer tier AT each order instant:
+        //  2024-02-01 -> tier 1 (before upgrade)
+        //  2024-05-01 -> tier 1 (still before upgrade on 2024-06-01)
+        //  2024-09-01 -> tier 2 (after upgrade)
+        assert_eq!(v_at(&parts[1], rows[0].sample_index[1]), Some(1));
+        assert_eq!(v_at(&parts[1], rows[1].sample_index[1]), Some(1));
+        assert_eq!(v_at(&parts[1], rows[2].sample_index[1]), Some(2));
+    }
+
+    #[test]
+    fn events_participant_absent_before_it_existed_is_null() {
+        // Order placed before the customer record existed -> customer absent.
+        let driver = Participant::ungated(timeline(&[("2024-01-05", 10)]));
+        let customer = Participant::ungated(timeline(&[("2024-02-01", 1)]));
+        let parts = vec![driver, customer];
+        let rows = align_events(&parts, 0, t("2024-01-01"), t("2024-12-01")).unwrap();
+        assert_eq!(rows.len(), 1);
+        // Driver present at its own event; customer absent (None).
+        assert!(rows[0].sample_index[0].is_some());
+        assert_eq!(rows[0].sample_index[1], None);
+    }
+
+    #[test]
+    fn events_range_boundaries_half_open() {
+        // Change-points exactly at `from` (included) and exactly at `to` (excluded).
+        let driver = Participant::ungated(timeline(&[
+            ("2024-01-01", 1), // == from  -> included
+            ("2024-06-01", 2), // interior -> included
+            ("2025-01-01", 3), // == to    -> excluded
+        ]));
+        let parts = vec![driver];
+        let rows = align_events(&parts, 0, t("2024-01-01"), t("2025-01-01")).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            rows[0].coordinate,
+            AlignCoordinate::Instant(t("2024-01-01"))
+        );
+        assert_eq!(
+            rows[1].coordinate,
+            AlignCoordinate::Instant(t("2024-06-01"))
+        );
+    }
+
+    #[test]
+    fn events_edge_gate_absent_when_edge_not_valid() {
+        // Customer reached via an edge valid only [2024-03-01, 2024-08-01).
+        let driver = Participant::ungated(timeline(&[
+            ("2024-02-01", 10), // edge not yet valid -> customer absent
+            ("2024-05-01", 20), // edge valid          -> customer present
+            ("2024-09-01", 30), // edge expired        -> customer absent
+        ]));
+        let customer = Participant {
+            timeline: timeline(&[("2024-01-01", 7)]),
+            gate: Some(PresenceIntervals {
+                intervals: vec![(t("2024-03-01"), t("2024-08-01"))],
+            }),
+        };
+        let parts = vec![driver, customer];
+        let rows = align_events(&parts, 0, t("2024-01-01"), t("2025-01-01")).unwrap();
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].sample_index[1], None); // edge not valid yet
+        assert!(rows[1].sample_index[1].is_some()); // edge valid
+        assert_eq!(rows[2].sample_index[1], None); // edge expired
+    }
+
+    #[test]
+    fn overlap_piecewise_intersection_of_two_timelines() {
+        // A: [Jan..Apr)=a1, [Apr..)=a2 ; B: [Feb..)=b1
+        let a = Participant::ungated(timeline(&[("2024-01-01", 1), ("2024-04-01", 2)]));
+        let b = Participant::ungated(timeline(&[("2024-02-01", 10)]));
+        let parts = vec![a, b];
+        let rows = align_overlap(&parts, t("2024-01-01"), t("2024-06-01")).unwrap();
+        // Boundaries in range: from=Jan01, Feb01 (B), Apr01 (A). Sub-intervals:
+        //  [Jan01,Feb01) -> B absent -> DROPPED
+        //  [Feb01,Apr01) -> a1 & b1  -> kept
+        //  [Apr01,Jun01) -> a2 & b1  -> kept
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            rows[0].coordinate,
+            AlignCoordinate::Interval {
+                from: t("2024-02-01"),
+                to: t("2024-04-01")
+            }
+        );
+        assert_eq!(v_at(&parts[0], rows[0].sample_index[0]), Some(1));
+        assert_eq!(v_at(&parts[1], rows[0].sample_index[1]), Some(10));
+        assert_eq!(
+            rows[1].coordinate,
+            AlignCoordinate::Interval {
+                from: t("2024-04-01"),
+                to: t("2024-06-01")
+            }
+        );
+        assert_eq!(v_at(&parts[0], rows[1].sample_index[0]), Some(2));
+    }
+
+    #[test]
+    fn overlap_empty_when_no_co_hold_gap() {
+        // A present only early, B present only late: no overlap at all.
+        let a = Participant::ungated(timeline(&[("2024-01-01", 1)]));
+        let mut a_gated = a;
+        a_gated.gate = Some(PresenceIntervals {
+            intervals: vec![(t("2024-01-01"), t("2024-03-01"))],
+        });
+        let b = Participant {
+            timeline: timeline(&[("2024-05-01", 2)]),
+            gate: None,
+        };
+        let parts = vec![a_gated, b];
+        let rows = align_overlap(&parts, t("2024-01-01"), t("2024-12-01")).unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn overlap_edge_appears_and_disappears_mid_range() {
+        // Product price + supplier rating co-held only while the SUPPLIES edge
+        // is valid [Mar..Aug).
+        let product = Participant::ungated(timeline(&[("2024-01-01", 100)]));
+        let supplier = Participant {
+            timeline: timeline(&[("2024-01-01", 5)]),
+            gate: Some(PresenceIntervals {
+                intervals: vec![(t("2024-03-01"), t("2024-08-01"))],
+            }),
+        };
+        let parts = vec![product, supplier];
+        let rows = align_overlap(&parts, t("2024-01-01"), t("2024-12-01")).unwrap();
+        // Only one co-hold sub-interval: exactly the edge's validity window.
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].coordinate,
+            AlignCoordinate::Interval {
+                from: t("2024-03-01"),
+                to: t("2024-08-01")
+            }
+        );
+    }
+
+    #[test]
+    fn overlap_adjacent_versions_tile_without_gap_or_overlap() {
+        let a = Participant::ungated(timeline(&[
+            ("2024-01-01", 1),
+            ("2024-02-01", 2),
+            ("2024-03-01", 3),
+        ]));
+        let parts = vec![a];
+        let rows = align_overlap(&parts, t("2024-01-01"), t("2024-04-01")).unwrap();
+        assert_eq!(rows.len(), 3);
+        // Contiguous: each end == next start, union == [from,to).
+        assert_eq!(
+            rows[0].coordinate,
+            AlignCoordinate::Interval {
+                from: t("2024-01-01"),
+                to: t("2024-02-01")
+            }
+        );
+        assert_eq!(
+            rows[2].coordinate,
+            AlignCoordinate::Interval {
+                from: t("2024-03-01"),
+                to: t("2024-04-01")
+            }
+        );
+    }
+
+    #[test]
+    fn errors_empty_range_and_no_participants_and_driver_oob() {
+        let p = Participant::ungated(timeline(&[("2024-01-01", 1)]));
+        let one = std::slice::from_ref(&p);
+        assert_eq!(
+            align_events(one, 0, t("2024-02-01"), t("2024-01-01")),
+            Err(AlignError::EmptyRange)
+        );
+        assert_eq!(
+            align_events(&[], 0, t("2024-01-01"), t("2024-02-01")),
+            Err(AlignError::NoParticipants)
+        );
+        assert_eq!(
+            align_events(one, 5, t("2024-01-01"), t("2024-02-01")),
+            Err(AlignError::DriverOutOfRange)
+        );
+        assert_eq!(
+            align_overlap(&[], t("2024-01-01"), t("2024-02-01")),
+            Err(AlignError::NoParticipants)
+        );
+    }
+
+    #[test]
+    fn events_same_valid_from_deduplicated_to_one_instant() {
+        // Two driver change-points share a valid_from (a same-instant
+        // correction already resolved) -> one event instant.
+        let driver = Participant::ungated(Timeline {
+            changes: vec![
+                ChangePoint {
+                    valid_from: t("2024-03-01"),
+                    properties: PropertyMapBuilder::new().insert("v", 1).build(),
+                },
+                ChangePoint {
+                    valid_from: t("2024-03-01"),
+                    properties: PropertyMapBuilder::new().insert("v", 2).build(),
+                },
+            ],
+        });
+        let rows = align_events(&[driver], 0, t("2024-01-01"), t("2024-12-01")).unwrap();
+        assert_eq!(rows.len(), 1);
+    }
+}

--- a/src/query/temporal_join.rs
+++ b/src/query/temporal_join.rs
@@ -46,12 +46,20 @@ pub enum AlignMode {
 }
 
 /// One believed change-point in an entity's valid-time timeline: the entity's
-/// reconstructed state (`properties`) holds from `valid_from` until the next
-/// change-point (or forever, for the last one).
+/// reconstructed state (`properties`) holds over the half-open valid interval
+/// `[valid_from, valid_to)`. `valid_to == i64::MAX` marks an open (never
+/// retracted / deleted) interval that holds until the next change-point (or
+/// forever, for the last one); a finite `valid_to` marks a **closed** interval
+/// (a retraction #3230, a delete tombstone, or a gap) after which the entity is
+/// **absent** — the covering version stops contributing at `valid_to`.
 #[derive(Debug, Clone)]
 pub struct ChangePoint {
     /// Valid-time interval start, microseconds since epoch.
     pub valid_from: i64,
+    /// Valid-time interval end (exclusive), microseconds since epoch;
+    /// `i64::MAX` for an open interval. The entity is absent at/after this
+    /// instant unless a later change-point re-establishes it.
+    pub valid_to: i64,
     /// The version's reconstructed properties at this change-point.
     pub properties: PropertyMap,
 }
@@ -75,12 +83,24 @@ impl Timeline {
         Timeline { changes }
     }
 
-    /// Index of the most recent change-point at or before `instant`
-    /// (`valid_from <= instant`), or `None` if the entity did not yet exist.
+    /// Index of the version covering `instant`: the most recent change-point at
+    /// or before `instant` (`valid_from <= instant`), **provided that
+    /// change-point's valid interval still covers `instant`** (`instant <
+    /// valid_to`). Returns `None` if the entity did not yet exist, or its
+    /// covering version's valid interval has closed (a retraction / delete /
+    /// valid-time gap): a closed or deleted node is **absent**, not present
+    /// forever (Issue #3379 correctness — symmetric with the edge-gate path).
     #[must_use]
     pub fn sample_index_at(&self, instant: i64) -> Option<usize> {
         // changes is ascending; find the last one with valid_from <= instant.
-        self.changes.iter().rposition(|c| c.valid_from <= instant)
+        let idx = self.changes.iter().rposition(|c| c.valid_from <= instant)?;
+        // Honor the covering version's closed valid_to: at/after it the entity
+        // is absent (retraction #3230 / delete / gap before the next version).
+        if instant >= self.changes[idx].valid_to {
+            None
+        } else {
+            Some(idx)
+        }
     }
 }
 
@@ -189,6 +209,37 @@ pub enum AlignError {
     TooManyInstants(usize),
 }
 
+/// Map an [`AlignError`] to the structured [`crate::core::error::Error`] the
+/// executor/MCP surface renders (an `InvalidParameter` / `UnsupportedFeature`
+/// [`crate::core::error::QueryError`]), mirroring the converter's
+/// `window_error_to_query_error`. Produces a human-readable sentence rather
+/// than a `Debug`-formatted enum (so the `TooManyInstants` cap names the
+/// [`MAX_ALIGN_INSTANTS`] limit instead of surfacing `TooManyInstants(100001)`).
+#[must_use]
+pub(crate) fn align_error_to_query_error(err: AlignError) -> crate::core::error::Error {
+    use crate::core::error::{Error, QueryError};
+    let reason = match err {
+        AlignError::EmptyRange => {
+            "the valid-time range end must be strictly after the start".to_string()
+        }
+        AlignError::NoParticipants => {
+            "a temporal join requires at least one participant entity".to_string()
+        }
+        AlignError::DriverOutOfRange => {
+            "the event-aligned driver is not a bound participant in the pattern".to_string()
+        }
+        AlignError::TooManyInstants(n) => format!(
+            "the valid-time range and entity volatility would generate {n} alignment \
+             instants / boundaries, exceeding the limit of {MAX_ALIGN_INSTANTS}; narrow the \
+             range or reduce the number of participants"
+        ),
+    };
+    Error::Query(QueryError::InvalidParameter {
+        parameter: "temporal join".to_string(),
+        reason,
+    })
+}
+
 /// Event-aligned join (Issue #3379, [`AlignMode::Events`]).
 ///
 /// Emits one row per distinct driver change-point instant `T` with
@@ -256,29 +307,47 @@ pub fn align_overlap(
         return Err(AlignError::EmptyRange);
     }
 
-    // Boundary set: `from`, every participant change-point in [from, to), and
-    // every gating-edge interval boundary in (from, to). A BTreeSet keeps them
-    // sorted and unique.
+    // Boundary set: `from`, every participant change-point boundary in the
+    // range (both `valid_from` — an appearance / value change — and a *closed*
+    // `valid_to` — a retraction / delete / gap where the entity becomes
+    // absent, Issue #3379), and every gating-edge interval boundary in
+    // (from, to). A BTreeSet keeps them sorted and unique. The cap is checked
+    // inside the inner loops so the boundary count is tightly bounded (matches
+    // `align_events`).
     let mut boundaries: std::collections::BTreeSet<i64> = std::collections::BTreeSet::new();
     boundaries.insert(from);
     for p in participants {
         for cp in &p.timeline.changes {
             if cp.valid_from >= from && cp.valid_from < to {
                 boundaries.insert(cp.valid_from);
+                if boundaries.len() > MAX_ALIGN_INSTANTS {
+                    return Err(AlignError::TooManyInstants(boundaries.len()));
+                }
+            }
+            // A closed valid_to ends the entity's presence: split the tiling
+            // there so the sub-interval after it is dropped (absent).
+            if cp.valid_to > from && cp.valid_to < to {
+                boundaries.insert(cp.valid_to);
+                if boundaries.len() > MAX_ALIGN_INSTANTS {
+                    return Err(AlignError::TooManyInstants(boundaries.len()));
+                }
             }
         }
         if let Some(gate) = &p.gate {
             for (s, e) in &gate.intervals {
                 if *s > from && *s < to {
                     boundaries.insert(*s);
+                    if boundaries.len() > MAX_ALIGN_INSTANTS {
+                        return Err(AlignError::TooManyInstants(boundaries.len()));
+                    }
                 }
                 if *e > from && *e < to {
                     boundaries.insert(*e);
+                    if boundaries.len() > MAX_ALIGN_INSTANTS {
+                        return Err(AlignError::TooManyInstants(boundaries.len()));
+                    }
                 }
             }
-        }
-        if boundaries.len() > MAX_ALIGN_INSTANTS {
-            return Err(AlignError::TooManyInstants(boundaries.len()));
         }
     }
 
@@ -312,12 +381,29 @@ mod tests {
         parse_boundary_micros(rfc).unwrap()
     }
 
-    /// Build a timeline of `(valid_from_rfc, tier_int)` change-points.
+    /// Build a timeline of `(valid_from_rfc, tier_int)` change-points, each with
+    /// an open (`i64::MAX`) valid interval — the common "never retracted" case.
     fn timeline(points: &[(&str, i64)]) -> Timeline {
         let changes = points
             .iter()
             .map(|(vf, tier)| ChangePoint {
                 valid_from: t(vf),
+                valid_to: i64::MAX,
+                properties: PropertyMapBuilder::new().insert("v", *tier).build(),
+            })
+            .collect();
+        Timeline::from_changes(changes)
+    }
+
+    /// Build a timeline of `(valid_from_rfc, valid_to_rfc_or_none, tier_int)`
+    /// change-points, so a closed (retracted / deleted / gapped) valid interval
+    /// can be expressed. `None` for the end means open (`i64::MAX`).
+    fn timeline_closed(points: &[(&str, Option<&str>, i64)]) -> Timeline {
+        let changes = points
+            .iter()
+            .map(|(vf, vt, tier)| ChangePoint {
+                valid_from: t(vf),
+                valid_to: vt.map_or(i64::MAX, t),
                 properties: PropertyMapBuilder::new().insert("v", *tier).build(),
             })
             .collect();
@@ -567,15 +653,157 @@ mod tests {
             changes: vec![
                 ChangePoint {
                     valid_from: t("2024-03-01"),
+                    valid_to: i64::MAX,
                     properties: PropertyMapBuilder::new().insert("v", 1).build(),
                 },
                 ChangePoint {
                     valid_from: t("2024-03-01"),
+                    valid_to: i64::MAX,
                     properties: PropertyMapBuilder::new().insert("v", 2).build(),
                 },
             ],
         });
         let rows = align_events(&[driver], 0, t("2024-01-01"), t("2024-12-01")).unwrap();
         assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn sample_index_absent_at_or_after_closed_valid_to() {
+        // A single closed change-point: present in [Jan, Mar), absent from Mar.
+        let tl = timeline_closed(&[("2024-01-01", Some("2024-03-01"), 1)]);
+        assert_eq!(tl.sample_index_at(t("2023-12-31")), None); // before it existed
+        assert_eq!(tl.sample_index_at(t("2024-01-01")), Some(0)); // at valid_from
+        assert_eq!(tl.sample_index_at(t("2024-02-15")), Some(0)); // interior
+        assert_eq!(tl.sample_index_at(t("2024-03-01")), None); // exactly valid_to (excluded)
+        assert_eq!(tl.sample_index_at(t("2024-06-01")), None); // after retraction
+    }
+
+    #[test]
+    fn sample_index_absent_across_a_valid_time_gap() {
+        // Present [Jan, Mar), gap [Mar, Jun), present again [Jun, ..).
+        let tl = timeline_closed(&[
+            ("2024-01-01", Some("2024-03-01"), 1),
+            ("2024-06-01", None, 2),
+        ]);
+        assert_eq!(v_at_tl(&tl, tl.sample_index_at(t("2024-02-01"))), Some(1)); // first interval
+        assert_eq!(tl.sample_index_at(t("2024-04-15")), None); // in the gap -> absent
+        assert_eq!(v_at_tl(&tl, tl.sample_index_at(t("2024-07-01"))), Some(2)); // re-established
+    }
+
+    #[test]
+    fn events_participant_nulled_after_retraction() {
+        // Driver has an event before AND after the participant is retracted at
+        // Jun; the participant's column is null at the post-retraction event.
+        let driver = Participant::ungated(timeline(&[("2024-03-01", 10), ("2024-09-01", 20)]));
+        let participant =
+            Participant::ungated(timeline_closed(&[("2024-01-01", Some("2024-06-01"), 7)]));
+        let parts = vec![driver, participant];
+        let rows = align_events(&parts, 0, t("2024-01-01"), t("2025-01-01")).unwrap();
+        assert_eq!(rows.len(), 2);
+        // Mar event: participant still present (before Jun retraction).
+        assert_eq!(v_at(&parts[1], rows[0].sample_index[1]), Some(7));
+        // Sep event: participant retracted -> absent (None -> null column).
+        assert_eq!(rows[1].sample_index[1], None);
+    }
+
+    #[test]
+    fn overlap_co_hold_ends_at_participant_retraction() {
+        // Product held all range; supplier retracted at Jun -> the co-hold
+        // sub-interval must END at Jun, not run to the range end.
+        let product = Participant::ungated(timeline(&[("2024-01-01", 100)]));
+        let supplier =
+            Participant::ungated(timeline_closed(&[("2024-01-01", Some("2024-06-01"), 5)]));
+        let parts = vec![product, supplier];
+        let rows = align_overlap(&parts, t("2024-01-01"), t("2024-12-01")).unwrap();
+        // Exactly one co-hold sub-interval: [Jan, Jun); [Jun, Dec) is dropped
+        // because the supplier is absent after its retraction.
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].coordinate,
+            AlignCoordinate::Interval {
+                from: t("2024-01-01"),
+                to: t("2024-06-01")
+            }
+        );
+        assert_eq!(v_at(&parts[0], rows[0].sample_index[0]), Some(100));
+        assert_eq!(v_at(&parts[1], rows[0].sample_index[1]), Some(5));
+    }
+
+    #[test]
+    fn errors_zero_width_range_is_empty_range_both_modes() {
+        // from == to: an exact zero-width range is empty for both modes.
+        let p = Participant::ungated(timeline(&[("2024-01-01", 1)]));
+        let one = std::slice::from_ref(&p);
+        assert_eq!(
+            align_events(one, 0, t("2024-01-01"), t("2024-01-01")),
+            Err(AlignError::EmptyRange)
+        );
+        assert_eq!(
+            align_overlap(one, t("2024-01-01"), t("2024-01-01")),
+            Err(AlignError::EmptyRange)
+        );
+    }
+
+    #[test]
+    fn errors_overlap_inverted_range_is_empty_range() {
+        // to < from: an inverted range is empty for overlap mode too (events
+        // is already covered in `errors_empty_range_and_no_participants_...`).
+        let p = Participant::ungated(timeline(&[("2024-01-01", 1)]));
+        let one = std::slice::from_ref(&p);
+        assert_eq!(
+            align_overlap(one, t("2024-02-01"), t("2024-01-01")),
+            Err(AlignError::EmptyRange)
+        );
+    }
+
+    #[test]
+    fn errors_too_many_instants_both_modes_and_maps_to_invalid_parameter() {
+        use crate::core::error::{Error, QueryError};
+        // Build a driver/participant with > MAX_ALIGN_INSTANTS distinct
+        // change-points (one microsecond apart) so both modes trip the cap.
+        let changes: Vec<ChangePoint> = (0..=(MAX_ALIGN_INSTANTS as i64 + 1))
+            .map(|i| ChangePoint {
+                valid_from: i,
+                valid_to: i64::MAX,
+                properties: PropertyMapBuilder::new().insert("v", i).build(),
+            })
+            .collect();
+        let p = Participant::ungated(Timeline::from_changes(changes));
+        let one = std::slice::from_ref(&p);
+        let from = 0;
+        let to = MAX_ALIGN_INSTANTS as i64 + 5;
+        assert_eq!(
+            align_events(one, 0, from, to),
+            Err(AlignError::TooManyInstants(MAX_ALIGN_INSTANTS + 1))
+        );
+        assert!(matches!(
+            align_overlap(one, from, to),
+            Err(AlignError::TooManyInstants(_))
+        ));
+        // The cap surfaces as a structured InvalidParameter, not a Debug dump.
+        let mapped =
+            align_error_to_query_error(AlignError::TooManyInstants(MAX_ALIGN_INSTANTS + 1));
+        match mapped {
+            Error::Query(QueryError::InvalidParameter { reason, .. }) => {
+                assert!(
+                    reason.contains(&MAX_ALIGN_INSTANTS.to_string()),
+                    "reason should name the limit, got: {reason}"
+                );
+                assert!(
+                    !reason.contains("TooManyInstants"),
+                    "reason should be a human sentence, not a Debug dump: {reason}"
+                );
+            }
+            other => panic!("expected InvalidParameter, got {other:?}"),
+        }
+    }
+
+    /// Read the `v` int at a raw timeline index (for closed-timeline tests).
+    fn v_at_tl(tl: &Timeline, idx: Option<usize>) -> Option<i64> {
+        let i = idx?;
+        match tl.changes[i].properties.get("v") {
+            Some(crate::core::property::PropertyValue::Int(n)) => Some(*n),
+            _ => None,
+        }
     }
 }

--- a/tests/aql_temporal_join.rs
+++ b/tests/aql_temporal_join.rs
@@ -234,12 +234,22 @@ fn overlap_two_entities_hand_computed() {
 // validity (here, "appears in March") is honored at each alignment instant, so
 // no sub-interval before the edge existed is emitted.
 //
-// (The symmetric "edge disappears" half is covered by the pure-core unit test
-// `overlap_edge_appears_and_disappears_mid_range`: a *fully* retracted edge is
-// removed from the current adjacency index, so — like #3225 AS OF traversal,
-// which enumerates candidates from current state — it can no longer be bound
-// by a MATCH; the gating math itself handles closed intervals. This is a
-// documented v1 limitation.)
+// (The symmetric "edge disappears" half — and, identically, a *participant
+// node* whose valid interval is closed mid-range by a retraction (#3230) or
+// delete — is covered by the pure-core unit tests
+// (`overlap_edge_appears_and_disappears_mid_range`,
+// `overlap_co_hold_ends_at_participant_retraction`,
+// `events_participant_nulled_after_retraction`,
+// `sample_index_absent_at_or_after_closed_valid_to`). A *fully* retracted /
+// deleted edge OR node is removed from the current adjacency / label index, so
+// — like #3225 AS OF traversal, which enumerates candidates from current state
+// — it can no longer be bound by a MATCH (verified: retract / future-retract /
+// detach all drop the entity from binding, and update-after-retract is
+// rejected, so no bindable closed-interval participant can be constructed
+// through the public API). The alignment math itself fully honors the closed
+// interval once an entity is bound; only candidate discovery is current-state.
+// This is a documented v1 limitation, so the closed-interval semantics are
+// unit-tested rather than e2e.)
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -416,4 +426,118 @@ fn errors_are_structured() {
          OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' \
          RETURN a.price",
     );
+}
+
+// ---------------------------------------------------------------------------
+// Review finding: DRIVER as the FAR node of a traversal. The driver must be
+// present at its own event even though it is reached via the connecting edge —
+// the driver is ungated by construction, so its own column is never null at its
+// event (the edge validity does not gate the driver itself).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn events_driver_is_far_node_never_nulls_its_own_column() {
+    let db = AletheiaDB::new().expect("db");
+    // Anchor (product) and far node (supplier); DRIVER is the far node.
+    let product = create_node_vt(&db, "Product", "price", 100, ts("2024-01-01T00:00:00Z"));
+    let supplier = create_node_vt(&db, "Supplier", "rating", 5, ts("2024-02-01T00:00:00Z"));
+    update_node_vt(&db, supplier, "rating", 4, ts("2024-08-01T00:00:00Z"));
+    // Edge appears only in March (valid [Mar, now), still current/bindable). At
+    // the supplier's FEB event the edge is not yet valid: if the driver were
+    // gated by it, the driver's OWN `rating` column would be null there.
+    create_edge_vt(
+        &db,
+        product,
+        supplier,
+        "SUPPLIED_BY",
+        ts("2024-03-01T00:00:00Z"),
+    );
+
+    let result = rows(
+        &db,
+        "MATCH (p:Product)-[:SUPPLIED_BY]->(s:Supplier) \
+         ALIGN EVENTS DRIVER s \
+         OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2025-01-01T00:00:00Z' \
+         RETURN s.rating AS rating",
+    );
+
+    // Two supplier (driver) events: Feb (rating 5) and Aug (rating 4). The
+    // driver's own `rating` column must be populated at BOTH — crucially at Feb,
+    // where the connecting edge is not yet valid. Before the fix the far-node
+    // driver was gated by that edge and this column was null.
+    assert_eq!(result.len(), 2, "one row per driver (supplier) event");
+    assert_eq!(
+        col_str(&result[0], "align_valid_time").as_deref(),
+        Some("2024-02-01T00:00:00.000000Z")
+    );
+    assert_eq!(
+        col_i64(&result[0], "rating"),
+        Some(5),
+        "driver present at its own Feb event despite edge not yet valid"
+    );
+    assert_eq!(
+        col_i64(&result[1], "rating"),
+        Some(4),
+        "driver present at its own Aug event"
+    );
+    assert!(
+        !is_null(&result[0], "rating") && !is_null(&result[1], "rating"),
+        "driver column must never be null at its own event"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Review finding: `RETURN <bare-var>` (no property key) yields the participant's
+// node-id as an Int column under the variable's default column name.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn events_return_bare_variable_yields_node_id_column() {
+    let db = AletheiaDB::new().expect("db");
+    let order = create_node_vt(&db, "Purchase", "total", 10, ts("2024-02-01T00:00:00Z"));
+    update_node_vt(&db, order, "total", 20, ts("2024-09-01T00:00:00Z"));
+
+    let result = rows(
+        &db,
+        "MATCH (o:Purchase) \
+         ALIGN EVENTS DRIVER o \
+         OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2025-01-01T00:00:00Z' \
+         RETURN o",
+    );
+    assert_eq!(result.len(), 2);
+    // Default column name is the bare variable, and the value is the node id.
+    assert_eq!(col_i64(&result[0], "o"), Some(order.as_u64() as i64));
+    assert_eq!(col_i64(&result[1], "o"), Some(order.as_u64() as i64));
+}
+
+// ---------------------------------------------------------------------------
+// Review finding: incoming-direction pattern `(o)<-[:R]-(c)` (all other e2e
+// tests are outgoing). The join must resolve participants and gating edge for
+// the reversed arrow identically.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn events_incoming_direction_pattern() {
+    let db = AletheiaDB::new().expect("db");
+    // customer -[:PLACED]-> order, queried from the order as (o)<-[:PLACED]-(c).
+    let customer = create_node_vt(&db, "Customer", "tier", 1, ts("2024-01-01T00:00:00Z"));
+    update_node_vt(&db, customer, "tier", 2, ts("2024-06-01T00:00:00Z"));
+    let order = create_node_vt(&db, "Purchase", "total", 10, ts("2024-02-01T00:00:00Z"));
+    update_node_vt(&db, order, "total", 20, ts("2024-09-01T00:00:00Z"));
+    create_edge_vt(&db, customer, order, "PLACED", ts("2024-01-01T00:00:00Z"));
+
+    let result = rows(
+        &db,
+        "MATCH (o:Purchase)<-[:PLACED]-(c:Customer) \
+         ALIGN EVENTS DRIVER o \
+         OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2025-01-01T00:00:00Z' \
+         RETURN o.total, c.tier AS tier",
+    );
+    // Same expected alignment as the outgoing analog: Feb order -> tier 1,
+    // Sep order -> tier 2 (after the June upgrade).
+    assert_eq!(result.len(), 2);
+    assert_eq!(col_i64(&result[0], "o.total"), Some(10));
+    assert_eq!(col_i64(&result[0], "tier"), Some(1));
+    assert_eq!(col_i64(&result[1], "o.total"), Some(20));
+    assert_eq!(col_i64(&result[1], "tier"), Some(2));
 }

--- a/tests/aql_temporal_join.rs
+++ b/tests/aql_temporal_join.rs
@@ -1,0 +1,419 @@
+//! End-to-end tests for AQL temporal joins (Issue #3379).
+//!
+//! These exercise the full pipeline (`execute_aql` -> parser -> converter ->
+//! planner -> executor) and assert hand-computed alignment output for both
+//! modes (event-aligned and interval-overlap), the documented half-open
+//! boundary rules, bi-temporal `AS OF SYSTEM_TIME` correctness, traversal /
+//! edge-validity composition, empty-overlap handling, and structured errors.
+//! The pure interval math has its own unit tests in
+//! `src/query/temporal_join.rs`; these cover semantics that require real
+//! bi-temporal history.
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::PropertyMapBuilder;
+use aletheiadb::api::transaction::WriteRequestOptions;
+use aletheiadb::core::error::{Error, QueryError};
+use aletheiadb::core::property::PropertyValue;
+use aletheiadb::core::temporal::Timestamp;
+use aletheiadb::core::{EdgeId, NodeId};
+use aletheiadb::query::executor::QueryRow;
+use aletheiadb::query::temporal_window::parse_boundary_micros;
+
+fn micros(rfc: &str) -> i64 {
+    parse_boundary_micros(rfc).expect("valid rfc3339")
+}
+
+fn ts(rfc: &str) -> Timestamp {
+    Timestamp::from(micros(rfc))
+}
+
+fn rows(db: &AletheiaDB, aql: &str) -> Vec<QueryRow> {
+    db.execute_aql(aql)
+        .expect("query executes")
+        .collect_all()
+        .expect("collect rows")
+}
+
+fn col<'a>(row: &'a QueryRow, name: &str) -> Option<&'a PropertyValue> {
+    row.columns
+        .as_ref()
+        .and_then(|cols| cols.iter().find(|(k, _)| k == name).map(|(_, v)| v))
+}
+
+fn col_i64(row: &QueryRow, name: &str) -> Option<i64> {
+    match col(row, name) {
+        Some(PropertyValue::Int(i)) => Some(*i),
+        _ => None,
+    }
+}
+
+fn col_str(row: &QueryRow, name: &str) -> Option<String> {
+    match col(row, name) {
+        Some(PropertyValue::String(s)) => Some(s.to_string()),
+        _ => None,
+    }
+}
+
+fn is_null(row: &QueryRow, name: &str) -> bool {
+    matches!(col(row, name), Some(PropertyValue::Null))
+}
+
+fn create_node_vt(db: &AletheiaDB, label: &str, key: &str, val: i64, vf: Timestamp) -> NodeId {
+    db.create_node_with_options(
+        label,
+        PropertyMapBuilder::new().insert(key, val).build(),
+        WriteRequestOptions::new().with_valid_from(vf),
+    )
+    .expect("create node")
+}
+
+fn update_node_vt(db: &AletheiaDB, id: NodeId, key: &str, val: i64, vf: Timestamp) {
+    db.update_node_with_options(
+        id,
+        PropertyMapBuilder::new().insert(key, val).build(),
+        WriteRequestOptions::new().with_valid_from(vf),
+    )
+    .expect("update node");
+}
+
+fn create_edge_vt(db: &AletheiaDB, src: NodeId, dst: NodeId, label: &str, vf: Timestamp) -> EdgeId {
+    db.create_edge_with_options(
+        src,
+        dst,
+        label,
+        PropertyMapBuilder::new().build(),
+        WriteRequestOptions::new().with_valid_from(vf),
+    )
+    .expect("create edge")
+}
+
+// ---------------------------------------------------------------------------
+// AC 1/2/4: event-aligned join over a traversal — "customer tier at order time".
+// ---------------------------------------------------------------------------
+
+#[test]
+fn events_customer_tier_at_each_order_time() {
+    let db = AletheiaDB::new().expect("db");
+    // Customer with a tier that upgrades mid-year.
+    let customer = create_node_vt(&db, "Customer", "tier", 1, ts("2024-01-01T00:00:00Z"));
+    update_node_vt(&db, customer, "tier", 2, ts("2024-06-01T00:00:00Z"));
+    // Order placed (v1) in Feb, amended (v2) in Sep, amended (v3) in ... only 2 events in range.
+    let order = create_node_vt(&db, "Purchase", "total", 10, ts("2024-02-01T00:00:00Z"));
+    update_node_vt(&db, order, "total", 20, ts("2024-09-01T00:00:00Z"));
+    // Order -> Customer edge (valid all year).
+    create_edge_vt(
+        &db,
+        order,
+        customer,
+        "PLACED_BY",
+        ts("2024-01-01T00:00:00Z"),
+    );
+
+    let result = rows(
+        &db,
+        "MATCH (o:Purchase)-[:PLACED_BY]->(c:Customer) \
+         ALIGN EVENTS DRIVER o \
+         OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2025-01-01T00:00:00Z' \
+         RETURN o.total, c.tier AS tier",
+    );
+
+    // Two driver (order) change-points in range: Feb-01, Sep-01.
+    assert_eq!(result.len(), 2, "one row per order event");
+    assert_eq!(
+        col_str(&result[0], "align_valid_time").as_deref(),
+        Some("2024-02-01T00:00:00.000000Z")
+    );
+    // Feb order: order total 10, customer still tier 1 (upgrade is Jun).
+    assert_eq!(col_i64(&result[0], "o.total"), Some(10));
+    assert_eq!(col_i64(&result[0], "tier"), Some(1));
+    // Sep order: order total 20, customer now tier 2.
+    assert_eq!(
+        col_str(&result[1], "align_valid_time").as_deref(),
+        Some("2024-09-01T00:00:00.000000Z")
+    );
+    assert_eq!(col_i64(&result[1], "o.total"), Some(20));
+    assert_eq!(col_i64(&result[1], "tier"), Some(2));
+}
+
+// ---------------------------------------------------------------------------
+// AC 3: participant absent (order placed before customer existed) -> null.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn events_participant_absent_is_null() {
+    let db = AletheiaDB::new().expect("db");
+    let customer = create_node_vt(&db, "Customer", "tier", 1, ts("2024-03-01T00:00:00Z"));
+    let order = create_node_vt(&db, "Purchase", "total", 10, ts("2024-01-15T00:00:00Z"));
+    create_edge_vt(
+        &db,
+        order,
+        customer,
+        "PLACED_BY",
+        ts("2024-01-01T00:00:00Z"),
+    );
+
+    let result = rows(
+        &db,
+        "MATCH (o:Purchase)-[:PLACED_BY]->(c:Customer) \
+         ALIGN EVENTS DRIVER o \
+         OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-12-01T00:00:00Z' \
+         RETURN o.total, c.tier AS tier",
+    );
+    assert_eq!(result.len(), 1);
+    // Order placed Jan-15, before the customer record existed (Mar-01).
+    assert_eq!(col_i64(&result[0], "o.total"), Some(10));
+    assert!(is_null(&result[0], "tier"), "customer absent -> null tier");
+}
+
+// ---------------------------------------------------------------------------
+// AC 6: interval-overlap hand-computed fixture with overlapping, adjacent, and
+// gapped versions across two entities.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn overlap_two_entities_hand_computed() {
+    let db = AletheiaDB::new().expect("db");
+    // Product price: 100 from Jan, 150 from Apr.
+    let product = create_node_vt(&db, "Product", "price", 100, ts("2024-01-01T00:00:00Z"));
+    update_node_vt(&db, product, "price", 150, ts("2024-04-01T00:00:00Z"));
+    // Supplier rating: 5 from Feb (did not exist in January -> Jan is a gap).
+    let supplier = create_node_vt(&db, "Supplier", "rating", 5, ts("2024-02-01T00:00:00Z"));
+    update_node_vt(&db, supplier, "rating", 4, ts("2024-05-01T00:00:00Z"));
+    create_edge_vt(
+        &db,
+        product,
+        supplier,
+        "SUPPLIED_BY",
+        ts("2024-01-01T00:00:00Z"),
+    );
+
+    let result = rows(
+        &db,
+        "MATCH (p:Product)-[:SUPPLIED_BY]->(s:Supplier) \
+         ALIGN OVERLAP \
+         OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-06-01T00:00:00Z' \
+         RETURN p.price AS price, s.rating AS rating",
+    );
+
+    // Boundaries in range: Jan-01(from), Feb-01(supplier), Apr-01(product),
+    // May-01(supplier). Sub-intervals:
+    //  [Jan,Feb) -> supplier absent -> DROPPED (gap)
+    //  [Feb,Apr) -> price 100, rating 5
+    //  [Apr,May) -> price 150, rating 5
+    //  [May,Jun) -> price 150, rating 4
+    assert_eq!(
+        result.len(),
+        3,
+        "three co-hold sub-intervals (Jan gap dropped)"
+    );
+
+    assert_eq!(
+        col_str(&result[0], "overlap_from").as_deref(),
+        Some("2024-02-01T00:00:00.000000Z")
+    );
+    assert_eq!(
+        col_str(&result[0], "overlap_to").as_deref(),
+        Some("2024-04-01T00:00:00.000000Z")
+    );
+    assert_eq!(col_i64(&result[0], "price"), Some(100));
+    assert_eq!(col_i64(&result[0], "rating"), Some(5));
+
+    assert_eq!(col_i64(&result[1], "price"), Some(150));
+    assert_eq!(col_i64(&result[1], "rating"), Some(5));
+
+    assert_eq!(
+        col_str(&result[2], "overlap_to").as_deref(),
+        Some("2024-06-01T00:00:00.000000Z")
+    );
+    assert_eq!(col_i64(&result[2], "price"), Some(150));
+    assert_eq!(col_i64(&result[2], "rating"), Some(4));
+}
+
+// ---------------------------------------------------------------------------
+// AC 2/6: an edge that appears mid-range gates the overlap. The relationship's
+// validity (here, "appears in March") is honored at each alignment instant, so
+// no sub-interval before the edge existed is emitted.
+//
+// (The symmetric "edge disappears" half is covered by the pure-core unit test
+// `overlap_edge_appears_and_disappears_mid_range`: a *fully* retracted edge is
+// removed from the current adjacency index, so — like #3225 AS OF traversal,
+// which enumerates candidates from current state — it can no longer be bound
+// by a MATCH; the gating math itself handles closed intervals. This is a
+// documented v1 limitation.)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn overlap_edge_appears_mid_range_gates_the_join() {
+    let db = AletheiaDB::new().expect("db");
+    let product = create_node_vt(&db, "Product", "price", 100, ts("2024-01-01T00:00:00Z"));
+    let supplier = create_node_vt(&db, "Supplier", "rating", 5, ts("2024-01-01T00:00:00Z"));
+    // Edge appears in March and remains valid (current) -> present [Mar, now).
+    create_edge_vt(
+        &db,
+        product,
+        supplier,
+        "SUPPLIED_BY",
+        ts("2024-03-01T00:00:00Z"),
+    );
+
+    let result = rows(
+        &db,
+        "MATCH (p:Product)-[:SUPPLIED_BY]->(s:Supplier) \
+         ALIGN OVERLAP \
+         OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-12-01T00:00:00Z' \
+         RETURN p.price AS price, s.rating AS rating",
+    );
+
+    // The edge is not valid before March, so [Jan, Mar) is dropped; the single
+    // co-hold sub-interval begins exactly when the edge appears.
+    assert_eq!(
+        result.len(),
+        1,
+        "edge gates the join to start at its appearance"
+    );
+    assert_eq!(
+        col_str(&result[0], "overlap_from").as_deref(),
+        Some("2024-03-01T00:00:00.000000Z")
+    );
+    assert_eq!(
+        col_str(&result[0], "overlap_to").as_deref(),
+        Some("2024-12-01T00:00:00.000000Z")
+    );
+    assert_eq!(col_i64(&result[0], "price"), Some(100));
+    assert_eq!(col_i64(&result[0], "rating"), Some(5));
+}
+
+// ---------------------------------------------------------------------------
+// AC 3: transaction-time pinning — a later correction does not rewrite the
+// analytics pinned before it was recorded.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn events_as_of_system_time_pins_belief() {
+    let db = AletheiaDB::new().expect("db");
+    let customer = create_node_vt(&db, "Customer", "tier", 1, ts("2024-01-01T00:00:00Z"));
+    let order = create_node_vt(&db, "Purchase", "total", 10, ts("2024-02-01T00:00:00Z"));
+    create_edge_vt(
+        &db,
+        order,
+        customer,
+        "PLACED_BY",
+        ts("2024-01-01T00:00:00Z"),
+    );
+    // Pin the transaction time NOW, before recording a correction.
+    let pin = Timestamp::from(aletheiadb::core::temporal::time::now().wallclock());
+    // Later correction: backdate the tier to 9 effective Jan-01 (a restatement).
+    update_node_vt(&db, customer, "tier", 9, ts("2024-01-01T00:00:00Z"));
+
+    // As of the pin, the correction is invisible -> tier is still 1.
+    let pinned = rows(
+        &db,
+        &format!(
+            "MATCH (o:Purchase)-[:PLACED_BY]->(c:Customer) \
+             ALIGN EVENTS DRIVER o \
+             OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-12-01T00:00:00Z' \
+             AS OF SYSTEM_TIME {} \
+             RETURN c.tier AS tier",
+            pin.wallclock()
+        ),
+    );
+    assert_eq!(pinned.len(), 1);
+    assert_eq!(
+        col_i64(&pinned[0], "tier"),
+        Some(1),
+        "pinned belief excludes the later correction"
+    );
+
+    // With no tx-time pin (now), the correction IS visible -> tier is 9.
+    let current = rows(
+        &db,
+        "MATCH (o:Purchase)-[:PLACED_BY]->(c:Customer) \
+         ALIGN EVENTS DRIVER o \
+         OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-12-01T00:00:00Z' \
+         RETURN c.tier AS tier",
+    );
+    assert_eq!(col_i64(&current[0], "tier"), Some(9));
+}
+
+// ---------------------------------------------------------------------------
+// AC 1: single bound node (degenerate join) — overlap over one entity's history.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn overlap_single_node_history_tiles_range() {
+    let db = AletheiaDB::new().expect("db");
+    let p = create_node_vt(&db, "Product", "price", 100, ts("2024-01-01T00:00:00Z"));
+    update_node_vt(&db, p, "price", 200, ts("2024-02-01T00:00:00Z"));
+    update_node_vt(&db, p, "price", 300, ts("2024-03-01T00:00:00Z"));
+
+    let result = rows(
+        &db,
+        "MATCH (p:Product) \
+         ALIGN OVERLAP \
+         OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-04-01T00:00:00Z' \
+         RETURN p.price AS price",
+    );
+    assert_eq!(result.len(), 3);
+    assert_eq!(col_i64(&result[0], "price"), Some(100));
+    assert_eq!(col_i64(&result[1], "price"), Some(200));
+    assert_eq!(col_i64(&result[2], "price"), Some(300));
+}
+
+// ---------------------------------------------------------------------------
+// AC 5: structured errors for malformed specs.
+// ---------------------------------------------------------------------------
+
+fn expect_invalid(db: &AletheiaDB, aql: &str) {
+    // The error may surface at plan/convert time (`execute_aql`) or, defensively,
+    // while draining rows (`collect_all`). Either is acceptable.
+    let err = match db.execute_aql(aql) {
+        Ok(results) => match results.collect_all() {
+            Ok(_) => panic!("expected a structured query error, got success"),
+            Err(e) => e,
+        },
+        Err(e) => e,
+    };
+    assert!(
+        matches!(
+            err,
+            Error::Query(QueryError::InvalidParameter { .. })
+                | Error::Query(QueryError::UnsupportedFeature { .. })
+        ),
+        "expected a structured query error, got {err:?}"
+    );
+}
+
+#[test]
+fn errors_are_structured() {
+    let db = AletheiaDB::new().expect("db");
+    let _ = create_node_vt(&db, "Product", "price", 1, ts("2024-01-01T00:00:00Z"));
+
+    // Unknown RETURN variable.
+    expect_invalid(
+        &db,
+        "MATCH (p:Product) ALIGN OVERLAP \
+         OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' \
+         RETURN q.price",
+    );
+    // Empty/backwards range.
+    expect_invalid(
+        &db,
+        "MATCH (p:Product) ALIGN OVERLAP \
+         OVER VALID_TIME FROM '2024-02-01T00:00:00Z' TO '2024-01-01T00:00:00Z' \
+         RETURN p.price",
+    );
+    // Driver variable not a participant.
+    expect_invalid(
+        &db,
+        "MATCH (p:Product) ALIGN EVENTS DRIVER x \
+         OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' \
+         RETURN p.price",
+    );
+    // Unsupported multi-hop pattern.
+    expect_invalid(
+        &db,
+        "MATCH (a:Product)-[:R]->(b:Product)-[:R]->(c:Product) ALIGN OVERLAP \
+         OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2024-02-01T00:00:00Z' \
+         RETURN a.price",
+    );
+}


### PR DESCRIPTION
## Summary

Implements **Issue #3379 — temporal joins**: a new AQL `ALIGN` operator that correlates two or more entities (bound by id or via a graph traversal) at **matching valid-time coordinates** over a range, in two modes. It turns the analyst/LLM's `O(versions)` client-side loop of `AS OF` lookups + hand-rolled boundary zip into one declarative, correct-by-default statement.

```aql
MATCH (o:Purchase)-[:PLACED_BY]->(c:Customer)
ALIGN EVENTS DRIVER o
  OVER VALID_TIME FROM '2024-01-01T00:00:00Z' TO '2025-01-01T00:00:00Z'
RETURN o.total, c.tier AS tier      -- customer tier AT each order instant
```

**Design (chosen approach):** a storage-free semantic core (`src/query/temporal_join.rs`) implements both alignment modes over abstract per-entity *timelines*; a terminal executor op (`TemporalJoinIterator`) drains the matched-participant stream, reconstructs each participant's believed valid-time history (+ gating-edge presence) at the pinned tx-time, and runs the core. This mirrors the merged #3363 temporal-window terminal-op pattern (ast → parser → converter → ir → plan → planner → executor) and keeps the subtle half-open boundary math exhaustively unit-testable.

## Acceptance criteria → evidence

| # | Acceptance criterion | Evidence |
|---|----------------------|----------|
| 1 | AQL temporal-align with two modes (event-aligned ASOF + interval-overlap), both expressible | `ALIGN EVENTS DRIVER` / `ALIGN OVERLAP` grammar; parser tests `test_parse_align_events_mode`, `test_parse_align_overlap_mode_no_driver`; core `align_events`/`align_overlap` |
| 2 | Composes with MATCH graph patterns; entities bindable by traversal; edge validity honored at the alignment instant | `events_customer_tier_at_each_order_time`, `overlap_edge_appears_mid_range_gates_the_join`, `events_incoming_direction_pattern`; pure `events_edge_gate_absent_when_edge_not_valid`, `overlap_edge_appears_and_disappears_mid_range` |
| 3 | Boundary + dimension semantics (half-open; `valid_from==instant` included; tx-time defaults now, independently pinnable; **closed valid intervals honored**; no non-co-holding pairs) | pure `events_range_boundaries_half_open`, `sample_index_is_most_recent_at_or_before`, `sample_index_absent_at_or_after_closed_valid_to`, `sample_index_absent_across_a_valid_time_gap`, `overlap_empty_when_no_co_hold_gap`; e2e `events_as_of_system_time_pins_belief`, `events_participant_absent_is_null` |
| 4 | Results carry alignment coordinates as RFC 3339 | `align_valid_time` (events) / `overlap_from`+`overlap_to` (overlap) columns; asserted in `events_customer_tier_at_each_order_time`, `overlap_two_entities_hand_computed` |
| 5 | Available via MCP `query` tool within row/limit contracts | Rides the same computed-`columns` row rendering as #3363/#558 (`query_row_to_json`); no `src/mcp` change needed |
| 6 | CI correctness fixture, both modes, hand-computed (overlapping/adjacent/gapped versions, edge/node appears/disappears, empty-overlap, boundary) | `src/query/temporal_join.rs` unit fixture + `tests/aql_temporal_join.rs` e2e, incl. `overlap_two_entities_hand_computed`, `overlap_adjacent_versions_tile_without_gap_or_overlap`, `overlap_co_hold_ends_at_participant_retraction` |
| 7 | "Correlated point-in-time analysis" guide, both modes + the client loop it replaces | `docs/guides/temporal-joins.md` |

## Review fixes (commit 8b0e47a)

Addresses a 4-angle code review of the temporal-join feature:

- **BLOCKER:** `TemporalJoinIterator::drain` no longer holds the `historical` `parking_lot` read guard across `input.next()` (recursive-read deadlock / writer-starvation hazard). It now drains the upstream matched-participant stream into a `Vec` and drops the input **before** acquiring the read lock, mirroring the #3363 sibling.
- **Node valid-time closure honored:** `ChangePoint` carries an explicit `valid_to`; `sample_index_at` returns absent at/after a covering version's closed `valid_to` (retraction #3230 / delete / gap), and `align_overlap` adds those boundaries — a retracted/deleted participant is absent, not present forever (symmetric with the edge-gate path).
- **No silent error swallowing:** `node_timeline` / `edge_presence` return `Result` and distinguish a genuine storage error (surfaced as `QueryError`) from not-found (legitimate empty timeline).
- **Gated-driver invariant:** the event-aligned driver is ungated by construction, so naming the far node of a traversal as `DRIVER` never emits a row with the driver's own column null.
- **Cap error message:** `align_error_to_query_error` maps `TooManyInstants` to a structured `InvalidParameter` naming `MAX_ALIGN_INSTANTS` (no Debug dump); the cap is checked inside `align_overlap`'s inner insert loops.
- **Docs:** the transaction-time pinning claim is corrected to the honest same-`valid_from`-only v1 scope, and the closed-interval wording now reflects that node closure is handled (a full transaction-interval-`contains` scope would drop genuinely-held history under append-only supersession, so it is a documented follow-up rather than the taken fix).

New tests: 6 unit (`temporal_join.rs`: closed `valid_to` / gap, retraction closure both modes, zero-width & inverted range, >100k-instant cap → both modes → `InvalidParameter`) and 3 e2e (`aql_temporal_join.rs`: `DRIVER` as far node, `RETURN` bare-var node-id column, incoming-direction `(o)<-[:R]-(c)`). The closed-interval node/edge cases stay **unit-tested only** because a fully retracted/deleted entity cannot be bound by a current-state MATCH — verified against retract / future-retract / detach / update-after-retract (documented v1 candidate-discovery limitation).

## Verification (verbatim)

```
cargo clippy --all-targets --all-features -- -D warnings   -> exit 0 (clean)

test result: ok. 18 passed; 0 failed  (query::temporal_join unit)
test result: ok. 10 passed; 0 failed  (tests/aql_temporal_join.rs e2e)
test result: ok. 4705 passed; 0 failed; 3 ignored  (whole lib, --features sql,cypher)
```

The two **known** sandbox uid-0 IO-injection tests (`havoc_flush_deadlock::test_flush_deadlock_on_io_error`, `regression_flush_corruption::test_metadata_corruption_on_error`) always fail in this environment and are unrelated to this change.

## Notes / gaps (for review)

- **Incidental fix (Lane 4 owns the trunk fix):** the one-line removal of a duplicate `ENC_INDEX_KEY_VERSION_V1` import in `src/db/rotation.rs` is an incidental fix for a **trunk build break** — the duplicate import landed via merge #3639 and makes the branch base fail the default `cargo test` / clippy build. **Lane 4 owns the trunk-side fix**, so this hunk will simply **vanish when the branch next merges trunk**; no action is needed here.
- **v1 scope (documented):** supported patterns are one bound node or a single-hop traversal (multi-hop/variable-length/comma patterns → structured `UnsupportedFeature`). A **fully-retracted/deleted edge OR node cannot be re-bound by a current-state MATCH** — candidates enumerate from the current adjacency/label index, the same limitation #3225 AS OF traversal documents; the alignment math itself fully honors closed intervals once an entity is bound (covered by the pure-core unit tests). `MAX_ALIGN_INSTANTS` (100,000) range cap with a structured error.
- Out of scope per the issue: SQL:2011 surface (#311), windowed aggregation over the output (#3363), tx-time-delta joins, Allen interval predicates, streaming (#3375).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MM68sFWVTxKbBRnCq1VTrD