### PR TITLE
fix(encryption): provision keyring version at open() (pre-existing #488)

### DIFF
--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -391,6 +391,25 @@ impl AletheiaDB {
                 .as_ref()
                 .map(|mgr| Arc::clone(mgr.wal_cipher()));
 
+            // Issue #488 version-provisioning: derive the keyring `current_version`
+            // from durable on-disk state (index-file AEIX headers + WAL segment
+            // headers, with a pending rotation ledger as authority) so a
+            // rotate-then-cold-reopen reports the real version instead of a
+            // hard-coded 1. Only when encryption AND persistence are enabled;
+            // otherwise `None` reproduces prior behavior exactly. Computed here,
+            // before the WAL is built, so both keyrings are provisioned in
+            // lockstep. See `resolve_provisioned_key_version` for precedence.
+            let provisioned_key_version = if config.encryption.enabled && config.persistence.enabled
+            {
+                Some(crate::db::rotation::resolve_provisioned_key_version(
+                    &config.persistence.data_dir.join("indexes"),
+                    &config.wal.wal_dir,
+                    &config.persistence.data_dir,
+                )?)
+            } else {
+                None
+            };
+
             let wal_system_config = ConcurrentWalSystemConfig {
                 wal_dir: config.wal.wal_dir,
                 num_stripes: config.wal.num_stripes,
@@ -404,6 +423,7 @@ impl AletheiaDB {
                 durability_mode,
                 write_buffer_size: config.wal.write_buffer_size,
                 wal_cipher: wal_cipher.clone(),
+                wal_key_version: provisioned_key_version,
                 tolerate_torn_tail: config.wal.tolerate_torn_tail,
             };
 
@@ -471,12 +491,24 @@ impl AletheiaDB {
                 let index_cipher = encryption_manager
                     .as_ref()
                     .map(|mgr| Arc::clone(mgr.index_cipher()));
-                Some(Arc::new(
-                    crate::storage::index_persistence::IndexPersistenceManager::with_cipher(
+                // Issue #488 version-provisioning: build the index keyring at the
+                // resolved on-disk version so `index_rotation_status` /
+                // `encryption verify` classify rotated files correctly after a
+                // cold reopen and the next rotation increments from the real
+                // version. Reads stay `match_any` (identical to `with_cipher`);
+                // `None` falls back to `with_cipher` (unchanged behavior).
+                let manager = match provisioned_key_version {
+                    Some(v) => crate::storage::index_persistence::IndexPersistenceManager::with_cipher_versioned(
+                        &config.persistence.data_dir,
+                        index_cipher,
+                        v,
+                    ),
+                    None => crate::storage::index_persistence::IndexPersistenceManager::with_cipher(
                         &config.persistence.data_dir,
                         index_cipher,
                     ),
-                ))
+                };
+                Some(Arc::new(manager))
             } else {
                 None
             };
@@ -925,6 +957,7 @@ impl AletheiaDB {
                 durability_mode,
                 write_buffer_size: wal_config.write_buffer_size,
                 wal_cipher: None,
+                wal_key_version: None,
                 tolerate_torn_tail: wal_config.tolerate_torn_tail,
             };
 

--- a/src/db/rotation.rs
+++ b/src/db/rotation.rs
@@ -1251,6 +1251,62 @@ fn read_rotation_state_at(path: &std::path::Path) -> Result<Option<RotationLedge
     }))
 }
 
