### PR TITLE
feat(encryption): cold-tier (redb) key rotation — completes full-MEK all-layer rotation (#3617 PR3 of 3)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -258,6 +258,36 @@ PersistenceConfig {
 }
 ```
 
+### Cold Storage (Redb) Configuration
+
+The optional on-disk cold tier (`RedbColdStorage`, configured via `RedbConfig`)
+holds unlimited bi-temporal history. It is constructed directly rather than
+through the unified config (see the tiered-storage guide).
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `compression` | CompressionAlgorithm | Zstd | Compression algorithm for stored values |
+| `enable_checksums` | bool | true | Application-level CRC32 checksums on compressed payloads (on top of Redb's own) |
+| `cache_size_bytes` | usize | 0 | Redb internal cache size in bytes (0 = Redb default) |
+| `reencrypt_batch_size` | usize | 4096 | Cold-tier rotation re-encrypt batch size: `(key, value)` pairs re-encrypted per redb write transaction during a key-rotation bulk pass (Issue #3617 PR3) |
+
+**`reencrypt_batch_size` trade-off:** the bulk re-encrypt pass that rewraps
+every cold value under a rotated key runs in bounded, cursor-resumable
+transactions of this many values each. A **larger** value amortizes commit cost
+(fewer, larger transactions → faster) at the price of longer write-transaction
+holds, more per-transaction memory, and a longer crash-replay window; a
+**smaller** value resumes at finer granularity and uses less memory but commits
+more often. A value of `0` would make no forward progress, so it is floored to
+`1` (both at the `RedbConfig::with_reencrypt_batch_size` setter and the read
+site). This is a **runtime knob only** — it does not affect the on-disk format.
+
+```rust
+use aletheiadb::storage::redb_cold_storage::RedbConfig;
+
+// Smaller batches: lower memory + finer-grained rotation resume.
+let config = RedbConfig::new().with_reencrypt_batch_size(512);
+```
+
 ## Configuration Presets
 
 ### Development (Default)

--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -194,13 +194,13 @@ Usage:\n\
                   without reading or printing key material. Alias: keys info.\n\
                   Not configured is reported informationally (exit 0).\n\
   keys verify   — Verify the named key file loads and is valid (health check).\n\
-  keys rotate   — Rotate the index-encryption key (Issue #488). Start a rotation\n\
-                  with --new-key/--new-env-var, or --status/--resume/--cancel an\n\
-                  in-flight one. Requires an encrypted, index-persistent database\n\
-                  (open via ALETHEIADB_CONFIG). NOTE: index-only rotation refuses\n\
-                  safely while any other layer (WAL/cold/checkpoint) is encrypted\n\
-                  under the same key — the normal uniform-MEK case; full-MEK\n\
-                  all-layer rotation is a follow-up.\n\
+  keys rotate   — Rotate the master encryption key (Issue #3617). Start a\n\
+                  rotation with --new-key/--new-env-var, or --status/--resume/\n\
+                  --cancel an in-flight one. Requires an encrypted, index-\n\
+                  persistent database (open via ALETHEIADB_CONFIG). Re-keys EVERY\n\
+                  encrypted-at-rest layer — index, checkpoint, WAL, and cold\n\
+                  storage — so a subsequent key-provider switch is safe. A crash\n\
+                  mid-rotation resumes automatically on the next open.\n\
 \nEncryption at rest (Issue #490):\n\
   encryption status  — Per-layer (WAL/index/checkpoints/cold) encryption status.\n\
   encryption verify  — Prove the configured cipher actually decrypts the database\n\
@@ -603,13 +603,13 @@ fn keys_verify(args: &[String]) -> Result<(), String> {
 /// `ALETHEIADB_DATA_DIR`); rotation requires an encrypted, index-persistent
 /// database. Key bytes are NEVER printed.
 ///
-/// ## Cross-layer refusal is expected on a normally-encrypted database
+/// ## Full-MEK, all-layer rotation (Issue #3617)
 ///
-/// The engine performs an *index-only* rotation and refuses (safely) when any
-/// other at-rest layer (WAL / cold / checkpoint) is encrypted under the same
-/// master key. AletheiaDB's config encrypts uniformly, so a normally-opened
-/// encrypted database has an encrypted WAL and `--new-key` will correctly
-/// refuse. Full-MEK (all-layer) rotation is a documented follow-up.
+/// The engine re-keys EVERY encrypted-at-rest layer under the master key —
+/// index, checkpoint, WAL, and cold storage — so a uniformly-encrypted database
+/// rotates fully and a subsequent key-provider switch is safe. A crash
+/// mid-rotation resumes automatically on the next open (each layer's pass is
+/// idempotent / cursor-resumable).
 fn keys_rotate(args: &[String]) -> Result<(), String> {
     let status = args.iter().any(|a| a == "--status");
     let resume = args.iter().any(|a| a == "--resume");

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -846,7 +846,19 @@ impl AletheiaDB {
                 let mut cold_storage = RedbColdStorage::new(&cold_storage_path, RedbConfig::new())?;
 
                 if let Some(ref enc_mgr) = encryption_manager {
-                    cold_storage = cold_storage.with_cipher(Arc::clone(enc_mgr.cold_cipher()));
+                    // Issue #3617 PR3 version-provisioning: build the cold keyring
+                    // at the provisioned key version (the max on-disk key version,
+                    // or `ledger.new_version - 1` mid-rotation) so freshly written
+                    // cold values stamp the real version and stay in lockstep with
+                    // index/WAL after a rotate-then-reopen. Reads stay `match_any`
+                    // (identical to `with_cipher`); `None` falls back to
+                    // `with_cipher` (unchanged behavior for a never-rotated DB).
+                    cold_storage = match provisioned_key_version {
+                        Some(v) => {
+                            cold_storage.with_cipher_versioned(Arc::clone(enc_mgr.cold_cipher()), v)
+                        }
+                        None => cold_storage.with_cipher(Arc::clone(enc_mgr.cold_cipher())),
+                    };
                 }
 
                 let cold_storage = Arc::new(cold_storage);
@@ -854,6 +866,22 @@ impl AletheiaDB {
                 // Create tiered storage with warm cache configuration
                 let tiered_config = TieredStorageConfig::default();
                 let tiered_storage = TieredStorage::new(tiered_config, cold_storage);
+
+                // Issue #3617 PR3: finish a startup-resumed COLD key rotation. The
+                // cold store is built here — AFTER index/WAL resume — so it is the
+                // last layer to settle; this completes the bulk re-encrypt from the
+                // durable redb cursor (idempotent, skips already-wrapped values),
+                // retires the old cold generation, and clears the rotation ledger.
+                // A no-op when no rotation is pending or cold is not in scope.
+                if let Some(ref manager) = persistence_manager
+                    && config.encryption.enabled
+                {
+                    crate::db::rotation::finalize_resumed_cold_rotation(
+                        manager,
+                        &config.encryption,
+                        tiered_storage.cold_storage(),
+                    )?;
+                }
 
                 // Merge the cold tier's persisted extent bounds into the
                 // temporal index so `temporal_extent` spans history migrated to

--- a/src/db/rotation.rs
+++ b/src/db/rotation.rs
@@ -1780,6 +1780,24 @@ pub fn finalize_resumed_wal_rotation(
 /// or the cold store is unencrypted — so `db::config` can call it unconditionally
 /// on the encrypted-persistent startup path.
 ///
+/// # Crash caveat: resume under the OLD key, THEN switch (inherited from PR2)
+///
+/// This is the inherent "resume under old key, then switch" contract of a
+/// full-MEK rotation, structurally identical to PR2's WAL resume contract
+/// (`install_pending_wal_generations`). While a rotation is `Pending`, the
+/// **old** MEK must remain available to finish it: the cold store is opened at
+/// its provisioned OLD generation, and the still-half-rotated `ACV1@base`
+/// (old-DEK) values are decrypted with that old cold DEK during the resumed bulk
+/// pass. If instead the operator reopens under the **new** key alone while a
+/// rotation crashed mid-cold-pass, the surviving old-DEK values can no longer be
+/// decrypted — the read is a **loud** AEAD authentication failure, so `open()`
+/// returns `Err` and the DB is unopenable rather than silently returning wrong
+/// data. Recovery is straightforward and lossless: reopen once under the OLD key
+/// so this resume completes (re-wrapping every value at the new generation and
+/// clearing the ledger), after which the new key alone reads everything. The
+/// fault is therefore availability-only and fully recoverable, never integrity
+/// loss.
+///
 /// # Errors
 ///
 /// Returns an error if the recorded new key source cannot be sourced or the bulk

--- a/src/db/rotation.rs
+++ b/src/db/rotation.rs
@@ -68,6 +68,7 @@ use crate::storage::index_persistence::reencrypt::DecryptProbeReport;
 use crate::storage::index_persistence::{
     IndexKeyRotation, IndexPersistenceManager, RotationError, RotationProgress, RotationStatus,
 };
+use crate::storage::redb_cold_storage::RedbColdStorage;
 use crate::storage::wal::concurrent_system::ConcurrentWalSystem;
 
 /// Summary of a completed index key rotation.
@@ -174,6 +175,16 @@ fn derive_wal_dek(
         .map_err(|e| RotationError::KeyProvider(e.to_string()))
 }
 
+/// Derive the cold-storage DEK for a MEK using the shared HKDF context (Issue
+/// #3617 PR3).
+fn derive_cold_dek(
+    mek: Zeroizing<[u8; 32]>,
+) -> std::result::Result<Zeroizing<[u8; 32]>, RotationError> {
+    KeyDerivation::new(mek)
+        .derive_cold_dek()
+        .map_err(|e| RotationError::KeyProvider(e.to_string()))
+}
+
 /// Force-roll the WAL under the new DEK and retire the old-generation segments
 /// (Issue #3617). Shared by the forward driver and crash-resume.
 ///
@@ -234,6 +245,20 @@ fn mark_wal_complete(manager: &IndexPersistenceManager) -> Result<()> {
         && ledger.wal != LayerStatus::Complete
     {
         ledger.wal = LayerStatus::Complete;
+        write_ledger(manager, &ledger)?;
+    }
+    Ok(())
+}
+
+/// Rewrite the durable ledger flipping `layer.cold=complete` (Issue #3617 PR3),
+/// preserving every other field. A no-op when no ledger is present. Keeps the
+/// #488 P0.2 ordering: the completion is fsync'd before the old cold generation
+/// is retired / the ledger is cleared.
+fn mark_cold_complete(manager: &IndexPersistenceManager) -> Result<()> {
+    if let Some(mut ledger) = read_rotation_state(manager)?
+        && ledger.cold != LayerStatus::Complete
+    {
+        ledger.cold = LayerStatus::Complete;
         write_ledger(manager, &ledger)?;
     }
     Ok(())
@@ -572,20 +597,18 @@ impl AletheiaDB {
     /// is the sole encrypted surface — the only case an index-only key rotation
     /// is safe. Never exposes ciphers or key material.
     fn conflicting_encrypted_layers(&self) -> Vec<&'static str> {
-        let mut layers = Vec::new();
-        // WAL is now rotatable by the full-MEK driver (Issue #3617 PR2): a
-        // checkpoint → force-roll under the new WAL DEK → truncate of the old
-        // segments re-keys it with no bulk rewrite, so it is no longer a
-        // cross-layer conflict.
+        // Full-MEK rotation now covers every encrypted-at-rest layer (Issue
+        // #3617): the index/checkpoint tree (PR1), the WAL (PR2, checkpoint →
+        // force-roll under the new WAL DEK → truncate the old segments), and the
+        // cold/redb tier (PR3, transactional bulk re-encrypt of every stored
+        // value). None of them is a cross-layer conflict any more, so a uniformly
+        // encrypted database rotates fully and this returns empty.
         //
-        // Cold storage is NOT yet covered (PR3): when a tiered/cold store is
-        // configured and encryption is enabled, its files are under the cold DEK
-        // from the same MEK, so an index+WAL rotation would still strand them —
-        // keep refusing until the cold re-keyer lands.
-        if self.encryption_manager.is_some() && self.historical.read().has_tiered_storage() {
-            layers.push("cold_storage");
-        }
-        layers
+        // Retained as the extension point the P0.1 guard consults: a FUTURE
+        // encrypted-at-rest layer with no rotation support MUST push its name here
+        // (and be re-encrypted by the driver) rather than silently stranding its
+        // bytes under the old MEK after a provider switch.
+        Vec::new()
     }
 
     /// Prerequisite check shared by status and rotate: index persistence must be
@@ -710,7 +733,18 @@ impl AletheiaDB {
         // PR2). The startup path instead passes `None` and defers via
         // `finalize_resumed_wal_rotation`.
         let persist = || self.persist_indexes();
-        resume_pending_rotation(&manager, &enc_cfg, Some(&self.wal), Some(&persist))
+        let report = resume_pending_rotation(&manager, &enc_cfg, Some(&self.wal), Some(&persist))?;
+        // Cold layer (Issue #3617 PR3): on the LIVE resume path the cold store is
+        // already wired, so finish any pending cold rotation here (idempotent —
+        // resumes from the redb cursor / skips already-wrapped values) and clear
+        // the ledger. `resume_pending_rotation` deferred the clear while cold was
+        // `Pending`. A no-op when cold is not in flight.
+        if report.is_some()
+            && let Some(tiered) = self.historical.read().tiered_storage_arc()
+        {
+            finalize_resumed_cold_rotation(&manager, &enc_cfg, tiered.cold_storage())?;
+        }
+        Ok(report)
     }
 
     fn run_rotation(
@@ -767,6 +801,11 @@ impl AletheiaDB {
         // resume drives it; `write_ledger` fsyncs the file and its parent dir,
         // and only once it returns does the driver flip any keyring.
         let wal_in_scope = self.wal.is_encrypted();
+        // Cold storage is in scope (Issue #3617 PR3) when encryption is
+        // configured and a tiered/cold store is present — its values are under
+        // the cold DEK from the same MEK and must be bulk re-encrypted.
+        let cold_in_scope =
+            self.encryption_manager.is_some() && self.historical.read().has_tiered_storage();
 
         // WAL-rotation invariant (Issue #3617): checkpoint BEFORE the ledger is
         // written. `persist_indexes` captures every committed entry into the
@@ -782,7 +821,12 @@ impl AletheiaDB {
 
         write_ledger(
             manager,
-            &RotationLedger::forward_scope(new_version, new_key_source.clone(), wal_in_scope),
+            &RotationLedger::forward_scope(
+                new_version,
+                new_key_source.clone(),
+                wal_in_scope,
+                cold_in_scope,
+            ),
         )?;
         self.emit_rotation_audit(&AuditEvent::RotationStarted {
             old_version,
@@ -804,6 +848,20 @@ impl AletheiaDB {
                 .map(|lc| Arc::clone(&lc.new))
                 .ok_or_else(|| rotation_err(RotationError::NotConfigured))?;
             self.rotate_wal_layer(manager, wal_new_cipher, new_version)?;
+        }
+
+        // Cold layer (Issue #3617 PR3): transactional bulk re-encrypt of every
+        // stored value from the old cold DEK to the new one. Runs after WAL; the
+        // cold DEK is domain-separated (`"cold"` HKDF context) so there is no
+        // cross-layer dependency. Completes #3617 — after this every
+        // encrypted-at-rest byte decrypts under the new MEK's DEKs.
+        if cold_in_scope {
+            let cold_new_cipher = layer_ciphers
+                .iter()
+                .find(|lc| lc.layer == RotationLayer::Cold)
+                .map(|lc| Arc::clone(&lc.new))
+                .ok_or_else(|| rotation_err(RotationError::NotConfigured))?;
+            self.rotate_cold_layer(manager, cold_new_cipher, new_version)?;
         }
 
         clear_rotation_state(manager);
@@ -882,6 +940,47 @@ impl AletheiaDB {
             .into());
         }
         mark_wal_complete(manager)?;
+        Ok(())
+    }
+
+    /// Re-key the cold (redb) layer to `new_cold_cipher` (Issue #3617 PR3) by a
+    /// transactional bulk re-encrypt of every stored value.
+    ///
+    /// Sequence:
+    /// 1. **Reach the cold store** through `historical.tiered_storage_arc()`, then
+    ///    DROP the `historical` guard — the redb write transactions self-serialize,
+    ///    so no AletheiaDB primitive is held across the (potentially long) pass,
+    ///    honoring the CLAUDE.md lock order (cold sits under `historical`).
+    /// 2. **Install** the new cold DEK as generation `new_key_version`, keeping the
+    ///    old generation live so a half-rotated store still reads old-generation
+    ///    values under the `ACV1` wrapper dispatch.
+    /// 3. **Bulk re-encrypt** every `node_versions`/`edge_versions` value to the
+    ///    new generation, in redb-atomic batches, resumable via a durable redb
+    ///    cursor; `flushed_lsn`/`temporal_extent` are never touched.
+    /// 4. **Retire** the old generation (every value is now wrapped at the new
+    ///    version), so the old cold DEK can be dropped after a provider switch.
+    /// 5. **Complete** — flip `layer.cold=complete` in the durable ledger.
+    ///
+    /// A no-op when no cold store is configured or the cold store is unencrypted.
+    fn rotate_cold_layer(
+        &self,
+        manager: &IndexPersistenceManager,
+        new_cold_cipher: Arc<dyn Cipher>,
+        new_key_version: u32,
+    ) -> Result<()> {
+        // Grab the cold-store handle under a brief `historical` read lock, then
+        // drop the guard: the bulk pass runs WITHOUT holding `historical`.
+        let Some(tiered) = self.historical.read().tiered_storage_arc() else {
+            return Ok(());
+        };
+        let cold = tiered.cold_storage();
+        if !cold.is_encrypted() {
+            return Ok(());
+        }
+        cold.install_cold_generation(new_key_version, new_cold_cipher)?;
+        cold.reencrypt_cold_values(new_key_version)?;
+        cold.retire_cold_generations(new_key_version)?;
+        mark_cold_complete(manager)?;
         Ok(())
     }
 }
@@ -988,23 +1087,32 @@ impl RotationLedger {
         }
     }
 
-    /// The PR2 cross-layer plan (Issue #3617): index + checkpoint always
+    /// The full-MEK cross-layer plan (Issue #3617): index + checkpoint always
     /// re-key through the index engine; the WAL is `Pending` when it is
-    /// encrypted (the full-MEK driver re-keys it), else `Skipped`; cold remains
-    /// out of scope (`Skipped`) until PR3.
-    fn forward_scope(new_version: u32, new_source: KeyProviderConfig, wal_in_scope: bool) -> Self {
+    /// encrypted (the full-MEK driver force-rolls it), else `Skipped`; cold is
+    /// `Pending` when a tiered/cold store is encrypted (PR3 bulk re-encrypts it),
+    /// else `Skipped`.
+    fn forward_scope(
+        new_version: u32,
+        new_source: KeyProviderConfig,
+        wal_in_scope: bool,
+        cold_in_scope: bool,
+    ) -> Self {
+        let scope = |in_scope: bool| {
+            if in_scope {
+                LayerStatus::Pending
+            } else {
+                LayerStatus::Skipped
+            }
+        };
         Self {
             direction: RotationDirection::Forward,
             new_version,
             new_source,
             index: LayerStatus::Pending,
             checkpoint: LayerStatus::Pending,
-            wal: if wal_in_scope {
-                LayerStatus::Pending
-            } else {
-                LayerStatus::Skipped
-            },
-            cold: LayerStatus::Skipped,
+            wal: scope(wal_in_scope),
+            cold: scope(cold_in_scope),
         }
     }
 }
@@ -1427,6 +1535,13 @@ pub fn resume_pending_rotation(
     //   the replay read), so replay decrypts every segment regardless of
     //   generation; the ledger stays PENDING for the finalize pass.
     let wal_pending = matches!(ledger.wal, LayerStatus::Pending);
+    // Cold layer (Issue #3617 PR3): the cold store is NOT reachable here (on the
+    // startup path it is constructed AFTER this pass; a free function has no `self`
+    // to reach it). When cold is `Pending` the ledger MUST survive this pass so
+    // the cold re-encrypt + final clear run in `finalize_resumed_cold_rotation`
+    // once the cold store exists. Both the live and startup resume paths honor
+    // this by gating the clear below on `!cold_pending`.
+    let cold_pending = matches!(ledger.cold, LayerStatus::Pending);
     // DEFECT #3617-PR2: track whether the WAL layer actually finished retiring so
     // the final `clear_rotation_state` below is GATED on real completion (never
     // clears the ledger while an old-generation segment survives).
@@ -1518,7 +1633,7 @@ pub fn resume_pending_rotation(
             // window this fix closes. The index re-encrypt + `complete()` above
             // are durable and idempotent, so leaving the ledger for the finalize
             // pass is safe and re-entrant across another crash.
-            if !wal_finalize_deferred {
+            if !wal_finalize_deferred && !cold_pending {
                 clear_rotation_state(manager);
                 logger.log(&AuditEvent::RotationCompleted {
                     new_version: ledger.new_version,
@@ -1634,6 +1749,71 @@ pub fn finalize_resumed_wal_rotation(
         .into());
     }
     mark_wal_complete(manager)?;
+    // Issue #3617 PR3: if the cold layer is still `Pending`, LEAVE the ledger for
+    // `finalize_resumed_cold_rotation` (which runs after the cold store is built)
+    // to complete cold and clear it. Clearing here would drop the ledger while
+    // cold values are still half-rotated, wedging a provider switch.
+    if !matches!(ledger.cold, LayerStatus::Pending) {
+        clear_rotation_state(manager);
+    }
+    Ok(())
+}
+
+/// Finalize a startup-resumed COLD (redb) key rotation (Issue #3617 PR3),
+/// completing the transactional bulk re-encrypt and clearing the ledger.
+///
+/// The cold store is constructed on the durable `open()` path AFTER
+/// [`resume_pending_rotation`] and [`finalize_resumed_wal_rotation`] have run
+/// (index + WAL are re-keyed before the cold tier is wired), so cold is the LAST
+/// layer to settle and this function performs the final ledger clear. It is
+/// idempotent and resumable:
+///
+/// 1. re-derive + install the new cold DEK generation (the old generation is
+///    already the cold store's provisioned single generation);
+/// 2. run [`RedbColdStorage::reencrypt_cold_values`], which resumes from the
+///    durable redb cursor and skips any value already wrapped at the target
+///    version — so a crash mid-batch resumes with no double-encrypt;
+/// 3. retire the old cold generation, mark `layer.cold=complete`, and clear the
+///    ledger (every layer has now settled).
+///
+/// A no-op (`Ok(())`) when no ledger is present, the cold layer is not `Pending`,
+/// or the cold store is unencrypted — so `db::config` can call it unconditionally
+/// on the encrypted-persistent startup path.
+///
+/// # Errors
+///
+/// Returns an error if the recorded new key source cannot be sourced or the bulk
+/// re-encrypt pass fails (a genuine wrong/absent key surfaces loudly; the ledger
+/// is left `Pending` for a later resume).
+pub fn finalize_resumed_cold_rotation(
+    manager: &Arc<IndexPersistenceManager>,
+    enc_cfg: &EncryptionConfig,
+    cold: &RedbColdStorage,
+) -> Result<()> {
+    let Some(ledger) = read_rotation_state(manager)? else {
+        return Ok(());
+    };
+    if !matches!(ledger.cold, LayerStatus::Pending) {
+        return Ok(());
+    }
+    if !cold.is_encrypted() {
+        return Ok(());
+    }
+
+    // Re-derive + install the new cold generation (idempotent: a re-run replaces
+    // the same-version generation). The old generation is the cold store's
+    // provisioned single generation, still live for reading old-DEK values.
+    let new_cold_dek = derive_cold_dek(load_mek(&ledger.new_source).map_err(rotation_err)?)
+        .map_err(rotation_err)?;
+    let new_cold_cipher: Arc<dyn Cipher> =
+        Arc::from(create_cipher(enc_cfg.algorithm, &new_cold_dek));
+    cold.install_cold_generation(ledger.new_version, new_cold_cipher)?;
+
+    // Resume the bulk re-encrypt from the redb cursor (skips already-wrapped
+    // values), retire the old generation, then complete + clear the ledger.
+    cold.reencrypt_cold_values(ledger.new_version)?;
+    cold.retire_cold_generations(ledger.new_version)?;
+    mark_cold_complete(manager)?;
     clear_rotation_state(manager);
     Ok(())
 }
@@ -1672,6 +1852,40 @@ mod tests {
                 load_on_startup: true,
                 ..Default::default()
             })
+            .encryption(EncryptionConfig::file_based(key_file))
+            .build();
+        AletheiaDB::with_unified_config(config).unwrap()
+    }
+
+    /// Build a fully-encrypted DB WITH an encrypted cold (redb) tier (Issue
+    /// #3617 PR3): WAL + index + cold all under the same MEK. This is the
+    /// configuration a full-MEK rotation must cover end to end.
+    fn build_db_with_cold(root: &Path, key_file: &Path) -> AletheiaDB {
+        use crate::config::HistoricalConfigBuilder;
+        use std::time::Duration;
+        let config = AletheiaDBConfig::builder()
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(root.join("wal"))
+                    .durability_mode(DurabilityMode::GroupCommit {
+                        max_delay_ms: 5,
+                        max_batch_size: 64,
+                    })
+                    .build(),
+            )
+            .persistence(crate::storage::index_persistence::PersistenceConfig {
+                enabled: true,
+                data_dir: root.join("data"),
+                load_on_startup: true,
+                ..Default::default()
+            })
+            .historical(
+                HistoricalConfigBuilder::new()
+                    .enable_cold_storage(true)
+                    .cold_storage_path(root.join("cold.redb"))
+                    .migration_age_threshold(Duration::from_secs(3600))
+                    .build(),
+            )
             .encryption(EncryptionConfig::file_based(key_file))
             .build();
         AletheiaDB::with_unified_config(config).unwrap()
@@ -2102,13 +2316,12 @@ mod tests {
     }
 
     #[test]
-    fn rotate_still_refuses_when_cold_storage_encrypted() {
-        // Issue #3617 PR2: cold storage is NOT yet covered (PR3). A DB with
-        // encrypted cold storage must STILL refuse — an index+WAL rotation would
-        // strand the cold values under the old MEK.
-        use crate::config::HistoricalConfigBuilder;
-        use std::time::Duration;
-
+    fn rotate_reencrypts_cold() {
+        // Issue #3617 PR3 (completes the issue): a fully-encrypted DB with an
+        // ENCRYPTED COLD tier (WAL + index + cold under the same MEK) now ROTATES
+        // fully — the driver bulk re-encrypts every cold value to the new cold
+        // DEK, so a subsequent provider switch is safe. This flips the former
+        // cross-layer refusal.
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
         let old_key = root.join("old.key");
@@ -2116,51 +2329,99 @@ mod tests {
         crate::encryption::FileKeyProvider::generate_key_file(&old_key).unwrap();
         crate::encryption::FileKeyProvider::generate_key_file(&new_key).unwrap();
 
-        let config = AletheiaDBConfig::builder()
-            .wal(
-                WalConfigBuilder::new()
-                    .wal_dir(root.join("wal"))
-                    .durability_mode(DurabilityMode::GroupCommit {
-                        max_delay_ms: 5,
-                        max_batch_size: 64,
-                    })
-                    .build(),
-            )
-            .persistence(crate::storage::index_persistence::PersistenceConfig {
-                enabled: true,
-                data_dir: root.join("data"),
-                load_on_startup: true,
-                ..Default::default()
-            })
-            .historical(
-                HistoricalConfigBuilder::new()
-                    .enable_cold_storage(true)
-                    .cold_storage_path(root.join("cold.redb"))
-                    .migration_age_threshold(Duration::from_secs(3600))
-                    .build(),
-            )
-            .encryption(EncryptionConfig::file_based(&old_key))
-            .build();
-        let db = AletheiaDB::with_unified_config(config).unwrap();
-        seed(&db);
-        assert!(db.wal.is_encrypted());
+        use crate::core::interning::GLOBAL_INTERNER;
+        use crate::core::version::{EntityVersion, NodeVersion};
 
-        let conflicting = db.conflicting_encrypted_layers();
-        assert!(
-            conflicting.contains(&"cold_storage"),
-            "cold storage must still be a conflict until PR3, got: {conflicting:?}"
-        );
-        let err = db
-            .rotate_index_keys(KeyProviderConfig::File {
-                path: new_key.clone(),
-            })
-            .unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("other encrypted-at-rest layers") && msg.contains("cold_storage"),
-            "expected cross-layer refusal naming cold_storage, got: {msg}"
-        );
-        assert!(!root.join("data").join("rotation.state").exists());
+        // A cold value to prove the bulk pass actually re-encrypts stored data
+        // (seeded nodes live in the hot tier; migration is age-gated). Written
+        // directly to the cold store so it is present as `ACV1@1` before rotation.
+        let cold_vid = crate::core::id::VersionId::new(9001).unwrap();
+        let (alice, bob) = {
+            let db = build_db_with_cold(root, &old_key);
+            let ids = seed(&db);
+            assert!(db.wal.is_encrypted(), "precondition: WAL is encrypted");
+
+            // Seed one cold-tier value directly.
+            let cold_node = NodeVersion::new_anchor(
+                cold_vid,
+                crate::core::NodeId::new(500).unwrap(),
+                crate::core::temporal::BiTemporalInterval::current(1234.into()),
+                GLOBAL_INTERNER.intern("Person").unwrap(),
+                PropertyMapBuilder::new().insert("name", "Carol").build(),
+            );
+            {
+                let tiered = db
+                    .historical
+                    .read()
+                    .tiered_storage_arc()
+                    .expect("cold tier configured");
+                let cold = tiered.cold_storage();
+                assert!(cold.is_encrypted(), "precondition: cold tier is encrypted");
+                cold.store_node_version(&cold_node).unwrap();
+                assert_eq!(
+                    cold.current_cold_key_version(),
+                    Some(1),
+                    "cold values start at generation 1"
+                );
+            }
+
+            // The cross-layer guard no longer refuses — cold is rotatable.
+            assert!(
+                db.conflicting_encrypted_layers().is_empty(),
+                "cold storage is now rotatable → no cross-layer conflict"
+            );
+
+            let flushed_before = {
+                let tiered = db.historical.read().tiered_storage_arc().unwrap();
+                tiered.cold_storage().get_flushed_lsn().unwrap()
+            };
+
+            let report = db
+                .rotate_index_keys(KeyProviderConfig::File {
+                    path: new_key.clone(),
+                })
+                .expect("full-MEK rotation (index+WAL+cold) must succeed");
+            assert_eq!(report.new_version, 2);
+            assert!(!root.join("data").join("rotation.state").exists());
+
+            // The cold layer was bulk re-encrypted to the new generation.
+            {
+                let tiered = db.historical.read().tiered_storage_arc().unwrap();
+                let cold = tiered.cold_storage();
+                assert_eq!(
+                    cold.cold_value_format_version().unwrap(),
+                    Some(2),
+                    "cold values must be re-wrapped at the new generation"
+                );
+                // The value still decodes (now under the new cold DEK).
+                let loaded = cold
+                    .get_node_version(cold_vid)
+                    .unwrap()
+                    .expect("cold value survives rotation");
+                assert_eq!(loaded.version_id(), cold_vid);
+                // flushed_lsn (plaintext metadata) is untouched by the pass.
+                assert_eq!(cold.get_flushed_lsn().unwrap(), flushed_before);
+            }
+            ids
+        };
+
+        // Provider switch: reopen under the NEW key ONLY — WAL replays, index +
+        // cold values all decrypt under the new MEK's DEKs.
+        {
+            let db = build_db_with_cold(root, &new_key);
+            assert_eq!(db.node_count(), 2, "graph recovers under the new key");
+            assert_eq!(db.edge_count(), 1);
+            db.get_node(alice)
+                .expect("alice recovers under the new key");
+            db.get_node(bob).expect("bob recovers under the new key");
+            let tiered = db.historical.read().tiered_storage_arc().unwrap();
+            let cold = tiered.cold_storage();
+            let loaded = cold
+                .get_node_version(cold_vid)
+                .unwrap()
+                .expect("cold value decrypts under the new key alone");
+            assert_eq!(loaded.version_id(), cold_vid);
+        }
     }
 
     /// Crash right after the rotation ledger was fsync'd but before any layer
@@ -2192,7 +2453,8 @@ mod tests {
                     KeyProviderConfig::File {
                         path: new_key.clone(),
                     },
-                    true, // WAL in scope
+                    true,  // WAL in scope
+                    false, // cold not in scope
                 ),
             )
             .unwrap();
@@ -2366,6 +2628,7 @@ mod tests {
                         path: new_key.clone(),
                     },
                     true,
+                    false, // cold not in scope
                 ),
             )
             .unwrap();
@@ -3708,7 +3971,8 @@ mod tests {
                     KeyProviderConfig::File {
                         path: new_key.clone(),
                     },
-                    true, // WAL in scope
+                    true,  // WAL in scope
+                    false, // cold not in scope
                 ),
             )
             .unwrap();
@@ -3832,6 +4096,7 @@ mod tests {
                         path: new_key.clone(),
                     },
                     true,
+                    false, // cold not in scope
                 ),
             )
             .unwrap();

--- a/src/storage/redb_cold_storage/keyring.rs
+++ b/src/storage/redb_cold_storage/keyring.rs
@@ -1,0 +1,251 @@
+//! Cold-tier (redb) key ring and self-describing value wrapper (Issue #3617 PR3).
+//!
+//! A full-MEK key rotation re-keys the cold tier by a **transactional bulk
+//! re-encrypt** of every stored value: each `node_versions`/`edge_versions`
+//! value is decrypted under the OLD cold DEK and re-encrypted under the NEW cold
+//! DEK. To read correctly during (and after) such a rotation the cold store must
+//! hold BOTH generations at once and select per value, exactly like the WAL
+//! ([`WalKeyring`](crate::encryption::wal_encryption::WalKeyring)) and index
+//! ([`IndexKeyring`](crate::storage::index_persistence::common::IndexKeyring))
+//! keyrings. [`ColdKeyring`] is that holder, deliberately mirroring their shape
+//! (a small `Vec` of generations, a `current` stamped into freshly written
+//! values, and a single-cipher `match_any` back-compat mode).
+//!
+//! # Self-describing value wrapper (`ACV1`)
+//!
+//! Cold values are compress-then-encrypt with empty AAD, and a legacy value is
+//! opaque AEAD ciphertext whose leading bytes are effectively random — so a bare
+//! 1-byte discriminator would be ambiguous. Re-encrypted values are therefore
+//! prefixed with an 8-byte self-describing header:
+//!
+//! ```text
+//! Wrapped value:  [magic "ACV1":4][key_version:u32 LE:4][ AEAD(compress(record)) ]
+//! Legacy value:   [ AEAD(compress(record)) ]            # exactly the pre-#3617 format
+//! ```
+//!
+//! Read dispatch ([`parse_cold_wrapper`] in front of decrypt): a value is
+//! treated as wrapped ONLY IF it begins with `ACV1` **and** the following `u32`
+//! names a generation the live keyring holds; otherwise it is treated as a
+//! legacy bare ciphertext and decrypted under the oldest (pre-rotation) cold
+//! generation. This double check makes a false positive astronomically
+//! unlikely: a genuine legacy ciphertext would have to begin with the exact
+//! 4-byte magic (~2⁻³²) AND have its next 4 bytes equal a small, currently-held
+//! key-version (~2⁻³² for the tiny set of live versions) — a combined ~2⁻⁶⁴
+//! event, and even then it fails LOUDLY as an AEAD authentication error (the
+//! wrong slice is fed to `decrypt`), never as silent wrong data. The same
+//! 4-byte-magic collision argument is used one layer down by
+//! [`COLD_RECORD_MAGIC_V2`](super) for the in-record provenance tag.
+//!
+//! No key material is ever written into the wrapper (a `key_version` integer
+//! only), logged, or rendered by `Debug`.
+
+use std::sync::{Arc, RwLock};
+
+use crate::encryption::Cipher;
+
+/// Magic prefix identifying an `ACV1`-wrapped cold value. Deliberately the
+/// printable ASCII `b"ACV1"` (**A**letheia **C**old **V**alue v**1**), distinct
+/// from the record-level [`COLD_RECORD_MAGIC_V2`](super::COLD_RECORD_MAGIC_V2)
+/// `[0xA1,0x37,0xC0,0xDE]` / [`COLD_RECORD_MAGIC_V3`](super::COLD_RECORD_MAGIC_V3)
+/// `[0xB2,0x48,0xD1,0xEF]` — those tag the *record* inside the ciphertext, this
+/// tags the *stored value* outside it, so they never occupy the same byte
+/// position, but keeping the values disjoint avoids any reviewer confusion.
+pub(super) const COLD_VALUE_MAGIC: [u8; 4] = *b"ACV1";
+
+/// Total length of the `ACV1` wrapper prefix (4-byte magic + 4-byte key_version).
+pub(super) const COLD_VALUE_WRAPPER_LEN: usize = 8;
+
+/// The `key_version` a fresh (never-rotated) encrypted cold store stamps into
+/// its `ACV1` value wrappers. Mirrors [`INITIAL_WAL_KEY_VERSION`] /
+/// `ENC_INDEX_KEY_VERSION_V1` so all three layers number their first generation
+/// identically.
+///
+/// [`INITIAL_WAL_KEY_VERSION`]: crate::encryption::wal_encryption::INITIAL_WAL_KEY_VERSION
+pub(super) const INITIAL_COLD_KEY_VERSION: u32 = 1;
+
+/// Prepend the `ACV1` wrapper to an AEAD ciphertext, stamping `key_version`.
+pub(super) fn wrap_cold_value(key_version: u32, ciphertext: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(COLD_VALUE_WRAPPER_LEN + ciphertext.len());
+    out.extend_from_slice(&COLD_VALUE_MAGIC);
+    out.extend_from_slice(&key_version.to_le_bytes());
+    out.extend_from_slice(ciphertext);
+    out
+}
+
+/// If `value` begins with the `ACV1` magic and is long enough to carry the
+/// key-version, return `(key_version, ciphertext_without_wrapper)`; otherwise
+/// `None` (a legacy, unwrapped value). This does NOT consult the keyring — the
+/// caller checks whether the returned `key_version` names a held generation and
+/// falls back to the legacy path if not.
+pub(super) fn parse_cold_wrapper(value: &[u8]) -> Option<(u32, &[u8])> {
+    if value.len() < COLD_VALUE_WRAPPER_LEN || value[..4] != COLD_VALUE_MAGIC {
+        return None;
+    }
+    let key_version = u32::from_le_bytes([value[4], value[5], value[6], value[7]]);
+    Some((key_version, &value[COLD_VALUE_WRAPPER_LEN..]))
+}
+
+#[derive(Clone)]
+struct ColdKeyGeneration {
+    key_version: u32,
+    cipher: Arc<dyn Cipher>,
+}
+
+struct ColdKeyringInner {
+    /// All live generations (1 before rotation, 2 during, 1 after). Small.
+    generations: Vec<ColdKeyGeneration>,
+    /// Version stamped into freshly written values (the newest generation).
+    current_version: u32,
+    /// Back-compat mode: a lone generation created from a single cipher decrypts
+    /// ANY value (any `key_version`, or a legacy value carrying no wrapper) with
+    /// that one cipher. This is the never-rotated steady state and, crucially,
+    /// the post-provider-switch state: after a completed rotation the operator
+    /// reopens under the new key alone, so the single new-DEK keyring must still
+    /// read the new-DEK values regardless of the `key_version` they were stamped
+    /// with during the rotation.
+    match_any: bool,
+}
+
+/// A cheaply-cloneable, shared-mutable set of cold DEK ciphers addressed by
+/// `key_version` (Issue #3617 PR3).
+///
+/// Clones share the same underlying state, so the rotation driver can advance
+/// the current generation (making new writes stamp + encrypt under the new DEK)
+/// while readers holding clones observe the change immediately. Never exposes
+/// key material; `Debug` is redacted.
+#[derive(Clone)]
+pub struct ColdKeyring {
+    inner: Arc<RwLock<ColdKeyringInner>>,
+}
+
+impl std::fmt::Debug for ColdKeyring {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never render key material — only opaque generation metadata.
+        let inner = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        f.debug_struct("ColdKeyring")
+            .field("generations", &inner.generations.len())
+            .field("current_version", &inner.current_version)
+            .field("match_any", &inner.match_any)
+            .finish()
+    }
+}
+
+impl ColdKeyring {
+    /// A single-generation keyring from one cipher (the non-rotation path).
+    ///
+    /// Reads decrypt any value (any wrapper `key_version`, or a legacy value with
+    /// no wrapper) with this cipher and writes stamp
+    /// [`INITIAL_COLD_KEY_VERSION`].
+    pub fn single(cipher: Arc<dyn Cipher>) -> Self {
+        Self::single_versioned(cipher, INITIAL_COLD_KEY_VERSION)
+    }
+
+    /// A single-generation cold keyring pinned to an explicit `key_version`
+    /// (Issue #488 version-provisioning parity). Reads decrypt every value with
+    /// this one cipher (`match_any`, byte-identical to [`Self::single`]); only
+    /// the write-stamp / reported [`current_version`](Self::current_version) is
+    /// pinned to `key_version`. The durable `open()` path builds the cold keyring
+    /// at the provisioned key version so freshly written values stamp the real
+    /// version instead of a stale [`INITIAL_COLD_KEY_VERSION`], keeping the cold
+    /// layer in lockstep with index/WAL after a rotate-then-reopen.
+    pub fn single_versioned(cipher: Arc<dyn Cipher>, key_version: u32) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(ColdKeyringInner {
+                generations: vec![ColdKeyGeneration {
+                    key_version,
+                    cipher,
+                }],
+                current_version: key_version,
+                match_any: true,
+            })),
+        }
+    }
+
+    /// The current (write) cipher and the `key_version` it stamps into new value
+    /// wrappers, or `None` if the keyring somehow holds no generation.
+    pub fn current(&self) -> Option<(Arc<dyn Cipher>, u32)> {
+        let inner = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        let v = inner.current_version;
+        inner
+            .generations
+            .iter()
+            .find(|g| g.key_version == v)
+            .map(|g| (g.cipher.clone(), v))
+    }
+
+    /// The version freshly written values are stamped with.
+    pub fn current_version(&self) -> u32 {
+        self.inner
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .current_version
+    }
+
+    /// Resolve the decryption cipher for a value, given the `key_version` read
+    /// from its wrapper (`Some` for an `ACV1`-wrapped value, `None` for a legacy
+    /// value that carries no wrapper).
+    ///
+    /// * `match_any` (single-cipher) keyring → the sole cipher for every value
+    ///   (never-rotated / post-switch steady state).
+    /// * strict keyring, legacy value (`None`) → the OLDEST (minimum-version,
+    ///   i.e. pre-rotation) generation — the DEK legacy values were written under
+    ///   before the rotation advanced the generation.
+    /// * strict keyring, `Some(kv)` → the generation stamped `kv`, or `None` when
+    ///   no such generation is held (a genuine wrong/absent key surfaces as a loud
+    ///   AEAD failure downstream rather than silent wrong data).
+    pub(super) fn cipher_for_value(&self, key_version: Option<u32>) -> Option<Arc<dyn Cipher>> {
+        let inner = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        if inner.match_any {
+            return inner.generations.first().map(|g| g.cipher.clone());
+        }
+        match key_version {
+            Some(kv) => inner
+                .generations
+                .iter()
+                .find(|g| g.key_version == kv)
+                .map(|g| g.cipher.clone()),
+            None => inner
+                .generations
+                .iter()
+                .min_by_key(|g| g.key_version)
+                .map(|g| g.cipher.clone()),
+        }
+    }
+
+    /// Whether a generation with `key_version` is currently held (a `match_any`
+    /// single keyring holds every version).
+    pub(super) fn has_version(&self, key_version: u32) -> bool {
+        let inner = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        inner.match_any
+            || inner
+                .generations
+                .iter()
+                .any(|g| g.key_version == key_version)
+    }
+
+    /// Add a new generation and make it current. Switches the keyring to strict
+    /// per-version dispatch (leaving `match_any`). Idempotent for a version
+    /// already present (its cipher is replaced). Used by the rotation driver to
+    /// install the new cold DEK before the bulk re-encrypt pass.
+    pub(super) fn add_generation(&self, key_version: u32, cipher: Arc<dyn Cipher>) {
+        let mut inner = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        inner.match_any = false;
+        inner.generations.retain(|g| g.key_version != key_version);
+        inner.generations.push(ColdKeyGeneration {
+            key_version,
+            cipher,
+        });
+        inner.current_version = key_version;
+    }
+
+    /// Retire every generation except `key_version`, which becomes the sole,
+    /// current generation. Used by the rotation driver at completion once every
+    /// value is re-wrapped under the new generation, so the old cold DEK can be
+    /// dropped.
+    pub(super) fn retain_only(&self, key_version: u32) {
+        let mut inner = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        inner.generations.retain(|g| g.key_version == key_version);
+        inner.current_version = key_version;
+        inner.match_any = false;
+    }
+}

