### PR TITLE
Implement Cypher MERGE multi-match binding (Issue #3623)

### DIFF
--- a/src/cypher/mutation.rs
+++ b/src/cypher/mutation.rs
@@ -103,6 +103,15 @@ pub fn execute(
     // Static validation independent of the data (fails before any transaction).
     validate(write)?;
 
+    // Cap the fan-out working set (Issue #3623 review): a MERGE that matches
+    // many committed entities -- or several chained MERGEs -- multiplies the
+    // working set combinatorially (up to N^k for k MERGEs over N matches each),
+    // and every binding buffers writes in this single transaction. Bound it with
+    // the SAME configurable `max_schema_as_of_entities` limit the read matcher
+    // uses (see `match_bindings` in `multi_pattern.rs`), turning a potential OOM
+    // into an honest structured rejection. Read once, up front.
+    let binding_cap = db.historical.read().max_schema_as_of_entities();
+
     // Read phase: matched rows drive the write clauses. A statement with no
     // reading part (a bare `CREATE`) runs once against a single empty binding.
     let base_rows: Vec<Binding> = match &write.reading {
@@ -153,9 +162,21 @@ pub fn execute(
                     &mut deleted_edges,
                     &mut created_edges,
                     &mut created_nodes,
+                    binding_cap,
                 )?;
+                // Aggregate cap after each clause (Issue #3623 review): every
+                // clause is 1->1 except MERGE (which fans 1->N), so this bounds
+                // the whole working set as it grows clause-over-clause. Defense
+                // in depth alongside the mid-extend check inside the MERGE arm.
+                if rows.len() > binding_cap {
+                    return Err(fanout_cap_error(binding_cap).into());
+                }
             }
             if let Some(ret) = &write.return_clause {
+                // The RETURN order of fanned rows is intentionally left
+                // unasserted: openCypher gives no row order without ORDER BY, so
+                // the emission order of a multi-match MERGE's fan-out is not a
+                // contract (tests assert the SET of rows, not their sequence).
                 for binding in &rows {
                     return_snapshots.push(collect_return_snapshots(ret, binding)?);
                 }
@@ -293,11 +314,28 @@ fn validate_return(ret: &CypherReturn) -> std::result::Result<(), CypherError> {
 // Clause application
 // ---------------------------------------------------------------------------
 
+/// The structured rejection returned when a statement's fan-out working set
+/// exceeds the configured cap (Issue #3623 review). Mirrors the read matcher's
+/// [`match_bindings`] cap error shape (a [`CypherError::UnsupportedFeature`]
+/// keyed on the same `max_schema_as_of_entities` knob) so the write phase
+/// reports a combinatorial MERGE blow-up as an honest structured error rather
+/// than exhausting memory.
+fn fanout_cap_error(binding_cap: usize) -> CypherError {
+    CypherError::UnsupportedFeature(format!(
+        "MERGE fan-out working set exceeds {binding_cap} bindings; a MERGE matching \
+         many committed entities (or multiple chained MERGEs) multiplies the working \
+         set combinatorially, each binding buffering writes in one transaction -- add \
+         a more selective pattern or labels to narrow the match (configurable via \
+         max_schema_as_of_entities)"
+    ))
+}
+
 /// Apply one write clause to the whole working set of bindings, returning the
 /// resulting set. Most clauses are 1->1 (each input binding maps to itself after
 /// its side effects), but a MERGE whose pattern matches multiple committed
 /// entities fans one binding into N (Issue #3623), so this maps `Vec<Binding>`
-/// to `Vec<Binding>` rather than mutating a single binding in place.
+/// to `Vec<Binding>` rather than mutating a single binding in place. `binding_cap`
+/// bounds the MERGE fan-out mid-extend (Issue #3623 review).
 #[allow(clippy::too_many_arguments)]
 fn apply_clause(
     tx: &mut crate::api::transaction::WriteTransaction,
@@ -309,6 +347,7 @@ fn apply_clause(
     deleted_edges: &mut HashSet<EdgeId>,
     created_edges: &mut Vec<(EdgeId, NodeId, NodeId)>,
     created_nodes: &mut Vec<(NodeId, String, PropertyMap)>,
+    binding_cap: usize,
 ) -> Result<Vec<Binding>> {
     match clause {
         CypherWriteClause::Create(patterns) => {
@@ -372,6 +411,14 @@ fn apply_clause(
                     created_edges,
                     created_nodes,
                 )?);
+                // Bound the fan-out mid-extend (Issue #3623 review): a single
+                // MERGE matching many committed entities across many input
+                // bindings could otherwise balloon `out` to ~cap^2 before the
+                // caller's post-clause check runs. Reject as soon as it exceeds
+                // the cap, matching the read matcher's per-step bound.
+                if out.len() > binding_cap {
+                    return Err(fanout_cap_error(binding_cap).into());
+                }
             }
             Ok(out)
         }
@@ -420,6 +467,28 @@ fn apply_clause(
 /// every one. The write executor carries a working set of bindings
 /// (`Vec<Binding>`) precisely so this fan-out composes with subsequent clauses
 /// and `RETURN` (each fanned row runs the rest of the statement independently).
+///
+/// ## Combinatorial cost and the aggregate cap
+///
+/// Fan-out is **multiplicative**: `M` base rows times `N` matches per MERGE, and
+/// `k` chained MERGEs can grow the working set to `M * N^k` bindings, each
+/// buffering its own writes inside the one transaction. To keep a pathological
+/// statement from exhausting memory, the working set is bounded by the same
+/// configurable `max_schema_as_of_entities` limit the read matcher applies to
+/// its intermediate binding count. The bound is checked mid-extend here and
+/// again after each clause in [`execute`]; exceeding it returns the structured
+/// [`fanout_cap_error`] ([`CypherError::UnsupportedFeature`]) rather than an OOM.
+///
+/// ## Bi-temporal multi-versioning of a single entity
+///
+/// Because `ON MATCH SET` (and any following write clause) runs **once per
+/// fanned row**, a single statement can record MULTIPLE new bi-temporal
+/// versions of ONE entity when that entity is bound by more than one match/row
+/// (e.g. a node reached by two matched relationship paths, or the far node of a
+/// base-row cross product). Each per-row update is a distinct `update_node`, so
+/// the entity is versioned once per binding -- a known deviation from
+/// openCypher's set-once-per-write semantics that is documented, not deduped, in
+/// v1.
 ///
 /// # v1 concurrency
 ///

--- a/src/cypher/mutation.rs
+++ b/src/cypher/mutation.rs
@@ -136,13 +136,18 @@ pub fn execute(
         let mut created_nodes: Vec<(NodeId, String, PropertyMap)> = Vec::new();
 
         for base in &base_rows {
-            let mut binding = base.clone();
+            // Working set of bindings for this base row. A clause maps the set:
+            // CREATE/SET/DELETE are 1->1, but a MERGE whose pattern matches
+            // multiple committed entities fans one binding into N (openCypher
+            // whole-pattern MATCH semantics, Issue #3623), so later clauses and
+            // RETURN run once per fanned row.
+            let mut rows: Vec<Binding> = vec![base.clone()];
             for clause in &write.clauses {
-                apply_clause(
+                rows = apply_clause(
                     tx,
                     db,
                     clause,
-                    &mut binding,
+                    rows,
                     params,
                     &mut deleted_nodes,
                     &mut deleted_edges,
@@ -151,7 +156,9 @@ pub fn execute(
                 )?;
             }
             if let Some(ret) = &write.return_clause {
-                return_snapshots.push(collect_return_snapshots(ret, &binding)?);
+                for binding in &rows {
+                    return_snapshots.push(collect_return_snapshots(ret, binding)?);
+                }
             }
         }
         Ok(())
@@ -286,54 +293,88 @@ fn validate_return(ret: &CypherReturn) -> std::result::Result<(), CypherError> {
 // Clause application
 // ---------------------------------------------------------------------------
 
+/// Apply one write clause to the whole working set of bindings, returning the
+/// resulting set. Most clauses are 1->1 (each input binding maps to itself after
+/// its side effects), but a MERGE whose pattern matches multiple committed
+/// entities fans one binding into N (Issue #3623), so this maps `Vec<Binding>`
+/// to `Vec<Binding>` rather than mutating a single binding in place.
 #[allow(clippy::too_many_arguments)]
 fn apply_clause(
     tx: &mut crate::api::transaction::WriteTransaction,
     db: &AletheiaDB,
     clause: &CypherWriteClause,
-    binding: &mut Binding,
+    rows: Vec<Binding>,
     params: &Params,
     deleted_nodes: &mut HashSet<NodeId>,
     deleted_edges: &mut HashSet<EdgeId>,
     created_edges: &mut Vec<(EdgeId, NodeId, NodeId)>,
     created_nodes: &mut Vec<(NodeId, String, PropertyMap)>,
-) -> Result<()> {
+) -> Result<Vec<Binding>> {
     match clause {
         CypherWriteClause::Create(patterns) => {
-            for pattern in patterns {
-                create_pattern(tx, pattern, binding, params, created_edges, created_nodes)?;
+            let mut out = Vec::with_capacity(rows.len());
+            for mut binding in rows {
+                for pattern in patterns {
+                    create_pattern(
+                        tx,
+                        pattern,
+                        &mut binding,
+                        params,
+                        created_edges,
+                        created_nodes,
+                    )?;
+                }
+                out.push(binding);
             }
-            Ok(())
+            Ok(out)
         }
         CypherWriteClause::Set(items) => {
-            apply_set(tx, items, binding, params, deleted_nodes, deleted_edges)
+            let mut out = Vec::with_capacity(rows.len());
+            for binding in rows {
+                apply_set(tx, items, &binding, params, deleted_nodes, deleted_edges)?;
+                out.push(binding);
+            }
+            Ok(out)
         }
-        CypherWriteClause::Delete { detach, targets } => apply_delete(
-            tx,
-            *detach,
-            targets,
-            binding,
-            deleted_nodes,
-            deleted_edges,
-            created_edges,
-        ),
+        CypherWriteClause::Delete { detach, targets } => {
+            let mut out = Vec::with_capacity(rows.len());
+            for binding in rows {
+                apply_delete(
+                    tx,
+                    *detach,
+                    targets,
+                    &binding,
+                    deleted_nodes,
+                    deleted_edges,
+                    created_edges,
+                )?;
+                out.push(binding);
+            }
+            Ok(out)
+        }
         CypherWriteClause::Merge {
             pattern,
             on_create,
             on_match,
-        } => apply_merge(
-            tx,
-            db,
-            pattern,
-            on_create,
-            on_match,
-            binding,
-            params,
-            deleted_nodes,
-            deleted_edges,
-            created_edges,
-            created_nodes,
-        ),
+        } => {
+            let mut out = Vec::with_capacity(rows.len());
+            for binding in rows {
+                out.extend(apply_merge(
+                    tx,
+                    db,
+                    pattern,
+                    on_create,
+                    on_match,
+                    binding,
+                    params,
+                    deleted_nodes,
+                    deleted_edges,
+                    created_edges,
+                    created_nodes,
+                )?);
+            }
+            Ok(out)
+        }
     }
 }
 
@@ -371,14 +412,14 @@ fn apply_clause(
 /// `MATCH (p:Person) MERGE (p)-[:R]->(c:City {name:'NYC'})` correctly creates
 /// one NYC per person (a NYC connected only to p1 does not satisfy p2's path).
 ///
-/// # v1 limitation: multi-match
+/// # Multi-match binding (Issue #3623)
 ///
-/// The single-binding-per-row write executor cannot expand one MERGE into
-/// multiple output rows. A MERGE whose pattern matches MORE THAN ONE committed
-/// entity is therefore **rejected** with a structured `UnsupportedFeature`
-/// error rather than silently binding the first (openCypher would bind all and
-/// apply `ON MATCH SET` to every one). Add a uniquely-identifying property or a
-/// unique constraint so the pattern identifies at most one entity.
+/// A MERGE whose pattern matches MORE THAN ONE committed entity binds **all**
+/// matches (openCypher whole-pattern MATCH semantics): it fans the input
+/// binding into one output binding per match and applies `ON MATCH SET` to
+/// every one. The write executor carries a working set of bindings
+/// (`Vec<Binding>`) precisely so this fan-out composes with subsequent clauses
+/// and `RETURN` (each fanned row runs the rest of the statement independently).
 ///
 /// # v1 concurrency
 ///
@@ -394,65 +435,75 @@ fn apply_merge(
     pattern: &CypherPattern,
     on_create: &[CypherSetItem],
     on_match: &[CypherSetItem],
-    binding: &mut Binding,
+    binding: Binding,
     params: &Params,
     deleted_nodes: &HashSet<NodeId>,
     deleted_edges: &HashSet<EdgeId>,
     created_edges: &mut Vec<(EdgeId, NodeId, NodeId)>,
     created_nodes: &mut Vec<(NodeId, String, PropertyMap)>,
-) -> Result<()> {
+) -> Result<Vec<Binding>> {
     // Pre-transaction match against committed current state, filtered to rows
-    // consistent with variables already bound in this row. Collected into a Vec
-    // so the borrow of `binding` ends before the branches mutate it.
+    // consistent with variables already bound in this row. Fully drained into a
+    // Vec before any write so no read borrow is held across the tx mutations.
     let committed: Vec<Binding> = match_bindings(db, std::slice::from_ref(pattern), None, params)?
         .into_iter()
-        .filter(|row| consistent_with(row, binding))
+        .filter(|row| consistent_with(row, &binding))
         .collect();
 
-    // Second finding: a MERGE pattern that matches more than one committed
-    // entity cannot be expressed by the single-binding-per-row executor. Reject
-    // rather than silently binding the first / dropping rows (openCypher would
-    // bind ALL matches and apply ON MATCH SET to every one).
-    if committed.len() > 1 {
-        return Err(CypherError::UnsupportedFeature(
-            "MERGE pattern matched multiple existing entities; MERGE requires a pattern that \
-             identifies at most one (add a uniquely-identifying property or a unique constraint)"
-                .to_string(),
-        )
-        .into());
-    }
-
-    if let Some(row) = committed.into_iter().next() {
-        // MATCH branch: adopt the newly-discovered bindings (a leading
-        // variable already present is rebound to the same id), then apply
-        // ON MATCH SET only. A bare match (empty on_match) records nothing.
-        for (name, entity) in row {
-            bind(binding, &name, entity);
+    // MATCH branch (Issue #3623): a pattern matching one OR MORE committed
+    // entities binds ALL of them (openCypher whole-pattern MATCH semantics),
+    // fanning the input binding into one output binding per match and applying
+    // ON MATCH SET to every one. A bare match (empty on_match) records nothing.
+    if !committed.is_empty() {
+        let mut out = Vec::with_capacity(committed.len());
+        for row in committed {
+            let mut b = binding.clone();
+            for (name, entity) in row {
+                bind(&mut b, &name, entity);
+            }
+            apply_set(tx, on_match, &b, params, deleted_nodes, deleted_edges)?;
+            out.push(b);
         }
-        apply_set(tx, on_match, binding, params, deleted_nodes, deleted_edges)?;
-        return Ok(());
+        return Ok(out);
     }
 
-    // No committed match. For a single-node pattern that would be created (an
-    // unbound/labelled node), consult this statement's created-node ledger so
-    // repeated single-node MERGEs of the same key dedup to one node.
-    if let Some(node) = single_creatable_node(pattern, binding)
+    // No committed match: a single output binding (create or ledger-match).
+    let mut binding = binding;
+
+    // For a single-node pattern that would be created (an unbound/labelled
+    // node), consult this statement's created-node ledger so repeated
+    // single-node MERGEs of the same key dedup to one node.
+    if let Some(node) = single_creatable_node(pattern, &binding)
         && let Some(id) = find_created_single_node(node, created_nodes, params)?
     {
         // Ledger MATCH branch: bind the buffered-created node and apply
         // ON MATCH SET only (no create, no whole-pattern duplicate).
         if let Some(var) = &node.variable {
-            bind(binding, var, EntityResult::NodeId(id));
+            bind(&mut binding, var, EntityResult::NodeId(id));
         }
-        apply_set(tx, on_match, binding, params, deleted_nodes, deleted_edges)?;
-        return Ok(());
+        apply_set(tx, on_match, &binding, params, deleted_nodes, deleted_edges)?;
+        return Ok(vec![binding]);
     }
 
     // CREATE branch: create the whole pattern (a bound leading variable is
     // reused; the unbound remainder is created), then ON CREATE SET.
-    create_pattern(tx, pattern, binding, params, created_edges, created_nodes)?;
-    apply_set(tx, on_create, binding, params, deleted_nodes, deleted_edges)?;
-    Ok(())
+    create_pattern(
+        tx,
+        pattern,
+        &mut binding,
+        params,
+        created_edges,
+        created_nodes,
+    )?;
+    apply_set(
+        tx,
+        on_create,
+        &binding,
+        params,
+        deleted_nodes,
+        deleted_edges,
+    )?;
+    Ok(vec![binding])
 }
 
 /// If a MERGE pattern is a single node that would be *created* (exactly one

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -8331,6 +8331,318 @@ mod mutations {
         assert_eq!(str_prop(&rows[0].entity, "name").unwrap(), "NYC");
     }
 
+    /// #18f (Issue #3623 review) The fan-out working set is bounded by the same
+    /// configurable `max_schema_as_of_entities` cap the read matcher uses. Two
+    /// chained MERGEs each matching N committed 'Dup' persons multiply the
+    /// working set to N*N; exceeding the cap returns a structured
+    /// `UnsupportedFeature` rejection (never an OOM/panic) with the whole
+    /// transaction aborted. Each individual match (3) stays under the cap, so
+    /// this exercises the *fan-out* bound, not the read matcher's per-pattern one.
+    #[test]
+    fn merge_fanout_exceeding_cap_is_structured_error() {
+        use crate::config::{AletheiaDBConfig, HistoricalConfigBuilder, WalConfigBuilder};
+        use crate::core::error::QueryError;
+        use crate::test_utils::unique_wal_dir;
+
+        // Isolate the WAL dir (Issue #3500) since this test builds its own config.
+        let wal_home = unique_wal_dir();
+        let config = AletheiaDBConfig::builder()
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(wal_home.path().join("wal"))
+                    .build(),
+            )
+            .historical(
+                HistoricalConfigBuilder::new()
+                    .max_schema_as_of_entities(5)
+                    .build(),
+            )
+            .build();
+        let db = AletheiaDB::with_unified_config(config).unwrap();
+        for _ in 0..3 {
+            db.create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Dup").build(),
+            )
+            .unwrap();
+        }
+        let before = db.node_count();
+        // 3 matches x 3 matches = 9 working-set bindings > cap of 5.
+        match db.execute_cypher("MERGE (n:Person {name: 'Dup'}) MERGE (m:Person {name: 'Dup'})") {
+            Ok(_) => panic!("expected a structured fan-out cap error, got Ok"),
+            Err(Error::Query(QueryError::UnsupportedFeature { .. })) => {}
+            Err(other) => panic!("expected UnsupportedFeature cap error, got {other:?}"),
+        }
+        assert_eq!(
+            db.node_count(),
+            before,
+            "no partial write on a capped fan-out"
+        );
+    }
+
+    /// #18g (Issue #3623) Relationship-pattern multi-match: a MERGE relationship
+    /// pattern matching multiple committed paths binds ALL of them -- one fanned
+    /// row per matched path, `ON MATCH SET` applied to every far node, and
+    /// nothing created.
+    #[test]
+    fn merge_relationship_multi_match_binds_all_paths() {
+        use crate::core::property::PropertyMap;
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "A").build(),
+            )
+            .unwrap();
+        let b = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "B").build(),
+            )
+            .unwrap();
+        let c = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "C").build(),
+            )
+            .unwrap();
+        let d = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "D").build(),
+            )
+            .unwrap();
+        // Two committed KNOWS paths: (A)->(B), (C)->(D).
+        db.create_edge(a, b, "KNOWS", PropertyMap::new()).unwrap();
+        db.create_edge(c, d, "KNOWS", PropertyMap::new()).unwrap();
+        let before_nodes = db.node_count();
+        let before_edges = db.edge_count();
+
+        let rows = run(
+            &db,
+            "MERGE (x:Person)-[:KNOWS]->(y:Person) ON MATCH SET y.touched = 1 RETURN x, y",
+        );
+
+        // (a) one row per matched path.
+        assert_eq!(rows.len(), 2, "one RETURN row per matched KNOWS path");
+        // (b) ON MATCH SET on the far node applied to EVERY matched path.
+        assert_eq!(
+            db.get_node(b).unwrap().get_property("touched"),
+            Some(&PropertyValue::Int(1))
+        );
+        assert_eq!(
+            db.get_node(d).unwrap().get_property("touched"),
+            Some(&PropertyValue::Int(1))
+        );
+        // Near nodes are untouched (only the far endpoint `y` was SET).
+        assert_eq!(db.get_node(a).unwrap().get_property("touched"), None);
+        assert_eq!(db.get_node(c).unwrap().get_property("touched"), None);
+        // (c) counts unchanged -- pure match, no create.
+        assert_eq!(
+            db.node_count(),
+            before_nodes,
+            "no node created on relationship multi-match"
+        );
+        assert_eq!(
+            db.edge_count(),
+            before_edges,
+            "no edge created on relationship multi-match"
+        );
+    }
+
+    /// #18h (Issue #3623) Same-entity multi-versioning finding: when one node is
+    /// the far endpoint of TWO matched paths, `ON MATCH SET` runs once per fanned
+    /// row, so the shared node is versioned ONCE PER binding -- a documented
+    /// deviation from openCypher's set-once semantics (see the `apply_merge`
+    /// docstring). This asserts the current double-bump so it stays visible.
+    #[test]
+    fn merge_shared_target_versioned_once_per_matched_path() {
+        use crate::core::property::PropertyMap;
+        let db = AletheiaDB::new().unwrap();
+        let a = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "A").build(),
+            )
+            .unwrap();
+        let b = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "B").build(),
+            )
+            .unwrap();
+        let hub = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Hub").build(),
+            )
+            .unwrap();
+        // Two paths share the far node `hub`: (A)->(Hub), (B)->(Hub).
+        db.create_edge(a, hub, "KNOWS", PropertyMap::new()).unwrap();
+        db.create_edge(b, hub, "KNOWS", PropertyMap::new()).unwrap();
+        let hub_versions_before = db.get_node_history(hub).unwrap().version_count();
+
+        run(
+            &db,
+            "MERGE (x:Person)-[:KNOWS]->(y:Person) ON MATCH SET y.seen = 1",
+        );
+
+        // `hub` is bound by two matched paths -> two per-row updates -> two new
+        // versions (the same-entity double-bump this finding surfaces).
+        assert_eq!(
+            db.get_node_history(hub).unwrap().version_count(),
+            hub_versions_before + 2,
+            "shared far node is versioned once per matched path (documented double-bump)"
+        );
+        assert_eq!(
+            db.get_node(hub).unwrap().get_property("seen"),
+            Some(&PropertyValue::Int(1))
+        );
+    }
+
+    /// #18i (Issue #3623) Atomicity on mid-fan-out failure: a multi-match MERGE
+    /// whose `ON MATCH SET` succeeds on an early fanned row but violates a unique
+    /// constraint on a later one aborts the WHOLE transaction -- NO node is
+    /// mutated (all version counts unchanged), proving all-or-nothing across the
+    /// fan-out.
+    #[test]
+    fn merge_multi_match_mid_fanout_failure_is_atomic() {
+        let db = AletheiaDB::new().unwrap();
+        db.unique_constraint("Person", "tag").enable().unwrap();
+        let mut ids = Vec::new();
+        for _ in 0..2 {
+            ids.push(
+                db.create_node(
+                    "Person",
+                    PropertyMapBuilder::new().insert("name", "Dup").build(),
+                )
+                .unwrap(),
+            );
+        }
+        let before: Vec<usize> = ids
+            .iter()
+            .map(|id| db.get_node_history(*id).unwrap().version_count())
+            .collect();
+
+        // Both matched 'Dup' nodes fan out; `ON MATCH SET tag='X'` on the first
+        // reserves the unique value, the second collides -> commit-time abort.
+        let result = db.execute_cypher("MERGE (n:Person {name: 'Dup'}) ON MATCH SET n.tag = 'X'");
+        assert!(
+            result.is_err(),
+            "the colliding multi-match MERGE must abort"
+        );
+
+        // No node mutated: every version count is unchanged, no `tag` persisted.
+        for (id, was) in ids.iter().zip(before) {
+            assert_eq!(
+                db.get_node_history(*id).unwrap().version_count(),
+                was,
+                "no partial mutation on abort"
+            );
+            assert_eq!(
+                db.get_node(*id).unwrap().get_property("tag"),
+                None,
+                "no tag persisted on abort"
+            );
+        }
+    }
+
+    /// #18j (Issue #3623) `ON CREATE SET` does NOT fire on the multi-match
+    /// branch: two committed 'Dup' nodes matched by a MERGE apply only
+    /// `ON MATCH SET`; none receives the `ON CREATE SET` property.
+    #[test]
+    fn merge_multi_match_on_create_set_does_not_fire() {
+        let db = AletheiaDB::new().unwrap();
+        for _ in 0..2 {
+            db.create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Dup").build(),
+            )
+            .unwrap();
+        }
+        run(
+            &db,
+            "MERGE (n:Person {name: 'Dup'}) ON CREATE SET n.created = 1 ON MATCH SET n.touched = 1",
+        );
+        for id in db.scan_nodes_by_label("Person") {
+            let node = db.get_node(id).unwrap();
+            assert_eq!(
+                node.get_property("touched"),
+                Some(&PropertyValue::Int(1)),
+                "ON MATCH SET fires on every matched node"
+            );
+            assert_eq!(
+                node.get_property("created"),
+                None,
+                "ON CREATE SET must not fire on the multi-match branch"
+            );
+        }
+    }
+
+    /// #18k (Issue #3623) A write clause AFTER a multi-match MERGE composes per
+    /// fanned row: `MERGE (...) CREATE (n)-[:HAS]->(t:Tag)` over two matched
+    /// nodes creates one Tag + one edge PER fanned row (two of each).
+    #[test]
+    fn merge_multi_match_following_create_composes_per_row() {
+        let db = AletheiaDB::new().unwrap();
+        for _ in 0..2 {
+            db.create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Dup").build(),
+            )
+            .unwrap();
+        }
+        run(
+            &db,
+            "MERGE (n:Person {name: 'Dup'}) CREATE (n)-[:HAS]->(t:Tag)",
+        );
+        assert_eq!(
+            db.scan_nodes_by_label("Tag").count(),
+            2,
+            "one Tag per fanned row"
+        );
+        assert_eq!(db.edge_count(), 2, "one HAS edge per fanned row");
+    }
+
+    /// #18l (Issue #3623) M base rows x N matches: a leading MATCH yielding 2
+    /// rows followed by a MERGE multi-matching 2 each yields the full 2x2=4
+    /// cross-product -- RETURN emits 4 rows and a following CREATE fires once per
+    /// cross-product row (4 edges), with no new match-target created.
+    #[test]
+    fn merge_base_by_match_cross_product() {
+        let db = AletheiaDB::new().unwrap();
+        for _ in 0..2 {
+            db.create_node(
+                "Base",
+                PropertyMapBuilder::new().insert("name", "P").build(),
+            )
+            .unwrap();
+        }
+        for _ in 0..2 {
+            db.create_node(
+                "Widget",
+                PropertyMapBuilder::new().insert("name", "Dup").build(),
+            )
+            .unwrap();
+        }
+        let rows = run(
+            &db,
+            "MATCH (p:Base {name: 'P'}) MERGE (n:Widget {name: 'Dup'}) \
+             CREATE (p)-[:SAW]->(n) RETURN p, n",
+        );
+        assert_eq!(
+            rows.len(),
+            4,
+            "2 base rows x 2 matches = 4 cross-product rows"
+        );
+        assert_eq!(db.edge_count(), 4, "one SAW edge per cross-product row");
+        assert_eq!(
+            db.scan_nodes_by_label("Widget").count(),
+            2,
+            "no new Widget created (pure match)"
+        );
+    }
+
     /// #19 A pre-bound variable re-matched by the MERGE candidate scan exercises
     /// the `consistent_with` true-branch and `entity_same` node path:
     /// `MATCH (a:Person {name:'A'}) MERGE (a:Person {name:'A'})` binds `a`, the

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -8215,14 +8215,14 @@ mod mutations {
         assert_eq!(db.edge_count(), 3);
     }
 