+/// Resolve the key version the index and WAL keyrings should be PROVISIONED to
+/// at `open()` (Issue #488 version-provisioning fast-follow).
+///
+/// # The bug this fixes
+///
+/// At `open()` the keyrings were built at the hard-coded base version
+/// ([`IndexKeyring::single`] → `ENC_INDEX_KEY_VERSION_V1`,
+/// [`WalKeyring::single`] → `INITIAL_WAL_KEY_VERSION`), because the
+/// post-rotation key version is never persisted where `open()` reads it (the
+/// rotation ledger is cleared on completion). After a rotate-then-cold-reopen
+/// under the new key that mis-provisioned `current_version == 1` makes
+/// `index_rotation_status` / `encryption verify` FALSE-FAIL (v2 files classify
+/// as "unknown") and wedges the *next* rotation (it recomputes `new_version =
+/// 1 + 1 = 2` and hits the P0.3 `ForeignKeyVersionFile` identity check against
+/// the existing v2 files).
+///
+/// # Precedence
+///
+/// 1. **Pending rotation ledger** — the currently CONFIGURED key still
+///    corresponds to the OLD generation (the provider switch happens only after
+///    a rotation COMPLETES), so we provision to `ledger.new_version - 1` (the
+///    old version, since `new_version = old_version + 1` by construction) and
+///    let startup [`resume_pending_rotation`] drive the keyring to the ledger
+///    target. Provisioning to the *max on-disk* here would instead be the
+///    target itself and would mis-label the configured (old) cipher as the new
+///    version, breaking resume; the ledger target is therefore the authority
+///    for the *final* `current_version` (reached via resume), not the build
+///    version. This holds for a `cancel` ledger too (old = target - 1).
+/// 2. **No pending ledger** (a completed rotation, or never rotated) — provision
+///    to the MAX stamped key version across BOTH persisted layers: index-file
+///    `AEIX` headers folded with WAL segment headers. A never-rotated database
+///    has no stamped version above the base, so this resolves to the base and
+///    reproduces prior behavior exactly.
+pub(crate) fn resolve_provisioned_key_version(
+    indexes_dir: &std::path::Path,
+    wal_dir: &std::path::Path,
+    rotation_state_dir: &std::path::Path,
+) -> Result<u32> {
+    const BASE: u32 = crate::storage::index_persistence::common::ENC_INDEX_KEY_VERSION_V1;
+
+    // 1. A pending ledger is the authority for a mid-rotation-crash state.
+    let ledger_path = rotation_state_dir.join("rotation.state");
+    if let Some(ledger) = read_rotation_state_at(&ledger_path)? {
+        return Ok(ledger.new_version.saturating_sub(1).max(BASE));
+    }
+
+    // 2. Otherwise the max stamped version across the index and WAL layers.
+    let index_v =
+        crate::storage::index_persistence::reencrypt::max_index_key_version_in_dir(indexes_dir)
+            .map_err(rotation_err)?
+            .unwrap_or(BASE);
+    let wal_v =
+        crate::storage::wal::segment_reader::max_key_version_in_dir(wal_dir).unwrap_or(BASE);
+    Ok(index_v.max(wal_v).max(BASE))
+}
+
 /// Install BOTH WAL key generations into the live WAL keyring when a rotation
 /// ledger is PENDING at startup — BEFORE the startup replay read (Issue #3617
 /// PR2 crash-consistency).
@@ -2167,6 +2223,220 @@ mod tests {
             assert_eq!(db.node_count(), 2, "graph recovers under the new key");
             assert_eq!(db.edge_count(), 1);
         }
