### PR TITLE
feat(encryption): WAL-DEK key rotation (#3617 PR2 of 3)

### DIFF
--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -534,6 +534,15 @@ impl AletheiaDB {
             // loading indexes, so the index directory is a single, uniform key
             // generation by the time it is read back (a crash mid-rotation left
             // a mix of old/new key files plus a `rotation.state` breadcrumb).
+            //
+            // Issue #3617 PR2 (resume-path double-crash data-loss fix): pass
+            // `wal_persist = None` — the startup path DEFERS retiring the
+            // old-generation WAL segments (indexes are not loaded yet, so a
+            // persist here would snapshot empty state). Retirement + ledger clear
+            // happen in `finalize_resumed_wal_rotation` below, AFTER the snapshot
+            // is loaded and the WAL is replayed into current state and captured by
+            // a synchronous `persist_indexes()`. This pass still installs both WAL
+            // generations so the replay read decrypts every segment.
             if let Some(ref manager) = persistence_manager
                 && config.encryption.enabled
             {
@@ -541,6 +550,7 @@ impl AletheiaDB {
                     manager,
                     &config.encryption,
                     Some(&db.wal),
+                    None,
                 )?;
             }
 
@@ -742,6 +752,33 @@ impl AletheiaDB {
                     db.edge_id_gen.ensure_at_least(max_eid + 1);
                 }
                 db.version_id_gen.ensure_at_least(next_version_id);
+            }
+
+            // Issue #3617 PR2 (resume-path double-crash data-loss fix): PHASE 2 of
+            // a startup-resumed WAL key rotation. `resume_pending_rotation` above
+            // installed both WAL generations but DEFERRED retiring the
+            // old-generation segments (indexes were not loaded yet, so a persist
+            // then would have snapshotted empty state). Now that the snapshot is
+            // loaded and the WAL has been replayed into current state, retire the
+            // old-generation segments — but only AFTER a SYNCHRONOUS
+            // `persist_indexes()` captures the replayed `[checkpoint, seal)` writes
+            // (run inside `finalize_resumed_wal_rotation`, after the seal and
+            // before the retire). So no old-generation WAL segment is deleted until
+            // its entries are durable in the index snapshot, closing the window
+            // where a second crash before the async checkpoint lost them. A no-op
+            // when no WAL rotation is pending. MUST run BEFORE the background
+            // persistence thread starts, so the synchronous persist is the one
+            // that closes the window (not a racy async checkpoint).
+            if let Some(ref manager) = persistence_manager
+                && config.encryption.enabled
+                && config.persistence.load_on_startup
+            {
+                crate::db::rotation::finalize_resumed_wal_rotation(
+                    manager,
+                    &config.encryption,
+                    &db.wal,
+                    || db.persist_indexes(),
+                )?;
             }
 
             // Start background persistence thread if enabled

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -522,7 +522,11 @@ impl AletheiaDB {
             if let Some(ref manager) = persistence_manager
                 && config.encryption.enabled
             {
-                crate::db::rotation::resume_pending_rotation(manager, &config.encryption)?;
+                crate::db::rotation::resume_pending_rotation(
+                    manager,
+                    &config.encryption,
+                    Some(&db.wal),
+                )?;
             }
 
             // Load indexes on startup if enabled

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -419,6 +419,21 @@ impl AletheiaDB {
             // used as a targeted fallback below only when a cipher is
             // configured, preserving the #3420/#3430 encrypted seed exactly.
             //
+            // Issue #3617 PR2 (crash-consistency): if a WAL rotation ledger is
+            // PENDING, install BOTH the old and new WAL key generations into the
+            // keyring BEFORE the replay read, so a half-rotated WAL (old-DEK +
+            // new-DEK segments both on disk) decrypts regardless of generation.
+            // Without this the read below fails on new-DEK frames before
+            // `resume_pending_rotation` (further down) can install the new
+            // generation. Additive: a no-op when no rotation is pending.
+            if config.encryption.enabled && config.persistence.enabled {
+                crate::db::rotation::install_pending_wal_generations(
+                    &wal,
+                    &config.encryption,
+                    &config.persistence.data_dir,
+                )?;
+            }
+
             // Held (as `mut`, consumed by whichever replay branch runs) across
             // index load so no later pass re-reads the segment directory.
             let mut startup_wal_entries = wal.read_from(crate::storage::wal::LSN::initial())?;

--- a/src/db/rotation.rs
+++ b/src/db/rotation.rs
@@ -703,7 +703,14 @@ impl AletheiaDB {
             .encryption_config
             .clone()
             .ok_or_else(|| rotation_err(RotationError::NotConfigured))?;
-        resume_pending_rotation(&manager, &enc_cfg, Some(&self.wal))
+        // Live-db resume: the index state is already loaded, so drive the WAL
+        // layer with a REAL persist-before-retire closure (mirrors the forward
+        // path). This keeps the resume lossless here too — the old no-op persist
+        // could strand un-checkpointed writes on this path as well (Issue #3617
+        // PR2). The startup path instead passes `None` and defers via
+        // `finalize_resumed_wal_rotation`.
+        let persist = || self.persist_indexes();
+        resume_pending_rotation(&manager, &enc_cfg, Some(&self.wal), Some(&persist))
     }
 
     fn run_rotation(
@@ -1317,6 +1324,7 @@ pub fn resume_pending_rotation(
     manager: &Arc<IndexPersistenceManager>,
     enc_cfg: &EncryptionConfig,
     wal: Option<&ConcurrentWalSystem>,
+    wal_persist: Option<&dyn Fn() -> Result<()>>,
 ) -> Result<Option<RotationReport>> {
     let Some(ledger) = read_rotation_state(manager)? else {
         return Ok(None);
@@ -1341,19 +1349,42 @@ pub fn resume_pending_rotation(
     // WAL layer (Issue #3617 PR2): when the ledger records the WAL as in flight
     // and a WAL system is available, add BOTH generations to its keyring — so a
     // half-rotated directory (old-DEK + new-DEK segments) replays correctly on
-    // this open — and drive the layer to completion idempotently. Resume does
-    // NOT re-checkpoint (indexes are not loaded yet at startup): the forward
-    // driver checkpointed BEFORE writing the ledger, so every old-DEK segment is
-    // already captured durably and can be retired unconditionally.
+    // this open — and drive the layer to completion idempotently.
+    //
+    // Retirement (physically deleting the old-generation segments) is only safe
+    // once every write those segments hold is durable in the index snapshot. The
+    // `wal_persist` argument selects HOW that guarantee is met:
+    //
+    // * `Some(persist)` — LIVE-db resume (`resume_pending_index_rotation`): the
+    //   index state is already loaded, so we persist-then-retire INLINE, exactly
+    //   like the forward `rotate_wal_layer` path (seal → persist → retire).
+    //
+    // * `None` — STARTUP resume (`db::config`): indexes are NOT loaded yet (index
+    //   load + WAL replay run AFTER this pass), so a persist here would snapshot
+    //   EMPTY state and retiring the old-generation segments would strand every
+    //   write in `[checkpoint, seal)` that lives only in the in-RAM replay buffer
+    //   until the async checkpoint — a second crash would lose it (DEFECT
+    //   #3617-PR2 resume-path double-crash window). We therefore DEFER the
+    //   roll+retire+ledger-clear to `finalize_resumed_wal_rotation`, run after
+    //   replay + a SYNCHRONOUS `persist_indexes()`. Both WAL generations are
+    //   already installed here (and by `install_pending_wal_generations` before
+    //   the replay read), so replay decrypts every segment regardless of
+    //   generation; the ledger stays PENDING for the finalize pass.
     let wal_pending = matches!(ledger.wal, LayerStatus::Pending);
     // DEFECT #3617-PR2: track whether the WAL layer actually finished retiring so
     // the final `clear_rotation_state` below is GATED on real completion (never
     // clears the ledger while an old-generation segment survives).
     let mut wal_incomplete = false;
+    // DEFECT #3617-PR2 (resume-path double-crash): set when the startup path
+    // defers WAL retirement to `finalize_resumed_wal_rotation`; the ledger MUST
+    // NOT be cleared here while an un-snapshotted old-generation segment survives.
+    let mut wal_finalize_deferred = false;
     if wal_pending
         && let Some(wal) = wal
         && let Some(wal_keyring) = wal.wal_keyring()
     {
+        // Always install BOTH generations so a half-rotated directory replays
+        // correctly regardless of which mode drives retirement.
         let new_wal_dek = derive_wal_dek(load_mek(&ledger.new_source).map_err(rotation_err)?)
             .map_err(rotation_err)?;
         let new_wal_cipher: Arc<dyn Cipher> =
@@ -1361,14 +1392,24 @@ pub fn resume_pending_rotation(
         // The startup keyring is `single(old_wal_dek)`; adding the new generation
         // makes both live (legacy/old-kv → old, new-kv → new).
         wal_keyring.add_generation(ledger.new_version, Arc::clone(&new_wal_cipher));
-        // Resume cannot re-checkpoint (indexes are not loaded yet at startup):
-        // the startup replay read has already captured every on-disk segment
-        // BEFORE this retire runs, so the no-op persist is safe here.
-        roll_and_retire_wal(wal, new_wal_cipher, ledger.new_version, || Ok(()))?;
-        if wal.all_segments_use_key_version(ledger.new_version) {
-            mark_wal_complete(manager)?;
-        } else {
-            wal_incomplete = true;
+        match wal_persist {
+            Some(persist) => {
+                // Live-db resume: persist-before-retire is lossless (mirrors the
+                // forward path — the seal runs first, then `persist` captures any
+                // post-checkpoint write now sealed into an old-gen segment, then
+                // the retire deletes segments whose data is already snapshotted).
+                roll_and_retire_wal(wal, new_wal_cipher, ledger.new_version, persist)?;
+                if wal.all_segments_use_key_version(ledger.new_version) {
+                    mark_wal_complete(manager)?;
+                } else {
+                    wal_incomplete = true;
+                }
+            }
+            None => {
+                // Startup resume: defer roll+retire+ledger-clear to
+                // `finalize_resumed_wal_rotation` (after replay + sync persist).
+                wal_finalize_deferred = true;
+            }
         }
     }
 
@@ -1413,11 +1454,21 @@ pub fn resume_pending_rotation(
                 }
                 .into());
             }
-            clear_rotation_state(manager);
-            logger.log(&AuditEvent::RotationCompleted {
-                new_version: ledger.new_version,
-                duration_ms: started.elapsed().as_millis() as u64,
-            });
+            // DEFECT #3617-PR2 (resume-path double-crash): when the startup path
+            // deferred WAL retirement, the ledger MUST stay PENDING until
+            // `finalize_resumed_wal_rotation` has synchronously snapshotted the
+            // replayed state and retired the old-generation segments. Clearing it
+            // here (before the deferred retire) would re-open the very data-loss
+            // window this fix closes. The index re-encrypt + `complete()` above
+            // are durable and idempotent, so leaving the ledger for the finalize
+            // pass is safe and re-entrant across another crash.
+            if !wal_finalize_deferred {
+                clear_rotation_state(manager);
+                logger.log(&AuditEvent::RotationCompleted {
+                    new_version: ledger.new_version,
+                    duration_ms: started.elapsed().as_millis() as u64,
+                });
+            }
             RotationReport {
                 old_version,
                 new_version: ledger.new_version,
@@ -1450,6 +1501,85 @@ pub fn resume_pending_rotation(
     };
 
     Ok(Some(report))
+}
+
+/// Phase 2 of a startup-resumed WAL key rotation (Issue #3617 PR2): retire the
+/// old-generation WAL segments and clear the ledger, AFTER the startup replay has
+/// been captured by a synchronous persist.
+///
+/// This closes the resume-path double-crash data-loss window. On the startup
+/// path [`resume_pending_rotation`] (called with `wal_persist = None`) installs
+/// both WAL generations but does NOT retire — because at that point the index
+/// state is not loaded, so a persist would snapshot empty state and retiring the
+/// old-generation segments would strand the `[checkpoint, seal)` writes that live
+/// only in the in-RAM replay buffer. Once `db::config` has loaded the snapshot
+/// and replayed the WAL into current state, it calls this function, which:
+///
+/// 1. re-installs the new WAL generation (idempotent),
+/// 2. force-rolls under the new DEK, runs `persist` (a SYNCHRONOUS
+///    `persist_indexes()` capturing the now-replayed state) AFTER the seal and
+///    BEFORE the retire — reusing the forward-path `roll_and_retire_wal`
+///    ordering verbatim — then retires the sealed old-generation segments, and
+/// 3. once no old-generation segment remains, marks the WAL layer complete and
+///    clears the ledger.
+///
+/// So no old-generation WAL segment is ever deleted until its entries are durable
+/// in the index snapshot — on BOTH the forward and resume paths.
+///
+/// A no-op (returns `Ok(())`) when no ledger is present, the WAL layer is not
+/// `Pending`, or the WAL is unencrypted — so `db::config` can call it
+/// unconditionally on the encrypted-persistent startup path. Completion-gated
+/// exactly like the forward path: if a stale old-generation segment cannot be
+/// retired, the ledger is left PENDING and an error is surfaced so a later resume
+/// finishes it (never reports success while a stranded old-DEK tail survives).
+///
+/// # Errors
+///
+/// Returns an error if the recorded new key source cannot be sourced, the persist
+/// fails, the roll/retire fails, or a stale old-generation segment survives
+/// retirement (ledger left pending).
+pub fn finalize_resumed_wal_rotation(
+    manager: &Arc<IndexPersistenceManager>,
+    enc_cfg: &EncryptionConfig,
+    wal: &ConcurrentWalSystem,
+    persist: impl FnOnce() -> Result<()>,
+) -> Result<()> {
+    let Some(ledger) = read_rotation_state(manager)? else {
+        return Ok(());
+    };
+    if !matches!(ledger.wal, LayerStatus::Pending) {
+        return Ok(());
+    }
+    let Some(wal_keyring) = wal.wal_keyring() else {
+        return Ok(());
+    };
+
+    // Re-derive + re-install the new WAL generation (idempotent: it was already
+    // installed by `resume_pending_rotation` / `install_pending_wal_generations`).
+    let new_wal_dek = derive_wal_dek(load_mek(&ledger.new_source).map_err(rotation_err)?)
+        .map_err(rotation_err)?;
+    let new_wal_cipher: Arc<dyn Cipher> = Arc::from(create_cipher(enc_cfg.algorithm, &new_wal_dek));
+    wal_keyring.add_generation(ledger.new_version, Arc::clone(&new_wal_cipher));
+
+    // Seal → persist (captures the replayed `[checkpoint, seal)` writes into the
+    // durable index snapshot) → retire. Identical ordering to the forward path.
+    roll_and_retire_wal(wal, new_wal_cipher, ledger.new_version, persist)?;
+
+    // Completion-gated: only mark complete + clear once every old-generation
+    // segment is gone; otherwise leave the ledger PENDING for a later resume.
+    if !wal.all_segments_use_key_version(ledger.new_version) {
+        return Err(StorageError::InconsistentState {
+            reason:
+                "WAL key rotation resume-finalize incomplete: old-generation segment(s) remain \
+                     after retirement. Ledger left pending for a later resume; do NOT drop the old \
+                     key until it completes."
+                    .to_string(),
+        }
+        .into());
+    }
+    mark_wal_complete(manager)?;
+    clear_rotation_state(manager);
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1846,7 +1976,7 @@ mod tests {
                     .index_cipher(),
             )),
         ));
-        let report = resume_pending_rotation(&resume_mgr, &enc_cfg, None)
+        let report = resume_pending_rotation(&resume_mgr, &enc_cfg, None, None)
             .unwrap()
             .expect("a pending rotation should resume");
         assert_eq!(report.new_version, 2);
@@ -2204,7 +2334,7 @@ mod tests {
                     .index_cipher(),
             )),
         ));
-        let err = resume_pending_rotation(&manager, &enc_cfg, None).unwrap_err();
+        let err = resume_pending_rotation(&manager, &enc_cfg, None, None).unwrap_err();
         assert!(
             err.to_string().contains("corrupt"),
             "corrupt breadcrumb must abort startup, got: {err}"
@@ -2212,7 +2342,7 @@ mod tests {
         // And an ABSENT breadcrumb is a clean no-op (distinguish absent vs corrupt).
         std::fs::remove_file(data_dir.join("rotation.state")).unwrap();
         assert!(
-            resume_pending_rotation(&manager, &enc_cfg, None)
+            resume_pending_rotation(&manager, &enc_cfg, None, None)
                 .unwrap()
                 .is_none()
         );
@@ -2292,7 +2422,7 @@ mod tests {
                     .index_cipher(),
             )),
         ));
-        let report = resume_pending_rotation(&resume_mgr, &enc_cfg, None)
+        let report = resume_pending_rotation(&resume_mgr, &enc_cfg, None, None)
             .unwrap()
             .expect("a pending cancel should resume");
         assert_eq!(report.new_version, 1, "cancel rolls back to the old key");
@@ -2767,7 +2897,7 @@ mod tests {
                     .index_cipher(),
             )),
         ));
-        let report = resume_pending_rotation(&resume_mgr, &enc_cfg, None)
+        let report = resume_pending_rotation(&resume_mgr, &enc_cfg, None, None)
             .unwrap()
             .expect("a pending rotation should resume from the v2 ledger");
         assert_eq!(report.new_version, 2);
@@ -2877,7 +3007,7 @@ mod tests {
                     .index_cipher(),
             )),
         ));
-        let report = resume_pending_rotation(&resume_mgr, &enc_cfg, None)
+        let report = resume_pending_rotation(&resume_mgr, &enc_cfg, None, None)
             .unwrap()
             .expect("a pending rotation should resume");
         assert_eq!(report.new_version, 2);
@@ -2968,7 +3098,7 @@ mod tests {
                     .index_cipher(),
             )),
         ));
-        let report = resume_pending_rotation(&resume_mgr, &enc_cfg, None)
+        let report = resume_pending_rotation(&resume_mgr, &enc_cfg, None, None)
             .unwrap()
             .expect("an index=Complete ledger should still resume to verify+clear");
         assert_eq!(report.new_version, 2);
@@ -3046,7 +3176,7 @@ mod tests {
                     .index_cipher(),
             )),
         ));
-        let err = resume_pending_rotation(&resume_mgr, &enc_cfg, None).expect_err(
+        let err = resume_pending_rotation(&resume_mgr, &enc_cfg, None, None).expect_err(
             "a ledger claiming index=Complete over unmigrated old-key files MUST fail closed",
         );
         // The verify_complete() fail-closed path (OldKeyFilesRemain /
@@ -3235,6 +3365,134 @@ mod tests {
              pre-roll WAL LSN {wal_lsn_before_roll}, else a retired segment holds \
              un-snapshotted acknowledged writes (crash-consistency data-loss window)"
         );
+    }
+
+    /// DEFECT #3617-PR2 (resume-path double-crash data-loss window): on the
+    /// forward path `rotate_wal_layer` persists the index snapshot AFTER the roll
+    /// and BEFORE retiring the old-generation segments, so a retired segment never
+    /// holds an un-snapshotted write. The RESUME (startup) path used to retire the
+    /// old-generation segments with a NO-OP persist while the durable index
+    /// manifest still sat at the pre-rotation checkpoint LSN — any write
+    /// acknowledged between that checkpoint and the seal then lived ONLY in the
+    /// in-RAM replay buffer (applied to current state) and in an on-disk segment
+    /// that resume immediately deleted. A SECOND crash before the async
+    /// background checkpoint therefore lost it: on the next open the snapshot is
+    /// still at the checkpoint LSN and the segment holding the write is gone.
+    ///
+    /// The fix defers the resume-path retire+ledger-clear until after the startup
+    /// replay has been captured by a SYNCHRONOUS `persist_indexes()`, so no
+    /// old-generation WAL segment is deleted until its entries are durable in the
+    /// index snapshot. This test builds the crash-A on-disk state (a
+    /// post-checkpoint write living only in an old-generation segment, PENDING
+    /// ledger), runs the resume/open path, and asserts BOTH the crux manifest-LSN
+    /// invariant (the durable manifest must cover the pre-retire write) AND that
+    /// the write survives a SECOND crash with no async checkpoint in between.
+    #[test]
+    fn resume_path_persists_before_retiring_survives_second_crash() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let old_key = root.join("old.key");
+        let new_key = root.join("new.key");
+        crate::encryption::FileKeyProvider::generate_key_file(&old_key).unwrap();
+        crate::encryption::FileKeyProvider::generate_key_file(&new_key).unwrap();
+
+        // ── Crash A: a forward WAL rotation crashed between the seal and the
+        // post-roll persist. On disk: the seeded graph is durable in the index
+        // snapshot at checkpoint LSN L_c; a post-checkpoint write ("Carol") lives
+        // ONLY in the (old-generation) active WAL segment at an LSN above L_c; the
+        // ledger is PENDING with the WAL in scope.
+        //
+        // The crash is simulated with `std::mem::forget` so the db's `Drop`
+        // (which signals the background persistence thread to run a FINAL
+        // shutdown persist_all_indexes) never runs — exactly like a `SIGKILL`.
+        // A clean drop here would durably snapshot Carol and mask the bug. ──
+        let carol_wal_lsn;
+        let checkpoint_lsn;
+        {
+            let db = build_db(root, &old_key);
+            seed(&db); // persists indexes — the PRE-rotation checkpoint at L_c
+            let manager = db.persistence_manager.clone().unwrap();
+            checkpoint_lsn = manager.load_manifest_and_strings().unwrap().lsn;
+
+            // Post-checkpoint write: acknowledged AFTER the checkpoint, so its LSN
+            // is above L_c and it lives only in the old-DEK active WAL segment (not
+            // in the durable snapshot). GroupCommit durability makes it durable in
+            // the WAL before `create_node` returns.
+            db.create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Carol").build(),
+            )
+            .unwrap();
+            carol_wal_lsn = db.wal.current_lsn().0;
+            assert!(
+                carol_wal_lsn > checkpoint_lsn,
+                "precondition: Carol's write (wal LSN {carol_wal_lsn}) is above the checkpoint \
+                 manifest LSN ({checkpoint_lsn})"
+            );
+
+            // Plant the PENDING ledger (WAL in scope): a rotation is in flight.
+            super::write_ledger(
+                &manager,
+                &super::RotationLedger::forward_scope(
+                    2,
+                    KeyProviderConfig::File {
+                        path: new_key.clone(),
+                    },
+                    true, // WAL in scope
+                ),
+            )
+            .unwrap();
+            assert!(root.join("data").join("rotation.state").exists());
+            // On-disk index snapshot is still at the pre-rotation checkpoint.
+            assert_eq!(
+                manager.load_manifest_and_strings().unwrap().lsn,
+                checkpoint_lsn,
+                "precondition: Carol is NOT yet in the durable index snapshot"
+            );
+            std::mem::forget(db); // crash A — skip the clean-shutdown final persist
+        }
+
+        // ── Reopen 1 (crash-A recovery): the startup resume path runs. Read the
+        // durable manifest IMMEDIATELY, then crash again (`mem::forget`) so no
+        // async/shutdown checkpoint captures Carol after resume. The crux
+        // invariant: by the time resume has retired any old-generation segment,
+        // the durable manifest LSN must already cover Carol. The old
+        // no-op-persist resume left the manifest stuck at L_c, so a second crash
+        // here lost Carol. ──
+        let manifest_lsn_after_resume;
+        {
+            let db = build_db(root, &old_key);
+            let manager = db.persistence_manager.clone().unwrap();
+            manifest_lsn_after_resume = manager.load_manifest_and_strings().unwrap().lsn;
+            assert_eq!(
+                db.node_count(),
+                3,
+                "Alice, Bob, Carol all present in RAM after resume+replay"
+            );
+            assert!(
+                manifest_lsn_after_resume >= carol_wal_lsn,
+                "resume must snapshot every pre-retire write into the durable manifest BEFORE \
+                 retiring its old-generation segment: manifest LSN {manifest_lsn_after_resume} \
+                 must cover Carol's WAL LSN {carol_wal_lsn} (checkpoint was {checkpoint_lsn}), \
+                 else a retired segment held un-snapshotted acknowledged writes and a second \
+                 crash before the async checkpoint loses them (resume-path data-loss window)"
+            );
+            std::mem::forget(db); // crash B — no async/shutdown checkpoint runs
+        }
+
+        // ── Reopen 2 (crash-B recovery, now under the NEW key — the rotation
+        // completed during reopen 1): with no async/shutdown checkpoint between
+        // reopen 1 and here, Carol survives ONLY if reopen 1 durably snapshotted
+        // her before retiring her old-generation segment. ──
+        {
+            let db = build_db(root, &new_key);
+            assert_eq!(
+                db.node_count(),
+                3,
+                "Carol survives the second crash — reopen 1 durably snapshotted her before \
+                 retiring her old-generation WAL segment"
+            );
+        }
     }
 
     /// DEFECT #3617-PR2 (dual-generation startup install): a half-rotated WAL —