--- a/src/storage/redb_cold_storage/keyring.rs
+++ b/src/storage/redb_cold_storage/keyring.rs
@@ -25,16 +25,39 @@
 //!
 //! Read dispatch ([`parse_cold_wrapper`] in front of decrypt): a value is
 //! treated as wrapped ONLY IF it begins with `ACV1` **and** the following `u32`
-//! names a generation the live keyring holds; otherwise it is treated as a
-//! legacy bare ciphertext and decrypted under the oldest (pre-rotation) cold
-//! generation. This double check makes a false positive astronomically
-//! unlikely: a genuine legacy ciphertext would have to begin with the exact
-//! 4-byte magic (~2⁻³²) AND have its next 4 bytes equal a small, currently-held
-//! key-version (~2⁻³² for the tiny set of live versions) — a combined ~2⁻⁶⁴
-//! event, and even then it fails LOUDLY as an AEAD authentication error (the
-//! wrong slice is fed to `decrypt`), never as silent wrong data. The same
-//! 4-byte-magic collision argument is used one layer down by
-//! [`COLD_RECORD_MAGIC_V2`](super) for the in-record provenance tag.
+//! names a generation the live keyring holds ([`has_version`](ColdKeyring::has_version));
+//! otherwise it is treated as a legacy bare ciphertext and decrypted under the
+//! oldest (pre-rotation) cold generation.
+//!
+//! ## False-positive probability (be precise: it depends on the keyring mode)
+//!
+//! How much the second check (the held-version test) actually discriminates
+//! depends on whether the keyring is in `match_any` or strict mode — and the
+//! common case is the *weaker* one:
+//!
+//! * **Single-generation `match_any` keyring** — the never-rotated steady state,
+//!   and the post-provider-switch state after a completed rotation (the operator
+//!   reopens under the new key alone). Here [`has_version`](ColdKeyring::has_version)
+//!   **short-circuits `true` for every `key_version`**, so the held-version test
+//!   adds **no** discrimination: a legacy bare ciphertext is misclassified as
+//!   wrapped as soon as its first 4 bytes happen to equal the `ACV1` magic —
+//!   probability **~2⁻³²** (NOT 2⁻⁶⁴). The trailing `u32` is irrelevant to the
+//!   classification in this mode.
+//! * **Strict (mid-rotation, 2-generation) keyring** — only here does the
+//!   held-version test bite: the leading 4 bytes must equal `ACV1` (~2⁻³²) AND
+//!   the next 4 bytes must equal one of the tiny set of currently-held key
+//!   versions (~2⁻³²), a combined **~2⁻⁶⁴** event. The 2⁻⁶⁴ figure applies to
+//!   this mode ONLY.
+//!
+//! Crucially, in **either** mode a misclassification is a **loud AEAD
+//! authentication failure** — the wrong byte slice is fed to `decrypt`, the tag
+//! check fails, and the read returns an `Err` (a read *availability* fault). It
+//! is **NEVER** silent wrong data or integrity loss: a corrupted/misparsed value
+//! cannot forge a valid AEAD tag, so no plaintext is ever returned for it. The
+//! ~2⁻³² event therefore costs *availability of that one value* (recoverable by
+//! reopening under the correct key), not correctness. The same 4-byte-magic
+//! collision argument is used one layer down by [`COLD_RECORD_MAGIC_V2`](super)
+//! for the in-record provenance tag.
 //!
 //! No key material is ever written into the wrapper (a `key_version` integer
 //! only), logged, or rendered by `Debug`.