+    }
+
+    // ── Issue #488 version-provisioning fast-follow ──────────────────────
+    //
+    // At `open()` the keyring's `current_version` was hard-coded to 1, because
+    // the post-rotation key version is never persisted where `open()` reads it
+    // (the rotation ledger is cleared on completion). These tests pin the fix:
+    // provision `current_version` from durable on-disk state so `verify` /
+    // `index_rotation_status` classify rotated files correctly and a second
+    // rotation increments from the real version instead of re-using 2.
+
+    /// Headline symptom: after a completed rotation to v2 and a genuine COLD
+    /// reopen under the new key, `index_rotation_status` must report NO unknown
+    /// files. Before the fix the reopened keyring reports `current_version = 1`,
+    /// so the v2 files classify as "unknown" (a false-FAIL of `encryption
+    /// verify`) even though they decrypt cleanly.
+    #[test]
+    fn verify_passes_after_cold_reopen_of_rotated_db() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let old_key = root.join("old.key");
+        let new_key = root.join("new.key");
+        crate::encryption::FileKeyProvider::generate_key_file(&old_key).unwrap();
+        crate::encryption::FileKeyProvider::generate_key_file(&new_key).unwrap();
+        let indexes_dir = root.join("data").join("indexes");
+
+        // Rotate a fully-encrypted DB (WAL + index) to the new key.
+        {
+            let db = build_db(root, &old_key);
+            seed(&db);
+            let report = db
+                .rotate_index_keys(KeyProviderConfig::File {
+                    path: new_key.clone(),
+                })
+                .expect("rotation must succeed");
+            assert_eq!(report.new_version, 2);
+        }
+        // All on-disk index files are now at v2.
+        assert!(assert_all_at_version(&indexes_dir, 2) > 0);
+
+        // Genuine COLD reopen under the NEW key only (fresh manager/keyring).
+        let db = build_db(root, &new_key);
+        let status = db
+            .index_rotation_status()
+            .expect("status probe must succeed after reopen");
+        assert_eq!(
+            status.unknown, 0,
+            "reopened keyring must classify v2 files as current, not unknown: {status:?}"
+        );
+        assert!(
+            status.is_fully_rotated(),
+            "a cold-reopened rotated DB must read as fully rotated: {status:?}"
+        );
+        // The active-decrypt probe (Issue #3618) must also pass.
+        let probe = db
+            .verify_index_decryptable()
+            .expect("decrypt probe must succeed");
+        assert!(
+            probe.decrypt_failed.is_empty(),
+            "bodies must decrypt under the reopened new key: {probe:?}"
+        );
+    }
+
+    /// A second rotation after a cold reopen must compute `new_version = 3`
+    /// (not re-use 2) and must NOT wedge on the `ForeignKeyVersionFile`
+    /// identity check against the existing v2 files. Before the fix the
+    /// reopened keyring reports `current_version = 1`, so the second rotation
+    /// recomputes `new_version = 2` and wedges.
+    #[test]
+    fn second_rotation_after_reopen_does_not_wedge() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let old_key = root.join("old.key");
+        let new_key = root.join("new.key");
+        let newer_key = root.join("newer.key");
+        crate::encryption::FileKeyProvider::generate_key_file(&old_key).unwrap();
+        crate::encryption::FileKeyProvider::generate_key_file(&new_key).unwrap();
+        crate::encryption::FileKeyProvider::generate_key_file(&newer_key).unwrap();
+
+        // First rotation: v1 -> v2.
+        {
+            let db = build_db(root, &old_key);
+            seed(&db);
+            let report = db
+                .rotate_index_keys(KeyProviderConfig::File {
+                    path: new_key.clone(),
+                })
+                .expect("first rotation must succeed");
+            assert_eq!(report.new_version, 2);
+        }
+
+        // Cold reopen under the new key, write, then rotate AGAIN.
+        let db = build_db(root, &new_key);
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Carol").build(),
+        )
+        .unwrap();
+        db.persist_indexes().unwrap();
+
+        let report = db
+            .rotate_index_keys(KeyProviderConfig::File {
+                path: newer_key.clone(),
+            })
+            .expect("second rotation must not wedge on ForeignKeyVersionFile");
+        assert_eq!(
+            report.old_version, 2,
+            "second rotation must see the provisioned current version 2"
+        );
+        assert_eq!(
+            report.new_version, 3,
+            "second rotation must increment to 3, not re-use 2"
+        );
+        assert!(db.index_rotation_status().unwrap().is_fully_rotated());
+    }
+
+    /// A mid-rotation crash leaves a PENDING ledger (target v2) and a mix of
+    /// on-disk versions. On reopen the resolved current version must follow the
+    /// ledger target once resume completes the rotation, and the DB must open +
+    /// resume correctly.
+    #[test]
+    fn mid_rotation_crash_reopen_provisions_from_ledger() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let old_key = root.join("old.key");
+        let new_key = root.join("new.key");
+        crate::encryption::FileKeyProvider::generate_key_file(&old_key).unwrap();
+        crate::encryption::FileKeyProvider::generate_key_file(&new_key).unwrap();
+
+        // Seed + persist, then plant a durable ledger simulating a crash right
+        // after it was fsync'd (index + WAL pending, target v2).
+        {
+            let db = build_db(root, &old_key);
+            seed(&db);
+            let manager = db.persistence_manager.as_ref().unwrap().clone();
+            super::write_ledger(
+                &manager,
+                &super::RotationLedger::forward_scope(
+                    2,
+                    KeyProviderConfig::File {
+                        path: new_key.clone(),
+                    },
+                    true,
+                ),
+            )
+            .unwrap();
+            assert!(root.join("data").join("rotation.state").exists());
+        }
+
+        // Reopen under the OLD key (rotation in flight): startup resume must
+        // complete the rotation and clear the ledger, and the final provisioned
+        // current version must follow the ledger target (v2).
+        {
+            let db = build_db(root, &old_key);
+            assert!(
+                !root.join("data").join("rotation.state").exists(),
+                "startup resume must complete the pending rotation"
+            );
+            assert_eq!(db.node_count(), 2, "graph intact after resume");
+            let status = db.index_rotation_status().unwrap();
+            assert_eq!(
+                status.unknown, 0,
+                "no unknown files after resume: {status:?}"
+            );
+            assert!(
+                status.is_fully_rotated(),
+                "resume must leave a uniform v2 dataset: {status:?}"
+            );
+            assert_eq!(
+                assert_all_at_version(&root.join("data").join("indexes"), 2),
+                status.at_current,
+                "all index files at ledger target v2"
+            );
+        }
+
+        // Provider switch: reopen under the NEW key only — everything decrypts,
+        // and a fresh reopen classifies as fully rotated (current version v2).
+        {
+            let db = build_db(root, &new_key);
+            assert_eq!(db.node_count(), 2, "graph recovers under the new key");
+            assert!(db.index_rotation_status().unwrap().is_fully_rotated());
+        }
+    }
+
+    /// The provisioned version is the MAX of the index-header version and the
+    /// WAL-segment version. Unit-tests the resolver directly (no pending
+    /// ledger): index files at v2, WAL segments at v1 -> resolves to 2.
+    #[test]
+    fn provisioned_version_is_max_across_index_and_wal() {
+        use crate::storage::index_persistence::common::encrypt_index_bytes_versioned;
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let data_dir = root.join("data");
+        let indexes_dir = data_dir.join("indexes");
+        let wal_dir = root.join("wal");
+        std::fs::create_dir_all(&indexes_dir).unwrap();
+        std::fs::create_dir_all(&wal_dir).unwrap();
+
+        // An encrypted index file stamped at v2.
+        let key = root.join("k.key");
+        crate::encryption::FileKeyProvider::generate_key_file(&key).unwrap();
+        let cipher = std::sync::Arc::clone(
+            EncryptionManager::from_config(&EncryptionConfig::file_based(&key))
+                .unwrap()
+                .index_cipher(),
+        );
+        let body = encrypt_index_bytes_versioned(b"manifest-body", &cipher, 2).unwrap();
+        std::fs::write(indexes_dir.join("manifest.idx"), &body).unwrap();
+
+        // No WAL segments (v1 default) and no pending ledger -> resolves to the
+        // index version (2), the max across the two layers.
+        let resolved =
+            super::resolve_provisioned_key_version(&indexes_dir, &wal_dir, &data_dir).unwrap();
+        assert_eq!(resolved, 2, "resolved version must be the max (index v2)");
     }
 
     #[test]

