### PR TITLE
feat(encryption): durable encryption-state authority — #3616 foundation (PR 1 of 4)

### DIFF
--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -353,6 +353,9 @@ impl AletheiaDB {
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn with_unified_config(config: AletheiaDBConfig) -> Result<Self> {
         let result = (|| {
+            // Rebound mutable so the durable encryption-state authority
+            // (Issue #3616) can override `config.encryption` below.
+            let mut config = config;
             let durability_mode = config.wal.durability_mode;
 
             // Capture provenance-chain settings before `config.wal.wal_dir` is
@@ -365,6 +368,65 @@ impl AletheiaDB {
                 .parent()
                 .map(std::path::Path::to_path_buf)
                 .unwrap_or_else(|| std::path::PathBuf::from("."));
+
+            // Issue #3616: the durable encryption-state authority
+            // (`{persistence.data_dir}/encryption.state`) is the AUTHORITY for
+            // the encryption on/off decision — it WINS over the TOML/env-derived
+            // `EncryptionConfig`. This is what lets an `encryption enable`
+            // migration flip a database to encrypted-at-rest so the NEXT open()
+            // uses the cipher even though the operator's plaintext config is
+            // unchanged. Precedence & fail-closed contract (see
+            // `db::encryption_state`):
+            //   * absent           -> no override; today's TOML/env behavior.
+            //   * enabled + source -> force encryption ON under that key source.
+            //   * disabled         -> force encryption OFF.
+            //   * corrupt / enabled-without-source -> read returns Err -> open
+            //     aborts loudly (fail-closed; NEVER a silent plaintext fallback).
+            // On DIVERGENCE a LOUD warning naming BOTH sources is logged so an
+            // operator is never silently overridden.
+            if config.persistence.enabled
+                && let Some(authority) = crate::db::encryption_state::read_encryption_state(
+                    &config.persistence.data_dir,
+                )?
+            {
+                if authority.enabled != config.encryption.enabled {
+                    crate::db::encryption_state::log_authority_warning(&format!(
+                        "encryption-state authority at {} records enabled={}, OVERRIDING the \
+                         loaded config (encryption.enabled={}). The durable authority wins; \
+                         opening with enabled={}.",
+                        crate::db::encryption_state::encryption_state_path(
+                            &config.persistence.data_dir
+                        )
+                        .display(),
+                        authority.enabled,
+                        config.encryption.enabled,
+                        authority.enabled,
+                    ));
+                }
+                if authority.enabled {
+                    // The reader guarantees an enabled authority carries a key
+                    // source. Compose that key SOURCE with the config's
+                    // algorithm/audit; a missing/unreadable key then fails
+                    // `EncryptionManager::from_config` below, so open() refuses
+                    // rather than falling back to plaintext (fail-closed).
+                    let key_source =
+                        authority
+                            .key_source
+                            .ok_or_else(|| -> crate::core::error::Error {
+                                crate::core::error::StorageError::InconsistentState {
+                                    reason:
+                                        "encryption-state authority is enabled but resolved no \
+                                         key source"
+                                            .to_string(),
+                                }
+                                .into()
+                            })?;
+                    config.encryption.enabled = true;
+                    config.encryption.key_provider = key_source;
+                } else {
+                    config.encryption.enabled = false;
+                }
+            }
 
             // Create encryption manager if encryption is enabled
             let encryption_manager = if config.encryption.enabled {

--- a/src/db/encryption_state.rs
+++ b/src/db/encryption_state.rs
@@ -1,0 +1,457 @@
+//! Durable encryption-state authority — `{data_dir}/encryption.state` (Issue #3616).
+//!
+//! A tiny, versioned, line-based file that records the **authoritative**
+//! encryption-at-rest posture of a durable database: whether encryption is on,
+//! and — as a non-secret *reference*, never key bytes — where the Master
+//! Encryption Key is sourced from. It is the durable authority the
+//! plaintext↔encrypted migration engine (Issue #3616) flips so the *next*
+//! [`open()`](crate::AletheiaDB::open) uses the correct mode, independent of the
+//! operator's TOML/env config.
+//!
+//! # Why a separate file (not the TOML)?
+//!
+//! The operator's `ALETHEIADB_CONFIG` TOML (or `ALETHEIADB_DATA_DIR`, which is
+//! hard-wired plaintext) is *input*, not durable database state. After an
+//! `encryption enable` migration rewrites every at-rest byte through the cipher,
+//! something inside the data dir must tell the next `open()` "this database is
+//! now encrypted, under this key source" — otherwise the operator's unchanged
+//! plaintext TOML would try to open encrypted bytes as plaintext and fail. This
+//! file is that durable record.
+//!
+//! # Precedence (the authority WINS)
+//!
+//! [`read_encryption_state`] is consulted by `open()` (see
+//! [`with_unified_config`](crate::AletheiaDB::with_unified_config)) as the
+//! **authority** for the encryption on/off decision — it overrides the
+//! TOML/env-derived [`EncryptionConfig`]. On divergence (the authority says one
+//! thing, the config another) a LOUD warning naming BOTH sources is logged so an
+//! operator is never silently overridden.
+//!
+//! # Fail-closed
+//!
+//! This file *guards encryption*, so it never guesses:
+//! * **absent** → `Ok(None)` — not enabled via the authority; fall through to
+//!   TOML/env (today's behavior, fully backward compatible).
+//! * **present & well-formed** → `Ok(Some(_))`.
+//! * **present but corrupt** → `Err(_)` — startup aborts loudly for manual
+//!   intervention; a garbled authority is NEVER treated as "not enabled".
+//!
+//! When the authority says `enabled` but the referenced key source is
+//! missing/unreadable, `open()` refuses (the encryption manager fails to source
+//! the MEK) rather than falling back to plaintext.
+//!
+//! # Security
+//!
+//! Only a key-source **reference** is ever written — a File path or an Env var
+//! NAME — exactly like the rotation ledger. Key bytes, passphrases, and tokens
+//! are never persisted here; passphrase/KMS/Vault sources (which carry secrets
+//! or multi-field config the line format cannot round-trip) are refused
+//! fail-closed by [`write_encryption_state_durable`], mirroring the rotation
+//! ledger's File/Env-only constraint.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::error::{Result, StorageError};
+use crate::encryption::config::KeyProviderConfig;
+
+/// Current on-disk format version of the authority file. Bumped when the line
+/// schema evolves; an unknown version fails closed (never guessed).
+const ENCRYPTION_STATE_VERSION: u32 = 1;
+
+/// The durable encryption-state authority parsed from `{data_dir}/encryption.state`.
+///
+/// `enabled` is the authoritative on/off decision. `key_source` is present iff
+/// `enabled` and is restricted to File/Env references (never key bytes).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EncryptionState {
+    /// Whether encryption at rest is authoritatively ON for this database.
+    pub enabled: bool,
+    /// The non-secret key-source reference (File path / Env var name). `Some`
+    /// iff `enabled`; `None` when the authority records "disabled".
+    pub key_source: Option<KeyProviderConfig>,
+}
+
+impl EncryptionState {
+    /// Construct the "encryption enabled under `key_source`" authority.
+    ///
+    /// `key_source` must be a File or Env reference; other backends are refused
+    /// at write time (they carry secrets the line format cannot persist).
+    ///
+    /// The producer is the `encryption enable` migration engine (Issue #3616,
+    /// landing in a follow-up commit on this same PR). Until then only the
+    /// READ + precedence path is wired into `open()`, so this constructor and
+    /// [`write_encryption_state_durable`] have test-only callers.
+    #[allow(dead_code)]
+    pub(crate) fn enabled(key_source: KeyProviderConfig) -> Self {
+        Self {
+            enabled: true,
+            key_source: Some(key_source),
+        }
+    }
+}
+
+/// Path of the durable authority file within a data dir.
+pub(crate) fn encryption_state_path(data_dir: &Path) -> PathBuf {
+    data_dir.join("encryption.state")
+}
+
+/// Reduce a corrupt-file detail to a fail-closed error (never fabricates state).
+fn corrupt(detail: &str) -> crate::core::error::Error {
+    StorageError::InconsistentState {
+        reason: format!(
+            "encryption.state present but corrupt ({detail}); manual intervention required"
+        ),
+    }
+    .into()
+}
+
+/// Read + parse the durable encryption-state authority for `data_dir`.
+///
+/// Fail-closed: absent → `Ok(None)`, well-formed → `Ok(Some(_))`, present but
+/// corrupt / unreadable → `Err(_)`. A malformed authority is NEVER downgraded to
+/// "not enabled" — that would silently open an encrypted database as plaintext.
+///
+/// Accepted key-source kinds are `file` / `env` only; any other kind (or an
+/// `enabled=true` record with no key source) is corrupt.
+pub(crate) fn read_encryption_state(data_dir: &Path) -> Result<Option<EncryptionState>> {
+    read_encryption_state_at(&encryption_state_path(data_dir))
+}
+
+/// Path-based core of [`read_encryption_state`], so tests and future startup
+/// wiring can target an exact file. Same fail-closed contract.
+pub(crate) fn read_encryption_state_at(path: &Path) -> Result<Option<EncryptionState>> {
+    let body = match std::fs::read_to_string(path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(StorageError::io_error(format!(
+                "encryption.state present but unreadable ({e}); manual intervention required"
+            ))
+            .into());
+        }
+    };
+
+    let mut version = None;
+    let mut enabled = None;
+    let mut kind = None;
+    let mut value = None;
+    for line in body.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Some((k, v)) = line.split_once('=') else {
+            return Err(corrupt("malformed line"));
+        };
+        match k {
+            "version" => version = Some(v.parse::<u32>().map_err(|_| corrupt("bad version"))?),
+            "enabled" => {
+                enabled = Some(match v {
+                    "true" => true,
+                    "false" => false,
+                    other => return Err(corrupt(&format!("bad enabled {other:?}"))),
+                })
+            }
+            "key_source_kind" => kind = Some(v.to_string()),
+            "key_source_value" => value = Some(v.to_string()),
+            // Unknown keys are ignored for forward-compatibility, mirroring the
+            // rotation ledger reader.
+            _ => {}
+        }
+    }
+
+    // `version=` is MANDATORY — a well-formed writer always emits it, so its
+    // absence means a truncated/garbled file, not a legacy artifact.
+    let version = version.ok_or_else(|| corrupt("missing version"))?;
+    if version != ENCRYPTION_STATE_VERSION {
+        return Err(corrupt(&format!("unsupported version {version}")));
+    }
+    let enabled = enabled.ok_or_else(|| corrupt("missing enabled"))?;
+
+    if !enabled {
+        return Ok(Some(EncryptionState {
+            enabled: false,
+            key_source: None,
+        }));
+    }
+
+    // enabled → a File/Env key-source reference is required (fail-closed: an
+    // enabled authority with no resolvable key source is corrupt, never a
+    // silent plaintext fallback).
+    let value = value.ok_or_else(|| corrupt("missing key_source_value"))?;
+    let key_source = match kind.as_deref() {
+        Some("file") => KeyProviderConfig::File { path: value.into() },
+        Some("env") => KeyProviderConfig::Env { variable: value },
+        Some(other) => return Err(corrupt(&format!("unsupported key_source_kind {other:?}"))),
+        None => return Err(corrupt("missing key_source_kind")),
+    };
+    Ok(Some(EncryptionState {
+        enabled: true,
+        key_source: Some(key_source),
+    }))
+}
+
+/// Durably write the encryption-state authority for `data_dir`.
+///
+/// Uses the SAME ordered, crash-safe write as the rotation ledger — temp →
+/// `sync_all` → atomic rename → parent-directory fsync
+/// ([`write_durable`](crate::db::rotation::write_durable)) — so a power loss can
+/// never leave a torn authority file. No key material is written: only a
+/// non-secret File/Env reference.
+///
+/// # Errors
+///
+/// * The key source is a passphrase/KMS/Vault backend (refused fail-closed —
+///   those carry secrets or multi-field config the line format cannot persist,
+///   mirroring the rotation ledger).
+/// * An enabled state carries no key source, or a disabled state carries one
+///   (a caller bug — the authority must be internally consistent).
+/// * The directory cannot be created or the file cannot be written durably.
+///
+/// The production caller is the `encryption enable` migration engine (Issue
+/// #3616), which lands in a follow-up commit on this PR; this foundation commit
+/// wires only the READ + precedence path into `open()`, so the writer's only
+/// callers today are the round-trip / crash-safety tests below.
+#[allow(dead_code)]
+pub(crate) fn write_encryption_state_durable(
+    data_dir: &Path,
+    state: &EncryptionState,
+) -> Result<()> {
+    let body = match (state.enabled, &state.key_source) {
+        (true, Some(source)) => {
+            let (kind, value) = match source {
+                KeyProviderConfig::File { path } => ("file", path.to_string_lossy().into_owned()),
+                KeyProviderConfig::Env { variable } => ("env", variable.clone()),
+                KeyProviderConfig::PassphraseFile { .. }
+                | KeyProviderConfig::Kms { .. }
+                | KeyProviderConfig::Vault { .. } => {
+                    let (provider_type, _) = source.describe();
+                    return Err(StorageError::PersistenceError(format!(
+                        "recording a {provider_type} key source in the encryption-state authority \
+                         is not supported (only file/env references can be persisted without \
+                         leaking a secret)"
+                    ))
+                    .into());
+                }
+            };
+            format!(
+                "version={ENCRYPTION_STATE_VERSION}\nenabled=true\nkey_source_kind={kind}\nkey_source_value={value}\n"
+            )
+        }
+        (true, None) => {
+            return Err(StorageError::PersistenceError(
+                "cannot record an enabled encryption-state authority with no key source"
+                    .to_string(),
+            )
+            .into());
+        }
+        (false, Some(_)) => {
+            return Err(StorageError::PersistenceError(
+                "cannot record a disabled encryption-state authority with a key source".to_string(),
+            )
+            .into());
+        }
+        (false, None) => format!("version={ENCRYPTION_STATE_VERSION}\nenabled=false\n"),
+    };
+
+    std::fs::create_dir_all(data_dir)
+        .map_err(|e| StorageError::io_error(format!("Failed to create data dir: {e}")))?;
+    crate::db::rotation::write_durable(&encryption_state_path(data_dir), body.as_bytes())
+}
+
+/// Emit a LOUD warning under either logging configuration, matching the crate's
+/// `observability`-gated logging style (mirrors `log_registry_warning` in
+/// `src/db/snapshot.rs`).
+pub(crate) fn log_authority_warning(message: &str) {
+    #[cfg(feature = "observability")]
+    tracing::warn!("{}", message);
+    #[cfg(not(feature = "observability"))]
+    eprintln!("WARNING: {}", message);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp() -> tempfile::TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    #[test]
+    fn absent_reads_as_none() {
+        let dir = tmp();
+        assert_eq!(read_encryption_state(dir.path()).unwrap(), None);
+    }
+
+    #[test]
+    fn round_trips_enabled_file_source() {
+        let dir = tmp();
+        let state = EncryptionState::enabled(KeyProviderConfig::File {
+            path: "/etc/aletheia/mek.key".into(),
+        });
+        write_encryption_state_durable(dir.path(), &state).unwrap();
+        assert_eq!(read_encryption_state(dir.path()).unwrap(), Some(state));
+    }
+
+    #[test]
+    fn round_trips_enabled_env_source() {
+        let dir = tmp();
+        let state = EncryptionState::enabled(KeyProviderConfig::Env {
+            variable: "ALETHEIADB_MEK".to_string(),
+        });
+        write_encryption_state_durable(dir.path(), &state).unwrap();
+        assert_eq!(read_encryption_state(dir.path()).unwrap(), Some(state));
+    }
+
+    #[test]
+    fn round_trips_disabled() {
+        let dir = tmp();
+        let state = EncryptionState {
+            enabled: false,
+            key_source: None,
+        };
+        write_encryption_state_durable(dir.path(), &state).unwrap();
+        assert_eq!(read_encryption_state(dir.path()).unwrap(), Some(state));
+    }
+
+    #[test]
+    fn write_leaves_no_temp_file() {
+        // The atomic write must not leave a `.tmp` sibling on success.
+        let dir = tmp();
+        write_encryption_state_durable(
+            dir.path(),
+            &EncryptionState::enabled(KeyProviderConfig::Env {
+                variable: "MEK".to_string(),
+            }),
+        )
+        .unwrap();
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains("tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file left behind: {leftovers:?}");
+    }
+
+    #[test]
+    fn no_key_bytes_on_disk_only_reference() {
+        // Hygiene: the file must carry only a path/name reference, never key
+        // material. We seed a File source whose *path string* is distinctive and
+        // assert the on-disk bytes contain the reference but nothing resembling
+        // raw key bytes beyond it.
+        let dir = tmp();
+        write_encryption_state_durable(
+            dir.path(),
+            &EncryptionState::enabled(KeyProviderConfig::File {
+                path: "/keys/unique-ref-path.key".into(),
+            }),
+        )
+        .unwrap();
+        let bytes = std::fs::read(encryption_state_path(dir.path())).unwrap();
+        let text = String::from_utf8(bytes).unwrap();
+        assert!(text.contains("/keys/unique-ref-path.key"));
+        assert!(text.contains("key_source_kind=file"));
+        // Only the four documented keys appear.
+        for line in text.lines().filter(|l| !l.trim().is_empty()) {
+            let key = line.split_once('=').unwrap().0;
+            assert!(
+                matches!(
+                    key,
+                    "version" | "enabled" | "key_source_kind" | "key_source_value"
+                ),
+                "unexpected key on disk: {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn corrupt_missing_version_fails_closed() {
+        let dir = tmp();
+        std::fs::write(
+            encryption_state_path(dir.path()),
+            b"enabled=true\nkey_source_kind=env\nkey_source_value=MEK\n",
+        )
+        .unwrap();
+        assert!(read_encryption_state(dir.path()).is_err());
+    }
+
+    #[test]
+    fn corrupt_unknown_version_fails_closed() {
+        let dir = tmp();
+        std::fs::write(
+            encryption_state_path(dir.path()),
+            b"version=99\nenabled=true\nkey_source_kind=env\nkey_source_value=MEK\n",
+        )
+        .unwrap();
+        assert!(read_encryption_state(dir.path()).is_err());
+    }
+
+    #[test]
+    fn corrupt_malformed_line_fails_closed() {
+        let dir = tmp();
+        std::fs::write(
+            encryption_state_path(dir.path()),
+            b"version=1\nthis_is_not_kv\n",
+        )
+        .unwrap();
+        assert!(read_encryption_state(dir.path()).is_err());
+    }
+
+    #[test]
+    fn enabled_without_key_source_is_corrupt() {
+        // Fail-closed: an enabled authority MUST resolve a key source; a record
+        // that says enabled but names none is corrupt, never a plaintext fallback.
+        let dir = tmp();
+        std::fs::write(
+            encryption_state_path(dir.path()),
+            b"version=1\nenabled=true\n",
+        )
+        .unwrap();
+        assert!(read_encryption_state(dir.path()).is_err());
+    }
+
+    #[test]
+    fn enabled_with_unknown_kind_is_corrupt() {
+        let dir = tmp();
+        std::fs::write(
+            encryption_state_path(dir.path()),
+            b"version=1\nenabled=true\nkey_source_kind=kms\nkey_source_value=arn:whatever\n",
+        )
+        .unwrap();
+        assert!(read_encryption_state(dir.path()).is_err());
+    }
+
+    #[test]
+    fn writing_secret_backed_source_is_refused() {
+        // Passphrase/KMS/Vault sources are refused fail-closed — they carry
+        // secrets or multi-field config the line format cannot round-trip.
+        let dir = tmp();
+        let state = EncryptionState {
+            enabled: true,
+            key_source: Some(KeyProviderConfig::PassphraseFile {
+                path: "/k.aekf".into(),
+                passphrase_env: "PASS".to_string(),
+            }),
+        };
+        assert!(write_encryption_state_durable(dir.path(), &state).is_err());
+        // And nothing partial was left on disk.
+        assert_eq!(read_encryption_state(dir.path()).unwrap(), None);
+    }
+
+    #[test]
+    fn overwrite_replaces_prior_state() {
+        let dir = tmp();
+        write_encryption_state_durable(
+            dir.path(),
+            &EncryptionState::enabled(KeyProviderConfig::Env {
+                variable: "OLD".to_string(),
+            }),
+        )
+        .unwrap();
+        let updated = EncryptionState::enabled(KeyProviderConfig::File {
+            path: "/new.key".into(),
+        });
+        write_encryption_state_durable(dir.path(), &updated).unwrap();
+        assert_eq!(read_encryption_state(dir.path()).unwrap(), Some(updated));
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -32,6 +32,8 @@ pub mod changefeed_sub;
 pub mod config;
 /// Uniqueness constraint builder.
 pub mod constraint_builder;
+/// Durable encryption-state authority — `{data_dir}/encryption.state` (Issue #3616).
+pub(crate) mod encryption_state;
 /// Queryable bi-temporal extent of the dataset (Issue #3238).
 pub mod extent;
 /// GraphView implementation.

--- a/src/db/rotation.rs
+++ b/src/db/rotation.rs
@@ -1185,7 +1185,10 @@ fn write_ledger(manager: &IndexPersistenceManager, ledger: &RotationLedger) -> R
 /// of the parent directory. Guarantees the breadcrumb is on stable storage
 /// before the caller proceeds (Issue #488 P0.2). Leaves no temp file behind on
 /// success.
-fn write_durable(path: &std::path::Path, bytes: &[u8]) -> Result<()> {
+///
+/// `pub(crate)` so the encryption-state authority (Issue #3616) can flip its
+/// durable file with the exact same crash-safe ordering as the rotation ledger.
+pub(crate) fn write_durable(path: &std::path::Path, bytes: &[u8]) -> Result<()> {
     use std::io::Write;
     let parent = path.parent().ok_or_else(|| {
         StorageError::io_error("rotation.state path has no parent directory".to_string())

--- a/tests/encryption_state_authority.rs
+++ b/tests/encryption_state_authority.rs
@@ -1,0 +1,116 @@
+//! Integration coverage for the durable encryption-state authority
+//! (`{data_dir}/encryption.state`) as consumed by `AletheiaDB::open()`
+//! (Issue #3616).
+//!
+//! These exercise the PRODUCTION-wired READ + precedence + fail-closed path in
+//! `with_unified_config`. The authority file is planted directly on disk (the
+//! `encryption enable` migration engine that *writes* it lands in a follow-up
+//! commit on this PR); the round-trip/crash-safety of the writer itself is
+//! covered by the unit tests in `src/db/encryption_state.rs`.
+
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+
+/// The authority file lives under the persistence data dir, which
+/// `durable_config_for_data_dir` roots at `{path}/indexes`.
+fn authority_path(root: &std::path::Path) -> std::path::PathBuf {
+    root.join("indexes").join("encryption.state")
+}
+
+#[test]
+fn absent_authority_opens_as_before() {
+    // Backward compatibility: a durable database with NO authority file opens
+    // and round-trips exactly as today.
+    let dir = tempfile::tempdir().unwrap();
+    let id = {
+        let db = AletheiaDB::open(dir.path()).unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .unwrap()
+    };
+    let db = AletheiaDB::open(dir.path()).unwrap();
+    let node = db.get_node(id).unwrap();
+    assert_eq!(
+        node.properties.get("name").and_then(|v| v.as_str()),
+        Some("Alice")
+    );
+    assert!(!authority_path(dir.path()).exists());
+}
+
+#[test]
+fn enabled_authority_with_missing_key_refuses_open() {
+    // Precedence + fail-closed: the same plaintext data dir that opens cleanly
+    // with no authority REFUSES once an `enabled` authority naming an
+    // unresolvable key source is planted — the authority forced encryption ON,
+    // and a missing key never degrades to a silent plaintext open.
+    let dir = tempfile::tempdir().unwrap();
+
+    // First open establishes the durable directory tree (incl. `indexes/`).
+    {
+        let db = AletheiaDB::open(dir.path()).unwrap();
+        db.create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+    }
+    // Sanity: it reopens fine while no authority exists.
+    drop(AletheiaDB::open(dir.path()).unwrap());
+
+    // Plant an authority that says "encrypted under env var $NOPE_UNSET_MEK"
+    // (guaranteed unset), so the encryption manager cannot source the MEK.
+    std::fs::write(
+        authority_path(dir.path()),
+        b"version=1\nenabled=true\nkey_source_kind=env\nkey_source_value=ALETHEIADB_NOPE_UNSET_MEK_3616\n",
+    )
+    .unwrap();
+
+    let result = AletheiaDB::open(dir.path());
+    assert!(
+        result.is_err(),
+        "open() must refuse (fail-closed) when the authority is enabled but the key source is \
+         unresolvable, never fall back to plaintext"
+    );
+}
+
+#[test]
+fn corrupt_authority_refuses_open() {
+    // A present-but-corrupt authority aborts startup loudly (never guessed as
+    // "not enabled").
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let db = AletheiaDB::open(dir.path()).unwrap();
+        db.create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+    }
+    std::fs::write(authority_path(dir.path()), b"garbage-not-key-value\n").unwrap();
+
+    assert!(
+        AletheiaDB::open(dir.path()).is_err(),
+        "open() must fail closed on a corrupt encryption-state authority"
+    );
+}
+
+#[test]
+fn disabled_authority_opens_plaintext() {
+    // An authority that records `enabled=false` agrees with the plaintext
+    // durable config and opens normally (exercises the read + no-op override).
+    let dir = tempfile::tempdir().unwrap();
+    let id = {
+        let db = AletheiaDB::open(dir.path()).unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+        )
+        .unwrap()
+    };
+    std::fs::write(authority_path(dir.path()), b"version=1\nenabled=false\n").unwrap();
+
+    let db = AletheiaDB::open(dir.path()).unwrap();
+    assert_eq!(
+        db.get_node(id)
+            .unwrap()
+            .properties
+            .get("name")
+            .and_then(|v| v.as_str()),
+        Some("Bob")
+    );
+}


### PR DESCRIPTION
## Before / After (plain language)

**Before** — a database's encrypted-vs-plaintext state is known only from the operator's `ALETHEIADB_CONFIG` TOML/env; nothing in the data dir records it.

**After** — `open()` reads a durable, versioned `{persistence.data_dir}/indexes/encryption.state` authority file (when present) recording enabled + the key-source REFERENCE (File path / Env var name — never key bytes), and treats it as authoritative for the on/off decision. This is the foundation the plaintext↔encrypted migration engine (#3616) needs to flip encryption state crash-consistently.

## How

- **New `src/db/encryption_state.rs`**: versioned line-based format (version=1, enabled, key_source_kind ∈ {file,env}, key_source_value), written atomically via the rotation ledger's `write_durable` (temp→sync_all→rename→parent-dir fsync). Secret-backed sources (passphrase/KMS/Vault) are refused at write time. Fail-closed reader: absent → None (today's behavior), corrupt/unknown-version/missing-field → Err (never guessed as "not enabled").
- **`src/db/config.rs`**: `with_unified_config` reads the authority before building the encryption manager; PRECEDENCE — the authority wins over TOML/env for on/off; on DIVERGENCE it logs a loud warning naming both sources; FAIL-CLOSED — enabled-but-key-source-missing refuses to open (never plaintext fallback).
- **`src/db/rotation.rs`**: `write_durable` made `pub(crate)` for reuse.

## Safety / why it's safe to merge ahead

**Behavior-preserving when no authority file exists** — `open()` reads `Ok(None)` and falls through to today's TOML/env decision. No production code writes the file yet (the migration engine that writes it lands in the follow-up PRs), so merging this changes nothing observable until an authority file is created. Two constructors carry documented `#[allow(dead_code)]` (foundation-for-follow-up).

## Scope / re-scope note

This is PR 1 of a coordinator-approved 4-PR breakdown of #3616 (plaintext↔encrypted migration):

1. **this authority foundation** →
2. **WAL runtime keyring-install** [interior-mutable `wal_keyring`, the structural blocker] →
3. **enable engine** [index plaintext→AEIX + cold bare→ACV1 + migration ledger/resume + the crux authority-flip-before-ledger-clear ordering + CLI `encryption enable`] →
4. **disable** [mirror].

The remaining PRs are handed to a successor session.

## Testing

13 unit + 4 integration tests (round-trip, no-key-bytes-on-disk, corrupt-refuses-open, enabled-missing-key-refuses-open, precedence-override, disabled-authority-opens-plaintext, absent-authority-unchanged, no-temp-left). Gates green on a fresh /dev/shm build: both clippy sets 0-warning, fmt clean, Feature Matrix, 3 standalone encryption checks, full suite green modulo the documented uid-0 test.

## Known follow-ups (from review, non-blocking)

- Warn on key-source divergence when both sides are enabled (PR1 only covers the on/off axis).
- A divergence-warning-text assertion + KMS/Vault write-refusal test.

Refs #3616.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRMi3NFi3FwGqXoon9Fqga)_