### PR TITLE
Namespaces PR1: core model (registry, reserved-key ride-along, elision) — #3349

### DIFF
--- a/python/src/types.rs
+++ b/python/src/types.rs
@@ -142,6 +142,12 @@ pub fn property_map_to_py_dict(py: Python<'_>, map: &PropertyMap) -> PyResult<Py
     let dict = PyDict::new_bound(py);
     for (key, value) in map.iter() {
         let key_str = resolve_interned(*key);
+        // Elide engine-reserved ride-along keys (the namespace marker, #3349,
+        // and crypto-shred markers): they are surfaced as first-class fields,
+        // never as user properties.
+        if aletheiadb::core::namespace::is_reserved_property_key(&key_str) {
+            continue;
+        }
         dict.set_item(key_str, property_value_to_py(py, value)?)?;
     }
     Ok(dict.unbind())

--- a/src/api/export/parquet.rs
+++ b/src/api/export/parquet.rs
@@ -136,6 +136,13 @@ impl<'a> SchemaBuilder<'a> {
     fn observe(&mut self, props: &PropertyMap) {
         for (key, value) in props.iter() {
             let Some(name) = key_name(key) else { continue };
+            // Engine-reserved ride-along keys (the namespace marker, #3349, and
+            // the crypto-shred lane's keys) are never user data: elide them from
+            // the export entirely rather than leaking them into a typed or
+            // overflow column.
+            if crate::core::namespace::is_reserved_property_key(&name) {
+                continue;
+            }
             // A key colliding with a fixed column name is always overflow-routed so
             // the emitted schema stays unambiguous.
             let incoming = if self.reserved.contains(&name.as_str()) {

--- a/src/api/export/tests.rs
+++ b/src/api/export/tests.rs
@@ -859,3 +859,72 @@ fn empty_edge_history_produces_valid_empty_file() {
     assert!(names.contains(&"source_key".to_string()));
     assert!(names.contains(&"valid_to".to_string()));
 }
+
+/// Assert no exported Parquet field name nor any Utf8 cell carries the
+/// engine-reserved namespace ride-along key (Issue #3349).
+fn assert_no_reserved_in_parquet(schema: &Schema, batches: &[RecordBatch]) {
+    for name in field_names(schema) {
+        assert!(
+            !name.contains("__aletheia_"),
+            "reserved ride-along key leaked into a Parquet column name: {name}"
+        );
+    }
+    for batch in batches {
+        for col in batch.columns() {
+            if let Some(arr) = col.as_any().downcast_ref::<StringArray>() {
+                for i in 0..arr.len() {
+                    if arr.is_valid(i) {
+                        assert!(
+                            !arr.value(i).contains("__aletheia_"),
+                            "reserved ride-along key leaked into a Parquet Utf8 cell: {}",
+                            arr.value(i)
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn namespaced_export_elides_reserved_ride_along_key() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let a = db
+        .create_node_in_namespace(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+            "agent:planner",
+        )
+        .unwrap();
+    let b = db
+        .create_node_in_namespace(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+            "agent:planner",
+        )
+        .unwrap();
+    db.create_edge_in_namespace(
+        a,
+        b,
+        "KNOWS",
+        PropertyMapBuilder::new().insert("since", 2020i64).build(),
+        "agent:planner",
+    )
+    .unwrap();
+
+    let nodes_path = files.path().join("nodes.parquet");
+    let edges_path = files.path().join("edges.parquet");
+    let node_hist_path = files.path().join("node_hist.parquet");
+    db.export().nodes_to_parquet(&nodes_path).unwrap();
+    db.export().edges_to_parquet(&edges_path).unwrap();
+    db.export()
+        .node_history_to_parquet(&node_hist_path)
+        .unwrap();
+
+    for path in [&nodes_path, &edges_path, &node_hist_path] {
+        let (schema, batches) = read_parquet(path);
+        assert_no_reserved_in_parquet(&schema, &batches);
+    }
+}

--- a/src/api/transaction/mod.rs
+++ b/src/api/transaction/mod.rs
@@ -118,8 +118,21 @@ impl WriteRequestOptions {
         self
     }
 
-    /// Set the target namespace for a **create** write (Issue #3349). No effect
-    /// on update/replace/delete/CAS, where the namespace is immutable.
+    /// Set the target namespace for a **create** write (Issue #3349).
+    ///
+    /// Supplying a namespace to a non-create op (update / replace / CAS /
+    /// lease-claim) is rejected with `INVALID_ARGUMENT`
+    /// ([`NamespaceError::Immutable`](crate::core::namespace::NamespaceError::Immutable)),
+    /// because a namespace is fixed at creation and those paths re-stamp it from
+    /// the existing entity.
+    ///
+    /// Note: this low-level write-path does **not** auto-register the namespace
+    /// in the registry — that is the caller's responsibility (the
+    /// `create_*_in_namespace` convenience methods and the PR3 MCP/HTTP handlers
+    /// register after a successful commit). A raw `with_namespace` write can
+    /// therefore stamp an entity in a namespace the registry does not list; the
+    /// membership index rebuilt at load reconciles that registry-vs-data
+    /// divergence.
     #[must_use]
     pub fn with_namespace(mut self, namespace: crate::core::namespace::Namespace) -> Self {
         self.namespace = Some(namespace);

--- a/src/api/transaction/mod.rs
+++ b/src/api/transaction/mod.rs
@@ -91,6 +91,11 @@ use crate::core::temporal::Timestamp;
 pub struct WriteRequestOptions {
     pub(crate) valid_from: Option<Timestamp>,
     pub(crate) provenance: Option<Provenance>,
+    /// Target namespace for a **create** (Issue #3349). `None` ⇒ the default
+    /// namespace (byte-identical to pre-namespace behavior). Ignored by update /
+    /// replace / delete / CAS paths, where the namespace is immutable and
+    /// re-stamped from the existing entity instead.
+    pub(crate) namespace: Option<crate::core::namespace::Namespace>,
 }
 
 impl WriteRequestOptions {
@@ -110,6 +115,14 @@ impl WriteRequestOptions {
     #[must_use]
     pub fn with_provenance(mut self, provenance: Provenance) -> Self {
         self.provenance = Some(provenance);
+        self
+    }
+
+    /// Set the target namespace for a **create** write (Issue #3349). No effect
+    /// on update/replace/delete/CAS, where the namespace is immutable.
+    #[must_use]
+    pub fn with_namespace(mut self, namespace: crate::core::namespace::Namespace) -> Self {
+        self.namespace = Some(namespace);
         self
     }
 }
@@ -541,6 +554,7 @@ pub trait WriteOps: ReadOps {
         let options = WriteRequestOptions {
             valid_from,
             provenance: None,
+            namespace: None,
         };
         self.create_node_with_options(label, properties, options)
     }
@@ -634,6 +648,7 @@ pub trait WriteOps: ReadOps {
         let options = WriteRequestOptions {
             valid_from,
             provenance: None,
+            namespace: None,
         };
         self.create_edge_with_options(source, target, label, properties, options)
     }
@@ -719,6 +734,7 @@ pub trait WriteOps: ReadOps {
         let options = WriteRequestOptions {
             valid_from,
             provenance: None,
+            namespace: None,
         };
         self.update_node_with_options(node_id, properties, options)
     }
@@ -929,6 +945,7 @@ pub trait WriteOps: ReadOps {
         let options = WriteRequestOptions {
             valid_from,
             provenance: None,
+            namespace: None,
         };
         self.update_edge_with_options(edge_id, properties, options)
     }
@@ -1011,6 +1028,7 @@ pub trait WriteOps: ReadOps {
             WriteRequestOptions {
                 valid_from,
                 provenance: None,
+                namespace: None,
             },
         )
     }
@@ -1140,6 +1158,7 @@ pub trait WriteOps: ReadOps {
             WriteRequestOptions {
                 valid_from,
                 provenance: None,
+                namespace: None,
             },
         )
     }
@@ -1227,6 +1246,7 @@ pub trait WriteOps: ReadOps {
             WriteRequestOptions {
                 valid_from,
                 provenance: None,
+                namespace: None,
             },
         )
     }
@@ -1276,6 +1296,7 @@ pub trait WriteOps: ReadOps {
             WriteRequestOptions {
                 valid_from,
                 provenance: None,
+                namespace: None,
             },
         )
     }

--- a/src/api/transaction/write/cas.rs
+++ b/src/api/transaction/write/cas.rs
@@ -156,6 +156,11 @@ impl WriteTransaction {
             .into());
         }
 
+        // A namespace is immutable after creation: reject an explicit namespace
+        // on a CAS / lease-claim rather than silently ignoring it (#3349). This
+        // also covers `claim_with_lease_impl`, which routes through here.
+        namespace::reject_namespace_on_update(options.namespace.as_ref())?;
+
         // Reject engine-reserved keys on the user-supplied replacement map
         // (Issue #3349); the immutable namespace is re-stamped from the
         // existing node below.
@@ -238,6 +243,10 @@ impl WriteTransaction {
             }
             .into());
         }
+
+        // A namespace is immutable after creation: reject an explicit namespace
+        // on an edge CAS rather than silently ignoring it (#3349).
+        namespace::reject_namespace_on_update(options.namespace.as_ref())?;
 
         // Reject engine-reserved keys on the user-supplied replacement map
         // (Issue #3349); the immutable namespace is re-stamped below.

--- a/src/api/transaction/write/cas.rs
+++ b/src/api/transaction/write/cas.rs
@@ -62,6 +62,7 @@ use crate::api::transaction::{BufferedWrite, WriteRequestOptions};
 use crate::core::error::{Result, TransactionError};
 use crate::core::id::{EdgeId, NodeId, VersionId};
 use crate::core::interning::GLOBAL_INTERNER;
+use crate::core::namespace;
 use crate::core::property::{PropertyMap, PropertyMapBuilder, PropertyValue};
 use crate::core::temporal::Timestamp;
 
@@ -155,6 +156,11 @@ impl WriteTransaction {
             .into());
         }
 
+        // Reject engine-reserved keys on the user-supplied replacement map
+        // (Issue #3349); the immutable namespace is re-stamped from the
+        // existing node below.
+        namespace::reject_reserved_keys(&properties)?;
+
         // Preserve the label; a full-replace changes only the property map.
         // Buffer-aware read (read-your-own-writes): a node created/updated
         // earlier in THIS transaction is a valid CAS target.
@@ -195,7 +201,8 @@ impl WriteTransaction {
             .map(std::sync::Arc::new);
 
         // Full REPLACE (no PATCH merge): the provided map becomes the node's
-        // entire property state.
+        // entire property state. Re-stamp the immutable namespace (#3349).
+        let properties = namespace::restamp_namespace(properties, &node.properties);
         self.buffer.add(BufferedWrite::UpdateNode {
             node_id,
             version_id,
@@ -232,6 +239,10 @@ impl WriteTransaction {
             .into());
         }
 
+        // Reject engine-reserved keys on the user-supplied replacement map
+        // (Issue #3349); the immutable namespace is re-stamped below.
+        namespace::reject_reserved_keys(&properties)?;
+
         let edge = match self.read_own_edge(edge_id) {
             Ok(edge) => edge,
             Err(_) => {
@@ -264,7 +275,9 @@ impl WriteTransaction {
             .filter(|p| !p.is_empty())
             .map(std::sync::Arc::new);
 
-        // Full REPLACE of properties; source/target/label preserved.
+        // Full REPLACE of properties; source/target/label preserved. Re-stamp
+        // the immutable namespace (#3349).
+        let properties = namespace::restamp_namespace(properties, &edge.properties);
         self.buffer.add(BufferedWrite::UpdateEdge {
             edge_id,
             version_id,

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -1690,6 +1690,10 @@ impl WriteOps for WriteTransaction {
                 .into());
             }
 
+            // A namespace is immutable after creation: reject an explicit
+            // namespace on this update rather than silently ignoring it (#3349).
+            namespace::reject_namespace_on_update(options.namespace.as_ref())?;
+
             // Reject engine-reserved keys on the incoming PATCH (Issue #3349):
             // a user may not set/overwrite a namespace/shred ride-along key.
             namespace::reject_reserved_keys(&properties)?;
@@ -1795,6 +1799,10 @@ impl WriteOps for WriteTransaction {
                 .into());
             }
 
+            // A namespace is immutable after creation: reject an explicit
+            // namespace on this update rather than silently ignoring it (#3349).
+            namespace::reject_namespace_on_update(options.namespace.as_ref())?;
+
             // Reject engine-reserved keys on the incoming PATCH (Issue #3349).
             namespace::reject_reserved_keys(&properties)?;
 
@@ -1884,6 +1892,10 @@ impl WriteOps for WriteTransaction {
                 .into());
             }
 
+            // A namespace is immutable after creation: reject an explicit
+            // namespace on this replace rather than silently ignoring it (#3349).
+            namespace::reject_namespace_on_update(options.namespace.as_ref())?;
+
             // Reject engine-reserved keys on the user-supplied overwrite map
             // (Issue #3349); the immutable namespace is re-stamped from the
             // existing node inside `buffer_node_replace`.
@@ -1911,6 +1923,10 @@ impl WriteOps for WriteTransaction {
                 }
                 .into());
             }
+
+            // A namespace is immutable after creation: reject an explicit
+            // namespace on this replace rather than silently ignoring it (#3349).
+            namespace::reject_namespace_on_update(options.namespace.as_ref())?;
 
             // Reject engine-reserved keys on the user-supplied overwrite map
             // (Issue #3349); the immutable namespace is re-stamped from the

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -21,6 +21,7 @@ use crate::core::hlc::{
 };
 use crate::core::id::{EdgeId, IdGenerator, NodeId, VersionId};
 use crate::core::interning::GLOBAL_INTERNER;
+use crate::core::namespace;
 use crate::core::property::{PropertyMap, PropertyMapBuilder, PropertyValue};
 use crate::core::provenance::Provenance;
 use crate::core::temporal::{Timestamp, time};
@@ -1147,6 +1148,10 @@ impl WriteTransaction {
         let existing = self.read_own_node(node_id)?;
         let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
 
+        // Re-stamp the immutable namespace from the existing node (Issue #3349)
+        // so a full overwrite (replace / remove-property) can never drop it.
+        let properties = namespace::restamp_namespace(properties, &existing.properties);
+
         // A replace may add, change, OR remove vector properties; mark the
         // buffer so the temporal vector index is notified on commit if either
         // the old or the new state carries a vector.
@@ -1223,6 +1228,10 @@ impl WriteTransaction {
 
         let edge_id = edge.id;
         let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
+
+        // Re-stamp the immutable namespace from the existing edge (Issue #3349)
+        // so a full overwrite (replace / remove-property) can never drop it.
+        let properties = namespace::restamp_namespace(properties, &edge.properties);
 
         // A replace may add/change/remove vector properties.
         if !self.buffer.has_vector_operations()
@@ -1511,10 +1520,20 @@ impl WriteOps for WriteTransaction {
                 .into());
             }
 
+            // Reject any engine-reserved property key on the user-supplied map
+            // BEFORE stamping the namespace (Issue #3349): a caller may not
+            // forge/overwrite a `__aletheia_*` / `__shred_*` ride-along key.
+            namespace::reject_reserved_keys(&properties)?;
+
             // Generate IDs
             let node_id = NodeId::new_unchecked(self.node_id_gen.next()?);
             let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
             let label_interned = GLOBAL_INTERNER.intern(label)?;
+
+            // Stamp the namespace ride-along (Issue #3349). `None` ⇒ default,
+            // which is deliberately NOT stamped (byte-identical to legacy data).
+            let ns = options.namespace.clone().unwrap_or_default();
+            let properties = namespace::stamp_namespace(properties, &ns);
 
             // Get timestamp: use provided valid_from or default to transaction start time
             let timestamp = self.start_timestamp;
@@ -1564,10 +1583,17 @@ impl WriteOps for WriteTransaction {
                 .into());
             }
 
+            // Reject engine-reserved keys before stamping the namespace (#3349).
+            namespace::reject_reserved_keys(&properties)?;
+
             // Generate IDs
             let edge_id = EdgeId::new_unchecked(self.edge_id_gen.next()?);
             let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
             let label_interned = GLOBAL_INTERNER.intern(label)?;
+
+            // Stamp the namespace ride-along (Issue #3349); default not stamped.
+            let ns = options.namespace.clone().unwrap_or_default();
+            let properties = namespace::stamp_namespace(properties, &ns);
 
             // Get timestamp: use provided valid_from or default to transaction start time
             let timestamp = self.start_timestamp;
@@ -1664,6 +1690,10 @@ impl WriteOps for WriteTransaction {
                 .into());
             }
 
+            // Reject engine-reserved keys on the incoming PATCH (Issue #3349):
+            // a user may not set/overwrite a namespace/shred ride-along key.
+            namespace::reject_reserved_keys(&properties)?;
+
             // Get current node to preserve label and existing properties.
             // Buffer-aware read (Issue #3417): read-your-own-writes so an
             // update of a node created/updated earlier in THIS transaction
@@ -1681,8 +1711,11 @@ impl WriteOps for WriteTransaction {
                 builder = builder.insert_by_key(*key, value.clone());
             }
 
-            // Build the final merged property map
-            let merged_properties = builder.build();
+            // Build the final merged property map, then re-stamp the immutable
+            // namespace from the existing node (Issue #3349). A PATCH inherently
+            // preserves the ride-along key; re-stamping makes that a hard
+            // guarantee that no update path can ever drop or change it.
+            let merged_properties = namespace::restamp_namespace(builder.build(), &node.properties);
 
             // A PATCH may drop or downgrade a vector (e.g. overwrite the
             // embedding key with a scalar, or remove it): mark the buffer so
@@ -1762,6 +1795,9 @@ impl WriteOps for WriteTransaction {
                 .into());
             }
 
+            // Reject engine-reserved keys on the incoming PATCH (Issue #3349).
+            namespace::reject_reserved_keys(&properties)?;
+
             // Get current edge to preserve source, target, label and existing
             // properties. Buffer-aware read (Issue #3417): read-your-own-writes
             // so an update of a same-tx-created/updated edge merges onto the
@@ -1778,8 +1814,9 @@ impl WriteOps for WriteTransaction {
                 builder = builder.insert_by_key(*key, value.clone());
             }
 
-            // Build the final merged property map
-            let merged_properties = builder.build();
+            // Build the merged map, then re-stamp the immutable namespace from
+            // the existing edge (Issue #3349).
+            let merged_properties = namespace::restamp_namespace(builder.build(), &edge.properties);
 
             // Get timestamp: use provided valid_from or default to transaction start time
             let timestamp = self.start_timestamp;
@@ -1847,6 +1884,11 @@ impl WriteOps for WriteTransaction {
                 .into());
             }
 
+            // Reject engine-reserved keys on the user-supplied overwrite map
+            // (Issue #3349); the immutable namespace is re-stamped from the
+            // existing node inside `buffer_node_replace`.
+            namespace::reject_reserved_keys(&properties)?;
+
             let label_interned = GLOBAL_INTERNER.intern(label)?;
             self.buffer_node_replace(node_id, label_interned, properties, options)
         })();
@@ -1870,6 +1912,11 @@ impl WriteOps for WriteTransaction {
                 .into());
             }
 
+            // Reject engine-reserved keys on the user-supplied overwrite map
+            // (Issue #3349); the immutable namespace is re-stamped from the
+            // existing edge inside `buffer_edge_replace`.
+            namespace::reject_reserved_keys(&properties)?;
+
             // Verify the edge exists and capture its immutable endpoints/type
             // (read-your-own-writes, Issue #3417). Full overwrite of properties
             // only: source/target/label are preserved from the existing edge.
@@ -1881,6 +1928,15 @@ impl WriteOps for WriteTransaction {
     }
 
     fn remove_node_property(&mut self, node_id: NodeId, key: &str) -> Result<()> {
+        // An engine-reserved key (the namespace ride-along, #3349) is not a
+        // user property and may not be targeted for removal.
+        if namespace::is_reserved_property_key(key) {
+            return Err(namespace::NamespaceError::ReservedPropertyKey {
+                key: key.to_string(),
+            }
+            .into())
+            .record_error_metric();
+        }
         // Check transaction state up front so an absent-key no-op on an
         // inactive transaction still reports the state error.
         if self.state != TxState::Active {
@@ -1919,6 +1975,14 @@ impl WriteOps for WriteTransaction {
     }
 
     fn remove_edge_property(&mut self, edge_id: EdgeId, key: &str) -> Result<()> {
+        // An engine-reserved key (#3349) is not a user property.
+        if namespace::is_reserved_property_key(key) {
+            return Err(namespace::NamespaceError::ReservedPropertyKey {
+                key: key.to_string(),
+            }
+            .into())
+            .record_error_metric();
+        }
         if self.state != TxState::Active {
             return Err(TransactionError::InvalidState {
                 current: format!("{:?}", self.state),

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -42,6 +42,9 @@ pub enum Error {
     /// Derivation-lineage validation errors (Issue #3371).
     #[error("Lineage error: {0}")]
     Lineage(crate::core::lineage::LineageError),
+    /// Namespace validation / registry errors (Issue #3349).
+    #[error("Namespace error: {0}")]
+    Namespace(crate::core::namespace::NamespaceError),
     /// Query-related errors.
     #[error("Query error: {0}")]
     Query(QueryError),
@@ -93,6 +96,7 @@ impl Error {
                 Error::Temporal(_) => crate::observability::ErrorCategory::Temporal,
                 Error::Provenance(_) => crate::observability::ErrorCategory::Other,
                 Error::Lineage(_) => crate::observability::ErrorCategory::Other,
+                Error::Namespace(_) => crate::observability::ErrorCategory::Other,
                 Error::Query(_) => crate::observability::ErrorCategory::Query,
                 Error::Transaction(_) => crate::observability::ErrorCategory::Transaction,
                 Error::Vector(_) => crate::observability::ErrorCategory::Vector,
@@ -153,6 +157,12 @@ impl From<crate::core::provenance::ProvenanceError> for Error {
 impl From<crate::core::lineage::LineageError> for Error {
     fn from(e: crate::core::lineage::LineageError) -> Self {
         Error::Lineage(e)
+    }
+}
+
+impl From<crate::core::namespace::NamespaceError> for Error {
+    fn from(e: crate::core::namespace::NamespaceError) -> Self {
+        Error::Namespace(e)
     }
 }
 

--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -101,6 +101,26 @@ impl Node {
         self.properties.get(key)
     }
 
+    /// The node's namespace (Issue #3349), read from the reserved ride-along
+    /// property key. A node carrying no key — every `default` and every legacy
+    /// node — resolves to
+    /// [`Namespace::DEFAULT`](crate::core::namespace::Namespace::DEFAULT).
+    #[inline]
+    #[must_use]
+    pub fn namespace(&self) -> crate::core::namespace::Namespace {
+        crate::core::namespace::namespace_of(&self.properties)
+    }
+
+    /// A user-facing copy of the node's properties with all engine-reserved
+    /// keys (the `__aletheia_*` / `__shred_*` prefixes, including the namespace
+    /// ride-along) elided (Issue #3349). The namespace is surfaced separately
+    /// via [`namespace`](Self::namespace).
+    #[inline]
+    #[must_use]
+    pub fn user_properties(&self) -> crate::core::property::PropertyMap {
+        crate::core::namespace::user_facing_properties(&self.properties)
+    }
+
     /// Check if this node has a specific label.
     #[inline]
     pub fn has_label(&self, label: InternedString) -> bool {
@@ -231,6 +251,24 @@ impl Edge {
     #[inline]
     pub fn get_property(&self, key: &str) -> Option<&crate::core::property::PropertyValue> {
         self.properties.get(key)
+    }
+
+    /// The edge's namespace (Issue #3349), read from the reserved ride-along
+    /// property key. An edge carrying no key resolves to
+    /// [`Namespace::DEFAULT`](crate::core::namespace::Namespace::DEFAULT).
+    #[inline]
+    #[must_use]
+    pub fn namespace(&self) -> crate::core::namespace::Namespace {
+        crate::core::namespace::namespace_of(&self.properties)
+    }
+
+    /// A user-facing copy of the edge's properties with all engine-reserved
+    /// keys elided (Issue #3349); the namespace is surfaced separately via
+    /// [`namespace`](Self::namespace).
+    #[inline]
+    #[must_use]
+    pub fn user_properties(&self) -> crate::core::property::PropertyMap {
+        crate::core::namespace::user_facing_properties(&self.properties)
     }
 
     /// Check if this edge has a specific label.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -37,6 +37,7 @@ pub mod hlc;
 pub mod id;
 pub mod interning;
 pub mod lineage;
+pub mod namespace;
 pub mod observer;
 pub mod property;
 pub mod provenance;
@@ -59,6 +60,7 @@ pub use lineage::{
     LineageClosure, LineageEntry, LineageError, LineageQueryOptions, LineageRecord, LineageRef,
     LineageStore,
 };
+pub use namespace::{NAMESPACE_KEY, Namespace, NamespaceError};
 pub use property::{PropertyKey, PropertyMap, PropertyMapBuilder, PropertyValue};
 pub use provenance::{
     Provenance, ProvenanceBuilder, ProvenanceError, ProvenanceFilter, ProvenanceFilterError,

--- a/src/core/namespace.rs
+++ b/src/core/namespace.rs
@@ -1,0 +1,481 @@
+//! Agent-scoped memory namespaces — core model (Issue #3349, PR1).
+//!
+//! A **namespace** is a stable string label on the *ownership / visibility*
+//! axis, orthogonal to the type `label` axis. A node's `label` says *what kind
+//! of thing* it is (`Person`); its `namespace` says *whose scope it lives in*
+//! (`agent:planner`). Every node/edge belongs to exactly one namespace, fixed
+//! at creation and **immutable for the life of the entity**.
+//!
+//! # Storage: reserved-key ride-along (no WAL format change)
+//!
+//! Following the #3596 (`replace_*`) and #3604 (CAS/lease) precedent, the
+//! namespace is persisted as a **reserved, engine-owned property-map entry**
+//! ([`NAMESPACE_KEY`]) written through the *existing*
+//! `CreateNode`/`UpdateNode`/`CreateEdge`/`UpdateEdge` ops — no new
+//! `WalOperation` field and no `WAL_VERSION` bump. Because it rides an existing
+//! property map, it round-trips for free through WAL replay, anchor/delta
+//! reconstruction, cold-tier migration, and `.albk` backup. A legacy entity
+//! simply lacks the key ⇒ it resolves to [`Namespace::DEFAULT`].
+//!
+//! To keep the `default` namespace byte-identical to pre-namespace data (and to
+//! preserve exact back-compat for omitted-namespace writes), the ride-along key
+//! is stamped **only for non-default namespaces**; a `default` entity carries no
+//! key at all, exactly like a legacy one.
+//!
+//! # Reserved property-key policy
+//!
+//! The **entire** `__aletheia_*` property-key prefix is reserved for
+//! engine-owned ride-along keys (not just [`NAMESPACE_KEY`]). The `__shred_*`
+//! prefix is likewise reserved for the GDPR crypto-shred lane. Any **user**
+//! write whose property map contains a key with either prefix is rejected with
+//! a structured [`NamespaceError::ReservedPropertyKey`] (→ MCP
+//! `INVALID_ARGUMENT`) at the central write-validation seam, so a caller can
+//! never forge or overwrite a namespace marker. Engine-reserved keys are
+//! **elided** from every user-facing property view and surfaced instead as a
+//! first-class `namespace` field.
+
+use crate::core::interning::GLOBAL_INTERNER;
+use crate::core::property::{PropertyMap, PropertyMapBuilder, PropertyValue};
+
+/// The engine-owned property key under which an entity's namespace rides along
+/// its property map. Reserved: rejected on user writes, elided from user-facing
+/// views. See the [module docs](self).
+pub const NAMESPACE_KEY: &str = "__aletheia_ns";
+
+/// Reserved engine-owned property-key prefix. The **entire** prefix is reserved
+/// (Issue #3349 coordinator ruling), not just [`NAMESPACE_KEY`].
+pub const ALETHEIA_RESERVED_PREFIX: &str = "__aletheia_";
+
+/// Reserved property-key prefix owned by the GDPR crypto-shred lane. User
+/// writes carrying it are rejected here so the two lanes never collide.
+pub const SHRED_RESERVED_PREFIX: &str = "__shred_";
+
+/// Maximum length of a namespace identifier, in bytes.
+pub const MAX_NAMESPACE_LEN: usize = 128;
+
+/// The read-selector keyword that is **not** a creatable namespace name.
+const ALL_SELECTOR: &str = "all";
+
+/// Whether a property key is engine-reserved (owned by the namespace ride-along
+/// or the crypto-shred lane) and therefore forbidden on user writes and elided
+/// from user-facing views.
+///
+/// This is the single source of truth for the reserved-prefix policy; wire it
+/// into every place that either validates an incoming user property map or
+/// renders one to a user-facing payload.
+#[inline]
+#[must_use]
+pub fn is_reserved_property_key(key: &str) -> bool {
+    key.starts_with(ALETHEIA_RESERVED_PREFIX) || key.starts_with(SHRED_RESERVED_PREFIX)
+}
+
+/// A validated namespace identifier (Issue #3349).
+///
+/// Construct via [`Namespace::new`] (validating) or [`Namespace::default`] (the
+/// reserved [`Namespace::DEFAULT`] namespace). Identifier rules: non-empty, at
+/// most [`MAX_NAMESPACE_LEN`] bytes, charset `[A-Za-z0-9._:/-]`, case-sensitive.
+/// The read-selector keyword `all` is **not** a creatable name.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Namespace(String);
+
+impl Namespace {
+    /// The implicit default namespace. Any entity created without an explicit
+    /// namespace — and every legacy entity carrying no ride-along key — lives
+    /// here.
+    pub const DEFAULT: &'static str = "default";
+
+    /// Validate and construct a namespace from a string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NamespaceError::InvalidName`] (→ MCP `INVALID_ARGUMENT`, with
+    /// the offending value carried in the error) when `name` is empty, exceeds
+    /// [`MAX_NAMESPACE_LEN`] bytes, contains a character outside
+    /// `[A-Za-z0-9._:/-]`, or is the reserved read-selector keyword `all`.
+    pub fn new(name: impl Into<String>) -> Result<Self, NamespaceError> {
+        let name = name.into();
+        if name.is_empty() {
+            return Err(NamespaceError::InvalidName {
+                name,
+                reason: "namespace must not be empty".to_string(),
+            });
+        }
+        if name.len() > MAX_NAMESPACE_LEN {
+            return Err(NamespaceError::InvalidName {
+                reason: format!(
+                    "namespace must be at most {MAX_NAMESPACE_LEN} bytes (got {})",
+                    name.len()
+                ),
+                name,
+            });
+        }
+        if name == ALL_SELECTOR {
+            return Err(NamespaceError::InvalidName {
+                name,
+                reason: "'all' is a read-scope selector, not a creatable namespace".to_string(),
+            });
+        }
+        if let Some(bad) = name
+            .chars()
+            .find(|c| !matches!(c, 'A'..='Z' | 'a'..='z' | '0'..='9' | '.' | '_' | ':' | '/' | '-'))
+        {
+            return Err(NamespaceError::InvalidName {
+                reason: format!(
+                    "namespace contains invalid character {bad:?}; allowed charset is \
+                     [A-Za-z0-9._:/-]"
+                ),
+                name,
+            });
+        }
+        Ok(Namespace(name))
+    }
+
+    /// The namespace as a string slice.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Whether this is the implicit [`Namespace::DEFAULT`] namespace.
+    #[inline]
+    #[must_use]
+    pub fn is_default(&self) -> bool {
+        self.0 == Self::DEFAULT
+    }
+
+    /// Consume into the owned string.
+    #[inline]
+    #[must_use]
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl Default for Namespace {
+    fn default() -> Self {
+        Namespace(Self::DEFAULT.to_string())
+    }
+}
+
+impl std::fmt::Display for Namespace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::str::FromStr for Namespace {
+    type Err = NamespaceError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Namespace::new(s)
+    }
+}
+
+/// Structured namespace errors, mapped to the #3234 MCP error codes at the MCP
+/// boundary (see `crate::mcp::error`). All are caller faults and never
+/// retriable.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum NamespaceError {
+    /// A namespace name failed validation (empty, too long, bad charset, or the
+    /// reserved `all` selector). Maps to `INVALID_ARGUMENT`; the offending
+    /// `name` is carried for the caller.
+    #[error("invalid namespace name {name:?}: {reason}")]
+    InvalidName {
+        /// The offending value.
+        name: String,
+        /// Why it was rejected.
+        reason: String,
+    },
+    /// A referenced namespace is not registered. Maps to `NOT_FOUND`; the
+    /// `namespace` name is carried for the caller.
+    #[error("namespace {namespace:?} not found")]
+    NotFound {
+        /// The missing namespace name.
+        namespace: String,
+    },
+    /// A `create_namespace` collided with an existing registration (including
+    /// the implicit `default`). Maps to `CONFLICT`.
+    #[error("namespace {namespace:?} already exists")]
+    AlreadyExists {
+        /// The conflicting namespace name.
+        namespace: String,
+    },
+    /// A user write carried an engine-reserved property key (`__aletheia_*` or
+    /// `__shred_*`). Maps to `INVALID_ARGUMENT`.
+    #[error(
+        "property key {key:?} is engine-reserved (the '__aletheia_*' and '__shred_*' prefixes \
+         are reserved) and may not be set by a user write"
+    )]
+    ReservedPropertyKey {
+        /// The offending reserved key.
+        key: String,
+    },
+}
+
+// ============================================================================
+// Ride-along read/write helpers
+// ============================================================================
+
+/// Extract an entity's namespace from its property map (Issue #3349).
+///
+/// A map missing [`NAMESPACE_KEY`] — every `default` entity and every legacy
+/// entity — resolves to [`Namespace::DEFAULT`]. A stored value that somehow
+/// fails validation also degrades to the default rather than erroring (the
+/// engine controls what it writes, so this is defensive only).
+#[must_use]
+pub fn namespace_of(properties: &PropertyMap) -> Namespace {
+    match properties
+        .get(NAMESPACE_KEY)
+        .and_then(PropertyValue::as_str)
+    {
+        Some(s) => Namespace::new(s).unwrap_or_default(),
+        None => Namespace::default(),
+    }
+}
+
+/// Return the first engine-reserved key present in an incoming **user**
+/// property map, if any. Used by the write-validation seam to reject a forged
+/// namespace/shred marker before it can be stamped or committed.
+#[must_use]
+pub fn first_reserved_key(properties: &PropertyMap) -> Option<String> {
+    for (key, _) in properties.iter() {
+        if let Some(name) = GLOBAL_INTERNER.resolve_with(*key, |s| s.to_string())
+            && is_reserved_property_key(&name)
+        {
+            return Some(name);
+        }
+    }
+    None
+}
+
+/// Reject an incoming user property map that carries any engine-reserved key.
+///
+/// This is the central enforcement point for the reserved-prefix policy; call
+/// it on the caller-supplied map at every write entry point, **before** the
+/// namespace is stamped (so the engine's own stamp is never rejected).
+///
+/// # Errors
+///
+/// [`NamespaceError::ReservedPropertyKey`] naming the offending key.
+pub fn reject_reserved_keys(properties: &PropertyMap) -> Result<(), NamespaceError> {
+    match first_reserved_key(properties) {
+        Some(key) => Err(NamespaceError::ReservedPropertyKey { key }),
+        None => Ok(()),
+    }
+}
+
+/// Stamp the namespace ride-along key onto a **create** property map.
+///
+/// The default namespace is deliberately **not** stamped: a `default` entity
+/// carries no ride-along key, keeping it byte-identical to a legacy entity so
+/// omitted-namespace behavior is unchanged. A non-default namespace is written
+/// as a [`PropertyValue::String`] under [`NAMESPACE_KEY`].
+#[must_use]
+pub fn stamp_namespace(properties: PropertyMap, namespace: &Namespace) -> PropertyMap {
+    if namespace.is_default() {
+        return properties;
+    }
+    PropertyMapBuilder::from_map(properties)
+        .insert(NAMESPACE_KEY, PropertyValue::from(namespace.as_str()))
+        .build()
+}
+
+/// Re-stamp the **immutable** namespace onto a full-overwrite / merged property
+/// map, reading it from the entity's existing property map.
+///
+/// A namespace is fixed at creation and can never be dropped or changed, so
+/// every update PATCH, `replace_*`, CAS, and lease-claim re-stamps it from the
+/// existing entity. If the existing entity is in the default namespace there is
+/// nothing to carry (and the new map already lacks the key).
+#[must_use]
+pub fn restamp_namespace(new_properties: PropertyMap, existing: &PropertyMap) -> PropertyMap {
+    let ns = namespace_of(existing);
+    stamp_namespace(new_properties, &ns)
+}
+
+/// Produce a user-facing copy of a property map with **all** engine-reserved
+/// keys elided (Issue #3349). The namespace is surfaced separately as a
+/// first-class field via [`namespace_of`]; the ride-along key must never leak
+/// into a user-facing payload.
+///
+/// Returns the original map unchanged (a cheap `Arc` clone) when it carries no
+/// reserved key — the overwhelmingly common case — so the default namespace
+/// pays nothing.
+#[must_use]
+pub fn user_facing_properties(properties: &PropertyMap) -> PropertyMap {
+    if first_reserved_key(properties).is_none() {
+        return properties.clone();
+    }
+    let mut builder = PropertyMapBuilder::new();
+    for (key, value) in properties.iter() {
+        let keep = GLOBAL_INTERNER
+            .resolve_with(*key, |s| !is_reserved_property_key(s))
+            .unwrap_or(true);
+        if keep {
+            builder = builder.insert_by_key(*key, value.clone());
+        }
+    }
+    builder.build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::property::PropertyMapBuilder;
+
+    #[test]
+    fn valid_names_accepted() {
+        for name in [
+            "default",
+            "agent:planner",
+            "session:2026-07-08-run3",
+            "shared",
+            "a",
+            "A.b_c-d/e:f",
+        ] {
+            assert!(Namespace::new(name).is_ok(), "{name} should be valid");
+        }
+    }
+
+    #[test]
+    fn empty_name_rejected_with_value() {
+        let err = Namespace::new("").unwrap_err();
+        match err {
+            NamespaceError::InvalidName { name, .. } => assert_eq!(name, ""),
+            other => panic!("expected InvalidName, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bad_charset_rejected_with_value() {
+        let err = Namespace::new("has space").unwrap_err();
+        match err {
+            NamespaceError::InvalidName { name, .. } => assert_eq!(name, "has space"),
+            other => panic!("expected InvalidName, got {other:?}"),
+        }
+        assert!(Namespace::new("emoji😀").is_err());
+        assert!(Namespace::new("comma,sep").is_err());
+    }
+
+    #[test]
+    fn too_long_rejected() {
+        let long = "a".repeat(MAX_NAMESPACE_LEN + 1);
+        assert!(Namespace::new(&long).is_err());
+        let ok = "a".repeat(MAX_NAMESPACE_LEN);
+        assert!(Namespace::new(&ok).is_ok());
+    }
+
+    #[test]
+    fn all_selector_rejected() {
+        assert!(matches!(
+            Namespace::new("all"),
+            Err(NamespaceError::InvalidName { .. })
+        ));
+        // Case-sensitive: "All" is a distinct, valid name.
+        assert!(Namespace::new("All").is_ok());
+    }
+
+    #[test]
+    fn default_is_default() {
+        assert!(Namespace::default().is_default());
+        assert_eq!(Namespace::default().as_str(), "default");
+        assert!(Namespace::new("default").unwrap().is_default());
+        assert!(!Namespace::new("agent:x").unwrap().is_default());
+    }
+
+    #[test]
+    fn reserved_prefix_policy() {
+        assert!(is_reserved_property_key("__aletheia_ns"));
+        assert!(is_reserved_property_key("__aletheia_foo"));
+        assert!(is_reserved_property_key("__shred_x"));
+        assert!(!is_reserved_property_key("name"));
+        assert!(!is_reserved_property_key("_aletheia_ns"));
+        assert!(!is_reserved_property_key("aletheia_ns"));
+    }
+
+    #[test]
+    fn namespace_key_is_reserved() {
+        assert!(is_reserved_property_key(NAMESPACE_KEY));
+    }
+
+    #[test]
+    fn stamp_and_read_round_trip() {
+        let ns = Namespace::new("agent:planner").unwrap();
+        let props = PropertyMapBuilder::new().insert("name", "Alice").build();
+        let stamped = stamp_namespace(props, &ns);
+        assert_eq!(namespace_of(&stamped), ns);
+        // The reserved key is present in raw storage form...
+        assert!(stamped.contains_key(NAMESPACE_KEY));
+        // ...but elided from the user-facing view.
+        let view = user_facing_properties(&stamped);
+        assert!(!view.contains_key(NAMESPACE_KEY));
+        assert_eq!(
+            view.get("name").and_then(PropertyValue::as_str),
+            Some("Alice")
+        );
+    }
+
+    #[test]
+    fn default_namespace_not_stamped() {
+        let props = PropertyMapBuilder::new().insert("name", "Bob").build();
+        let stamped = stamp_namespace(props.clone(), &Namespace::default());
+        // No ride-along key: byte-identical to legacy data.
+        assert!(!stamped.contains_key(NAMESPACE_KEY));
+        assert_eq!(namespace_of(&stamped), Namespace::default());
+    }
+
+    #[test]
+    fn missing_key_resolves_to_default() {
+        let props = PropertyMapBuilder::new().insert("name", "Legacy").build();
+        assert_eq!(namespace_of(&props), Namespace::default());
+    }
+
+    #[test]
+    fn restamp_preserves_immutable_namespace() {
+        let ns = Namespace::new("agent:planner").unwrap();
+        let existing = stamp_namespace(
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+            &ns,
+        );
+        // A full-overwrite map (no ns key) re-stamps back to the original ns.
+        let overwrite = PropertyMapBuilder::new().insert("name", "Alice2").build();
+        let restamped = restamp_namespace(overwrite, &existing);
+        assert_eq!(namespace_of(&restamped), ns);
+    }
+
+    #[test]
+    fn reject_reserved_keys_catches_forgery() {
+        let props = PropertyMapBuilder::new()
+            .insert("name", "Alice")
+            .insert(NAMESPACE_KEY, "forged")
+            .build();
+        assert!(matches!(
+            reject_reserved_keys(&props),
+            Err(NamespaceError::ReservedPropertyKey { .. })
+        ));
+
+        let shred = PropertyMapBuilder::new().insert("__shred_x", 1).build();
+        assert!(reject_reserved_keys(&shred).is_err());
+
+        let clean = PropertyMapBuilder::new().insert("name", "Alice").build();
+        assert!(reject_reserved_keys(&clean).is_ok());
+    }
+
+    #[test]
+    fn user_facing_properties_no_reserved_keys() {
+        let props = PropertyMapBuilder::new()
+            .insert("name", "Alice")
+            .insert(NAMESPACE_KEY, "agent:x")
+            .build();
+        let view = user_facing_properties(&props);
+        for (key, _) in view.iter() {
+            let name = GLOBAL_INTERNER
+                .resolve_with(*key, |s| s.to_string())
+                .unwrap();
+            assert!(
+                !is_reserved_property_key(&name),
+                "reserved key {name} leaked into user-facing view"
+            );
+        }
+    }
+}

--- a/src/core/namespace.rs
+++ b/src/core/namespace.rs
@@ -210,6 +210,12 @@ pub enum NamespaceError {
         /// The offending reserved key.
         key: String,
     },
+    /// A namespace was explicitly supplied to a non-create write
+    /// (update / replace / CAS / lease-claim). A namespace is fixed at creation,
+    /// so passing one to an update-class op is a caller error rather than a
+    /// silent no-op. Maps to `INVALID_ARGUMENT`.
+    #[error("namespace is immutable and cannot be changed after creation")]
+    Immutable,
 }
 
 // ============================================================================
@@ -223,7 +229,7 @@ pub enum NamespaceError {
 /// fails validation also degrades to the default rather than erroring (the
 /// engine controls what it writes, so this is defensive only).
 #[must_use]
-pub fn namespace_of(properties: &PropertyMap) -> Namespace {
+pub(crate) fn namespace_of(properties: &PropertyMap) -> Namespace {
     match properties
         .get(NAMESPACE_KEY)
         .and_then(PropertyValue::as_str)
@@ -237,7 +243,12 @@ pub fn namespace_of(properties: &PropertyMap) -> Namespace {
 /// property map, if any. Used by the write-validation seam to reject a forged
 /// namespace/shred marker before it can be stamped or committed.
 #[must_use]
-pub fn first_reserved_key(properties: &PropertyMap) -> Option<String> {
+pub(crate) fn first_reserved_key(properties: &PropertyMap) -> Option<String> {
+    // Fast path: an empty property map (a common no-property write) can carry no
+    // reserved key, so skip the per-key interner-resolve scan entirely.
+    if properties.is_empty() {
+        return None;
+    }
     for (key, _) in properties.iter() {
         if let Some(name) = GLOBAL_INTERNER.resolve_with(*key, |s| s.to_string())
             && is_reserved_property_key(&name)
@@ -257,11 +268,32 @@ pub fn first_reserved_key(properties: &PropertyMap) -> Option<String> {
 /// # Errors
 ///
 /// [`NamespaceError::ReservedPropertyKey`] naming the offending key.
-pub fn reject_reserved_keys(properties: &PropertyMap) -> Result<(), NamespaceError> {
+pub(crate) fn reject_reserved_keys(properties: &PropertyMap) -> Result<(), NamespaceError> {
     match first_reserved_key(properties) {
         Some(key) => Err(NamespaceError::ReservedPropertyKey { key }),
         None => Ok(()),
     }
+}
+
+/// Reject an explicit namespace supplied to a **non-create** write
+/// (update / replace / CAS / lease-claim).
+///
+/// A namespace is fixed at creation and immutable thereafter; the update-class
+/// paths re-stamp it from the existing entity, so an explicit namespace on such
+/// a call would otherwise be a **silent no-op success**. Rejecting it up front
+/// keeps the surface never-silently-wrong.
+///
+/// # Errors
+///
+/// [`NamespaceError::Immutable`] (→ MCP `INVALID_ARGUMENT`) when `namespace` is
+/// `Some`.
+pub(crate) fn reject_namespace_on_update(
+    namespace: Option<&Namespace>,
+) -> Result<(), NamespaceError> {
+    if namespace.is_some() {
+        return Err(NamespaceError::Immutable);
+    }
+    Ok(())
 }
 
 /// Stamp the namespace ride-along key onto a **create** property map.
@@ -271,7 +303,7 @@ pub fn reject_reserved_keys(properties: &PropertyMap) -> Result<(), NamespaceErr
 /// omitted-namespace behavior is unchanged. A non-default namespace is written
 /// as a [`PropertyValue::String`] under [`NAMESPACE_KEY`].
 #[must_use]
-pub fn stamp_namespace(properties: PropertyMap, namespace: &Namespace) -> PropertyMap {
+pub(crate) fn stamp_namespace(properties: PropertyMap, namespace: &Namespace) -> PropertyMap {
     if namespace.is_default() {
         return properties;
     }
@@ -288,7 +320,10 @@ pub fn stamp_namespace(properties: PropertyMap, namespace: &Namespace) -> Proper
 /// existing entity. If the existing entity is in the default namespace there is
 /// nothing to carry (and the new map already lacks the key).
 #[must_use]
-pub fn restamp_namespace(new_properties: PropertyMap, existing: &PropertyMap) -> PropertyMap {
+pub(crate) fn restamp_namespace(
+    new_properties: PropertyMap,
+    existing: &PropertyMap,
+) -> PropertyMap {
     let ns = namespace_of(existing);
     stamp_namespace(new_properties, &ns)
 }
@@ -302,7 +337,7 @@ pub fn restamp_namespace(new_properties: PropertyMap, existing: &PropertyMap) ->
 /// reserved key — the overwhelmingly common case — so the default namespace
 /// pays nothing.
 #[must_use]
-pub fn user_facing_properties(properties: &PropertyMap) -> PropertyMap {
+pub(crate) fn user_facing_properties(properties: &PropertyMap) -> PropertyMap {
     if first_reserved_key(properties).is_none() {
         return properties.clone();
     }

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -593,6 +593,13 @@ impl AletheiaDB {
                 crate::db::snapshot::registry_path_for(&config.persistence),
             )?);
 
+            // Namespace registry (Issue #3349): durable sidecar at
+            // `{data_dir}/namespaces.json` when index persistence is enabled,
+            // in-memory-only otherwise. Loaded here so registrations survive restart.
+            let namespaces = Arc::new(crate::db::namespace::NamespaceRegistry::open(
+                crate::db::namespace::registry_path_for(&config.persistence),
+            )?);
+
             let mut db = AletheiaDB {
                 current: Arc::new(CurrentStorage::new()),
                 historical: Arc::new(RwLock::new(HistoricalStorage::from_unified_config(
@@ -628,6 +635,7 @@ impl AletheiaDB {
                     crate::core::changefeed_subscription::ChangefeedBroadcaster::new(),
                 ),
                 snapshots,
+                namespaces,
                 chain: None,
                 _tempdir: None,
             };
@@ -1091,6 +1099,8 @@ impl AletheiaDB {
                 ),
                 // Ephemeral (no index persistence): in-memory-only registry.
                 snapshots: Arc::new(crate::db::snapshot::SnapshotRegistry::in_memory()),
+                // Ephemeral namespace registry (Issue #3349): in-memory only.
+                namespaces: Arc::new(crate::db::namespace::NamespaceRegistry::in_memory()),
                 chain: None,
                 _tempdir: None,
             };

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -40,6 +40,8 @@ pub mod extent;
 pub mod graph_view;
 /// Fact-to-fact derivation lineage API (Issue #3371).
 pub mod lineage;
+/// Agent-scoped memory namespaces: registry + namespaced entity creation (Issue #3349).
+pub mod namespace;
 /// Basic graph operations (CRUD).
 pub mod ops;
 /// Point-in-time restore (PITR) to a transaction-time coordinate (Issue #3374).
@@ -74,6 +76,7 @@ pub use crate::storage::backup::BackupSummary;
 pub use constraint_builder::UniqueConstraintBuilder;
 pub use extent::{LabelExtent, TemporalExtent, TimeBounds};
 pub use lineage::{FactStatus, LineageView, LineageViewEntry};
+pub use namespace::NamespaceInfo;
 pub use ops::NodesAtTime;
 pub use pitr::{PitrCoord, PitrPlan, PitrTarget};
 pub use schema::{EdgeTypeSchema, GraphSchema, LabelSchema, SchemaInstant};
@@ -249,6 +252,16 @@ pub struct AletheiaDB {
     /// a `{data_dir}/snapshots.json` sidecar when index persistence is enabled;
     /// in-memory-only for ephemeral databases. See [`crate::db::snapshot`].
     pub(crate) snapshots: Arc<snapshot::SnapshotRegistry>,
+    /// Agent-scoped namespace registry (Issue #3349).
+    ///
+    /// Maps a namespace name to its `{description, created_at}` metadata so
+    /// namespaces are creatable / listable / describable even when empty.
+    /// Auto-registered on first write to an unknown namespace. Entirely off the
+    /// data write path (a leaf, like [`snapshots`](Self::snapshots)). Durably
+    /// persisted to a `{data_dir}/namespaces.json` sidecar when index
+    /// persistence is enabled; in-memory-only for ephemeral databases. See
+    /// [`crate::db::namespace`].
+    pub(crate) namespaces: Arc<namespace::NamespaceRegistry>,
     /// Opt-in tamper-evident provenance hash chain (Issue #3351).
     ///
     /// `None` unless `config.chain.enabled`. When present, each committed

--- a/src/db/namespace.rs
+++ b/src/db/namespace.rs
@@ -1,0 +1,651 @@
+//! Agent-scoped namespace registry and namespaced entity creation (Issue #3349).
+//!
+//! The registry maps a namespace name to its `{description, created_at}`
+//! metadata so namespaces are **creatable, listable, and describable even when
+//! empty** (a namespace need not contain any entity to exist). Writing to an
+//! unknown namespace **auto-registers** it (create-on-write memory semantics);
+//! there is no strict mode in v1. To mitigate the typo risk that auto-register
+//! introduces, [`AletheiaDB::list_namespaces`] surfaces every registered
+//! namespace so a caller can discover an accidental `agnet:planner`.
+//!
+//! # Durability
+//!
+//! The registry persists as `{data_dir}/namespaces.json` using the same atomic
+//! temp→fsync→rename + quarantine-on-corrupt pattern as `snapshots.json`
+//! ([`crate::db::snapshot`]): a corrupt or unreadable sidecar never bricks
+//! startup — it is quarantined aside (`*.corrupt`) and the registry starts
+//! empty. Ephemeral `AletheiaDB::new()` is in-memory only.
+//!
+//! # The implicit `default` namespace
+//!
+//! [`Namespace::DEFAULT`] is always present and is never written to the sidecar
+//! (so a `default`-only database's file stays empty). It cannot be created
+//! explicitly (that is a `CONFLICT`) or deleted (`INVALID_ARGUMENT`), and it is
+//! always the first entry in a listing.
+
+use crate::core::error::{Error, Result};
+use crate::core::namespace::{Namespace, NamespaceError};
+use crate::core::temporal::{Timestamp, time};
+use crate::db::AletheiaDB;
+use parking_lot::RwLock;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Persisted-format version for the namespace registry sidecar (mirrors the
+/// snapshot registry). Bumped only on an incompatible on-disk change.
+#[cfg(feature = "serde")]
+const PERSIST_FORMAT_VERSION: u32 = 1;
+
+/// Public metadata for a registered namespace (Issue #3349).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NamespaceInfo {
+    /// The namespace name.
+    pub name: String,
+    /// Optional human-readable description.
+    pub description: Option<String>,
+    /// When the namespace was registered (transaction time). The implicit
+    /// `default` namespace reports epoch 0.
+    pub created_at: Timestamp,
+}
+
+/// The on-disk per-entry shape. `created_at` is stored as bare wallclock
+/// microseconds — a creation bookmark needs no HLC-logical precision.
+#[cfg(feature = "serde")]
+#[derive(Serialize, Deserialize)]
+struct PersistedEntry {
+    name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    created_at_micros: i64,
+}
+
+#[cfg(feature = "serde")]
+impl From<&NamespaceInfo> for PersistedEntry {
+    fn from(info: &NamespaceInfo) -> Self {
+        PersistedEntry {
+            name: info.name.clone(),
+            description: info.description.clone(),
+            created_at_micros: info.created_at.wallclock(),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl From<PersistedEntry> for NamespaceInfo {
+    fn from(e: PersistedEntry) -> Self {
+        NamespaceInfo {
+            name: e.name,
+            description: e.description,
+            created_at: Timestamp::from(e.created_at_micros),
+        }
+    }
+}
+
+/// The on-disk registry envelope (versioned, mirrors the snapshot registry).
+#[cfg(feature = "serde")]
+#[derive(Serialize, Deserialize)]
+struct PersistedRegistry {
+    version: u32,
+    namespaces: Vec<PersistedEntry>,
+}
+
+/// Synthetic metadata for the always-present implicit `default` namespace.
+fn default_info() -> NamespaceInfo {
+    NamespaceInfo {
+        name: Namespace::DEFAULT.to_string(),
+        description: Some("The implicit default namespace".to_string()),
+        created_at: Timestamp::from(0),
+    }
+}
+
+/// In-process registry of namespaces, optionally persisted to a sidecar JSON
+/// file. Entirely off the data write path (a leaf; mutating it never touches
+/// current/historical storage, the WAL, or `current_timestamp`).
+pub(crate) struct NamespaceRegistry {
+    entries: RwLock<HashMap<String, NamespaceInfo>>,
+    persist_path: Option<PathBuf>,
+    /// Serializes concurrent disk saves (the in-memory map has its own
+    /// `RwLock`; this guards the temp-file+rename dance and the mutate+save
+    /// critical sections).
+    save_lock: parking_lot::Mutex<()>,
+}
+
+impl NamespaceRegistry {
+    /// An empty, memory-only registry (no file is ever written).
+    pub(crate) fn in_memory() -> Self {
+        Self {
+            entries: RwLock::new(HashMap::new()),
+            persist_path: None,
+            save_lock: parking_lot::Mutex::new(()),
+        }
+    }
+
+    /// Open a registry, loading any existing sidecar at `path`.
+    ///
+    /// Mirrors [`SnapshotRegistry::open`](crate::db::snapshot): a missing file
+    /// yields an empty registry (first run); a corrupt / unparseable /
+    /// unknown-future-version / unreadable file is quarantined aside
+    /// (`*.corrupt`) and startup proceeds with an empty registry rather than
+    /// bricking (a namespace registry is a non-critical bookmark, unlike the
+    /// security-critical auth key store).
+    pub(crate) fn open(path: Option<PathBuf>) -> Result<Self> {
+        let registry = Self {
+            entries: RwLock::new(HashMap::new()),
+            persist_path: path.clone(),
+            save_lock: parking_lot::Mutex::new(()),
+        };
+        #[cfg(feature = "serde")]
+        if let Some(path) = path {
+            match std::fs::read_to_string(&path) {
+                Ok(contents) => match serde_json::from_str::<PersistedRegistry>(&contents) {
+                    Ok(parsed) if parsed.version <= PERSIST_FORMAT_VERSION => {
+                        let mut entries = registry.entries.write();
+                        for entry in parsed.namespaces {
+                            let info: NamespaceInfo = entry.into();
+                            // Never let a persisted `default` shadow the synthetic one.
+                            if info.name != Namespace::DEFAULT {
+                                entries.insert(info.name.clone(), info);
+                            }
+                        }
+                    }
+                    Ok(parsed) => {
+                        log_registry_warning(&format!(
+                            "namespace registry at {} has unsupported future version {} (this \
+                             build understands up to {}); quarantining it and starting empty",
+                            path.display(),
+                            parsed.version,
+                            PERSIST_FORMAT_VERSION
+                        ));
+                        quarantine_corrupt_registry(&path);
+                    }
+                    Err(e) => {
+                        log_registry_warning(&format!(
+                            "failed to parse namespace registry at {} ({e}); quarantining it and \
+                             starting empty",
+                            path.display()
+                        ));
+                        quarantine_corrupt_registry(&path);
+                    }
+                },
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => {
+                    log_registry_warning(&format!(
+                        "failed to read namespace registry at {} ({e}); quarantining it and \
+                         starting empty",
+                        path.display()
+                    ));
+                    quarantine_corrupt_registry(&path);
+                }
+            }
+        }
+        Ok(registry)
+    }
+
+    /// Explicitly create a namespace with an optional description.
+    ///
+    /// # Errors
+    ///
+    /// [`NamespaceError::AlreadyExists`] (→ `CONFLICT`) if the name is already
+    /// registered or is the implicit `default`.
+    pub(crate) fn create(
+        &self,
+        namespace: &Namespace,
+        description: Option<String>,
+    ) -> Result<NamespaceInfo> {
+        if namespace.is_default() {
+            return Err(NamespaceError::AlreadyExists {
+                namespace: namespace.as_str().to_string(),
+            }
+            .into());
+        }
+        let info = NamespaceInfo {
+            name: namespace.as_str().to_string(),
+            description,
+            created_at: time::now(),
+        };
+        let _guard = self.save_lock.lock();
+        {
+            let mut entries = self.entries.write();
+            if entries.contains_key(&info.name) {
+                return Err(NamespaceError::AlreadyExists {
+                    namespace: info.name.clone(),
+                }
+                .into());
+            }
+            entries.insert(info.name.clone(), info.clone());
+        }
+        if let Err(e) = self.save_locked() {
+            self.entries.write().remove(&info.name);
+            return Err(e);
+        }
+        Ok(info)
+    }
+
+    /// Idempotently ensure a namespace is registered (auto-register on write).
+    ///
+    /// A no-op for the implicit `default` namespace and for an
+    /// already-registered name. A newly-registered name is persisted; a persist
+    /// failure rolls back the in-memory insert and surfaces as `Err`.
+    pub(crate) fn ensure_registered(&self, namespace: &Namespace) -> Result<()> {
+        if namespace.is_default() {
+            return Ok(());
+        }
+        let name = namespace.as_str();
+        // Fast path: already present (common case) — no lock churn on the write path.
+        if self.entries.read().contains_key(name) {
+            return Ok(());
+        }
+        let _guard = self.save_lock.lock();
+        let inserted = {
+            let mut entries = self.entries.write();
+            if entries.contains_key(name) {
+                false
+            } else {
+                entries.insert(
+                    name.to_string(),
+                    NamespaceInfo {
+                        name: name.to_string(),
+                        description: None,
+                        created_at: time::now(),
+                    },
+                );
+                true
+            }
+        };
+        if inserted && let Err(e) = self.save_locked() {
+            self.entries.write().remove(name);
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    /// Fetch a namespace's metadata by name, or the synthetic `default` entry.
+    pub(crate) fn get(&self, name: &str) -> Option<NamespaceInfo> {
+        if name == Namespace::DEFAULT {
+            return Some(default_info());
+        }
+        self.entries.read().get(name).cloned()
+    }
+
+    /// List all namespaces: the implicit `default` first, then stored entries
+    /// in a stable order (created_at, then name).
+    pub(crate) fn list(&self) -> Vec<NamespaceInfo> {
+        let mut all: Vec<NamespaceInfo> = self.entries.read().values().cloned().collect();
+        all.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        let mut out = Vec::with_capacity(all.len() + 1);
+        out.push(default_info());
+        out.extend(all);
+        out
+    }
+
+    /// Delete a namespace registration.
+    ///
+    /// This removes only the **registry entry**, not any entities that carry
+    /// the namespace (v1 has no cross-namespace move/purge). It is intended for
+    /// cleaning up an empty or mistyped namespace.
+    ///
+    /// # Errors
+    ///
+    /// - [`NamespaceError::InvalidName`] (→ `INVALID_ARGUMENT`) when asked to
+    ///   delete the implicit `default`.
+    /// - [`NamespaceError::NotFound`] (→ `NOT_FOUND`) when the name is absent.
+    pub(crate) fn remove(&self, namespace: &Namespace) -> Result<()> {
+        if namespace.is_default() {
+            return Err(NamespaceError::InvalidName {
+                name: namespace.as_str().to_string(),
+                reason: "the default namespace cannot be deleted".to_string(),
+            }
+            .into());
+        }
+        let name = namespace.as_str();
+        let _guard = self.save_lock.lock();
+        let removed = {
+            let mut entries = self.entries.write();
+            match entries.remove(name) {
+                Some(removed) => removed,
+                None => {
+                    return Err(NamespaceError::NotFound {
+                        namespace: name.to_string(),
+                    }
+                    .into());
+                }
+            }
+        };
+        if let Err(e) = self.save_locked() {
+            self.entries.write().insert(removed.name.clone(), removed);
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    /// The durable-write body, assuming `save_lock` is held. A no-op for
+    /// in-memory-only registries.
+    fn save_locked(&self) -> Result<()> {
+        let Some(path) = &self.persist_path else {
+            return Ok(());
+        };
+        #[cfg(not(feature = "serde"))]
+        {
+            let _ = path;
+            return Ok(());
+        }
+        #[cfg(feature = "serde")]
+        {
+            self.save_serialized(path)
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    fn save_serialized(&self, path: &std::path::Path) -> Result<()> {
+        let mut infos: Vec<NamespaceInfo> = self.entries.read().values().cloned().collect();
+        infos.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        let namespaces: Vec<PersistedEntry> = infos.iter().map(PersistedEntry::from).collect();
+
+        let serialized = serde_json::to_vec_pretty(&PersistedRegistry {
+            version: PERSIST_FORMAT_VERSION,
+            namespaces,
+        })
+        .map_err(|e| Error::Other(format!("failed to serialize namespace registry: {e}")))?;
+
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let tmp_path = path.with_extension("tmp");
+        let _ = std::fs::remove_file(&tmp_path);
+        {
+            use std::io::Write as _;
+            let mut options = std::fs::OpenOptions::new();
+            options.write(true).create(true).truncate(true);
+            let mut file = options.open(&tmp_path)?;
+            file.write_all(&serialized)?;
+            file.sync_all()?;
+        }
+        std::fs::rename(&tmp_path, path)?;
+        #[cfg(unix)]
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::File::open(parent)?.sync_all()?;
+        }
+        Ok(())
+    }
+}
+
+/// Emit a namespace-registry warning under either logging configuration
+/// (mirrors the snapshot registry).
+#[cfg(feature = "serde")]
+fn log_registry_warning(message: &str) {
+    #[cfg(feature = "observability")]
+    tracing::warn!("{}", message);
+    #[cfg(not(feature = "observability"))]
+    eprintln!("WARNING: {}", message);
+}
+
+/// Move a corrupt/unreadable sidecar aside (`*.corrupt`) so startup proceeds
+/// with an empty registry while preserving the bad bytes for inspection.
+#[cfg(feature = "serde")]
+fn quarantine_corrupt_registry(path: &std::path::Path) {
+    let mut corrupt = path.as_os_str().to_owned();
+    corrupt.push(".corrupt");
+    let corrupt = PathBuf::from(corrupt);
+    if let Err(e) = std::fs::rename(path, &corrupt) {
+        log_registry_warning(&format!(
+            "could not quarantine corrupt namespace registry {} -> {}: {e}",
+            path.display(),
+            corrupt.display()
+        ));
+    }
+}
+
+/// Build the sidecar path for a database's namespace registry, or `None` when
+/// the database is ephemeral (persistence disabled). Lives **inside** the
+/// configured persistence directory at `{data_dir}/namespaces.json`, exactly
+/// like the snapshot registry.
+pub(crate) fn registry_path_for(
+    persistence: &crate::storage::index_persistence::PersistenceConfig,
+) -> Option<PathBuf> {
+    if !persistence.enabled {
+        return None;
+    }
+    Some(persistence.data_dir.join("namespaces.json"))
+}
+
+impl AletheiaDB {
+    /// Create a namespace with an optional description (Issue #3349).
+    ///
+    /// Namespaces need not contain any entity to exist; this makes an empty one
+    /// listable/describable up front. Writing to an unknown namespace also
+    /// auto-registers it, so this call is optional for most workflows.
+    ///
+    /// # Errors
+    ///
+    /// - `INVALID_ARGUMENT` if `name` fails validation (empty, too long, bad
+    ///   charset, or the reserved `all` selector).
+    /// - `CONFLICT` if the namespace already exists (including `default`).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn create_namespace(
+        &self,
+        name: impl AsRef<str>,
+        description: Option<String>,
+    ) -> Result<NamespaceInfo> {
+        let ns = Namespace::new(name.as_ref())?;
+        self.namespaces.create(&ns, description)
+    }
+
+    /// List all namespaces (the implicit `default` first, then registered ones
+    /// in creation order). Use this to catch a mistyped auto-registered
+    /// namespace.
+    #[must_use]
+    pub fn list_namespaces(&self) -> Vec<NamespaceInfo> {
+        self.namespaces.list()
+    }
+
+    /// Fetch a namespace's metadata by name.
+    ///
+    /// # Errors
+    ///
+    /// `NOT_FOUND` (with the name in the error) if the namespace is not
+    /// registered. The implicit `default` namespace always resolves.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn get_namespace(&self, name: impl AsRef<str>) -> Result<NamespaceInfo> {
+        let name = name.as_ref();
+        self.namespaces.get(name).ok_or_else(|| {
+            Error::Namespace(NamespaceError::NotFound {
+                namespace: name.to_string(),
+            })
+        })
+    }
+
+    /// Alias for [`get_namespace`](Self::get_namespace).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn describe_namespace(&self, name: impl AsRef<str>) -> Result<NamespaceInfo> {
+        self.get_namespace(name)
+    }
+
+    /// Delete a namespace registration (not its entities).
+    ///
+    /// # Errors
+    ///
+    /// - `INVALID_ARGUMENT` when asked to delete the implicit `default`.
+    /// - `NOT_FOUND` (with the name in the error) if the namespace is absent.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn delete_namespace(&self, name: impl AsRef<str>) -> Result<()> {
+        // Validate the name shape first so a malformed name is INVALID_ARGUMENT,
+        // not a confusing NOT_FOUND.
+        let ns = Namespace::new(name.as_ref())?;
+        self.namespaces.remove(&ns)
+    }
+
+    /// Create a node in the given namespace (Issue #3349).
+    ///
+    /// The namespace is validated, auto-registered if new, and stamped onto the
+    /// node as an immutable, engine-owned ride-along property. Passing
+    /// [`Namespace::DEFAULT`] is equivalent to plain
+    /// [`create_node`](Self::create_node).
+    ///
+    /// # Errors
+    ///
+    /// - `INVALID_ARGUMENT` if `namespace` fails validation or `properties`
+    ///   carries an engine-reserved key.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn create_node_in_namespace(
+        &self,
+        label: &str,
+        properties: crate::core::property::PropertyMap,
+        namespace: impl AsRef<str>,
+    ) -> Result<crate::core::id::NodeId> {
+        use crate::api::transaction::{WriteOps, WriteRequestOptions};
+        let ns = Namespace::new(namespace.as_ref())?;
+        self.namespaces.ensure_registered(&ns)?;
+        let options = WriteRequestOptions::new().with_namespace(ns);
+        self.write(|tx| tx.create_node_with_options(label, properties, options))
+    }
+
+    /// Create an edge in the given namespace (Issue #3349). See
+    /// [`create_node_in_namespace`](Self::create_node_in_namespace).
+    ///
+    /// # Errors
+    ///
+    /// - `INVALID_ARGUMENT` if `namespace` fails validation or `properties`
+    ///   carries an engine-reserved key.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn create_edge_in_namespace(
+        &self,
+        source: crate::core::id::NodeId,
+        target: crate::core::id::NodeId,
+        label: &str,
+        properties: crate::core::property::PropertyMap,
+        namespace: impl AsRef<str>,
+    ) -> Result<crate::core::id::EdgeId> {
+        use crate::api::transaction::{WriteOps, WriteRequestOptions};
+        let ns = Namespace::new(namespace.as_ref())?;
+        self.namespaces.ensure_registered(&ns)?;
+        let options = WriteRequestOptions::new().with_namespace(ns);
+        self.write(|tx| tx.create_edge_with_options(source, target, label, properties, options))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_path_none_when_persistence_disabled() {
+        let cfg = crate::storage::index_persistence::PersistenceConfig::default();
+        assert!(!cfg.enabled);
+        assert_eq!(registry_path_for(&cfg), None);
+    }
+
+    #[test]
+    fn registry_path_inside_data_dir() {
+        let cfg = crate::storage::index_persistence::PersistenceConfig {
+            enabled: true,
+            data_dir: PathBuf::from("/var/lib/aletheia/indexes"),
+            ..Default::default()
+        };
+        assert_eq!(
+            registry_path_for(&cfg),
+            Some(PathBuf::from("/var/lib/aletheia/indexes/namespaces.json"))
+        );
+    }
+
+    #[test]
+    fn in_memory_create_get_list_conflict_remove() {
+        let reg = NamespaceRegistry::in_memory();
+        let ns = Namespace::new("agent:planner").unwrap();
+
+        // default is always present but not stored.
+        assert!(reg.get("default").is_some());
+        assert_eq!(reg.list().len(), 1);
+
+        let info = reg.create(&ns, Some("planner scope".to_string())).unwrap();
+        assert_eq!(info.name, "agent:planner");
+        assert_eq!(reg.get("agent:planner").unwrap().name, "agent:planner");
+
+        // list: default first, then the created one.
+        let list = reg.list();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].name, "default");
+        assert_eq!(list[1].name, "agent:planner");
+
+        // Duplicate create -> CONFLICT (AlreadyExists).
+        assert!(matches!(
+            reg.create(&ns, None),
+            Err(Error::Namespace(NamespaceError::AlreadyExists { .. }))
+        ));
+
+        // Creating default -> CONFLICT.
+        assert!(matches!(
+            reg.create(&Namespace::default(), None),
+            Err(Error::Namespace(NamespaceError::AlreadyExists { .. }))
+        ));
+
+        // Remove -> gone; second remove -> NOT_FOUND.
+        reg.remove(&ns).unwrap();
+        assert!(reg.get("agent:planner").is_none());
+        assert!(matches!(
+            reg.remove(&ns),
+            Err(Error::Namespace(NamespaceError::NotFound { .. }))
+        ));
+
+        // Removing default -> INVALID_ARGUMENT.
+        assert!(matches!(
+            reg.remove(&Namespace::default()),
+            Err(Error::Namespace(NamespaceError::InvalidName { .. }))
+        ));
+    }
+
+    #[test]
+    fn ensure_registered_is_idempotent_and_skips_default() {
+        let reg = NamespaceRegistry::in_memory();
+        reg.ensure_registered(&Namespace::default()).unwrap();
+        assert_eq!(reg.list().len(), 1, "default is never stored");
+
+        let ns = Namespace::new("session:1").unwrap();
+        reg.ensure_registered(&ns).unwrap();
+        reg.ensure_registered(&ns).unwrap();
+        assert_eq!(reg.list().len(), 2, "auto-register is idempotent");
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn open_round_trips_and_quarantines_corrupt() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("namespaces.json");
+
+        let reg = NamespaceRegistry::open(Some(path.clone())).unwrap();
+        reg.create(&Namespace::new("agent:a").unwrap(), Some("a".to_string()))
+            .unwrap();
+        reg.create(&Namespace::new("agent:b").unwrap(), None)
+            .unwrap();
+
+        // Reload -> identical (default + the two stored).
+        let reloaded = NamespaceRegistry::open(Some(path.clone())).unwrap();
+        let names: Vec<String> = reloaded.list().into_iter().map(|i| i.name).collect();
+        assert_eq!(names, vec!["default", "agent:a", "agent:b"]);
+        assert_eq!(
+            reloaded.get("agent:a").unwrap().description,
+            Some("a".to_string())
+        );
+
+        // Corrupt the file -> quarantine + empty on next open.
+        std::fs::write(&path, b"not json {{{").unwrap();
+        let after = NamespaceRegistry::open(Some(path.clone())).unwrap();
+        assert_eq!(after.list().len(), 1, "corrupt file -> only default");
+        assert!(!path.exists());
+        assert!(dir.path().join("namespaces.json.corrupt").exists());
+    }
+}

--- a/src/db/namespace.rs
+++ b/src/db/namespace.rs
@@ -509,9 +509,18 @@ impl AletheiaDB {
     ) -> Result<crate::core::id::NodeId> {
         use crate::api::transaction::{WriteOps, WriteRequestOptions};
         let ns = Namespace::new(namespace.as_ref())?;
+        let options = WriteRequestOptions::new().with_namespace(ns.clone());
+        // Register the namespace only AFTER the write commits successfully.
+        // `ensure_registered` fsyncs a new registry entry; running it first would
+        // leave a durable empty namespace behind if the write then failed (e.g.
+        // a reserved-key rejection or constraint violation), even though the call
+        // returns Err (#3349). Preferring data-without-registry over
+        // registry-without-data keeps the registry from accumulating phantom
+        // namespaces; the membership index (PR2) rebuilds registry state from the
+        // data at load, so the surviving divergence is self-healing.
+        let node_id = self.write(|tx| tx.create_node_with_options(label, properties, options))?;
         self.namespaces.ensure_registered(&ns)?;
-        let options = WriteRequestOptions::new().with_namespace(ns);
-        self.write(|tx| tx.create_node_with_options(label, properties, options))
+        Ok(node_id)
     }
 
     /// Create an edge in the given namespace (Issue #3349). See
@@ -532,9 +541,13 @@ impl AletheiaDB {
     ) -> Result<crate::core::id::EdgeId> {
         use crate::api::transaction::{WriteOps, WriteRequestOptions};
         let ns = Namespace::new(namespace.as_ref())?;
+        let options = WriteRequestOptions::new().with_namespace(ns.clone());
+        // Register only AFTER a successful commit; see `create_node_in_namespace`
+        // for why (a failed write must not leave a durable empty namespace).
+        let edge_id = self
+            .write(|tx| tx.create_edge_with_options(source, target, label, properties, options))?;
         self.namespaces.ensure_registered(&ns)?;
-        let options = WriteRequestOptions::new().with_namespace(ns);
-        self.write(|tx| tx.create_edge_with_options(source, target, label, properties, options))
+        Ok(edge_id)
     }
 }
 

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -294,7 +294,14 @@ fn build_schema(
         .into_iter()
         .map(|(label, (count, keys))| {
             total_nodes += count;
-            let mut property_keys: Vec<String> = keys.into_iter().map(resolve_label).collect();
+            // Elide engine-reserved ride-along keys (the namespace marker,
+            // #3349, and crypto-shred markers): they are not user property keys
+            // and must never surface in the schema.
+            let mut property_keys: Vec<String> = keys
+                .into_iter()
+                .map(resolve_label)
+                .filter(|k| !crate::core::namespace::is_reserved_property_key(k))
+                .collect();
             property_keys.sort_unstable();
             LabelSchema {
                 label: resolve_label(label),
@@ -312,7 +319,12 @@ fn build_schema(
         .into_iter()
         .map(|(edge_type, (count, keys))| {
             total_edges += count;
-            let mut property_keys: Vec<String> = keys.into_iter().map(resolve_label).collect();
+            // Elide engine-reserved ride-along keys (see the node branch).
+            let mut property_keys: Vec<String> = keys
+                .into_iter()
+                .map(resolve_label)
+                .filter(|k| !crate::core::namespace::is_reserved_property_key(k))
+                .collect();
             property_keys.sort_unstable();
             EdgeTypeSchema {
                 edge_type: resolve_label(edge_type),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,9 +126,9 @@ pub use core::temporal::time;
 pub use core::{
     BiTemporalInterval, ChangeFeedPage, ChangeFeedQuery, ChangeFilter, ChangeRecord, ChangeType,
     ChangefeedBroadcaster, ChangefeedConfig, Edge, EdgeId, EntityId, EntityKind, GLOBAL_INTERNER,
-    InternedString, Node, NodeHeader, NodeId, PropertyKey, PropertyMap, PropertyMapBuilder,
-    PropertyValue, Provenance, RecvError, StringInterner, Subscription, TimeRange, Timestamp,
-    VersionId,
+    InternedString, NAMESPACE_KEY, Namespace, NamespaceError, Node, NodeHeader, NodeId,
+    PropertyKey, PropertyMap, PropertyMapBuilder, PropertyValue, Provenance, RecvError,
+    StringInterner, Subscription, TimeRange, Timestamp, VersionId,
 };
 
 pub use api::{ReadOps, ReadTransaction, TxId, TxState, WriteOps, WriteTransaction};
@@ -138,8 +138,8 @@ pub use core::error::{
 pub use db::{
     AletheiaDB, BackupSummary, ColdStorageDetails, ColdStorageTierStats, CurrentStateStats,
     DatabaseStats, EdgeTypeSchema, FactStatus, GraphSchema, HistoricalDepthStats, LabelExtent,
-    LabelSchema, LineageView, LineageViewEntry, PitrCoord, PitrPlan, PitrTarget, SchemaInstant,
-    SimilarityQuery, SimilaritySource, TemporalExtent, TierAccessStats, TimeBounds,
+    LabelSchema, LineageView, LineageViewEntry, NamespaceInfo, PitrCoord, PitrPlan, PitrTarget,
+    SchemaInstant, SimilarityQuery, SimilaritySource, TemporalExtent, TierAccessStats, TimeBounds,
     UniqueConstraintBuilder, VectorIndexBuilder, WalStateStats,
 };
 pub use index::{

--- a/src/mcp/error.rs
+++ b/src/mcp/error.rs
@@ -220,6 +220,7 @@ fn classify_db_error(e: &Error) -> (McpErrorCode, bool) {
         // A provenance bundle failing validation is a caller fault.
         Error::Provenance(_) => (McpErrorCode::InvalidArgument, false),
         Error::Lineage(le) => classify_lineage_error(le),
+        Error::Namespace(ne) => classify_namespace_error(ne),
         // A PITR (#3374) target outside the achievable window, or a window that
         // crosses a post-backup vocabulary change, is a caller-fault precondition
         // failure; each error's Display explains the remediation. All other
@@ -250,6 +251,21 @@ fn classify_lineage_error(e: &crate::core::lineage::LineageError) -> (McpErrorCo
             (McpErrorCode::InvalidArgument, false)
         }
         LineageError::AlreadyRecorded(_) => (McpErrorCode::FailedPrecondition, false),
+    }
+}
+
+/// Map a namespace error (Issue #3349). All are caller faults and never
+/// retriable: an invalid name or a forged engine-reserved property key is
+/// `INVALID_ARGUMENT`, an unknown namespace is `NOT_FOUND`, and a duplicate
+/// `create_namespace` is `CONFLICT`.
+fn classify_namespace_error(e: &crate::core::namespace::NamespaceError) -> (McpErrorCode, bool) {
+    use crate::core::namespace::NamespaceError;
+    match e {
+        NamespaceError::InvalidName { .. } | NamespaceError::ReservedPropertyKey { .. } => {
+            (McpErrorCode::InvalidArgument, false)
+        }
+        NamespaceError::NotFound { .. } => (McpErrorCode::NotFound, false),
+        NamespaceError::AlreadyExists { .. } => (McpErrorCode::Conflict, false),
     }
 }
 

--- a/src/mcp/error.rs
+++ b/src/mcp/error.rs
@@ -261,9 +261,9 @@ fn classify_lineage_error(e: &crate::core::lineage::LineageError) -> (McpErrorCo
 fn classify_namespace_error(e: &crate::core::namespace::NamespaceError) -> (McpErrorCode, bool) {
     use crate::core::namespace::NamespaceError;
     match e {
-        NamespaceError::InvalidName { .. } | NamespaceError::ReservedPropertyKey { .. } => {
-            (McpErrorCode::InvalidArgument, false)
-        }
+        NamespaceError::InvalidName { .. }
+        | NamespaceError::ReservedPropertyKey { .. }
+        | NamespaceError::Immutable => (McpErrorCode::InvalidArgument, false),
         NamespaceError::NotFound { .. } => (McpErrorCode::NotFound, false),
         NamespaceError::AlreadyExists { .. } => (McpErrorCode::Conflict, false),
     }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1306,6 +1306,12 @@ impl AletheiaMcpServer {
         let mut result = HashMap::new();
         for (key, value) in props.iter() {
             let key_str = self.interned_to_string(*key);
+            // Elide engine-reserved ride-along keys (the namespace marker,
+            // #3349, and crypto-shred markers) — they are surfaced as
+            // first-class fields, never as user properties.
+            if crate::core::namespace::is_reserved_property_key(&key_str) {
+                continue;
+            }
             result.insert(key_str, self.property_value_to_json(value, include_vectors));
         }
         result

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -17614,3 +17614,131 @@ mod embedding_tools_tests {
         }
     }
 }
+
+// ============================================================================
+// Namespace reserved-key elision — SURFACE sweep (Issue #3349, PR1).
+//
+// The unit sweep in `core::namespace` only proves the elision *helper* strips
+// the ride-along key. These tests prove the production MCP serializers actually
+// call it: a namespaced node AND edge are created, then every read tool is
+// exercised through `dispatch_tool_json` (the exact seam the HTTP surface also
+// routes through) and its serialized JSON is asserted to contain no
+// `__aletheia_` substring. Without the serializer guards these fail (red).
+// ============================================================================
+#[cfg(test)]
+mod namespace_surface_sweep_tests {
+    use super::*;
+
+    /// Seed a namespaced node + edge and return `(server, src, dst)` as u64 ids.
+    fn seed_namespaced() -> (AletheiaMcpServer, u64, u64) {
+        let server = create_test_server();
+        let a = server
+            .db()
+            .create_node_in_namespace(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Alice").build(),
+                "agent:planner",
+            )
+            .expect("create namespaced node a");
+        let b = server
+            .db()
+            .create_node_in_namespace(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Bob").build(),
+                "agent:planner",
+            )
+            .expect("create namespaced node b");
+        server
+            .db()
+            .create_edge_in_namespace(
+                a,
+                b,
+                "KNOWS",
+                PropertyMapBuilder::new().insert("since", 2020).build(),
+                "agent:planner",
+            )
+            .expect("create namespaced edge");
+        (server, a.as_u64(), b.as_u64())
+    }
+
+    /// Assert a serialized tool response leaks no engine-reserved ride-along key.
+    fn assert_no_reserved(json: &str, tool: &str) {
+        assert!(
+            !json.contains("__aletheia_"),
+            "reserved ride-along key leaked into `{tool}` response: {json}"
+        );
+        // The full namespace marker specifically must be absent.
+        assert!(
+            !json.contains(crate::core::namespace::NAMESPACE_KEY),
+            "namespace key leaked into `{tool}` response: {json}"
+        );
+    }
+
+    #[test]
+    fn sweep_get_node_elides_reserved_key() {
+        let (server, a, _b) = seed_namespaced();
+        let out = server.dispatch_tool_json("get_node", serde_json::json!({ "node_id": a }));
+        // The node is still returned with its user property...
+        assert!(out.contains("Alice"), "expected the node payload: {out}");
+        // ...but the ride-along key is elided.
+        assert_no_reserved(&out, "get_node");
+    }
+
+    #[test]
+    fn sweep_list_nodes_elides_reserved_key() {
+        let (server, _a, _b) = seed_namespaced();
+        let out = server.dispatch_tool_json("list_nodes", serde_json::json!({ "label": "Person" }));
+        assert!(out.contains("Alice"), "expected node list payload: {out}");
+        assert_no_reserved(&out, "list_nodes");
+    }
+
+    #[test]
+    fn sweep_traverse_elides_reserved_key() {
+        let (server, a, _b) = seed_namespaced();
+        let out = server.dispatch_tool_json(
+            "traverse",
+            serde_json::json!({ "start_node_id": a, "edge_label": "KNOWS" }),
+        );
+        assert!(
+            out.contains("Bob"),
+            "expected traversal to reach Bob: {out}"
+        );
+        assert_no_reserved(&out, "traverse");
+    }
+
+    #[test]
+    fn sweep_get_node_history_elides_reserved_key() {
+        let (server, a, _b) = seed_namespaced();
+        // Add a second version so history has content beyond the create.
+        server.dispatch_tool_json(
+            "update_node",
+            serde_json::json!({ "node_id": a, "properties": { "age": 30 } }),
+        );
+        let out =
+            server.dispatch_tool_json("get_node_history", serde_json::json!({ "node_id": a }));
+        assert!(out.contains("Alice"), "expected history payload: {out}");
+        assert_no_reserved(&out, "get_node_history");
+    }
+
+    #[test]
+    fn sweep_query_return_n_elides_reserved_key() {
+        let (server, _a, _b) = seed_namespaced();
+        // AQL is always available under `mcp-server` (no cypher feature needed).
+        let out = server.dispatch_tool_json(
+            "query",
+            serde_json::json!({ "language": "aql", "query": "MATCH (n:Person) RETURN n" }),
+        );
+        assert!(out.contains("Alice"), "expected query rows: {out}");
+        assert_no_reserved(&out, "query");
+    }
+
+    #[test]
+    fn sweep_get_schema_elides_reserved_key() {
+        let (server, _a, _b) = seed_namespaced();
+        let out = server.dispatch_tool_json("get_schema", serde_json::json!({}));
+        // The user property key IS a legitimate schema key...
+        assert!(out.contains("name"), "expected schema payload: {out}");
+        // ...but the ride-along key must never surface as a schema property key.
+        assert_no_reserved(&out, "get_schema");
+    }
+}

--- a/src/storage/index_persistence/graph.rs
+++ b/src/storage/index_persistence/graph.rs
@@ -184,15 +184,22 @@ pub fn restore_property_map(persisted: &PersistedPropertyMap) -> Result<Property
     for (key_idx, value) in &persisted.entries {
         let key_id = crate::core::InternedString::from_raw(*key_idx);
         let val = restore_property_value(value)?;
-        builder = GLOBAL_INTERNER
-            .resolve_with(key_id, |key_str| builder.insert(key_str, val))
-            .ok_or_else(|| {
-                IndexPersistenceError::Serialization(format!(
-                    "Failed to resolve interned property key with ID: {}. \
+        // Resolve the key to an owned Arc<str> BEFORE inserting it into the
+        // builder. `resolve_with` runs its closure while holding a DashMap shard
+        // read-guard on the interner; calling `builder.insert` (which re-interns
+        // the key) inside that closure re-enters the interner on the same shard
+        // and can self-deadlock under concurrent writers (shard reader/writer
+        // starvation — a restore racing another thread's fresh intern). Cloning
+        // the Arc via `resolve` releases the guard before the re-intern.
+        #[allow(deprecated)]
+        let key_str = GLOBAL_INTERNER.resolve(key_id).ok_or_else(|| {
+            IndexPersistenceError::Serialization(format!(
+                "Failed to resolve interned property key with ID: {}. \
                  This likely indicates data corruption.",
-                    key_idx
-                ))
-            })?;
+                key_idx
+            ))
+        })?;
+        builder = builder.insert(key_str.as_ref(), val);
     }
     Ok(builder.build())
 }

--- a/tests/namespaces_pr1.rs
+++ b/tests/namespaces_pr1.rs
@@ -3,9 +3,7 @@
 //! Covers the design doc's T1–T3, T9 (registry + ride-along replay), T10, and
 //! the hard-requirement reserved-key elision SWEEP.
 
-use aletheiadb::core::namespace::{
-    NAMESPACE_KEY, is_reserved_property_key, user_facing_properties,
-};
+use aletheiadb::core::namespace::{NAMESPACE_KEY, is_reserved_property_key};
 use aletheiadb::{AletheiaDB, Namespace, NamespaceError, PropertyMapBuilder, PropertyValue};
 
 fn props(name: &str) -> aletheiadb::PropertyMap {
@@ -349,8 +347,8 @@ fn sweep_reserved_key_never_leaks_user_facing() {
     assert!(!ee.user_properties().contains_key(NAMESPACE_KEY));
     assert_no_reserved_bytes(&ee.user_properties(), "edge view");
 
-    // The free-function view helper is airtight too.
-    let stripped = user_facing_properties(&na.properties);
+    // The public user-facing accessor is airtight too.
+    let stripped = na.user_properties();
     assert!(!stripped.contains_key(NAMESPACE_KEY));
 }
 
@@ -389,4 +387,369 @@ fn sweep_backup_restore_preserves_namespace_and_elides() {
     assert!(!ee.user_properties().contains_key(NAMESPACE_KEY));
     assert_no_reserved_bytes(&na.user_properties(), "restored node view");
     assert_no_reserved_bytes(&ee.user_properties(), "restored edge view");
+}
+
+// ============================================================================
+// Reserved-key rejection across EVERY write seam (T2, exhaustive).
+// ============================================================================
+
+fn reserved_map(key: &str) -> aletheiadb::PropertyMap {
+    PropertyMapBuilder::new().insert(key, "x").build()
+}
+
+fn is_reserved_err(err: &aletheiadb::Error) -> bool {
+    matches!(
+        err,
+        aletheiadb::Error::Namespace(NamespaceError::ReservedPropertyKey { .. })
+    )
+}
+
+#[test]
+fn reserved_key_rejected_on_every_property_map_seam() {
+    use aletheiadb::PropertyValue;
+    use aletheiadb::core::temporal::time;
+
+    for forged in ["__aletheia_ns", "__shred_x"] {
+        let db = AletheiaDB::new().unwrap();
+        let a = db.create_node("Person", props("A")).unwrap();
+        let b = db.create_node("Person", props("B")).unwrap();
+        let e = db.create_edge(a, b, "KNOWS", props("edge")).unwrap();
+
+        // update_edge (PATCH)
+        assert!(
+            is_reserved_err(
+                &db.update_edge_with_valid_time(e, reserved_map(forged), None)
+                    .unwrap_err()
+            ),
+            "update_edge must reject {forged}"
+        );
+        // replace_node (full overwrite)
+        assert!(
+            is_reserved_err(
+                &db.replace_node(a, "Person", reserved_map(forged))
+                    .unwrap_err()
+            ),
+            "replace_node must reject {forged}"
+        );
+        // replace_edge (full overwrite)
+        assert!(
+            is_reserved_err(&db.replace_edge(e, reserved_map(forged)).unwrap_err()),
+            "replace_edge must reject {forged}"
+        );
+        // compare_and_set_node
+        let nv = db.get_node(a).unwrap().current_version;
+        assert!(
+            is_reserved_err(
+                &db.compare_and_set_node(a, nv, reserved_map(forged))
+                    .unwrap_err()
+            ),
+            "compare_and_set_node must reject {forged}"
+        );
+        // compare_and_set_edge
+        let ev = db.get_edge(e).unwrap().current_version;
+        assert!(
+            is_reserved_err(
+                &db.compare_and_set_edge(e, ev, reserved_map(forged))
+                    .unwrap_err()
+            ),
+            "compare_and_set_edge must reject {forged}"
+        );
+        // claim_with_lease
+        let nv2 = db.get_node(a).unwrap().current_version;
+        let lease_until = time::from_secs(time::now().wallclock() / 1_000_000 + 3_600);
+        assert!(
+            is_reserved_err(
+                &db.claim_with_lease(
+                    a,
+                    nv2,
+                    "lease_owner",
+                    "lease_until",
+                    PropertyValue::from("worker-1"),
+                    lease_until,
+                    reserved_map(forged),
+                )
+                .unwrap_err()
+            ),
+            "claim_with_lease must reject {forged}"
+        );
+        // remove_node_property / remove_edge_property (key is the forged one)
+        assert!(
+            is_reserved_err(&db.remove_node_property(a, forged).unwrap_err()),
+            "remove_node_property must reject {forged}"
+        );
+        assert!(
+            is_reserved_err(&db.remove_edge_property(e, forged).unwrap_err()),
+            "remove_edge_property must reject {forged}"
+        );
+    }
+}
+
+// ============================================================================
+// Edge + CAS immutability re-stamp: every non-create path preserves the ns.
+// ============================================================================
+
+#[test]
+fn edge_and_cas_paths_preserve_immutable_namespace() {
+    use aletheiadb::PropertyValue;
+    use aletheiadb::core::temporal::time;
+
+    let db = AletheiaDB::new().unwrap();
+    let a = db
+        .create_node_in_namespace("Person", props("Alice"), "agent:planner")
+        .unwrap();
+    let b = db
+        .create_node_in_namespace("Person", props("Bob"), "agent:planner")
+        .unwrap();
+    let e = db
+        .create_edge_in_namespace(a, b, "KNOWS", props("edge"), "agent:planner")
+        .unwrap();
+
+    // update_edge PATCH
+    db.update_edge_with_valid_time(e, PropertyMapBuilder::new().insert("k", 1).build(), None)
+        .unwrap();
+    assert_eq!(
+        db.get_edge(e).unwrap().namespace().as_str(),
+        "agent:planner"
+    );
+
+    // replace_edge full overwrite (no ns key in the new map)
+    db.replace_edge(e, PropertyMapBuilder::new().insert("since", 2021).build())
+        .unwrap();
+    assert_eq!(
+        db.get_edge(e).unwrap().namespace().as_str(),
+        "agent:planner"
+    );
+
+    // compare_and_set_node
+    let nv = db.get_node(a).unwrap().current_version;
+    db.compare_and_set_node(
+        a,
+        nv,
+        PropertyMapBuilder::new().insert("name", "Alice3").build(),
+    )
+    .unwrap();
+    assert_eq!(
+        db.get_node(a).unwrap().namespace().as_str(),
+        "agent:planner"
+    );
+
+    // compare_and_set_edge
+    let ev = db.get_edge(e).unwrap().current_version;
+    db.compare_and_set_edge(
+        e,
+        ev,
+        PropertyMapBuilder::new().insert("since", 2022).build(),
+    )
+    .unwrap();
+    assert_eq!(
+        db.get_edge(e).unwrap().namespace().as_str(),
+        "agent:planner"
+    );
+
+    // claim_with_lease
+    let nv2 = db.get_node(a).unwrap().current_version;
+    let lease_until = time::from_secs(time::now().wallclock() / 1_000_000 + 3_600);
+    db.claim_with_lease(
+        a,
+        nv2,
+        "lease_owner",
+        "lease_until",
+        PropertyValue::from("worker-1"),
+        lease_until,
+        PropertyMapBuilder::new().insert("name", "Alice4").build(),
+    )
+    .unwrap();
+    assert_eq!(
+        db.get_node(a).unwrap().namespace().as_str(),
+        "agent:planner"
+    );
+}
+
+// ============================================================================
+// Adversarial "cannot move": forged ns rejected; clean re-stamp keeps original;
+// explicit namespace on a non-create op is INVALID_ARGUMENT (never a silent no-op).
+// ============================================================================
+
+#[test]
+fn forged_namespace_on_replace_and_cas_is_rejected() {
+    let db = AletheiaDB::new().unwrap();
+    let a = db
+        .create_node_in_namespace("Person", props("Alice"), "agent:a")
+        .unwrap();
+    let b = db
+        .create_node_in_namespace("Person", props("Bob"), "agent:a")
+        .unwrap();
+    let e = db
+        .create_edge_in_namespace(a, b, "KNOWS", props("edge"), "agent:a")
+        .unwrap();
+
+    // A forged `__aletheia_ns="other"` in the overwrite map is rejected as a
+    // reserved key — it can never be applied to move the entity.
+    let forged = PropertyMapBuilder::new()
+        .insert("name", "Alice2")
+        .insert(NAMESPACE_KEY, "other")
+        .build();
+    assert!(is_reserved_err(
+        &db.replace_node(a, "Person", forged.clone()).unwrap_err()
+    ));
+    let forged_edge = PropertyMapBuilder::new()
+        .insert(NAMESPACE_KEY, "other")
+        .build();
+    assert!(is_reserved_err(
+        &db.replace_edge(e, forged_edge).unwrap_err()
+    ));
+    let nv = db.get_node(a).unwrap().current_version;
+    assert!(is_reserved_err(
+        &db.compare_and_set_node(a, nv, forged).unwrap_err()
+    ));
+    // Still in the original namespace after all rejected attempts.
+    assert_eq!(db.get_node(a).unwrap().namespace().as_str(), "agent:a");
+}
+
+#[test]
+fn explicit_namespace_on_non_create_is_invalid_argument() {
+    use aletheiadb::api::transaction::WriteRequestOptions;
+    use aletheiadb::core::temporal::time;
+    use aletheiadb::{PropertyValue, core::namespace::Namespace as Ns};
+
+    let db = AletheiaDB::new().unwrap();
+    let a = db
+        .create_node_in_namespace("Person", props("Alice"), "agent:a")
+        .unwrap();
+    let b = db
+        .create_node_in_namespace("Person", props("Bob"), "agent:a")
+        .unwrap();
+    let e = db
+        .create_edge_in_namespace(a, b, "KNOWS", props("edge"), "agent:a")
+        .unwrap();
+
+    let other = Ns::new("agent:b").unwrap();
+    let is_immutable = |err: &aletheiadb::Error| {
+        matches!(err, aletheiadb::Error::Namespace(NamespaceError::Immutable))
+    };
+
+    // update_node
+    let opts = WriteRequestOptions::new().with_namespace(other.clone());
+    assert!(is_immutable(
+        &db.update_node_with_options(a, props("x"), opts)
+            .unwrap_err()
+    ));
+    // update_edge
+    let opts = WriteRequestOptions::new().with_namespace(other.clone());
+    assert!(is_immutable(
+        &db.update_edge_with_options(e, props("x"), opts)
+            .unwrap_err()
+    ));
+    // replace_node
+    let opts = WriteRequestOptions::new().with_namespace(other.clone());
+    assert!(is_immutable(
+        &db.replace_node_with_options(a, "Person", props("x"), opts)
+            .unwrap_err()
+    ));
+    // replace_edge
+    let opts = WriteRequestOptions::new().with_namespace(other.clone());
+    assert!(is_immutable(
+        &db.replace_edge_with_options(e, props("x"), opts)
+            .unwrap_err()
+    ));
+    // compare_and_set_node
+    let nv = db.get_node(a).unwrap().current_version;
+    let opts = WriteRequestOptions::new().with_namespace(other.clone());
+    assert!(is_immutable(
+        &db.compare_and_set_node_with_options(a, nv, props("x"), opts)
+            .unwrap_err()
+    ));
+    // compare_and_set_edge
+    let ev = db.get_edge(e).unwrap().current_version;
+    let opts = WriteRequestOptions::new().with_namespace(other.clone());
+    assert!(is_immutable(
+        &db.compare_and_set_edge_with_options(e, ev, props("x"), opts)
+            .unwrap_err()
+    ));
+    // claim_with_lease
+    let nv2 = db.get_node(a).unwrap().current_version;
+    let lease_until = time::from_secs(time::now().wallclock() / 1_000_000 + 3_600);
+    let opts = WriteRequestOptions::new().with_namespace(other);
+    assert!(is_immutable(
+        &db.claim_with_lease_with_options(
+            a,
+            nv2,
+            "lease_owner",
+            "lease_until",
+            PropertyValue::from("worker-1"),
+            lease_until,
+            props("x"),
+            opts,
+        )
+        .unwrap_err()
+    ));
+
+    // Nothing moved: still agent:a.
+    assert_eq!(db.get_node(a).unwrap().namespace().as_str(), "agent:a");
+    assert_eq!(db.get_edge(e).unwrap().namespace().as_str(), "agent:a");
+}
+
+// ============================================================================
+// SHOULD-FIX #3 — a create that fails validation leaves NO registered namespace.
+// ============================================================================
+
+#[test]
+fn failed_create_does_not_leave_namespace_registered() {
+    let db = AletheiaDB::new().unwrap();
+    // A forged reserved key makes the write fail AFTER namespace validation but
+    // BEFORE (now) any registration; the namespace must not be registered.
+    let bad = PropertyMapBuilder::new().insert("__shred_x", 1).build();
+    let err = db
+        .create_node_in_namespace("Person", bad, "agent:doomed")
+        .unwrap_err();
+    assert!(is_reserved_err(&err));
+
+    let names: Vec<String> = db.list_namespaces().into_iter().map(|i| i.name).collect();
+    assert!(
+        !names.contains(&"agent:doomed".to_string()),
+        "a failed write must not durably register its namespace: {names:?}"
+    );
+}
+
+// ============================================================================
+// Delete-namespace-then-write: writing to a deleted namespace re-auto-registers.
+// ============================================================================
+
+#[test]
+fn delete_namespace_then_write_reregisters() {
+    let db = AletheiaDB::new().unwrap();
+    db.create_namespace("agent:x", None).unwrap();
+    db.delete_namespace("agent:x").unwrap();
+    assert!(db.describe_namespace("agent:x").is_err());
+
+    // A write to the now-absent namespace auto-registers it again.
+    db.create_node_in_namespace("Person", props("Alice"), "agent:x")
+        .unwrap();
+    let names: Vec<String> = db.list_namespaces().into_iter().map(|i| i.name).collect();
+    assert!(
+        names.contains(&"agent:x".to_string()),
+        "writing to a deleted namespace must re-auto-register it: {names:?}"
+    );
+}
+
+// ============================================================================
+// Historical-read view elides the ride-along key (T3 extension).
+// ============================================================================
+
+#[test]
+fn historical_read_view_elides_namespace_key() {
+    use aletheiadb::core::temporal::time;
+    let db = AletheiaDB::new().unwrap();
+    let id = db
+        .create_node_in_namespace("Person", props("Alice"), "agent:planner")
+        .unwrap();
+    // Capture a valid-time coordinate at/after creation so the node is valid there.
+    let vt = time::now();
+
+    // Reconstruct at a valid-time within the node's validity: the point-in-time
+    // view still carries the namespace as a first-class field, elided from props.
+    let node = db.get_node_at_valid_time(id, vt).unwrap();
+    assert_eq!(node.namespace().as_str(), "agent:planner");
+    assert!(!node.user_properties().contains_key(NAMESPACE_KEY));
+    assert_no_reserved_bytes(&node.user_properties(), "historical node view");
 }

--- a/tests/namespaces_pr1.rs
+++ b/tests/namespaces_pr1.rs
@@ -1,0 +1,392 @@
+//! Namespaces PR1 — core model integration tests (Issue #3349).
+//!
+//! Covers the design doc's T1–T3, T9 (registry + ride-along replay), T10, and
+//! the hard-requirement reserved-key elision SWEEP.
+
+use aletheiadb::core::namespace::{
+    NAMESPACE_KEY, is_reserved_property_key, user_facing_properties,
+};
+use aletheiadb::{AletheiaDB, Namespace, NamespaceError, PropertyMapBuilder, PropertyValue};
+
+fn props(name: &str) -> aletheiadb::PropertyMap {
+    PropertyMapBuilder::new().insert("name", name).build()
+}
+
+// ============================================================================
+// T1 — back-compat: omitted namespace resolves to `default`.
+// ============================================================================
+
+#[test]
+fn t1_omitted_namespace_resolves_to_default() {
+    let db = AletheiaDB::new().unwrap();
+    let id = db.create_node("Person", props("Alice")).unwrap();
+    let node = db.get_node(id).unwrap();
+
+    // A node created with no namespace lives in `default`...
+    assert_eq!(node.namespace(), Namespace::default());
+    // ...and carries NO ride-along key (byte-identical to legacy data).
+    assert!(!node.properties.contains_key(NAMESPACE_KEY));
+    // The user-facing view is unchanged from pre-namespace behavior.
+    assert_eq!(
+        node.user_properties()
+            .get("name")
+            .and_then(PropertyValue::as_str),
+        Some("Alice")
+    );
+    assert_eq!(node.user_properties().len(), node.properties.len());
+}
+
+#[test]
+fn t1_create_in_default_namespace_equals_plain_create() {
+    let db = AletheiaDB::new().unwrap();
+    let plain = db.create_node("Person", props("A")).unwrap();
+    let explicit = db
+        .create_node_in_namespace("Person", props("B"), "default")
+        .unwrap();
+
+    // Neither carries the ride-along key; both resolve to default.
+    assert!(
+        !db.get_node(plain)
+            .unwrap()
+            .properties
+            .contains_key(NAMESPACE_KEY)
+    );
+    assert!(
+        !db.get_node(explicit)
+            .unwrap()
+            .properties
+            .contains_key(NAMESPACE_KEY)
+    );
+    assert_eq!(
+        db.get_node(explicit).unwrap().namespace(),
+        Namespace::default()
+    );
+}
+
+// ============================================================================
+// T2 — reserved key: user writes carrying a reserved key are rejected + elided.
+// ============================================================================
+
+#[test]
+fn t2_reserved_key_rejected_on_create() {
+    let db = AletheiaDB::new().unwrap();
+    for bad_key in [NAMESPACE_KEY, "__aletheia_foo", "__shred_x"] {
+        let p = PropertyMapBuilder::new().insert(bad_key, "x").build();
+        let err = db.create_node("Person", p).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                aletheiadb::Error::Namespace(NamespaceError::ReservedPropertyKey { .. })
+            ),
+            "expected ReservedPropertyKey for {bad_key}, got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn t2_reserved_key_rejected_on_update_and_edge() {
+    let db = AletheiaDB::new().unwrap();
+    let a = db.create_node("Person", props("A")).unwrap();
+    let b = db.create_node("Person", props("B")).unwrap();
+
+    // update PATCH carrying a reserved key -> rejected.
+    let bad = PropertyMapBuilder::new()
+        .insert("__aletheia_ns", "forged")
+        .build();
+    assert!(matches!(
+        db.update_node_with_valid_time(a, bad, None).unwrap_err(),
+        aletheiadb::Error::Namespace(NamespaceError::ReservedPropertyKey { .. })
+    ));
+
+    // create_edge carrying a reserved key -> rejected.
+    let bad_edge = PropertyMapBuilder::new().insert("__shred_y", 1).build();
+    assert!(matches!(
+        db.create_edge(a, b, "KNOWS", bad_edge).unwrap_err(),
+        aletheiadb::Error::Namespace(NamespaceError::ReservedPropertyKey { .. })
+    ));
+}
+
+#[test]
+fn t2_reserved_key_elided_from_views() {
+    let db = AletheiaDB::new().unwrap();
+    let id = db
+        .create_node_in_namespace("Person", props("Alice"), "agent:planner")
+        .unwrap();
+    let node = db.get_node(id).unwrap();
+
+    // Raw storage carries the ride-along key...
+    assert!(node.properties.contains_key(NAMESPACE_KEY));
+    // ...but it is elided from the user-facing view and surfaced as `namespace`.
+    let view = node.user_properties();
+    assert!(!view.contains_key(NAMESPACE_KEY));
+    assert_eq!(node.namespace().as_str(), "agent:planner");
+    for (key, _) in view.iter() {
+        let name = aletheiadb::GLOBAL_INTERNER
+            .resolve_with(*key, |s| s.to_string())
+            .unwrap();
+        assert!(
+            !is_reserved_property_key(&name),
+            "reserved key {name} leaked"
+        );
+    }
+}
+
+// ============================================================================
+// T3 — immutability / re-stamp across update PATCH, replace, retract.
+// ============================================================================
+
+#[test]
+fn t3_update_patch_preserves_namespace() {
+    let db = AletheiaDB::new().unwrap();
+    let id = db
+        .create_node_in_namespace("Person", props("Alice"), "agent:planner")
+        .unwrap();
+
+    // A PATCH that does not (and cannot) touch the namespace key preserves it.
+    db.update_node_with_valid_time(
+        id,
+        PropertyMapBuilder::new().insert("age", 30).build(),
+        None,
+    )
+    .unwrap();
+    let node = db.get_node(id).unwrap();
+    assert_eq!(node.namespace().as_str(), "agent:planner");
+    assert_eq!(
+        node.get_property("age").and_then(PropertyValue::as_int),
+        Some(30)
+    );
+}
+
+#[test]
+fn t3_replace_node_preserves_namespace() {
+    let db = AletheiaDB::new().unwrap();
+    let id = db
+        .create_node_in_namespace("Person", props("Alice"), "agent:planner")
+        .unwrap();
+
+    // A full overwrite (new label + entirely new map, no ns key) must NOT drop
+    // the immutable namespace.
+    db.replace_node(
+        id,
+        "Human",
+        PropertyMapBuilder::new().insert("name", "Alice2").build(),
+    )
+    .unwrap();
+    let node = db.get_node(id).unwrap();
+    assert_eq!(node.namespace().as_str(), "agent:planner");
+    assert!(node.has_label_str("Human"));
+}
+
+#[test]
+fn t3_retract_preserves_namespace_in_history() {
+    use aletheiadb::core::temporal::time;
+    let db = AletheiaDB::new().unwrap();
+    let id = db
+        .create_node_in_namespace("Person", props("Alice"), "agent:planner")
+        .unwrap();
+
+    // Capture a valid-time coordinate within the node's validity, then close
+    // its valid interval strictly after it. A point-in-time read at the earlier
+    // coordinate must still reconstruct the node with its original namespace —
+    // retraction never moves an entity between namespaces (it lives in history).
+    let vt = time::now();
+    let retract_at = time::from_secs(vt.wallclock() / 1_000_000 + 3_600);
+    db.retract_node(id, retract_at).unwrap();
+    let node = db.get_node_at_valid_time(id, vt).unwrap();
+    assert_eq!(node.namespace().as_str(), "agent:planner");
+}
+
+#[test]
+fn t3_no_api_moves_entity_between_namespaces() {
+    let db = AletheiaDB::new().unwrap();
+    let id = db
+        .create_node_in_namespace("Person", props("Alice"), "agent:a")
+        .unwrap();
+    // Even a user PATCH attempting to set the key is rejected (T2), so there is
+    // no path to change the namespace. Confirm after a benign update it is
+    // still agent:a.
+    db.update_node_with_valid_time(id, PropertyMapBuilder::new().insert("k", "v").build(), None)
+        .unwrap();
+    assert_eq!(db.get_node(id).unwrap().namespace().as_str(), "agent:a");
+}
+
+// ============================================================================
+// T9 — registry durability + ride-along survives WAL replay.
+// ============================================================================
+
+#[test]
+fn t9_registry_and_ride_along_survive_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("db");
+
+    let node_id;
+    {
+        let db = AletheiaDB::open(&path).unwrap();
+        db.create_namespace("agent:planner", Some("planner scope".to_string()))
+            .unwrap();
+        db.create_namespace("agent:researcher", None).unwrap();
+        // Auto-register on write to a brand-new namespace.
+        node_id = db
+            .create_node_in_namespace("Person", props("Alice"), "session:run1")
+            .unwrap();
+    }
+
+    // Reopen: registry entries survive AND the ride-along namespace resolves
+    // after WAL replay / index load.
+    {
+        let db = AletheiaDB::open(&path).unwrap();
+        let names: Vec<String> = db.list_namespaces().into_iter().map(|i| i.name).collect();
+        assert!(names.contains(&"default".to_string()));
+        assert!(names.contains(&"agent:planner".to_string()));
+        assert!(names.contains(&"agent:researcher".to_string()));
+        // Auto-registered namespace persisted too.
+        assert!(names.contains(&"session:run1".to_string()));
+        assert_eq!(
+            db.describe_namespace("agent:planner").unwrap().description,
+            Some("planner scope".to_string())
+        );
+        // Ride-along survived replay.
+        assert_eq!(
+            db.get_node(node_id).unwrap().namespace().as_str(),
+            "session:run1"
+        );
+    }
+}
+
+// ============================================================================
+// T10 — structured errors with the offending value.
+// ============================================================================
+
+#[test]
+fn t10_invalid_and_empty_names_are_invalid_argument() {
+    let db = AletheiaDB::new().unwrap();
+    for bad in ["", "has space", "all", "comma,x"] {
+        let err = db.create_namespace(bad, None).unwrap_err();
+        match err {
+            aletheiadb::Error::Namespace(NamespaceError::InvalidName { name, .. }) => {
+                assert_eq!(name, bad, "offending value carried in error");
+            }
+            other => panic!("expected InvalidName for {bad:?}, got {other:?}"),
+        }
+    }
+    // Namespaced create with a bad name is INVALID_ARGUMENT too.
+    assert!(matches!(
+        db.create_node_in_namespace("Person", props("A"), "bad space")
+            .unwrap_err(),
+        aletheiadb::Error::Namespace(NamespaceError::InvalidName { .. })
+    ));
+}
+
+#[test]
+fn t10_unknown_describe_and_delete_are_not_found() {
+    let db = AletheiaDB::new().unwrap();
+    match db.describe_namespace("nope").unwrap_err() {
+        aletheiadb::Error::Namespace(NamespaceError::NotFound { namespace }) => {
+            assert_eq!(namespace, "nope");
+        }
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+    match db.delete_namespace("nope").unwrap_err() {
+        aletheiadb::Error::Namespace(NamespaceError::NotFound { namespace }) => {
+            assert_eq!(namespace, "nope");
+        }
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+    // default cannot be created (CONFLICT) or deleted (INVALID_ARGUMENT).
+    assert!(matches!(
+        db.create_namespace("default", None).unwrap_err(),
+        aletheiadb::Error::Namespace(NamespaceError::AlreadyExists { .. })
+    ));
+    assert!(matches!(
+        db.delete_namespace("default").unwrap_err(),
+        aletheiadb::Error::Namespace(NamespaceError::InvalidName { .. })
+    ));
+}
+
+// ============================================================================
+// SWEEP — the reserved ride-along key never leaks into any user-facing payload.
+// ============================================================================
+
+/// Assert a serialized property map contains no engine-reserved key bytes.
+fn assert_no_reserved_bytes(map: &aletheiadb::PropertyMap, context: &str) {
+    let bytes = map.serialize().expect("serialize");
+    let needle = NAMESPACE_KEY.as_bytes();
+    let leaked = bytes.windows(needle.len()).any(|w| w == needle);
+    assert!(!leaked, "reserved key leaked into serialized {context}");
+}
+
+#[test]
+fn sweep_reserved_key_never_leaks_user_facing() {
+    let db = AletheiaDB::new().unwrap();
+
+    // Nodes and edges in non-default namespaces.
+    let a = db
+        .create_node_in_namespace("Person", props("Alice"), "agent:planner")
+        .unwrap();
+    let b = db
+        .create_node_in_namespace("Person", props("Bob"), "agent:researcher")
+        .unwrap();
+    let e = db
+        .create_edge_in_namespace(a, b, "KNOWS", props("edge"), "shared")
+        .unwrap();
+
+    // Every Rust-level user-facing conversion elides the ride-along key.
+    let na = db.get_node(a).unwrap();
+    let nb = db.get_node(b).unwrap();
+    let ee = db.get_edge(e).unwrap();
+
+    for (view, ns) in [
+        (na.user_properties(), "agent:planner"),
+        (nb.user_properties(), "agent:researcher"),
+    ] {
+        assert!(!view.contains_key(NAMESPACE_KEY));
+        assert_no_reserved_bytes(&view, "node view");
+        let _ = ns;
+    }
+    assert_eq!(na.namespace().as_str(), "agent:planner");
+    assert_eq!(nb.namespace().as_str(), "agent:researcher");
+    assert_eq!(ee.namespace().as_str(), "shared");
+    assert!(!ee.user_properties().contains_key(NAMESPACE_KEY));
+    assert_no_reserved_bytes(&ee.user_properties(), "edge view");
+
+    // The free-function view helper is airtight too.
+    let stripped = user_facing_properties(&na.properties);
+    assert!(!stripped.contains_key(NAMESPACE_KEY));
+}
+
+#[test]
+fn sweep_backup_restore_preserves_namespace_and_elides() {
+    let dir = tempfile::tempdir().unwrap();
+    let backup_path = dir.path().join("snap.albk");
+
+    let (a, b, e);
+    {
+        let db = AletheiaDB::new().unwrap();
+        a = db
+            .create_node_in_namespace("Person", props("Alice"), "agent:planner")
+            .unwrap();
+        b = db
+            .create_node_in_namespace("Person", props("Bob"), "agent:researcher")
+            .unwrap();
+        e = db
+            .create_edge_in_namespace(a, b, "KNOWS", props("edge"), "shared")
+            .unwrap();
+        db.backup(&backup_path).unwrap();
+    }
+
+    // Restore into a fresh database: namespaces survive (internal round-trip)
+    // AND user-facing views still elide the ride-along key.
+    let restored = AletheiaDB::restore(&backup_path).unwrap();
+    let na = restored.get_node(a).unwrap();
+    let nb = restored.get_node(b).unwrap();
+    let ee = restored.get_edge(e).unwrap();
+
+    assert_eq!(na.namespace().as_str(), "agent:planner");
+    assert_eq!(nb.namespace().as_str(), "agent:researcher");
+    assert_eq!(ee.namespace().as_str(), "shared");
+
+    assert!(!na.user_properties().contains_key(NAMESPACE_KEY));
+    assert!(!ee.user_properties().contains_key(NAMESPACE_KEY));
+    assert_no_reserved_bytes(&na.user_properties(), "restored node view");
+    assert_no_reserved_bytes(&ee.user_properties(), "restored edge view");
+}


### PR DESCRIPTION
Part of #3349 (Agent-scoped memory namespaces). This is **PR1 of the serialized
slice plan — the core model only**. It adds **no** query/traversal surface and
**no** MCP/HTTP surface (parked for PR2/PR3), and makes **zero WAL on-disk
format change** (no new `WalOperation` field, no `WAL_VERSION` bump).

## Before

There is no ownership/visibility axis: every node/edge lives in one global,
unpartitioned space. Two agents writing to the same database stomp each other's
memory, and there is no way to scope, tag, or discover which scope a fact
belongs to.

## After

Every node/edge belongs to exactly one **namespace** — a stable string label on
the ownership/visibility axis, orthogonal to the type `label` — fixed at
creation and immutable for the life of the entity. Legacy/omitted-namespace data
resolves to `default` with zero migration and byte-identical behavior.

## How

**Ride-along storage (format-free, following the #3596 `replace_*` / #3604 CAS
precedent).** The namespace persists as a reserved, engine-owned property-map
entry under `__aletheia_ns`, written through the *existing*
Create/Update Node/Edge ops, so it round-trips for free through WAL replay,
anchor/delta reconstruction, and `.albk` backup. The **default** namespace is
deliberately **not** stamped, so `default`/legacy entities carry no key and stay
byte-identical (missing key ⇒ `default`).

**Reserved-key policy (coordinator ruling).** The **entire** `__aletheia_*`
prefix is engine-owned (plus the crypto-shred lane's `__shred_*`). A single
`is_reserved_property_key` gate rejects any **user** write carrying such a key
with a structured `INVALID_ARGUMENT`, and elides it from every user-facing view.

**Immutability.** Create stamps the namespace from the write options; update
PATCH, `replace_*`, `remove_property`, and CAS/lease all **re-stamp** it from
the existing entity, so no write path can drop or change it.

**Registry + durability.** `NamespaceRegistry` (create/get/list/describe/delete
+ auto-register on write) with a durable `{data_dir}/namespaces.json` sidecar
using the same atomic temp→fsync→rename + quarantine-on-corrupt pattern as
`snapshots.json`; in-memory only for ephemeral `AletheiaDB::new()`.

**Public Rust API.** `create_namespace` / `list_namespaces` / `get_namespace` /
`describe_namespace` / `delete_namespace`, plus `create_node_in_namespace` /
`create_edge_in_namespace`. `Node`/`Edge` gain `namespace()` and
`user_properties()` accessors. Errors reuse the #3234 codes. The Parquet
exporter elides reserved keys.

## Tests (red → green)

New `tests/namespaces_pr1.rs` (14 tests) + module unit tests (19):
- **T1** back-compat: omitted namespace ⇒ `default`, byte-identical to legacy.
- **T2** reserved-key create/update/edge rejection + elision from views.
- **T3** immutability across update PATCH, `replace_node`, and retract.
- **T9** registry durability (round-trip + corrupt-file quarantine) and
  ride-along survival across `open()` restart / WAL replay.
- **T10** structured errors carrying the offending value (`INVALID_ARGUMENT`,
  `NOT_FOUND`, `CONFLICT`).
- **SWEEP** (hard requirement): `__aletheia_ns` never leaks into any Rust-level
  user-facing conversion, including a backup→restore round-trip (namespace
  preserved internally, elided in views).

## Gates

`cargo fmt`, clippy (`--all-targets` on both the named feature set and
`--all-features`, `-D warnings`), `cargo check --no-default-features --tests`,
and full `cargo test` all pass (the only test failures are the two documented
uid-0 root I/O-error-injection tests, which the environment cannot provoke as
root).

## Scope / follow-ups

- **PR2**: secondary membership index, scoped reads/traversal/vector filtering,
  `QueryBuilder.in_namespace*`, AQL scope clause, per-namespace stats/schema.
- **PR3 (coordinated)**: MCP/HTTP namespace params + the three new namespace
  tools (triple-gated registry update).


---
_Generated by [Claude Code](https://claude.ai/code/session_01B3mvy2HNA1SWx6DTDcZe7x)_