--- a/src/encryption/wal_encryption.rs
+++ b/src/encryption/wal_encryption.rs
@@ -106,6 +106,27 @@ impl WalKeyring {
         }
     }
 
+    /// A single-generation WAL keyring pinned to an explicit `key_version`
+    /// (Issue #488 version-provisioning). Reads decrypt every segment with this
+    /// one cipher (`match_any`, byte-identical to [`Self::single`]); only the
+    /// write-stamp / reported [`current_version`](Self::current_version) is
+    /// pinned to `key_version`. The durable `open()` path builds the WAL keyring
+    /// at the max on-disk segment `key_version` so new segments stamp the real
+    /// version instead of a stale [`INITIAL_WAL_KEY_VERSION`], keeping the WAL
+    /// and index layers in lockstep after a rotate-then-reopen.
+    pub fn single_versioned(cipher: Arc<dyn Cipher>, key_version: u32) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(WalKeyringInner {
+                generations: vec![WalKeyGeneration {
+                    key_version,
+                    cipher,
+                }],
+                current_version: key_version,
+                match_any: true,
+            })),
+        }
+    }
+
     /// The current (write) cipher and the `key_version` it stamps into new
     /// segment headers, or `None` if the keyring somehow holds no generation.
     pub fn current(&self) -> Option<(Arc<dyn Cipher>, u32)> {

--- a/src/storage/index_persistence/common.rs
+++ b/src/storage/index_persistence/common.rs
@@ -75,9 +75,18 @@ impl IndexKeyring {
         }
     }
 
