### PR TITLE
feat(query): structured edge projection for SQL FROM edges (#3626)

### DIFF
--- a/src/db/rotation.rs
+++ b/src/db/rotation.rs
@@ -64,7 +64,6 @@ use crate::encryption::factory::Algorithm;
 use crate::encryption::factory::create_cipher;
 use crate::encryption::key_derivation::KeyDerivation;
 use crate::storage::index_persistence::common::{ENC_INDEX_KEY_VERSION_V1, IndexKeyring};
-use crate::storage::index_persistence::common::ENC_INDEX_KEY_VERSION_V1;
 use crate::storage::index_persistence::reencrypt::DecryptProbeReport;
 use crate::storage::index_persistence::{
     IndexKeyRotation, IndexPersistenceManager, RotationError, RotationProgress, RotationStatus,

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -312,10 +312,12 @@ impl QueryExecutor {
                 )),
 
                 // Full edge scan (SQL `SELECT * FROM edges`). Mirrors `NodeScan`.
-                // Yields `EntityResult::Edge` rows; note these survive `collect_all`
-                // / `count_all` / direct iteration but are dropped by the
-                // node-centric `collect_structured`/`collect_nodes` helpers, which
-                // remain node-only by design (see `results.rs`).
+                // Yields `EntityResult::Edge` rows; these survive `collect_all` /
+                // `count_all` / direct iteration and the edge-shaped structured
+                // projection `collect_structured_edges`/`collect_edges` (Issue
+                // #3626). The node-centric `collect_structured`/`collect_nodes`
+                // helpers remain node-only by design and drop edge rows (see
+                // `results.rs`).
                 PhysicalOp::EdgeScan { edge_type, .. } => Box::new(
                     iterators::EdgeScanIterator::new(edge_type.clone(), Arc::clone(&self.current)),
                 ),

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -38,6 +38,7 @@
 use crate::core::error::Result;
 use crate::core::graph::{Edge, Node};
 use crate::core::id::VersionId;
+use crate::core::interning::InternedString;
 use crate::core::property::{PropertyMap, PropertyValue};
 use crate::core::temporal::Timestamp;
 use crate::core::{EdgeId, NodeId};
@@ -379,6 +380,27 @@ impl QueryResults {
             }
         }
         Ok(nodes)
+    }
+
+    /// Collect only the full edges from the result stream, discarding scores, nodes, and paths.
+    ///
+    /// **Why?** The edge counterpart to [`collect_nodes`](Self::collect_nodes): useful for
+    /// `SELECT * FROM edges` (Issue #3607) and other edge-yielding queries where the caller
+    /// wants the [`Edge`] payloads directly. Node rows in the stream are dropped, mirroring the
+    /// way `collect_nodes` drops edge rows.
+    ///
+    /// ⚡ Bolt Optimization: Consumes the iterator directly to avoid allocating
+    /// a large intermediate `Vec` of all rows before extracting the edges.
+    /// Pre-allocates vector based on iterator's lower size bound.
+    pub fn collect_edges(mut self) -> Result<Vec<Edge>> {
+        let (lower, _) = self.iterator.size_hint();
+        let mut edges = Vec::with_capacity(lower);
+        while let Some(row) = self.iterator.next() {
+            if let EntityResult::Edge(e) = row?.entity {
+                edges.push(e);
+            }
+        }
+        Ok(edges)
     }
 
     /// Collect nodes with their scores
@@ -898,6 +920,253 @@ impl QueryResults {
             versions,
             columns,
         })
