### PR TITLE
test: de-flake global-METRICS counter tests (Wave-8 Lane P)

### DIFF
--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -4325,6 +4325,11 @@ mod lock_poisoning_tests {
     /// Poisoning `current_timestamp` causes `commit()` to return `LockPoisoned`
     /// instead of panicking.
     #[test]
+    // Produces `Error::Transaction(LockPoisoned)`, which bumps the process-global
+    // `error_transaction_total` metric under the `observability` feature. Join the
+    // `metrics` serial group so it never runs concurrently with the delta-based
+    // metric asserters that read that counter (de-flake, Wave-8 Lane P).
+    #[cfg_attr(feature = "observability", serial_test::serial(metrics))]
     fn test_timestamp_lock_poisoning_during_commit() {
         let harness = TestHarness::new();
         let poisoned_ts: Arc<Mutex<Timestamp>> = Arc::new(Mutex::new(time::now()));
@@ -4354,6 +4359,10 @@ mod lock_poisoning_tests {
     /// When multiple threads attempt concurrent commits against a poisoned lock,
     /// each thread gets a `LockPoisoned` error rather than panicking.
     #[test]
+    // Each thread produces `Error::Transaction(LockPoisoned)`, bumping the
+    // process-global `error_transaction_total` metric under `observability`. Join
+    // the `metrics` serial group (de-flake, Wave-8 Lane P).
+    #[cfg_attr(feature = "observability", serial_test::serial(metrics))]
     fn test_concurrent_commits_with_poisoned_lock() {
         let poisoned_ts: Arc<Mutex<Timestamp>> = Arc::new(Mutex::new(time::now()));
         poison_mutex(&poisoned_ts);
@@ -4398,6 +4407,10 @@ mod lock_poisoning_tests {
     /// Poisoning `commit_clock_observed_at` causes `commit()` to return
     /// `LockPoisoned` via the adaptive forward-jump guard, not a panic.
     #[test]
+    // Produces `Error::Transaction(LockPoisoned)`, bumping the process-global
+    // `error_transaction_total` metric under `observability`. Join the `metrics`
+    // serial group (de-flake, Wave-8 Lane P).
+    #[cfg_attr(feature = "observability", serial_test::serial(metrics))]
     fn test_commit_clock_observed_at_lock_poisoning() {
         let harness = TestHarness::new();
         let poisoned_clock: Arc<Mutex<Instant>> = Arc::new(Mutex::new(Instant::now()));

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -1309,17 +1309,25 @@ mod tests {
 
     #[cfg(feature = "observability")]
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(metrics)]
     fn test_result_ext_records_storage_metric_once() {
-        crate::observability::METRICS.reset();
-
+        // Delta-based assertion (not absolute-count-after-`reset()`): the counter
+        // is a process-global singleton shared across the whole test binary, so an
+        // absolute assertion races any concurrent test that bumps the same counter.
+        // Reading immediately before and after the single `record_error_metric()`
+        // call and asserting the increment is exactly 1 preserves the "recorded
+        // exactly once (not double-counted)" intent while being robust to concurrent
+        // neighbors. The `metrics` serial group fences out the known same-counter
+        // bumpers so the delta window is clean (de-flake, Wave-8 Lane P).
         let err: Result<()> = Err(StorageError::NodeNotFound(NodeId::new(1).unwrap()).into());
-        let snapshot = crate::observability::METRICS.snapshot();
-        assert_eq!(snapshot.error_storage_total, 0);
-
+        let before = crate::observability::METRICS.snapshot().error_storage_total;
         let _ = err.record_error_metric();
-        let snapshot = crate::observability::METRICS.snapshot();
-        assert_eq!(snapshot.error_storage_total, 1);
+        let after = crate::observability::METRICS.snapshot().error_storage_total;
+        assert_eq!(
+            after - before,
+            1,
+            "record_error_metric must record exactly one storage error"
+        );
     }
 
     #[test]

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -1950,6 +1950,11 @@ fn test_write_transaction_commit_then_rollback_path() {
 }
 
 #[test]
+// This test propagates an `Error::Storage`, which bumps the process-global
+// `error_storage_total` metric under the `observability` feature. It must join
+// the `metrics` serial group so it never runs concurrently with the delta-based
+// metric asserters that read that same counter (de-flake, Wave-8 Lane P).
+#[cfg_attr(feature = "observability", serial_test::serial(metrics))]
 fn test_write_closure_error_propagation() {
     let db = AletheiaDB::new().unwrap();
 
@@ -1972,6 +1977,10 @@ fn test_write_closure_error_propagation() {
 }
 
 #[test]
+// Propagates an `Error::Storage` (bumps `error_storage_total` under
+// `observability`); joins the `metrics` serial group so it never races the
+// delta-based metric asserters reading that counter (de-flake, Wave-8 Lane P).
+#[cfg_attr(feature = "observability", serial_test::serial(metrics))]
 fn test_read_closure_error_propagation() {
     let db = AletheiaDB::new().unwrap();
 
@@ -2763,23 +2772,39 @@ fn poison_mutex<T>(mutex: &std::sync::Arc<std::sync::Mutex<T>>) {
 
 #[cfg(feature = "observability")]
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(metrics)]
 fn test_create_node_transaction_error_counted_once_when_lock_poisoned() {
-    crate::observability::METRICS.reset();
     let db = AletheiaDB::new().unwrap();
 
     poison_mutex(&db.current_timestamp);
 
+    // Delta-based assertion (not absolute-count-after-`reset()`): the counter is
+    // a process-global singleton shared by the whole test binary, so an absolute
+    // assertion races any concurrent test that bumps the same counter. Reading
+    // the counter immediately before and after the single failing action, and
+    // asserting the increment attributable to THAT action is exactly 1, both
+    // preserves the "counted exactly once (not double-counted)" intent and is
+    // robust to concurrent neighbors. The `metrics` serial group additionally
+    // fences out the known same-counter bumpers so the delta window is clean.
+    let before = crate::observability::METRICS
+        .snapshot()
+        .error_transaction_total;
     let result = db.create_node("Person", PropertyMapBuilder::new().build());
     assert!(result.is_err());
+    let after = crate::observability::METRICS
+        .snapshot()
+        .error_transaction_total;
 
-    let snapshot = crate::observability::METRICS.snapshot();
-    assert_eq!(snapshot.error_transaction_total, 1);
+    assert_eq!(
+        after - before,
+        1,
+        "failing create_node must record exactly one transaction error"
+    );
 }
 
 #[cfg(feature = "observability")]
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(metrics)]
 fn test_vector_builder_duplicate_enable_counts_error_once() {
     use crate::index::vector::{DistanceMetric, HnswConfig};
 
@@ -2787,52 +2812,74 @@ fn test_vector_builder_duplicate_enable_counts_error_once() {
     db.enable_vector_index("embedding", HnswConfig::new(4, DistanceMetric::Cosine))
         .unwrap();
 
-    crate::observability::METRICS.reset();
+    // Delta-based (see `test_create_node_transaction_error_counted_once_when_lock_poisoned`
+    // for the rationale): robust to concurrent bumps of the process-global counter.
+    let before = crate::observability::METRICS.snapshot().error_vector_total;
     let result = db
         .vector_index("embedding")
         .hnsw(HnswConfig::new(4, DistanceMetric::Cosine))
         .enable();
     assert!(result.is_err());
+    let after = crate::observability::METRICS.snapshot().error_vector_total;
 
-    let snapshot = crate::observability::METRICS.snapshot();
-    assert_eq!(snapshot.error_vector_total, 1);
+    assert_eq!(
+        after - before,
+        1,
+        "duplicate vector-index enable must record exactly one vector error"
+    );
 }
 
 #[cfg(feature = "observability")]
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(metrics)]
 fn test_read_closure_db_error_counts_once() {
-    crate::observability::METRICS.reset();
     let db = AletheiaDB::new().unwrap();
 
     let missing_id = NodeId::new(999_999).unwrap();
+    // Delta-based (see `test_create_node_transaction_error_counted_once_when_lock_poisoned`
+    // for the rationale): robust to concurrent bumps of the process-global counter.
+    let before = crate::observability::METRICS.snapshot().error_storage_total;
     let result: Result<()> = db.read(|tx| {
         tx.get_node(missing_id)?;
         Ok(())
     });
     assert!(result.is_err());
+    let after = crate::observability::METRICS.snapshot().error_storage_total;
 
-    let snapshot = crate::observability::METRICS.snapshot();
-    assert_eq!(snapshot.error_storage_total, 1);
+    assert_eq!(
+        after - before,
+        1,
+        "failing read closure must record exactly one storage error"
+    );
 }
 
 #[cfg(feature = "observability")]
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(metrics)]
 fn test_write_commit_error_counts_once() {
-    crate::observability::METRICS.reset();
     let db = AletheiaDB::new().unwrap();
 
     poison_mutex(&db.commit_clock_observed_at);
 
+    // Delta-based (see `test_create_node_transaction_error_counted_once_when_lock_poisoned`
+    // for the rationale): robust to concurrent bumps of the process-global counter.
+    let before = crate::observability::METRICS
+        .snapshot()
+        .error_transaction_total;
     let result: Result<()> = db.write(|tx| {
         tx.create_node("Person", PropertyMapBuilder::new().build())?;
         Ok(())
     });
     assert!(result.is_err());
+    let after = crate::observability::METRICS
+        .snapshot()
+        .error_transaction_total;
 
-    let snapshot = crate::observability::METRICS.snapshot();
-    assert_eq!(snapshot.error_transaction_total, 1);
+    assert_eq!(
+        after - before,
+        1,
+        "failing write commit must record exactly one transaction error"
+    );
 }
 
 // ==================== Schema Discovery Tests (Issue #3214) ====================


### PR DESCRIPTION
## Before / After (plain language)

**Before.** A handful of tests assert on the process-global
`observability::METRICS` singleton — the *same* counter object shared by every
test in the lib test binary. Each asserter calls `METRICS.reset()` (zeroing the
whole singleton) and then asserts an **absolute** count of `1`. Under the Code
Coverage CI job (llvm-cov parallelism) they fail **~2/3 of the time** with
`left: 2, right: 1`: a concurrent non-serial test bumps the same counter inside
the asserter's `reset()`→`snapshot()` window, so the absolute count reads `2`.

**After.** The asserters no longer depend on global isolation. Each reads the
counter immediately **before** and **after** its single failing action and
asserts the *increment attributable to that action* is exactly `1` (a DELTA
assertion). No more destructive global `reset()`, and the measurement window
shrinks from `reset..new..action..snapshot` to just the action. On top of that,
every test that touches these counters — the 5 asserters **and** the 5
same-counter bumpers — now shares one named serial group
`#[serial_test::serial(metrics)]`, so the known racers can never overlap an
asserter's window.

## How

`record_error_metric()` maps `Error::Storage → error_storage_total`,
`Error::Transaction → error_transaction_total`, `Error::Vector →
error_vector_total` on the global `METRICS`. The racers were:

- **error_storage:** `test_write_closure_error_propagation`,
  `test_read_closure_error_propagation` (both `db.read/write` closures returning
  `Error::Storage`).
- **error_transaction:** the three `lock_poisoning_tests`
  (`test_timestamp_lock_poisoning_during_commit`,
  `test_concurrent_commits_with_poisoned_lock`,
  `test_commit_clock_observed_at_lock_poisoning`) — each returns
  `Error::Transaction(LockPoisoned)`.

Fix (test-only, no production code touched):

1. Convert the **five** asserters to delta assertions and drop `reset()`:
   - `src/db/tests.rs`: `test_create_node_transaction_error_counted_once_when_lock_poisoned`,
     `test_read_closure_db_error_counts_once`, `test_write_commit_error_counts_once`,
     `test_vector_builder_duplicate_enable_counts_error_once`
   - `src/core/error.rs`: `test_result_ext_records_storage_metric_once`
2. Put all asserters + all five bumpers in the named serial group `metrics`.
   Bumpers use `#[cfg_attr(feature = "observability", serial_test::serial(metrics))]`
   so they only serialize when the counter is actually live (these counters are
   `#[cfg(feature = "observability")]`, and observability is **not** a default
   feature — the tests run under the coverage job's `--all-features`).

## Approaches considered & tradeoffs

| Approach | Robustness | Verdict |
|---|---|---|
| **A. Pure delta only** | Narrows the window, but a concurrent bump of the same global counter *inside* the (now tiny) window still yields delta `2`. Not deterministic. | Insufficient alone |
| **B. Named serial group only (keep reset + absolute)** | Deterministic vs the known racers, but keeps the destructive global `reset()` and a wide `reset..action` window, so any *unknown* ungrouped bumper still flakes. | Fragile |
| **C. Hybrid: delta + named serial group (chosen)** | Serial group *deterministically* fences the known high-frequency racers; delta both removes `reset()` and shrinks the window to the single action, so any hypothetical unmarked bumper has a negligibly small target. Delta also better states the real intent — "*this action* counted the error exactly once, not twice." | **Chosen** |

## Risks, as concrete test scenarios

- *Concurrent same-counter bump mid-window* → primary flake. Killed by: group fences known bumpers; delta shrinks window. (Repro below.)
- *`reset()` clobbering a sibling asserter's expectation* → removed entirely (no more `reset()`).
- *Counter underflow in `after - before`* → impossible: counters are monotonic non-decreasing and `before` is read-before-`after` in program order, so `after >= before` always.
- *Non-observability / no-default-features build* → bumpers' `cfg_attr` compiles to a no-op; asserters are already `#[cfg(feature = "observability")]`. Verified `cargo check --no-default-features --tests` clean.
- *Real double-count regression (the bug these tests guard)* → still caught: our own action producing delta `2` fails the assertion.

## Acceptance criteria & evidence

| Criterion | Evidence |
|---|---|
| Original flake reproduced | Under `RUSTFLAGS="-C instrument-coverage"` (the coverage-job compile config), full lib suite `--test-threads=16`: `test_read_closure_db_error_counts_once ... FAILED` in 2/5 runs; `test_create_node_transaction_error_counted_once_when_lock_poisoned` panicked at `src/db/tests.rs:2777` with `assertion left == right failed / left: 2 / right: 1` (the exact task signature). |
| Flake dead after fix | Same instrumented full-suite config, `--test-threads=16`: **11/11 consecutive clean** in the first batch (interrupted only by a 10-min wall-clock, not a failure), background 20-run loop confirming. Native optimized binary is too fast to hit the window (0 repro in 30 targeted + 6 full-suite runs). |
| `cargo fmt --all` | Clean (one unrelated pre-existing drift in `tests/sql_integration.rs` reverted to keep the diff scoped). |
| `clippy --all-targets --all-features -D warnings` | Clean. |
| `clippy --all-targets --no-default-features -D warnings` | Pre-existing failure **unrelated to this PR**: `src/db/snapshot.rs:451` `needless_return` inside a `#[cfg(not(feature = "serde"))]` block (present verbatim on `origin/trunk`; default builds enable `serde` so the all-features gate never compiles that branch). Not in this diff. |
| `cargo check --no-default-features --tests` | Clean (only a pre-existing unused-import warning in the `snapshot_pin` test). |
| Affected tests pass | All 10 affected tests green together under `--features observability --test-threads=16`. |

### Repro loop (mechanism-faithful, instrument-coverage)

```bash
# Build the lib test binary exactly as the coverage job compiles it
CARGO_TARGET_DIR="$COV" RUSTFLAGS="-C instrument-coverage" \
  cargo test --features observability --lib --no-run
BIN=$(ls -t "$COV"/debug/deps/aletheiadb-* | grep -v '\.d$' | head -1)
export LLVM_PROFILE_FILE=/dev/null

# Full suite at high parallelism, N iterations, flag the metric asserters
for i in $(seq 1 20); do
  out=$("$BIN" --test-threads=16 2>&1)
  echo "$out" | grep -qE 'test_(read_closure_db_error|create_node_transaction_error_counted|result_ext_records_storage|write_commit_error_counts|vector_builder_duplicate_enable).*FAILED' \
    && echo "ITER $i METRIC FLAKE" || echo "iter $i OK"
done
```

**Trunk (before):** `... iter 2 OK / ITER 3 METRIC FLAKE / ITER 4 METRIC FLAKE / iter 5 OK ...`
plus the captured `left: 2 / right: 1` panic at `src/db/tests.rs:2777`.

**This branch (after):** 11/11 consecutive `iter N OK` in the first batch; extended run confirming (updating this line with the final tally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Evgi2AgnwjwMSgBArxg9BV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Evgi2AgnwjwMSgBArxg9BV)_