### PR TITLE
hotfix: unbreak trunk — remove duplicate ENC_INDEX_KEY_VERSION_V1 import (E0252)

### DIFF
--- a/src/db/rotation.rs
+++ b/src/db/rotation.rs
@@ -64,7 +64,6 @@ use crate::encryption::factory::Algorithm;
 use crate::encryption::factory::create_cipher;
 use crate::encryption::key_derivation::KeyDerivation;
 use crate::storage::index_persistence::common::{ENC_INDEX_KEY_VERSION_V1, IndexKeyring};
-use crate::storage::index_persistence::common::ENC_INDEX_KEY_VERSION_V1;
 use crate::storage::index_persistence::reencrypt::DecryptProbeReport;
 use crate::storage::index_persistence::{
     IndexKeyRotation, IndexPersistenceManager, RotationError, RotationProgress, RotationStatus,


### PR DESCRIPTION
## Trunk-unbreaking hotfix — merge AHEAD of everything

**This should merge ahead of all other lanes: every lane's local gates are red until it lands.**

### Before
Trunk fails to compile on the **default build**. The merge of #3639 (overlapping with #3634, both touched `src/db/rotation.rs`) concatenated two `use` groups, importing `ENC_INDEX_KEY_VERSION_V1` from `crate::storage::index_persistence::common` **twice**:

```rust
use crate::storage::index_persistence::common::{ENC_INDEX_KEY_VERSION_V1, IndexKeyring};
use crate::storage::index_persistence::common::ENC_INDEX_KEY_VERSION_V1;   // <-- duplicate
```

rustc rejects this with **E0252** ("the name `ENC_INDEX_KEY_VERSION_V1` is defined multiple times"), failing `cargo build` / `cargo test` / `cargo clippy` on the default feature set on clean trunk.

### After
The redundant standalone `use` line is removed; the symbol remains imported exactly once alongside `IndexKeyring`. **Surgical one-line deletion, no logic change.** Trunk compiles and the import appears once.

```diff
 use crate::storage::index_persistence::common::{ENC_INDEX_KEY_VERSION_V1, IndexKeyring};
-use crate::storage::index_persistence::common::ENC_INDEX_KEY_VERSION_V1;
 use crate::storage::index_persistence::reencrypt::DecryptProbeReport;
```

### Verification
- `cargo build` (default features) — **green** (the exact gate that was red with E0252)
- `cargo fmt --all -- --check` — **clean**

Refs #3617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRMi3NFi3FwGqXoon9Fqga

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRMi3NFi3FwGqXoon9Fqga)_