-    /// #18 Second finding: a MERGE whose pattern matches MORE THAN ONE committed
-    /// entity is rejected (the single-binding-per-row executor cannot expand
-    /// rows), with a structured error and NO partial write.
+    /// #18 (Issue #3623) A MERGE whose pattern matches MORE THAN ONE committed
+    /// entity now binds ALL matches (openCypher whole-pattern MATCH semantics)
+    /// and applies `ON MATCH SET` to every one -- no create, no rejection.
     #[test]
-    fn merge_multi_match_is_rejected_no_partial_write() {
+    fn merge_multi_match_binds_all_and_sets_each() {
         let db = AletheiaDB::new().unwrap();
         // Two Persons named 'Dup': a bare `MERGE (n:Person {name:'Dup'})` matches
-        // both, which cannot be expressed as a single row.
+        // both and fans into two rows.
         for _ in 0..2 {
             db.create_node(
                 "Person",
@@ -8231,16 +8231,104 @@ mod mutations {
             .unwrap();
         }
         let before = db.node_count();
-        assert_query_error(
+        run(
             &db,
             "MERGE (n:Person {name: 'Dup'}) ON MATCH SET n.touched = 1",
         );
-        assert_eq!(db.node_count(), before, "no partial write on multi-match");
-        assert_eq!(
-            int_prop_node(&db, "Person", "Dup", "touched"),
-            None,
-            "ON MATCH SET must not have applied to either match"
-        );
+        assert_eq!(db.node_count(), before, "no create on multi-match");
+        // ON MATCH SET applied to BOTH matched nodes.
+        for id in db.scan_nodes_by_label("Person") {
+            let node = db.get_node(id).unwrap();
+            assert_eq!(
+                node.get_property("touched"),
+                Some(&PropertyValue::Int(1)),
+                "ON MATCH SET must apply to every matched node"
+            );
+        }
+    }
+
+    /// #18b (Issue #3623) A multi-match MERGE with RETURN fans into one row per
+    /// matched entity.
+    #[test]
+    fn merge_multi_match_returns_row_per_match() {
+        let db = AletheiaDB::new().unwrap();
+        for _ in 0..3 {
+            db.create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Dup").build(),
+            )
+            .unwrap();
+        }
+        let rows = run(&db, "MERGE (n:Person {name: 'Dup'}) RETURN n");
+        assert_eq!(rows.len(), 3, "one RETURN row per matched entity");
+        for row in &rows {
+            assert_eq!(str_prop(&row.entity, "name").unwrap(), "Dup");
+        }
+    }
+
+    /// #18c (Issue #3623) A bare multi-match MERGE (no ON MATCH SET) records NO
+    /// new versions -- it is a pure match -- and creates nothing.
+    #[test]
+    fn merge_multi_match_bare_records_no_versions() {
+        let db = AletheiaDB::new().unwrap();
+        let mut ids = Vec::new();
+        for _ in 0..2 {
+            ids.push(
+                db.create_node(
+                    "Person",
+                    PropertyMapBuilder::new().insert("name", "Dup").build(),
+                )
+                .unwrap(),
+            );
+        }
+        let before: Vec<usize> = ids
+            .iter()
+            .map(|id| db.get_node_history(*id).unwrap().version_count())
+            .collect();
+        let before_count = db.node_count();
+        let rows = run(&db, "MERGE (n:Person {name: 'Dup'}) RETURN n");
+        assert_eq!(rows.len(), 2, "one row per match");
+        assert_eq!(db.node_count(), before_count, "no create");
+        for (id, was) in ids.iter().zip(before) {
+            assert_eq!(
+                db.get_node_history(*id).unwrap().version_count(),
+                was,
+                "a bare match must record no new version"
+            );
+        }
+    }
+
+    /// #18d (Issue #3623) A clause AFTER a multi-match MERGE runs per fanned row:
+    /// `SET n.x = 1` must apply to EVERY matched node (composition correctness).
+    #[test]
+    fn merge_multi_match_composes_with_following_clause() {
+        let db = AletheiaDB::new().unwrap();
+        for _ in 0..2 {
+            db.create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Dup").build(),
+            )
+            .unwrap();
+        }
+        run(&db, "MERGE (n:Person {name: 'Dup'}) SET n.x = 1");
+        for id in db.scan_nodes_by_label("Person") {
+            assert_eq!(
+                db.get_node(id).unwrap().get_property("x"),
+                Some(&PropertyValue::Int(1)),
+                "a SET after a multi-match MERGE must apply to every fanned row"
+            );
+        }
+    }
+
+    /// #18e (Issue #3623) The create branch still yields exactly ONE row / ONE
+    /// node when no committed match exists (no accidental fan-out).
+    #[test]
+    fn merge_no_match_creates_exactly_one_row() {
+        let db = AletheiaDB::new().unwrap();
+        let rows = run(&db, "MERGE (n:City {name: 'NYC'}) RETURN n");
+        assert_eq!(rows.len(), 1, "create branch yields exactly one row");
+        assert_eq!(db.scan_nodes_by_label("City").count(), 1);
+        assert_eq!(str_prop(&rows[0].entity, "name").unwrap(), "NYC");
     }
 
     /// #19 A pre-bound variable re-matched by the MERGE candidate scan exercises

--- a/src/db/rotation.rs
+++ b/src/db/rotation.rs
@@ -64,7 +64,6 @@ use crate::encryption::factory::Algorithm;
 use crate::encryption::factory::create_cipher;
 use crate::encryption::key_derivation::KeyDerivation;
 use crate::storage::index_persistence::common::{ENC_INDEX_KEY_VERSION_V1, IndexKeyring};
-use crate::storage::index_persistence::common::ENC_INDEX_KEY_VERSION_V1;
 use crate::storage::index_persistence::reencrypt::DecryptProbeReport;
 use crate::storage::index_persistence::{
     IndexKeyRotation, IndexPersistenceManager, RotationError, RotationProgress, RotationStatus,


### PR DESCRIPTION
## Summary

Closes #3623. Cypher `MERGE` previously returned a structured `UnsupportedFeature` rejection when its pattern matched **more than one** committed entity (added in #3609 as a v1 limitation), because the write executor was single-binding-per-row. openCypher whole-pattern MATCH semantics require binding **all** matches and applying `ON MATCH SET` to every one. This PR implements that multi-match binding.

## Approach

The write executor now carries a **working set of bindings** (`Vec`) per base row instead of a single `binding` mutated in place:

- `apply_clause` maps `Vec` → `Vec`. `CREATE`/`SET`/`DELETE` stay 1→1; `MERGE` fans one binding into N (one per committed match).
- `apply_merge` returns `Vec`: on match it produces one output binding per match with `ON MATCH SET` applied to each; on create/ledger-match it produces exactly one. The committed `match_bindings` read is fully **drained into a `Vec` before any `tx` write** (no read borrow held across mutations).
- `RETURN` snapshots every binding in the final working set, so a multi-match `MERGE` emits one row per matched entity and **later clauses run once per fanned row** (composition correctness — this is why the fan-out is threaded through the whole clause pipeline rather than handled locally inside `MERGE`, which would silently apply following clauses to only the first match).

Rejected alternative: MERGE-local fan-out (apply `ON MATCH SET` to all matches inside `apply_merge`, keep the primary binding = first match, stash extras only for RETURN). This would silently apply a clause *after* a multi-match MERGE to only the first match — a silently-wrong write, the exact failure mode to avoid.

Single-match, create, single-node ledger-dedup, and relationship-path semantics are all unchanged.

## Acceptance criteria → evidence

| # | Criterion (from #3623 / openCypher MERGE semantics) | Evidence |
|---|---|---|
| 1 | MERGE matching >1 committed entity no longer rejects; binds all and applies `ON MATCH SET` to every one | `merge_multi_match_binds_all_and_sets_each` — both `Dup` nodes get `touched=1`, no create |
| 2 | Multi-match MERGE with `RETURN` emits one row per matched entity | `merge_multi_match_returns_row_per_match` — 3 Dups → 3 rows |
| 3 | A bare multi-match MERGE (no `ON MATCH SET`) records **no** new versions and creates nothing | `merge_multi_match_bare_records_no_versions` — version counts unchanged, node_count unchanged, 2 rows |
| 4 | A clause **after** a multi-match MERGE runs per fanned row (composition) | `merge_multi_match_composes_with_following_clause` — `SET n.x=1` applies to every match |
| 5 | The create branch still yields exactly one row / one node (no accidental fan-out) | `merge_no_match_creates_exactly_one_row` |
| 6 | No regression to single-match / existing MERGE behavior | full `cypher::tests::mutations` module green |

## Review fixes

Addressing the 4-angle code review (correct + atomic, but with the gaps below).

**MAJOR — unbounded multiplicative fan-out (fixed).** Removing the old `committed.len() > 1` reject left the fan-out working set unbounded: a MERGE matching N committed entities — or several chained MERGEs — can grow the per-base working set to `M * N^k` bindings (e.g. `MERGE (a) MERGE (b)` → N² bindings), each buffering writes in one `WriteTransaction`, a memory/transaction DoS. Now the working set is bounded by the **same** configurable `max_schema_as_of_entities` limit the read matcher (`match_bindings`) already enforces on its intermediate binding count, returning the **same** structured `CypherError::UnsupportedFeature` rejection instead of OOMing. The cap is read once in `execute()` and checked both **mid-extend** inside the `Merge` arm of `apply_clause` (so a single clause can't balloon `out` to ~cap² before the caller looks) and **after each clause** in the base-row loop.

**New tests**

| Finding | Test |
|---|---|
| Fan-out past the cap → structured `UnsupportedFeature`, tx aborted, no OOM | `merge_fanout_exceeding_cap_is_structured_error` (cap=5, chained MERGE over 3 Dups = 9 > cap) |
| Relationship-pattern multi-match: one row per matched path, `ON MATCH SET` on every far node, no create | `merge_relationship_multi_match_binds_all_paths` |
| Same-entity double-versioning when a node is reached by two matched paths (documented deviation, now asserted) | `merge_shared_target_versioned_once_per_matched_path` |
| Atomicity / no-partial-write on mid-fan-out failure (unique-constraint collision on a later fanned row aborts the whole tx) | `merge_multi_match_mid_fanout_failure_is_atomic` |
| `ON CREATE SET` does **not** fire on the multi-match branch | `merge_multi_match_on_create_set_does_not_fire` |
| A following **CREATE** composes per fanned row (2 matches → 2 Tags + 2 edges) | `merge_multi_match_following_create_composes_per_row` |
| M base × N match cross-product (2×2 → 4 RETURN rows + 4 edges) | `merge_base_by_match_cross_product` |

**Docs.** Expanded the `apply_merge` docstring with the combinatorial fan-out cost + the new aggregate cap, and the single-entity multi-versioning deviation (one entity can be bi-temporally versioned multiple times when matched via multiple paths/rows). Added a one-line comment where fanned RETURN row order is intentionally unasserted (openCypher gives no order without ORDER BY).

## Quality gates

- `cargo fmt --all` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — **exit 0**, zero warnings
- `cargo test --features sql,cypher --lib` — **4713 passed; 0 failed; 3 ignored**
- `cypher::tests::mutations` — **66 passed; 0 failed**

## v1 caveats (unchanged from #3609)

- The pre-transaction match remains a documented check-then-act window; a unique constraint on the merged property closes it (first-committer-wins).
- No MCP surface change — Cypher writes execute only through `execute_cypher` / `execute_cypher_with_params`; the MCP `query` tool rejects mutating clauses before the parser runs.

## Incidental

Removed a duplicate `ENC_INDEX_KEY_VERSION_V1` import in `src/db/rotation.rs` (a merge artifact from #3639 currently breaking trunk's build with `E0252`) so this branch compiles. This is a duplicate trunk-fix that vanishes on the next trunk merge — not a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MM68sFWVTxKbBRnCq1VTrD)_