--- a/src/db/rotation.rs
+++ b/src/db/rotation.rs
@@ -179,16 +179,32 @@ fn derive_wal_dek(
 ///
 /// Installs `new_wal_cipher` as key generation `new_key_version` on the WAL
 /// keyring (so subsequent appends use the new DEK) via an atomic force-roll,
-/// then deletes every sealed old-DEK segment (identified by header — legacy or
-/// a different `key_version`). The caller MUST have already captured all
-/// committed data in a durable index snapshot whose manifest was persisted
-/// BEFORE the rotation ledger was written, so retiring old-DEK segments loses
-/// nothing. Idempotent: a re-run seals another fresh (already-new-generation)
-/// segment and re-retires (a no-op once the old tail is gone).
+/// runs `persist_after_roll`, then deletes every sealed old-DEK segment
+/// (identified by header — legacy or a different `key_version`). Idempotent: a
+/// re-run seals another fresh (already-new-generation) segment and re-retires (a
+/// no-op once the old tail is gone).
+///
+/// # Ordering (DEFECT #3617-PR2 data-loss fix)
+///
+/// The old sequence checkpointed only ONCE, BEFORE the ledger, then rolled and
+/// retired. Any write acknowledged between that pre-ledger checkpoint and the
+/// seal landed in the old active segment, was NOT in the pre-ledger snapshot,
+/// and was then physically deleted by the retire — surviving only in RAM, so a
+/// crash before the next periodic checkpoint lost an acknowledged write.
+///
+/// The fix reorders to **seal → persist_after_roll → retire**: after the seal,
+/// every old-generation segment is sealed and no new old-gen data can appear
+/// (fresh appends go to the new-gen active segment), so a persist here durably
+/// captures ALL old-gen data into the index manifest, and the subsequent
+/// header-based retire is then provably lossless. The forward driver supplies a
+/// real `persist_indexes()` closure; the startup-resume path supplies a no-op
+/// (indexes are not loaded yet at resume time — its safety rests on the startup
+/// replay read having already captured every segment before retire runs).
 fn roll_and_retire_wal(
     wal: &ConcurrentWalSystem,
     new_wal_cipher: Arc<dyn Cipher>,
     new_key_version: u32,
+    persist_after_roll: impl FnOnce() -> Result<()>,
 ) -> Result<()> {
     if wal.wal_keyring().is_none() {
         return Ok(());
@@ -201,6 +217,10 @@ fn roll_and_retire_wal(
     wal.seal_active_segment_for_rotation(move || {
         ring.add_generation(new_key_version, cipher);
     })?;
+    // Capture every post-checkpoint write (now sealed into an old-generation
+    // segment) into the durable index snapshot BEFORE retiring old-gen segments,
+    // so a retired segment never holds an un-snapshotted acknowledged write.
+    persist_after_roll()?;
     wal.retire_old_generation_segments(new_key_version)?;
     Ok(())
 }
@@ -803,12 +823,20 @@ impl AletheiaDB {
     /// 2. **Force-roll** — atomically seal the active (old-DEK) segment, advance
     ///    the WAL keyring to the new generation, and open a fresh segment written
     ///    under the new DEK.
-    /// 3. **Truncate** — drop every sealed old-DEK segment below the manifest
-    ///    LSN, so no old-DEK ciphertext remains and the old WAL DEK can be
-    ///    dropped after a provider switch.
-    /// 4. **Complete** — flip `layer.wal=complete` in the durable ledger, but
+    /// 3. **Re-checkpoint** — persist the index snapshot AGAIN, now that every
+    ///    old-generation segment is sealed and no new old-gen data can appear, so
+    ///    any write acknowledged between the pre-ledger checkpoint and the seal is
+    ///    captured durably BEFORE its segment is retired (DEFECT #3617-PR2
+    ///    data-loss fix — the old order retired it first, losing the write on a
+    ///    crash before the next periodic checkpoint).
+    /// 4. **Retire** — delete every sealed old-DEK segment (by header), now safe
+    ///    because step 3 durably captured all their data; no old-DEK ciphertext
+    ///    remains, so the old WAL DEK can be dropped after a provider switch.
+    /// 5. **Complete** — flip `layer.wal=complete` in the durable ledger, but
     ///    only once no old-generation segment remains on disk (fail-safe: if a
-    ///    tail could not be truncated, leave it `pending` for a later pass).
+    ///    tail could not be retired, return an error and leave it `pending` for a
+    ///    later pass — never report success while a stranded old-DEK tail
+    ///    survives).
     ///
     /// Assumes heavy writes are quiesced for its duration (the same contract as
     /// index rotation); an append racing the roll still recovers (durability),
@@ -822,19 +850,31 @@ impl AletheiaDB {
         if !self.wal.is_encrypted() {
             return Ok(());
         }
-        // The checkpoint (persist_indexes) already ran in `run_rotation` BEFORE
-        // the ledger was written, so the manifest already captures every
-        // committed entry — retiring the old-DEK segments here loses nothing.
-        //
-        // Force-roll under the new DEK, then retire the old-DEK segments.
-        roll_and_retire_wal(&self.wal, new_wal_cipher, new_key_version)?;
+        // Force-roll under the new DEK; the persist closure runs AFTER the seal
+        // (capturing any post-checkpoint write now sealed into an old-gen
+        // segment) and BEFORE the retire (DEFECT #3617-PR2 data-loss fix), so no
+        // retired segment holds an un-snapshotted acknowledged write.
+        roll_and_retire_wal(&self.wal, new_wal_cipher, new_key_version, || {
+            self.persist_indexes()
+        })?;
 
-        // Mark the WAL layer complete only once every old-generation segment is
-        // gone (so a completed rotation never leaves an unreadable tail after the
-        // old DEK is dropped).
-        if self.wal.all_segments_use_key_version(new_key_version) {
-            mark_wal_complete(manager)?;
+        // DEFECT #3617-PR2: gate completion/success on ACTUAL retirement. Mark
+        // the WAL layer complete only once every old-generation segment is gone.
+        // If a tail could not be retired (retire errored, or a stale old-gen
+        // segment remains), the rotation did NOT complete: surface an error so
+        // `run_rotation` leaves the ledger PENDING (never clears it) and never
+        // reports success — the operator must NOT drop the old key; a later
+        // resume finishes the retirement.
+        if !self.wal.all_segments_use_key_version(new_key_version) {
+            return Err(StorageError::InconsistentState {
+                reason: "WAL key rotation incomplete: old-generation segment(s) remain after \
+                         retirement. Rotation left pending for a later resume; do NOT drop the \
+                         old key until it completes."
+                    .to_string(),
+            }
+            .into());
         }
+        mark_wal_complete(manager)?;
         Ok(())
     }
 }
@@ -1089,8 +1129,16 @@ fn clear_rotation_state(manager: &IndexPersistenceManager) {
 /// (`missing version`) rather than being silently assumed to be any format.
 /// This is what lets the version dispatch below trust the number it reads.
 fn read_rotation_state(manager: &IndexPersistenceManager) -> Result<Option<RotationLedger>> {
-    let path = rotation_state_path(manager);
-    let body = match std::fs::read_to_string(&path) {
+    read_rotation_state_at(&rotation_state_path(manager))
+}
+
+/// Path-based core of [`read_rotation_state`] (Issue #3617 PR2): read + parse the
+/// ledger directly from `path`, so startup wiring that does not yet hold an
+/// [`IndexPersistenceManager`] (the pre-replay dual-generation WAL install) can
+/// consult the ledger from the persistence `data_dir` alone. Same fail-closed
+/// semantics: absent → `Ok(None)`, present-but-corrupt → `Err`.
+fn read_rotation_state_at(path: &std::path::Path) -> Result<Option<RotationLedger>> {
+    let body = match std::fs::read_to_string(path) {
         Ok(b) => b,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(e) => {
@@ -1196,6 +1244,55 @@ fn read_rotation_state(manager: &IndexPersistenceManager) -> Result<Option<Rotat
     }))
 }
 
+/// Install BOTH WAL key generations into the live WAL keyring when a rotation
+/// ledger is PENDING at startup — BEFORE the startup replay read (Issue #3617
+/// PR2 crash-consistency).
+///
+/// # Why (DEFECT: half-rotated WAL undecryptable at startup)
+///
+/// A mid-rotation crash leaves the WAL directory holding BOTH generations:
+/// old-DEK segments (not yet retired) and new-DEK segments (fresh appends after
+/// the roll). Startup's `wal.read_from` runs BEFORE [`resume_pending_rotation`]
+/// installs the new generation, so with only the single (old) keyring it cannot
+/// decrypt the new-DEK frames and the replay read fails before resume can help.
+///
+/// This installs the recorded new generation (derived from the ledger's
+/// `new_source`) alongside the old one FIRST, so the replay read decrypts each
+/// segment under its own generation. Additive and fail-closed: a no-op when no
+/// ledger is present, the WAL layer is not `Pending`, or the WAL is unencrypted.
+/// Never logs or returns key material.
+pub fn install_pending_wal_generations(
+    wal: &ConcurrentWalSystem,
+    enc_cfg: &EncryptionConfig,
+    data_dir: &std::path::Path,
+) -> Result<()> {
+    let ledger_path = data_dir.join("rotation.state");
+    let Some(ledger) = read_rotation_state_at(&ledger_path)? else {
+        return Ok(());
+    };
+    if !matches!(ledger.wal, LayerStatus::Pending) {
+        return Ok(());
+    }
+    let Some(wal_keyring) = wal.wal_keyring() else {
+        return Ok(());
+    };
+    // The old generation is already the single cipher in the startup keyring;
+    // re-derive the NEW WAL DEK from the ledger's recorded source. Both live only
+    // in `Zeroizing` and never leave it.
+    let Some((old_cipher, old_version)) = wal_keyring.current() else {
+        return Ok(());
+    };
+    let new_wal_dek = derive_wal_dek(load_mek(&ledger.new_source).map_err(rotation_err)?)
+        .map_err(rotation_err)?;
+    let new_wal_cipher: Arc<dyn Cipher> = Arc::from(create_cipher(enc_cfg.algorithm, &new_wal_dek));
+    // Re-assert the old generation (flips the keyring to strict per-version
+    // dispatch) then add the new one, so legacy/old-kv segments resolve to the
+    // old DEK and new-kv segments to the new DEK.
+    wal_keyring.add_generation(old_version, Arc::clone(&old_cipher));
+    wal_keyring.add_generation(ledger.new_version, new_wal_cipher);
+    Ok(())
+}
+
 /// Resume an interrupted index key rotation on startup (Issue #488).
 ///
 /// If a `rotation.state` breadcrumb is present, reconstruct the new generation
@@ -1249,6 +1346,10 @@ pub fn resume_pending_rotation(
     // driver checkpointed BEFORE writing the ledger, so every old-DEK segment is
     // already captured durably and can be retired unconditionally.
     let wal_pending = matches!(ledger.wal, LayerStatus::Pending);
+    // DEFECT #3617-PR2: track whether the WAL layer actually finished retiring so
+    // the final `clear_rotation_state` below is GATED on real completion (never
+    // clears the ledger while an old-generation segment survives).
+    let mut wal_incomplete = false;
     if wal_pending
         && let Some(wal) = wal
         && let Some(wal_keyring) = wal.wal_keyring()
@@ -1260,9 +1361,14 @@ pub fn resume_pending_rotation(
         // The startup keyring is `single(old_wal_dek)`; adding the new generation
         // makes both live (legacy/old-kv → old, new-kv → new).
         wal_keyring.add_generation(ledger.new_version, Arc::clone(&new_wal_cipher));
-        roll_and_retire_wal(wal, new_wal_cipher, ledger.new_version)?;
+        // Resume cannot re-checkpoint (indexes are not loaded yet at startup):
+        // the startup replay read has already captured every on-disk segment
+        // BEFORE this retire runs, so the no-op persist is safe here.
+        roll_and_retire_wal(wal, new_wal_cipher, ledger.new_version, || Ok(()))?;
         if wal.all_segments_use_key_version(ledger.new_version) {
             mark_wal_complete(manager)?;
+        } else {
+            wal_incomplete = true;
         }
     }
 
@@ -1292,6 +1398,21 @@ pub fn resume_pending_rotation(
                 RotationProgress::default()
             };
             engine.complete().map_err(rotation_err)?;
+            // DEFECT #3617-PR2: only clear the ledger when the WAL layer actually
+            // finished retiring its old generation. If an old-gen segment still
+            // survives, leave the ledger PENDING and surface an error so a later
+            // resume completes it — never report a completed resume while a
+            // stranded old-DEK tail remains (which would let the operator drop the
+            // old key and wedge startup).
+            if wal_incomplete {
+                return Err(StorageError::InconsistentState {
+                    reason: "WAL key rotation resume incomplete: old-generation segment(s) remain \
+                             after retirement. Ledger left pending for a later resume; do NOT drop \
+                             the old key until it completes."
+                        .to_string(),
+                }
+                .into());
+            }
             clear_rotation_state(manager);
             logger.log(&AuditEvent::RotationCompleted {
                 new_version: ledger.new_version,
@@ -2974,6 +3095,251 @@ mod tests {
         assert!(
             msg.contains("unsupported ledger version") || msg.contains("corrupt"),
             "expected an unsupported-version corruption error, got: {msg}"
+        );
+    }
+
+    /// DEFECT #3617-PR2 (completion-gating): if WAL retirement cannot remove
+    /// every old-generation segment, `rotate_index_keys` must NOT report success
+    /// and must NOT clear the ledger (else the operator drops the old MEK and a
+    /// stranded old-DEK segment wedges startup). A later resume, once the blocker
+    /// clears, finishes the rotation and ONLY THEN clears the ledger. Also pins
+    /// that `all_segments_use_key_version(new)` gates the clear.
+    #[test]
+    fn incomplete_wal_retirement_leaves_ledger_pending_and_no_success() {
+        use crate::storage::wal::segment_reader::{WAL_MAGIC, WAL_VERSION_ENCRYPTED_STRING_LABELS};
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let old_key = root.join("old.key");
+        let new_key = root.join("new.key");
+        crate::encryption::FileKeyProvider::generate_key_file(&old_key).unwrap();
+        crate::encryption::FileKeyProvider::generate_key_file(&new_key).unwrap();
+
+        let db = build_db(root, &old_key);
+        seed(&db);
+        let ledger_path = root.join("data").join("rotation.state");
+
+        // Plant a stale old-generation WAL segment retirement cannot remove: its
+        // id sits far above the active segment, so retire skips it as "active"
+        // and it survives — tripping `all_segments_use_key_version(new)` = false.
+        let stale = root.join("wal").join("999999.log");
+        let mut hdr = Vec::new();
+        hdr.extend_from_slice(&WAL_MAGIC);
+        hdr.push(WAL_VERSION_ENCRYPTED_STRING_LABELS); // legacy (old-generation) header
+        std::fs::write(&stale, &hdr).unwrap();
+
+        // (b) Rotation must FAIL (incomplete) — no success report.
+        let result = db.rotate_index_keys(KeyProviderConfig::File {
+            path: new_key.clone(),
+        });
+        assert!(
+            result.is_err(),
+            "incomplete WAL retirement must NOT report a success RotationReport"
+        );
+        assert!(
+            !db.wal.all_segments_use_key_version(2),
+            "precondition: a stale old-generation segment remains on disk"
+        );
+        // (a) Ledger must remain PENDING (not cleared).
+        assert!(
+            ledger_path.exists(),
+            "the ledger must remain pending when retirement is incomplete (never cleared)"
+        );
+
+        // (c) Clear the blocker; resume now completes and ONLY THEN clears.
+        std::fs::remove_file(&stale).unwrap();
+        let resumed = db
+            .resume_pending_index_rotation()
+            .expect("resume must not error once the blocker is cleared");
+        assert!(
+            resumed.is_some(),
+            "resume must complete the pending rotation"
+        );
+        assert!(
+            !ledger_path.exists(),
+            "resume clears the ledger only after full old-generation retirement"
+        );
+        assert!(
+            db.wal.all_segments_use_key_version(2),
+            "all remaining WAL segments now carry the new key_version"
+        );
+        assert_eq!(db.node_count(), 2, "data intact throughout");
+        assert_eq!(db.edge_count(), 1);
+    }
+
+    /// DEFECT #3617-PR2 (data-loss window): the OLD order retired (physically
+    /// deleted) the sealed old-generation WAL segments while the durable index
+    /// manifest still sat at the PRE-rotation checkpoint LSN. Any write
+    /// acknowledged between that checkpoint and the roll therefore lived only in a
+    /// segment that was then deleted, at an LSN ABOVE the manifest — so a crash
+    /// before the next periodic checkpoint would lose it (node/edge state is
+    /// recovered from the manifest snapshot + WAL replay, and the WAL no longer
+    /// held it). The fix persists AGAIN after the roll and before the retire.
+    ///
+    /// Observable invariant asserted here (independent of the index backstop):
+    /// after rotation, the persisted manifest LSN must be >= the WAL LSN of every
+    /// retired (pre-roll) write — i.e. no retired segment holds un-snapshotted
+    /// acknowledged entries.
+    #[test]
+    fn post_checkpoint_write_snapshotted_before_wal_retirement() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let old_key = root.join("old.key");
+        let new_key = root.join("new.key");
+        crate::encryption::FileKeyProvider::generate_key_file(&old_key).unwrap();
+        crate::encryption::FileKeyProvider::generate_key_file(&new_key).unwrap();
+
+        let db = build_db(root, &old_key);
+        seed(&db); // persists indexes — the PRE-rotation checkpoint
+        let manager = db.persistence_manager.clone().unwrap();
+
+        // Post-checkpoint write: acknowledged AFTER the checkpoint, so its LSN is
+        // above the checkpoint's manifest LSN and it lives in the old active WAL
+        // segment (not yet in the durable snapshot).
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Carol").build(),
+        )
+        .unwrap();
+
+        let manifest_lsn_checkpoint = manager.load_manifest_and_strings().unwrap().lsn;
+        let wal_lsn_before_roll = db.wal.current_lsn().0;
+        assert!(
+            wal_lsn_before_roll > manifest_lsn_checkpoint,
+            "precondition: the post-checkpoint write (wal LSN {wal_lsn_before_roll}) is above the \
+             checkpoint manifest LSN ({manifest_lsn_checkpoint})"
+        );
+
+        // Drive the WAL-layer rotation (roll -> [fix: persist] -> retire). The
+        // retire deletes the sealed old-generation segments holding the pre-roll
+        // writes.
+        let algorithm = db.encryption_config.as_ref().unwrap().algorithm;
+        let new_wal_dek = super::derive_wal_dek(
+            super::load_mek(&KeyProviderConfig::File {
+                path: new_key.clone(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        let new_wal_cipher: Arc<dyn Cipher> = Arc::from(create_cipher(algorithm, &new_wal_dek));
+        db.rotate_wal_layer(&manager, new_wal_cipher, 2)
+            .expect("WAL layer rotation must succeed");
+
+        // For the header-based retire to be lossless, the persisted manifest LSN
+        // must now cover every retired write. Without persist-after-roll it is
+        // still stuck at the pre-rotation checkpoint LSN — the data-loss window.
+        let manifest_lsn_after = manager.load_manifest_and_strings().unwrap().lsn;
+        assert!(
+            manifest_lsn_after >= wal_lsn_before_roll,
+            "persist-after-roll must snapshot all pre-roll writes into the durable manifest \
+             BEFORE retiring their segments: manifest LSN {manifest_lsn_after} must cover the \
+             pre-roll WAL LSN {wal_lsn_before_roll}, else a retired segment holds \
+             un-snapshotted acknowledged writes (crash-consistency data-loss window)"
+        );
+    }
+
+    /// DEFECT #3617-PR2 (dual-generation startup install): a half-rotated WAL —
+    /// old-DEK + new-DEK segments both on disk with a PENDING ledger — must have
+    /// BOTH WAL key generations installed BEFORE the startup replay read. A fresh
+    /// single(old) keyring (the startup state before resume runs) cannot decrypt
+    /// the new-DEK frames — they are dropped as an undecodable tail — silently
+    /// losing any write whose only durable copy is a new-DEK segment.
+    /// `install_pending_wal_generations`, called before the replay read, recovers
+    /// both generations. Asserted at the WAL-replay level so no index backstop
+    /// masks the loss.
+    #[test]
+    fn half_rotated_wal_needs_both_generations_installed_before_replay() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let wal_dir = root.join("wal");
+        let data_dir = root.join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        let old_key = root.join("old.key");
+        let new_key = root.join("new.key");
+        crate::encryption::FileKeyProvider::generate_key_file(&old_key).unwrap();
+        crate::encryption::FileKeyProvider::generate_key_file(&new_key).unwrap();
+
+        let enc_cfg = EncryptionConfig::file_based(&old_key);
+        let algorithm = enc_cfg.algorithm;
+        let old_wal_cipher: Arc<dyn Cipher> = Arc::from(create_cipher(
+            algorithm,
+            &super::derive_wal_dek(super::load_mek(&enc_cfg.key_provider).unwrap()).unwrap(),
+        ));
+        let new_wal_cipher: Arc<dyn Cipher> = Arc::from(create_cipher(
+            algorithm,
+            &super::derive_wal_dek(
+                super::load_mek(&KeyProviderConfig::File {
+                    path: new_key.clone(),
+                })
+                .unwrap(),
+            )
+            .unwrap(),
+        ));
+
+        // Lay down a half-rotated WAL with a real DB: Alice under the old DEK
+        // (kv=1), then roll to gen 2 and write Bob under the new DEK (kv=2), and
+        // record a PENDING ledger. No persist — the entries live ONLY in the WAL.
+        {
+            let db = build_db(root, &old_key);
+            db.create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Alice").build(),
+            )
+            .unwrap();
+            let ring = db.wal.wal_keyring().expect("encrypted WAL").clone();
+            let cipher = Arc::clone(&new_wal_cipher);
+            db.wal
+                .seal_active_segment_for_rotation(move || ring.add_generation(2, cipher))
+                .unwrap();
+            db.create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Bob").build(),
+            )
+            .unwrap();
+            let manager = db.persistence_manager.clone().unwrap();
+            super::write_ledger(
+                &manager,
+                &super::RotationLedger::forward_scope(
+                    2,
+                    KeyProviderConfig::File {
+                        path: new_key.clone(),
+                    },
+                    true,
+                ),
+            )
+            .unwrap();
+            // Drop (crash) with the rotation still pending.
+        }
+
+        let fresh_wal = || {
+            let mut cfg = ConcurrentWalSystemConfig::new(wal_dir.clone());
+            cfg.wal_cipher = Some(Arc::clone(&old_wal_cipher));
+            cfg.tolerate_torn_tail = true;
+            ConcurrentWalSystem::new(cfg).unwrap()
+        };
+        let lsn0 = crate::storage::wal::LSN::initial();
+
+        // A fresh single(old) keyring — the startup state BEFORE the install —
+        // cannot decrypt Bob's new-DEK (kv=2) frames: they are dropped, so only
+        // Alice's old-DEK (kv=1) entries come back. (A node create emits several
+        // framed WAL entries, so we compare counts rather than assume one each.)
+        let n_single = fresh_wal().read_from(lsn0).map(|v| v.len()).unwrap_or(0);
+
+        // Installing BOTH generations before the replay read makes Bob's new-DEK
+        // frames replayable too, so strictly MORE entries are recovered.
+        let wal = fresh_wal();
+        super::install_pending_wal_generations(&wal, &enc_cfg, &data_dir).unwrap();
+        let n_both = wal.read_from(lsn0).unwrap().len();
+        assert!(
+            n_single > 0,
+            "sanity: the old-DEK (Alice) entries must be recoverable ({n_single})"
+        );
+        assert!(
+            n_both > n_single,
+            "installing BOTH WAL generations must recover strictly more entries than a fresh \
+             single(old) keyring: the new-DEK (Bob) frames the old keyring silently drops \
+             become replayable (single={n_single}, both={n_both}). Without the pre-replay \
+             install, a half-rotated WAL loses every write whose only durable copy is a \
+             new-DEK segment."
         );
     }
 }

--- a/src/db/rotation.rs
+++ b/src/db/rotation.rs
@@ -64,11 +64,11 @@ use crate::encryption::factory::Algorithm;
 use crate::encryption::factory::create_cipher;
 use crate::encryption::key_derivation::KeyDerivation;
 use crate::storage::index_persistence::common::{ENC_INDEX_KEY_VERSION_V1, IndexKeyring};
-use crate::storage::index_persistence::common::ENC_INDEX_KEY_VERSION_V1;
 use crate::storage::index_persistence::reencrypt::DecryptProbeReport;
 use crate::storage::index_persistence::{
     IndexKeyRotation, IndexPersistenceManager, RotationError, RotationProgress, RotationStatus,
 };
+use crate::storage::wal::concurrent_system::ConcurrentWalSystem;
 
 /// Summary of a completed index key rotation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -163,6 +163,60 @@ fn derive_index_dek(
     KeyDerivation::new(mek)
         .derive_index_dek()
         .map_err(|e| RotationError::KeyProvider(e.to_string()))
+}
+
+/// Derive the WAL DEK for a MEK using the shared HKDF context (Issue #3617).
+fn derive_wal_dek(
+    mek: Zeroizing<[u8; 32]>,
+) -> std::result::Result<Zeroizing<[u8; 32]>, RotationError> {
+    KeyDerivation::new(mek)
+        .derive_wal_dek()
+        .map_err(|e| RotationError::KeyProvider(e.to_string()))
+}
+
+/// Force-roll the WAL under the new DEK and retire the old-generation segments
+/// (Issue #3617). Shared by the forward driver and crash-resume.
+///
+/// Installs `new_wal_cipher` as key generation `new_key_version` on the WAL
+/// keyring (so subsequent appends use the new DEK) via an atomic force-roll,
+/// then deletes every sealed old-DEK segment (identified by header — legacy or
+/// a different `key_version`). The caller MUST have already captured all
+/// committed data in a durable index snapshot whose manifest was persisted
+/// BEFORE the rotation ledger was written, so retiring old-DEK segments loses
+/// nothing. Idempotent: a re-run seals another fresh (already-new-generation)
+/// segment and re-retires (a no-op once the old tail is gone).
+fn roll_and_retire_wal(
+    wal: &ConcurrentWalSystem,
+    new_wal_cipher: Arc<dyn Cipher>,
+    new_key_version: u32,
+) -> Result<()> {
+    if wal.wal_keyring().is_none() {
+        return Ok(());
+    }
+    let ring = wal.wal_keyring().expect("checked above").clone();
+    let cipher = Arc::clone(&new_wal_cipher);
+    // The keyring flip runs inside the atomic seal→reopen hand-off (holding the
+    // coordinator writer mutex), so the sealed segment stays on the old DEK and
+    // the fresh segment is written under the new one.
+    wal.seal_active_segment_for_rotation(move || {
+        ring.add_generation(new_key_version, cipher);
+    })?;
+    wal.retire_old_generation_segments(new_key_version)?;
+    Ok(())
+}
+
+/// Rewrite the durable ledger flipping `layer.wal=complete` (Issue #3617),
+/// preserving every other field. A no-op when no ledger is present (already
+/// cleared). Keeps the #488 P0.2 ordering: the completion is fsync'd before the
+/// old generation is retired / the ledger is cleared.
+fn mark_wal_complete(manager: &IndexPersistenceManager) -> Result<()> {
+    if let Some(mut ledger) = read_rotation_state(manager)?
+        && ledger.wal != LayerStatus::Complete
+    {
+        ledger.wal = LayerStatus::Complete;
+        write_ledger(manager, &ledger)?;
+    }
+    Ok(())
 }
 
 /// The four encrypted-at-rest layers a full-MEK rotation must eventually cover
@@ -499,12 +553,15 @@ impl AletheiaDB {
     /// is safe. Never exposes ciphers or key material.
     fn conflicting_encrypted_layers(&self) -> Vec<&'static str> {
         let mut layers = Vec::new();
-        // WAL: encrypted under the WAL DEK derived from the same MEK.
-        if self.wal.is_encrypted() {
-            layers.push("wal");
-        }
-        // Cold storage: when a tiered/cold store is configured and encryption is
-        // enabled, its files are under the cold DEK from the same MEK.
+        // WAL is now rotatable by the full-MEK driver (Issue #3617 PR2): a
+        // checkpoint → force-roll under the new WAL DEK → truncate of the old
+        // segments re-keys it with no bulk rewrite, so it is no longer a
+        // cross-layer conflict.
+        //
+        // Cold storage is NOT yet covered (PR3): when a tiered/cold store is
+        // configured and encryption is enabled, its files are under the cold DEK
+        // from the same MEK, so an index+WAL rotation would still strand them —
+        // keep refusing until the cold re-keyer lands.
         if self.encryption_manager.is_some() && self.historical.read().has_tiered_storage() {
             layers.push("cold_storage");
         }
@@ -626,7 +683,7 @@ impl AletheiaDB {
             .encryption_config
             .clone()
             .ok_or_else(|| rotation_err(RotationError::NotConfigured))?;
-        resume_pending_rotation(&manager, &enc_cfg)
+        resume_pending_rotation(&manager, &enc_cfg, Some(&self.wal))
     }
 
     fn run_rotation(
@@ -679,23 +736,49 @@ impl AletheiaDB {
         // a contract-violating concurrent index persist) before the ledger is on
         // stable storage — a power loss can then never strand a new-key file
         // with a lost ledger (Issue #488 P0.2, preserved per-layer for #3617).
-        // `write_rotation_state` fsyncs the file and its parent dir; only once
-        // it returns does the driver flip the keyring.
-        write_rotation_state(
+        // The WAL layer is recorded `Pending` when it is encrypted, so crash
+        // resume drives it; `write_ledger` fsyncs the file and its parent dir,
+        // and only once it returns does the driver flip any keyring.
+        let wal_in_scope = self.wal.is_encrypted();
+
+        // WAL-rotation invariant (Issue #3617): checkpoint BEFORE the ledger is
+        // written. `persist_indexes` captures every committed entry into the
+        // durable index snapshot and stamps the manifest, so once the ledger
+        // exists ("a rotation is in flight") ALL pre-rotation WAL data is already
+        // durable outside the WAL. Crash-resume can then retire the old-DEK
+        // segments unconditionally without re-checkpointing (indexes are not
+        // loaded yet at startup-resume time). Skipped for an index-only rotation,
+        // preserving that path's exact behavior.
+        if wal_in_scope {
+            self.persist_indexes()?;
+        }
+
+        write_ledger(
             manager,
-            new_version,
-            new_key_source,
-            RotationDirection::Forward,
+            &RotationLedger::forward_scope(new_version, new_key_source.clone(), wal_in_scope),
         )?;
         self.emit_rotation_audit(&AuditEvent::RotationStarted {
             old_version,
             new_version,
         });
 
-        // Drive each recorded layer. PR1 runs only the index/checkpoint domain
-        // through the mature #488 engine; wal/cold are recorded Skipped.
+        // Drive the index/checkpoint domain through the mature #488 engine.
         let progress =
             drive_forward_layers(manager, &keyring, old_version, new_version, &layer_ciphers)?;
+
+        // WAL layer (Issue #3617 PR2): re-key the WAL with no bulk rewrite —
+        // checkpoint (persist) → force-roll under the new WAL DEK → truncate the
+        // old-DEK segments. Runs after the index pass so `persist_indexes` writes
+        // fresh index files under the already-installed new index generation.
+        if wal_in_scope {
+            let wal_new_cipher = layer_ciphers
+                .iter()
+                .find(|lc| lc.layer == RotationLayer::Wal)
+                .map(|lc| Arc::clone(&lc.new))
+                .ok_or_else(|| rotation_err(RotationError::NotConfigured))?;
+            self.rotate_wal_layer(manager, wal_new_cipher, new_version)?;
+        }
+
         clear_rotation_state(manager);
 
         Ok(RotationReport {
@@ -706,6 +789,53 @@ impl AletheiaDB {
             files_skipped: progress.files_skipped,
             duration_ms: started.elapsed().as_millis() as u64,
         })
+    }
+
+    /// Re-key the WAL layer to `new_wal_cipher` (Issue #3617 PR2), with no bulk
+    /// rewrite of historical segments.
+    ///
+    /// Sequence (no cold storage — the only case the cross-layer guard allows a
+    /// rotation through today):
+    /// 1. **Checkpoint** — `persist_indexes` captures the current in-memory
+    ///    state into the durable index snapshot and stamps the manifest with the
+    ///    applied-watermark LSN, so all committed data below that LSN survives a
+    ///    WAL truncation.
+    /// 2. **Force-roll** — atomically seal the active (old-DEK) segment, advance
+    ///    the WAL keyring to the new generation, and open a fresh segment written
+    ///    under the new DEK.
+    /// 3. **Truncate** — drop every sealed old-DEK segment below the manifest
+    ///    LSN, so no old-DEK ciphertext remains and the old WAL DEK can be
+    ///    dropped after a provider switch.
+    /// 4. **Complete** — flip `layer.wal=complete` in the durable ledger, but
+    ///    only once no old-generation segment remains on disk (fail-safe: if a
+    ///    tail could not be truncated, leave it `pending` for a later pass).
+    ///
+    /// Assumes heavy writes are quiesced for its duration (the same contract as
+    /// index rotation); an append racing the roll still recovers (durability),
+    /// but full old-tail retirement assumes no post-checkpoint writes.
+    fn rotate_wal_layer(
+        &self,
+        manager: &IndexPersistenceManager,
+        new_wal_cipher: Arc<dyn Cipher>,
+        new_key_version: u32,
+    ) -> Result<()> {
+        if !self.wal.is_encrypted() {
+            return Ok(());
+        }
+        // The checkpoint (persist_indexes) already ran in `run_rotation` BEFORE
+        // the ledger was written, so the manifest already captures every
+        // committed entry — retiring the old-DEK segments here loses nothing.
+        //
+        // Force-roll under the new DEK, then retire the old-DEK segments.
+        roll_and_retire_wal(&self.wal, new_wal_cipher, new_key_version)?;
+
+        // Mark the WAL layer complete only once every old-generation segment is
+        // gone (so a completed rotation never leaves an unreadable tail after the
+        // old DEK is dropped).
+        if self.wal.all_segments_use_key_version(new_key_version) {
+            mark_wal_complete(manager)?;
+        }
+        Ok(())
     }
 }
 
@@ -807,6 +937,26 @@ impl RotationLedger {
             index: LayerStatus::Pending,
             checkpoint: LayerStatus::Pending,
             wal: LayerStatus::Skipped,
+            cold: LayerStatus::Skipped,
+        }
+    }
+
+    /// The PR2 cross-layer plan (Issue #3617): index + checkpoint always
+    /// re-key through the index engine; the WAL is `Pending` when it is
+    /// encrypted (the full-MEK driver re-keys it), else `Skipped`; cold remains
+    /// out of scope (`Skipped`) until PR3.
+    fn forward_scope(new_version: u32, new_source: KeyProviderConfig, wal_in_scope: bool) -> Self {
+        Self {
+            direction: RotationDirection::Forward,
+            new_version,
+            new_source,
+            index: LayerStatus::Pending,
+            checkpoint: LayerStatus::Pending,
+            wal: if wal_in_scope {
+                LayerStatus::Pending
+            } else {
+                LayerStatus::Skipped
+            },
             cold: LayerStatus::Skipped,
         }
     }
@@ -1069,6 +1219,7 @@ fn read_rotation_state(manager: &IndexPersistenceManager) -> Result<Option<Rotat
 pub fn resume_pending_rotation(
     manager: &Arc<IndexPersistenceManager>,
     enc_cfg: &EncryptionConfig,
+    wal: Option<&ConcurrentWalSystem>,
 ) -> Result<Option<RotationReport>> {
     let Some(ledger) = read_rotation_state(manager)? else {
         return Ok(None);
@@ -1083,22 +1234,37 @@ pub fn resume_pending_rotation(
         .ok_or_else(|| rotation_err(RotationError::NotConfigured))?;
     let old_version = keyring.current_version();
 
-    // DERIVATION ASYMMETRY (Issue #3617 PR1): the forward driver
-    // (`run_rotation`) derives the full four-DEK `MekKeyset` (wal/index/cold/
-    // checkpoint) up front, but resume derives ONLY the index DEK here because
-    // PR1's only executable layer is the index domain (index + checkpoint, which
-    // rides the index DEK); wal/cold are recorded `Skipped` and have no resume
-    // work. This is a deliberate, load-bearing gap: PR2 (WAL) and PR3 (cold)
-    // MUST extend resume to derive AND drive their layers' DEKs — not just the
-    // forward path — or an interrupted full-MEK rotation would resume the index
-    // pass while silently leaving the WAL/cold layers half-rotated. Mirror the
-    // `MekKeyset::derive` + `drive_forward_layers` structure here when those
-    // engines land.
+    // Index DEK (index + checkpoint ride it). PR3 will add the cold DEK here.
     let new_dek = derive_index_dek(load_mek(&ledger.new_source).map_err(rotation_err)?)
         .map_err(rotation_err)?;
     let new_cipher: Arc<dyn Cipher> = Arc::from(create_cipher(enc_cfg.algorithm, &new_dek));
 
     keyring.add_generation(ledger.new_version, Arc::clone(&new_cipher));
+
+    // WAL layer (Issue #3617 PR2): when the ledger records the WAL as in flight
+    // and a WAL system is available, add BOTH generations to its keyring — so a
+    // half-rotated directory (old-DEK + new-DEK segments) replays correctly on
+    // this open — and drive the layer to completion idempotently. Resume does
+    // NOT re-checkpoint (indexes are not loaded yet at startup): the forward
+    // driver checkpointed BEFORE writing the ledger, so every old-DEK segment is
+    // already captured durably and can be retired unconditionally.
+    let wal_pending = matches!(ledger.wal, LayerStatus::Pending);
+    if wal_pending
+        && let Some(wal) = wal
+        && let Some(wal_keyring) = wal.wal_keyring()
+    {
+        let new_wal_dek = derive_wal_dek(load_mek(&ledger.new_source).map_err(rotation_err)?)
+            .map_err(rotation_err)?;
+        let new_wal_cipher: Arc<dyn Cipher> =
+            Arc::from(create_cipher(enc_cfg.algorithm, &new_wal_dek));
+        // The startup keyring is `single(old_wal_dek)`; adding the new generation
+        // makes both live (legacy/old-kv → old, new-kv → new).
+        wal_keyring.add_generation(ledger.new_version, Arc::clone(&new_wal_cipher));
+        roll_and_retire_wal(wal, new_wal_cipher, ledger.new_version)?;
+        if wal.all_segments_use_key_version(ledger.new_version) {
+            mark_wal_complete(manager)?;
+        }
+    }
 
     let engine = IndexKeyRotation::new(
         manager.indexes_path(),
@@ -1559,7 +1725,7 @@ mod tests {
                     .index_cipher(),
             )),
         ));
-        let report = resume_pending_rotation(&resume_mgr, &enc_cfg)
+        let report = resume_pending_rotation(&resume_mgr, &enc_cfg, None)
             .unwrap()
             .expect("a pending rotation should resume");
         assert_eq!(report.new_version, 2);
@@ -1570,10 +1736,11 @@ mod tests {
     // ── P0.1: cross-layer MEK-desync guard ───────────────────────────
 
     #[test]
-    fn rotate_refuses_when_wal_encrypted() {
-        // A fully-encrypted DB (WAL under the same MEK) must REFUSE an index-only
-        // rotation: rotating the index alone to a new MEK then switching the key
-        // provider would strand the WAL under the old key (catastrophic loss).
+    fn rotate_reencrypts_wal() {
+        // Issue #3617 PR2: a fully-encrypted DB WITHOUT cold storage (WAL + index
+        // under the same MEK) now ROTATES successfully — the full-MEK driver
+        // re-keys the WAL via checkpoint → force-roll → truncate, so a subsequent
+        // provider switch is safe. (This flips the former index-only refusal.)
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
         let old_key = root.join("old.key");
@@ -1581,10 +1748,101 @@ mod tests {
         crate::encryption::FileKeyProvider::generate_key_file(&old_key).unwrap();
         crate::encryption::FileKeyProvider::generate_key_file(&new_key).unwrap();
 
-        let db = build_db(root, &old_key); // WAL encrypted too
-        seed(&db);
-        assert!(db.wal.is_encrypted(), "precondition: WAL is encrypted");
+        let (alice, bob) = {
+            let db = build_db(root, &old_key); // WAL encrypted too
+            let ids = seed(&db);
+            assert!(db.wal.is_encrypted(), "precondition: WAL is encrypted");
+            assert!(
+                db.conflicting_encrypted_layers().is_empty(),
+                "no cold storage → WAL+index rotation is now allowed"
+            );
 
+            let report = db
+                .rotate_index_keys(KeyProviderConfig::File {
+                    path: new_key.clone(),
+                })
+                .expect("WAL+index rotation without cold storage must succeed");
+            assert_eq!(report.new_version, 2);
+
+            // Data is intact in-memory immediately after rotation.
+            assert_eq!(db.node_count(), 2);
+            assert_eq!(db.edge_count(), 1);
+
+            // The rotation cleared its ledger.
+            assert!(!root.join("data").join("rotation.state").exists());
+
+            // Every remaining WAL segment is stamped with the NEW key_version;
+            // the old-DEK segments were truncated.
+            assert!(
+                db.wal.all_segments_use_key_version(2),
+                "all remaining WAL segments must carry the new key_version"
+            );
+            ids
+        };
+
+        // Reopen under the NEW key ONLY (the provider switch the whole feature
+        // exists to make safe): the WAL replays under the new DEK, index files
+        // decrypt under the new DEK, and the graph is fully recovered.
+        {
+            let db = build_db(root, &new_key);
+            assert_eq!(db.node_count(), 2, "graph must recover under the new key");
+            assert_eq!(db.edge_count(), 1);
+            // Both seeded nodes are readable (and decrypt) under the new key.
+            db.get_node(alice)
+                .expect("alice recovers under the new key");
+            db.get_node(bob).expect("bob recovers under the new key");
+        }
+    }
+
+    #[test]
+    fn rotate_still_refuses_when_cold_storage_encrypted() {
+        // Issue #3617 PR2: cold storage is NOT yet covered (PR3). A DB with
+        // encrypted cold storage must STILL refuse — an index+WAL rotation would
+        // strand the cold values under the old MEK.
+        use crate::config::HistoricalConfigBuilder;
+        use std::time::Duration;
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let old_key = root.join("old.key");
+        let new_key = root.join("new.key");
+        crate::encryption::FileKeyProvider::generate_key_file(&old_key).unwrap();
+        crate::encryption::FileKeyProvider::generate_key_file(&new_key).unwrap();
+
+        let config = AletheiaDBConfig::builder()
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(root.join("wal"))
+                    .durability_mode(DurabilityMode::GroupCommit {
+                        max_delay_ms: 5,
+                        max_batch_size: 64,
+                    })
+                    .build(),
+            )
+            .persistence(crate::storage::index_persistence::PersistenceConfig {
+                enabled: true,
+                data_dir: root.join("data"),
+                load_on_startup: true,
+                ..Default::default()
+            })
+            .historical(
+                HistoricalConfigBuilder::new()
+                    .enable_cold_storage(true)
+                    .cold_storage_path(root.join("cold.redb"))
+                    .migration_age_threshold(Duration::from_secs(3600))
+                    .build(),
+            )
+            .encryption(EncryptionConfig::file_based(&old_key))
+            .build();
+        let db = AletheiaDB::with_unified_config(config).unwrap();
+        seed(&db);
+        assert!(db.wal.is_encrypted());
+
+        let conflicting = db.conflicting_encrypted_layers();
+        assert!(
+            conflicting.contains(&"cold_storage"),
+            "cold storage must still be a conflict until PR3, got: {conflicting:?}"
+        );
         let err = db
             .rotate_index_keys(KeyProviderConfig::File {
                 path: new_key.clone(),
@@ -1592,11 +1850,72 @@ mod tests {
             .unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("other encrypted-at-rest layers") && msg.contains("wal"),
-            "expected cross-layer refusal naming the WAL, got: {msg}"
+            msg.contains("other encrypted-at-rest layers") && msg.contains("cold_storage"),
+            "expected cross-layer refusal naming cold_storage, got: {msg}"
         );
-        // Refusal leaves NO breadcrumb behind (checked before any state write).
         assert!(!root.join("data").join("rotation.state").exists());
+    }
+
+    /// Crash right after the rotation ledger was fsync'd but before any layer
+    /// finished (design §5 step 2): the durable ledger records index + WAL
+    /// `pending`. On the next open — still under the OLD key, since the rotation
+    /// never completed — startup resume drives BOTH layers to completion (index
+    /// re-encrypted, WAL force-rolled + old segments truncated), clears the
+    /// ledger, and the graph is intact; a subsequent reopen under the NEW key
+    /// alone then succeeds (the provider switch is now safe).
+    #[test]
+    fn crash_after_ledger_resumes_wal_and_index() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let old_key = root.join("old.key");
+        let new_key = root.join("new.key");
+        crate::encryption::FileKeyProvider::generate_key_file(&old_key).unwrap();
+        crate::encryption::FileKeyProvider::generate_key_file(&new_key).unwrap();
+
+        // 1. Seed an encrypted DB and persist (the manifest covers all data), then
+        //    plant a durable ledger simulating a crash right after it was written.
+        {
+            let db = build_db(root, &old_key);
+            seed(&db); // persists indexes
+            let manager = db.persistence_manager.as_ref().unwrap().clone();
+            super::write_ledger(
+                &manager,
+                &super::RotationLedger::forward_scope(
+                    2,
+                    KeyProviderConfig::File {
+                        path: new_key.clone(),
+                    },
+                    true, // WAL in scope
+                ),
+            )
+            .unwrap();
+            assert!(root.join("data").join("rotation.state").exists());
+        }
+
+        // 2. Reopen under the OLD key (rotation in flight): startup resume
+        //    completes both layers and clears the ledger.
+        {
+            let db = build_db(root, &old_key);
+            assert!(
+                !root.join("data").join("rotation.state").exists(),
+                "startup resume must complete the pending rotation and clear the ledger"
+            );
+            assert_eq!(db.node_count(), 2, "graph intact after resume");
+            assert_eq!(db.edge_count(), 1);
+            assert!(
+                db.wal.all_segments_use_key_version(2),
+                "resume must retire the old-generation WAL segments"
+            );
+            // Resume is idempotent: a second run with no ledger is a clean no-op.
+            assert!(db.resume_pending_index_rotation().unwrap().is_none());
+        }
+
+        // 3. Provider switch: reopen under the NEW key only — everything decrypts.
+        {
+            let db = build_db(root, &new_key);
+            assert_eq!(db.node_count(), 2, "graph recovers under the new key");
+            assert_eq!(db.edge_count(), 1);
+        }
     }
 
     #[test]
@@ -1764,7 +2083,7 @@ mod tests {
                     .index_cipher(),
             )),
         ));
-        let err = resume_pending_rotation(&manager, &enc_cfg).unwrap_err();
+        let err = resume_pending_rotation(&manager, &enc_cfg, None).unwrap_err();
         assert!(
             err.to_string().contains("corrupt"),
             "corrupt breadcrumb must abort startup, got: {err}"
@@ -1772,7 +2091,7 @@ mod tests {
         // And an ABSENT breadcrumb is a clean no-op (distinguish absent vs corrupt).
         std::fs::remove_file(data_dir.join("rotation.state")).unwrap();
         assert!(
-            resume_pending_rotation(&manager, &enc_cfg)
+            resume_pending_rotation(&manager, &enc_cfg, None)
                 .unwrap()
                 .is_none()
         );
@@ -1852,7 +2171,7 @@ mod tests {
                     .index_cipher(),
             )),
         ));
-        let report = resume_pending_rotation(&resume_mgr, &enc_cfg)
+        let report = resume_pending_rotation(&resume_mgr, &enc_cfg, None)
             .unwrap()
             .expect("a pending cancel should resume");
         assert_eq!(report.new_version, 1, "cancel rolls back to the old key");
@@ -2327,7 +2646,7 @@ mod tests {
                     .index_cipher(),
             )),
         ));
-        let report = resume_pending_rotation(&resume_mgr, &enc_cfg)
+        let report = resume_pending_rotation(&resume_mgr, &enc_cfg, None)
             .unwrap()
             .expect("a pending rotation should resume from the v2 ledger");
         assert_eq!(report.new_version, 2);
@@ -2437,7 +2756,7 @@ mod tests {
                     .index_cipher(),
             )),
         ));
-        let report = resume_pending_rotation(&resume_mgr, &enc_cfg)
+        let report = resume_pending_rotation(&resume_mgr, &enc_cfg, None)
             .unwrap()
             .expect("a pending rotation should resume");
         assert_eq!(report.new_version, 2);
@@ -2528,7 +2847,7 @@ mod tests {
                     .index_cipher(),
             )),
         ));
