### PR TITLE
ci(coverage): cap build/link parallelism to bound peak linker memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,19 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
+    # The instrumented llvm-cov build links many coverage-instrumented test
+    # binaries; each final link spawns an `ld` whose peak RSS is large (embedded
+    # coverage maps + debuginfo). At the runner's default build parallelism
+    # several `ld` processes are resident at once, and their combined peak has
+    # intermittently exhausted runner memory -> `ld` SIGBUS / core-dump (a
+    # distinct flake mode from the metrics counter race). Cap concurrent
+    # build/link jobs so at most two linkers are resident simultaneously, roughly
+    # halving the peak link-memory ceiling. This throttles the BUILD phase only
+    # (test execution and, crucially, the coverage thresholds/gating below are
+    # untouched); no `timeout-minutes` is set on this job, so the modest
+    # build-time increase is safe.
+    env:
+      CARGO_BUILD_JOBS: "2"
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Before / After (plain language)

**Before:** The **Code Coverage** CI job intermittently dies at *instrumented link time* — `ld` takes a `SIGBUS` / core-dumps — from runner memory pressure. `cargo llvm-cov` builds coverage-instrumented test binaries for the whole workspace, and at the runner's default build parallelism several final-link `ld` processes run **at the same time**. Each instrumented link has a large peak RSS (embedded coverage maps + debuginfo), and their combined peak has repeatedly blown past the runner's RAM ceiling, killing the linker and reddening the job for no real reason. (This is a **distinct** flake mode from the metrics-counter race, which is a separate PR.)

**After:** At most **two** linkers are ever resident at once, so the peak link-time memory ceiling is roughly **halved** and stays under the runner's RAM budget — the job completes instead of dying at link.

## How

One targeted change, scoped to the coverage job only:

```yaml
  coverage:
    name: Code Coverage
    runs-on: ubuntu-latest
    env:
      CARGO_BUILD_JOBS: "2"
```

`CARGO_BUILD_JOBS` caps the number of parallel `rustc` invocations Cargo runs, and since each *final link* is a `rustc` invocation that spawns `ld`, this directly caps the number of **simultaneous `ld` processes** — the exact thing that OOMs. Fewer concurrent linkers ⇒ lower combined peak RSS ⇒ no SIGBUS.

- **Scoped to the build phase only.** `CARGO_BUILD_JOBS` throttles compilation/linking, not test *execution*, so the run phase is unaffected.
- **Thresholds and gating are byte-for-byte untouched.** The `Check coverage thresholds` step still runs `cargo llvm-cov … --fail-under-lines 85 --fail-under-functions 88 --fail-under-regions 88`, and the feature set (`config-toml,mcp-server,sharding-rpc,sql,cypher`) is unchanged. Nothing about what is measured or how pass/fail is decided changed.
- **Job-level `env`** so both `cargo llvm-cov` invocations (generate + threshold) honor it without duplicating flags.

## Why it lowers the memory ceiling at link

The SIGBUS is a classic OOM during `ld`. Peak memory during the coverage build ≈ (per-linker peak RSS) × (number of concurrent linkers). The per-linker peak is intrinsic to an instrumented binary (coverage `__llvm_prf` sections + DWARF) and hard to shrink without touching what's measured. The **concurrency multiplier**, however, is a free lever: dropping the default ~4-way parallelism to 2 roughly halves the aggregate peak with no change to the produced artifacts or the coverage numbers.

## Tradeoff / justification

- **Build-time regression (the cost):** capping to 2 jobs lengthens the compile phase (~1.3–1.5×). This is acceptable because the coverage job sets **no `timeout-minutes`**, so it inherits GitHub's 360-minute default — there is effectively **zero timeout risk** from the slower build (the reverse-brainstorm "does this blow the time limit?" concern is ruled out).
- **Why not `-C codegen-units=1`:** that mainly reduces `rustc` *codegen/optimization* memory, not `ld`'s peak (the total object bytes handed to the linker are ~unchanged), so it's an indirect fit for a *link-time* SIGBUS while still slowing the build. The parallelism cap attacks the root cause (concurrent linkers) more directly.
- **Why not `-j1`:** maximal memory relief but the largest build-time hit; `-j2` already removes the concurrency-driven OOM while retaining some parallelism.
- **Why not a bigger runner:** no larger-runner (`runs-on`) precedent exists anywhere in this workflow — every job uses `ubuntu-latest` — so inventing a runner label that may not be provisioned would be higher-risk than a config-only change.

## Verification (no unit test for a YAML edit)

- ✅ `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses cleanly.
- ✅ Coverage job structure intact (9 steps; `runs-on: ubuntu-latest`; new `env: {CARGO_BUILD_JOBS: "2"}`).
- ✅ Threshold/gating command unchanged: `--fail-under-lines 85 --fail-under-functions 88 --fail-under-regions 88`.
- ✅ Diff is +13 lines, single file, additive only.

### Risks to watch (verification points)
- **Build-time regression:** covered above — no job timeout configured, so safe.
- **Cache invalidation:** none — this changes an env var, not the `Cargo.lock`-keyed cache keys, so the cargo caches are reused exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Evgi2AgnwjwMSgBArxg9BV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Evgi2AgnwjwMSgBArxg9BV)_