--- a/src/storage/redb_cold_storage/mod.rs
+++ b/src/storage/redb_cold_storage/mod.rs
@@ -1036,15 +1036,6 @@ impl RedbColdStorage {
         self
     }
 
-    /// Access the cold key ring, if encryption is configured (Issue #3617 PR3).
-    ///
-    /// The rotation driver reaches through this to install the new generation and
-    /// retire the old one; a clone shares the same interior-mutable state, so the
-    /// change is observed by every read/write crypto site immediately.
-    pub fn cold_keyring(&self) -> Option<&ColdKeyring> {
-        self.keyring.as_ref()
-    }
-
     /// Whether the cold store encrypts values at rest.
     pub fn is_encrypted(&self) -> bool {
         self.keyring.is_some()

--- a/src/storage/redb_cold_storage/mod.rs
+++ b/src/storage/redb_cold_storage/mod.rs
@@ -99,12 +99,14 @@ const COLD_ROTATION_CURSOR_KEY: &str = "cold_rotation";
 /// resolves any residual legacy/wrapped ambiguity.
 const COLD_VALUE_FORMAT_KEY: &str = "cold_value_format";
 
-/// Batch size for the transactional bulk re-encrypt pass (Issue #3617 PR3): the
-/// number of `(key, value)` pairs rewritten per redb write transaction. Bounds
-/// per-transaction memory and work; the pass is resumable at batch granularity
-/// via [`COLD_ROTATION_CURSOR_KEY`], so a larger value trades a longer
-/// crash-replay window for fewer commits. 4096 keeps each transaction's
-/// materialized slice small while amortizing commit cost.
+/// Default batch size for the transactional bulk re-encrypt pass (Issue #3617
+/// PR3): the number of `(key, value)` pairs rewritten per redb write
+/// transaction. Bounds per-transaction memory and work; the pass is resumable
+/// at batch granularity via [`COLD_ROTATION_CURSOR_KEY`], so a larger value
+/// trades a longer crash-replay window for fewer commits. 4096 keeps each
+/// transaction's materialized slice small while amortizing commit cost. Runtime
+/// tunable via [`RedbConfig::reencrypt_batch_size`] /
+/// [`RedbConfig::with_reencrypt_batch_size`]; this const is the unset default.
 const COLD_REENCRYPT_BATCH_SIZE: usize = 4096;
 
 /// Layout-version tag for the hand-rolled [`COLD_ROTATION_CURSOR_KEY`] /
@@ -195,6 +197,11 @@ pub struct ColdReencryptStats {
     /// Values skipped because they were already wrapped at the target version
     /// (idempotent re-run / stale cursor).
     pub values_skipped: usize,
+    /// Number of redb write transactions committed across the whole pass, one
+    /// per non-empty batch (bounded by the configurable
+    /// [`RedbConfig::reencrypt_batch_size`]). Lets callers/tests observe that a
+    /// small batch cap was honored (a multi-batch pass reports `> 1`).
+    pub batches_committed: usize,
 }
 
 /// Layout version tag for the persisted extent record. Records with an
@@ -708,6 +715,17 @@ pub struct RedbConfig {
 
     /// Cache size in bytes for Redb (0 = use default).
     pub cache_size_bytes: usize,
+
+    /// Number of `(key, value)` pairs re-encrypted per redb write transaction
+    /// during a cold-tier key-rotation bulk re-encrypt pass (Issue #3617 PR3).
+    ///
+    /// Defaults to [`COLD_REENCRYPT_BATCH_SIZE`] (4096). A larger value trades a
+    /// longer crash-replay window and more per-transaction memory for fewer
+    /// commits; a smaller value yields more granular resume and lower memory at
+    /// the cost of more commits. A value of `0` makes no progress, so it is
+    /// floored to `1` at both the [`RedbConfig::with_reencrypt_batch_size`]
+    /// setter and the read site.
+    pub reencrypt_batch_size: usize,
 }
 
 impl Default for RedbConfig {
@@ -716,6 +734,7 @@ impl Default for RedbConfig {
             compression: CompressionAlgorithm::Zstd,
             enable_checksums: true,
             cache_size_bytes: 0,
+            reencrypt_batch_size: COLD_REENCRYPT_BATCH_SIZE,
         }
     }
 }