+    }
+
+    /// Collect all results into a structured [`EdgeQueryResult`].
+    ///
+    /// The edge counterpart to [`collect_structured`](Self::collect_structured) (Issue
+    /// #3626). Where `collect_structured` projects node rows into a node-shaped
+    /// [`QueryResult`] (and silently drops edges), this projects **edge** rows
+    /// (`SELECT * FROM edges`, Issue #3607) into an edge-shaped [`EdgeQueryResult`]:
+    /// parallel vectors of ids, endpoints, labels, properties, scores, and versions.
+    /// `collect_structured` itself is unchanged and remains node-only.
+    ///
+    /// Node rows in the stream are dropped, symmetric to the way the node-centric helpers
+    /// drop edge rows. The endpoint/label/property vectors are `Some` iff at least one full
+    /// [`EntityResult::Edge`] row was collected; a stream of bare [`EntityResult::EdgeId`]
+    /// rows populates only [`edges`](EdgeQueryResult::edges).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Any row fails to be read from the iterator
+    /// - A timestamp cannot be converted to a valid `VersionId` (exceeds `MAX_VALID_ID`)
+    ///
+    /// # Performance
+    ///
+    /// Like `collect_structured`, this collects **all** rows into memory (two passes). For
+    /// result sets exceeding 100K rows, prefer streaming the iterator directly.
+    pub fn collect_structured_edges(mut self) -> Result<EdgeQueryResult> {
+        // First pass: collect all rows.
+        let (lower, _) = self.iterator.size_hint();
+        let mut rows = Vec::with_capacity(lower);
+        while let Some(row) = self.iterator.next() {
+            rows.push(row?);
+        }
+
+        // Determine which fields we have (single pass). `has_any_full_edges` gates the
+        // endpoint/label/property vectors: they only make sense once a full `Edge` (not a
+        // bare `EdgeId`) has been seen.
+        let (mut has_any_full_edges, mut has_any_scores, mut has_any_versions) =
+            (false, false, false);
+        let mut edge_count = 0usize;
+        for row in &rows {
+            has_any_scores = has_any_scores || row.score.is_some();
+            has_any_versions = has_any_versions || row.timestamp.is_some();
+            match row.entity {
+                EntityResult::Edge(_) => {
+                    has_any_full_edges = true;
+                    edge_count += 1;
+                }
+                EntityResult::EdgeId(_) => edge_count += 1,
+                _ => {}
+            }
+        }
+
+        // Second pass: extract data with padding, keeping every vector parallel to `edges`.
+        let mut edges = Vec::with_capacity(edge_count);
+        let mut sources = has_any_full_edges.then(|| Vec::with_capacity(edge_count));
+        let mut targets = has_any_full_edges.then(|| Vec::with_capacity(edge_count));
+        let mut labels = has_any_full_edges.then(|| Vec::with_capacity(edge_count));
+        let mut properties = has_any_full_edges.then(|| Vec::with_capacity(edge_count));
+        let mut scores = has_any_scores.then(|| Vec::with_capacity(edge_count));
+        let mut versions = has_any_versions.then(|| Vec::with_capacity(edge_count));
+
+        for row in rows {
+            let QueryRow {
+                entity,
+                score,
+                path: _,
+                timestamp,
+                columns: _,
+                bindings: _,
+            } = row;
+
+            // Only edge-bearing rows contribute; node/null rows are dropped (edge-only,
+            // symmetric to `collect_structured`'s edge drop). We must keep the score/version
+            // pushes inside these arms so every parallel vector stays aligned to `edges`.
+            match entity {
+                EntityResult::Edge(e) => {
+                    edges.push(e.id);
+                    if let Some(ref mut s) = sources {
+                        s.push(e.source);
+                    }
+                    if let Some(ref mut t) = targets {
+                        t.push(e.target);
+                    }
+                    if let Some(ref mut l) = labels {
+                        l.push(e.label);
+                    }
+                    if let Some(ref mut p) = properties {
+                        p.push(e.properties);
+                    }
+                }
+                EntityResult::EdgeId(id) => {
+                    edges.push(id);
+                    // Pad the intrinsic-edge vectors: a bare `EdgeId` carries no endpoints,
+                    // label, or properties (mirrors how a bare `NodeId` pads empty properties
+                    // in `collect_structured`). The edge-scan path never produces bare
+                    // `EdgeId` rows, so this only guards a hypothetical mixed stream.
+                    if let Some(ref mut s) = sources {
+                        s.push(NodeId::new_unchecked(0));
+                    }
+                    if let Some(ref mut t) = targets {
+                        t.push(NodeId::new_unchecked(0));
+                    }
+                    if let Some(ref mut l) = labels {
+                        l.push(InternedString::from_raw(0));
+                    }
+                    if let Some(ref mut p) = properties {
+                        p.push(PropertyMap::default());
+                    }
+                }
+                // Nodes / null bindings are not edges: drop them, and do not advance any
+                // parallel vector so alignment with `edges` is preserved.
+                _ => continue,
+            }
+
+            // Extract or pad scores (parallel to `edges`).
+            if let Some(ref mut s) = scores {
+                s.push(score.unwrap_or(0.0));
+            }
+
+            // Extract or pad versions (parallel to `edges`), reusing the node path's
+            // timestamp→VersionId conversion and MAX_VALID_ID validation.
+            if let Some(ref mut v) = versions {
+                if let Some(timestamp) = timestamp {
+                    let wallclock = timestamp.wallclock();
+                    let ts_u64 = if wallclock < 0 {
+                        0_u64
+                    } else {
+                        wallclock as u64
+                    };
+                    let version_id = VersionId::new(ts_u64).map_err(|e| {
+                        crate::core::error::Error::Query(
+                            crate::core::error::QueryError::InvalidParameter {
+                                parameter: "timestamp".to_string(),
+                                reason: format!(
+                                    "Timestamp {} exceeds MAX_VALID_ID: {}",
+                                    timestamp, e
+                                ),
+                            },
+                        )
+                    })?;
+                    v.push(version_id);
+                } else {
+                    // SAFETY: VersionId(0) is always valid as 0 < MAX_VALID_ID.
+                    v.push(VersionId::new(0).expect("VersionId(0) should always be valid"));
+                }
+            }
+        }
+
+        Ok(EdgeQueryResult {
+            edges,
+            sources,
+            targets,
+            labels,
+            properties,
+            scores,
+            versions,
+        })
+    }
+}
+
+/// Aggregated edge query results in a structured format.
+///
+/// The edge-shaped counterpart to [`QueryResult`] (Issue #3626), produced by
+/// [`QueryResults::collect_structured_edges`]. Where `QueryResult` holds node ids plus
+/// parallel node metadata, `EdgeQueryResult` holds edge ids plus the data intrinsic to an
+/// edge — source/target endpoints and the interned label — alongside properties, scores,
+/// and versions.
+///
+/// # Alignment & Padding
+///
+/// Every `Option<Vec<_>>` field, when `Some`, is parallel to [`edges`](Self::edges) (same
+/// length, same order). The endpoint/label/property vectors are `Some` iff at least one
+/// full [`EntityResult::Edge`] row was collected; a stream of bare [`EntityResult::EdgeId`]
+/// rows leaves them `None`. In the (practically unreachable) mixed case, `EdgeId` rows pad
+/// endpoints with `NodeId(0)`, label with `InternedString(0)`, and empty properties —
+/// mirroring how [`QueryResult`] pads a bare `NodeId`'s properties.
+#[derive(Debug, Clone)]
+pub struct EdgeQueryResult {
+    /// Edge IDs from the query results, one per edge row, in stream order.
+    pub edges: Vec<EdgeId>,
+    /// Source node of each edge (parallel to `edges`). `Some` iff at least one full edge
+    /// was collected.
+    pub sources: Option<Vec<NodeId>>,
+    /// Target node of each edge (parallel to `edges`). `Some` iff at least one full edge
+    /// was collected.
+    pub targets: Option<Vec<NodeId>>,
+    /// Interned edge type/label of each edge (parallel to `edges`). `Some` iff at least one
+    /// full edge was collected.
+    pub labels: Option<Vec<InternedString>>,
+    /// Properties of each edge (parallel to `edges`). `Some` iff at least one full edge was
+    /// collected.
+    pub properties: Option<Vec<PropertyMap>>,
+    /// Similarity scores for ranked edge results (parallel to `edges`).
+    pub scores: Option<Vec<f32>>,
+    /// Version IDs for temporal edge results (parallel to `edges`).
+    pub versions: Option<Vec<VersionId>>,
+}
+
+impl EdgeQueryResult {
+    /// Create a new empty edge query result.
+    #[must_use]
+    pub fn new() -> Self {
+        EdgeQueryResult {
+            edges: Vec::new(),
+            sources: None,
+            targets: None,
+            labels: None,
+            properties: None,
+            scores: None,
+            versions: None,
+        }
+    }
+
+    /// Get the number of edge results.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.edges.len()
+    }
+
+    /// Check if the result is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.edges.is_empty()
+    }
+
+    /// Get edges zipped with their `(source, target)` endpoints, when endpoints are
+    /// available (i.e. full edges were collected).
+    #[must_use]
+    pub fn edges_with_endpoints(&self) -> Option<Vec<(EdgeId, NodeId, NodeId)>> {
+        match (&self.sources, &self.targets) {
+            (Some(sources), Some(targets)) => Some(
+                self.edges
+                    .iter()
+                    .zip(sources.iter())
+                    .zip(targets.iter())
+                    .map(|((edge, source), target)| (*edge, *source, *target))
+                    .collect(),
+            ),
+            _ => None,
+        }
+    }
+}
+
+impl Default for EdgeQueryResult {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -1599,6 +1868,246 @@ mod tests {
         assert!(structured.scores.is_none());
         assert!(structured.paths.is_none());
         assert!(structured.versions.is_none());
+    }
+
+    // -- Edge structured projection (Issue #3626) --------------------------------------
+
+    /// Build an edge with explicit id / endpoints / label / one property so tests can
+    /// assert each field round-trips independently.
+    fn edge_with(id: u64, source: u64, target: u64, label: &str, since: i64) -> Edge {
+        Edge::new(
+            EdgeId::new(id).unwrap(),
+            GLOBAL_INTERNER.intern(label).unwrap(),
+            NodeId::new(source).unwrap(),
+            NodeId::new(target).unwrap(),
+            PropertyMapBuilder::new().insert("since", since).build(),
+            VersionId::new(1).unwrap(),
+        )
+    }
+
+    #[test]
+    fn test_collect_structured_edges_basic() {
+        let rows = vec![
+            QueryRow::from_entity(EntityResult::Edge(edge_with(10, 1, 2, "KNOWS", 2020))),
+            QueryRow::from_entity(EntityResult::Edge(edge_with(11, 2, 3, "LIKES", 2021))),
+        ];
+        let results = QueryResults::new(Box::new(MockIterator::new(rows)));
+
+        let structured = results.collect_structured_edges().unwrap();
+        assert_eq!(structured.len(), 2);
+        assert!(!structured.is_empty());
+
+        assert_eq!(structured.edges[0], EdgeId::new(10).unwrap());
+        assert_eq!(structured.edges[1], EdgeId::new(11).unwrap());
+
+        let sources = structured
+            .sources
+            .as_ref()
+            .expect("full edges carry sources");
+        let targets = structured
+            .targets
+            .as_ref()
+            .expect("full edges carry targets");
+        assert_eq!(sources[0], NodeId::new(1).unwrap());
+        assert_eq!(targets[0], NodeId::new(2).unwrap());
+        assert_eq!(sources[1], NodeId::new(2).unwrap());
+        assert_eq!(targets[1], NodeId::new(3).unwrap());
+
+        let labels = structured.labels.as_ref().expect("full edges carry labels");
+        assert_eq!(labels[0], GLOBAL_INTERNER.intern("KNOWS").unwrap());
+        assert_eq!(labels[1], GLOBAL_INTERNER.intern("LIKES").unwrap());
+
+        let props = structured
+            .properties
+            .as_ref()
+            .expect("full edges carry properties");
+        assert_eq!(props[0].get("since"), Some(&PropertyValue::Int(2020)));
+        assert_eq!(props[1].get("since"), Some(&PropertyValue::Int(2021)));
+
+        // No scores / versions on these rows.
+        assert!(structured.scores.is_none());
+        assert!(structured.versions.is_none());
+    }
+
+    #[test]
+    fn test_collect_structured_edges_preserves_order() {
+        let rows = vec![
+            QueryRow::from_entity(EntityResult::Edge(edge_with(30, 1, 2, "KNOWS", 1))),
+            QueryRow::from_entity(EntityResult::Edge(edge_with(10, 3, 4, "KNOWS", 2))),
+            QueryRow::from_entity(EntityResult::Edge(edge_with(20, 5, 6, "KNOWS", 3))),
+        ];
+        let results = QueryResults::new(Box::new(MockIterator::new(rows)));
+
+        let structured = results.collect_structured_edges().unwrap();
+        let ids: Vec<u64> = structured.edges.iter().map(|e| e.as_u64()).collect();
+        assert_eq!(
+            ids,
+            vec![30, 10, 20],
+            "edges preserve stream order, not sorted"
+        );
+    }
+
+    #[test]
+    fn test_collect_structured_edges_with_scores() {
+        let rows = vec![
+            QueryRow::with_score(EntityResult::Edge(edge_with(10, 1, 2, "KNOWS", 1)), 0.9),
+            QueryRow::with_score(EntityResult::Edge(edge_with(11, 2, 3, "KNOWS", 2)), 0.8),
+        ];
+        let results = QueryResults::new(Box::new(MockIterator::new(rows)));
+
+        let structured = results.collect_structured_edges().unwrap();
+        let scores = structured.scores.expect("scores present");
+        assert_eq!(scores, vec![0.9, 0.8]);
+    }
+
+    #[test]
+    fn test_collect_structured_edges_with_timestamps() {
+        let rows = vec![
+            QueryRow::from_entity(EntityResult::Edge(edge_with(10, 1, 2, "KNOWS", 1)))
+                .at_time(100.into()),
+            QueryRow::from_entity(EntityResult::Edge(edge_with(11, 2, 3, "KNOWS", 2)))
+                .at_time(200.into()),
+        ];
+        let results = QueryResults::new(Box::new(MockIterator::new(rows)));
+
+        let structured = results.collect_structured_edges().unwrap();
+        let versions = structured.versions.expect("versions present");
+        assert_eq!(versions[0], VersionId::new(100).unwrap());
+        assert_eq!(versions[1], VersionId::new(200).unwrap());
+    }
+
+    #[test]
+    fn test_collect_structured_edges_drops_nodes() {
+        // A mixed stream: only the edge rows survive; node rows are dropped and do NOT
+        // advance any parallel vector (edge-only, symmetric to collect_structured's edge drop).
+        let rows = vec![
+            QueryRow::from_entity(EntityResult::Node(test_node(1))),
+            QueryRow::with_score(EntityResult::Edge(edge_with(10, 1, 2, "KNOWS", 7)), 0.5),
+            QueryRow::from_entity(EntityResult::NodeId(NodeId::new(9).unwrap())),
+        ];
+        let results = QueryResults::new(Box::new(MockIterator::new(rows)));
+
+        let structured = results.collect_structured_edges().unwrap();
+        assert_eq!(structured.len(), 1, "only the single edge row survives");
+        assert_eq!(structured.edges[0], EdgeId::new(10).unwrap());
+        // Parallel vectors stayed aligned to the surviving edge only.
+        assert_eq!(structured.sources.as_ref().unwrap().len(), 1);
+        assert_eq!(structured.scores.as_ref().unwrap(), &vec![0.5]);
+    }
+
+    #[test]
+    fn test_collect_structured_edges_empty() {
+        let rows: Vec<QueryRow> = vec![];
+        let results = QueryResults::new(Box::new(MockIterator::new(rows)));
+
+        let structured = results.collect_structured_edges().unwrap();
+        assert!(structured.is_empty());
+        assert_eq!(structured.len(), 0);
+        assert!(structured.sources.is_none());
+        assert!(structured.targets.is_none());
+        assert!(structured.labels.is_none());
+        assert!(structured.properties.is_none());
+        assert!(structured.scores.is_none());
+        assert!(structured.versions.is_none());
+        assert!(structured.edges_with_endpoints().is_none());
+    }
+
+    #[test]
+    fn test_collect_structured_edges_id_only_stream() {
+        // A stream of bare EdgeId rows populates only `edges`; the intrinsic-edge vectors
+        // stay None because no full Edge was seen.
+        let rows = vec![
+            QueryRow::from_entity(EntityResult::EdgeId(EdgeId::new(10).unwrap())),
+            QueryRow::from_entity(EntityResult::EdgeId(EdgeId::new(11).unwrap())),
+        ];
+        let results = QueryResults::new(Box::new(MockIterator::new(rows)));
+
+        let structured = results.collect_structured_edges().unwrap();
+        assert_eq!(structured.len(), 2);
+        assert_eq!(structured.edges[0], EdgeId::new(10).unwrap());
+        assert!(structured.sources.is_none());
+        assert!(structured.targets.is_none());
+        assert!(structured.labels.is_none());
+        assert!(structured.properties.is_none());
+        assert!(structured.edges_with_endpoints().is_none());
+    }
+
+    #[test]
+    fn test_collect_structured_edges_mixed_full_and_id_pads() {
+        // Mixed full-edge + bare-id: parallel vectors exist (a full edge was seen) and the
+        // bare-id row is padded so every vector stays aligned to `edges`.
+        let rows = vec![
+            QueryRow::from_entity(EntityResult::Edge(edge_with(10, 1, 2, "KNOWS", 5))),
+            QueryRow::from_entity(EntityResult::EdgeId(EdgeId::new(11).unwrap())),
+        ];
+        let results = QueryResults::new(Box::new(MockIterator::new(rows)));
+
+        let structured = results.collect_structured_edges().unwrap();
+        assert_eq!(structured.len(), 2);
+        let sources = structured.sources.as_ref().unwrap();
+        let targets = structured.targets.as_ref().unwrap();
+        let props = structured.properties.as_ref().unwrap();
+        assert_eq!(sources.len(), 2);
+        assert_eq!(targets.len(), 2);
+        assert_eq!(props.len(), 2);
+        // Full edge keeps real data.
+        assert_eq!(sources[0], NodeId::new(1).unwrap());
+        assert_eq!(props[0].get("since"), Some(&PropertyValue::Int(5)));
+        // Bare-id row is padded (endpoints NodeId(0), empty properties).
+        assert_eq!(sources[1], NodeId::new(0).unwrap());
+        assert_eq!(targets[1], NodeId::new(0).unwrap());
+        assert!(props[1].get("since").is_none());
+    }
+
+    #[test]
+    fn test_collect_structured_edges_edges_with_endpoints() {
+        let rows = vec![
+            QueryRow::from_entity(EntityResult::Edge(edge_with(10, 1, 2, "KNOWS", 1))),
+            QueryRow::from_entity(EntityResult::Edge(edge_with(11, 3, 4, "KNOWS", 2))),
+        ];
+        let results = QueryResults::new(Box::new(MockIterator::new(rows)));
+
+        let structured = results.collect_structured_edges().unwrap();
+        let triples = structured
+            .edges_with_endpoints()
+            .expect("endpoints available");
+        assert_eq!(
+            triples,
+            vec![
+                (
+                    EdgeId::new(10).unwrap(),
+                    NodeId::new(1).unwrap(),
+                    NodeId::new(2).unwrap()
+                ),
+                (
+                    EdgeId::new(11).unwrap(),
+                    NodeId::new(3).unwrap(),
+                    NodeId::new(4).unwrap()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_collect_edges_returns_full_edges_and_drops_nodes() {
+        let rows = vec![
+            QueryRow::from_entity(EntityResult::Node(test_node(1))),
+            QueryRow::from_entity(EntityResult::Edge(edge_with(10, 1, 2, "KNOWS", 1))),
+            QueryRow::from_entity(EntityResult::Edge(edge_with(11, 2, 3, "KNOWS", 2))),
+        ];
+        let results = QueryResults::new(Box::new(MockIterator::new(rows)));
+
+        let edges = results.collect_edges().unwrap();
+        assert_eq!(edges.len(), 2, "node row dropped, both edges kept");
+        assert_eq!(edges[0].id, EdgeId::new(10).unwrap());
+        assert_eq!(edges[1].source, NodeId::new(2).unwrap());
+    }
+
+    #[test]
+    fn test_edge_query_result_default_is_empty() {
+        let r = EdgeQueryResult::default();
+        assert!(r.is_empty());
+        assert_eq!(r.len(), 0);
     }
 
     #[test]

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -961,14 +961,23 @@ impl QueryResults {
             (false, false, false);
         let mut edge_count = 0usize;
         for row in &rows {
-            has_any_scores = has_any_scores || row.score.is_some();
-            has_any_versions = has_any_versions || row.timestamp.is_some();
+            // Only edge/edge-id rows may flip the score/version gates: this projection is
+            // edge-only, so a node row that happens to carry a score/timestamp in a
+            // hypothetical mixed stream must not turn the edge result's `scores`/`versions`
+            // into an all-default-padded `Some`. (EdgeScan yields homogeneous edge rows, so
+            // this is an honesty guard, not a reachable correctness bug.)
             match row.entity {
                 EntityResult::Edge(_) => {
                     has_any_full_edges = true;
                     edge_count += 1;
+                    has_any_scores = has_any_scores || row.score.is_some();
+                    has_any_versions = has_any_versions || row.timestamp.is_some();
                 }
-                EntityResult::EdgeId(_) => edge_count += 1,
+                EntityResult::EdgeId(_) => {
+                    edge_count += 1;
+                    has_any_scores = has_any_scores || row.score.is_some();
+                    has_any_versions = has_any_versions || row.timestamp.is_some();
+                }
                 _ => {}
             }
         }
@@ -1161,6 +1170,34 @@ impl EdgeQueryResult {
             ),
             _ => None,
         }
+    }
+
+    /// Get edges zipped with their similarity scores (if available), mirroring
+    /// [`QueryResult::nodes_with_scores`]. `Some` iff at least one collected edge row carried
+    /// a score.
+    #[must_use]
+    pub fn edges_with_scores(&self) -> Option<Vec<(EdgeId, f32)>> {
+        self.scores.as_ref().map(|scores| {
+            self.edges
+                .iter()
+                .zip(scores.iter())
+                .map(|(edge, score)| (*edge, *score))
+                .collect()
+        })
+    }
+
+    /// Get edges zipped with their version IDs (if available), mirroring
+    /// [`QueryResult::nodes_with_versions`]. `Some` iff at least one collected edge row carried
+    /// a timestamp.
+    #[must_use]
+    pub fn edges_with_versions(&self) -> Option<Vec<(EdgeId, VersionId)>> {
+        self.versions.as_ref().map(|versions| {
+            self.edges
+                .iter()
+                .zip(versions.iter())
+                .map(|(edge, version)| (*edge, *version))
+                .collect()
+        })
     }
 }
 
@@ -2108,6 +2145,209 @@ mod tests {
         let r = EdgeQueryResult::default();
         assert!(r.is_empty());
         assert_eq!(r.len(), 0);
+    }
+
+    #[test]
+    fn test_collect_structured_edges_bare_id_pads_scores_and_versions() {
+        // A bare `EdgeId` row following a full edge that carries a score and a timestamp
+        // must pad the score/version vectors so both stay parallel to `edges` (length 2).
+        let rows = vec![
+            QueryRow::with_score(EntityResult::Edge(edge_with(10, 1, 2, "KNOWS", 1)), 0.9)
+                .at_time(100.into()),
+            QueryRow::from_entity(EntityResult::EdgeId(EdgeId::new(11).unwrap())),
+        ];
+        let results = QueryResults::new(Box::new(MockIterator::new(rows)));
+
+        let structured = results.collect_structured_edges().unwrap();
+        assert_eq!(structured.len(), 2);
+
+        let scores = structured.scores.expect("scores present");
+        assert_eq!(scores, vec![0.9, 0.0], "index-1 padded, aligned to edges");
+
+        let versions = structured.versions.expect("versions present");
+        assert_eq!(
+            versions,
+            vec![VersionId::new(100).unwrap(), VersionId::new(0).unwrap()],
+            "index-1 padded with VersionId(0), aligned to edges"
+        );
+    }
+
+    #[test]
+    fn test_collect_structured_edges_partial_score_and_timestamp_pads() {
+        // Two full edge rows where ONLY the first carries a score and ONLY the first a
+        // timestamp: the second row is padded (default score 0.0, VersionId(0)) so both
+        // vectors stay aligned to `edges`.
+        let rows = vec![
+            QueryRow::with_score(EntityResult::Edge(edge_with(10, 1, 2, "KNOWS", 1)), 0.9)
+                .at_time(100.into()),
+            QueryRow::from_entity(EntityResult::Edge(edge_with(11, 2, 3, "KNOWS", 2))),
+        ];
+        let results = QueryResults::new(Box::new(MockIterator::new(rows)));
+
+        let structured = results.collect_structured_edges().unwrap();
+        assert_eq!(structured.len(), 2);
+
+        let scores = structured.scores.expect("scores present");
+        assert_eq!(scores, vec![0.9, 0.0], "index-1 padded default score");
+
+        let versions = structured.versions.expect("versions present");
+        assert_eq!(
+            versions,
+            vec![VersionId::new(100).unwrap(), VersionId::new(0).unwrap()],
+            "index-1 padded default version"
+        );
+    }
+
+    #[test]
+    fn test_collect_structured_edges_negative_timestamp_clamped() {
+        // A negative wallclock is clamped to VersionId(0) (reachable via From<i64>).
+        let rows = vec![
+            QueryRow::from_entity(EntityResult::Edge(edge_with(10, 1, 2, "KNOWS", 1)))
+                .at_time((-5i64).into()),
+        ];
+        let results = QueryResults::new(Box::new(MockIterator::new(rows)));
+
+        let structured = results.collect_structured_edges().unwrap();
+        let versions = structured.versions.expect("versions present");
+        assert_eq!(versions[0], VersionId::new(0).unwrap());
+    }
+
+    #[test]
+    fn test_collect_structured_edges_large_timestamp_boundary() {
+        // Mirrors the node path's `test_collect_structured_with_invalid_timestamp`:
+        // i64::MAX - 1000 as u64 is still < MAX_VALID_ID, so the conversion succeeds.
+        // The `InvalidParameter` (MAX_VALID_ID) arm is therefore provably unreachable
+        // through the safe `Timestamp` type -- a corrupted/out-of-range wallclock is the
+        // only way to trip it -- consistent with the node path.
+        let rows = vec![
+            QueryRow::from_entity(EntityResult::Edge(edge_with(10, 1, 2, "KNOWS", 1)))
+                .at_time((i64::MAX - 1000).into()),
+        ];
+        let results = QueryResults::new(Box::new(MockIterator::new(rows)));
+
+        let result = results.collect_structured_edges();
+        assert!(result.is_ok());
+        let versions = result.unwrap().versions.expect("versions present");
+        assert_eq!(
+            versions[0],
+            VersionId::new((i64::MAX - 1000) as u64).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_collect_edges_empty_stream() {
+        let rows: Vec<QueryRow> = vec![];
+        let results = QueryResults::new(Box::new(MockIterator::new(rows)));
+
+        let edges = results.collect_edges().unwrap();
+        assert!(edges.is_empty());
+    }
+
+    #[test]
+    fn test_collect_edges_drops_bare_edge_ids() {
+        // `collect_edges` matches only `EntityResult::Edge` and silently drops bare
+        // `EdgeId` rows -- a real behavior contrast with `collect_structured_edges`, which
+        // keeps them (populating `edges`). Assert both halves of the contrast.
+        let make_rows = || {
+            vec![
+                QueryRow::from_entity(EntityResult::EdgeId(EdgeId::new(10).unwrap())),
+                QueryRow::from_entity(EntityResult::EdgeId(EdgeId::new(11).unwrap())),
+            ]
+        };
+
+        let dropped = QueryResults::new(Box::new(MockIterator::new(make_rows())))
+            .collect_edges()
+            .unwrap();
+        assert!(dropped.is_empty(), "collect_edges drops bare EdgeId rows");
+
+        let kept = QueryResults::new(Box::new(MockIterator::new(make_rows())))
+            .collect_structured_edges()
+            .unwrap();
+        assert_eq!(kept.len(), 2, "collect_structured_edges keeps EdgeId rows");
+    }
+
+    #[test]
+    fn test_edge_query_result_edges_with_scores() {
+        let rows = vec![
+            QueryRow::with_score(EntityResult::Edge(edge_with(10, 1, 2, "KNOWS", 1)), 0.9),
+            QueryRow::with_score(EntityResult::Edge(edge_with(11, 2, 3, "KNOWS", 2)), 0.8),
+        ];
+        let results = QueryResults::new(Box::new(MockIterator::new(rows)));
+
+        let structured = results.collect_structured_edges().unwrap();
+        let pairs = structured.edges_with_scores().expect("scores available");
+        assert_eq!(
+            pairs,
+            vec![
+                (EdgeId::new(10).unwrap(), 0.9),
+                (EdgeId::new(11).unwrap(), 0.8),
+            ]
+        );
+
+        // No scores -> None (mirrors nodes_with_scores).
+        let no_scores =
+            QueryResults::new(Box::new(MockIterator::new(vec![QueryRow::from_entity(
+                EntityResult::Edge(edge_with(10, 1, 2, "KNOWS", 1)),
+            )])))
+            .collect_structured_edges()
+            .unwrap();
+        assert!(no_scores.edges_with_scores().is_none());
+    }
+
+    #[test]
+    fn test_edge_query_result_edges_with_versions() {
+        let rows = vec![
+            QueryRow::from_entity(EntityResult::Edge(edge_with(10, 1, 2, "KNOWS", 1)))
+                .at_time(100.into()),
+            QueryRow::from_entity(EntityResult::Edge(edge_with(11, 2, 3, "KNOWS", 2)))
+                .at_time(200.into()),
+        ];
+        let results = QueryResults::new(Box::new(MockIterator::new(rows)));
+
+        let structured = results.collect_structured_edges().unwrap();
+        let pairs = structured
+            .edges_with_versions()
+            .expect("versions available");
+        assert_eq!(
+            pairs,
+            vec![
+                (EdgeId::new(10).unwrap(), VersionId::new(100).unwrap()),
+                (EdgeId::new(11).unwrap(), VersionId::new(200).unwrap()),
+            ]
+        );
+
+        // No timestamps -> None (mirrors nodes_with_versions).
+        let no_versions =
+            QueryResults::new(Box::new(MockIterator::new(vec![QueryRow::from_entity(
+                EntityResult::Edge(edge_with(10, 1, 2, "KNOWS", 1)),
+            )])))
+            .collect_structured_edges()
+            .unwrap();
+        assert!(no_versions.edges_with_versions().is_none());
+    }
+
+    #[test]
+    fn test_collect_structured_edges_node_score_does_not_flip_gate() {
+        // Honesty guard (finding 7): a node row carrying a score/timestamp in a mixed
+        // stream must NOT turn the edge result's `scores`/`versions` into all-default `Some`.
+        // Only edge/edge-id rows may flip the gate. (Unreachable in practice -- EdgeScan is
+        // homogeneous -- but proves the two-pass gate is edge-only.)
+        let rows = vec![
+            QueryRow::with_score(EntityResult::Node(test_node(1)), 0.7).at_time(999.into()),
+            QueryRow::from_entity(EntityResult::Edge(edge_with(10, 1, 2, "KNOWS", 1))),
+        ];
+        let results = QueryResults::new(Box::new(MockIterator::new(rows)));
+
+        let structured = results.collect_structured_edges().unwrap();
+        assert_eq!(structured.len(), 1, "only the edge row survives");
+        assert!(
+            structured.scores.is_none(),
+            "node-only score must not gate edge scores on"
+        );
+        assert!(
+            structured.versions.is_none(),
+            "node-only timestamp must not gate edge versions on"
+        );
     }
 
     #[test]

--- a/tests/sql_integration.rs
+++ b/tests/sql_integration.rs
@@ -16,9 +16,10 @@
 //!
 //! The query executor executes `Sort` (ORDER BY) and `EdgeScan` (`FROM edges`)
 //! physical operators end-to-end. `SELECT * FROM edges` yields edge rows
-//! consumed via `collect_all()` (the node-centric `collect_structured()` /
-//! `collect_nodes()` helpers remain node-only, see the v1 limitation note in
-//! the `select_edges` module); ORDER BY returns rows in sorted order.
+//! consumed via `collect_all()` or the edge-shaped structured projection
+//! `collect_structured_edges()` / `collect_edges()` (Issue #3626); the
+//! node-centric `collect_structured()` / `collect_nodes()` helpers remain
+//! node-only by design. ORDER BY returns rows in sorted order.
 
 #![cfg(feature = "sql")]
 
@@ -566,13 +567,12 @@ mod order_by {
 // ## v1 limitations
 //
 // `SELECT * FROM edges` yields `EntityResult::Edge` rows that are consumed via
-// `collect_all()` / `count_all()` / direct iteration (the paths these tests
-// use). The node-centric structured helpers `collect_structured()` /
+// `collect_all()` / `count_all()` / direct iteration, or via the edge-shaped
+// structured projection `collect_structured_edges()` / `collect_edges()`
+// (Issue #3626). The node-centric structured helpers `collect_structured()` /
 // `collect_nodes()` intentionally remain node-only (they populate a
-// `Vec<NodeId>`), so they silently drop edge rows -- a pre-existing shape that
-// this change deliberately does not widen (that would ripple into the
-// node-oriented structured-result consumers). Consume edge scans via
-// `collect_all()`.
+// `Vec<NodeId>`) and silently drop edge rows -- edges are surfaced structurally
+// by their own `collect_structured_edges()` counterpart instead.
 //
 // A `WHERE` predicate over *edge property* leaves cannot yet filter edge rows
 // (the FilterIterator's single-entity AQL edge pipeline passes non-provenance
@@ -780,8 +780,10 @@ mod select_edges {
     #[test]
     fn select_edges_collect_all_is_the_consumption_path() {
         // Explicitly assert the primary consumption path (collect_all) surfaces
-        // edge rows -- the node-centric collect_nodes()/collect_structured()
-        // helpers remain node-only by design (see the module v1-limitation note).
+        // edge rows. The node-centric collect_nodes()/collect_structured()
+        // helpers remain node-only by design; the edge-shaped structured path is
+        // collect_structured_edges()/collect_edges() (Issue #3626, exercised by
+        // select_edges_collect_structured_edges below).
         let db = setup_graph_db();
         let query = parse_sql("SELECT * FROM edges").expect("Failed to parse SQL");
         let rows = db
@@ -794,6 +796,89 @@ mod select_edges {
             "collect_all must surface every row as an Edge entity"
         );
         assert_eq!(rows.len(), 2);
+    }
+
+    #[test]
+    fn select_edges_collect_structured_edges() {
+        // Issue #3626: the edge-shaped structured projection. `SELECT * FROM edges`
+        // -> collect_structured_edges() yields parallel vectors of ids, endpoints,
+        // labels, and properties -- the edge counterpart to collect_structured().
+        let db = setup_graph_db();
+
+        // Resolve node ids by name so the endpoint assertion is order-independent.
+        let node_rows = db
+            .execute_query(parse_sql("SELECT * FROM nodes").expect("parse nodes"))
+            .expect("node scan should execute")
+            .collect_all()
+            .expect("collect node rows");
+        let id_of = |name: &str| {
+            node_rows
+                .iter()
+                .filter_map(|r| r.entity.as_node())
+                .find(|n| n.get_property("name") == Some(&PropertyValue::String(name.into())))
+                .map(|n| n.id)
+                .unwrap_or_else(|| panic!("node named {name} should exist"))
+        };
+        let (alice, bob, carol) = (id_of("Alice"), id_of("Bob"), id_of("Carol"));
+
+        let structured = db
+            .execute_query(parse_sql("SELECT * FROM edges").expect("parse edges"))
+            .expect("Edge scan should execute")
+            .collect_structured_edges()
+            .expect("collect_structured_edges should succeed");
+
+        assert_eq!(
+            structured.len(),
+            2,
+            "setup_graph_db has exactly 2 KNOWS edges"
+        );
+        assert!(!structured.is_empty());
+
+        // Endpoints are available (full edges) and match Alice->Bob, Bob->Carol.
+        let triples = structured
+            .edges_with_endpoints()
+            .expect("full edges expose endpoints");
+        let mut endpoints: Vec<(u64, u64)> = triples
+            .iter()
+            .map(|(_, s, t)| (s.as_u64(), t.as_u64()))
+            .collect();
+        endpoints.sort_unstable();
+        let mut expected = vec![
+            (alice.as_u64(), bob.as_u64()),
+            (bob.as_u64(), carol.as_u64()),
+        ];
+        expected.sort_unstable();
+        assert_eq!(endpoints, expected, "structured endpoints must round-trip");
+
+        // Labels resolve to KNOWS for both edges.
+        let labels = structured.labels.as_ref().expect("labels present");
+        assert!(
+            labels.iter().all(|l| l.to_string() == "KNOWS"),
+            "both edges are KNOWS"
+        );
+
+        // Properties vector is present and parallel to edges.
+        let props = structured.properties.as_ref().expect("properties present");
+        assert_eq!(props.len(), 2);
+
+        // No temporal / ranking context on a plain scan.
+        assert!(structured.scores.is_none());
+        assert!(structured.versions.is_none());
+    }
+
+    #[test]
+    fn select_edges_collect_structured_edges_empty_db() {
+        // A database with no edges yields an empty EdgeQueryResult (all Option fields
+        // None), not an error.
+        let db = setup_person_db();
+        let structured = db
+            .execute_query(parse_sql("SELECT * FROM edges").expect("parse edges"))
+            .expect("Edge scan should execute")
+            .collect_structured_edges()
+            .expect("collect_structured_edges should succeed on empty edge set");
+        assert!(structured.is_empty());
+        assert!(structured.sources.is_none());
+        assert!(structured.edges_with_endpoints().is_none());
     }
 }
 


### PR DESCRIPTION
Closes #3626 (wave-6 triage residue of #3607, origin #3607).

## Summary

`SELECT * FROM edges` (`EdgeScan`, #3607) yields `EntityResult::Edge` rows that were consumable only via `collect_all()` / `count_all()` / direct iteration. The structured helper `collect_structured()` → `QueryResult` is node-shaped (`nodes: Vec`) and hits the `_ =&gt; {}` arm on edge rows, silently dropping them. #3607 deliberately did **not** widen `QueryResult` (feared an MCP ripple). This PR adds the **edge-shaped** structured projection while leaving `collect_structured()` exactly node-only, as the issue requires.

## Before / After

**Before:** an edge scan had no structured-projection path — only raw row iteration. `collect_structured()` returned an all-empty node result for an edge stream.

**After:** `SELECT * FROM edges` → `collect_structured_edges()` returns an `EdgeQueryResult` with parallel vectors of edge ids, `(source, target)` endpoints, interned labels, properties, scores, and versions. `collect_structured()` / `collect_nodes()` are byte-for-byte unchanged and remain node-only.

## How

New API in `src/query/executor/results.rs`, mirroring the node-side `collect_structured` / `collect_nodes` pair (Approach 2 — additive sibling, chosen over widening the node-shaped `QueryResult` which the issue rules out and which risked confusing existing node consumers):

- **`EdgeQueryResult`** — edge-shaped counterpart to `QueryResult`. `edges: Vec` plus `sources`/`targets: Option&gt;`, `labels: Option&gt;`, `properties: Option&gt;`, `scores`/`versions`. Every `Option&gt;`, when `Some`, is parallel to `edges`. Endpoint/label/property vectors are `Some` iff at least one full `Edge` was collected. Helpers: `new`/`Default`/`len`/`is_empty`/`edges_with_endpoints()`/`edges_with_scores()`/`edges_with_versions()`.
- **`QueryResults::collect_structured_edges()`** — two-pass edge collector mirroring `collect_structured`: reuses the identical timestamp→`VersionId` conversion + `MAX_VALID_ID` validation (structured `InvalidParameter`, never `{e:?}`); drops node/null rows (edge-only, symmetric to the node helper&#39;s edge drop) without advancing any parallel vector, so alignment to `edges` is preserved; a bare `EntityResult::EdgeId` row (never produced by any operator today — only defined/unit-tested) pads endpoints (`NodeId(0)`), label (`InternedString(0)`), empty properties, exactly mirroring how the node path pads a bare `NodeId`&#39;s properties.
- **`QueryResults::collect_edges()`** — edge counterpart to `collect_nodes()`, returns `Vec`.

**Scope / safety:** no `src/mcp/**` change — MCP does not consume `QueryResult`/`collect_structured` (verified). No shared `FilterIterator`/`SortIterator` change, so AQL/Cypher edge semantics are untouched. Collection is pure over an already-materialized row stream — no storage guard is held across iteration. Stale &#34;dropped by structured helpers by design&#34; doc notes in `src/query/executor/mod.rs` and `tests/sql_integration.rs` now point at the new edge path.

## Review fixes

Addressing a 3-angle code review (code found correct — no logic blockers/majors; gaps were test coverage + minor parity). Commit `889479d`:

- **Tests for the parallel-vector pad/alignment arms** (the highest-value gap): a bare-`EdgeId` row pads scores/versions parallel to `edges` (`[0.9, 0.0]` / `[V(100), V(0)]`); partial score/timestamp in a full-edge stream pads the absent index; negative wallclock clamps to `VersionId(0)`; large-timestamp boundary (`i64::MAX-1000`) succeeds and documents the `MAX_VALID_ID` arm as unreachable through the safe `Timestamp` type (consistent with the node path); `collect_edges` empty-stream + a bare-`EdgeId` **drop** contrast (`collect_edges` drops them, `collect_structured_edges` keeps them).
- **API parity**: added `edges_with_scores()` / `edges_with_versions()` accessors on `EdgeQueryResult` mirroring the node struct&#39;s `nodes_with_scores()` / `nodes_with_versions()` (backing fields already existed), each with a test.
- **Honesty nit**: the two-pass gate now flips `has_any_scores` / `has_any_versions` only on edge/edge-id rows, so a node row carrying a score/timestamp in a hypothetical mixed stream can&#39;t turn an edge result&#39;s `scores`/`versions` into all-default-padded `Some` (unreachable in practice — `EdgeScan` is homogeneous — proven by a test).

Deferred (out of scope): a `Display`/comfy_table impl for `EdgeQueryResult`; the `src/db/rotation.rs` duplicate-import removal is Lane 4&#39;s trunk fix (see Incidental).

## v1 limitations

- Endpoint/label/property vectors require full `Edge` rows; a hypothetical stream of bare `EntityResult::EdgeId` rows populates only `edges` (no operator produces such a stream today).
- `versions` is derived from the row&#39;s temporal `timestamp` (consistent with the node path), not the edge&#39;s intrinsic `current_version`; a plain `SELECT * FROM edges` carries no timestamp, so `versions` is `None` there.
- Edge-property `WHERE` / `ORDER BY` remain rejected with the #3607 structured &#34;not yet supported&#34; error (unchanged; out of scope).

## Acceptance criteria → evidence

| # | AC (from #3626) | Evidence |
|---|---|---|
| 1 | Add structured projection for edge scans | `EdgeQueryResult` + `collect_structured_edges()` / `collect_edges()` in `src/query/executor/results.rs`; unit tests `test_collect_structured_edges_basic`, `_preserves_order`, `_with_scores`, `_with_timestamps`, `_edges_with_endpoints`, `test_collect_edges_returns_full_edges_and_drops_nodes` |
| 2 | End-to-end over real `SELECT * FROM edges` | `tests/sql_integration.rs::select_edges::select_edges_collect_structured_edges` (2 KNOWS edges, endpoints + labels + properties round-trip), `select_edges_collect_structured_edges_empty_db` |
| 3 | `collect_structured` stays node-only | node helpers untouched; `test_collect_structured_edges_drops_nodes` / `test_collect_edges_returns_full_edges_and_drops_nodes` prove the edge path drops node rows and vice-versa; all pre-existing `test_collect_structured_*` still pass |
| 4 | Edge cases (empty / id-only / mixed) don&#39;t OOM or misalign | `test_collect_structured_edges_empty`, `_id_only_stream`, `_mixed_full_and_id_pads`, `test_edge_query_result_default_is_empty` |

## Test evidence

`cargo test --features sql,cypher --lib` → **4722 passed; 0 failed; 3 ignored** (includes the edge tests: 11 original + 9 review-fix additions).

`cargo test --features sql --test sql_integration` → **65 passed; 0 failed** (was 63; +2 new edge structured tests).

`cargo fmt --all` applied. `cargo clippy --all-targets --all-features -- -D warnings` → clean (exit 0).

The two known uid-0 IO-injection integration failures (`test_flush_deadlock_on_io_error`, `test_metadata_corruption_on_error`) are pre-existing and unrelated.

## Incidental

Removes a duplicate `ENC_INDEX_KEY_VERSION_V1` import in `src/db/rotation.rs` (E0252 build break on current trunk from merge #3639). This is a trunk-fix duplicate that vanishes on the next trunk merge — not a separate change, and not opened as its own PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MM68sFWVTxKbBRnCq1VTrD)_