-    /// A single-generation keyring pinned to an explicit `key_version` (strict
-    /// dispatch). Used by rotation tests to construct pinned/mixed keyrings.
-    #[cfg(test)]
+    /// A single-generation keyring pinned to an explicit `key_version`.
+    ///
+    /// Reads decrypt ANY header `key_version` with this one cipher (`match_any`,
+    /// byte-identical to [`Self::single`]); only the write-stamp / reported
+    /// [`current_version`](Self::current_version) is pinned to `key_version`.
+    /// This is the constructor the durable `open()` path uses to PROVISION the
+    /// keyring at the max on-disk key version (Issue #488 version-provisioning):
+    /// without it `open()` always reports `current_version == 1`, so a rotated
+    /// dataset's v2 files classify as "unknown" (a `verify` false-FAIL) and the
+    /// next rotation re-uses version 2 and wedges on the P0.3 identity check.
+    /// Callers that need strict per-version dispatch build the ring and then
+    /// [`add_generation`](Self::add_generation), which leaves `match_any`.
     pub(crate) fn single_versioned(cipher: Arc<dyn Cipher>, key_version: u32) -> Self {
         Self {
             inner: Arc::new(RwLock::new(KeyringInner {
@@ -86,7 +95,7 @@ impl IndexKeyring {
                     cipher,
                 }],
                 current_version: key_version,
-                match_any: false,
+                match_any: true,
             })),
         }
     }

--- a/src/storage/index_persistence/loader.rs
+++ b/src/storage/index_persistence/loader.rs
@@ -53,6 +53,28 @@ impl IndexPersistenceManager {
         }
     }
 
+    /// Like [`Self::with_cipher`] but PROVISIONS the single-generation keyring's
+    /// write-stamp version to `key_version` (Issue #488 version-provisioning).
+    ///
+    /// The durable `open()` path resolves `key_version` from the max on-disk key
+    /// version (index-file AEIX headers folded with WAL segment headers) so a
+    /// rotated-then-reopened database reports the correct
+    /// [`current_version`](super::common::IndexKeyring::current_version) instead
+    /// of a hard-coded 1. Reads stay `match_any` (the sole cipher decrypts every
+    /// header version, byte-identical to [`Self::with_cipher`]); only the
+    /// stamped/reported version differs. Passing `None` is plaintext (no
+    /// keyring), exactly like [`Self::with_cipher`].
+    pub fn with_cipher_versioned(
+        base_path: impl Into<PathBuf>,
+        index_cipher: Option<Arc<dyn Cipher>>,
+        key_version: u32,
+    ) -> Self {
+        Self {
+            base_path: base_path.into(),
+            keyring: index_cipher.map(|c| IndexKeyring::single_versioned(c, key_version)),
+        }
+    }
+
     /// Create a new persistence manager with an explicit
     /// [`IndexKeyring`](super::common::IndexKeyring) (Issue #488 key rotation).
     /// Test-only: production builds the manager via [`Self::with_cipher`] and

--- a/src/storage/index_persistence/reencrypt.rs
+++ b/src/storage/index_persistence/reencrypt.rs
@@ -478,6 +478,30 @@ fn peek_key_version(path: &Path) -> Result<Option<u32>, RotationError> {
     Ok(index_file_key_version(&header[..filled]))
 }
 