-        let report = resume_pending_rotation(&resume_mgr, &enc_cfg)
+        let report = resume_pending_rotation(&resume_mgr, &enc_cfg, None)
             .unwrap()
             .expect("an index=Complete ledger should still resume to verify+clear");
         assert_eq!(report.new_version, 2);
@@ -2606,7 +2925,7 @@ mod tests {
                     .index_cipher(),
             )),
         ));
-        let err = resume_pending_rotation(&resume_mgr, &enc_cfg).expect_err(
+        let err = resume_pending_rotation(&resume_mgr, &enc_cfg, None).expect_err(
             "a ledger claiming index=Complete over unmigrated old-key files MUST fail closed",
         );
         // The verify_complete() fail-closed path (OldKeyFilesRemain /

--- a/src/encryption/wal_encryption.rs
+++ b/src/encryption/wal_encryption.rs
@@ -159,6 +159,12 @@ impl WalKeyring {
 
     /// Whether a generation with `key_version` is currently held (a `match_any`
     /// single keyring holds every version).
+    ///
+    /// Test-only for now (Issue #3617 PR2): no production path consults it —
+    /// segment dispatch goes through [`cipher_for_segment`](Self::cipher_for_segment).
+    /// `#[cfg(test)]`-gated rather than removed so PR3 can re-expose it if a
+    /// production caller lands.
+    #[cfg(test)]
     pub fn has_version(&self, key_version: u32) -> bool {
         let inner = self.inner.read().unwrap_or_else(|e| e.into_inner());
         inner.match_any

--- a/src/encryption/wal_encryption.rs
+++ b/src/encryption/wal_encryption.rs
@@ -17,13 +17,182 @@
 //! (Additional Authenticated Data) so any tampering with them is detected during
 //! decryption.
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use crate::encryption::Cipher;
 use crate::encryption::error::EncryptionError;
 
 /// Byte offset where the encrypted payload begins (24-byte header + 1-byte op type).
 const WAL_HEADER_SIZE: usize = 25;
+
+/// The `key_version` a fresh (never-rotated) encrypted WAL stamps into its
+/// keyversioned segment headers (Issue #3617). Mirrors the index keyring's
+/// `ENC_INDEX_KEY_VERSION_V1` starting point so the two layers number their
+/// first generation identically.
+pub const INITIAL_WAL_KEY_VERSION: u32 = 1;
+
+// ── WAL key ring (dual-generation rotation, Issue #3617) ─────────────
+//
+// A full-MEK key rotation re-keys the WAL layer WITHOUT a bulk rewrite: new
+// appends are written under the NEW WAL DEK (in `KEYVERSIONED` segments
+// stamping the new `key_version`), while legacy/old-DEK segments still on disk
+// replay under the OLD DEK until they are truncated. To decrypt correctly the
+// recovery reader must therefore be able to hold BOTH generations at once and
+// select per segment. The `WalKeyring` is that holder — the WAL analogue of the
+// index [`IndexKeyring`](crate::storage::index_persistence::common::IndexKeyring),
+// deliberately mirroring its shape (small `Vec` of generations, a `current`
+// stamped into new segments, and a single-cipher `match_any` back-compat mode).
+
+#[derive(Clone)]
+struct WalKeyGeneration {
+    key_version: u32,
+    cipher: Arc<dyn Cipher>,
+}
+
+struct WalKeyringInner {
+    /// All live generations (1 before rotation, 2 during, 1 after). Small.
+    generations: Vec<WalKeyGeneration>,
+    /// Version stamped into freshly written segments (the newest generation).
+    current_version: u32,
+    /// Back-compat mode: a lone generation created from a single cipher
+    /// decrypts ANY segment (any `key_version`, or a legacy header carrying
+    /// none) with that one cipher. This is the never-rotated steady state and,
+    /// crucially, the post-provider-switch state: after a completed rotation the
+    /// operator reopens under the new key alone, so the single new-DEK keyring
+    /// must still read the new-DEK segments regardless of the `key_version` they
+    /// were stamped with during the rotation.
+    match_any: bool,
+}
+
+/// A cheaply-cloneable, shared-mutable set of WAL DEK ciphers addressed by
+/// `key_version` (Issue #3617).
+///
+/// Clones share the same underlying state, so the rotation driver can advance
+/// the current generation (making new appends stamp + encrypt under the new
+/// DEK) while the flush coordinator and recovery reader holding clones observe
+/// the change immediately. Never exposes key material; `Debug` is redacted.
+#[derive(Clone)]
+pub struct WalKeyring {
+    inner: Arc<RwLock<WalKeyringInner>>,
+}
+
+impl std::fmt::Debug for WalKeyring {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never render key material — only opaque generation metadata.
+        let inner = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        f.debug_struct("WalKeyring")
+            .field("generations", &inner.generations.len())
+            .field("current_version", &inner.current_version)
+            .field("match_any", &inner.match_any)
+            .finish()
+    }
+}
+
+impl WalKeyring {
+    /// A single-generation keyring from one cipher (the non-rotation path).
+    ///
+    /// Reads decrypt any segment (any header `key_version`, or a legacy header
+    /// with none) with this cipher and writes stamp [`INITIAL_WAL_KEY_VERSION`].
+    pub fn single(cipher: Arc<dyn Cipher>) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(WalKeyringInner {
+                generations: vec![WalKeyGeneration {
+                    key_version: INITIAL_WAL_KEY_VERSION,
+                    cipher,
+                }],
+                current_version: INITIAL_WAL_KEY_VERSION,
+                match_any: true,
+            })),
+        }
+    }
+
+    /// The current (write) cipher and the `key_version` it stamps into new
+    /// segment headers, or `None` if the keyring somehow holds no generation.
+    pub fn current(&self) -> Option<(Arc<dyn Cipher>, u32)> {
+        let inner = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        let v = inner.current_version;
+        inner
+            .generations
+            .iter()
+            .find(|g| g.key_version == v)
+            .map(|g| (g.cipher.clone(), v))
+    }
+
+    /// The version freshly written segments are stamped with.
+    pub fn current_version(&self) -> u32 {
+        self.inner
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .current_version
+    }
+
+    /// Resolve the decryption cipher for a segment, given the `key_version` read
+    /// from its header (`Some` for a `KEYVERSIONED` segment, `None` for a legacy
+    /// segment that carries no key-version field).
+    ///
+    /// * `match_any` (single-cipher) keyring → the sole cipher for every
+    ///   segment (never-rotated / post-switch steady state).
+    /// * strict keyring, legacy segment (`None`) → the OLDEST (minimum-version,
+    ///   i.e. pre-rotation) generation — the DEK legacy segments were written
+    ///   under before the rotation advanced the generation.
+    /// * strict keyring, `Some(kv)` → the generation stamped `kv`, or `None`
+    ///   when no such generation is held (a genuine wrong/absent key surfaces as
+    ///   a loud AEAD failure downstream rather than silent wrong data).
+    pub fn cipher_for_segment(&self, key_version: Option<u32>) -> Option<Arc<dyn Cipher>> {
+        let inner = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        if inner.match_any {
+            return inner.generations.first().map(|g| g.cipher.clone());
+        }
+        match key_version {
+            Some(kv) => inner
+                .generations
+                .iter()
+                .find(|g| g.key_version == kv)
+                .map(|g| g.cipher.clone()),
+            None => inner
+                .generations
+                .iter()
+                .min_by_key(|g| g.key_version)
+                .map(|g| g.cipher.clone()),
+        }
+    }
+
+    /// Whether a generation with `key_version` is currently held (a `match_any`
+    /// single keyring holds every version).
+    pub fn has_version(&self, key_version: u32) -> bool {
+        let inner = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        inner.match_any
+            || inner
+                .generations
+                .iter()
+                .any(|g| g.key_version == key_version)
+    }
+
+    /// Add a new generation and make it current. Switches the keyring to strict
+    /// per-version dispatch (leaving `match_any`). Idempotent for a version
+    /// already present (its cipher is replaced). Used by the rotation driver to
+    /// install the new WAL DEK before force-rolling the active segment.
+    pub fn add_generation(&self, key_version: u32, cipher: Arc<dyn Cipher>) {
+        let mut inner = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        inner.match_any = false;
+        inner.generations.retain(|g| g.key_version != key_version);
+        inner.generations.push(WalKeyGeneration {
+            key_version,
+            cipher,
+        });
+        inner.current_version = key_version;
+    }
+
+    /// Number of live generations (test/introspection helper; never leaks keys).
+    #[cfg(test)]
+    pub fn generation_count(&self) -> usize {
+        self.inner
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .generations
+            .len()
+    }
+}
 
 /// Encrypt the payload portion of a serialized WAL entry.
 ///
