### PR TITLE
feat(ts-sdk): send priority_properties on the 8 budgetable GET reads (#3638)

### DIFF
--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -662,9 +662,9 @@ export class AletheiaClient {
    * `GET /schema` — node labels, edge types, and property keys with counts
    * (optional bi-temporal via `asOf*`).
    *
-   * Only the scalar token/byte budget is sent — `priority_properties` is an
-   * array the `GET` query-string extractor cannot decode (see
-   * {@link budgetQuery} / {@link GetSchemaOptions}).
+   * Only the scalar token/byte budget is sent — `getSchema` is not one of the
+   * eight `priority_properties` GET reads, and its {@link GetSchemaOptions}
+   * type offers no `priorityProperties` (see {@link schemaBudgetQuery}).
    */
   getSchema(opts: GetSchemaOptions = {}): Promise<SchemaResponse> {
     return this.transport.request<SchemaResponse>({
@@ -673,7 +673,7 @@ export class AletheiaClient {
       query: {
         as_of_valid_time: optTime(opts.asOfValidTime),
         as_of_transaction_time: optTime(opts.asOfTransactionTime),
-        ...budgetQuery(opts),
+        ...schemaBudgetQuery(opts),
       },
     });
   }
@@ -752,25 +752,64 @@ function reqTime(t: TimeInput): string {
 }
 
 /**
- * Build the #3353 budget query fragment (query-string form) — **scalar params
- * only**.
+ * Comma-join `priorityProperties` for a GET query string, or `undefined` when
+ * there is nothing to send.
  *
- * `priority_properties` is deliberately NOT emitted on GET reads. The autumn
- * GET routes decode the query string with `axum::extract::Query`, i.e.
- * `serde_urlencoded` 0.7.1, whose value deserializer forwards `deserialize_seq`
- * to `deserialize_any` and visits a plain string
- * (`serde_urlencoded-0.7.1/src/de.rs:234-249`, the `Part` deserializer). A
- * `Vec<String>` field therefore cannot be produced from **any** query encoding
- * — a repeated key, a comma-joined single key, anything — every form is a
- * `serde` type error and the extractor returns 400. Emitting it here would turn
- * every budgeted GET read into a hard 400. The scalar `max_response_tokens` /
- * `max_response_bytes` (`u64`) parse fine.
+ * The server's GET routes (since PR #3638) accept `priority_properties` as a
+ * single **comma-separated** query param and split it on `,` server-side, so we
+ * join the array with a comma. The transport URL-encodes the joined value once
+ * (`,` → `%2C`), so it always rides as ONE param (never repeated keys, which
+ * `serde_urlencoded` still cannot decode into a `Vec`).
  *
- * Array budgeting (`priorityProperties`) is honored only on the POST-body reads
- * (`findNodesAtTime`, `findSimilar`, `hybridQuery`), whose JSON body is parsed
- * by `serde_json` — see {@link budgetBody}.
+ * An `undefined` or empty array yields `undefined` so the key is omitted
+ * entirely — never a bare `?priority_properties=`. (A property name that itself
+ * contains a comma is ambiguous under the server's comma-split contract; that
+ * is an inherent limitation of the wire format, shared with every
+ * comma-separated query param.)
+ */
+function joinPriority(priorityProperties?: string[]): string | undefined {
+  if (priorityProperties === undefined || priorityProperties.length === 0) {
+    return undefined;
+  }
+  return priorityProperties.join(',');
+}
+
+/**
+ * Build the #3353 budget query fragment (query-string form) for the eight
+ * budgetable GET reads (`getNode`, `listNodes`, `getEdge`, `listEdges`,
+ * `traverse`, `getNodeHistory`, and the two adjacency reads via
+ * {@link adjacencyQuery}).
+ *
+ * Emits the scalar `max_response_tokens` / `max_response_bytes` (`u64`) and,
+ * since server PR #3638, the comma-joined `priority_properties` (see
+ * {@link joinPriority}). The POST-body reads (`findNodesAtTime`, `findSimilar`,
+ * `hybridQuery`) carry the raw array instead — see {@link budgetBody}.
+ *
+ * Note: `getSchema` uses the scalar-only {@link schemaBudgetQuery} and is NOT
+ * one of the eight — its bespoke options type never offers
+ * `priorityProperties`.
  */
 function budgetQuery(opts: {
+  maxResponseTokens?: number;
+  maxResponseBytes?: number;
+  priorityProperties?: string[];
+}): Record<string, number | string | undefined> {
+  return {
+    max_response_tokens: opts.maxResponseTokens,
+    max_response_bytes: opts.maxResponseBytes,
+    priority_properties: joinPriority(opts.priorityProperties),
+  };
+}
+
+/**
+ * Build the scalar-only budget query fragment for `GET /schema`.
+ *
+ * `getSchema` is deliberately excluded from the eight `priority_properties`
+ * GET reads: its {@link GetSchemaOptions} type offers no `priorityProperties`,
+ * so this fragment carries only the scalar token/byte budget and never a
+ * `priority_properties` key.
+ */
+function schemaBudgetQuery(opts: {
   maxResponseTokens?: number;
   maxResponseBytes?: number;
 }): Record<string, number | undefined> {

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -232,15 +232,15 @@ export interface BudgetOptions {
   /**
    * Property keys to protect first as the response degrades.
    *
-   * **POST-body reads only.** It is honored on the JSON-body reads
+   * Honored on both surfaces. The POST-body reads
    * ({@link AletheiaClient.findNodesAtTime}, {@link AletheiaClient.findSimilar},
-   * {@link AletheiaClient.hybridQuery}). It is **ignored on GET-query reads**
-   * (`getNode`/`listNodes`/`listEdges`/`getEdge`/`traverse`/adjacency/history):
-   * the server's GET query-string extractor (`serde_urlencoded`) cannot decode
-   * an array field, so this SDK does not place it on the query string (doing so
-   * would 400 the request). To prioritize properties on a GET read, use
-   * `maxResponseBytes`/`maxResponseTokens` and, if needed, fetch specific
-   * entities individually.
+   * {@link AletheiaClient.hybridQuery}) carry it as a JSON array. The eight
+   * budgetable GET reads
+   * (`getNode`/`listNodes`/`getEdge`/`listEdges`/`traverse`/`getNodeHistory`
+   * and the two adjacency reads) serialize it **comma-joined** onto the query
+   * string, which the server (PR #3638) splits on `,` server-side. An empty
+   * array is omitted. `getSchema` is not one of the eight — its options type
+   * does not offer this field.
    */
   priorityProperties?: string[];
 }
@@ -690,11 +690,10 @@ export interface QueryResponse {
  * Options for {@link AletheiaClient.getSchema}. `asOf*` switch to a bi-temporal
  * snapshot.
  *
- * Note: `getSchema` is a `GET`, and the server's query-string extractor
- * (`serde_urlencoded`) cannot decode a repeated key into a `Vec<String>`, so
- * `priorityProperties` is **not** offered here (it would 400 the request) — only
- * the scalar token/byte budget is honored on `GET /schema`. Use
- * `maxResponseBytes`/`maxResponseTokens` to bound the schema response.
+ * Note: `getSchema` is not one of the eight `priority_properties` GET reads, so
+ * `priorityProperties` is **not** offered here — only the scalar token/byte
+ * budget is honored on `GET /schema`. Use `maxResponseBytes`/`maxResponseTokens`
+ * to bound the schema response.
  */
 export interface GetSchemaOptions {
   asOfValidTime?: TimeInput;

--- a/clients/typescript/test/budget-query.test.ts
+++ b/clients/typescript/test/budget-query.test.ts
@@ -3,21 +3,23 @@ import { AletheiaClient } from '../src/index.js';
 import { edgeFixture, mockFetch, nodeFixture, type RecordedRequest } from './fixtures.js';
 
 /**
- * Regression guard for the pre-existing `priority_properties`-on-GET bug.
+ * `priority_properties` on GET reads (server PR #3638).
  *
- * The autumn GET routes decode the query string with `axum::extract::Query` =
- * `serde_urlencoded` 0.7.1. Its value deserializer (`Part`) forwards
- * `deserialize_seq` to `deserialize_any`, which visits a plain **string**
- * (serde_urlencoded-0.7.1 `src/de.rs:234-249`). A `Vec<String>` field therefore
- * cannot be produced from ANY query-string encoding — a repeated key, a
- * comma-joined key, anything — so emitting `priority_properties` on a GET read
- * makes the extractor 400 the whole request.
+ * The server's GET routes now accept `priority_properties` as a single,
+ * **comma-separated** query param (they split on `,` server-side), so the SDK
+ * serializes the `priorityProperties: string[]` option comma-joined onto the
+ * query string of the eight budgetable GET reads. This mirrors the POST-body
+ * reads, whose JSON body already carries the raw array.
  *
- * These tests assert the SDK never places a `priority_properties` key on a GET
- * query string (so the 400 cannot recur), while the scalar budget params
- * (`max_response_tokens`/`max_response_bytes`, which serde_urlencoded parses as
- * `u64`) still ride. They also assert the array budget IS preserved on the
- * POST-body reads, whose JSON body is parsed by `serde_json` (arrays fine).
+ * Notes on encoding:
+ *  - The value is joined with `,` then URL-encoded ONCE by the transport
+ *    (`%2C`), so `URLSearchParams.get()` decodes it back to `"a,b"`.
+ *  - It rides as ONE param, not repeated keys — `getAll()` has length 1 — so
+ *    the server sees a single comma-separated string, never a `Vec` from
+ *    repeated keys (which `serde_urlencoded` still cannot decode).
+ *  - An empty array is omitted entirely (no bare `?priority_properties=`).
+ *  - `getSchema` uses a bespoke scalar-only options type and is deliberately
+ *    NOT one of the eight — it never emits `priority_properties`.
  */
 async function capture(
   responseBody: unknown,
@@ -29,13 +31,17 @@ async function capture(
   return calls[0]!;
 }
 
-const budget = { maxResponseTokens: 800, maxResponseBytes: 4096, priorityProperties: ['title', 'name'] };
+const budget = {
+  maxResponseTokens: 800,
+  maxResponseBytes: 4096,
+  priorityProperties: ['title', 'name'],
+};
 
-describe('priority_properties is never emitted on GET query reads (#3353 / serde_urlencoded)', () => {
-  const nodeList = { nodes: [], count: 0 };
-  const edgeList = { edges: [], count: 0 };
-  const traverseBody = { results: [], count: 0 };
+const nodeList = { nodes: [], count: 0 };
+const edgeList = { edges: [], count: 0 };
+const traverseBody = { results: [], count: 0 };
 
+describe('priority_properties is comma-joined onto the eight budgetable GET reads (#3638)', () => {
   const getReads: Array<[string, (db: AletheiaClient) => Promise<unknown>, unknown]> = [
     ['getNode', (db) => db.getNode(1, budget), nodeFixture(1, 'Doc', {})],
     ['listNodes', (db) => db.listNodes({ label: 'Doc', ...budget }), nodeList],
@@ -45,20 +51,62 @@ describe('priority_properties is never emitted on GET query reads (#3353 / serde
     ['getOutgoingEdges', (db) => db.getOutgoingEdges(1, budget), edgeList],
     ['getIncomingEdges', (db) => db.getIncomingEdges(1, budget), edgeList],
     ['getNodeHistory', (db) => db.getNodeHistory(1, budget), { node_id: 1, results: [] }],
-    ['getSchema', (db) => db.getSchema(budget), { node_labels: [], edge_types: [] }],
   ];
 
   for (const [name, run, body] of getReads) {
-    it(`${name}: emits scalar budget but NO priority_properties key`, async () => {
+    it(`${name}: emits comma-joined priority_properties + scalar budget`, async () => {
       const req = await capture(body, run);
       expect(req.method).toBe('GET');
-      // The 400-causing array key must never appear on the query string.
-      expect(req.query.has('priority_properties')).toBe(false);
-      // The scalar budget (serde_urlencoded parses these as u64) still rides.
+      // Comma-joined, decoded back through URLSearchParams.
+      expect(req.query.get('priority_properties')).toBe('title,name');
+      // ONE param, not repeated keys.
+      expect(req.query.getAll('priority_properties')).toHaveLength(1);
+      // The scalar budget still rides.
       expect(req.query.get('max_response_tokens')).toBe('800');
       expect(req.query.get('max_response_bytes')).toBe('4096');
     });
   }
+});
+
+describe('priority_properties GET serialization — edge cases', () => {
+  it('empty array is omitted entirely (no bare ?priority_properties=)', async () => {
+    const req = await capture(nodeList, (db) =>
+      db.listNodes({ label: 'Doc', priorityProperties: [] }),
+    );
+    expect(req.query.has('priority_properties')).toBe(false);
+  });
+
+  it('undefined is omitted (unchanged prior behavior)', async () => {
+    const req = await capture(nodeList, (db) => db.listNodes({ label: 'Doc' }));
+    expect(req.query.has('priority_properties')).toBe(false);
+  });
+
+  it('single element rides as a bare value', async () => {
+    const req = await capture(nodeList, (db) =>
+      db.listNodes({ label: 'Doc', priorityProperties: ['name'] }),
+    );
+    expect(req.query.get('priority_properties')).toBe('name');
+    expect(req.query.getAll('priority_properties')).toHaveLength(1);
+  });
+
+  it('property names with special chars are URL-encoded (single param survives)', async () => {
+    const req = await capture(nodeList, (db) =>
+      db.listNodes({ label: 'Doc', priorityProperties: ['a b', 'c&d'] }),
+    );
+    // Decoded round-trip: one param, comma-joined, special chars intact.
+    expect(req.query.getAll('priority_properties')).toHaveLength(1);
+    expect(req.query.get('priority_properties')).toBe('a b,c&d');
+  });
+
+  it('getSchema is NOT one of the eight — never emits priority_properties', async () => {
+    // getSchema's typed options omit priorityProperties; even if a caller forces
+    // one through at runtime, the scalar-only schema query drops it.
+    const req = await capture({ node_labels: [], edge_types: [] }, (db) =>
+      db.getSchema({ maxResponseTokens: 1000, priorityProperties: ['x'] } as never),
+    );
+    expect(req.query.has('priority_properties')).toBe(false);
+    expect(req.query.get('max_response_tokens')).toBe('1000');
+  });
 });
 
 describe('priority_properties IS preserved on POST-body reads (serde_json arrays)', () => {

--- a/clients/typescript/test/stubs.test.ts
+++ b/clients/typescript/test/stubs.test.ts
@@ -166,7 +166,7 @@ describe('vector / query / schema / stats / batch / lineage wiring (#3627)', () 
     expect(req.query.get('as_of_valid_time')).toBe(toWireTime('2024-01-01T00:00:00Z'));
     expect(req.query.get('as_of_transaction_time')).toBe(toWireTime('2024-06-01T00:00:00Z'));
     expect(req.query.get('max_response_tokens')).toBe('1000');
-    // priority_properties is NOT sent on GET (serde_urlencoded can't decode a repeated key).
+    // getSchema is not one of the eight priority_properties GET reads (#3638).
     expect(req.query.has('priority_properties')).toBe(false);
     // Response parse: the schema payload round-trips.
     expect((result as { node_labels: unknown[] }).node_labels).toHaveLength(1);


### PR DESCRIPTION
## Before / After (plain language)

**Before:** The TypeScript SDK silently dropped `priorityProperties` on every GET read. A caller could pass `priorityProperties: ['title', 'name']` to `getNode`/`listNodes`/`traverse`/etc. and it would never reach the server — only the scalar `maxResponseTokens`/`maxResponseBytes` rode the query string. The old code deliberately omitted it because the server's `serde_urlencoded` GET extractor couldn't decode an array field (it would 400).

**After:** Server PR #3638 taught the eight budgetable GET routes to accept `priority_properties` as a single **comma-separated** query param (split on `,` server-side). The SDK now serializes `priorityProperties` comma-joined onto the query string of all eight GET reads:

- `getNode`, `listNodes`, `getEdge`, `listEdges`, `traverse`, `getNodeHistory`, `getOutgoingEdges`, `getIncomingEdges`

`getSchema` is **not** one of the eight (bespoke scalar-only options type) and continues to send only the scalar budget.

## How

- New `joinPriority(props?)` helper: comma-joins the array, returns `undefined` for `undefined`/empty (so the key is omitted — never a bare `?priority_properties=`).
- `budgetQuery(opts)` now emits `priority_properties: joinPriority(opts.priorityProperties)` as a single string value. The transport URL-encodes it **once** (`,` → `%2C`), so it always rides as **one** param, never repeated keys (which `serde_urlencoded` still can't decode into a `Vec`).
- New scalar-only `schemaBudgetQuery(opts)` used exclusively by `getSchema`, so the exclusion is structural (not an accident of what a caller passes).
- `BudgetOptions.priorityProperties` / `GetSchemaOptions` doc comments updated to reflect the new behavior.

**Regression guard preserved:** POST-body timestamp fields remain **decimal-microsecond STRINGS** (`toWireTime`, `time.test.ts` `#blocker` guard) — untouched. Only GET query serialization of `priority_properties` changed.

## Approach tradeoffs

- **Central join in `budgetQuery` (chosen):** all eight reads route through one chokepoint (six directly, two via `adjacencyQuery`), so the comma-join lives in exactly one place. Minimal churn; `getSchema` opts out with its own scalar helper.
- **Join at each call site (rejected):** eight near-identical edits, easy to drift.
- **Emit array + change transport to comma-join (rejected):** the transport serializes arrays as repeated keys and is shared by every query param; changing it globally is broader and riskier than the server contract requires (server wants comma-separated *only* for this field).

## Risks-as-tests (edge cases)

| Risk | Test |
|------|------|
| Double-encoding | `getAll()` length 1 + decoded round-trip `'a b,c&d'` — special chars survive, encoded once |
| Empty array → `?priority_properties=` | asserts key omitted entirely |
| `undefined` regression | asserts key omitted (prior behavior) |
| Single element | `priority_properties=name`, one param |
| Multiple elements comma-joined | `priority_properties=title,name` on all 8 reads |
| `getSchema` leakage | forced `as never` cast still omits the key |
| POST timestamp guard still green | `time.test.ts` decimal-microsecond-string guard passes |

## AC evidence

All inside `clients/typescript`:

- **vitest:** `Test Files 12 passed (12) · Tests 92 passed (92)` (was 86; +4 net new tests, +2 build.test now runs post-build). Red→green confirmed (10 failing before impl → 0 after).
- **lint** (`eslint .`, no-`any` rule): clean, no `any` introduced (test uses `as never`, not `any`).
- **typecheck** (`tsc --noEmit` + examples project): clean.
- **build** (`tsup`): ESM + CJS + DTS build success.
- **smoke** (`node scripts/smoke.mjs && node scripts/smoke.cjs`): `ESM smoke OK` / `CJS smoke OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Evgi2AgnwjwMSgBArxg9BV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Evgi2AgnwjwMSgBArxg9BV)_