### PR TITLE
ci(mutants): add sql,cypher to MUTANTS_FEATURES so gated modules are mutated

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -27,7 +27,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  MUTANTS_FEATURES: "config-toml,mcp-server,sharding-rpc"
+  MUTANTS_FEATURES: "config-toml,mcp-server,sharding-rpc,sql,cypher"
   # Pinned for reproducibility and stable flag/exit-code semantics
   # (--sharding round-robin requires cargo-mutants 27.x; exit codes per
   # https://mutants.rs/exit-codes.html: 0 = all caught, 2 = missed mutants,


### PR DESCRIPTION
## Summary

One-line fix to `.github/workflows/mutants.yml`: add `sql,cypher` to `MUTANTS_FEATURES`.

```diff
-  MUTANTS_FEATURES: "config-toml,mcp-server,sharding-rpc"
+  MUTANTS_FEATURES: "config-toml,mcp-server,sharding-rpc,sql,cypher"
```

## Before / After (plain language)

**BEFORE** — the informational **Mutants (PR diff)** check failed on any PR touching `src/cypher/**` (and `src/sql/**`). Those modules are cfg-gated behind their feature flags (`#[cfg(feature = "cypher")] pub mod cypher;` and `#[cfg(feature = "sql")] pub mod sql;` in `src/lib.rs`). Because `MUTANTS_FEATURES` omitted `sql,cypher`, the mutated code **compiled out** under that feature set, so the tests that would catch those mutants never ran — every cypher/sql mutant scored "missed" (0.0% < 60% threshold) and the check went red.

**AFTER** — with `sql,cypher` added, the gated modules **compile in** and their catching tests actually run, so mutations in those modules are scored honestly instead of all showing up as spurious misses.

## How

Single-line feature-string change. This is the exact same cfg-gating class already fixed for the **Code Coverage** job in #3625 (PR #3633, merged), which added `sql,cypher` to that job's `llvm-cov` feature set. This change mirrors that set **exactly** — the coverage job now uses `config-toml,mcp-server,sharding-rpc,sql,cypher` (`.github/workflows/ci.yml`), and so does the mutants job after this change.

The check **remains informational** — no gating status, threshold, or timeout was changed. `MUTANTS_FEATURES` feeds both the PR-diff invocation and the weekly-sample invocation, so both now compile the gated modules in.

## Verification (static)

- `sql` and `cypher` are real cargo features: `Cargo.toml` — `sql = ["dep:sqlparser"]` (line 341), `cypher = []` (line 344).
- Both gate mutatable code modules: `src/lib.rs` lines 85–89 cfg-gate `pub mod sql;` / `pub mod cypher;`.
- No nextest baseline-exclusion filter is present in this workflow (none was needed — the two chmod-based fault-injection tests only fail under uid 0, and GitHub `ubuntu-latest` runs as a non-root user), so nothing to preserve there.
- YAML validated with `yaml.safe_load` (OK).

## Expected runtime delta

`cargo mutants` will now also generate and test mutants for `src/cypher/**` (~19.5K lines) and `src/sql/**` (~5.8K lines) — together ~7.5% of the `src/` tree — where before they were skipped (compiled out).

- **PR-diff job** (`timeout-minutes: 90`): only mutates code in the PR diff (`--in-diff`), so the delta is bounded per-PR. For a cypher/sql-touching PR, those diff-mutants now actually run the test suite (previously instant "missed"), so wall-time for such PRs increases. **Flag:** a large cypher/sql-heavy PR could approach the 90-minute timeout — worth watching; a timeout bump may be a follow-up if it proves tight in practice. Not changed here (prefer flagging over silently changing).
- **Weekly full-sample job** (`timeout-minutes: 350`, 96 shards, round-robin): the total mutant population grows by roughly the added-module fraction, spread across shards, so per-shard time rises modestly and stays well within the 350-minute budget.

No thresholds or gating changed; only the feature string.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9AsbevK7LAWEXzJANvyG4)_