@@ -236,5 +405,74 @@ mod tests {
                 actual: 10
             })
         ));
+    }
+
+    // ── WalKeyring (Issue #3617) ─────────────────────────────────────
+
+    #[test]
+    fn keyring_single_matches_any_version() {
+        let cipher = aes_cipher();
+        let ring = WalKeyring::single(Arc::clone(&cipher));
+        assert_eq!(ring.current_version(), INITIAL_WAL_KEY_VERSION);
+        assert_eq!(ring.generation_count(), 1);
+        // A single-cipher keyring decrypts any segment: a legacy header (None),
+        // its own version, or an unrelated version stamped during a since-
+        // completed rotation (post-provider-switch state).
+        assert!(ring.cipher_for_segment(None).is_some());
+        assert!(
+            ring.cipher_for_segment(Some(INITIAL_WAL_KEY_VERSION))
+                .is_some()
+        );
+        assert!(ring.cipher_for_segment(Some(999)).is_some());
+        assert!(ring.has_version(7));
+    }
+
+    #[test]
+    fn keyring_dual_generation_dispatch() {
+        let old = aes_cipher();
+        let new = aes_cipher();
+        let ring = WalKeyring::single(Arc::clone(&old));
+        ring.add_generation(2, Arc::clone(&new));
+        // Now strict: current stamps the new version.
+        assert_eq!(ring.current_version(), 2);
+        assert_eq!(ring.generation_count(), 2);
+        let (cur, v) = ring.current().unwrap();
+        assert_eq!(v, 2);
+        assert!(Arc::ptr_eq(&cur, &new));
+        // Legacy segment (no key_version) resolves to the pre-rotation (oldest)
+        // generation.
+        assert!(Arc::ptr_eq(&ring.cipher_for_segment(None).unwrap(), &old));
+        // Keyversioned segments resolve to their exact generation.
+        assert!(Arc::ptr_eq(
+            &ring.cipher_for_segment(Some(1)).unwrap(),
+            &old
+        ));
+        assert!(Arc::ptr_eq(
+            &ring.cipher_for_segment(Some(2)).unwrap(),
+            &new
+        ));
+        // An unheld version is a loud miss (no silent wrong-key), not a fallback.
+        assert!(ring.cipher_for_segment(Some(3)).is_none());
+    }
+
+    #[test]
+    fn keyring_add_generation_is_idempotent_for_same_version() {
+        let old = aes_cipher();
+        let new = aes_cipher();
+        let ring = WalKeyring::single(Arc::clone(&old));
+        ring.add_generation(2, Arc::clone(&new));
+        ring.add_generation(2, Arc::clone(&new));
+        assert_eq!(ring.generation_count(), 2);
+        assert_eq!(ring.current_version(), 2);
+    }
+
+    #[test]
+    fn keyring_debug_redacts_key_material() {
+        let ring = WalKeyring::single(aes_cipher());
+        let rendered = format!("{ring:?}");
+        assert!(rendered.contains("WalKeyring"));
+        assert!(rendered.contains("current_version"));
+        // Never renders the cipher/algorithm/key bytes.
+        assert!(!rendered.to_lowercase().contains("aes"));
     }
 }

--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -938,7 +938,7 @@ mod tests {
         let wal = ConcurrentWalSystem::new(encrypted_sync_config(dir.path(), Arc::clone(&old_dek)))
             .unwrap();
 
-        // Write a couple entries under the OLD generation (v15, key_version 1).
+        // Write a couple entries under the OLD generation (v16, key_version 1).
         wal.append(create_test_operation(1)).unwrap();
         wal.append(create_test_operation(2)).unwrap();
 

--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -319,10 +319,14 @@ pub struct ConcurrentWalSystem {
     /// Crash-torn-tail recovery policy applied by [`Self::read_from`]
     /// (Issue #3433).
     tolerate_torn_tail: bool,
-    /// Optional WAL cipher for encryption at rest. Retained so [`Self::read_from`]
-    /// can decrypt encrypted segments during recovery replay; the write path
-    /// receives its own copy through the inner `ConcurrentWal`.
-    wal_cipher: Option<Arc<dyn crate::encryption::cipher::Cipher>>,
+    /// Optional WAL DEK keyring for encryption at rest (Issue #3617). Retained
+    /// so [`Self::read_from`] can decrypt encrypted segments during recovery
+    /// replay — dispatching per segment on its `key_version` so a mixed
+    /// old-DEK/new-DEK directory (an in-flight full-MEK rotation) replays
+    /// correctly. The flush coordinator holds a clone (shared `Arc` state), so
+    /// advancing the current generation here is observed by the write path
+    /// immediately.
+    wal_keyring: Option<crate::encryption::wal_encryption::WalKeyring>,
 }
 
 impl ConcurrentWalSystem {
@@ -337,6 +341,16 @@ impl ConcurrentWalSystem {
             segments_to_retain: config.segments_to_retain,
         };
 
+        // Build the WAL DEK keyring from the configured cipher (Issue #3617). A
+        // never-rotated encrypted WAL starts as a single-generation keyring
+        // (stamps INITIAL_WAL_KEY_VERSION, decrypts any segment); a full-MEK
+        // rotation later advances it to a second generation. Plaintext WALs have
+        // no keyring.
+        let wal_keyring = config
+            .wal_cipher
+            .clone()
+            .map(crate::encryption::wal_encryption::WalKeyring::single);
+
         // Create FlushCoordinator config
         let coordinator_config = FlushCoordinatorConfig {
             wal_dir: config.wal_dir,
@@ -348,11 +362,8 @@ impl ConcurrentWalSystem {
                 DurabilityMode::Synchronous | DurabilityMode::GroupCommit { .. }
             ),
             write_buffer_size: config.write_buffer_size,
-            wal_cipher: config.wal_cipher.clone(),
+            wal_keyring: wal_keyring.clone(),
         };
-
-        // Retain the cipher on the system for the recovery read path.
-        let wal_cipher = config.wal_cipher.clone();
 
         let wal = Arc::new(ConcurrentWal::new(wal_config)?);
         let coordinator = Arc::new(FlushCoordinator::new(coordinator_config)?);
@@ -427,7 +438,7 @@ impl ConcurrentWalSystem {
             group_commit,
             consecutive_flush_errors,
             tolerate_torn_tail: config.tolerate_torn_tail,
-            wal_cipher,
+            wal_keyring,
         })
     }
 
@@ -773,7 +784,62 @@ impl ConcurrentWalSystem {
     /// undecryptable. Never exposes the cipher or any key material.
     #[must_use]
     pub(crate) fn is_encrypted(&self) -> bool {
-        self.wal_cipher.is_some()
+        self.wal_keyring.is_some()
+    }
+
+    /// The WAL DEK keyring, if this WAL is encrypted (Issue #3617).
+    ///
+    /// Exposed so the full-MEK rotation driver can install the new WAL DEK
+    /// generation before force-rolling the active segment. Never returns key
+    /// material directly — only the shared, redacting-`Debug` keyring handle.
+    #[must_use]
+    pub(crate) fn wal_keyring(&self) -> Option<&crate::encryption::wal_encryption::WalKeyring> {
+        self.wal_keyring.as_ref()
+    }
+
+    /// Whether every on-disk WAL segment is stamped with `key_version` — the
+    /// rotation driver's "old generation fully retired" signal (Issue #3617).
+    /// See [`FlushCoordinator::all_segments_use_key_version`].
+    pub(crate) fn all_segments_use_key_version(&self, key_version: u32) -> bool {
+        self.coordinator.all_segments_use_key_version(key_version)
+    }
+
+    /// Retire (delete) every sealed old-generation WAL segment, keeping only
+    /// segments stamped `keep_key_version` and the active segment (Issue #3617).
+    /// See [`FlushCoordinator::retire_old_generation_segments`].
+    pub(crate) fn retire_old_generation_segments(&self, keep_key_version: u32) -> Result<usize> {
+        self.coordinator
+            .retire_old_generation_segments(keep_key_version)
+    }
+
+    /// Force-roll the active WAL segment for a full-MEK key rotation (Issue
+    /// #3617): drain and durably flush every in-flight ring-buffer entry into
+    /// the CURRENT (old-generation) segment, then atomically seal it, run
+    /// `advance` (which flips the WAL keyring to the new generation), and open a
+    /// fresh segment stamped with — and encrypting under — the new generation.
+    ///
+    /// # Quiesce / correctness
+    ///
+    /// Appends land in the lock-free ring buffer BEFORE any flush. This method
+    /// first drains and flushes them (with fsync) into the old segment, so no
+    /// acknowledged entry is lost across the roll. The subsequent seal + keyring
+    /// flip + reopen all run under the coordinator `writer` mutex, which every
+    /// flush also holds while it reads the write cipher and writes the segment
+    /// header — so the (segment header generation, frame-encrypting generation)
+    /// pair is always consistent and a batch can never straddle two generations.
+    /// Any append racing the roll is simply picked up by whichever flush runs
+    /// next and written, consistently, to whatever segment is current at that
+    /// flush. `advance` runs while holding only the `writer` mutex, so it must
+    /// not acquire any lock ordered after `wal` (no cold flush inside it).
+    pub(crate) fn seal_active_segment_for_rotation<F: FnOnce()>(&self, advance: F) -> Result<()> {
+        // 1. Drain + flush all pending entries into the current (old) segment,
+        //    with fsync, so nothing acknowledged is left only in the ring buffer.
+        let entries = self.wal.drain_all();
+        if !entries.is_empty() {
+            self.coordinator.flush(entries, true)?;
+        }
+        // 2. Seal old + flip keyring + open new, atomically under the writer mutex.
+        self.coordinator.seal_active_segment_and_reopen(advance)
     }
 
     /// Read WAL entries from disk, starting from the specified LSN.
@@ -790,10 +856,10 @@ impl ConcurrentWalSystem {
         // segments cannot be decoded without it, so an encryption-at-rest
         // database replaying its WAL tail after a crash must decrypt here.
         // Passing `None` (no encryption) preserves plaintext behavior exactly.
-        crate::storage::wal_reader::read_wal_entries_with_cipher_and_options(
+        crate::storage::wal::segment_reader::read_entries_from_dir_with_keyring(
             self.wal_dir(),
             start_lsn,
-            self.wal_cipher.as_ref(),
+            self.wal_keyring.as_ref(),
             self.tolerate_torn_tail,
         )
     }
@@ -844,6 +910,146 @@ mod tests {
             valid_from: time::now(),
             provenance: None,
         }
+    }
+
+    // ── Issue #3617: WAL DEK force-roll (dual-generation rotation) ────────
+
+    fn wal_test_cipher(seed: u8) -> Arc<dyn crate::encryption::cipher::Cipher> {
+        use zeroize::Zeroizing;
+        let key = Zeroizing::new([seed; 32]);
+        Arc::new(crate::encryption::Aes256GcmCipher::new(&key))
+    }
+
+    fn encrypted_sync_config(
+        dir: &std::path::Path,
+        cipher: Arc<dyn crate::encryption::cipher::Cipher>,
+    ) -> ConcurrentWalSystemConfig {
+        let mut config = ConcurrentWalSystemConfig::new(dir);
+        config.durability_mode = DurabilityMode::Synchronous;
+        config.wal_cipher = Some(cipher);
+        config
+    }
+
+    #[test]
+    fn force_roll_writes_new_generation_and_recovers_both() {
+        let dir = tempdir().unwrap();
+        let old_dek = wal_test_cipher(7);
+        let new_dek = wal_test_cipher(9);
+        let wal = ConcurrentWalSystem::new(encrypted_sync_config(dir.path(), Arc::clone(&old_dek)))
+            .unwrap();
+
+        // Write a couple entries under the OLD generation (v15, key_version 1).
+        wal.append(create_test_operation(1)).unwrap();
+        wal.append(create_test_operation(2)).unwrap();
+
+        // Force-roll: seal the old segment and start a new one under a NEW DEK
+        // (key_version 2). The keyring flip runs inside the atomic hand-off.
+        let ring = wal.wal_keyring().unwrap().clone();
+        let advance_cipher = Arc::clone(&new_dek);
+        wal.seal_active_segment_for_rotation(move || {
+            ring.add_generation(2, advance_cipher);
+        })
+        .unwrap();
+
+        // Subsequent appends land in the fresh, new-generation segment.
+        wal.append(create_test_operation(3)).unwrap();
+        wal.append(create_test_operation(4)).unwrap();
+        wal.flush().unwrap();
+
+        // Recovery via the (now two-generation) keyring recovers every entry —
+        // old segments under the old DEK, new under the new.
+        let entries = wal.read_from(LSN::initial()).unwrap();
+        let ids: Vec<u64> = entries
+            .iter()
+            .filter_map(|e| match &e.operation {
+                WalOperation::CreateNode { node_id, .. } => Some(node_id.as_u64()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            ids,
+            vec![1, 2, 3, 4],
+            "all entries across both generations recover"
+        );
+    }
+
+    /// Hammer appends from many threads WHILE a force-roll happens: every
+    /// acknowledged entry must recover (none lost) and decrypt (none unreadable),
+    /// proving the seal is atomic w.r.t. concurrent appenders (Issue #3617).
+    #[test]
+    fn append_hammer_across_force_roll_loses_nothing() {
+        use std::sync::Barrier;
+        use std::sync::atomic::{AtomicU64, Ordering as AtOrd};
+
+        let dir = tempdir().unwrap();
+        let old_dek = wal_test_cipher(7);
+        let new_dek = wal_test_cipher(9);
+        let mut config = ConcurrentWalSystemConfig::new(dir.path());
+        config.durability_mode = DurabilityMode::GroupCommit {
+            max_batch_size: 16,
+            max_delay_ms: 2,
+        };
+        config.wal_cipher = Some(Arc::clone(&old_dek));
+        let wal = Arc::new(ConcurrentWalSystem::new(config).unwrap());
+
+        let threads = 4u64;
+        let per_thread = 200u64;
+        let next_id = Arc::new(AtomicU64::new(1));
+        let barrier = Arc::new(Barrier::new(threads as usize + 1));
+
+        let mut handles = Vec::new();
+        for _ in 0..threads {
+            let wal = Arc::clone(&wal);
+            let next_id = Arc::clone(&next_id);
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..per_thread {
+                    let id = next_id.fetch_add(1, AtOrd::Relaxed);
+                    let (_lsn, handle) = wal
+                        .wal
+                        .append_with_handle(create_test_operation(id))
+                        .unwrap();
+                    // Ensure the entry is flushed so nothing is stuck unflushed.
+                    let _ = wal.commit();
+                    let _ = handle.wait();
+                }
+            }));
+        }
+
+        // Release the appenders, then force-roll partway through the storm.
+        barrier.wait();
+        std::thread::sleep(std::time::Duration::from_millis(3));
+        let ring = wal.wal_keyring().unwrap().clone();
+        let advance_cipher = Arc::clone(&new_dek);
+        wal.seal_active_segment_for_rotation(move || {
+            ring.add_generation(2, advance_cipher);
+        })
+        .unwrap();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+        wal.flush().unwrap();
+
+        let total = threads * per_thread;
+        let entries = wal.read_from(LSN::initial()).unwrap();
+        let mut ids: Vec<u64> = entries
+            .iter()
+            .filter_map(|e| match &e.operation {
+                WalOperation::CreateNode { node_id, .. } => Some(node_id.as_u64()),
+                _ => None,
+            })
+            .collect();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(
+            ids.len() as u64,
+            total,
+            "every acknowledged entry across the roll must recover (none lost, none unreadable)"
+        );
+        assert_eq!(*ids.first().unwrap(), 1);
+        assert_eq!(*ids.last().unwrap(), total);
     }
 
     #[test]