+/// The maximum `key_version` stamped across the persisted index files under
+/// `indexes_dir` (Issue #488 version-provisioning).
+///
+/// Reads only file *headers* via [`peek_key_version`]; returns `None` when the
+/// directory holds no encrypted-index files (plaintext or empty). The durable
+/// `open()` path folds this with the WAL segment version to provision the index
+/// keyring's current version, so a rotated-then-reopened database reports the
+/// real version instead of a hard-coded 1.
+pub(crate) fn max_index_key_version_in_dir(
+    indexes_dir: &Path,
+) -> Result<Option<u32>, RotationError> {
+    let mut files = Vec::new();
+    if indexes_dir.exists() {
+        collect_index_files(indexes_dir, &mut files)?;
+    }
+    let mut max: Option<u32> = None;
+    for path in files {
+        if let Some(v) = peek_key_version(&path)? {
+            max = Some(max.map_or(v, |m| m.max(v)));
+        }
+    }
+    Ok(max)
+}
+
 /// A temp/scratch file the rotation engine must never treat as an index file.
 fn is_scratch_file(name: &str) -> bool {
     name.ends_with(".tmp") || name.contains(".tmp.") || name.starts_with(".aeix-usearch-tmp-")

--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -80,6 +80,15 @@ pub struct ConcurrentWalSystemConfig {
     /// When set, entries are encrypted before writing to disk and segments
     /// use version 2 format. Passed through to `FlushCoordinatorConfig`.
     pub wal_cipher: Option<Arc<dyn crate::encryption::cipher::Cipher>>,
+    /// Optional provisioned WAL key version (Issue #488 version-provisioning).
+    ///
+    /// When set alongside `wal_cipher`, the WAL keyring is built at this version
+    /// (via [`WalKeyring::single_versioned`]) instead of the hard-coded
+    /// [`INITIAL_WAL_KEY_VERSION`], so a rotate-then-reopen stamps and reports
+    /// the real on-disk version. `None` (the default) reproduces prior behavior
+    /// exactly. Ignored when `wal_cipher` is `None` (a plaintext WAL has no
+    /// keyring).
+    pub wal_key_version: Option<u32>,
     /// Recovery policy for a crash-torn trailing entry (Issue #3433).
     ///
     /// When `true` (the default), [`ConcurrentWalSystem::read_from`] tolerates
@@ -104,6 +113,7 @@ impl std::fmt::Debug for ConcurrentWalSystemConfig {
                 "wal_cipher",
                 &self.wal_cipher.as_ref().map(|c| c.algorithm_name()),
             )
+            .field("wal_key_version", &self.wal_key_version)
             .field("tolerate_torn_tail", &self.tolerate_torn_tail)
             .finish()
     }
@@ -121,6 +131,7 @@ impl Default for ConcurrentWalSystemConfig {
             durability_mode: DurabilityMode::Synchronous,
             write_buffer_size: 64 * 1024, // 64 KB
             wal_cipher: None,
+            wal_key_version: None,
             tolerate_torn_tail: true,
         }
     }
