### PR TITLE
fix(mcp): await_changes catch-up filter + recv_timeout offload (follow-up to #3652)

### DIFF
--- a/crates/aletheia-server/src/changefeed_stream.rs
+++ b/crates/aletheia-server/src/changefeed_stream.rs
@@ -15,8 +15,15 @@
 //!    the `await_changes` long-poll tool (`#[api_doc(mcp)]`), delegating to
 //!    [`AletheiaMcpServer::await_changes`](aletheiadb::mcp::AletheiaMcpServer::await_changes).
 //!
-//! Both are [`ReadClass`]. The blocking `recv_timeout` long-poll is driven on a
-//! `spawn_blocking` worker so it never starves the async runtime.
+//! Both are [`ReadClass`]. The runtime-protection strategy differs by surface:
+//! these **HTTP** handlers offload the blocking `recv_timeout` long-poll onto a
+//! `spawn_blocking` worker so it never starves the async runtime. The **native
+//! MCP** `await_changes` tool (invoked directly over stdio, not through this
+//! HTTP projection) instead uses a `block_in_place` runtime bridge inside
+//! `AletheiaMcpServer::await_changes` for the same protection (it has no
+//! `spawn_blocking` boundary to rely on). Note the idle SSE reap latency is
+//! bounded by [`STREAM_POLL_INTERVAL`] (~15s) after a client disconnects — an
+//! actively-delivering feed cleans up immediately when its receiver drops.
 
 use std::convert::Infallible;
 use std::time::Duration;
@@ -204,8 +211,10 @@ pub async fn changes_stream(
 /// `POST /changes/await` — the MCP-over-HTTP projection of the `await_changes`
 /// long-poll tool (Issue #3375). [`ReadClass`]. HTTP + MCP tool.
 ///
-/// Delegates to [`AletheiaMcpServer::await_changes`]; the blocking long-poll is
-/// driven on a `spawn_blocking` worker so it does not starve the async runtime.
+/// Delegates to [`AletheiaMcpServer::await_changes`]. On this **HTTP** surface
+/// the blocking long-poll is driven on a `spawn_blocking` worker so it does not
+/// starve the async runtime (the native stdio MCP tool has no such boundary and
+/// uses a `block_in_place` runtime bridge internally instead).
 pub async fn await_changes_impl(state: ServerState, req: AwaitChangesRequest) -> Json<Value> {
     let server = state.mcp_server();
     let out = tokio::task::spawn_blocking(move || server.await_changes(req))

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -5634,8 +5634,11 @@ impl AletheiaMcpServer {
 
         // Subscribe FIRST so the frontier is captured before the catch-up read:
         // any change committed after this point is buffered in the subscription,
-        // so the catch-up→block handoff is gap-free.
-        let sub = match self.db.subscribe_changes(filter) {
+        // so the catch-up→block handoff is gap-free. Clone the filter into the
+        // subscription so the handler retains a copy to post-filter the catch-up
+        // page with (the blocking leg is filtered by the subscription itself, so
+        // the catch-up leg must apply the SAME predicate — Fix 1).
+        let sub = match self.db.subscribe_changes(filter.clone()) {
             Ok(s) => s,
             Err(e) => {
                 // A subscribe cap breach is transient (another consumer may
@@ -5684,10 +5687,27 @@ impl AletheiaMcpServer {
                 cursor: Some(token.to_string()),
             };
             match self.db.list_changes(&query) {
+                // The window scanned rows: post-filter them with the SAME
+                // ChangeFilter the blocking leg's subscription applies, so a
+                // filtered subscription's resume path never returns
+                // non-matching changes (Fix 1). The resume token is the last
+                // SCANNED cursor (page.next_cursor, or the last scanned row's
+                // cursor when the scan reached the window's end) — NOT the last
+                // matching row — so a page that filters down to nothing still
+                // advances the caller past every scanned row (no re-scan/stall).
                 Ok(page) if !page.changes.is_empty() => {
-                    let resume = page.changes.last().map(|r| r.cursor().encode());
+                    let filtered: Vec<crate::core::ChangeRecord> = page
+                        .changes
+                        .iter()
+                        .filter(|r| filter.matches(r))
+                        .cloned()
+                        .collect();
+                    let resume = page
+                        .next_cursor
+                        .clone()
+                        .or_else(|| page.changes.last().map(|r| r.cursor().encode()));
                     return self.await_changes_success(
-                        &page.changes,
+                        &filtered,
                         resume,
                         false,
                         page.next_cursor.is_some(),
@@ -5701,7 +5721,23 @@ impl AletheiaMcpServer {
         // Block for the next change up to the clamped timeout (default 25s, hard
         // cap 60s). `recv_timeout(0)` returns instantly (Ok(empty)).
         let timeout_ms = req.timeout_ms.unwrap_or(25_000).min(60_000);
-        match sub.recv_timeout(std::time::Duration::from_millis(timeout_ms)) {
+        let timeout = std::time::Duration::from_millis(timeout_ms);
+        // SAFETY/why: `recv_timeout` parks this worker for up to 60s. On a
+        // multi-thread Tokio runtime (the `aletheia-mcp` binary and
+        // `aletheia-server`), run it inside `block_in_place` so Tokio can spin
+        // up a replacement worker — otherwise one native-stdio long-poll would
+        // stall the whole async `call_tool` dispatch loop. On a current-thread
+        // runtime or with no runtime at all (embedded/programmatic callers),
+        // `block_in_place` would panic, so call `recv_timeout` inline as before.
+        // Mirrors the `block_on_embedding` runtime guard; only this blocking
+        // call needs the bridge (subscribe/list_changes are fast).
+        let recv_result = match tokio::runtime::Handle::try_current() {
+            Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+                tokio::task::block_in_place(|| sub.recv_timeout(timeout))
+            }
+            _ => sub.recv_timeout(timeout),
+        };
+        match recv_result {
             Ok(recs) if !recs.is_empty() => {
                 let resume = recs.last().map(|r| r.cursor().encode());
                 self.await_changes_success(&recs, resume, false, false)

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -1581,55 +1581,174 @@ mod changefeed_await_tests {
 
     #[test]
     fn subscribe_then_write_delivers_the_change() {
-        // A change committed CONCURRENTLY with a blocking await must be delivered
-        // — either live through recv_timeout, or (deterministically) on the next
-        // poll's resume-token catch-up. The writer is gated on the subscription
-        // being registered, so the write lands strictly after subscribe: the
-        // timed-out poll's resume_token (the subscribe-time baseline) therefore
-        // precedes the write, and a catch-up from it is guaranteed to find it.
-        // All timeouts bounded (≤ 60ms) so nothing hangs.
+        // Deterministic LIVE-branch delivery (Fix 3): subscribe FIRST, commit a
+        // write (which buffers the change into the live subscription), THEN
+        // `recv_timeout` drains it immediately — exercising the live push path
+        // directly, with no from_token so no catch-up leg can mask a broken live
+        // wakeup. Bounded timeout so a regressed live path fails fast, never
+        // hangs, and is non-flaky (the write is fully committed before recv).
+        use crate::core::changefeed::ChangeType;
+        use crate::core::changefeed_subscription::ChangeFilter;
+
         let server = create_test_server();
-        let db = server.db().clone();
-        let writer = std::thread::spawn(move || {
-            let start = std::time::Instant::now();
-            while db.changefeed_subscription_count() == 0 {
-                if start.elapsed() > Duration::from_millis(40) {
-                    break;
-                }
-                std::thread::sleep(Duration::from_millis(1));
-            }
-            db.create_node("Person", props("Bob")).unwrap();
+        let db = server.db();
+
+        // Subscribe with the same all-matching filter the tool builds by default.
+        let sub = db
+            .subscribe_changes(ChangeFilter::all())
+            .expect("subscribe");
+
+        // Commit a write strictly AFTER subscribe: it is buffered into `sub`.
+        db.create_node("Person", props("Bob")).unwrap();
+
+        // LIVE branch: recv_timeout drains the buffered change immediately — this
+        // is the live wakeup path, not a catch-up fallback nor an empty timeout.
+        let recs = sub
+            .recv_timeout(Duration::from_millis(60))
+            .expect("live recv must not lag");
+        assert!(
+            !recs.is_empty(),
+            "the committed change is delivered on the LIVE branch (not an empty timeout)"
+        );
+        assert_eq!(
+            recs.len(),
+            1,
+            "exactly the one committed change is delivered"
+        );
+        assert_eq!(recs[0].label, "Person");
+        assert_eq!(recs[0].change_type, ChangeType::Created);
+    }
+
+    #[test]
+    fn catch_up_applies_the_subscription_filter() {
+        // Fix 1 (a): a resume (catch-up) over a window of MIXED changes must
+        // return ONLY the changes matching the subscription's ChangeFilter.
+        // Previously the catch-up leg returned page.changes VERBATIM (unfiltered),
+        // so a filtered subscription's resume path leaked non-matching changes.
+        let server = create_test_server();
+
+        // Window: created (Alice) + modified (Alice) + created (Carol) +
+        // deleted (Carol) → a mix of all three change types.
+        let alice: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            derived_from: None,
+            valid_time: None,
+            label: "Person".to_string(),
+            properties: None,
+            provenance: None,
+        }))
+        .expect("create Alice");
+        let mut bumped = HashMap::new();
+        bumped.insert("age".to_string(), serde_json::json!(31));
+        server.update_node(UpdateNodeRequest {
+            derived_from: None,
+            valid_time: None,
+            node_id: alice.id,
+            properties: bumped,
+            provenance: None,
+        });
+        let carol: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            derived_from: None,
+            valid_time: None,
+            label: "Person".to_string(),
+            properties: None,
+            provenance: None,
+        }))
+        .expect("create Carol");
+        server.delete_node(DeleteNodeRequest {
+            node_id: carol.id,
+            detach: None,
+            valid_time: None,
         });
 
+        // Subscribe filtered to deletes only and catch up from the start of time.
         let mut req = await_req();
-        req.timeout_ms = Some(60);
-        let v1: serde_json::Value = serde_json::from_str(&server.await_changes(req)).unwrap();
-        writer.join().unwrap();
-        assert!(v1.get("error").is_none(), "unexpected error: {v1}");
+        req.change_types = Some(vec!["deleted".to_string()]);
+        req.from_token = Some(ChangeCursor::baseline_after(Timestamp::from(0)));
+        req.timeout_ms = Some(0); // catch-up must return without blocking
+        let v: serde_json::Value = serde_json::from_str(&server.await_changes(req)).unwrap();
 
-        // Resolve the change either from the live poll or the resume-token catch-up.
-        let changes = if v1["count"].as_u64().unwrap_or(0) >= 1 {
-            assert_eq!(v1["timed_out"], serde_json::json!(false), "got: {v1}");
-            v1["changes"].as_array().unwrap().clone()
-        } else {
-            // Live recv missed it under this scheduling; the write is after the
-            // subscribe-time baseline, so a catch-up from the poll's resume_token
-            // deterministically delivers it (timeout 0 → never blocks).
-            let token = v1["resume_token"]
-                .as_str()
-                .expect("resume token")
-                .to_string();
-            let mut req2 = await_req();
-            req2.from_token = Some(token);
-            req2.timeout_ms = Some(0);
-            let v2: serde_json::Value = serde_json::from_str(&server.await_changes(req2)).unwrap();
-            assert!(v2.get("error").is_none(), "unexpected error: {v2}");
-            v2["changes"].as_array().expect("changes array").clone()
-        };
+        assert!(v.get("error").is_none(), "unexpected error: {v}");
+        assert_eq!(
+            v["timed_out"],
+            serde_json::json!(false),
+            "scanned rows: {v}"
+        );
+        let changes = v["changes"].as_array().expect("changes array");
+        assert!(
+            !changes.is_empty(),
+            "the delete matches the filter and must be returned: {v}"
+        );
+        for c in changes {
+            assert_eq!(
+                c["change_type"],
+                serde_json::json!("deleted"),
+                "only deleted changes survive the filter: {v}"
+            );
+        }
+    }
 
-        assert_eq!(changes.len(), 1, "the committed change is delivered");
-        assert_eq!(changes[0]["label"], serde_json::json!("Person"));
-        assert_eq!(changes[0]["change_type"], serde_json::json!("created"));
+    #[test]
+    fn catch_up_advances_resume_token_when_page_filters_to_empty() {
+        // Fix 1 (b): when a scanned page has rows but the filter removes them all,
+        // await_changes must STILL advance past the scanned rows (resume_token =
+        // last scanned cursor / next_cursor, has_more = next_cursor.is_some()) and
+        // return immediately — so a fully-filtered-out page makes progress instead
+        // of re-scanning the same rows or stalling into the block.
+        let server = create_test_server();
+        // Four created changes; NONE are deletes.
+        for _ in 0..4 {
+            server.create_node(CreateNodeRequest {
+                derived_from: None,
+                valid_time: None,
+                label: "Person".to_string(),
+                properties: None,
+                provenance: None,
+            });
+        }
+
+        let mut req = await_req();
+        req.change_types = Some(vec!["deleted".to_string()]); // matches nothing here
+        req.from_token = Some(ChangeCursor::baseline_after(Timestamp::from(0)));
+        req.limit = Some(2); // bound the page → next_cursor Some, has_more true
+        req.timeout_ms = Some(0);
+        let v: serde_json::Value = serde_json::from_str(&server.await_changes(req)).unwrap();
+
+        assert!(v.get("error").is_none(), "unexpected error: {v}");
+        // The page scanned 2 rows, all filtered out: immediate empty, not a block.
+        assert_eq!(
+            v["timed_out"],
+            serde_json::json!(false),
+            "scanned rows → not a timeout: {v}"
+        );
+        assert_eq!(
+            v["count"],
+            serde_json::json!(0),
+            "all rows filtered out: {v}"
+        );
+        assert_eq!(
+            v["has_more"],
+            serde_json::json!(true),
+            "more scanned pages remain: {v}"
+        );
+        let token = v["resume_token"]
+            .as_str()
+            .expect("advanced resume token")
+            .to_string();
+
+        // Resuming from the advanced token scans the NEXT page — real progress,
+        // no re-scan of the first page and no stall.
+        let mut req2 = await_req();
+        req2.change_types = Some(vec!["deleted".to_string()]);
+        req2.from_token = Some(token);
+        req2.limit = Some(2);
+        req2.timeout_ms = Some(0);
+        let v2: serde_json::Value = serde_json::from_str(&server.await_changes(req2)).unwrap();
+        assert!(v2.get("error").is_none(), "unexpected error: {v2}");
+        assert_eq!(v2["count"], serde_json::json!(0), "still no deletes: {v2}");
+        assert!(
+            v2["resume_token"].as_str().is_some(),
+            "the resume anchor still advances: {v2}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fast-follow fixing two MAJOR review findings from #3652 (which merged at f8ac01d before the fix commit landed), plus tests and docs.

## Before / After
- **Filtered changefeed resume** — Before: a subscription with `node_labels`/`edge_types`/`change_types` that resumed via `await_changes` got non-matching changes back (the catch-up leg called `list_changes` without re-applying the filter). After: the catch-up page is post-filtered against the subscription's `ChangeFilter`; `resume_token`/`has_more` advance by the last *scanned* cursor so progress is preserved even when a page filters to empty.
- **Native stdio `await_changes`** — Before: `recv_timeout` ran inline on the async `call_tool` worker up to 60s, able to stall a low-worker stdio MCP server. After: the `recv_timeout` is wrapped in the existing `block_on_embedding`-style `block_in_place` runtime bridge (multi-thread runtime → block_in_place; current-thread/no-runtime → direct). HTTP handlers (already `spawn_blocking`) unchanged.

## How
`src/mcp/server.rs` `handle_await_changes`: clone the ChangeFilter before it moves into `subscribe_changes`; post-filter the bounded catch-up page; wrap `recv_timeout` in the runtime bridge. Tests: `catch_up_applies_the_subscription_filter`, `catch_up_advances_resume_token_when_page_filters_to_empty`, deterministic `subscribe_then_write_delivers_the_change`. Docs scoped in `changefeed_stream.rs`.

## Gates
fmt clean; clippy CI-set + `--all-features` `-D warnings` both green; `cargo test --lib mcp::` 541 passed; bench registry-completeness 58 PASS. aletheia-server parity build could not run locally (sandbox disk exhaustion) — the server change is doc-comment-only; CI is the backstop.

## Follow-ups (not in this PR)
- Inherited: `list_changes` materializes the whole (tx_from, now] window before applying `limit` (pre-existing in the shipped `list_changes`/#3216) — recommend a filter+limit pushdown into the scan.
- No per-principal quota on the shared 128-subscription cap (bounded + retriable; fairness follow-up).
- Abandoned HTTP `/changes/await` calls hold their subscription slot until timeout (bounded ≤60s) — consider a shorter default long-poll for the HTTP projection.

Relates to #3652.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rf3NcaT2K2sQNmT1dU19ft)_