### PR TITLE
feat(server): inbound HTTP + MCP-over-HTTP concurrency budgets and body cap (#3561)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8529,6 +8529,7 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/crates/aletheia-server/Cargo.toml
+++ b/crates/aletheia-server/Cargo.toml
@@ -51,8 +51,10 @@ tower_governor = { version = "0.8", default-features = false, features = ["axum"
 governor = "0.10"
 # The custom `/mcp` security gate (B4) is a hand-written `tower::Layer` /
 # `tower::Service`; `secure_mcp` accepts any such layer. autumn-web 0.5 / axum
-# 0.8 are on tower 0.5.
-tower = { version = "0.5" }
+# 0.8 are on tower 0.5. The `limit` feature adds
+# `GlobalConcurrencyLimitLayer` — the inbound HTTP + MCP-over-HTTP concurrency
+# budgets with backpressure (Issue #3561 §8 AC1/AC5).
+tower = { version = "0.5", features = ["limit"] }
 # Cursor-signing primitive (Lane B4): base64url token encoding, SHA-256 for the
 # hand-rolled HMAC (no extra hmac crate — mirrors legacy `src/mcp/cursor.rs`),
 # constant-time MAC compare via subtle, a random per-process secret via rand,

--- a/crates/aletheia-server/src/security/concurrency.rs
+++ b/crates/aletheia-server/src/security/concurrency.rs
@@ -1,0 +1,70 @@
+//! Inbound-connection concurrency budgets (Issue #3561 §8, AC1 / AC5).
+//!
+//! AletheiaDB is **embedded** — a single process holds one `Arc`, so there is
+//! deliberately **no outbound DB connection pool** (§8 explicit non-goal). The
+//! only "pool" concern is **inbound** HTTP / MCP-over-HTTP client concurrency,
+//! and this module carries the two `tower::limit` concurrency budgets that bound
+//! it with **backpressure** (queue, not reject — distinct from the load-shedding
+//! [`InFlightLimiter`](crate::security::resource_limits::InFlightLimiter), which
+//! returns a `503` at capacity):
+//!
+//! 1. [`app_concurrency_layer`] — an app-wide
+//!    [`GlobalConcurrencyLimitLayer`] bounding the number of HTTP requests being
+//!    processed concurrently across the whole surface (AC1). Sourced from
+//!    [`SecurityConfig::max_concurrent_requests`].
+//! 2. [`mcp_session_layer`] — the same primitive scoped to the `/mcp` endpoint
+//!    (composed with the [`McpSecurityLayer`](crate::security::mcp_gate::McpSecurityLayer)
+//!    via [`secure_mcp`](autumn_web::app::AppBuilder::secure_mcp)), bounding the
+//!    number of concurrent MCP-over-HTTP sessions — where multi-agent load
+//!    actually lands (AC5). Sourced from [`SecurityConfig::max_mcp_sessions`].
+//!
+//! # Global, not per-service
+//!
+//! Both use [`GlobalConcurrencyLimitLayer`] rather than
+//! [`ConcurrencyLimitLayer`](tower::limit::ConcurrencyLimitLayer): axum clones
+//! the wrapped service per connection, and the *global* variant holds the
+//! permit semaphore in the layer itself (an `Arc<Semaphore>`), so every cloned
+//! service shares one budget. A per-service `ConcurrencyLimitLayer` would give
+//! each connection its own independent limit — not a surface-wide cap.
+//!
+//! # Default-off (parity)
+//!
+//! Both constructors return `None` unless the operator opts in (the cap is
+//! `Some(n)` with `n > 0`), mirroring the default-off `tower-governor` rate
+//! limiter ([`governor_layer`](crate::security::rate_limit::governor_layer)): by
+//! default no layer is mounted and behavior is byte-for-byte today's (no
+//! backpressure). A configured `Some(0)` is treated as "no budget" (`None`) —
+//! a zero-permit semaphore would wedge every request, never a useful config.
+
+use crate::security::SecurityConfig;
+use tower::limit::GlobalConcurrencyLimitLayer;
+
+/// Build a **global** (surface-wide) concurrency-limit layer from a permit cap,
+/// **default-off**.
+///
+/// Returns `None` for `None`/`Some(0)` (no layer, today's behavior); otherwise a
+/// [`GlobalConcurrencyLimitLayer`] whose shared semaphore admits at most `cap`
+/// concurrently-processed requests and back-pressures (parks in `poll_ready`)
+/// the rest until a permit frees.
+#[must_use]
+fn concurrency_layer(cap: Option<usize>) -> Option<GlobalConcurrencyLimitLayer> {
+    match cap {
+        Some(n) if n > 0 => Some(GlobalConcurrencyLimitLayer::new(n)),
+        _ => None,
+    }
+}
+
+/// The app-wide HTTP concurrency budget (AC1), from
+/// [`SecurityConfig::max_concurrent_requests`]. `None` (default) mounts no layer.
+#[must_use]
+pub fn app_concurrency_layer(cfg: &SecurityConfig) -> Option<GlobalConcurrencyLimitLayer> {
+    concurrency_layer(cfg.max_concurrent_requests)
+}
+
+/// The `/mcp`-scoped MCP-over-HTTP session budget (AC5), from
+/// [`SecurityConfig::max_mcp_sessions`]. `None` (default) mounts no layer, so the
+/// `/mcp` endpoint carries only its security gate, unchanged.
+#[must_use]
+pub fn mcp_session_layer(cfg: &SecurityConfig) -> Option<GlobalConcurrencyLimitLayer> {
+    concurrency_layer(cfg.max_mcp_sessions)
+}

--- a/crates/aletheia-server/src/security/mod.rs
+++ b/crates/aletheia-server/src/security/mod.rs
@@ -18,14 +18,16 @@
 //! - [`auth::Authorized`] **authenticates and enforces the RBAC class** via
 //!   [`authorize`] (Lane B): a role that does not permit the handler's
 //!   declared `C::CLASS` gets a byte-identical 403.
-//! - [`resource_limits`], [`rate_limit`], [`cursor`] carry the Lane B security
-//!   **primitives** — per-query timeout/row/byte caps + bounded in-flight guard
-//!   (#3542 / #3550), the default-off `tower-governor` rate-limit layer (#3561
-//!   §8), and signed opaque cursor tokens (#3360). They are the building blocks
-//!   the B4 wiring PR mounts via [`apply_security`]; PR1 behavior is unchanged
-//!   until then (rate limiting off, generous caps, no cursor validation wired).
+//! - [`resource_limits`], [`rate_limit`], [`cursor`], [`concurrency`] carry the
+//!   Lane B security **primitives** — per-query timeout/row/byte caps + bounded
+//!   in-flight guard (#3542 / #3550), the default-off `tower-governor`
+//!   rate-limit layer (#3561 §8), signed opaque cursor tokens (#3360), and the
+//!   default-off inbound HTTP + MCP-over-HTTP concurrency budgets with
+//!   backpressure (#3561 §8 AC1/AC5). They are the building blocks
+//!   [`apply_security`] mounts.
 
 pub mod auth;
+pub mod concurrency;
 pub mod cursor;
 pub mod mcp_gate;
 pub mod rate_limit;
@@ -33,10 +35,12 @@ pub mod rbac;
 pub mod resource_limits;
 
 use aletheiadb::auth::{AuthMode, AuthStore};
+use autumn_web::config::AutumnConfig;
 use autumn_web::prelude::AppState as AutumnAppState;
 use autumn_web::test::TestApp;
 use std::sync::Arc;
 use std::time::Duration;
+use tower::ServiceBuilder;
 
 pub use auth::{
     AccessClassMarker, AdminClass, ApiKeyStore, AuthStoreTokenAdapter, Authorized, MetricsClass,
@@ -85,7 +89,28 @@ pub struct SecurityConfig {
     /// Max concurrently-live cursors per connection (Lane B4, #3360 default
     /// 128). Wired at B4.
     pub max_live_cursors_per_conn: usize,
+    /// App-wide HTTP concurrency budget (Issue #3561 §8 AC1). `None` = **off**
+    /// (default, parity with today); `Some(n)` mounts a global
+    /// [`tower::limit::GlobalConcurrencyLimitLayer`] admitting at most `n`
+    /// concurrently-processed requests and back-pressuring the rest. `Some(0)`
+    /// is treated as off (see [`concurrency::app_concurrency_layer`]).
+    pub max_concurrent_requests: Option<usize>,
+    /// Concurrency budget for MCP-over-HTTP sessions on `/mcp` (Issue #3561 §8
+    /// AC5). `None` = **off** (default, parity); `Some(n)` composes a global
+    /// concurrency limit over the `/mcp` security gate so at most `n` MCP
+    /// sessions are processed concurrently, back-pressuring the rest.
+    pub max_mcp_sessions: Option<usize>,
+    /// Max accepted request body size, in bytes (Issue #3561 §8 AC3 / #3108).
+    /// Applied app-wide via [`axum::extract::DefaultBodyLimit`]; an over-limit
+    /// body is rejected `413` before it is buffered. Default 2 MiB, matching the
+    /// legacy HTTP surface's `DEFAULT_MAX_REQUEST_BODY_BYTES` (and axum's own
+    /// implicit default), so making it explicit changes no client behavior.
+    pub max_request_body_bytes: usize,
 }
+
+/// Default app-wide request-body cap (2 MiB), matching the legacy HTTP surface's
+/// `DEFAULT_MAX_REQUEST_BODY_BYTES` (Issue #3108) and axum's implicit default.
+pub const DEFAULT_MAX_REQUEST_BODY_BYTES: usize = 2 * 1024 * 1024;
 
 impl SecurityConfig {
     /// Build a config from a shared store and mode, with the not-yet-wired
@@ -104,6 +129,9 @@ impl SecurityConfig {
             max_in_flight_queries: 64,
             cursor_ttl: Duration::from_secs(300),
             max_live_cursors_per_conn: 128,
+            max_concurrent_requests: None,
+            max_mcp_sessions: None,
+            max_request_body_bytes: DEFAULT_MAX_REQUEST_BODY_BYTES,
         }
     }
 
@@ -140,6 +168,28 @@ impl SecurityConfig {
     #[must_use]
     pub fn with_max_in_flight_queries(mut self, cap: usize) -> Self {
         self.max_in_flight_queries = cap;
+        self
+    }
+
+    /// Set the app-wide HTTP concurrency budget (AC1). `None`/`Some(0)` = off.
+    #[must_use]
+    pub fn with_max_concurrent_requests(mut self, cap: Option<usize>) -> Self {
+        self.max_concurrent_requests = cap;
+        self
+    }
+
+    /// Set the MCP-over-HTTP session concurrency budget (AC5). `None`/`Some(0)`
+    /// = off.
+    #[must_use]
+    pub fn with_max_mcp_sessions(mut self, cap: Option<usize>) -> Self {
+        self.max_mcp_sessions = cap;
+        self
+    }
+
+    /// Override the app-wide request-body cap in bytes (AC3, `DefaultBodyLimit`).
+    #[must_use]
+    pub fn with_max_request_body_bytes(mut self, bytes: usize) -> Self {
+        self.max_request_body_bytes = bytes;
         self
     }
 }
@@ -241,10 +291,40 @@ impl axum::extract::FromRequestParts<AutumnAppState> for ServerSecurityState {
 /// enforce per-request.
 #[must_use]
 pub fn apply_security(app: TestApp, cfg: &SecurityConfig) -> TestApp {
-    // 1. Custom /mcp gate (both modes; branches on mode internally).
-    let app = app.secure_mcp(McpSecurityLayer::new(cfg.store.clone(), cfg.mode));
+    // 1. Custom /mcp gate (both modes; branches on mode internally), optionally
+    //    fronted by the MCP-over-HTTP session concurrency budget (AC5). When a
+    //    budget is set, a global concurrency limit is composed OUTSIDE the gate
+    //    (permit acquired before any auth work), so at most `max_mcp_sessions`
+    //    MCP requests are processed concurrently, back-pressuring the rest.
+    let mcp_auth = McpSecurityLayer::new(cfg.store.clone(), cfg.mode);
+    let app = match concurrency::mcp_session_layer(cfg) {
+        Some(budget) => app.secure_mcp(ServiceBuilder::new().layer(budget).layer(mcp_auth)),
+        None => app.secure_mcp(mcp_auth),
+    };
 
-    // 2. Default-off per-IP rate limiter, mounted app-wide only when enabled.
+    // 2. App-wide request-body cap (AC3 / #3108): reject an over-limit body with
+    //    `413` before it is buffered/deserialized. autumn already mounts a global
+    //    `DefaultBodyLimit` from `security.upload.max_request_size_bytes` (an
+    //    outer `.layer(DefaultBodyLimit)` here would be overridden by that inner
+    //    one), so the effective, non-overridden knob is that config value — set
+    //    it from `max_request_body_bytes` so the operator-configurable cap
+    //    actually takes effect on the assembled surface. (autumn merges `/mcp`
+    //    after this middleware, so `/mcp` keeps its own built-in 2 MiB limit —
+    //    the gate buffers to that bound independently.)
+    let mut autumn_cfg = AutumnConfig::default();
+    autumn_cfg.security.upload.max_request_size_bytes = cfg.max_request_body_bytes;
+    let app = app.config(autumn_cfg);
+
+    // 3. App-wide HTTP concurrency budget (AC1), default-off. When enabled, a
+    //    global concurrency limit back-pressures requests over the cap surface-
+    //    wide (queue, not reject — the load-shedding 503 path is the separate
+    //    per-query `InFlightLimiter`).
+    let app = match concurrency::app_concurrency_layer(cfg) {
+        Some(layer) => app.layer(layer),
+        None => app,
+    };
+
+    // 4. Default-off per-IP rate limiter, mounted app-wide only when enabled.
     //    When enabled, retain the `RateLimit`'s GC handle and drive it from a
     //    lifecycle-tied background task so the per-IP keyed state cannot grow
     //    without bound (MUST-FIX 8c). The task holds only a weak handle, so it

--- a/crates/aletheia-server/tests/connection_lifecycle.rs
+++ b/crates/aletheia-server/tests/connection_lifecycle.rs
@@ -1,0 +1,328 @@
+//! Acceptance tests for the inbound connection / MCP-session lifecycle budgets
+//! (autumn migration §8 / Issue #3561): the app-wide HTTP concurrency limit
+//! (AC1), the `DefaultBodyLimit` request-body cap (AC3), and the MCP-over-HTTP
+//! session concurrency budget (AC5) — all with **backpressure**, default-off
+//! for the concurrency budgets (parity), always-on for the body cap.
+//!
+//! Each is proven two ways where practical:
+//!   * **Seam-level** — the `tower::limit::GlobalConcurrencyLimitLayer` / axum
+//!     `DefaultBodyLimit` mounted on a bare `Router`, so the enforcement
+//!     semantics (peak-concurrency ceiling, 413) are observed directly and
+//!     deterministically.
+//!   * **App-level** — the assembled server (`build_server_client*`) wired via
+//!     `apply_security`, proving the config actually mounts the layer.
+//!
+//! TDD note: the concurrency enforcement tests are written to be
+//! scheduler-robust — a controlled gate holds handlers open so peak concurrency
+//! is observed under a real ceiling, never raced against wall-clock timing.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use aletheia_server::SecurityConfig;
+use aletheia_server::security::concurrency::{app_concurrency_layer, mcp_session_layer};
+use aletheiadb::auth::{AuthMode, AuthStore, Role};
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::post;
+use tower::limit::GlobalConcurrencyLimitLayer;
+use tower::{Layer, Service, ServiceExt};
+
+const ADMIN_TOKEN: &str = "admin-token-abcdefghijklmnop";
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+fn config() -> SecurityConfig {
+    SecurityConfig::new(Arc::new(AuthStore::new()), AuthMode::Anonymous)
+}
+
+fn admin_store() -> Arc<AuthStore> {
+    let store = Arc::new(AuthStore::new());
+    store
+        .insert_bootstrap_key("admin", Role::Admin, ADMIN_TOKEN)
+        .expect("admin key");
+    store
+}
+
+fn db_with_node() -> Arc<AletheiaDB> {
+    let db = Arc::new(AletheiaDB::new().expect("db"));
+    db.create_node(
+        "Person",
+        PropertyMapBuilder::new().insert("name", "Alice").build(),
+    )
+    .expect("node");
+    db
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// AC1 — app-wide HTTP concurrency budget (default-off, backpressure)
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Default parity: a conservative config builds no layer, so no request is ever
+/// back-pressured (today's behavior, unchanged).
+#[test]
+fn ac1_default_config_yields_no_app_concurrency_layer() {
+    let cfg = config();
+    assert!(
+        cfg.max_concurrent_requests.is_none(),
+        "app concurrency budget is off by default"
+    );
+    assert!(
+        app_concurrency_layer(&cfg).is_none(),
+        "no layer unless the operator opts in"
+    );
+    // Some(0) is treated as off — a zero-permit budget would wedge everything.
+    let zero = cfg.clone().with_max_concurrent_requests(Some(0));
+    assert!(
+        app_concurrency_layer(&zero).is_none(),
+        "Some(0) is treated as no budget"
+    );
+}
+
+/// Enabled: the global limit admits at most `cap` requests concurrently and
+/// back-pressures the rest (parks them in `poll_ready`) until a permit frees —
+/// then every request eventually completes (backpressure, NOT rejection).
+#[tokio::test]
+async fn ac1_enabled_caps_concurrency_and_backpressures() {
+    let cfg = config().with_max_concurrent_requests(Some(2));
+    let layer = app_concurrency_layer(&cfg).expect("layer built when enabled");
+    assert_peak_concurrency_capped(layer, 2).await;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// AC5 — MCP-over-HTTP session budget (default-off, backpressure)
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Default parity: no `/mcp` session budget layer unless opted in.
+#[test]
+fn ac5_default_config_yields_no_mcp_session_layer() {
+    let cfg = config();
+    assert!(
+        cfg.max_mcp_sessions.is_none(),
+        "mcp session budget off by default"
+    );
+    assert!(
+        mcp_session_layer(&cfg).is_none(),
+        "no layer unless opted in"
+    );
+    let zero = cfg.clone().with_max_mcp_sessions(Some(0));
+    assert!(
+        mcp_session_layer(&zero).is_none(),
+        "Some(0) is treated as no budget"
+    );
+}
+
+/// Enabled: the MCP session budget uses the same global-concurrency primitive,
+/// so it caps concurrent MCP requests and back-pressures the overflow.
+#[tokio::test]
+async fn ac5_enabled_caps_mcp_sessions_and_backpressures() {
+    let cfg = config().with_max_mcp_sessions(Some(2));
+    let layer = mcp_session_layer(&cfg).expect("layer built when enabled");
+    assert_peak_concurrency_capped(layer, 2).await;
+}
+
+/// The MCP session budget is enabled end-to-end without breaking dispatch: an
+/// assembled server with `max_mcp_sessions = Some(1)` still serves a `/mcp`
+/// `tools/list` `200` (the budget bounds concurrency, it does not reject).
+#[tokio::test]
+async fn ac5_app_with_mcp_budget_still_serves_mcp() {
+    let cfg = SecurityConfig::new(admin_store(), AuthMode::Required).with_max_mcp_sessions(Some(1));
+    let client = aletheia_server::build_server_client_with_config(db_with_node(), cfg);
+    let resp = client
+        .post("/mcp")
+        .header("authorization", &format!("Bearer {ADMIN_TOKEN}"))
+        .json(&serde_json::json!({"jsonrpc":"2.0","id":1,"method":"tools/list"}))
+        .send()
+        .await;
+    assert_eq!(
+        resp.status.as_u16(),
+        200,
+        "budget-enabled /mcp still dispatches"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// AC3 — DefaultBodyLimit request-body cap (always-on, 413)
+// ════════════════════════════════════════════════════════════════════════════
+
+/// The config default matches the legacy HTTP surface (2 MiB, #3108).
+#[test]
+fn ac3_default_body_cap_is_2_mib() {
+    assert_eq!(
+        config().max_request_body_bytes,
+        2 * 1024 * 1024,
+        "default body cap matches legacy DEFAULT_MAX_REQUEST_BODY_BYTES"
+    );
+}
+
+/// Seam-level: a `DefaultBodyLimit::max(N)` layer rejects an `N+1`-byte body with
+/// `413 Payload Too Large` and passes an `N`-byte body (inclusive boundary).
+#[tokio::test]
+async fn ac3_body_over_limit_is_413_under_is_ok() {
+    const LIMIT: usize = 64;
+    let app = Router::new()
+        .route(
+            "/echo",
+            post(|body: axum::body::Bytes| async move { format!("got {}", body.len()) }),
+        )
+        .layer(axum::extract::DefaultBodyLimit::max(LIMIT));
+
+    // Exactly LIMIT bytes: within budget → 200.
+    let ok = app
+        .clone()
+        .oneshot(post_bytes("/echo", vec![b'x'; LIMIT]))
+        .await
+        .expect("served");
+    assert_eq!(ok.status(), StatusCode::OK, "N-byte body is within budget");
+
+    // LIMIT + 1 bytes: over budget → 413.
+    let too_big = app
+        .clone()
+        .oneshot(post_bytes("/echo", vec![b'x'; LIMIT + 1]))
+        .await
+        .expect("served");
+    assert_eq!(
+        too_big.status(),
+        StatusCode::PAYLOAD_TOO_LARGE,
+        "over-limit body is rejected 413"
+    );
+}
+
+/// App-level: an assembled server built with a tiny `max_request_body_bytes`
+/// rejects an over-limit POST body with `413`, proving `apply_security` wires
+/// `DefaultBodyLimit` onto the real surface.
+#[tokio::test]
+async fn ac3_app_rejects_oversize_body_413() {
+    let cfg =
+        SecurityConfig::new(admin_store(), AuthMode::Required).with_max_request_body_bytes(32);
+    let client = aletheia_server::build_server_client_with_config(db_with_node(), cfg);
+
+    // A create_node body well over 32 bytes.
+    let big = serde_json::json!({
+        "label": "Person",
+        "properties": { "name": "a-name-that-makes-this-body-exceed-thirty-two-bytes" }
+    });
+    let resp = client
+        .post("/nodes")
+        .header("authorization", &format!("Bearer {ADMIN_TOKEN}"))
+        .json(&big)
+        .send()
+        .await;
+    assert_eq!(
+        resp.status.as_u16(),
+        413,
+        "oversize body rejected before handler logic"
+    );
+}
+
+// ── shared concurrency-enforcement harness ───────────────────────────────────
+
+/// Drive `cap + 1` concurrent requests through a `GlobalConcurrencyLimitLayer`
+/// wrapping a **gated** handler and assert the observed peak concurrency never
+/// exceeds `cap` (the overflow request is back-pressured), then release the gate
+/// and assert every request completes `200`.
+///
+/// Robust-by-construction (not timing-raced): each admitted handler increments a
+/// live counter, records the running peak, then blocks on a controlled
+/// semaphore. Only after the live count settles at `cap` (the overflow parked in
+/// the layer's `poll_ready`) is the gate opened.
+async fn assert_peak_concurrency_capped(layer: GlobalConcurrencyLimitLayer, cap: usize) {
+    let gate = Arc::new(tokio::sync::Semaphore::new(0));
+    let live = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+
+    let handler = {
+        let gate = Arc::clone(&gate);
+        let live = Arc::clone(&live);
+        let peak = Arc::clone(&peak);
+        tower::service_fn(move |_req: Request<Body>| {
+            let gate = Arc::clone(&gate);
+            let live = Arc::clone(&live);
+            let peak = Arc::clone(&peak);
+            async move {
+                let now = live.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(now, Ordering::SeqCst);
+                // Hold the handler (and thus the concurrency permit) open until
+                // the gate is released.
+                let _permit = gate.acquire().await.expect("gate open");
+                live.fetch_sub(1, Ordering::SeqCst);
+                Ok::<_, std::convert::Infallible>(axum::response::Response::new(Body::from("ok")))
+            }
+        })
+    };
+
+    // One shared service instance → clones share the global permit semaphore.
+    let svc = layer.layer(handler);
+
+    let total = cap + 1;
+    let mut tasks: Vec<tokio::task::JoinHandle<axum::response::Response<Body>>> = Vec::new();
+    for _ in 0..total {
+        let mut svc = svc.clone();
+        tasks.push(tokio::spawn(async move {
+            svc.ready()
+                .await
+                .expect("ready")
+                .call(empty_post())
+                .await
+                .expect("service responded")
+        }));
+    }
+
+    // Wait until exactly `cap` handlers are admitted and live (the overflow is
+    // parked in poll_ready). Bounded spin so a regression that admits > cap
+    // fails fast rather than hanging.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if live.load(Ordering::SeqCst) == cap {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "handlers never settled at the cap (live = {})",
+            live.load(Ordering::SeqCst)
+        );
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+
+    // Give any (erroneously admitted) overflow a chance to slip through, then
+    // assert the ceiling held.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(
+        live.load(Ordering::SeqCst),
+        cap,
+        "no more than `cap` handlers run concurrently (overflow is back-pressured)"
+    );
+    assert_eq!(
+        peak.load(Ordering::SeqCst),
+        cap,
+        "peak concurrency equals the cap, never exceeds it"
+    );
+
+    // Release the gate: all handlers (including the back-pressured overflow)
+    // proceed and complete — backpressure delayed, never rejected.
+    gate.add_permits(total);
+    for t in tasks {
+        let resp = t.await.expect("task");
+        assert_eq!(resp.status(), StatusCode::OK, "every request completes 200");
+    }
+}
+
+fn empty_post() -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/")
+        .body(Body::empty())
+        .expect("request")
+}
+
+fn post_bytes(uri: &str, bytes: Vec<u8>) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(uri)
+        .body(Body::from(bytes))
+        .expect("request")
+}


### PR DESCRIPTION
## Before / After (plain language)

**Before.** The autumn-web server crate had its inbound-connection safeguards only *partially* wired: the `tower-governor` rate limiter, the per-query timeout→429 path, the signed-cursor TTL/cap, and per-session `/mcp` auth were all in place, but there was **no concurrency ceiling** on the surface. A flood of concurrent HTTP requests — or concurrent MCP-over-HTTP agent sessions on `POST /mcp`, where multi-agent load actually lands — could pile up unbounded, and the request-body cap was left entirely to axum/autumn's implicit default (not operator-configurable through our `SecurityConfig`).

**After.** `SecurityConfig` now carries three inbound-connection budgets, wired through `apply_security`:

- an **app-wide HTTP concurrency limit** (`max_concurrent_requests`) with **backpressure** (AC1),
- an **MCP-over-HTTP session budget** on `/mcp` (`max_mcp_sessions`) with backpressure (AC5), and
- an **operator-configurable request-body cap** (`max_request_body_bytes`, default 2 MiB) that now actually takes effect on the assembled surface (AC3).

The two concurrency budgets are **default-off** (parity with today, matching the existing default-off `tower-governor` pattern); the body cap is always-on at the 2 MiB legacy default. MCP **stdio** is untouched (AC8), and there is still **no outbound DB connection pool** — AletheiaDB is embedded, single `Arc` (explicit non-goal).

## How (implementation)

- **New `security::concurrency` module** — two default-off constructors (`app_concurrency_layer`, `mcp_session_layer`) returning `Option<tower::limit::GlobalConcurrencyLimitLayer>`. The *global* variant shares one permit semaphore across axum's per-connection service clones, so the cap is surface-wide, not per-connection. `None`/`Some(0)` → no layer (byte-for-byte today's behavior). Enabled the `tower` `limit` feature.
- **`apply_security` wiring** — the MCP session budget is composed *outside* the existing `McpSecurityLayer` via `ServiceBuilder` and mounted through `secure_mcp`; the app-wide budget is mounted via `.layer()` alongside the governor limiter.
- **Body cap (AC3)** — autumn-web already mounts a global `DefaultBodyLimit` from `security.upload.max_request_size_bytes` **inside** its router build, which *overrides* an outer `.layer(DefaultBodyLimit)`. So the effective, non-overridden knob is that config value: `apply_security` sets it from `max_request_body_bytes` via `TestApp::config(..)`. (An initial outer-layer attempt returned 200 in the app-level RED test, which is what surfaced this.)
- `SecurityConfig` gains `max_concurrent_requests: Option<usize>`, `max_mcp_sessions: Option<usize>`, `max_request_body_bytes: usize` (+ builders and a `DEFAULT_MAX_REQUEST_BODY_BYTES` constant).

Distinct from the existing per-query `InFlightLimiter` (which **load-sheds** with a retriable `503` at capacity): these budgets **back-pressure** (queue, then serve — never reject), which is what AC1/AC5 call for.

## Condensed plan

- **Brainstorm.** Caps: (a) tower `GlobalConcurrencyLimitLayer` (backpressure), (b) hand-rolled semaphore layer, (c) load-shedding with 503. Body cap: (a) outer `DefaultBodyLimit`, (b) autumn's own upload config, (c) `tower_http::RequestBodyLimitLayer`.
- **Reverse brainstorm (how could this cause an outage?).** `Some(0)` cap wedging every request → treated as off. Unbounded per-key limiter map → concurrency limits hold no per-key state (permits only). Backpressure that never releases → permits are RAII-released when the response future completes. Outer body-limit silently overridden by the framework → exactly what happened; fixed by driving autumn's own config knob.
- **Six-hats (tight).** *Facts:* most §8 ACs already landed; the gap is concurrency + an effective body cap. *Risks:* framework layer-ordering overriding ours; flaky concurrency tests. *Benefits:* real ceiling on multi-agent `/mcp` load. *Feelings:* default-off keeps parity fear low. *Creative:* reuse one global-concurrency primitive for both AC1 and AC5. *Process:* strict TDD, isolated-target gates.
- **Chosen approach:** tower `GlobalConcurrencyLimitLayer` for both budgets (smallest diff, real backpressure, one primitive), autumn's own upload-config value for the body cap (the only knob that isn't overridden). Rejected the hand-rolled layer (more code, no benefit) and the outer `DefaultBodyLimit` (proven ineffective here).
- **Risks → tests:** default-off parity; `Some(0)`→off; peak-concurrency never exceeds the cap; back-pressured overflow still completes (not rejected); body `413` over / `200` at the boundary; app-level body `413`; budget-enabled `/mcp` still dispatches.

## AC evidence table

| AC (verbatim) | Evidence |
|---|---|
| Restore an in-process `tower::ConcurrencyLimit` layer for HTTP backpressure | `concurrency::app_concurrency_layer` (`GlobalConcurrencyLimitLayer`); tests `ac1_default_config_yields_no_app_concurrency_layer`, `ac1_enabled_caps_concurrency_and_backpressures` |
| Restore an in-process `tower-governor` rate-limit layer (HTTP 429)… keep the existing `RateLimitConfig` public API | Pre-existing `rate_limit::governor_layer` + `RateLimitSettings`, mounted in `apply_security`; `security_rate_limit.rs` (unchanged, green) |
| Preserve body-size limiting (`DefaultBodyLimit`, #3108) | `apply_security` sets `security.upload.max_request_size_bytes`; tests `ac3_default_body_cap_is_2_mib`, `ac3_body_over_limit_is_413_under_is_ok`, `ac3_app_rejects_oversize_body_413` |
| Wire per-query timeout → 429 (composes with #3368) | Pre-existing `resource_limits::run_with_timeout`/`timeout_error` (429 `WallClockTimeout`); `security_resource_limits.rs` (unchanged, green) |
| Define a connection/session budget for MCP-over-HTTP: a max-concurrent-MCP-sessions cap with backpressure | `concurrency::mcp_session_layer` composed over the `/mcp` gate; tests `ac5_default_config_yields_no_mcp_session_layer`, `ac5_enabled_caps_mcp_sessions_and_backpressures`, `ac5_app_with_mcp_budget_still_serves_mcp` |
| Enforce a per-session cursor cap + TTL… (TTL 5 min, cap 128) | Pre-existing `cursor::LiveCursorRegistry` + `CursorSecret` (defaults 300 s / 128 in `SecurityConfig::new`); `security_cursor.rs` (unchanged, green) |
| Apply per-session auth to MCP-over-HTTP sessions | Pre-existing `mcp_gate::McpSecurityLayer` via `secure_mcp`; `security_mcp_gate.rs` (unchanged, green) |
| Keep MCP stdio as-is (single session, process-lifetime) | No stdio code touched (change is HTTP-surface-only) |
| **Non-goal:** no outbound DB connection pool — embedded, single `Arc` | No pool added; embedded `Arc<AletheiaDB>` unchanged |

## Notes / gate status

- New acceptance suite `crates/aletheia-server/tests/connection_lifecycle.rs` (8 tests, all green). Full `aletheia-server` test suite green (all parity suites + the 8 new tests). `cargo fmt --all --check` clean. `cargo clippy --all-targets --all-features -- -D warnings` clean for the whole workspace.
- **Pre-existing, out-of-scope:** `cargo clippy --no-default-features -- -D warnings` (and `cargo check --no-default-features --tests`) trip a `clippy::needless_return` in `src/db/snapshot.rs:451` — a `return Ok(())` inside `#[cfg(not(feature = "serde"))]`, present on `trunk` and unrelated to this change (that file is outside this lane's ownership). Left untouched.
- No golden files regenerated.
- Pre-existing unrelated trailing-whitespace drift in `tests/sql_integration.rs` (surfaced by `cargo fmt --all`) was **left untouched** to stay in scope — a suggested follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MLuLxMyM1vhUXLFQTMn1E

---
_Generated by [Claude Code](https://claude.ai/code/session_017MLuLxMyM1vhUXLFQTMn1E)_