@@ -346,10 +357,20 @@ impl ConcurrentWalSystem {
         // (stamps INITIAL_WAL_KEY_VERSION, decrypts any segment); a full-MEK
         // rotation later advances it to a second generation. Plaintext WALs have
         // no keyring.
-        let wal_keyring = config
-            .wal_cipher
-            .clone()
-            .map(crate::encryption::wal_encryption::WalKeyring::single);
+        //
+        // Issue #488 version-provisioning: when the durable `open()` path
+        // resolves a provisioned key version from durable on-disk state, build
+        // the keyring at that version (still `match_any`, so mixed/legacy
+        // segments decrypt exactly as before) so new segments stamp the real
+        // version and `current_version` reports it. `None` reproduces prior
+        // behavior exactly.
+        let wal_keyring = config.wal_cipher.clone().map(|cipher| {
+            use crate::encryption::wal_encryption::WalKeyring;
+            match config.wal_key_version {
+                Some(v) => WalKeyring::single_versioned(cipher, v),
+                None => WalKeyring::single(cipher),
+            }
+        });
 
         // Create FlushCoordinator config
         let coordinator_config = FlushCoordinatorConfig {

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -683,6 +683,56 @@ pub fn max_lsn_in_dir(
     Ok(max)
 }
 
+/// Scan a WAL directory for the maximum stamped `key_version` across all
+/// segments (Issue #488 version-provisioning).
+///
+/// Reads only segment *headers* — never decrypts a body — so it needs no
+/// cipher and is safe to call before the keyring exists. Returns `None` when no
+/// segment carries a stamped key version: an unencrypted WAL, an empty
+/// directory, or only legacy/pre-rotation segments that predate the
+/// [`WAL_VERSION_ENCRYPTED_KEYVERSIONED`] container. The durable `open()` path
+/// folds this into the provisioned keyring version alongside the index-file
+/// header version. Per-segment I/O errors are swallowed (best-effort, like
+/// [`max_lsn_in_dir`]); a segment whose header does not carry a key version
+/// simply does not contribute.
+#[must_use]
+pub fn max_key_version_in_dir(wal_dir: &Path) -> Option<u32> {
+    let mut max: Option<u32> = None;
+    for (_, path) in sorted_segment_paths(wal_dir) {
+        if let Some(kv) = segment_key_version(&path) {
+            max = Some(max.map_or(kv, |m| m.max(kv)));
+        }
+    }
+    max
+}
+
+/// Read only a WAL segment header and return its stamped `key_version`, or
+/// `None` for a legacy/plaintext/short/undecodable header. Never reads or
+/// decrypts the segment body.
+fn segment_key_version(path: &Path) -> Option<u32> {
+    use std::io::Read;
+    let mut file = File::open(path).ok()?;
+    let mut header = [0u8; WAL_KEYVERSIONED_HEADER_SIZE];
+    let mut filled = 0usize;
+    while filled < header.len() {
+        match file.read(&mut header[filled..]) {
+            Ok(0) => break,
+            Ok(n) => filled += n,
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(_) => return None,
+        }
+    }
+    let buffer = &header[..filled];
+    if buffer.len() < WAL_HEADER_SIZE || buffer[0..4] != WAL_MAGIC {
+        return None;
+    }
+    let version = buffer[4];
+    match decode_header_layout(version, buffer) {
+        Ok((_, key_version)) => key_version,
+        Err(_) => None,
+    }
+}
+
 /// Best-effort maximum-LSN scan of a single segment (see [`max_lsn_in_dir`]).
 ///
 /// Never fails on undecodable entry data — returns the maximum LSN of the


### PR DESCRIPTION
## Before / After

**Before** — after a key rotation and a fresh restart, `encryption verify` reported the rotated index files as an unheld key version and FAILED (even though the data decrypts fine), and a second rotation would wedge because the new version number was recomputed as if no rotation had happened.

**After** — on open, the keyring's current key version is derived from durable on-disk state, so `encryption verify` passes on a rotated database and a subsequent rotation correctly increments the version.

This is a pre-existing bug from the original index key-rotation work (#481/#488), surfaced during #3617 PR2 review; data was never at risk (the single keyring decrypts any header version).

## How

`open()` (the durable `with_unified_config` path) now resolves a provisioned key version via `resolve_provisioned_key_version` — a pending rotation ledger's target is the authority (provision the old version = `new_version - 1`, `saturating_sub` guarded; resume drives to the target); otherwise `max(index manifest AEIX header version, max WAL segment key_version)`, floored at the base version so a never-rotated DB is unchanged. Both keyrings are built version-pinned via `single_versioned` / `with_cipher_versioned` (kept `match_any` so mixed-version legacy files still decrypt — this aligns `single_versioned` with the already-`match_any` `single`).

## Cross-lane note

Touches `src/storage/index_persistence/common.rs` (make the existing test-only `single_versioned` `pub(crate)` + set `match_any: true` to match `single`) and `src/storage/index_persistence/loader.rs` (one additive `with_cipher_versioned` fn) — outside Lane 4's core files but coordinator-cleared (no lane owns those this wave). In-lane: config.rs, rotation.rs, encryption/wal_encryption.rs, index_persistence/reencrypt.rs, storage/wal/{concurrent_system,segment_reader}.rs.

## Testing

`verify_passes_after_cold_reopen_of_rotated_db`, `second_rotation_after_reopen_does_not_wedge`, `mid_rotation_crash_reopen_provisions_from_ledger`, `provisioned_version_is_max_across_index_and_wal` (all TDD RED→GREEN); existing rotation/index_encryption/cli_encryption/AEIX-guard tests green; clippy 0 warnings (CI set + all-features), fmt clean, Feature Matrix, standalone encryption checks — all on a fresh build.

## Known follow-up (out of scope)

`cancel_pending_rotation` still hard-codes old_version = v1 (a pre-existing v1→v2-only limitation, unaffected by this change) — worth a separate fix.

Adversarial review (7 checks) passed: match_any flip safe, precedence underflow-proof, open path panic-safe on crafted data, no secret leak.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRMi3NFi3FwGqXoon9Fqga)_