@@ -783,6 +802,31 @@ impl RedbConfig {
     /// ```
     pub fn cache_size_bytes(mut self, size: usize) -> Self {
         self.cache_size_bytes = size;
+        self
+    }
+
+    /// Set the cold-tier rotation re-encrypt batch size: the number of
+    /// `(key, value)` pairs re-encrypted per redb write transaction during a
+    /// bulk key-rotation pass (Issue #3617 PR3).
+    ///
+    /// A larger value amortizes commit cost (fewer, larger transactions) at the
+    /// price of longer write-transaction holds, more per-transaction memory, and
+    /// a longer crash-replay window; a smaller value resumes at finer
+    /// granularity and uses less memory but commits more often. `0` would make
+    /// no forward progress, so it is floored to `1`.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::storage::redb_cold_storage::RedbConfig;
+    ///
+    /// let config = RedbConfig::new().with_reencrypt_batch_size(1024);
+    /// // A 0 is clamped up to a minimum of 1 so the pass always advances.
+    /// let clamped = RedbConfig::new().with_reencrypt_batch_size(0);
+    /// assert_eq!(clamped.reencrypt_batch_size, 1);
+    /// ```
+    pub fn with_reencrypt_batch_size(mut self, size: usize) -> Self {
+        self.reencrypt_batch_size = size.max(1);
         self
     }
 
@@ -1664,6 +1708,10 @@ impl RedbColdStorage {
     ) -> Result<()> {
         use std::ops::Bound;
         let table_def = table_kind.table();
+        // Configurable per-transaction batch size (Issue #3617 PR3). Floored to
+        // 1 so a misconfigured 0 (e.g. via a direct/serde-deserialized field
+        // write that bypasses `with_reencrypt_batch_size`) still makes progress.
+        let batch_size = self.config.reencrypt_batch_size.max(1);
         loop {
             let write_txn = self
                 .db
@@ -1688,8 +1736,8 @@ impl RedbColdStorage {
                     let range = table
                         .range::<u64>((lower, Bound::Unbounded))
                         .map_err(map_storage_error("Failed to range cold table"))?;
-                    let mut v = Vec::with_capacity(COLD_REENCRYPT_BATCH_SIZE);
-                    for entry in range.take(COLD_REENCRYPT_BATCH_SIZE) {
+                    let mut v = Vec::with_capacity(batch_size);
+                    for entry in range.take(batch_size) {
                         let (k, val) =
                             entry.map_err(map_storage_error("Failed to read cold entry"))?;
                         v.push((k.value(), val.value().to_vec()));
@@ -1754,9 +1802,10 @@ impl RedbColdStorage {
             write_txn
                 .commit()
                 .map_err(map_commit_error("Failed to commit cold rotation batch"))?;
+            stats.batches_committed += 1;
 
             resume_after = last_key;
-            if batch_len < COLD_REENCRYPT_BATCH_SIZE {
+            if batch_len < batch_size {
                 // Fewer than a full batch means the table is exhausted.
                 break;
             }

--- a/src/storage/redb_cold_storage/mod.rs
+++ b/src/storage/redb_cold_storage/mod.rs
@@ -68,6 +68,11 @@ use serde::{Deserialize, Serialize};
 #[cfg(test)]
 use std::sync::atomic::AtomicBool;
 
+mod keyring;
+
+pub use keyring::ColdKeyring;
+use keyring::{parse_cold_wrapper, wrap_cold_value};
+
 // Table definitions with static lifetimes
 const NODE_VERSIONS_TABLE: redb::TableDefinition<'static, u64, &'static [u8]> =
     redb::TableDefinition::new("node_versions");
@@ -81,6 +86,116 @@ const FLUSHED_LSN_KEY: &str = "flushed_lsn";
 
 /// Metadata key for the persisted cold-tier bi-temporal extent (Issue #3389).
 const TEMPORAL_EXTENT_KEY: &str = "temporal_extent";
+
+/// Metadata key for the durable cold key-rotation resume cursor (Issue #3617
+/// PR3). Present only WHILE a bulk re-encrypt pass is in flight; advanced in the
+/// SAME redb write transaction as each batch of value rewrites (so it is atomic
+/// with them) and deleted on completion.
+const COLD_ROTATION_CURSOR_KEY: &str = "cold_rotation";
+
+/// Metadata key for the terminal cold value-format marker (Issue #3617 PR3).
+/// Written once every value is re-wrapped under the target generation: records
+/// `wrapped@{target_version}`, the whole-store flag that authoritatively
+/// resolves any residual legacy/wrapped ambiguity.
+const COLD_VALUE_FORMAT_KEY: &str = "cold_value_format";
+
+/// Batch size for the transactional bulk re-encrypt pass (Issue #3617 PR3): the
+/// number of `(key, value)` pairs rewritten per redb write transaction. Bounds
+/// per-transaction memory and work; the pass is resumable at batch granularity
+/// via [`COLD_ROTATION_CURSOR_KEY`], so a larger value trades a longer
+/// crash-replay window for fewer commits. 4096 keeps each transaction's
+/// materialized slice small while amortizing commit cost.
+const COLD_REENCRYPT_BATCH_SIZE: usize = 4096;
+
+/// Layout-version tag for the hand-rolled [`COLD_ROTATION_CURSOR_KEY`] /
+/// [`COLD_VALUE_FORMAT_KEY`] records. Records with an unrecognized tag are
+/// treated as absent (an older binary falls back to a full pass rather than
+/// misreading bytes), mirroring [`EXTENT_RECORD_VERSION`].
+const COLD_ROTATION_RECORD_VERSION: u8 = 1;
+
+/// Which value-bearing table a cold rotation cursor is pointing into. Encoded as
+/// a single discriminant byte in the durable cursor record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ColdTableKind {
+    Node,
+    Edge,
+}
+
+impl ColdTableKind {
+    fn as_u8(self) -> u8 {
+        match self {
+            ColdTableKind::Node => 0,
+            ColdTableKind::Edge => 1,
+        }
+    }
+
+    fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(ColdTableKind::Node),
+            1 => Some(ColdTableKind::Edge),
+            _ => None,
+        }
+    }
+
+    fn table(self) -> redb::TableDefinition<'static, u64, &'static [u8]> {
+        match self {
+            ColdTableKind::Node => NODE_VERSIONS_TABLE,
+            ColdTableKind::Edge => EDGE_VERSIONS_TABLE,
+        }
+    }
+}
+
+/// Durable resume cursor for the cold bulk re-encrypt pass (Issue #3617 PR3).
+///
+/// Hand-rolled fixed-width bytes (no serde, so the Feature Matrix stays clean):
+/// `[version:u8][target_version:u32 LE][table:u8][last_completed_key:u64 LE]`.
+/// `last_completed_key` is the highest `VersionId` already re-wrapped in
+/// `table`; the pass resumes at `> last_completed_key`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ColdRotationCursor {
+    target_version: u32,
+    table: ColdTableKind,
+    last_completed_key: u64,
+}
+
+impl ColdRotationCursor {
+    const LEN: usize = 1 + 4 + 1 + 8;
+
+    fn to_bytes(self) -> [u8; Self::LEN] {
+        let mut out = [0u8; Self::LEN];
+        out[0] = COLD_ROTATION_RECORD_VERSION;
+        out[1..5].copy_from_slice(&self.target_version.to_le_bytes());
+        out[5] = self.table.as_u8();
+        out[6..14].copy_from_slice(&self.last_completed_key.to_le_bytes());
+        out
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != Self::LEN || bytes[0] != COLD_ROTATION_RECORD_VERSION {
+            return None;
+        }
+        let target_version = u32::from_le_bytes([bytes[1], bytes[2], bytes[3], bytes[4]]);
+        let table = ColdTableKind::from_u8(bytes[5])?;
+        let last_completed_key = u64::from_le_bytes([
+            bytes[6], bytes[7], bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13],
+        ]);
+        Some(Self {
+            target_version,
+            table,
+            last_completed_key,
+        })
+    }
+}
+
+/// Statistics returned by a cold bulk re-encrypt pass (Issue #3617 PR3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ColdReencryptStats {
+    /// Values re-encrypted+re-wrapped under the target generation.
+    pub values_rewrapped: usize,
+    /// Values skipped because they were already wrapped at the target version
+    /// (idempotent re-run / stale cursor).
+    pub values_skipped: usize,
+}
 
 /// Layout version tag for the persisted extent record. Records with an
 /// unrecognized version are treated as absent, so an older binary that cannot
@@ -716,8 +831,14 @@ pub struct RedbColdStorage {
     config: RedbConfig,
     /// Statistics tracker.
     stats: AtomicColdStorageStats,
-    /// Optional cipher for encrypting data at rest.
-    cipher: Option<Arc<dyn crate::encryption::cipher::Cipher>>,
+    /// Optional cold key ring for encrypting data at rest (Issue #3617 PR3).
+    ///
+    /// `None` when encryption is disabled (values stored as bare
+    /// compressed bytes, unchanged from the unencrypted path). When present it
+    /// holds one generation in the steady state and two during a full-MEK key
+    /// rotation, so a half-rotated store reads every value under its own
+    /// generation via the `ACV1` wrapper dispatch.
+    keyring: Option<ColdKeyring>,
     /// Fault injection flag for testing.
     #[cfg(test)]
     fail_writes: AtomicBool,
@@ -822,7 +943,7 @@ impl RedbColdStorage {
             db,
             config,
             stats,
-            cipher: None,
+            keyring: None,
             #[cfg(test)]
             fail_writes: AtomicBool::new(false),
             #[cfg(test)]
@@ -882,39 +1003,160 @@ impl RedbColdStorage {
     /// # }
     /// ```
     #[must_use]
-    pub fn with_cipher(mut self, cipher: Arc<dyn crate::encryption::cipher::Cipher>) -> Self {
-        self.cipher = Some(cipher);
+    pub fn with_cipher(self, cipher: Arc<dyn crate::encryption::cipher::Cipher>) -> Self {
+        self.with_cold_keyring(ColdKeyring::single(cipher))
+    }
+
+    /// Set the encryption cipher pinned to an explicit `key_version` for at-rest
+    /// encryption (Issue #3617 PR3 version-provisioning parity).
+    ///
+    /// Reads decrypt every value with this one cipher (`match_any`, identical to
+    /// [`with_cipher`](Self::with_cipher)); only the write-stamp / reported cold
+    /// key version is pinned to `key_version`. The durable `open()` path uses this
+    /// to PROVISION the cold keyring at the same version index/WAL are provisioned
+    /// to after a rotate-then-reopen, so freshly written cold values stamp the
+    /// real version rather than a stale base.
+    #[must_use]
+    pub fn with_cipher_versioned(
+        self,
+        cipher: Arc<dyn crate::encryption::cipher::Cipher>,
+        key_version: u32,
+    ) -> Self {
+        self.with_cold_keyring(ColdKeyring::single_versioned(cipher, key_version))
+    }
+
+    /// Set the full cold key ring for at-rest encryption (Issue #3617 PR3).
+    ///
+    /// Used by the rotation driver to install a keyring already holding both the
+    /// old and new generations before a bulk re-encrypt pass. Most callers should
+    /// use [`with_cipher`](Self::with_cipher).
+    #[must_use]
+    pub fn with_cold_keyring(mut self, keyring: ColdKeyring) -> Self {
+        self.keyring = Some(keyring);
         self
     }
 
-    /// Encrypt data if a cipher is configured, otherwise return as-is.
+    /// Access the cold key ring, if encryption is configured (Issue #3617 PR3).
+    ///
+    /// The rotation driver reaches through this to install the new generation and
+    /// retire the old one; a clone shares the same interior-mutable state, so the
+    /// change is observed by every read/write crypto site immediately.
+    pub fn cold_keyring(&self) -> Option<&ColdKeyring> {
+        self.keyring.as_ref()
+    }
+
+    /// Whether the cold store encrypts values at rest.
+    pub fn is_encrypted(&self) -> bool {
+        self.keyring.is_some()
+    }
+
+    /// The `key_version` freshly written cold values are stamped with, or `None`
+    /// when encryption is disabled (Issue #3617 PR3).
+    pub fn current_cold_key_version(&self) -> Option<u32> {
+        self.keyring.as_ref().map(ColdKeyring::current_version)
+    }
+
+    /// Install a new cold DEK generation for a key rotation (Issue #3617 PR3),
+    /// keeping the existing generation(s) live so a half-rotated store still reads
+    /// old-generation values. Idempotent for an already-present version. Makes the
+    /// new generation current, so subsequent writes stamp it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the store is not encrypted (no keyring to extend).
+    pub fn install_cold_generation(
+        &self,
+        key_version: u32,
+        cipher: Arc<dyn crate::encryption::cipher::Cipher>,
+    ) -> Result<()> {
+        let ring = self.keyring.as_ref().ok_or_else(|| {
+            Into::<crate::core::error::Error>::into(StorageError::InconsistentState {
+                reason: "cold storage is not encrypted; cannot install a key generation"
+                    .to_string(),
+            })
+        })?;
+        ring.add_generation(key_version, cipher);
+        Ok(())
+    }
+
+    /// Retire every cold DEK generation except `key_version`, which becomes the
+    /// sole current generation (Issue #3617 PR3). Called after a verified full
+    /// re-encrypt pass so the old cold DEK can be dropped.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the store is not encrypted.
+    pub fn retire_cold_generations(&self, key_version: u32) -> Result<()> {
+        let ring = self.keyring.as_ref().ok_or_else(|| {
+            Into::<crate::core::error::Error>::into(StorageError::InconsistentState {
+                reason: "cold storage is not encrypted; cannot retire key generations".to_string(),
+            })
+        })?;
+        ring.retain_only(key_version);
+        Ok(())
+    }
+
+    /// Encrypt a compressed value for storage, applying the self-describing
+    /// `ACV1` wrapper when encryption is configured (Issue #3617 PR3).
+    ///
+    /// The value is stamped with the cold keyring's CURRENT `key_version` so a
+    /// half-rotated store distinguishes old- from new-generation values on read.
+    /// A no-op (returns the input) when encryption is disabled.
     fn encrypt_if_needed(&self, data: Vec<u8>) -> Result<Vec<u8>> {
-        match self.cipher {
-            Some(ref cipher) => {
-                cipher
-                    .encrypt(&data, &[])
-                    .map_err(|e| -> crate::core::error::Error {
-                        StorageError::Encryption(format!("Cold storage encryption failed: {e}"))
-                            .into()
-                    })
+        match self.keyring {
+            Some(ref ring) => {
+                let (cipher, key_version) = ring.current().ok_or_else(|| {
+                    Into::<crate::core::error::Error>::into(StorageError::Encryption(
+                        "Cold storage keyring holds no generation".to_string(),
+                    ))
+                })?;
+                let ciphertext =
+                    cipher
+                        .encrypt(&data, &[])
+                        .map_err(|e| -> crate::core::error::Error {
+                            StorageError::Encryption(format!("Cold storage encryption failed: {e}"))
+                                .into()
+                        })?;
+                Ok(wrap_cold_value(key_version, &ciphertext))
             }
             None => Ok(data),
         }
     }
 
-    /// Decrypt data if a cipher is configured, otherwise return as-is.
+    /// Decrypt a stored value, transparently handling both `ACV1`-wrapped
+    /// (post-rotation) and legacy bare-ciphertext values (Issue #3617 PR3).
+    ///
+    /// Dispatch: a value is treated as wrapped ONLY IF it begins with the `ACV1`
+    /// magic AND names a `key_version` the keyring holds; otherwise it is a legacy
+    /// value decrypted under the oldest (pre-rotation) cold generation. See
+    /// [`keyring`](crate::storage::redb_cold_storage::keyring) for the collision
+    /// argument. A no-op (returns a copy) when encryption is disabled.
     fn decrypt_if_needed(&self, data: &[u8]) -> Result<Vec<u8>> {
-        match self.cipher {
-            Some(ref cipher) => {
-                cipher
-                    .decrypt(data, &[])
-                    .map_err(|e| -> crate::core::error::Error {
-                        StorageError::Encryption(format!("Cold storage decryption failed: {e}"))
-                            .into()
-                    })
-            }
-            None => Ok(data.to_vec()),
+        let Some(ref ring) = self.keyring else {
+            return Ok(data.to_vec());
+        };
+        // Wrapped iff ACV1 magic AND the stamped version names a held generation.
+        if let Some((key_version, ciphertext)) = parse_cold_wrapper(data)
+            && ring.has_version(key_version)
+            && let Some(cipher) = ring.cipher_for_value(Some(key_version))
+        {
+            return cipher
+                .decrypt(ciphertext, &[])
+                .map_err(|e| -> crate::core::error::Error {
+                    StorageError::Encryption(format!("Cold storage decryption failed: {e}")).into()
+                });
         }
+        // Legacy bare ciphertext → oldest (pre-rotation) / sole generation.
+        let cipher = ring.cipher_for_value(None).ok_or_else(|| {
+            Into::<crate::core::error::Error>::into(StorageError::Encryption(
+                "Cold storage keyring holds no generation".to_string(),
+            ))
+        })?;
+        cipher
+            .decrypt(data, &[])
+            .map_err(|e| -> crate::core::error::Error {
+                StorageError::Encryption(format!("Cold storage decryption failed: {e}")).into()
+            })
     }
 
     /// Get the absolute or relative path to the Redb database file.
@@ -965,19 +1207,32 @@ impl RedbColdStorage {
         EncodeFn: Fn(&V) -> Vec<u8> + Sync + Send,
     {
         let cold_config = self.config.to_cold_storage_config();
-        let cipher_ref = &self.cipher;
+        // Resolve the current cold generation ONCE up front so the parallel
+        // compression closure is `Sync` (no borrow of `self.keyring`'s lock) and
+        // every value in the batch is wrapped under the same `key_version`.
+        let cold_generation: Option<(Arc<dyn crate::encryption::cipher::Cipher>, u32)> =
+            match self.keyring {
+                Some(ref ring) => Some(ring.current().ok_or_else(|| {
+                    Into::<crate::core::error::Error>::into(StorageError::Encryption(
+                        "Cold storage keyring holds no generation".to_string(),
+                    ))
+                })?),
+                None => None,
+            };
+        let cold_generation_ref = &cold_generation;
 
-        // Helper closure: compress then optionally encrypt.
+        // Helper closure: compress then optionally encrypt+`ACV1`-wrap.
         let compress_and_encrypt = |data: &[u8]| -> Result<Vec<u8>> {
             let compressed = crate::storage::compression::compress(data, &cold_config)?;
-            match cipher_ref {
-                Some(cipher) => {
-                    cipher
-                        .encrypt(&compressed, &[])
-                        .map_err(|e| -> crate::core::error::Error {
+            match cold_generation_ref {
+                Some((cipher, key_version)) => {
+                    let ciphertext = cipher.encrypt(&compressed, &[]).map_err(
+                        |e| -> crate::core::error::Error {
                             StorageError::Encryption(format!("Cold storage encryption failed: {e}"))
                                 .into()
-                        })
+                        },
+                    )?;
+                    Ok(wrap_cold_value(*key_version, &ciphertext))
                 }
                 None => Ok(compressed),
             }
@@ -1231,6 +1486,290 @@ impl RedbColdStorage {
             .map_err(|e| -> crate::core::error::Error {
                 StorageError::io_error(format!("Failed to write temporal_extent: {}", e)).into()
             })?;
+        Ok(())
+    }
+
+    // ========================================================================
+    // Cold-tier key rotation: transactional bulk re-encrypt (Issue #3617 PR3)
+    // ========================================================================
+
+    /// Read the durable cold-rotation resume cursor, if a pass is in flight.
+    ///
+    /// `Ok(None)` when no cursor is present or its record is unrecognized (an
+    /// older binary falls back to a full pass). O(1) metadata read.
+    fn read_cold_rotation_cursor(&self) -> Result<Option<ColdRotationCursor>> {
+        let read_txn = self
+            .db
+            .begin_read()
+            .map_err(map_transaction_error("Failed to begin read transaction"))?;
+        let table = match read_txn.open_table(METADATA_TABLE) {
+            Ok(table) => table,
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(None),
+            Err(e) => {
+                return Err(
+                    StorageError::io_error(format!("Failed to open metadata table: {e}")).into(),
+                );
+            }
+        };
+        match table.get(COLD_ROTATION_CURSOR_KEY) {
+            Ok(Some(value)) => Ok(ColdRotationCursor::from_bytes(value.value())),
+            Ok(None) => Ok(None),
+            Err(e) => Err(StorageError::io_error(format!(
+                "Failed to read cold_rotation cursor: {e}"
+            ))
+            .into()),
+        }
+    }
+
+    /// The target `key_version` every cold value has been re-wrapped to, per the
+    /// durable [`COLD_VALUE_FORMAT_KEY`] marker (Issue #3617 PR3). `Ok(None)` when
+    /// the store has never completed a rotation (values may be legacy or `ACV1`
+    /// at the base version). Used by tests and the resume driver to confirm a
+    /// finished pass without re-scanning every value.
+    pub fn cold_value_format_version(&self) -> Result<Option<u32>> {
+        let read_txn = self
+            .db
+            .begin_read()
+            .map_err(map_transaction_error("Failed to begin read transaction"))?;
+        let table = match read_txn.open_table(METADATA_TABLE) {
+            Ok(table) => table,
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(None),
+            Err(e) => {
+                return Err(
+                    StorageError::io_error(format!("Failed to open metadata table: {e}")).into(),
+                );
+            }
+        };
+        match table.get(COLD_VALUE_FORMAT_KEY) {
+            Ok(Some(value)) => {
+                let bytes: &[u8] = value.value();
+                if bytes.len() == 5 && bytes[0] == COLD_ROTATION_RECORD_VERSION {
+                    Ok(Some(u32::from_le_bytes([
+                        bytes[1], bytes[2], bytes[3], bytes[4],
+                    ])))
+                } else {
+                    Ok(None)
+                }
+            }
+            Ok(None) => Ok(None),
+            Err(e) => {
+                Err(StorageError::io_error(format!("Failed to read cold_value_format: {e}")).into())
+            }
+        }
+    }
+
+    /// Transactionally re-encrypt every stored cold value to the `target_version`
+    /// generation (Issue #3617 PR3), decrypting each under its own (old/legacy)
+    /// generation and re-encrypting under the target cold DEK, in bounded
+    /// per-transaction batches, resumable via a durable redb cursor.
+    ///
+    /// # Preconditions
+    ///
+    /// The store must be encrypted and its keyring must hold BOTH the target
+    /// generation (installed by the driver) and every source generation needed to
+    /// decrypt existing values. New appends interleaved with the pass already
+    /// stamp the current (target) generation and are simply skipped as
+    /// already-wrapped.
+    ///
+    /// # Crash-consistency
+    ///
+    /// Each batch's value rewrites and the cursor advance commit in ONE redb write
+    /// transaction, so the cursor never runs ahead of (or behind) the durable
+    /// rewrites — a crash resumes from exactly the last committed key. The `ACV1`
+    /// wrapper is the idempotency backstop: a value already wrapped at
+    /// `target_version` is skipped, so a re-run after a stale cursor never
+    /// double-encrypts. Only `node_versions`/`edge_versions` VALUES are touched;
+    /// `flushed_lsn` and `temporal_extent` (incl. the #3389 per-dimension bounds)
+    /// are never read or rewritten, so they are preserved untouched.
+    ///
+    /// On completion the durable [`COLD_VALUE_FORMAT_KEY`] marker is set to
+    /// `wrapped@target_version` and the resume cursor is deleted.
+    ///
+    /// # Errors
+    ///
+    /// * encryption is not configured, or the keyring does not hold
+    ///   `target_version`;
+    /// * a value fails to decrypt (a genuine wrong/absent key — surfaced loudly,
+    ///   never silent wrong data) or a redb transaction fails.
+    pub fn reencrypt_cold_values(&self, target_version: u32) -> Result<ColdReencryptStats> {
+        let ring = self.keyring.as_ref().ok_or_else(|| {
+            Into::<crate::core::error::Error>::into(StorageError::InconsistentState {
+                reason: "cold storage is not encrypted; cannot rotate cold keys".to_string(),
+            })
+        })?;
+        if !ring.has_version(target_version) {
+            return Err(StorageError::InconsistentState {
+                reason: "cold keyring does not hold the target generation for rotation".to_string(),
+            }
+            .into());
+        }
+        // The cipher every value is re-encrypted UNDER (the target generation).
+        let target_cipher = ring.cipher_for_value(Some(target_version)).ok_or_else(|| {
+            Into::<crate::core::error::Error>::into(StorageError::InconsistentState {
+                reason: "cold keyring target generation missing a cipher".to_string(),
+            })
+        })?;
+
+        let mut stats = ColdReencryptStats::default();
+
+        // Resume point: a cursor for THIS target resumes it; any other cursor
+        // (stale, from an aborted earlier rotation) is ignored and the pass
+        // restarts from the node table (idempotent — already-wrapped values are
+        // skipped). Tables are always processed Node then Edge.
+        let (start_table, start_after) = match self.read_cold_rotation_cursor()? {
+            Some(c) if c.target_version == target_version => (c.table, Some(c.last_completed_key)),
+            _ => (ColdTableKind::Node, None),
+        };
+
+        let tables = [ColdTableKind::Node, ColdTableKind::Edge];
+        let start_idx = tables.iter().position(|t| *t == start_table).unwrap_or(0);
+        for (i, &table) in tables.iter().enumerate() {
+            if i < start_idx {
+                // A table before the cursor's table is already fully processed.
+                continue;
+            }
+            let resume_after = if i == start_idx { start_after } else { None };
+            self.reencrypt_one_table(
+                table,
+                target_version,
+                &target_cipher,
+                resume_after,
+                &mut stats,
+            )?;
+        }
+
+        // Terminal marker: whole store is wrapped at the target; drop the cursor.
+        let write_txn = self
+            .db
+            .begin_write()
+            .map_err(map_transaction_error("Failed to begin write transaction"))?;
+        {
+            let mut meta = write_txn
+                .open_table(METADATA_TABLE)
+                .map_err(map_table_error("Failed to open metadata table"))?;
+            let mut format_bytes = [0u8; 5];
+            format_bytes[0] = COLD_ROTATION_RECORD_VERSION;
+            format_bytes[1..5].copy_from_slice(&target_version.to_le_bytes());
+            meta.insert(COLD_VALUE_FORMAT_KEY, format_bytes.as_slice())
+                .map_err(map_storage_error("Failed to write cold_value_format"))?;
+            meta.remove(COLD_ROTATION_CURSOR_KEY)
+                .map_err(map_storage_error("Failed to clear cold_rotation cursor"))?;
+        }
+        write_txn.commit().map_err(map_commit_error(
+            "Failed to commit cold rotation completion",
+        ))?;
+
+        Ok(stats)
+    }
+
+    /// Re-encrypt one value-bearing table in bounded, cursor-advancing batches.
+    fn reencrypt_one_table(
+        &self,
+        table_kind: ColdTableKind,
+        target_version: u32,
+        target_cipher: &Arc<dyn crate::encryption::cipher::Cipher>,
+        mut resume_after: Option<u64>,
+        stats: &mut ColdReencryptStats,
+    ) -> Result<()> {
+        use std::ops::Bound;
+        let table_def = table_kind.table();
+        loop {
+            let write_txn = self
+                .db
+                .begin_write()
+                .map_err(map_transaction_error("Failed to begin write transaction"))?;
+
+            let mut last_key = resume_after;
+            let batch_len;
+            {
+                let mut table = write_txn
+                    .open_table(table_def)
+                    .map_err(map_table_error("Failed to open versions table"))?;
+
+                // Collect a bounded slice of (key, value) into owned buffers FIRST
+                // — a redb iterator borrows the table immutably and cannot be held
+                // across the `insert` calls below (which need `&mut table`).
+                let collected: Vec<(u64, Vec<u8>)> = {
+                    let lower = match resume_after {
+                        Some(k) => Bound::Excluded(k),
+                        None => Bound::Unbounded,
+                    };
+                    let range = table
+                        .range::<u64>((lower, Bound::Unbounded))
+                        .map_err(map_storage_error("Failed to range cold table"))?;
+                    let mut v = Vec::with_capacity(COLD_REENCRYPT_BATCH_SIZE);
+                    for entry in range.take(COLD_REENCRYPT_BATCH_SIZE) {
+                        let (k, val) =
+                            entry.map_err(map_storage_error("Failed to read cold entry"))?;
+                        v.push((k.value(), val.value().to_vec()));
+                    }
+                    v
+                };
+
+                batch_len = collected.len();
+                if batch_len == 0 {
+                    // Table exhausted — nothing to commit; abort the empty txn.
+                    drop(table);
+                    drop(write_txn);
+                    break;
+                }
+
+                for (key, value) in &collected {
+                    // Idempotency backstop: already wrapped at the target → skip.
+                    if let Some((kv, _)) = parse_cold_wrapper(value)
+                        && kv == target_version
+                    {
+                        stats.values_skipped += 1;
+                        last_key = Some(*key);
+                        continue;
+                    }
+                    // Decrypt under the value's own (old/legacy) generation, then
+                    // re-encrypt the SAME compressed bytes under the target DEK and
+                    // re-wrap. Value-identity-preserving: no record is decoded, so
+                    // temporal bounds cannot change.
+                    let compressed = self.decrypt_if_needed(value)?;
+                    let ciphertext = target_cipher.encrypt(&compressed, &[]).map_err(
+                        |e| -> crate::core::error::Error {
+                            StorageError::Encryption(format!(
+                                "Cold storage re-encryption failed: {e}"
+                            ))
+                            .into()
+                        },
+                    )?;
+                    let wrapped = wrap_cold_value(target_version, &ciphertext);
+                    table
+                        .insert(*key, wrapped.as_slice())
+                        .map_err(map_storage_error("Failed to rewrite cold value"))?;
+                    stats.values_rewrapped += 1;
+                    last_key = Some(*key);
+                }
+            }
+
+            // Advance the durable cursor in the SAME transaction as the rewrites,
+            // so a crash resumes from exactly the last committed key.
+            {
+                let cursor = ColdRotationCursor {
+                    target_version,
+                    table: table_kind,
+                    last_completed_key: last_key.unwrap_or(0),
+                };
+                let mut meta = write_txn
+                    .open_table(METADATA_TABLE)
+                    .map_err(map_table_error("Failed to open metadata table"))?;
+                meta.insert(COLD_ROTATION_CURSOR_KEY, cursor.to_bytes().as_slice())
+                    .map_err(map_storage_error("Failed to write cold_rotation cursor"))?;
+            }
+
+            write_txn
+                .commit()
+                .map_err(map_commit_error("Failed to commit cold rotation batch"))?;
+
+            resume_after = last_key;
+            if batch_len < COLD_REENCRYPT_BATCH_SIZE {
+                // Fewer than a full batch means the table is exhausted.
+                break;
+            }
+        }
         Ok(())
     }
 

--- a/src/storage/redb_cold_storage/tests.rs
+++ b/src/storage/redb_cold_storage/tests.rs
@@ -2384,6 +2384,337 @@ fn test_no_cipher_backward_compatible() {
 }
 
 // ========================================================================
+// Cold-tier key rotation (Issue #3617 PR3): ACV1 wrapper, bulk re-encrypt,
+// resume cursor, legacy fallback.
+// ========================================================================
+
+/// AES-256-GCM cipher whose key's first byte is `b` (distinct DEKs for the two
+/// rotation generations).
+fn cipher_with_byte(b: u8) -> Arc<dyn crate::encryption::cipher::Cipher> {
+    use crate::encryption::Aes256GcmCipher;
+    use zeroize::Zeroizing;
+    let mut key = Zeroizing::new([0u8; 32]);
+    key[0] = b;
+    key[1] = 0x5A;
+    Arc::new(Aes256GcmCipher::new(&key))
+}
+
+/// Read the raw (undecoded) stored value for a key from a versions table.
+fn raw_value(
+    storage: &RedbColdStorage,
+    table_def: redb::TableDefinition<'static, u64, &'static [u8]>,
+    key: u64,
+) -> Vec<u8> {
+    let rtxn = storage.db.begin_read().unwrap();
+    let t = rtxn.open_table(table_def).unwrap();
+    t.get(key).unwrap().unwrap().value().to_vec()
+}
+
+/// Write a raw metadata record (e.g. a planted resume cursor).
+fn insert_raw_metadata(storage: &RedbColdStorage, key: &'static str, bytes: &[u8]) {
+    let wtxn = storage.db.begin_write().unwrap();
+    {
+        let mut t = wtxn.open_table(METADATA_TABLE).unwrap();
+        t.insert(key, bytes).unwrap();
+    }
+    wtxn.commit().unwrap();
+}
+
+/// Insert a raw value directly into a versions table (bypassing the wrapper), to
+/// plant a legacy or mid-rotation on-disk state.
+fn insert_raw(
+    storage: &RedbColdStorage,
+    table_def: redb::TableDefinition<'static, u64, &'static [u8]>,
+    key: u64,
+    bytes: &[u8],
+) {
+    let wtxn = storage.db.begin_write().unwrap();
+    {
+        let mut t = wtxn.open_table(table_def).unwrap();
+        t.insert(key, bytes).unwrap();
+    }
+    wtxn.commit().unwrap();
+}
+
+#[test]
+fn legacy_cold_value_reads_under_current_dek() {
+    // A pre-#3617 value is bare compress-then-encrypt with NO ACV1 wrapper. It
+    // must still read after the keyring refactor (backward compatibility).
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("legacy.redb");
+    let cipher = test_cipher();
+
+    let storage = RedbColdStorage::new(&db_path, RedbConfig::new())
+        .unwrap()
+        .with_cipher(Arc::clone(&cipher));
+
+    // Hand-build a legacy (unwrapped) value exactly as the pre-#3617 store did.
+    let version = create_test_node_version(1);
+    let compressed = storage.compress(&encode_node_version(&version)).unwrap();
+    let bare = cipher.encrypt(&compressed, &[]).unwrap();
+    insert_raw(&storage, NODE_VERSIONS_TABLE, 1, &bare);
+
+    // Reads via the keyring fall back to the legacy (bare-ciphertext) path.
+    let loaded = storage
+        .get_node_version(version.version_id())
+        .unwrap()
+        .expect("a legacy unwrapped value must still read");
+    assert_eq!(loaded.version_id(), version.version_id());
+    assert_eq!(loaded.node_id, version.node_id);
+}
+
+#[test]
+fn cold_value_roundtrips_with_acv1_wrapper() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("acv1.redb");
+    let cipher = test_cipher();
+
+    let storage = RedbColdStorage::new(&db_path, RedbConfig::new())
+        .unwrap()
+        .with_cipher(Arc::clone(&cipher));
+
+    let version = create_test_node_version(7);
+    storage.store_node_version(&version).unwrap();
+
+    // The stored value carries the ACV1 wrapper stamped at the current version.
+    let raw = raw_value(&storage, NODE_VERSIONS_TABLE, 7);
+    let (kv, _ct) = parse_cold_wrapper(&raw).expect("a written value must be ACV1-wrapped");
+    assert_eq!(kv, 1, "fresh encrypted store stamps generation 1");
+
+    let loaded = storage
+        .get_node_version(version.version_id())
+        .unwrap()
+        .expect("wrapped value round-trips");
+    assert_eq!(loaded.version_id(), version.version_id());
+    drop(storage);
+
+    // Reading the same ACV1@1 value under a keyring that holds ONLY generation 2
+    // (unknown version 1) must fail LOUDLY (AEAD auth) — never silent wrong data.
+    let ring = ColdKeyring::single(Arc::clone(&cipher));
+    ring.add_generation(2, Arc::clone(&cipher));
+    ring.retain_only(2); // strict keyring with gen 2 only; version 1 is unknown
+    let storage2 = RedbColdStorage::new(&db_path, RedbConfig::new())
+        .unwrap()
+        .with_cold_keyring(ring);
+    let result = storage2.get_node_version(version.version_id());
+    assert!(
+        result.is_err(),
+        "an ACV1 value naming an unheld generation must fail loudly, not read wrong data"
+    );
+}
+
+#[test]
+fn bulk_reencrypt_rewrites_all_values_new_generation() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("bulk.redb");
+    let c1 = cipher_with_byte(0x11);
+    let c2 = cipher_with_byte(0x22);
+
+    let storage = RedbColdStorage::new(&db_path, RedbConfig::new())
+        .unwrap()
+        .with_cipher(Arc::clone(&c1));
+
+    let nodes: Vec<NodeVersion> = (1..=3).map(create_test_node_version).collect();
+    let edges: Vec<EdgeVersion> = (10..=11).map(create_test_edge_version).collect();
+    storage
+        .store_batch_with_lsn(&nodes, &edges, LSN(100))
+        .unwrap();
+
+    let flushed_before = storage.get_flushed_lsn().unwrap();
+    let extent_before = storage.get_temporal_extent_bounds().unwrap();
+    assert_eq!(flushed_before, Some(LSN(100)));
+
+    // Install the new generation and bulk re-encrypt every value to it.
+    storage.install_cold_generation(2, Arc::clone(&c2)).unwrap();
+    let stats = storage.reencrypt_cold_values(2).unwrap();
+    assert_eq!(stats.values_rewrapped, 5, "3 nodes + 2 edges re-wrapped");
+    assert_eq!(stats.values_skipped, 0);
+
+    // Every value is now ACV1@2, and the terminal format marker is set.
+    for k in 1..=3 {
+        let (kv, _) = parse_cold_wrapper(&raw_value(&storage, NODE_VERSIONS_TABLE, k)).unwrap();
+        assert_eq!(kv, 2, "node {k} must be re-wrapped at generation 2");
+    }
+    for k in 10..=11 {
+        let (kv, _) = parse_cold_wrapper(&raw_value(&storage, EDGE_VERSIONS_TABLE, k)).unwrap();
+        assert_eq!(kv, 2, "edge {k} must be re-wrapped at generation 2");
+    }
+    assert_eq!(storage.cold_value_format_version().unwrap(), Some(2));
+
+    // Plaintext metadata is preserved untouched by the value-only pass.
+    assert_eq!(storage.get_flushed_lsn().unwrap(), flushed_before);
+    assert_eq!(storage.get_temporal_extent_bounds().unwrap(), extent_before);
+
+    // Every value still decodes (now under the new cold DEK).
+    storage.retire_cold_generations(2).unwrap();
+    for node in &nodes {
+        let loaded = storage
+            .get_node_version(node.version_id())
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded.version_id(), node.version_id());
+    }
+    for edge in &edges {
+        let loaded = storage
+            .get_edge_version(edge.version_id())
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded.version_id(), edge.version_id());
+    }
+}
+
+#[test]
+fn crash_mid_cold_batch_resumes_from_cursor() {
+    // Simulate a crash after some batches committed: nodes 1..=3 are already
+    // re-wrapped at generation 2 with a durable cursor at (node, key=3); nodes
+    // 4..=5 remain at generation 1. Resume must continue from the cursor (no
+    // double-encrypt of 1..=3), finish 4..=5, and complete.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("resume.redb");
+    let c1 = cipher_with_byte(0x33);
+    let c2 = cipher_with_byte(0x44);
+
+    let storage = RedbColdStorage::new(&db_path, RedbConfig::new())
+        .unwrap()
+        .with_cipher(Arc::clone(&c1));
+    let nodes: Vec<NodeVersion> = (1..=5).map(create_test_node_version).collect();
+    for n in &nodes {
+        storage.store_node_version(n).unwrap();
+    }
+    storage.install_cold_generation(2, Arc::clone(&c2)).unwrap();
+
+    // Manually re-wrap nodes 1..=3 to ACV1@2 and plant the resume cursor.
+    for k in 1..=3u64 {
+        let raw = raw_value(&storage, NODE_VERSIONS_TABLE, k);
+        let compressed = storage.decrypt_if_needed(&raw).unwrap();
+        let ct2 = c2.encrypt(&compressed, &[]).unwrap();
+        insert_raw(&storage, NODE_VERSIONS_TABLE, k, &wrap_cold_value(2, &ct2));
+    }
+    let cursor = ColdRotationCursor {
+        target_version: 2,
+        table: ColdTableKind::Node,
+        last_completed_key: 3,
+    };
+    insert_raw_metadata(&storage, COLD_ROTATION_CURSOR_KEY, &cursor.to_bytes());
+    let node1_before = raw_value(&storage, NODE_VERSIONS_TABLE, 1);
+
+    // Resume.
+    let stats = storage.reencrypt_cold_values(2).unwrap();
+    // Nodes 1..=3 are past the cursor (not revisited); only 4..=5 are rewrapped.
+    assert_eq!(
+        stats.values_rewrapped, 2,
+        "only nodes 4,5 remain to re-wrap"
+    );
+
+    // No double-encrypt: node 1's bytes are unchanged.
+    assert_eq!(
+        raw_value(&storage, NODE_VERSIONS_TABLE, 1),
+        node1_before,
+        "an already-wrapped value past the cursor must not be re-encrypted"
+    );
+    // Every node now ACV1@2 and the pass completed (cursor cleared, marker set).
+    for k in 1..=5u64 {
+        let (kv, _) = parse_cold_wrapper(&raw_value(&storage, NODE_VERSIONS_TABLE, k)).unwrap();
+        assert_eq!(kv, 2);
+    }
+    assert_eq!(storage.cold_value_format_version().unwrap(), Some(2));
+    assert!(storage.read_cold_rotation_cursor().unwrap().is_none());
+
+    // All values still read.
+    storage.retire_cold_generations(2).unwrap();
+    for n in &nodes {
+        let loaded = storage.get_node_version(n.version_id()).unwrap().unwrap();
+        assert_eq!(loaded.version_id(), n.version_id());
+    }
+}
+
+#[test]
+fn reencrypt_is_idempotent_over_already_wrapped_values() {
+    // A re-run after a stale/absent cursor must skip already-target-wrapped
+    // values, never double-encrypt (the ACV1 wrapper is the idempotency backstop).
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("idem.redb");
+    let c1 = cipher_with_byte(0x55);
+    let c2 = cipher_with_byte(0x66);
+
+    let storage = RedbColdStorage::new(&db_path, RedbConfig::new())
+        .unwrap()
+        .with_cipher(Arc::clone(&c1));
+    for n in (1..=4).map(create_test_node_version) {
+        storage.store_node_version(&n).unwrap();
+    }
+    storage.install_cold_generation(2, Arc::clone(&c2)).unwrap();
+    let first = storage.reencrypt_cold_values(2).unwrap();
+    assert_eq!(first.values_rewrapped, 4);
+
+    let raw_after_first = raw_value(&storage, NODE_VERSIONS_TABLE, 1);
+    // Re-run: every value is already ACV1@2, so all are skipped, none rewrapped.
+    let second = storage.reencrypt_cold_values(2).unwrap();
+    assert_eq!(second.values_rewrapped, 0);
+    assert_eq!(second.values_skipped, 4);
+    assert_eq!(
+        raw_value(&storage, NODE_VERSIONS_TABLE, 1),
+        raw_after_first,
+        "an idempotent re-run must not change already-wrapped bytes"
+    );
+}
+
+#[test]
+fn mixed_legacy_and_wrapped_values_read_during_rotation() {
+    // During an interrupted rotation the store holds a mix: some legacy (bare,
+    // old DEK) values and some ACV1@2 (new DEK) values. A two-generation keyring
+    // reads both correctly.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("mixed.redb");
+    let c1 = cipher_with_byte(0x77);
+    let c2 = cipher_with_byte(0x88);
+
+    // Two-generation keyring: gen 1 (old, c1) + gen 2 (new, c2), current = 2.
+    let ring = ColdKeyring::single(Arc::clone(&c1));
+    ring.add_generation(2, Arc::clone(&c2));
+    let storage = RedbColdStorage::new(&db_path, RedbConfig::new())
+        .unwrap()
+        .with_cold_keyring(ring);
+
+    // Legacy (bare) value under the OLD DEK at key 1.
+    let legacy = create_test_node_version(1);
+    let legacy_bare = c1
+        .encrypt(
+            &storage.compress(&encode_node_version(&legacy)).unwrap(),
+            &[],
+        )
+        .unwrap();
+    insert_raw(&storage, NODE_VERSIONS_TABLE, 1, &legacy_bare);
+
+    // Freshly-written value is wrapped ACV1@2 under the NEW DEK at key 2.
+    let fresh = create_test_node_version(2);
+    storage.store_node_version(&fresh).unwrap();
+    let (kv, _) = parse_cold_wrapper(&raw_value(&storage, NODE_VERSIONS_TABLE, 2)).unwrap();
+    assert_eq!(
+        kv, 2,
+        "a write during rotation stamps the current (new) generation"
+    );
+
+    // Both read correctly, each under its own generation.
+    assert_eq!(
+        storage
+            .get_node_version(legacy.version_id())
+            .unwrap()
+            .unwrap()
+            .version_id(),
+        legacy.version_id()
+    );
+    assert_eq!(
+        storage
+            .get_node_version(fresh.version_id())
+            .unwrap()
+            .unwrap()
+            .version_id(),
+        fresh.version_id()
+    );
+}
+
+// ========================================================================
 // Version-counter seeding at open (Issue #3222 review follow-up)
 // ========================================================================
 

--- a/src/storage/redb_cold_storage/tests.rs
+++ b/src/storage/redb_cold_storage/tests.rs
@@ -2714,6 +2714,224 @@ fn mixed_legacy_and_wrapped_values_read_during_rotation() {
     );
 }
 
+#[test]
+fn bulk_reencrypt_upgrades_all_legacy_table() {
+    // Pre-#3617 on-disk state: values are BARE compress-then-encrypt with NO
+    // ACV1 wrapper. Every existing bulk test seeds ACV1@1 via `store_*`, so the
+    // legacy(unwrapped) -> wrapped upgrade THROUGH the bulk pass is otherwise
+    // uncovered. A full-MEK rotation must upgrade every such legacy value to
+    // ACV1@new and re-key it (counted as re-wrapped, never skipped).
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("legacy_bulk.redb");
+    let c1 = cipher_with_byte(0x11);
+    let c2 = cipher_with_byte(0x22);
+
+    // Two-generation keyring: legacy (bare) values decrypt under the OLDEST
+    // generation (gen 1 = c1); the bulk pass re-encrypts every value to gen 2.
+    let ring = ColdKeyring::single(Arc::clone(&c1));
+    ring.add_generation(2, Arc::clone(&c2));
+    let storage = RedbColdStorage::new(&db_path, RedbConfig::new())
+        .unwrap()
+        .with_cold_keyring(ring);
+
+    // Seed 3 node + 2 edge LEGACY bare values (no ACV1 wrapper), exactly as the
+    // pre-#3617 store wrote them: compress, encrypt under the old DEK, insert raw.
+    for id in 1..=3u64 {
+        let n = create_test_node_version(id);
+        let bare = c1
+            .encrypt(&storage.compress(&encode_node_version(&n)).unwrap(), &[])
+            .unwrap();
+        insert_raw(&storage, NODE_VERSIONS_TABLE, id, &bare);
+    }
+    for id in 10..=11u64 {
+        let e = create_test_edge_version(id);
+        let bare = c1
+            .encrypt(&storage.compress(&encode_edge_version(&e)).unwrap(), &[])
+            .unwrap();
+        insert_raw(&storage, EDGE_VERSIONS_TABLE, id, &bare);
+    }
+
+    // Bulk re-encrypt: every legacy value is upgraded to ACV1@2 (re-wrapped),
+    // none skipped (nothing was already at the target generation).
+    let stats = storage.reencrypt_cold_values(2).unwrap();
+    assert_eq!(
+        stats.values_rewrapped, 5,
+        "3 legacy nodes + 2 legacy edges must all be upgraded through the bulk pass"
+    );
+    assert_eq!(
+        stats.values_skipped, 0,
+        "no legacy value was already ACV1@2, so none may be skipped"
+    );
+
+    // Every value is now ACV1@2 (upgraded from bare legacy) and the marker is set.
+    for id in 1..=3u64 {
+        let (kv, _) = parse_cold_wrapper(&raw_value(&storage, NODE_VERSIONS_TABLE, id)).unwrap();
+        assert_eq!(kv, 2, "legacy node {id} must upgrade to ACV1@2");
+    }
+    for id in 10..=11u64 {
+        let (kv, _) = parse_cold_wrapper(&raw_value(&storage, EDGE_VERSIONS_TABLE, id)).unwrap();
+        assert_eq!(kv, 2, "legacy edge {id} must upgrade to ACV1@2");
+    }
+    assert_eq!(storage.cold_value_format_version().unwrap(), Some(2));
+
+    // Retire the old generation, then confirm every upgraded value decrypts under
+    // the NEW cold DEK alone — proving the legacy bytes were truly re-keyed.
+    storage.retire_cold_generations(2).unwrap();
+    for id in 1..=3u64 {
+        let n = create_test_node_version(id);
+        assert_eq!(
+            storage.get_node_version(n.id).unwrap().unwrap().id,
+            n.id,
+            "upgraded node {id} must decrypt under the new DEK"
+        );
+    }
+    for id in 10..=11u64 {
+        let e = create_test_edge_version(id);
+        assert_eq!(
+            storage.get_edge_version(e.id).unwrap().unwrap().id,
+            e.id,
+            "upgraded edge {id} must decrypt under the new DEK"
+        );
+    }
+}
+
+#[test]
+fn crafted_acv1_prefixed_legacy_value_fails_loudly() {
+    // Finding 1(d): a legacy bare ciphertext whose leading bytes happen to
+    // collide with the `ACV1` magic + a held key-version (a ~2^-32 event under a
+    // single-generation `match_any` keyring, where `has_version` short-circuits
+    // `true` so ONLY the 4-byte magic discriminates) is MISCLASSIFIED as wrapped.
+    // This MUST surface as a LOUD AEAD authentication failure (a read
+    // availability fault) — never a panic, and never silent wrong data.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("crafted.redb");
+    let cipher = test_cipher();
+
+    // Single-generation (match_any) keyring: `has_version` returns true for EVERY
+    // version, so the trailing u32 adds no discrimination on read.
+    let storage = RedbColdStorage::new(&db_path, RedbConfig::new())
+        .unwrap()
+        .with_cipher(Arc::clone(&cipher));
+
+    // A genuine legacy bare ciphertext for node 1, whose leading 8 bytes we then
+    // FORCE to collide with `ACV1` + held version 1. This simulates the ~2^-32
+    // event where a real ciphertext prefix equals the wrapper header: the first 8
+    // bytes are truly part of the ciphertext, so treating them as a wrapper strips
+    // real ciphertext bytes and the AEAD tag can no longer authenticate.
+    let version = create_test_node_version(1);
+    let mut crafted = cipher
+        .encrypt(
+            &storage.compress(&encode_node_version(&version)).unwrap(),
+            &[],
+        )
+        .unwrap();
+    assert!(
+        crafted.len() >= 8,
+        "an AEAD ciphertext is always at least the wrapper length"
+    );
+    crafted[0..4].copy_from_slice(b"ACV1"); // COLD_VALUE_MAGIC
+    crafted[4..8].copy_from_slice(&1u32.to_le_bytes()); // a held key-version
+    insert_raw(&storage, NODE_VERSIONS_TABLE, 1, &crafted);
+
+    // parse_cold_wrapper now (mis)reads it as ACV1@1; has_version(1) short-circuits
+    // true under match_any, so it is decrypted as wrapped and the 8-byte-stripped
+    // slice is fed to `decrypt` -> AEAD auth fails -> Err (loud, availability-only).
+    let result = storage.get_node_version(version.id);
+    assert!(
+        result.is_err(),
+        "a crafted ACV1-colliding legacy value must fail loudly (AEAD auth), \
+         never return silent wrong data (finding 1(d): loud, availability-only)"
+    );
+}
+
+#[test]
+fn cold_rotation_resumes_after_real_reopen() {
+    // Genuine cross-process-style resume: partially rotate + plant a DURABLE
+    // cursor, DROP the redb + storage handle (closing the on-disk file), then
+    // reopen a FRESH `RedbColdStorage` from the same path and resume. The cursor
+    // must be read from durable redb metadata (not in-process state), the pass
+    // must continue from it with no double-encrypt, and every value must end
+    // ACV1@2 decrypting under the new DEK.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("reopen_resume.redb");
+    let c1 = cipher_with_byte(0xA1);
+    let c2 = cipher_with_byte(0xB2);
+
+    // Handle A: store 5 nodes (ACV1@1), manually rewrap the 1..=3 prefix to
+    // ACV1@2 + plant the resume cursor at (Node, key=3), then DROP the handle.
+    let node1_before;
+    {
+        let storage = RedbColdStorage::new(&db_path, RedbConfig::new())
+            .unwrap()
+            .with_cipher(Arc::clone(&c1));
+        for id in 1..=5u64 {
+            storage
+                .store_node_version(&create_test_node_version(id))
+                .unwrap();
+        }
+        storage.install_cold_generation(2, Arc::clone(&c2)).unwrap();
+        for id in 1..=3u64 {
+            let raw = raw_value(&storage, NODE_VERSIONS_TABLE, id);
+            let compressed = storage.decrypt_if_needed(&raw).unwrap();
+            let ct2 = c2.encrypt(&compressed, &[]).unwrap();
+            insert_raw(&storage, NODE_VERSIONS_TABLE, id, &wrap_cold_value(2, &ct2));
+        }
+        let cursor = ColdRotationCursor {
+            target_version: 2,
+            table: ColdTableKind::Node,
+            last_completed_key: 3,
+        };
+        insert_raw_metadata(&storage, COLD_ROTATION_CURSOR_KEY, &cursor.to_bytes());
+        node1_before = raw_value(&storage, NODE_VERSIONS_TABLE, 1);
+    } // drop handle A: closes the redb file so the reopen is genuinely from disk
+
+    // Handle B: reopen FRESH from disk with a 2-generation keyring, then resume.
+    let ring = ColdKeyring::single(Arc::clone(&c1));
+    ring.add_generation(2, Arc::clone(&c2));
+    let storage = RedbColdStorage::new(&db_path, RedbConfig::new())
+        .unwrap()
+        .with_cold_keyring(ring);
+
+    // The durable cursor is read from redb metadata by the freshly-opened handle.
+    assert_eq!(
+        storage
+            .read_cold_rotation_cursor()
+            .unwrap()
+            .map(|c| c.last_completed_key),
+        Some(3),
+        "reopened handle must read the durable resume cursor from disk"
+    );
+
+    let stats = storage.reencrypt_cold_values(2).unwrap();
+    assert_eq!(
+        stats.values_rewrapped, 2,
+        "only nodes 4,5 remain past the durable cursor"
+    );
+
+    // No double-encrypt of the already-done prefix after reopen.
+    assert_eq!(
+        raw_value(&storage, NODE_VERSIONS_TABLE, 1),
+        node1_before,
+        "a value past the durable cursor must not be re-encrypted after a real reopen"
+    );
+    for id in 1..=5u64 {
+        let (kv, _) = parse_cold_wrapper(&raw_value(&storage, NODE_VERSIONS_TABLE, id)).unwrap();
+        assert_eq!(kv, 2, "every node must end ACV1@2");
+    }
+    assert!(
+        storage.read_cold_rotation_cursor().unwrap().is_none(),
+        "cursor cleared on completion"
+    );
+    assert_eq!(storage.cold_value_format_version().unwrap(), Some(2));
+
+    // Every value decrypts under the new DEK alone.
+    storage.retire_cold_generations(2).unwrap();
+    for id in 1..=5u64 {
+        let v = create_test_node_version(id);
+        assert_eq!(storage.get_node_version(v.id).unwrap().unwrap().id, v.id);
+    }
+}
+
 // ========================================================================
 // Version-counter seeding at open (Issue #3222 review follow-up)
 // ========================================================================

--- a/src/storage/redb_cold_storage/tests.rs
+++ b/src/storage/redb_cold_storage/tests.rs
@@ -2660,6 +2660,114 @@ fn reencrypt_is_idempotent_over_already_wrapped_values() {
 }
 
 #[test]
+fn reencrypt_honors_configurable_batch_size() {
+    // Issue #3617 PR3: the per-transaction re-encrypt batch size is a runtime
+    // knob (`RedbConfig::reencrypt_batch_size`). Configure a SMALL cap (2), seed
+    // MORE values than the cap (5 nodes), and assert the pass (a) re-wraps every
+    // value under the new DEK and (b) actually spanned MULTIPLE bounded batches
+    // (batches_committed > 1), proving the small cap is honored, not ignored.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("small_batch.redb");
+    let c1 = cipher_with_byte(0x77);
+    let c2 = cipher_with_byte(0x88);
+
+    let config = RedbConfig::new().with_reencrypt_batch_size(2);
+    assert_eq!(config.reencrypt_batch_size, 2);
+    let storage = RedbColdStorage::new(&db_path, config)
+        .unwrap()
+        .with_cipher(Arc::clone(&c1));
+
+    let nodes: Vec<NodeVersion> = (1..=5).map(create_test_node_version).collect();
+    for n in &nodes {
+        storage.store_node_version(n).unwrap();
+    }
+
+    storage.install_cold_generation(2, Arc::clone(&c2)).unwrap();
+    let stats = storage.reencrypt_cold_values(2).unwrap();
+
+    // (a) every value re-wrapped at the new generation.
+    assert_eq!(stats.values_rewrapped, 5, "all 5 nodes re-wrapped");
+    assert_eq!(stats.values_skipped, 0);
+    for k in 1..=5u64 {
+        let (kv, _) = parse_cold_wrapper(&raw_value(&storage, NODE_VERSIONS_TABLE, k)).unwrap();
+        assert_eq!(kv, 2, "node {k} must be re-wrapped at generation 2");
+    }
+    assert_eq!(storage.cold_value_format_version().unwrap(), Some(2));
+
+    // (b) the small cap of 2 over 5 values forced ceil(5/2) = 3 committed
+    // batches (2 + 2 + 1), so the cap was honored, not ignored.
+    assert_eq!(
+        stats.batches_committed, 3,
+        "a batch cap of 2 over 5 values must span 3 bounded transactions"
+    );
+
+    // Every value still decrypts under the new cold DEK.
+    storage.retire_cold_generations(2).unwrap();
+    for n in &nodes {
+        let loaded = storage.get_node_version(n.version_id()).unwrap().unwrap();
+        assert_eq!(loaded.version_id(), n.version_id());
+    }
+}
+
+#[test]
+fn reencrypt_default_batch_size_is_single_transaction() {
+    // Default (unset) behavior is unchanged: with the 4096 default a 5-value
+    // pass commits in exactly ONE batch — the guarantee that omitting the knob
+    // reproduces prior behavior.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("default_batch.redb");
+    let c1 = cipher_with_byte(0x99);
+    let c2 = cipher_with_byte(0xAA);
+
+    let storage = RedbColdStorage::new(&db_path, RedbConfig::new())
+        .unwrap()
+        .with_cipher(Arc::clone(&c1));
+    assert_eq!(RedbConfig::new().reencrypt_batch_size, 4096);
+
+    for n in (1..=5).map(create_test_node_version) {
+        storage.store_node_version(&n).unwrap();
+    }
+    storage.install_cold_generation(2, Arc::clone(&c2)).unwrap();
+    let stats = storage.reencrypt_cold_values(2).unwrap();
+    assert_eq!(stats.values_rewrapped, 5);
+    assert_eq!(
+        stats.batches_committed, 1,
+        "the 4096 default re-wraps 5 values in a single transaction"
+    );
+}
+
+#[test]
+fn reencrypt_zero_batch_size_is_floored_to_one() {
+    // A 0 batch size would make no forward progress; the setter (and the read
+    // site) floor it to 1. The pass must still complete, spanning one batch per
+    // value (5 values -> 5 committed batches).
+    let cfg = RedbConfig::new().with_reencrypt_batch_size(0);
+    assert_eq!(cfg.reencrypt_batch_size, 1, "0 is clamped up to 1");
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("zero_batch.redb");
+    let c1 = cipher_with_byte(0xBB);
+    let c2 = cipher_with_byte(0xCC);
+    let storage = RedbColdStorage::new(&db_path, cfg)
+        .unwrap()
+        .with_cipher(Arc::clone(&c1));
+    for n in (1..=5).map(create_test_node_version) {
+        storage.store_node_version(&n).unwrap();
+    }
+    storage.install_cold_generation(2, Arc::clone(&c2)).unwrap();
+    let stats = storage.reencrypt_cold_values(2).unwrap();
+    assert_eq!(stats.values_rewrapped, 5);
+    assert_eq!(
+        stats.batches_committed, 5,
+        "a floored batch size of 1 commits once per value"
+    );
+    for k in 1..=5u64 {
+        let (kv, _) = parse_cold_wrapper(&raw_value(&storage, NODE_VERSIONS_TABLE, k)).unwrap();
+        assert_eq!(kv, 2);
+    }
+}
+
+#[test]
 fn mixed_legacy_and_wrapped_values_read_during_rotation() {
     // During an interrupted rotation the store holds a mix: some legacy (bare,
     // old DEK) values and some ACV1@2 (new DEK) values. A two-generation keyring

--- a/tests/cli_encryption.rs
+++ b/tests/cli_encryption.rs
@@ -20,12 +20,13 @@
 //! (exit 0), re-encrypting every persisted file and bumping the key version --
 //! and that success is what these tests assert.
 //!
-//! The one at-rest layer NOT yet covered is cold storage (PR3): when a tiered
-//! cold store is configured under the same master key, an index+WAL rotation
-//! would strand the cold values, so the cross-layer guard STILL refuses and
-//! names `cold_storage`. `keys_rotate_start_with_cold_storage_refuses_cross_layer`
-//! asserts that CLI refusal end-to-end (the unit test
-//! `rotate_still_refuses_when_cold_storage_encrypted` covers the engine level).
+//! Cold storage is now covered too (Issue #3617 PR3): a tiered cold store
+//! configured under the same master key is bulk re-encrypted to the new cold
+//! DEK during the rotation, so `keys rotate` against a DB with an encrypted cold
+//! tier now SUCCEEDS. `keys_rotate_start_with_cold_storage_succeeds` asserts that
+//! end-to-end (the unit test `rotate_reencrypts_cold` covers the engine level).
+//! With all four at-rest layers (index, checkpoint, WAL, cold) rotatable, the
+//! cross-layer refusal is gone for a uniformly-encrypted database.
 
 use std::path::Path;
 use std::process::Command;
@@ -695,12 +696,12 @@ mod encrypted {
     }
 
     #[test]
-    fn keys_rotate_start_with_cold_storage_refuses_cross_layer() {
-        // Issue #3617 PR2: cold storage is NOT yet covered (PR3). A DB with an
-        // encrypted cold tier configured must STILL refuse an index+WAL rotation
-        // (it would strand the cold values under the old MEK). This is the CLI
-        // end-to-end counterpart to the engine unit test
-        // `rotate_still_refuses_when_cold_storage_encrypted`.
+    fn keys_rotate_start_with_cold_storage_succeeds() {
+        // Issue #3617 PR3 (completes the issue): a DB with an encrypted cold tier
+        // now ROTATES fully via the CLI — the driver bulk re-encrypts every cold
+        // value to the new cold DEK, so a subsequent provider switch is safe.
+        // This flips the former cross-layer refusal (CLI end-to-end counterpart to
+        // the engine unit test `rotate_reencrypts_cold`).
         let f = make_encrypted_db_with_cold();
         let new_key = f.toml_path.parent().unwrap().join("rotate-to.key");
         FileKeyProvider::generate_key_file(&new_key).unwrap();
@@ -709,15 +710,19 @@ mod encrypted {
             &["keys", "rotate", "--new-key", new_key.to_str().unwrap()],
             &cfg_env(&f),
         );
-        assert_ne!(
+        assert_eq!(
             r.code, 0,
-            "rotate with encrypted cold storage configured must still refuse; stdout={:?}",
-            r.stdout
+            "rotate with an encrypted cold tier must now succeed; stdout={:?} stderr={:?}",
+            r.stdout, r.stderr
         );
         let c = r.combined_lower();
         assert!(
-            c.contains("cold_storage"),
-            "refusal must name the conflicting cold_storage layer; got={c:?}"
+            c.contains("rotation complete"),
+            "success must print the completion headline; got={c:?}"
+        );
+        assert!(
+            !c.contains("other encrypted-at-rest layers") && !c.contains("cold_storage"),
+            "must not be the cross-layer refusal; got={c:?}"
         );
         assert!(!c.contains("panicked"), "must not panic; got={c:?}");
         assert_no_key_leak(&r, &[f.key_path.as_path(), new_key.as_path()]);


### PR DESCRIPTION
> **MAINTAINER SIGN-OFF NEEDED: on-disk cold-value format change (`ACV1` wrapper).** This PR introduces a new self-describing prefix on every encrypted cold (redb) value. Old bare-ciphertext values still read (legacy fallback), but new/rotated values carry the `ACV1` header. Please review the format and its false-positive/availability properties (below) before merge.

Completes **#3617** (full-MEK, all-layer key rotation). PR1 rotated index/checkpoint, PR2 rotated the WAL; **this PR3 rotates the cold (redb) tier**, the final encrypted-at-rest layer.

## Before / After (plain language)

- **Before:** a database with cold storage configured still **refused** `keys rotate` — only the index and WAL layers could rotate, and `conflicting_encrypted_layers` reported cold as un-rotatable.
- **After:** a uniformly-encrypted **index + WAL + cold** database rotates its master key **end-to-end**. The cold tier's stored values are transactionally **bulk re-encrypted** under the new key, **crash-resumably**, completing #3617's all-layer rotation. `conflicting_encrypted_layers` is now empty, so full rotation succeeds.

## How

- **`ColdKeyring`** — an interior-mutable **2-generation** cold keyring (one generation in steady state, two mid-rotation), deliberately mirroring the WAL (`WalKeyring`) and index (`IndexKeyring`) keyrings. `Debug` is redacted; key material lives only in the ciphers.
- **`ACV1` self-describing value wrapper** `[magic "ACV1":4][key_version:u32 LE:4]` applied at both encrypt sites (single store + batch), with a **legacy bare-ciphertext fallback**: on read a value is treated as wrapped only if it starts with `ACV1` **and** names a held generation; otherwise it is a pre-#3617 bare ciphertext decrypted under the oldest generation.
  - **False-positive property (stated honestly):** under a **single-generation `match_any`** keyring (the never-rotated / post-provider-switch steady state), `has_version` short-circuits `true`, so **only the 4-byte magic discriminates** — a legacy-prefix collision is **~2⁻³²**, *not* 2⁻⁶⁴. The ~2⁻⁶⁴ figure holds **only** for a strict (mid-rotation, 2-generation) keyring. **Crucially, in either mode a misfire is a LOUD AEAD authentication failure** (a read *availability* fault, recoverable by reopening under the correct key) — **never silent wrong data / integrity loss** (a mangled slice cannot forge a valid AEAD tag).
- **`reencrypt_cold_values`** — an in-place **transactional bulk re-encrypt** over `node_versions` + `edge_versions` in bounded batches. A durable redb **resume cursor** is committed in the **same redb write txn** as each batch (crash-atomic), and the `ACV1` wrapper makes the pass **idempotent** (already-`@target` values are skipped, so a resumed pass never double-encrypts). Only value bytes are touched — plaintext `flushed_lsn` and `temporal_extent` (incl. #3389 per-dimension bounds) are preserved.
- **Crash contract (inherited from PR2):** while a rotation is `Pending` the **old** key must remain available to finish it. Reopening under the **new** key alone after a mid-cold-pass crash fails `open()` **loudly** (old-DEK `ACV1@base` values no longer decrypt) until reopened once under the **old** key to let resume complete — loud, never silent, fully recoverable; the inherent "resume under old key, then switch" contract of full-MEK rotation.

## Cross-lane: `src/db/config.rs` (~30 lines, coordinator-cleared)

Analogous to the PR2 WAL wiring. On the encrypted durable-open path, `config.rs`:
1. **Provisions** the cold keyring at the resolved rotate-then-reopen key version (`with_cipher_versioned` / `single_versioned`), so freshly written cold values stamp the real generation rather than a stale `INITIAL_COLD_KEY_VERSION` after a rotate-then-reopen.
2. **Calls `finalize_resumed_cold_rotation(...)`** *after* the cold store is built (index + WAL resume first; cold is the last layer to settle). This completes a startup-resumed cold rotation from the durable redb cursor (idempotent), retires the old cold generation, marks `cold=complete`, and clears the rotation ledger. It is a no-op when no rotation is pending or cold is out of scope, so the durable-open path can call it unconditionally.

## Testing

Cold-store level (all green):
- `rotate_reencrypts_cold` — full **index + WAL + cold** rotation, then reopen under the new key alone and read.
- `keys_rotate_start_with_cold_storage_succeeds` / cold-storage refusal tests **flipped from refusal to success** (engine + CLI); index-only rotation stays green.
- `legacy_cold_value_reads_under_current_dek`, `cold_value_roundtrips_with_acv1_wrapper` (round-trip + **loud** wrong-generation failure), `bulk_reencrypt_rewrites_all_values_new_generation` (flushed_lsn / extent preserved), `crash_mid_cold_batch_resumes_from_cursor`, `reencrypt_is_idempotent_over_already_wrapped_values`, `mixed_legacy_and_wrapped_values_read_during_rotation`.

Added by this review-hardening pass:
- **`bulk_reencrypt_upgrades_all_legacy_table`** — seeds **legacy bare (unwrapped)** values and asserts the bulk pass upgrades *every* one to `ACV1@new` (counted in `values_rewrapped`, not skipped), each decrypting under the new DEK alone. Prior bulk tests all seed `ACV1@1`, so the legacy→wrapped upgrade *through the bulk pass* was uncovered.
- **`crafted_acv1_prefixed_legacy_value_fails_loudly`** — crafts a bare legacy value whose prefix collides with `ACV1` + a held key-version (the ~2⁻³² event under `match_any`) and asserts the read returns **`Err`** (loud AEAD failure), **never** a panic or silent wrong data. Proved loud-fail.
- **`cold_rotation_resumes_after_real_reopen`** — a genuine reopen: partially rotate + plant the durable cursor, **drop** the redb + storage handle, reopen a **fresh** `RedbColdStorage` from the same on-disk path, and assert resume reads the durable cursor and completes with no double-encrypt.

### Gate results (clean build in `/dev/shm`, verified fresh)

- `cargo fmt --all --check`: **clean**
- `cargo clippy --all-targets --features "config-toml,mcp-server,sharding-rpc,simulation" -- -D warnings`: **0**
- `cargo clippy --all-targets --all-features -- -D warnings`: **0**
- `cargo check --no-default-features --tests` (Feature Matrix): **pass** (exit 0)
- `cargo test --features "config-toml,mcp-server,sharding-rpc,simulation"` full suite on a **fresh** target dir: green except the documented known-OK uid-0 noise (`havoc_flush_deadlock::test_flush_deadlock_on_io_error`, `regression_flush_corruption::test_metadata_corruption_on_error`) — **zero** cold/rotation/encryption/AEIX failures.
- `cargo test --no-default-features --features "config-toml,encryption" --lib`: **4112 passed, 0 failed**
- Standalone: `cargo check --no-default-features --features encryption` / `encryption-aws-kms` / `encryption-vault`: **all pass**

## Doc-accuracy note

The `ACV1` collision comment (`keyring.rs`) and the PR3 commit narrative previously claimed a uniform ~2⁻⁶⁴; both are corrected here to the honest **~2⁻³² (loud-fail, availability-only)** property for the common single-generation `match_any` case. The wrapper logic and on-disk format are unchanged — only the documented probability was wrong.

---

Refs #3617. **Draft** pending maintainer sign-off on the `ACV1` on-disk cold-value format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRMi3NFi3FwGqXoon9Fqga)_