--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -128,7 +128,7 @@ pub struct FlushCoordinatorConfig {
     ///
     /// When set, entries are encrypted (4-byte length-prefixed) under the
     /// keyring's CURRENT generation and fresh segments use the keyversioned
-    /// (v15) header stamping that generation's `key_version`; a full-MEK
+    /// (v16) header stamping that generation's `key_version`; a full-MEK
     /// rotation advances the current generation so subsequent segments are
     /// written under the new DEK while legacy/old-DEK segments still replay
     /// under the retained old generation. When `None`, segments use the
@@ -412,7 +412,7 @@ impl FlushCoordinator {
     ///
     /// Returns `None` when the file cannot be read, is shorter than a full
     /// header, or does not start with the WAL magic bytes. For a keyversioned
-    /// (v15) segment the second element carries the stamped `key_version`; every
+    /// (v16) segment the second element carries the stamped `key_version`; every
     /// legacy (5-byte header) segment yields `None` there.
     fn read_segment_header_id(path: &Path) -> Option<(u8, Option<u32>)> {
         let mut header = [0u8; WAL_KEYVERSIONED_HEADER_SIZE];
@@ -436,7 +436,7 @@ impl FlushCoordinator {
 
     /// The (version, key_version) a freshly created segment is stamped with,
     /// derived from the configured WAL keyring's CURRENT generation (Issue
-    /// #3617). Encrypted → keyversioned (v15) header stamping the current
+    /// #3617). Encrypted → keyversioned (v16) header stamping the current
     /// generation's `key_version`; plaintext → the string-label (v13) header.
     ///
     /// Reading the keyring here (rather than caching a version) is what lets a
@@ -472,7 +472,7 @@ impl FlushCoordinator {
         }
 
         // New segments use the string-label payload format (Issue #3506). For an
-        // ENCRYPTED WAL they are additionally wrapped in the keyversioned (v15)
+        // ENCRYPTED WAL they are additionally wrapped in the keyversioned (v16)
         // container (Issue #3617), whose 9-byte header stamps the WAL DEK
         // generation (`key_version`) the frames are encrypted under, so a
         // full-MEK rotation can advance the write generation while legacy/old-DEK
@@ -548,7 +548,7 @@ impl FlushCoordinator {
                     e
                 )))
             })?;
-            // Keyversioned (v15) segments carry the 4-byte key_version (LE) after
+            // Keyversioned (v16) segments carry the 4-byte key_version (LE) after
             // the version byte (Issue #3617). Only the integer version is
             // written — never any key material.
             if let Some(kv) = write_key_version {
@@ -1152,7 +1152,7 @@ impl FlushCoordinator {
         Ok(removed)
     }
 
-    /// Whether EVERY on-disk `.log` segment is a keyversioned (v15) segment
+    /// Whether EVERY on-disk `.log` segment is a keyversioned (v16) segment
     /// stamped with `key_version` (Issue #3617).
     ///
     /// The rotation driver's "old generation fully retired" signal: it returns

--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -45,8 +45,10 @@ use super::ring_buffer::PendingEntry;
 use crate::core::error::{Error, Result, StorageError};
 
 use super::segment_reader::{
-    WAL_HEADER_SIZE, WAL_MAGIC, WAL_VERSION_ENCRYPTED_STRING_LABELS, WAL_VERSION_STRING_LABELS,
+    WAL_HEADER_SIZE, WAL_KEYVERSIONED_HEADER_SIZE, WAL_MAGIC, WAL_VERSION_ENCRYPTED_KEYVERSIONED,
+    WAL_VERSION_STRING_LABELS,
 };
+use crate::encryption::wal_encryption::WalKeyring;
 
 /// Metadata about a WAL segment's LSN range.
 ///
@@ -121,12 +123,17 @@ pub struct FlushCoordinatorConfig {
     pub sync_on_flush: bool,
     /// Write buffer size for segment files.
     pub write_buffer_size: usize,
-    /// Optional cipher for encrypting WAL entries before writing to disk.
+    /// Optional WAL DEK keyring for encrypting WAL entries before writing to
+    /// disk (Issue #3617).
     ///
-    /// When set, entries are encrypted with a 4-byte length prefix and
-    /// segments use version 2 format. When `None`, segments use version 1
-    /// (plaintext, backward compatible).
-    pub wal_cipher: Option<Arc<dyn crate::encryption::cipher::Cipher>>,
+    /// When set, entries are encrypted (4-byte length-prefixed) under the
+    /// keyring's CURRENT generation and fresh segments use the keyversioned
+    /// (v15) header stamping that generation's `key_version`; a full-MEK
+    /// rotation advances the current generation so subsequent segments are
+    /// written under the new DEK while legacy/old-DEK segments still replay
+    /// under the retained old generation. When `None`, segments use the
+    /// plaintext (v13) format (backward compatible).
+    pub wal_keyring: Option<WalKeyring>,
 }
 
 impl std::fmt::Debug for FlushCoordinatorConfig {
@@ -138,10 +145,7 @@ impl std::fmt::Debug for FlushCoordinatorConfig {
             .field("flush_interval_ms", &self.flush_interval_ms)
             .field("sync_on_flush", &self.sync_on_flush)
             .field("write_buffer_size", &self.write_buffer_size)
-            .field(
-                "wal_cipher",
-                &self.wal_cipher.as_ref().map(|c| c.algorithm_name()),
-            )
+            .field("wal_keyring", &self.wal_keyring)
             .finish()
     }
 }
@@ -155,7 +159,7 @@ impl Default for FlushCoordinatorConfig {
             flush_interval_ms: 10, // 10ms
             sync_on_flush: true,
             write_buffer_size: 64 * 1024, // 64 KB
-            wal_cipher: None,
+            wal_keyring: None,
         }
     }
 }
@@ -403,14 +407,50 @@ impl FlushCoordinator {
         SegmentMetadata::from_bytes(&bytes)
     }
 
-    /// Read the format version byte from an existing segment's header.
+    /// Read the format version byte + optional `key_version` from an existing
+    /// segment's header (Issue #3617).
     ///
     /// Returns `None` when the file cannot be read, is shorter than a full
-    /// header, or does not start with the WAL magic bytes.
-    fn read_segment_header_version(path: &Path) -> Option<u8> {
-        let mut header = [0u8; WAL_HEADER_SIZE];
-        File::open(path).ok()?.read_exact(&mut header).ok()?;
-        (header[0..4] == WAL_MAGIC).then_some(header[WAL_HEADER_SIZE - 1])
+    /// header, or does not start with the WAL magic bytes. For a keyversioned
+    /// (v15) segment the second element carries the stamped `key_version`; every
+    /// legacy (5-byte header) segment yields `None` there.
+    fn read_segment_header_id(path: &Path) -> Option<(u8, Option<u32>)> {
+        let mut header = [0u8; WAL_KEYVERSIONED_HEADER_SIZE];
+        let mut file = File::open(path).ok()?;
+        // Read at least the 5-byte legacy header; the extra 4 bytes are only
+        // meaningful (and required) for a keyversioned segment.
+        file.read_exact(&mut header[..WAL_HEADER_SIZE]).ok()?;
+        if header[0..4] != WAL_MAGIC {
+            return None;
+        }
+        let version = header[WAL_HEADER_SIZE - 1];
+        if version == WAL_VERSION_ENCRYPTED_KEYVERSIONED {
+            file.read_exact(&mut header[WAL_HEADER_SIZE..WAL_KEYVERSIONED_HEADER_SIZE])
+                .ok()?;
+            let kv = u32::from_le_bytes([header[5], header[6], header[7], header[8]]);
+            Some((version, Some(kv)))
+        } else {
+            Some((version, None))
+        }
+    }
+
+    /// The (version, key_version) a freshly created segment is stamped with,
+    /// derived from the configured WAL keyring's CURRENT generation (Issue
+    /// #3617). Encrypted → keyversioned (v15) header stamping the current
+    /// generation's `key_version`; plaintext → the string-label (v13) header.
+    ///
+    /// Reading the keyring here (rather than caching a version) is what lets a
+    /// force-roll pick up the NEW generation the moment the rotation driver
+    /// advances it — all serialized under the coordinator `writer` mutex so the
+    /// (segment header, encrypting cipher) pair is always consistent.
+    fn current_write_format(&self) -> (u8, Option<u32>) {
+        match &self.config.wal_keyring {
+            Some(keyring) => (
+                WAL_VERSION_ENCRYPTED_KEYVERSIONED,
+                Some(keyring.current_version()),
+            ),
+            None => (WAL_VERSION_STRING_LABELS, None),
+        }
     }
 
     /// Open or create the current segment file.
@@ -431,28 +471,25 @@ impl FlushCoordinator {
             return Ok(());
         }
 
-        // New segments use the string-label format (Issue #3506):
-        // WAL_VERSION_ENCRYPTED_STRING_LABELS (v14) for encrypted segments,
-        // WAL_VERSION_STRING_LABELS (v13) for plaintext. It is a strict
-        // superset of the destructive-op provenance format (Issue #3427,
-        // v11/v12) — itself a superset of the delete-version-id (Issue #3406),
-        // transaction-framing (Issue #3413), and principal-carrying provenance
-        // (Issues #3224 + #3350) formats — changing only how the
-        // node/edge/constraint LABEL is encoded: length-prefixed UTF-8 that is
-        // re-interned on read instead of a raw interner id, so labels are
-        // correct under any interner layout on replay. It keeps every prior
-        // field (framing markers, tombstone/retraction version_id, destructive
-        // provenance). The version bump signals the new label encoding so old
-        // readers reject the segment cleanly rather than mis-lengthing the
-        // variable-width label payload.
-        let write_version = if self.config.wal_cipher.is_some() {
-            WAL_VERSION_ENCRYPTED_STRING_LABELS
+        // New segments use the string-label payload format (Issue #3506). For an
+        // ENCRYPTED WAL they are additionally wrapped in the keyversioned (v15)
+        // container (Issue #3617), whose 9-byte header stamps the WAL DEK
+        // generation (`key_version`) the frames are encrypted under, so a
+        // full-MEK rotation can advance the write generation while legacy/old-DEK
+        // segments still replay under the retained old generation. Plaintext WALs
+        // keep the 5-byte v13 header. The version bump signals the new header so
+        // an older reader rejects the segment cleanly rather than misparsing it.
+        let (write_version, write_key_version) = self.current_write_format();
+        let header_size = if write_key_version.is_some() {
+            WAL_KEYVERSIONED_HEADER_SIZE
         } else {
-            WAL_VERSION_STRING_LABELS
+            WAL_HEADER_SIZE
         };
 
         // Allocate the next segment id, rolling past any existing non-empty
-        // segment whose header version differs from `write_version`.
+        // segment whose header (version AND key_version) differs from what this
+        // writer emits — appending new-format frames to an old-format segment
+        // would produce a mixed, unparseable file.
         let (segment_id, path, current_len) = loop {
             let segment_id = self.current_segment_id.fetch_add(1, Ordering::Relaxed) + 1;
             let path = self.segment_path(segment_id);
@@ -460,14 +497,14 @@ impl FlushCoordinator {
             if current_len == 0 {
                 break (segment_id, path, current_len);
             }
-            match Self::read_segment_header_version(&path) {
-                Some(version) if version == write_version => {
+            match Self::read_segment_header_id(&path) {
+                Some((version, kv)) if version == write_version && kv == write_key_version => {
                     break (segment_id, path, current_len);
                 }
                 _ => {
                     eprintln!(
-                        "WAL: not appending to existing segment {} (header version differs \
-                         from writer version {} or is unreadable); rolling to next segment",
+                        "WAL: not appending to existing segment {} (header version/key_version \
+                         differs from writer version {} or is unreadable); rolling to next segment",
                         path.display(),
                         write_version
                     );
@@ -511,8 +548,19 @@ impl FlushCoordinator {
                     e
                 )))
             })?;
+            // Keyversioned (v15) segments carry the 4-byte key_version (LE) after
+            // the version byte (Issue #3617). Only the integer version is
+            // written — never any key material.
+            if let Some(kv) = write_key_version {
+                writer.write_all(&kv.to_le_bytes()).map_err(|e| {
+                    Error::Storage(StorageError::IoError(format!(
+                        "Failed to write WAL key_version: {}",
+                        e
+                    )))
+                })?;
+            }
             self.current_segment_size
-                .store(WAL_HEADER_SIZE as u64, Ordering::Relaxed);
+                .store(header_size as u64, Ordering::Relaxed);
         } else {
             // For existing (version-matching) segments, we must initialize
             // the size correctly
@@ -539,71 +587,122 @@ impl FlushCoordinator {
     /// flush operations.
     fn maybe_rotate_segment(&self, writer_guard: &mut Option<BufWriter<File>>) -> Result<bool> {
         let current_size = self.current_segment_size.load(Ordering::Relaxed);
-
         if current_size >= self.config.segment_size as u64 {
-            let closing_segment_id = self.current_segment_id.load(Ordering::Relaxed);
+            self.seal_current(writer_guard)?;
+            return Ok(true);
+        }
+        Ok(false)
+    }
 
-            // 1. Flush current segment first.
-            // If this fails, we return error and DO NOT reset state or close the writer.
-            // This allows the next flush attempt to retry.
-            if let Some(writer) = writer_guard {
-                writer.flush().map_err(|e| {
+    /// Seal the current active segment: flush its buffer, capture and durably
+    /// write its `.meta` LSN range, fsync, drop the writer, and reset the
+    /// per-segment counters so the next [`ensure_segment_open`](Self::ensure_segment_open)
+    /// starts a fresh segment. Extracted from [`maybe_rotate_segment`](Self::maybe_rotate_segment)
+    /// so a force-roll (Issue #3617) can reuse the exact same seal/flush/meta
+    /// path without the size predicate.
+    ///
+    /// # Thread Safety
+    ///
+    /// The caller MUST hold the `writer` lock (`writer_guard`), so sealing is
+    /// atomic with respect to concurrent flushes. On any I/O error the writer is
+    /// already closed and counters reset, so the next flush opens a fresh
+    /// segment rather than smearing LSN ranges.
+    fn seal_current(&self, writer_guard: &mut Option<BufWriter<File>>) -> Result<()> {
+        let closing_segment_id = self.current_segment_id.load(Ordering::Relaxed);
+
+        // 1. Flush current segment first.
+        // If this fails, we return error and DO NOT reset state or close the writer.
+        // This allows the next flush attempt to retry.
+        if let Some(writer) = writer_guard {
+            writer.flush().map_err(|e| {
+                Error::Storage(StorageError::IoError(format!(
+                    "Failed to flush WAL segment: {}",
+                    e
+                )))
+            })?;
+        }
+
+        // 2. Capture state for metadata/cleanup before resetting
+        let min_lsn = self.current_segment_min_lsn.load(Ordering::Relaxed);
+        let max_lsn = self.current_segment_max_lsn.load(Ordering::Relaxed);
+        let entry_count = self.current_segment_entry_count.load(Ordering::Relaxed);
+
+        // 3. Close writer (drops BufWriter) - effectively "committing" to rotation
+        *writer_guard = None;
+
+        // 4. Reset size and LSN tracking for new segment immediately.
+        // We do this BEFORE sync/metadata write. This ensures that even if those subsequent
+        // steps fail, the internal state is clean for the next segment (which will be a NEW segment
+        // because writer is None). This prevents "smearing" LSN ranges.
+        self.current_segment_size.store(0, Ordering::Relaxed);
+        self.current_segment_min_lsn
+            .store(u64::MAX, Ordering::Relaxed);
+        self.current_segment_max_lsn.store(0, Ordering::Relaxed);
+        self.current_segment_entry_count.store(0, Ordering::Relaxed);
+
+        // 5. Sync before closing (using separate handle)
+        // If this fails, we return error, but state is already reset and writer closed.
+        if self.config.sync_on_flush {
+            let sync_guard = self.sync_handle.lock().unwrap_or_else(|e| e.into_inner());
+            if let Some(ref sync_file) = *sync_guard {
+                sync_file.sync_data().map_err(|e| {
                     Error::Storage(StorageError::IoError(format!(
-                        "Failed to flush WAL segment: {}",
+                        "Failed to sync WAL segment: {}",
                         e
                     )))
                 })?;
             }
-
-            // 2. Capture state for metadata/cleanup before resetting
-            let min_lsn = self.current_segment_min_lsn.load(Ordering::Relaxed);
-            let max_lsn = self.current_segment_max_lsn.load(Ordering::Relaxed);
-            let entry_count = self.current_segment_entry_count.load(Ordering::Relaxed);
-
-            // 3. Close writer (drops BufWriter) - effectively "committing" to rotation
-            *writer_guard = None;
-
-            // 4. Reset size and LSN tracking for new segment immediately.
-            // We do this BEFORE sync/metadata write. This ensures that even if those subsequent
-            // steps fail, the internal state is clean for the next segment (which will be a NEW segment
-            // because writer is None). This prevents "smearing" LSN ranges.
-            self.current_segment_size.store(0, Ordering::Relaxed);
-            self.current_segment_min_lsn
-                .store(u64::MAX, Ordering::Relaxed);
-            self.current_segment_max_lsn.store(0, Ordering::Relaxed);
-            self.current_segment_entry_count.store(0, Ordering::Relaxed);
-
-            // 5. Sync before closing (using separate handle)
-            // If this fails, we return error, but state is already reset and writer closed.
-            if self.config.sync_on_flush {
-                let sync_guard = self.sync_handle.lock().unwrap_or_else(|e| e.into_inner());
-                if let Some(ref sync_file) = *sync_guard {
-                    sync_file.sync_data().map_err(|e| {
-                        Error::Storage(StorageError::IoError(format!(
-                            "Failed to sync WAL segment: {}",
-                            e
-                        )))
-                    })?;
-                }
-            }
-
-            // 6. Write segment metadata (ADR-0025) using captured state
-            // If this fails, we return error, but state is already reset.
-            self.write_segment_metadata(closing_segment_id, min_lsn, max_lsn, entry_count)?;
-
-            // Clear sync handle
-            {
-                let mut sync_guard = self.sync_handle.lock().unwrap_or_else(|e| e.into_inner());
-                *sync_guard = None;
-            }
-
-            // Clean up old segments
-            self.cleanup_old_segments()?;
-
-            return Ok(true);
         }
 
-        Ok(false)
+        // 6. Write segment metadata (ADR-0025) using captured state
+        // If this fails, we return error, but state is already reset.
+        self.write_segment_metadata(closing_segment_id, min_lsn, max_lsn, entry_count)?;
+
+        // Clear sync handle
+        {
+            let mut sync_guard = self.sync_handle.lock().unwrap_or_else(|e| e.into_inner());
+            *sync_guard = None;
+        }
+
+        // Clean up old segments
+        self.cleanup_old_segments()?;
+
+        Ok(())
+    }
+
+    /// Force-seal the active segment and reopen a fresh one, running `advance`
+    /// under the coordinator `writer` mutex BETWEEN the seal and the reopen
+    /// (Issue #3617 WAL key rotation).
+    ///
+    /// This is the WAL force-roll primitive. The whole seal → `advance` →
+    /// reopen sequence is one critical section holding the `writer` mutex, so it
+    /// is serialized against every concurrent [`flush`](Self::flush) (which also
+    /// reads the write cipher AND writes the segment header under the same lock).
+    /// A rotation passes an `advance` closure that flips the WAL keyring to the
+    /// new generation; because the flip happens strictly between sealing the old
+    /// segment and opening the new one, the freshly opened segment's header
+    /// (`ensure_segment_open` re-reads the keyring) and every frame written into
+    /// it use the NEW generation, while the just-sealed segment and all its
+    /// frames stay on the OLD generation — never a split.
+    ///
+    /// The reopened segment's id is `> ` the sealed segment's id, so a subsequent
+    /// [`truncate_to_lsn`](Self::truncate_to_lsn) can drop the just-sealed
+    /// (old-generation) segment. `advance` must NOT acquire any lock ordered
+    /// after `wal` (e.g. it must not trigger a cold flush) — it only mutates the
+    /// in-memory keyring.
+    pub fn seal_active_segment_and_reopen<F: FnOnce()>(&self, advance: F) -> Result<()> {
+        let mut writer_guard = self.writer.lock().unwrap_or_else(|e| e.into_inner());
+        // Ensure there IS an active segment to seal (idempotent: a no-op reopen
+        // if nothing has been written yet still advances the id so the roll
+        // boundary is well-defined).
+        self.ensure_segment_open(&mut writer_guard)?;
+        self.seal_current(&mut writer_guard)?;
+        // Flip the write generation while the old segment is sealed and no new
+        // one is open — the atomic hand-off point.
+        advance();
+        // Open the fresh segment under the (possibly advanced) current generation.
+        self.ensure_segment_open(&mut writer_guard)?;
+        Ok(())
     }
 
     /// Clean up old segments beyond retention policy.
@@ -773,6 +872,19 @@ impl FlushCoordinator {
             let mut batch_min_lsn = u64::MAX;
             let mut batch_max_lsn = 0u64;
 
+            // Resolve the CURRENT WAL DEK cipher once, under the writer lock, so
+            // every entry in this batch is encrypted under the same generation as
+            // the segment header stamped by `ensure_segment_open` above (Issue
+            // #3617). A force-roll advances the keyring's current generation only
+            // while holding this same lock, so a batch can never be split across
+            // two generations.
+            let batch_cipher = self
+                .config
+                .wal_keyring
+                .as_ref()
+                .and_then(|k| k.current())
+                .map(|(cipher, _version)| cipher);
+
             // Write all entries
             {
                 let writer = writer_guard.as_mut().ok_or_else(|| {
@@ -790,8 +902,7 @@ impl FlushCoordinator {
                     // 4-byte LE length prefix so the reader knows how many bytes
                     // each encrypted entry occupies. Without a cipher, write the
                     // raw entry data directly (no allocation, zero overhead).
-                    let write_data: Cow<'_, [u8]> = if let Some(ref cipher) = self.config.wal_cipher
-                    {
+                    let write_data: Cow<'_, [u8]> = if let Some(ref cipher) = batch_cipher {
                         let encrypted = crate::encryption::wal_encryption::encrypt_wal_payload(
                             &entry.data,
                             cipher,
@@ -964,6 +1075,91 @@ impl FlushCoordinator {
     /// Get the WAL directory.
     pub fn wal_dir(&self) -> &Path {
         &self.config.wal_dir
+    }
+
+    /// Delete every sealed old-generation WAL segment during a key rotation
+    /// (Issue #3617), identified by HEADER — a legacy header (no key_version) or
+    /// a keyversioned header whose `key_version != keep_key_version`.
+    ///
+    /// Returns the number of `.log` files removed. The active segment
+    /// (`current_segment_id`) is never removed. Unlike
+    /// [`truncate_to_lsn`](Self::truncate_to_lsn), this does NOT require a
+    /// companion `.meta` file (an un-rotated active segment closed by a prior
+    /// shutdown has none), so it can retire the pre-rotation tail that
+    /// `truncate_to_lsn` would conservatively keep.
+    ///
+    /// # Safety
+    ///
+    /// The caller MUST have already captured every old-generation entry in a
+    /// durable snapshot outside the WAL (the index manifest, persisted BEFORE
+    /// the rotation ledger was written), so deleting these segments loses
+    /// nothing. The forward driver and crash-resume both guarantee this.
+    pub fn retire_old_generation_segments(&self, keep_key_version: u32) -> Result<usize> {
+        let current_id = self.current_segment_id.load(Ordering::Relaxed);
+        let mut removed = 0usize;
+        if let Ok(entries) = std::fs::read_dir(&self.config.wal_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().is_none_or(|ext| ext != "log") {
+                    continue;
+                }
+                let Some(segment_id) = path
+                    .file_stem()
+                    .and_then(|s| s.to_string_lossy().parse::<u64>().ok())
+                else {
+                    continue;
+                };
+                // Never remove the active segment.
+                if segment_id >= current_id {
+                    continue;
+                }
+                let is_old_generation = match Self::read_segment_header_id(&path) {
+                    Some((WAL_VERSION_ENCRYPTED_KEYVERSIONED, Some(kv))) => kv != keep_key_version,
+                    // Legacy header (pre-#3617) = old generation.
+                    Some((_, None)) => true,
+                    // Unreadable/empty header: leave it (defensive).
+                    _ => false,
+                };
+                if is_old_generation && std::fs::remove_file(&path).is_ok() {
+                    removed += 1;
+                    let _ = std::fs::remove_file(self.segment_meta_path(segment_id));
+                }
+            }
+        }
+        Ok(removed)
+    }
+
+    /// Whether EVERY on-disk `.log` segment is a keyversioned (v15) segment
+    /// stamped with `key_version` (Issue #3617).
+    ///
+    /// The rotation driver's "old generation fully retired" signal: it returns
+    /// `false` if any segment carries a legacy header (no key_version — a
+    /// pre-#3617 segment) or a different key_version (an old generation). A file
+    /// whose header cannot be read yet (a freshly created segment whose buffered
+    /// header has not been flushed to disk) is skipped, not treated as old — so
+    /// the just-opened new-generation segment never blocks completion. An empty
+    /// directory trivially satisfies the check.
+    pub fn all_segments_use_key_version(&self, key_version: u32) -> bool {
+        if let Ok(entries) = std::fs::read_dir(&self.config.wal_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().is_none_or(|ext| ext != "log") {
+                    continue;
+                }
+                match Self::read_segment_header_id(&path) {
+                    // A keyversioned segment: old generation iff its version differs.
+                    Some((WAL_VERSION_ENCRYPTED_KEYVERSIONED, Some(kv))) if kv != key_version => {
+                        return false;
+                    }
+                    // A legacy header (no key_version) is a pre-rotation generation.
+                    Some((_, None)) => return false,
+                    // New-generation segment, or an unreadable/not-yet-flushed
+                    // fresh segment header — neither blocks completion.
+                    _ => {}
+                }
+            }
+        }
+        true
     }
 }
 

--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -1120,9 +1120,32 @@ impl FlushCoordinator {
                     // Unreadable/empty header: leave it (defensive).
                     _ => false,
                 };
-                if is_old_generation && std::fs::remove_file(&path).is_ok() {
-                    removed += 1;
-                    let _ = std::fs::remove_file(self.segment_meta_path(segment_id));
+                if is_old_generation {
+                    // DEFECT #3617-PR2: a `remove_file` failure MUST propagate, not
+                    // be swallowed. Swallowing it let the rotation driver report
+                    // success (and clear the ledger) while a stranded old-DEK
+                    // segment remained on disk — after the operator dropped the old
+                    // MEK it could no longer be decrypted, wedging startup and
+                    // leaving the DB permanently unopenable. A NotFound race (the
+                    // file was already removed) is benign and treated as removed;
+                    // any other error propagates so the caller leaves the ledger
+                    // pending for a later resume.
+                    match std::fs::remove_file(&path) {
+                        Ok(()) => {
+                            removed += 1;
+                            let _ = std::fs::remove_file(self.segment_meta_path(segment_id));
+                        }
+                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                            // Already gone (benign race): treat as retired.
+                            let _ = std::fs::remove_file(self.segment_meta_path(segment_id));
+                        }
+                        Err(e) => {
+                            return Err(StorageError::IoError(format!(
+                                "Failed to retire old-generation WAL segment {path:?}: {e}"
+                            ))
+                            .into());
+                        }
+                    }
                 }
             }
         }
@@ -2347,5 +2370,59 @@ mod tests {
         // max() would be 50.
         let min_lsn = coordinator.get_min_lsn();
         assert_eq!(min_lsn, Some(LSN(10)));
+    }
+
+    /// DEFECT #3617-PR2: a real `remove_file` failure during old-generation
+    /// retirement MUST propagate, not be swallowed. Previously a swallowed error
+    /// let the rotation driver report success (and clear the ledger) while a
+    /// stranded old-DEK segment remained on disk — after the old MEK was dropped
+    /// it could no longer be decrypted, wedging startup permanently.
+    #[cfg(unix)]
+    #[test]
+    fn retire_old_generation_propagates_remove_file_errors() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // The read-only-directory injection below relies on DAC permission
+        // checks, which the root user bypasses (unlink still succeeds for uid 0).
+        // Skip under root — the same propagation is exercised end-to-end under any
+        // uid by the rotation-level completion-gating test
+        // (`incomplete_wal_retirement_leaves_ledger_pending_and_no_success`).
+        // SAFETY: `geteuid` is an always-safe libc call with no preconditions.
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path();
+
+        // Coordinator over an (initially empty) dir — no active segment is created
+        // eagerly, so no file collides with our planted old-generation segment.
+        let config = FlushCoordinatorConfig::new(wal_dir);
+        let coordinator = FlushCoordinator::new(config).unwrap();
+        // Make the active id high, so id 0 below is treated as OLD (id < active).
+        coordinator.current_segment_id.store(5, Ordering::Relaxed);
+
+        // Plant a legacy (old-generation) segment header at id 0.
+        let mut hdr = Vec::new();
+        hdr.extend_from_slice(&WAL_MAGIC);
+        hdr.push(WAL_VERSION_STRING_LABELS); // legacy header (no key_version)
+        std::fs::write(wal_dir.join("000000.log"), &hdr).unwrap();
+
+        // Make the directory read-only so `remove_file` fails with PermissionDenied
+        // (removal needs write permission on the parent directory, not the file).
+        let original = std::fs::metadata(wal_dir).unwrap().permissions();
+        let mut ro = original.clone();
+        ro.set_mode(0o500);
+        std::fs::set_permissions(wal_dir, ro).unwrap();
+
+        let result = coordinator.retire_old_generation_segments(2);
+
+        // Restore permissions BEFORE asserting so tempdir cleanup succeeds.
+        std::fs::set_permissions(wal_dir, original).unwrap();
+
+        assert!(
+            result.is_err(),
+            "a real remove_file failure must propagate as Err, not be swallowed"
+        );
     }
 }

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -1032,7 +1032,21 @@ fn read_segment_with_cipher_tolerant(
                 ))
                 .into());
             }
-            let (off, kv) = decode_header_layout(ver, buffer)?;
+            let (off, kv) = match decode_header_layout(ver, buffer) {
+                Ok(layout) => layout,
+                // A keyversioned (v15) header truncated mid-`key_version` (5..9
+                // bytes present) on the FINAL segment, under torn-tail tolerance,
+                // is a crash-torn empty tail — not a hard error. This mirrors the
+                // #3433 torn-tail contract already applied to a torn trailing
+                // ENTRY: without the full 9-byte header there are no decodable
+                // frames, so keep nothing and stop cleanly rather than aborting
+                // recovery on the whole segment.
+                Err(e) if tolerate_torn_tail => {
+                    log_torn_tail_warning(path, WAL_HEADER_SIZE, &e);
+                    return Ok(Vec::new());
+                }
+                Err(e) => return Err(e),
+            };
             (ver, off, kv)
         } else if !buffer.is_empty() {
             // Invalid format: no magic header
@@ -2936,6 +2950,40 @@ mod tests {
         }
     }
 
+    /// NIT #3617-PR2: a keyversioned (v15) header truncated mid-`key_version`
+    /// (5..9 bytes present) on the FINAL segment must be tolerated as an empty
+    /// torn tail under the #3433 contract — not hard-error the whole recovery
+    /// via `decode_header_layout`'s `?` before torn-tail tolerance applies. With
+    /// tolerance disabled it still hard-errors (strict policy).
+    #[test]
+    fn torn_v15_header_on_final_segment_is_tolerated_as_empty_tail() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("0.log");
+        // magic + version(15) + only 2 of the 4 key_version bytes = 7-byte torn header.
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&WAL_MAGIC);
+        bytes.push(WAL_VERSION_ENCRYPTED_KEYVERSIONED);
+        bytes.extend_from_slice(&[0u8, 0u8]); // partial key_version (torn)
+        std::fs::write(&path, &bytes).unwrap();
+        assert_eq!(bytes.len(), 7, "a 5..9-byte v15 header is a torn header");
+
+        let keyring = WalKeyring::single(aes_cipher());
+
+        // Tolerance ON (final segment): the torn header yields an empty tail.
+        let entries = read_entries_from_dir_with_keyring(dir.path(), LSN(1), Some(&keyring), true)
+            .expect("a torn v15 header on the final segment must be tolerated, not hard-error");
+        assert!(
+            entries.is_empty(),
+            "there are no decodable frames without a full 9-byte header"
+        );
+
+        // Tolerance OFF: the same torn header still hard-errors.
+        assert!(
+            read_entries_from_dir_with_keyring(dir.path(), LSN(1), Some(&keyring), false).is_err(),
+            "a torn v15 header must still hard-error when torn-tail tolerance is disabled"
+        );
+    }
+
     #[test]
     fn legacy_v14_segment_replays_under_keyring_old_generation() {
         let dir = TempDir::new().unwrap();
@@ -3049,7 +3097,12 @@ mod tests {
     }
 
     #[test]
-    fn keyversioned_truncated_header_is_rejected() {
+    fn keyversioned_truncated_header_is_rejected_under_strict_policy() {
+        // NIT #3617-PR2: a torn v15 header on the FINAL segment is now TOLERATED
+        // under the #3433 torn-tail contract (see
+        // `torn_v15_header_on_final_segment_is_tolerated_as_empty_tail`). This
+        // test pins the complementary STRICT case: with torn-tail tolerance
+        // DISABLED, the same truncated header still hard-errors.
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("0.log");
         {
@@ -3064,8 +3117,9 @@ mod tests {
         }
         let keyring = WalKeyring::single(aes_cipher());
         assert!(
-            read_entries_from_dir_with_keyring(dir.path(), LSN(1), Some(&keyring), true).is_err(),
-            "a keyversioned header truncated before its key_version must be rejected"
+            read_entries_from_dir_with_keyring(dir.path(), LSN(1), Some(&keyring), false).is_err(),
+            "a keyversioned header truncated before its key_version must be rejected when \
+             torn-tail tolerance is disabled"
         );
     }
 

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -200,8 +200,37 @@ pub(crate) const WAL_VERSION_STRING_LABELS: u8 = 13;
 /// string-label entry format (i.e. [`WAL_VERSION_STRING_LABELS`], Issue #3506).
 pub(crate) const WAL_VERSION_ENCRYPTED_STRING_LABELS: u8 = 14;
 
-/// Maximum supported WAL version (inclusive).
+/// Maximum supported WAL version (inclusive) for the *fixed-length* (5-byte)
+/// header families. The `KEYVERSIONED` container (Issue #3617) is a separate,
+/// variable-length header above this and is bounded by
+/// [`WAL_VERSION_KEYVERSIONED_MAX`].
 const WAL_VERSION_MAX: u8 = WAL_VERSION_ENCRYPTED_STRING_LABELS;
+
+/// WAL format version for encrypted segments that carry a 4-byte `key_version`
+/// in an EXTENDED (9-byte) header, enabling dual-generation full-MEK key
+/// rotation of the WAL layer (Issue #3617).
+///
+/// Header layout (little-endian):
+/// ```text
+///   [magic "GWAL":4][format version:1 = 15][key_version:u32 LE:4][frames…]
+/// ```
+/// (Legacy encrypted/plaintext segments keep the 5-byte header with no
+/// `key_version`.) The decrypted entry payload uses the CURRENT plaintext layout
+/// ([`WAL_VERSION_STRING_LABELS`], via [`payload_version`]); the `key_version`
+/// selects which WAL DEK generation decrypts the frames, so a rotation can write
+/// new appends under a new DEK while legacy segments still replay under the old
+/// one. An older binary rejects this version cleanly ("Unsupported WAL version")
+/// rather than misparsing the extended header.
+pub(crate) const WAL_VERSION_ENCRYPTED_KEYVERSIONED: u8 = WAL_VERSION_MAX + 1;
+
+/// Maximum supported WAL version (inclusive), including the variable-length
+/// `KEYVERSIONED` container (Issue #3617). The `ver > _` reject guards use this
+/// bound so a v15 segment parses instead of being rejected as unsupported.
+const WAL_VERSION_KEYVERSIONED_MAX: u8 = WAL_VERSION_ENCRYPTED_KEYVERSIONED;
+
+/// Number of extra header bytes a [`WAL_VERSION_ENCRYPTED_KEYVERSIONED`] segment
+/// carries beyond the 5-byte legacy header: the 4-byte `key_version` (u32 LE).
+pub(crate) const WAL_KEYVERSION_FIELD_SIZE: usize = 4;
 
 /// Returns `true` if `version` denotes an encrypted segment (the original
 /// encrypted format or one of its provenance/framing-carrying successors).
@@ -214,6 +243,7 @@ fn is_encrypted_version(version: u8) -> bool {
         || version == WAL_VERSION_ENCRYPTED_DELETE_VERSION_ID
         || version == WAL_VERSION_ENCRYPTED_DESTRUCTIVE_PROVENANCE
         || version == WAL_VERSION_ENCRYPTED_STRING_LABELS
+        || version == WAL_VERSION_ENCRYPTED_KEYVERSIONED
 }
 
 /// Returns `true` if `version` (a plaintext/payload version) supports the
@@ -275,7 +305,86 @@ fn payload_version(version: u8) -> u8 {
         WAL_VERSION_ENCRYPTED_DELETE_VERSION_ID => WAL_VERSION_DELETE_VERSION_ID,
         WAL_VERSION_ENCRYPTED_DESTRUCTIVE_PROVENANCE => WAL_VERSION_DESTRUCTIVE_PROVENANCE,
         WAL_VERSION_ENCRYPTED_STRING_LABELS => WAL_VERSION_STRING_LABELS,
+        // The keyversioned container (Issue #3617) only prefixes a key_version
+        // to the header; its decrypted entry payload uses the CURRENT plaintext
+        // layout, exactly like WAL_VERSION_ENCRYPTED_STRING_LABELS.
+        WAL_VERSION_ENCRYPTED_KEYVERSIONED => WAL_VERSION_STRING_LABELS,
         v => v,
+    }
+}
+
+/// The `WAL_VERSION_ENCRYPTED_KEYVERSIONED` header length (Issue #3617): the
+/// 5-byte legacy header plus the 4-byte `key_version`.
+pub(crate) const WAL_KEYVERSIONED_HEADER_SIZE: usize = WAL_HEADER_SIZE + WAL_KEYVERSION_FIELD_SIZE;
+
+/// Decode the segment header layout for a known-supported `version`.
+///
+/// Returns `(header_len, key_version)` — the number of leading header bytes
+/// before the first entry frame, and the stamped `key_version` for a
+/// [`WAL_VERSION_ENCRYPTED_KEYVERSIONED`] (v15) segment (`None` for every legacy
+/// 5-byte header). `buffer` must already have passed the magic + version-bound
+/// checks. Errors only when a v15 header is truncated before its 4-byte
+/// `key_version`.
+fn decode_header_layout(version: u8, buffer: &[u8]) -> Result<(usize, Option<u32>)> {
+    if version == WAL_VERSION_ENCRYPTED_KEYVERSIONED {
+        if buffer.len() < WAL_KEYVERSIONED_HEADER_SIZE {
+            return Err(StorageError::CorruptedData(
+                "Keyversioned WAL segment header truncated before key_version".to_string(),
+            )
+            .into());
+        }
+        let kv = u32::from_le_bytes([buffer[5], buffer[6], buffer[7], buffer[8]]);
+        Ok((WAL_KEYVERSIONED_HEADER_SIZE, Some(kv)))
+    } else {
+        Ok((WAL_HEADER_SIZE, None))
+    }
+}
+
+/// How a caller supplies WAL DEK ciphers to the segment reader (Issue #3617).
+///
+/// Recovery must decrypt each segment under the WAL DEK generation named by its
+/// header `key_version`; during a full-MEK rotation two generations are live at
+/// once. This resolver lets the reader select the right cipher per segment while
+/// keeping the legacy single-cipher entry points (`Option<&Arc<dyn Cipher>>`)
+/// working unchanged.
+pub enum WalCipherSource<'a> {
+    /// Plaintext WAL — no cipher.
+    None,
+    /// A single cipher used for every segment regardless of `key_version`
+    /// (the never-rotated / legacy single-generation callers).
+    Single(&'a Arc<dyn crate::encryption::cipher::Cipher>),
+    /// A multi-generation keyring: legacy segments resolve to the pre-rotation
+    /// (oldest) generation, keyversioned segments to the named generation.
+    Keyring(&'a crate::encryption::wal_encryption::WalKeyring),
+}
+
+impl WalCipherSource<'_> {
+    /// Whether any cipher material is present (an encrypted segment cannot be
+    /// read when this is `false`).
+    fn is_present(&self) -> bool {
+        !matches!(self, WalCipherSource::None)
+    }
+
+    /// Resolve the decryption cipher for a segment, given the `key_version` read
+    /// from its header (`None` for a legacy segment carrying no key-version).
+    fn resolve(
+        &self,
+        key_version: Option<u32>,
+    ) -> Option<Arc<dyn crate::encryption::cipher::Cipher>> {
+        match self {
+            WalCipherSource::None => None,
+            WalCipherSource::Single(c) => Some((*c).clone()),
+            WalCipherSource::Keyring(k) => k.cipher_for_segment(key_version),
+        }
+    }
+}
+
+impl<'a> From<Option<&'a Arc<dyn crate::encryption::cipher::Cipher>>> for WalCipherSource<'a> {
+    fn from(cipher: Option<&'a Arc<dyn crate::encryption::cipher::Cipher>>) -> Self {
+        match cipher {
+            Some(c) => WalCipherSource::Single(c),
+            None => WalCipherSource::None,
+        }
     }
 }
 
@@ -412,6 +521,36 @@ pub fn read_entries_from_dir_with_options(
     cipher: Option<&Arc<dyn crate::encryption::cipher::Cipher>>,
     tolerate_torn_tail: bool,
 ) -> Result<Vec<WalEntry>> {
+    read_entries_from_dir_with_source(wal_dir, start_lsn, &cipher.into(), tolerate_torn_tail)
+}
+
+/// Read all WAL entries from a directory using a multi-generation
+/// [`WalKeyring`](crate::encryption::wal_encryption::WalKeyring) (Issue #3617).
+///
+/// The dual-generation recovery entry point: a directory holding both old-DEK
+/// (legacy or keyversioned) segments and new-DEK keyversioned segments — the
+/// mixed state an in-flight full-MEK WAL rotation leaves — decrypts every
+/// segment under the WAL DEK generation its header names. `None` reads a
+/// plaintext WAL exactly like the single-cipher path with `None`.
+pub fn read_entries_from_dir_with_keyring(
+    wal_dir: &Path,
+    start_lsn: LSN,
+    keyring: Option<&crate::encryption::wal_encryption::WalKeyring>,
+    tolerate_torn_tail: bool,
+) -> Result<Vec<WalEntry>> {
+    let source = match keyring {
+        Some(k) => WalCipherSource::Keyring(k),
+        None => WalCipherSource::None,
+    };
+    read_entries_from_dir_with_source(wal_dir, start_lsn, &source, tolerate_torn_tail)
+}
+
+fn read_entries_from_dir_with_source(
+    wal_dir: &Path,
+    start_lsn: LSN,
+    source: &WalCipherSource<'_>,
+    tolerate_torn_tail: bool,
+) -> Result<Vec<WalEntry>> {
     let mut entries = Vec::new();
 
     // Only the FINAL segment is allowed to tolerate a torn trailing entry, and
@@ -421,7 +560,7 @@ pub fn read_entries_from_dir_with_options(
     for (i, (_, path)) in segment_paths.iter().enumerate() {
         let segment_tolerates = tolerate_torn_tail && i == last_idx;
         let segment_entries =
-            read_segment_with_cipher_tolerant(path, start_lsn, cipher, segment_tolerates)?;
+            read_segment_with_cipher_tolerant(path, start_lsn, source, segment_tolerates)?;
         entries.extend(segment_entries);
     }
 
@@ -575,16 +714,29 @@ fn max_lsn_in_segment(
     // it with a warning cannot under-seed relative to what replay applies —
     // and it keeps the constructor usable when e.g. another process is
     // mid-way through creating a segment in a shared WAL directory.
-    let (version, offset) = if buffer.len() >= WAL_HEADER_SIZE && buffer[0..4] == WAL_MAGIC {
+    let (version, offset, key_version) = if buffer.len() >= WAL_HEADER_SIZE
+        && buffer[0..4] == WAL_MAGIC
+    {
         let ver = buffer[4];
-        if ver > WAL_VERSION_MAX {
+        if ver > WAL_VERSION_KEYVERSIONED_MAX {
             log_scan_warning(&format!(
                 "Skipping WAL segment {:?} with unsupported version {} (max {}) during LSN seeding scan",
-                path, ver, WAL_VERSION_MAX
+                path, ver, WAL_VERSION_KEYVERSIONED_MAX
             ));
             return Ok(None);
         }
-        (ver, WAL_HEADER_SIZE)
+        match decode_header_layout(ver, buffer) {
+            Ok((off, kv)) => (ver, off, kv),
+            Err(_) => {
+                // A keyversioned header truncated before its key_version is a
+                // torn brand-new segment; it contributes no decodable LSNs.
+                log_scan_warning(&format!(
+                    "Skipping WAL segment {:?} with a truncated keyversioned header during LSN seeding scan",
+                    path
+                ));
+                return Ok(None);
+            }
+        }
     } else {
         log_scan_warning(&format!(
             "Skipping WAL segment {:?} without a valid GWAL header during LSN seeding scan",
@@ -594,7 +746,12 @@ fn max_lsn_in_segment(
     };
 
     if is_encrypted_version(version) {
-        let Some(cipher) = cipher else {
+        // The seeding scan uses the single configured cipher for every segment
+        // (Single/None semantics). A missing/mismatched generation just skips
+        // the segment — the index-manifest LSN floor is the second seed and any
+        // old-generation tail is truncated once the rotation completes.
+        let source: WalCipherSource<'_> = cipher.into();
+        let Some(cipher) = source.resolve(key_version) else {
             log_scan_warning(&format!(
                 "Skipping encrypted WAL segment {:?} (version {}) during LSN seeding scan: no cipher configured",
                 path, version
@@ -602,7 +759,7 @@ fn max_lsn_in_segment(
             return Ok(None);
         };
         Ok(scan_encrypted_max_lsn(
-            buffer, offset, cipher, path, version,
+            buffer, offset, &cipher, path, version,
         ))
     } else {
         Ok(scan_plaintext_max_lsn(buffer, offset, version, path))
@@ -790,7 +947,7 @@ pub fn read_segment_with_cipher(
     // entry hard-errors, exactly as before. Only the recovery dir-reader
     // (`read_entries_from_dir_with_cipher`) opts the FINAL segment into
     // torn-tail tolerance (Issue #3413).
-    read_segment_with_cipher_tolerant(path, start_lsn, cipher, false)
+    read_segment_with_cipher_tolerant(path, start_lsn, &cipher.into(), false)
 }
 
 /// Read WAL entries from a single segment, optionally tolerating a torn
@@ -806,7 +963,7 @@ pub fn read_segment_with_cipher(
 fn read_segment_with_cipher_tolerant(
     path: &Path,
     start_lsn: LSN,
-    cipher: Option<&Arc<dyn crate::encryption::cipher::Cipher>>,
+    source: &WalCipherSource<'_>,
     tolerate_torn_tail: bool,
 ) -> Result<Vec<WalEntry>> {
     // Open file, only treating NotFound as "empty" - all other errors are propagated
@@ -861,41 +1018,65 @@ fn read_segment_with_cipher_tolerant(
     let capacity_hint = (buffer.len() / 128).max(1);
     let mut entries = Vec::with_capacity(capacity_hint);
 
-    // Detect WAL format version
-    let (version, mut offset) = if buffer.len() >= WAL_HEADER_SIZE && buffer[0..4] == WAL_MAGIC {
-        // Version 1+ format: has magic header
-        let ver = buffer[4];
-        if ver > WAL_VERSION_MAX {
-            return Err(StorageError::CorruptedData(format!(
-                "Unsupported WAL version: {} (max supported: {})",
-                ver, WAL_VERSION_MAX
-            ))
+    // Detect WAL format version and header layout (Issue #3617: a v15
+    // KEYVERSIONED segment carries a 9-byte header with a trailing key_version;
+    // all legacy families use the 5-byte header).
+    let (version, mut offset, key_version) =
+        if buffer.len() >= WAL_HEADER_SIZE && buffer[0..4] == WAL_MAGIC {
+            // Version 1+ format: has magic header
+            let ver = buffer[4];
+            if ver > WAL_VERSION_KEYVERSIONED_MAX {
+                return Err(StorageError::CorruptedData(format!(
+                    "Unsupported WAL version: {} (max supported: {})",
+                    ver, WAL_VERSION_KEYVERSIONED_MAX
+                ))
+                .into());
+            }
+            let (off, kv) = decode_header_layout(ver, buffer)?;
+            (ver, off, kv)
+        } else if !buffer.is_empty() {
+            // Invalid format: no magic header
+            return Err(StorageError::CorruptedData(
+                "Invalid WAL segment: missing GWAL magic header".to_string(),
+            )
             .into());
-        }
-        (ver, WAL_HEADER_SIZE)
-    } else if !buffer.is_empty() {
-        // Invalid format: no magic header
-        return Err(StorageError::CorruptedData(
-            "Invalid WAL segment: missing GWAL magic header".to_string(),
-        )
-        .into());
-    } else {
-        return Ok(Vec::new()); // Empty segment
-    };
+        } else {
+            return Ok(Vec::new()); // Empty segment
+        };
 
-    // Encrypted segments (versions 2/4/6/8) require a cipher for decryption.
-    if is_encrypted_version(version) && cipher.is_none() {
-        return Err(StorageError::Encryption(format!(
-            "Cannot read encrypted WAL segment (version {}) without a cipher",
-            version
-        ))
-        .into());
-    }
+    // Encrypted segments require a WAL DEK. Resolve the right generation for
+    // this segment's key_version up front (legacy segments -> pre-rotation
+    // generation); a missing cipher/generation is a loud error, never silent
+    // wrong data. Only the integer version numbers are named — never key bytes.
+    let resolved_cipher = if is_encrypted_version(version) {
+        match source.resolve(key_version) {
+            Some(c) => Some(c),
+            None if source.is_present() => {
+                return Err(StorageError::Encryption(format!(
+                    "Cannot read encrypted WAL segment (version {}, key_version {:?}): \
+                     no matching WAL DEK generation available",
+                    version, key_version
+                ))
+                .into());
+            }
+            None => {
+                return Err(StorageError::Encryption(format!(
+                    "Cannot read encrypted WAL segment (version {}) without a cipher",
+                    version
+                ))
+                .into());
+            }
+        }
+    } else {
+        None
+    };
 
     // Dispatch to the appropriate parsing loop based on version.
     if is_encrypted_version(version) {
-        // Encrypted (2/4/6/8): length-prefixed encrypted entries.
-        let cipher = cipher.expect("cipher presence checked above");
+        // Encrypted: length-prefixed encrypted entries.
+        let cipher = resolved_cipher
+            .as_ref()
+            .expect("cipher presence checked above");
         parse_encrypted_entries(
             buffer,
             &mut offset,
@@ -2698,6 +2879,193 @@ mod tests {
         assert!(
             read_entries_from_dir_with_cipher(dir.path(), LSN(1), Some(&cipher)).is_err(),
             "an undecodable encrypted frame followed by a valid frame is mid-log corruption"
+        );
+    }
+
+    // ---- Issue #3617: keyversioned (v15) segments & dual-generation replay ----
+
+    use crate::encryption::wal_encryption::WalKeyring;
+
+    /// A second, distinct AES cipher (different fixed key) — the "new DEK" of a
+    /// rotation. Decrypting an [`aes_cipher`]-encrypted frame with this must fail.
+    fn aes_cipher_new() -> Arc<dyn crate::encryption::cipher::Cipher> {
+        use zeroize::Zeroizing;
+        let key = Zeroizing::new([9u8; 32]);
+        Arc::new(crate::encryption::Aes256GcmCipher::new(&key))
+    }
+
+    /// Write a keyversioned (v15) 9-byte header: magic + version + key_version(LE).
+    fn write_keyversioned_header(path: &Path, key_version: u32) {
+        use std::io::Write;
+        let mut file = File::create(path).unwrap();
+        file.write_all(&WAL_MAGIC).unwrap();
+        file.write_all(&[WAL_VERSION_ENCRYPTED_KEYVERSIONED])
+            .unwrap();
+        file.write_all(&key_version.to_le_bytes()).unwrap();
+        file.sync_all().unwrap();
+    }
+
+    #[test]
+    fn keyversioned_v15_segment_roundtrips_via_keyring() {
+        let dir = TempDir::new().unwrap();
+        let new_dek = aes_cipher_new();
+        let path = dir.path().join("0.log");
+        // v15 segment stamped key_version=2, frames encrypted under the new DEK.
+        write_keyversioned_header(&path, 2);
+        append_bytes(&path, &encrypted_frame(5, &new_dek));
+        append_bytes(&path, &encrypted_frame(7, &new_dek));
+
+        // Keyring with the new DEK at generation 2 (and an unrelated old DEK at 1).
+        let keyring = WalKeyring::single(aes_cipher());
+        keyring.add_generation(2, Arc::clone(&new_dek));
+
+        let entries = read_entries_from_dir_with_keyring(dir.path(), LSN(1), Some(&keyring), true)
+            .expect("v15 keyversioned segment must decrypt under its generation");
+        let lsns: Vec<u64> = entries.iter().map(|e| e.lsn.0).collect();
+        assert_eq!(lsns, vec![5, 7]);
+        // The 9-byte header offset must be honored: labels decode correctly.
+        for e in &entries {
+            match &e.operation {
+                WalOperation::CreateNode { label, .. } => assert!(
+                    GLOBAL_INTERNER
+                        .resolve_with(*label, |s| s == "TornTail3433")
+                        .unwrap()
+                ),
+                other => panic!("expected CreateNode, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn legacy_v14_segment_replays_under_keyring_old_generation() {
+        let dir = TempDir::new().unwrap();
+        let old_dek = aes_cipher();
+        let path = dir.path().join("0.log");
+        // Legacy v14 (5-byte header, no key_version), old DEK.
+        write_encrypted_header(&path);
+        append_bytes(&path, &encrypted_frame(3, &old_dek));
+
+        // Post-rotation keyring: old DEK is the pre-rotation (min) generation; a
+        // legacy segment with no key_version must resolve to it.
+        let keyring = WalKeyring::single(Arc::clone(&old_dek));
+        keyring.add_generation(2, aes_cipher_new());
+
+        let entries = read_entries_from_dir_with_keyring(dir.path(), LSN(1), Some(&keyring), true)
+            .expect("legacy v14 segment must replay under the pre-rotation generation");
+        assert_eq!(entries.iter().map(|e| e.lsn.0).collect::<Vec<_>>(), vec![3]);
+    }
+
+    /// The core mixed-generation replay: a WAL directory holding an OLD-DEK
+    /// legacy segment AND a NEW-DEK keyversioned segment recovers every entry —
+    /// old segments via the old DEK, new via the new — under one two-generation
+    /// keyring. Models `mixed_plaintext_and_encrypted_wal_segments_recover`.
+    #[test]
+    fn mixed_generation_wal_dir_recovers_all_entries() {
+        let dir = TempDir::new().unwrap();
+        let old_dek = aes_cipher();
+        let new_dek = aes_cipher_new();
+
+        // 0.log: legacy v14 under the OLD DEK.
+        let seg0 = dir.path().join("0.log");
+        write_encrypted_header(&seg0);
+        append_bytes(&seg0, &encrypted_frame(1, &old_dek));
+        append_bytes(&seg0, &encrypted_frame(2, &old_dek));
+
+        // 1.log: keyversioned v15 (key_version=2) under the NEW DEK.
+        let seg1 = dir.path().join("1.log");
+        write_keyversioned_header(&seg1, 2);
+        append_bytes(&seg1, &encrypted_frame(3, &new_dek));
+        append_bytes(&seg1, &encrypted_frame(4, &new_dek));
+
+        let keyring = WalKeyring::single(Arc::clone(&old_dek));
+        keyring.add_generation(2, Arc::clone(&new_dek));
+
+        let entries = read_entries_from_dir_with_keyring(dir.path(), LSN(1), Some(&keyring), true)
+            .expect("mixed old-DEK/new-DEK directory must recover all entries");
+        assert_eq!(
+            entries.iter().map(|e| e.lsn.0).collect::<Vec<_>>(),
+            vec![1, 2, 3, 4],
+            "every entry across both generations must be recovered, in LSN order"
+        );
+    }
+
+    #[test]
+    fn keyversioned_segment_wrong_generation_key_fails_loudly() {
+        let dir = TempDir::new().unwrap();
+        let new_dek = aes_cipher_new();
+        let path = dir.path().join("0.log");
+        write_keyversioned_header(&path, 2);
+        append_bytes(&path, &encrypted_frame(5, &new_dek));
+
+        // Keyring holds generation 2, but bound to the WRONG (old) cipher: AEAD
+        // authentication must fail rather than silently returning wrong data.
+        let keyring = WalKeyring::single(aes_cipher());
+        keyring.add_generation(2, aes_cipher()); // same old key, not new_dek
+        assert!(
+            read_entries_from_dir_with_keyring(dir.path(), LSN(1), Some(&keyring), false).is_err(),
+            "a v15 segment decrypted with the wrong generation key must fail loudly"
+        );
+    }
+
+    #[test]
+    fn keyversioned_segment_missing_generation_is_rejected() {
+        let dir = TempDir::new().unwrap();
+        let new_dek = aes_cipher_new();
+        let path = dir.path().join("0.log");
+        write_keyversioned_header(&path, 5); // key_version 5 not in the keyring
+        append_bytes(&path, &encrypted_frame(5, &new_dek));
+
+        let keyring = WalKeyring::single(aes_cipher());
+        keyring.add_generation(2, aes_cipher_new());
+        let err = read_entries_from_dir_with_keyring(dir.path(), LSN(1), Some(&keyring), true)
+            .expect_err("a segment naming an unheld key_version must be rejected");
+        // Error names the version numbers only — never key material.
+        let msg = err.to_string();
+        assert!(msg.contains("key_version"), "got: {msg}");
+    }
+
+    #[test]
+    fn unknown_version_beyond_keyversioned_max_is_rejected() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("0.log");
+        {
+            use std::io::Write;
+            let mut file = File::create(&path).unwrap();
+            file.write_all(&WAL_MAGIC).unwrap();
+            // A version one past the keyversioned max — an "older binary rejects
+            // a future format cleanly" guard.
+            file.write_all(&[WAL_VERSION_KEYVERSIONED_MAX + 1]).unwrap();
+            file.write_all(&[0u8; 32]).unwrap();
+            file.sync_all().unwrap();
+        }
+        let keyring = WalKeyring::single(aes_cipher());
+        let err = read_entries_from_dir_with_keyring(dir.path(), LSN(1), Some(&keyring), true)
+            .expect_err("a version beyond the supported max must be rejected");
+        assert!(
+            err.to_string().contains("Unsupported WAL version"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn keyversioned_truncated_header_is_rejected() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("0.log");
+        {
+            use std::io::Write;
+            let mut file = File::create(&path).unwrap();
+            file.write_all(&WAL_MAGIC).unwrap();
+            file.write_all(&[WAL_VERSION_ENCRYPTED_KEYVERSIONED])
+                .unwrap();
+            // Only 2 of the 4 key_version bytes: a torn brand-new segment header.
+            file.write_all(&[0u8, 0u8]).unwrap();
+            file.sync_all().unwrap();
+        }
+        let keyring = WalKeyring::single(aes_cipher());
+        assert!(
+            read_entries_from_dir_with_keyring(dir.path(), LSN(1), Some(&keyring), true).is_err(),
+            "a keyversioned header truncated before its key_version must be rejected"
         );
     }
 

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -212,7 +212,7 @@ const WAL_VERSION_MAX: u8 = WAL_VERSION_ENCRYPTED_STRING_LABELS;
 ///
 /// Header layout (little-endian):
 /// ```text
-///   [magic "GWAL":4][format version:1 = 15][key_version:u32 LE:4][frames…]
+///   [magic "GWAL":4][format version:1 = 16][key_version:u32 LE:4][frames…]
 /// ```
 /// (Legacy encrypted/plaintext segments keep the 5-byte header with no
 /// `key_version`.) The decrypted entry payload uses the CURRENT plaintext layout
@@ -221,16 +221,45 @@ const WAL_VERSION_MAX: u8 = WAL_VERSION_ENCRYPTED_STRING_LABELS;
 /// new appends under a new DEK while legacy segments still replay under the old
 /// one. An older binary rejects this version cleanly ("Unsupported WAL version")
 /// rather than misparsing the extended header.
-pub(crate) const WAL_VERSION_ENCRYPTED_KEYVERSIONED: u8 = WAL_VERSION_MAX + 1;
+///
+/// # Version-byte parity invariant
+///
+/// Encrypted WAL versions are EVEN by contract (2,4,…,14) and plaintext ones
+/// ODD (1,3,…,13); the encrypted-segment recovery tests assert every encrypted
+/// segment's version byte is even. `WAL_VERSION_MAX + 1` (15) is ODD, so this
+/// keyversioned *encrypted* container uses `WAL_VERSION_MAX + 2` (= 16, even)
+/// to preserve that invariant. Version 15 was never written to disk (this
+/// container is unreleased), so it stays an unused reserved gap between
+/// `WAL_VERSION_MAX` (14) and this value — a v15 segment is correctly rejected
+/// as an unsupported/unknown version.
+pub(crate) const WAL_VERSION_ENCRYPTED_KEYVERSIONED: u8 = WAL_VERSION_MAX + 2;
 
 /// Maximum supported WAL version (inclusive), including the variable-length
-/// `KEYVERSIONED` container (Issue #3617). The `ver > _` reject guards use this
-/// bound so a v15 segment parses instead of being rejected as unsupported.
+/// `KEYVERSIONED` container (Issue #3617). Used only in the "max supported"
+/// diagnostic on the unsupported-version reject; the actual accept/reject
+/// decision is [`is_supported_segment_version`], which additionally rejects the
+/// v15 gap between `WAL_VERSION_MAX` (14) and the keyversioned container (16).
 const WAL_VERSION_KEYVERSIONED_MAX: u8 = WAL_VERSION_ENCRYPTED_KEYVERSIONED;
 
 /// Number of extra header bytes a [`WAL_VERSION_ENCRYPTED_KEYVERSIONED`] segment
 /// carries beyond the 5-byte legacy header: the 4-byte `key_version` (u32 LE).
 pub(crate) const WAL_KEYVERSION_FIELD_SIZE: usize = 4;
+
+/// Returns `true` if `ver` is a WAL segment format version this build can
+/// decode.
+///
+/// Supported versions are the contiguous fixed-header families
+/// `1..=WAL_VERSION_MAX` (14) plus the variable-header keyversioned container
+/// [`WAL_VERSION_ENCRYPTED_KEYVERSIONED`] (16). Renumbering the keyversioned
+/// container from 15 to 16 — to preserve the encrypted-versions-are-EVEN parity
+/// invariant (Issue #3617) — leaves **15 an unused reserved gap** with no
+/// defined on-disk format; a v15 segment is therefore rejected as unsupported,
+/// exactly like any version above the max. (No writer ever emits v15, so this
+/// only guards against corruption or a forward-incompatible file.)
+#[inline]
+fn is_supported_segment_version(ver: u8) -> bool {
+    ver <= WAL_VERSION_MAX || ver == WAL_VERSION_ENCRYPTED_KEYVERSIONED
+}
 
 /// Returns `true` if `version` denotes an encrypted segment (the original
 /// encrypted format or one of its provenance/framing-carrying successors).
@@ -321,9 +350,9 @@ pub(crate) const WAL_KEYVERSIONED_HEADER_SIZE: usize = WAL_HEADER_SIZE + WAL_KEY
 ///
 /// Returns `(header_len, key_version)` — the number of leading header bytes
 /// before the first entry frame, and the stamped `key_version` for a
-/// [`WAL_VERSION_ENCRYPTED_KEYVERSIONED`] (v15) segment (`None` for every legacy
+/// [`WAL_VERSION_ENCRYPTED_KEYVERSIONED`] (v16) segment (`None` for every legacy
 /// 5-byte header). `buffer` must already have passed the magic + version-bound
-/// checks. Errors only when a v15 header is truncated before its 4-byte
+/// checks. Errors only when a v16 header is truncated before its 4-byte
 /// `key_version`.
 fn decode_header_layout(version: u8, buffer: &[u8]) -> Result<(usize, Option<u32>)> {
     if version == WAL_VERSION_ENCRYPTED_KEYVERSIONED {
@@ -718,7 +747,7 @@ fn max_lsn_in_segment(
         && buffer[0..4] == WAL_MAGIC
     {
         let ver = buffer[4];
-        if ver > WAL_VERSION_KEYVERSIONED_MAX {
+        if !is_supported_segment_version(ver) {
             log_scan_warning(&format!(
                 "Skipping WAL segment {:?} with unsupported version {} (max {}) during LSN seeding scan",
                 path, ver, WAL_VERSION_KEYVERSIONED_MAX
@@ -1018,14 +1047,14 @@ fn read_segment_with_cipher_tolerant(
     let capacity_hint = (buffer.len() / 128).max(1);
     let mut entries = Vec::with_capacity(capacity_hint);
 
-    // Detect WAL format version and header layout (Issue #3617: a v15
+    // Detect WAL format version and header layout (Issue #3617: a v16
     // KEYVERSIONED segment carries a 9-byte header with a trailing key_version;
     // all legacy families use the 5-byte header).
     let (version, mut offset, key_version) =
         if buffer.len() >= WAL_HEADER_SIZE && buffer[0..4] == WAL_MAGIC {
             // Version 1+ format: has magic header
             let ver = buffer[4];
-            if ver > WAL_VERSION_KEYVERSIONED_MAX {
+            if !is_supported_segment_version(ver) {
                 return Err(StorageError::CorruptedData(format!(
                     "Unsupported WAL version: {} (max supported: {})",
                     ver, WAL_VERSION_KEYVERSIONED_MAX
@@ -1034,7 +1063,7 @@ fn read_segment_with_cipher_tolerant(
             }
             let (off, kv) = match decode_header_layout(ver, buffer) {
                 Ok(layout) => layout,
-                // A keyversioned (v15) header truncated mid-`key_version` (5..9
+                // A keyversioned (v16) header truncated mid-`key_version` (5..9
                 // bytes present) on the FINAL segment, under torn-tail tolerance,
                 // is a crash-torn empty tail — not a hard error. This mirrors the
                 // #3433 torn-tail contract already applied to a torn trailing
@@ -2896,7 +2925,7 @@ mod tests {
         );
     }
 
-    // ---- Issue #3617: keyversioned (v15) segments & dual-generation replay ----
+    // ---- Issue #3617: keyversioned (v16) segments & dual-generation replay ----
 
     use crate::encryption::wal_encryption::WalKeyring;
 
@@ -2908,7 +2937,7 @@ mod tests {
         Arc::new(crate::encryption::Aes256GcmCipher::new(&key))
     }
 
-    /// Write a keyversioned (v15) 9-byte header: magic + version + key_version(LE).
+    /// Write a keyversioned (v16) 9-byte header: magic + version + key_version(LE).
     fn write_keyversioned_header(path: &Path, key_version: u32) {
         use std::io::Write;
         let mut file = File::create(path).unwrap();
@@ -2920,11 +2949,11 @@ mod tests {
     }
 
     #[test]
-    fn keyversioned_v15_segment_roundtrips_via_keyring() {
+    fn keyversioned_v16_segment_roundtrips_via_keyring() {
         let dir = TempDir::new().unwrap();
         let new_dek = aes_cipher_new();
         let path = dir.path().join("0.log");
-        // v15 segment stamped key_version=2, frames encrypted under the new DEK.
+        // v16 segment stamped key_version=2, frames encrypted under the new DEK.
         write_keyversioned_header(&path, 2);
         append_bytes(&path, &encrypted_frame(5, &new_dek));
         append_bytes(&path, &encrypted_frame(7, &new_dek));
@@ -2934,7 +2963,7 @@ mod tests {
         keyring.add_generation(2, Arc::clone(&new_dek));
 
         let entries = read_entries_from_dir_with_keyring(dir.path(), LSN(1), Some(&keyring), true)
-            .expect("v15 keyversioned segment must decrypt under its generation");
+            .expect("v16 keyversioned segment must decrypt under its generation");
         let lsns: Vec<u64> = entries.iter().map(|e| e.lsn.0).collect();
         assert_eq!(lsns, vec![5, 7]);
         // The 9-byte header offset must be honored: labels decode correctly.
@@ -2950,28 +2979,28 @@ mod tests {
         }
     }
 
-    /// NIT #3617-PR2: a keyversioned (v15) header truncated mid-`key_version`
+    /// NIT #3617-PR2: a keyversioned (v16) header truncated mid-`key_version`
     /// (5..9 bytes present) on the FINAL segment must be tolerated as an empty
     /// torn tail under the #3433 contract — not hard-error the whole recovery
     /// via `decode_header_layout`'s `?` before torn-tail tolerance applies. With
     /// tolerance disabled it still hard-errors (strict policy).
     #[test]
-    fn torn_v15_header_on_final_segment_is_tolerated_as_empty_tail() {
+    fn torn_v16_header_on_final_segment_is_tolerated_as_empty_tail() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("0.log");
-        // magic + version(15) + only 2 of the 4 key_version bytes = 7-byte torn header.
+        // magic + version(16) + only 2 of the 4 key_version bytes = 7-byte torn header.
         let mut bytes = Vec::new();
         bytes.extend_from_slice(&WAL_MAGIC);
         bytes.push(WAL_VERSION_ENCRYPTED_KEYVERSIONED);
         bytes.extend_from_slice(&[0u8, 0u8]); // partial key_version (torn)
         std::fs::write(&path, &bytes).unwrap();
-        assert_eq!(bytes.len(), 7, "a 5..9-byte v15 header is a torn header");
+        assert_eq!(bytes.len(), 7, "a 5..9-byte v16 header is a torn header");
 
         let keyring = WalKeyring::single(aes_cipher());
 
         // Tolerance ON (final segment): the torn header yields an empty tail.
         let entries = read_entries_from_dir_with_keyring(dir.path(), LSN(1), Some(&keyring), true)
-            .expect("a torn v15 header on the final segment must be tolerated, not hard-error");
+            .expect("a torn v16 header on the final segment must be tolerated, not hard-error");
         assert!(
             entries.is_empty(),
             "there are no decodable frames without a full 9-byte header"
@@ -2980,7 +3009,7 @@ mod tests {
         // Tolerance OFF: the same torn header still hard-errors.
         assert!(
             read_entries_from_dir_with_keyring(dir.path(), LSN(1), Some(&keyring), false).is_err(),
-            "a torn v15 header must still hard-error when torn-tail tolerance is disabled"
+            "a torn v16 header must still hard-error when torn-tail tolerance is disabled"
         );
     }
 
@@ -3019,7 +3048,7 @@ mod tests {
         append_bytes(&seg0, &encrypted_frame(1, &old_dek));
         append_bytes(&seg0, &encrypted_frame(2, &old_dek));
 
-        // 1.log: keyversioned v15 (key_version=2) under the NEW DEK.
+        // 1.log: keyversioned v16 (key_version=2) under the NEW DEK.
         let seg1 = dir.path().join("1.log");
         write_keyversioned_header(&seg1, 2);
         append_bytes(&seg1, &encrypted_frame(3, &new_dek));
@@ -3051,7 +3080,7 @@ mod tests {
         keyring.add_generation(2, aes_cipher()); // same old key, not new_dek
         assert!(
             read_entries_from_dir_with_keyring(dir.path(), LSN(1), Some(&keyring), false).is_err(),
-            "a v15 segment decrypted with the wrong generation key must fail loudly"
+            "a v16 segment decrypted with the wrong generation key must fail loudly"
         );
     }
 
@@ -3097,10 +3126,46 @@ mod tests {
     }
 
     #[test]
+    fn v15_reserved_gap_version_is_rejected() {
+        // Issue #3617: renumbering the keyversioned container from 15 to 16
+        // (encrypted versions are EVEN by contract) leaves 15 an unused reserved
+        // gap with no defined on-disk format. A segment stamped v15 — never
+        // written by any writer — must be rejected as unsupported, not silently
+        // parsed as a legacy 5-byte-header plaintext segment.
+        assert_eq!(
+            WAL_VERSION_ENCRYPTED_KEYVERSIONED, 16,
+            "keyversioned container must be even (16), not odd (15)"
+        );
+        assert!(
+            !is_supported_segment_version(15),
+            "v15 is a reserved gap and must not be a supported version"
+        );
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("0.log");
+        {
+            use std::io::Write;
+            let mut file = File::create(&path).unwrap();
+            file.write_all(&WAL_MAGIC).unwrap();
+            file.write_all(&[15u8]).unwrap(); // the reserved gap version
+            file.write_all(&[0u8; 32]).unwrap();
+            file.sync_all().unwrap();
+        }
+        let keyring = WalKeyring::single(aes_cipher());
+        let err = read_entries_from_dir_with_keyring(dir.path(), LSN(1), Some(&keyring), true)
+            .expect_err("a v15 reserved-gap segment must be rejected");
+        assert!(
+            err.to_string().contains("Unsupported WAL version"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
     fn keyversioned_truncated_header_is_rejected_under_strict_policy() {
-        // NIT #3617-PR2: a torn v15 header on the FINAL segment is now TOLERATED
+        // NIT #3617-PR2: a torn v16 header on the FINAL segment is now TOLERATED
         // under the #3433 torn-tail contract (see
-        // `torn_v15_header_on_final_segment_is_tolerated_as_empty_tail`). This
+        // `torn_v16_header_on_final_segment_is_tolerated_as_empty_tail`). This
         // test pins the complementary STRICT case: with torn-tail tolerance
         // DISABLED, the same truncated header still hard-errors.
         let dir = TempDir::new().unwrap();

--- a/tests/cli_encryption.rs
+++ b/tests/cli_encryption.rs
@@ -8,19 +8,24 @@
 //! Security-critical invariant asserted throughout: raw key hex must NEVER
 //! appear in stdout/stderr, in any encoding an error message might use.
 //!
-//! ## Architectural note (why no successful-rotation CLI test)
+//! ## Architectural note (rotation scope: WAL + index succeed, cold still refuses)
 //!
-//! The shipped rotation engine (`AletheiaDB::rotate_index_keys`) is *index
-//! layer only* and hard-refuses whenever any OTHER at-rest layer (WAL, cold,
-//! checkpoint) is encrypted under the same master key -- rotating the index
-//! alone to a new MEK would strand those layers (`rotation.rs` P0.1). Because
-//! AletheiaDB's config encrypts *uniformly* (enabling encryption encrypts the
-//! WAL too; there is no config knob for index-only encryption), a normally
-//! opened encrypted database ALWAYS has an encrypted WAL. Therefore
-//! `keys rotate --new-key` against any config-encrypted database correctly
-//! REFUSES with the cross-layer guard -- and that honest refusal is what these
-//! tests assert. A CLI-reachable successful rotation must wait on the
-//! documented full-MEK (all-layer) rotation follow-up.
+//! The rotation engine (`AletheiaDB::rotate_index_keys`) re-keys the index and,
+//! since Issue #3617 PR2, the WAL as well (checkpoint -> force-roll under the new
+//! WAL DEK -> truncate the old segments), so the WAL is no longer a cross-layer
+//! conflict. AletheiaDB's config encrypts *uniformly* (enabling encryption
+//! encrypts the WAL too), and the standard `make_encrypted_db` fixture configures
+//! only WAL + index persistence with NO cold storage. Therefore
+//! `keys rotate --new-key` / `--new-env-var` against that fixture now SUCCEEDS
+//! (exit 0), re-encrypting every persisted file and bumping the key version --
+//! and that success is what these tests assert.
+//!
+//! The one at-rest layer NOT yet covered is cold storage (PR3): when a tiered
+//! cold store is configured under the same master key, an index+WAL rotation
+//! would strand the cold values, so the cross-layer guard STILL refuses and
+//! names `cold_storage`. `keys_rotate_start_with_cold_storage_refuses_cross_layer`
+//! asserts that CLI refusal end-to-end (the unit test
+//! `rotate_still_refuses_when_cold_storage_encrypted` covers the engine level).
 
 use std::path::Path;
 use std::process::Command;
@@ -350,7 +355,7 @@ fn encryption_verify_disabled_is_informational() {
 mod encrypted {
     use super::*;
     use aletheiadb::AletheiaDB;
-    use aletheiadb::config::{AletheiaDBConfig, WalConfigBuilder};
+    use aletheiadb::config::{AletheiaDBConfig, HistoricalConfigBuilder, WalConfigBuilder};
     use aletheiadb::encryption::FileKeyProvider;
     use aletheiadb::encryption::config::EncryptionConfig;
     use aletheiadb::storage::index_persistence::PersistenceConfig;
@@ -437,6 +442,74 @@ mod encrypted {
         run_env(args, &borrowed)
     }
 
+    /// Create an encrypted database WITH an encrypted cold tier configured (in
+    /// addition to WAL + index persistence), then drop it, leaving a TOML config
+    /// the CLI can reopen. Used to assert that key rotation still refuses while a
+    /// cold tier is present (Issue #3617 PR3 is the cold re-keyer follow-up).
+    fn make_encrypted_db_with_cold() -> EncryptedFixture {
+        use std::time::Duration;
+
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let key_path = root.join("master.key");
+        FileKeyProvider::generate_key_file(&key_path).unwrap();
+
+        let config = AletheiaDBConfig::builder()
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(root.join("wal"))
+                    .durability_mode(DurabilityMode::GroupCommit {
+                        max_delay_ms: 5,
+                        max_batch_size: 64,
+                    })
+                    .build(),
+            )
+            .persistence(PersistenceConfig {
+                enabled: true,
+                data_dir: root.join("data"),
+                load_on_startup: true,
+                ..Default::default()
+            })
+            .historical(
+                HistoricalConfigBuilder::new()
+                    .enable_cold_storage(true)
+                    .cold_storage_path(root.join("cold.redb"))
+                    .migration_age_threshold(Duration::from_secs(3600))
+                    .build(),
+            )
+            .encryption(EncryptionConfig::file_based(&key_path))
+            .build();
+
+        let toml_path = root.join("aletheia.toml");
+        config.to_toml_file(&toml_path).unwrap();
+
+        // Seed from the SAME TOML the CLI will open, so paths match exactly.
+        {
+            let cfg = AletheiaDBConfig::from_toml_file(&toml_path).unwrap();
+            let db = AletheiaDB::with_unified_config(cfg).unwrap();
+            let a = db
+                .create_node(
+                    "Person",
+                    PropertyMapBuilder::new().insert("name", "Alice").build(),
+                )
+                .unwrap();
+            let b = db
+                .create_node(
+                    "Person",
+                    PropertyMapBuilder::new().insert("name", "Bob").build(),
+                )
+                .unwrap();
+            db.create_edge(a, b, "KNOWS", PropertyMap::new()).unwrap();
+            db.persist_indexes().unwrap();
+        }
+
+        EncryptedFixture {
+            _dir: dir,
+            toml_path,
+            key_path,
+        }
+    }
+
     #[test]
     fn keys_rotate_status_fresh_encrypted_reports_no_pending() {
         let f = make_encrypted_db();
@@ -455,7 +528,12 @@ mod encrypted {
     }
 
     #[test]
-    fn keys_rotate_start_uniform_encrypted_refuses_cross_layer() {
+    fn keys_rotate_start_uniform_encrypted_succeeds() {
+        // Issue #3617 PR2: a uniformly-encrypted DB with WAL + index persistence
+        // and NO cold storage is now fully rotatable. The WAL is re-keyed by the
+        // checkpoint -> force-roll -> truncate driver rather than treated as a
+        // cross-layer conflict, so `keys rotate --new-key` SUCCEEDS: it
+        // re-encrypts every persisted index file and bumps the key version.
         let f = make_encrypted_db();
         // A brand-new key to rotate TO.
         let new_key = f.toml_path.parent().unwrap().join("rotate-to.key");
@@ -465,15 +543,31 @@ mod encrypted {
             &["keys", "rotate", "--new-key", new_key.to_str().unwrap()],
             &cfg_env(&f),
         );
-        assert_ne!(
+        assert_eq!(
             r.code, 0,
-            "rotate on a uniformly-encrypted DB must refuse (WAL encrypted); stdout={:?}",
-            r.stdout
+            "rotate on a uniform WAL+index-encrypted DB (no cold) must succeed; \
+             stdout={:?} stderr={:?}",
+            r.stdout, r.stderr
         );
         let c = r.combined_lower();
+        // Success summary: completion headline + old->new key-version bump + the
+        // re-encrypted file count (the CLI's print_rotation_report / progress line).
         assert!(
-            c.contains("wal") && c.contains("encrypted"),
-            "refusal must name the conflicting WAL layer; got={c:?}"
+            c.contains("rotation complete"),
+            "success must print the completion headline; got={c:?}"
+        );
+        assert!(
+            c.contains("key version") && c.contains("->"),
+            "success must print the old->new key-version bump; got={c:?}"
+        );
+        assert!(
+            c.contains("re-encrypted"),
+            "success must report the re-encrypted file count; got={c:?}"
+        );
+        // It must NOT be the old cross-layer refusal.
+        assert!(
+            !c.contains("other encrypted-at-rest layers"),
+            "must not be the cross-layer refusal; got={c:?}"
         );
         assert!(!c.contains("panicked"), "must not panic; got={c:?}");
         assert_no_key_leak(&r, &[f.key_path.as_path(), new_key.as_path()]);
@@ -551,27 +645,82 @@ mod encrypted {
     }
 
     #[test]
-    fn keys_rotate_start_via_env_var_refuses_cross_layer() {
+    fn keys_rotate_start_via_env_var_succeeds() {
         // Exercises the `--new-env-var` start path (KeyProviderConfig::Env
-        // branch). On a uniformly-encrypted DB the cross-layer guard refuses
-        // before the env var is ever sourced, so the var need not exist.
+        // branch). Issue #3617 PR2: a uniform WAL+index DB (no cold) is now
+        // rotatable, so the guard no longer short-circuits -- the env var IS
+        // sourced and must hold the hex-encoded new MEK. We generate a fresh key
+        // and export its hex, then assert the rotation succeeds.
         let f = make_encrypted_db();
+        let new_key = f.toml_path.parent().unwrap().join("rotate-to.key");
+        FileKeyProvider::generate_key_file(&new_key).unwrap();
+        // EnvKeyProvider reads a hex-encoded MEK from the named variable.
+        let new_key_hex = std::fs::read_to_string(&new_key)
+            .unwrap()
+            .trim()
+            .to_string();
+
+        let mut env = cfg_env(&f);
+        env.push(("ALETHEIADB_MEK_NEW", new_key_hex));
         let r = run_with(
             &["keys", "rotate", "--new-env-var", "ALETHEIADB_MEK_NEW"],
+            &env,
+        );
+        assert_eq!(
+            r.code, 0,
+            "rotate via env-var on a uniform WAL+index-encrypted DB (no cold) must \
+             succeed; stdout={:?} stderr={:?}",
+            r.stdout, r.stderr
+        );
+        let c = r.combined_lower();
+        assert!(
+            c.contains("rotation complete"),
+            "success must print the completion headline; got={c:?}"
+        );
+        assert!(
+            c.contains("key version") && c.contains("->"),
+            "success must print the old->new key-version bump; got={c:?}"
+        );
+        assert!(
+            c.contains("re-encrypted"),
+            "success must report the re-encrypted file count; got={c:?}"
+        );
+        assert!(
+            !c.contains("other encrypted-at-rest layers"),
+            "must not be the cross-layer refusal; got={c:?}"
+        );
+        assert!(!c.contains("panicked"), "must not panic; got={c:?}");
+        // The exported hex is a key encoding: it must never leak into output.
+        assert_no_key_leak(&r, &[f.key_path.as_path(), new_key.as_path()]);
+    }
+
+    #[test]
+    fn keys_rotate_start_with_cold_storage_refuses_cross_layer() {
+        // Issue #3617 PR2: cold storage is NOT yet covered (PR3). A DB with an
+        // encrypted cold tier configured must STILL refuse an index+WAL rotation
+        // (it would strand the cold values under the old MEK). This is the CLI
+        // end-to-end counterpart to the engine unit test
+        // `rotate_still_refuses_when_cold_storage_encrypted`.
+        let f = make_encrypted_db_with_cold();
+        let new_key = f.toml_path.parent().unwrap().join("rotate-to.key");
+        FileKeyProvider::generate_key_file(&new_key).unwrap();
+
+        let r = run_with(
+            &["keys", "rotate", "--new-key", new_key.to_str().unwrap()],
             &cfg_env(&f),
         );
         assert_ne!(
             r.code, 0,
-            "rotate via env-var on a uniformly-encrypted DB must refuse; stdout={:?}",
+            "rotate with encrypted cold storage configured must still refuse; stdout={:?}",
             r.stdout
         );
         let c = r.combined_lower();
         assert!(
-            c.contains("wal") && c.contains("encrypted"),
-            "refusal must name the conflicting WAL layer; got={c:?}"
+            c.contains("cold_storage"),
+            "refusal must name the conflicting cold_storage layer; got={c:?}"
         );
         assert!(!c.contains("panicked"), "must not panic; got={c:?}");
-        assert_no_key_leak(&r, &[f.key_path.as_path()]);
+        assert_no_key_leak(&r, &[f.key_path.as_path(), new_key.as_path()]);
     }
 
     /// Overwrite the 4-byte little-endian `key_version` field (offset 6..10) of


### PR DESCRIPTION
## Before / After

**Before** — `keys rotate` refused a uniformly-encrypted database because master-key rotation didn't cover the WAL layer.

**After** — a uniformly WAL+index-encrypted DB (no cold storage) now rotates end-to-end: the active WAL segment is force-rolled onto the new data-encryption key, historical segments are retired once their data is durable in the index snapshot, and a half-rotated WAL replays correctly on restart. A DB with cold storage still refuses (cold is PR3).

## How

- New version-gated WAL segment header `WAL_VERSION_ENCRYPTED_KEYVERSIONED` (magic + version byte + `key_version:u32`, a 9-byte header vs the legacy 5); legacy v2–v14 segments still replay and resolve to the pre-rotation generation; an older binary rejects the new version cleanly.
- A multi-generation `WalKeyring` + `WalCipherSource` resolver so recovery selects the right DEK per segment by header key_version.
- Force-roll under the flush coordinator's writer mutex: the keyring generation flips between sealing the old segment and opening the new one, so no segment ever mixes DEK generations (proven by an append-hammer-across-roll test).
- Rotation driver: seal → `persist_indexes()` → retire old-generation segments, with completion gated on `all_segments_use_key_version(new)` and delete-failure propagation, so a partially-completed rotation is never reported as success and never clears the ledger (prevents a stranded old-DEK segment becoming unopenable after the operator drops the old key).
- Startup installs both key generations before the WAL replay read, and defers the resume-path retire until after a synchronous post-replay checkpoint, so no acknowledged write is deleted before it's durable — closing both a single-crash and a double-crash data-loss window.
- `conflicting_encrypted_layers` drops "wal" (now rotatable), keeps "cold_storage".

## Testing

- force-roll / append-hammer-across-roll / mixed-generation replay / crash-after-ledger-resume / incomplete-retirement-leaves-pending / half-rotated-both-generations / resume-path-double-crash-survival / torn-v15-header-tolerated
- updated CLI tests (uniform WAL+index now succeeds; WAL+cold still refuses)

**Gates**: clippy 0 warnings (CI feature set + all-features), fmt clean, Feature Matrix (`cargo check --no-default-features --tests`), 3 standalone encryption-feature checks, full test suite green (only known uid-0 havoc noise).

## Cross-lane: `src/db/config.rs`

This PR edits `src/db/config.rs` (outside Lane 4's core file list, coordinator-approved for #3617): it wires the live WAL into the startup crash-resume path, installs both WAL key generations before the replay read, and calls `finalize_resumed_wal_rotation` after replay so the resume path checkpoints before retiring.

Note: Lane 2's #3378 also wires startup pieces through config.rs/mod.rs — after #3378 merges this branch will re-merge trunk and re-verify the `open()` startup ordering (rotation-resume before index reads).

## Status / notes

**DRAFT** — held for maintainer sign-off on the on-disk WAL segment-header format change before it flips ready.

PR2 of 3 for #3617 (PR1 foundation #3639 merged; PR3 = cold-tier rotation).

A separate in-lane fast-follow will fix a pre-existing #488 keyring-version-provisioning gap (verify false-fails after a cold reopen of any rotated DB; data is unaffected).

Links: the design doc covers the full 3-PR plan.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRMi3NFi3FwGqXoon9Fqga)_