### PR TITLE
fix(backup): include #3218 unique-constraint registry in .albk backups

### DIFF
--- a/src/core/constraint.rs
+++ b/src/core/constraint.rs
@@ -132,6 +132,24 @@ pub struct SchemaConstraintDescriptor {
     pub properties: Vec<PropertyConstraintDescriptor>,
 }
 
+/// A serializable descriptor for one declared uniqueness constraint
+/// (Issue #3218).
+///
+/// Uniqueness constraints are normally persisted via the WAL
+/// (`DeclareUniqueConstraint`) and reconstructed by WAL replay. A `.albk`
+/// backup restores into a **fresh WAL**, so — like the #3378 schema
+/// constraints — the declarations must ride along in the backup payload
+/// (interned ids are not stable across restarts, so the durable form carries
+/// resolved strings) and be re-declared on restore.
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct UniqueConstraintDescriptor {
+    /// The node label the constraint is scoped to.
+    pub label: String,
+    /// The property key whose value must be unique per label.
+    pub property: String,
+}
+
 /// One aggregated violation in a [`ConformanceReport`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConformanceViolation {
@@ -404,6 +422,23 @@ impl ConstraintRegistry {
         self.declarations.remove(&(label, property));
         self.reservation_index
             .retain(|k, _| !(k.label == label && k.property == property));
+    }
+
+    /// Export all declared uniqueness constraints as serializable, string-keyed
+    /// descriptors (for the `.albk` backup payload, Issue #3218). Sorted
+    /// deterministically by `(label, property)` so backups are reproducible.
+    pub fn export_unique_constraints(&self) -> Vec<UniqueConstraintDescriptor> {
+        let mut out: Vec<UniqueConstraintDescriptor> = self
+            .list()
+            .into_iter()
+            .map(|(label, property)| UniqueConstraintDescriptor { label, property })
+            .collect();
+        out.sort_by(|a, b| {
+            a.label
+                .cmp(&b.label)
+                .then_with(|| a.property.cmp(&b.property))
+        });
+        out
     }
 
     /// List all declared constraints as `(label_string, property_string)` pairs.

--- a/src/db/backup.rs
+++ b/src/db/backup.rs
@@ -85,10 +85,14 @@ impl AletheiaDB {
             .unwrap_or_default()
             .as_micros() as i64;
 
-        // Capture declared schema constraints (Issue #3378) so they survive the
-        // backup→restore round-trip. (Uniqueness constraints, #3218, are WAL-
-        // persisted and are still NOT included in .albk — a known residue.)
+        // Capture declared schema constraints (Issue #3378) and uniqueness
+        // constraints (Issue #3218) so both survive the backup→restore
+        // round-trip. Uniqueness constraints are otherwise only WAL-persisted,
+        // so a fresh-WAL restore would silently drop them; they are captured
+        // here and re-declared on restore (see `reapply_unique_constraints`),
+        // which rebuilds the reservation index and writes a durable WAL record.
         let schema_constraints = self.constraint_registry.export_schema_constraints();
+        let unique_constraints = self.constraint_registry.export_unique_constraints();
 
         let payload = build_payload(
             current_snapshot,
@@ -98,6 +102,7 @@ impl AletheiaDB {
             source_lsn,
             created_at_micros,
             schema_constraints,
+            unique_constraints,
         )
         .map_err(Error::Backup)?;
 
@@ -149,6 +154,13 @@ impl AletheiaDB {
         // from the default "aletheiadb/wal" path.
         let config = build_restore_config(tmp.path(), tmp.path().join("wal"));
         let mut db = AletheiaDB::with_unified_config(config)?;
+
+        // Re-declare uniqueness constraints (Issue #3218) after the data is
+        // loaded: unlike the schema-constraint sidecar (loaded during startup
+        // above), uniqueness constraints are WAL-persisted, so they must be
+        // re-declared against the reopened DB — which rebuilds the reservation
+        // index from the restored nodes and writes a durable WAL record.
+        reapply_unique_constraints(&db, &payload.unique_constraints)?;
 
         // Keep the temp dir alive for the lifetime of the ephemeral DB.
         db._tempdir = Some(tmp);
@@ -202,8 +214,34 @@ impl AletheiaDB {
         // Reopen through the canonical durable config so the layout written above
         // is exactly the layout `open`/`open_from_env` will read on restart.
         let config = crate::config::durable_config_for_data_dir(data_dir);
-        AletheiaDB::with_unified_config(config)
+        let db = AletheiaDB::with_unified_config(config)?;
+
+        // Re-declare uniqueness constraints (Issue #3218). Because
+        // `enable_unique_constraint` appends a `DeclareUniqueConstraint` WAL
+        // record, the constraint is durable in the restored database and is
+        // recovered by normal WAL replay on a later reopen.
+        reapply_unique_constraints(&db, &payload.unique_constraints)?;
+        Ok(db)
     }
+}
+
+/// Re-declare each restored uniqueness constraint (Issue #3218) against a
+/// freshly-reopened database.
+///
+/// `enable_unique_constraint` runs the duplicate pre-flight scan (a safety net
+/// — a consistent backup enforced uniqueness, so no duplicates should exist),
+/// rebuilds the reservation index from the restored nodes, and appends a
+/// durable `DeclareUniqueConstraint` WAL record. A dangling/duplicate
+/// declaration surfaces as a normal error rather than silently dropping the
+/// constraint.
+fn reapply_unique_constraints(
+    db: &AletheiaDB,
+    descriptors: &[crate::core::constraint::UniqueConstraintDescriptor],
+) -> Result<()> {
+    for d in descriptors {
+        db.enable_unique_constraint(&d.label, &d.property)?;
+    }
+    Ok(())
 }
 
 /// The index-persistence base directory under a durable data root.

--- a/src/db/schema_constraint.rs
+++ b/src/db/schema_constraint.rs
@@ -23,8 +23,9 @@
 //! `.albk` backup payload, so a backup→restore round-trip preserves them.
 //!
 //! Note: the pre-existing uniqueness constraints (Issue #3218) are persisted via
-//! the WAL and are **not** captured in `.albk` today; the schema constraints
-//! added here *are*.
+//! the WAL; they are also folded into the `.albk` payload (as of the #3218
+//! backup fix) and re-declared on restore, so both constraint kinds survive a
+//! backup→restore round-trip.
 
 use crate::core::changefeed::EntityKind;
 use crate::core::constraint::{

--- a/src/storage/backup/mod.rs
+++ b/src/storage/backup/mod.rs
@@ -56,10 +56,14 @@ pub const BACKUP_MAGIC: [u8; 4] = *b"ALBK";
 /// - **4 -> 5** (Issue #3378): the payload gained `schema_constraints`
 ///   (declared property-type / required-key constraints).
 ///
+/// - **5 -> 6** (Issue #3218): the payload gained `unique_constraints`
+///   (declared uniqueness constraints; previously only WAL-persisted and thus
+///   silently dropped by a fresh-WAL restore).
+///
 /// Older artifacts are still restorable -- see [`BackupPayloadV1`],
-/// [`BackupPayloadV2`], [`BackupPayloadV3`], [`BackupPayloadV4`] and
-/// `read_artifact`.
-pub const BACKUP_FORMAT_VERSION: u16 = 5;
+/// [`BackupPayloadV2`], [`BackupPayloadV3`], [`BackupPayloadV4`],
+/// [`BackupPayloadV5`] and `read_artifact`.
+pub const BACKUP_FORMAT_VERSION: u16 = 6;
 
 /// Maximum allowed decompressed payload size (5 GiB).
 ///
@@ -203,9 +207,14 @@ pub(crate) struct BackupPayload {
     pub temporal: TemporalIndexData,
     /// Declared property-type / required-key schema constraints (Issue #3378).
     /// Empty for a schemaless database. Restored through the normal startup
-    /// sidecar-load path. (Uniqueness constraints, Issue #3218, are persisted
-    /// via the WAL and are still NOT captured here — a known residue.)
+    /// sidecar-load path.
     pub schema_constraints: Vec<crate::core::constraint::SchemaConstraintDescriptor>,
+    /// Declared uniqueness constraints (Issue #3218). Empty when none are
+    /// declared. Uniqueness constraints are otherwise only WAL-persisted, so a
+    /// fresh-WAL restore would drop them; they are captured here and
+    /// re-declared on restore (which rebuilds the reservation index and writes
+    /// a durable WAL record into the restored database).
+    pub unique_constraints: Vec<crate::core::constraint::UniqueConstraintDescriptor>,
 }
 
 /// Pre-provenance (Issue #3224) `BackupPayload` shape, i.e. `BACKUP_FORMAT_VERSION == 1`.
@@ -248,6 +257,7 @@ impl From<BackupPayloadV1> for BackupPayload {
             graph: v1.graph,
             temporal: v1.temporal.into(),
             schema_constraints: Vec::new(),
+            unique_constraints: Vec::new(),
         }
     }
 }
@@ -299,6 +309,7 @@ impl From<BackupPayloadV2> for BackupPayload {
             graph: v2.graph,
             temporal: v2.temporal.into(),
             schema_constraints: Vec::new(),
+            unique_constraints: Vec::new(),
         }
     }
 }
@@ -352,6 +363,7 @@ impl From<BackupPayloadV3> for BackupPayload {
             graph: v3.graph,
             temporal: v3.temporal.into(),
             schema_constraints: Vec::new(),
+            unique_constraints: Vec::new(),
         }
     }
 }
@@ -398,6 +410,56 @@ impl From<BackupPayloadV4> for BackupPayload {
             graph: v4.graph,
             temporal: v4.temporal,
             schema_constraints: Vec::new(),
+            unique_constraints: Vec::new(),
+        }
+    }
+}
+
+/// Pre-unique-constraint-backup (Issue #3218) `BackupPayload` shape, i.e.
+/// `BACKUP_FORMAT_VERSION == 5`.
+///
+/// Identical to [`BackupPayload`] but without the `unique_constraints` field
+/// (it uses the LIVE `TemporalIndexData`, unchanged since v4). Kept only so
+/// `read_artifact` can restore version-5 artifacts; the `From` impl defaults
+/// the uniqueness constraints to empty.
+#[derive(Debug, Clone, Encode, Decode)]
+pub(crate) struct BackupPayloadV5 {
+    /// Unix timestamp (microseconds) when the backup was created.
+    pub created_at_micros: i64,
+    /// WAL LSN at which the consistent snapshot was taken.
+    pub source_lsn: u64,
+    /// Number of current nodes.
+    pub current_node_count: u64,
+    /// Number of current edges.
+    pub current_edge_count: u64,
+    /// Number of node versions (hot + cold).
+    pub node_version_count: u64,
+    /// Number of edge versions (hot + cold).
+    pub edge_version_count: u64,
+    /// String interner state.
+    pub interner: StringInternerData,
+    /// Current graph state (nodes and edges).
+    pub graph: GraphIndexData,
+    /// Complete temporal version history.
+    pub temporal: TemporalIndexData,
+    /// Declared property-type / required-key schema constraints (Issue #3378).
+    pub schema_constraints: Vec<crate::core::constraint::SchemaConstraintDescriptor>,
+}
+
+impl From<BackupPayloadV5> for BackupPayload {
+    fn from(v5: BackupPayloadV5) -> Self {
+        BackupPayload {
+            created_at_micros: v5.created_at_micros,
+            source_lsn: v5.source_lsn,
+            current_node_count: v5.current_node_count,
+            current_edge_count: v5.current_edge_count,
+            node_version_count: v5.node_version_count,
+            edge_version_count: v5.edge_version_count,
+            interner: v5.interner,
+            graph: v5.graph,
+            temporal: v5.temporal,
+            schema_constraints: v5.schema_constraints,
+            unique_constraints: Vec::new(),
         }
     }
 }
@@ -683,6 +745,12 @@ pub(crate) fn read_artifact(path: &Path) -> Result<BackupPayload, BackupError> {
             })?;
             Ok(legacy.into())
         }
+        5 => {
+            let legacy: BackupPayloadV5 = bitcode::decode(&decoded_bytes).map_err(|e| {
+                BackupError::Serialization(format!("bitcode deserialization failed: {e}"))
+            })?;
+            Ok(legacy.into())
+        }
         v if v == BACKUP_FORMAT_VERSION => {
             let payload: BackupPayload = bitcode::decode(&decoded_bytes).map_err(|e| {
                 BackupError::Serialization(format!("bitcode deserialization failed: {e}"))
@@ -783,6 +851,7 @@ pub(crate) fn build_payload(
     source_lsn: u64,
     created_at_micros: i64,
     schema_constraints: Vec<crate::core::constraint::SchemaConstraintDescriptor>,
+    unique_constraints: Vec<crate::core::constraint::UniqueConstraintDescriptor>,
 ) -> Result<BackupPayload, BackupError> {
     let current_node_count = current_snapshot.node_count() as u64;
     let current_edge_count = current_snapshot.edge_count() as u64;
@@ -806,6 +875,7 @@ pub(crate) fn build_payload(
         graph,
         temporal,
         schema_constraints,
+        unique_constraints,
     })
 }
 
@@ -1004,6 +1074,7 @@ mod tests {
                 edge_anchors: vec![],
             },
             schema_constraints: vec![],
+            unique_constraints: vec![],
         }
     }
 
@@ -1423,6 +1494,75 @@ mod tests {
         assert!(
             restored.schema_constraints.is_empty(),
             "v4 artifact must restore with empty schema constraints"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Version-5 (pre-unique-constraint-backup, Issue #3218) compatibility
+    // -----------------------------------------------------------------------
+
+    /// Encode a version-5 artifact byte-for-byte the way a pre-#3218-backup
+    /// AletheiaDB would have: `[MAGIC][version=5][zstd(bitcode(BackupPayloadV5))]`.
+    fn encode_artifact_v5(payload: &BackupPayloadV5) -> Vec<u8> {
+        let encoded = bitcode::encode(payload);
+        let compressed = zstd::encode_all(encoded.as_slice(), 3).unwrap();
+        let mut out = Vec::with_capacity(6 + compressed.len());
+        out.extend_from_slice(&BACKUP_MAGIC);
+        out.extend_from_slice(&5u16.to_le_bytes());
+        out.extend_from_slice(&compressed);
+        out
+    }
+
+    /// A version-5 (Issue #3378 era, pre-#3218-backup) artifact -- the
+    /// immediately prior backup format this PR bumps -- must restore with
+    /// `unique_constraints` defaulting to empty (the field the v5 shape lacks),
+    /// while its `schema_constraints` are preserved verbatim.
+    #[test]
+    fn read_artifact_accepts_legacy_v5_format() {
+        use crate::core::constraint::{PropertyConstraintDescriptor, SchemaConstraintDescriptor};
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("legacy_v5.albk");
+
+        // The v5 shape uses the LIVE temporal/interner/graph structs (unchanged
+        // since v4), so reuse the current empty payload's members.
+        let empty = empty_payload();
+        let payload = BackupPayloadV5 {
+            created_at_micros: 66,
+            source_lsn: 13,
+            current_node_count: 0,
+            current_edge_count: 0,
+            node_version_count: 0,
+            edge_version_count: 0,
+            interner: empty.interner,
+            graph: empty.graph,
+            temporal: empty.temporal,
+            schema_constraints: vec![SchemaConstraintDescriptor {
+                entity_kind: "node".to_string(),
+                label: "Person".to_string(),
+                properties: vec![PropertyConstraintDescriptor {
+                    property: "name".to_string(),
+                    declared_type: None,
+                    required: true,
+                    nullable: true,
+                }],
+            }],
+        };
+
+        std::fs::write(&path, encode_artifact_v5(&payload)).unwrap();
+
+        let restored = read_artifact(&path).unwrap();
+
+        assert_eq!(restored.source_lsn, 13);
+        assert_eq!(restored.created_at_micros, 66);
+        // Schema constraints survive the v5 -> v6 upgrade verbatim.
+        assert_eq!(restored.schema_constraints.len(), 1);
+        assert_eq!(restored.schema_constraints[0].label, "Person");
+        // The pre-#3218-backup artifact carries no uniqueness constraints; the
+        // upgrade From impl defaults them to empty.
+        assert!(
+            restored.unique_constraints.is_empty(),
+            "v5 artifact must restore with empty unique constraints"
         );
     }
 

--- a/tests/backup_restore.rs
+++ b/tests/backup_restore.rs
@@ -520,3 +520,175 @@ fn prop_roundtrip_observationally_equivalent() {
         )
         .unwrap();
 }
+
+// ============================================================================
+// Test 9 — unique constraints survive backup/restore (Issue #3218 residue fix)
+// ============================================================================
+
+/// Regression: `.albk` backup must capture the WAL-persisted uniqueness
+/// constraint registry (Issue #3218). Before the fix, a fresh-WAL restore
+/// silently dropped every unique constraint — the restored DB happily accepted
+/// duplicate values that the original rejected.
+///
+/// After the fix, a backup→restore round-trip preserves the constraint AND its
+/// enforcement: a duplicate insert into the restored (ephemeral) DB is rejected.
+#[test]
+#[serial]
+fn roundtrip_preserves_and_enforces_unique_constraint() {
+    use aletheiadb::core::error::ConstraintError;
+
+    let db = AletheiaDB::new().unwrap();
+    db.unique_constraint("Person", "email").enable().unwrap();
+    db.create_node(
+        "Person",
+        PropertyMapBuilder::new().insert("email", "alice@x").build(),
+    )
+    .unwrap();
+
+    let tmp = TempDir::new().unwrap();
+    let backup_path = tmp.path().join("unique.albk");
+    db.backup(&backup_path).unwrap();
+
+    let restored = AletheiaDB::restore(&backup_path).unwrap();
+
+    // The constraint declaration must survive.
+    let constraints = restored.list_unique_constraints();
+    assert!(
+        constraints
+            .iter()
+            .any(|(l, p)| l == "Person" && p == "email"),
+        "Person/email unique constraint must survive restore, got: {constraints:?}"
+    );
+
+    // The restored duplicate value must still be REJECTED (reservation index
+    // rebuilt from the restored node).
+    let dup_existing = restored.create_node(
+        "Person",
+        PropertyMapBuilder::new().insert("email", "alice@x").build(),
+    );
+    let err = dup_existing.expect_err("duplicate of restored value must be rejected");
+    assert!(
+        matches!(
+            err.as_constraint(),
+            Some(ConstraintError::UniqueViolation { .. })
+        ),
+        "expected UniqueViolation for existing value, got: {err:?}"
+    );
+
+    // A brand-new value inserted post-restore is accepted, and re-inserting it
+    // is then rejected — proving the constraint is live, not just a static list.
+    restored
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("email", "bob@x").build(),
+        )
+        .expect("new distinct value must be accepted post-restore");
+    let dup_new = restored.create_node(
+        "Person",
+        PropertyMapBuilder::new().insert("email", "bob@x").build(),
+    );
+    assert!(
+        matches!(
+            dup_new
+                .expect_err("duplicate of new value must be rejected")
+                .as_constraint(),
+            Some(ConstraintError::UniqueViolation { .. })
+        ),
+        "constraint must enforce values written after restore"
+    );
+}
+
+/// A database with zero unique constraints must round-trip cleanly (no panic,
+/// empty constraint list on the restored side).
+#[test]
+#[serial]
+fn roundtrip_with_no_unique_constraints_is_clean() {
+    let (db, _, _) = build_sample_db();
+    let tmp = TempDir::new().unwrap();
+    let backup_path = tmp.path().join("none.albk");
+    db.backup(&backup_path).unwrap();
+
+    let restored = AletheiaDB::restore(&backup_path).unwrap();
+    assert!(
+        restored.list_unique_constraints().is_empty(),
+        "restore of a constraint-free DB must have no unique constraints"
+    );
+}
+
+/// Unique constraints and #3378 schema (type/required-key) constraints must
+/// BOTH survive the same backup→restore round-trip.
+#[test]
+#[serial]
+fn roundtrip_preserves_unique_and_schema_constraints_together() {
+    use aletheiadb::core::EntityKind;
+    use aletheiadb::core::constraint::DeclaredType;
+
+    let db = AletheiaDB::new().unwrap();
+    db.unique_constraint("Person", "email").enable().unwrap();
+    db.schema_constraint(EntityKind::Node, "Person")
+        .require_typed("age", DeclaredType::Integer)
+        .enable()
+        .unwrap();
+
+    let tmp = TempDir::new().unwrap();
+    let backup_path = tmp.path().join("both.albk");
+    db.backup(&backup_path).unwrap();
+
+    let restored = AletheiaDB::restore(&backup_path).unwrap();
+
+    assert!(
+        restored
+            .list_unique_constraints()
+            .iter()
+            .any(|(l, p)| l == "Person" && p == "email"),
+        "unique constraint must survive"
+    );
+    let schema = restored.list_schema_constraints();
+    assert!(
+        schema.iter().any(|d| d.label == "Person"
+            && d.properties
+                .iter()
+                .any(|p| p.property == "age" && p.required)),
+        "schema constraint must survive alongside the unique constraint, got: {schema:?}"
+    );
+}
+
+/// The durable restore path (`restore_to_data_dir`) must persist the
+/// re-declared unique constraint to the restored DB's WAL, so a subsequent
+/// reopen recovers it via normal WAL replay.
+#[test]
+#[serial]
+fn durable_restore_persists_unique_constraint_across_reopen() {
+    let db = AletheiaDB::new().unwrap();
+    db.unique_constraint("Person", "email").enable().unwrap();
+    db.create_node(
+        "Person",
+        PropertyMapBuilder::new().insert("email", "alice@x").build(),
+    )
+    .unwrap();
+
+    let tmp = TempDir::new().unwrap();
+    let backup_path = tmp.path().join("durable.albk");
+    db.backup(&backup_path).unwrap();
+
+    let data_dir = tmp.path().join("restored_data");
+    let restored = AletheiaDB::restore_to_data_dir(&backup_path, &data_dir).unwrap();
+    assert!(
+        restored
+            .list_unique_constraints()
+            .iter()
+            .any(|(l, p)| l == "Person" && p == "email"),
+        "durable restore must re-declare the unique constraint"
+    );
+    drop(restored);
+
+    // Reopen from disk — the constraint must come back via WAL replay.
+    let reopened = AletheiaDB::open(&data_dir).unwrap();
+    assert!(
+        reopened
+            .list_unique_constraints()
+            .iter()
+            .any(|(l, p)| l == "Person" && p == "email"),
+        "unique constraint must survive a reopen of the durably-restored DB"
+    );
+}


### PR DESCRIPTION
## Before / After (plain language)

**Before:** Taking a `.albk` backup and restoring it **silently dropped every uniqueness constraint** (Issue #3218). Uniqueness constraints are persisted only via the WAL (`DeclareUniqueConstraint`), and restore reopens into a *fresh* WAL — so `build_payload` (which captured only the #3378 type/required-key schema constraints) never carried them and they vanished. A restored database then **accepted duplicate values the original rejected** — a correctness/data-integrity bug.

**After:** A backup→restore round-trip preserves each unique constraint **and its enforcement**. Inserting a duplicate of a value that existed at backup time is rejected in the restored DB, and the constraint remains live for values written after restore. For durable restores it also survives a later reopen.

## How

Mirrors the #3378 schema-constraint approach as closely as possible:

1. **`core/constraint.rs`** — new serializable `UniqueConstraintDescriptor { label, property }` + `ConstraintRegistry::export_unique_constraints()` (deterministically sorted), paralleling `SchemaConstraintDescriptor` / `export_schema_constraints()`.
2. **`storage/backup/mod.rs`** — `BackupPayload` gains a `unique_constraints` field; `BACKUP_FORMAT_VERSION` bumped **5 → 6** with a frozen `BackupPayloadV5` shape + `From` impl (defaults the field to empty) and a `5 =>` arm in `read_artifact`, so older artifacts still restore. `build_payload` takes the new descriptors.
3. **`db/backup.rs`** — `backup()` captures `export_unique_constraints()`; both restore paths (`restore` ephemeral + `restore_to_data_dir` durable) re-declare them **after reopen** via `reapply_unique_constraints` → `enable_unique_constraint`, which rebuilds the reservation index from the restored nodes **and** appends a durable `DeclareUniqueConstraint` WAL record (so a durably-restored DB recovers the constraint via normal WAL replay on the next open).

Placement note: schema constraints are re-materialized as a startup sidecar *before* reopen; unique constraints have no startup sidecar (their durable mechanism is the WAL), so the faithful mirror is to re-declare them *after* reopen — same module, same payload-field pattern.

### Approach tradeoffs
- **Fold a field into the existing payload struct (chosen)** vs. a separate sidecar file in `materialize_to_dir`. Chosen to match #3378's payload-field approach exactly and keep one artifact/one version scheme. Requires a format-version bump + frozen `Vn` struct (bitcode is not self-describing) — identical to what v4→v5 did for schema constraints.
- **Re-declare via `enable_unique_constraint` (chosen)** vs. a lower-level raw `declare()`. `enable_unique_constraint` is the exact mirror of the "durable mechanism" (WAL), and additionally rebuilds the reservation index and runs a duplicate pre-flight safety net. A dangling/duplicate declaration surfaces as a normal error rather than a silent drop.

## Risks / edge cases → tests
| Risk | Test |
|------|------|
| Constraint dropped on restore; duplicate accepted | `roundtrip_preserves_and_enforces_unique_constraint` (present **and** enforced: existing-value dup rejected, new value accepted then its dup rejected) |
| Empty registry (absent field vs empty) breaks restore | `roundtrip_with_no_unique_constraints_is_clean` |
| Unique + schema constraints interfere | `roundtrip_preserves_unique_and_schema_constraints_together` |
| Durable restore doesn't persist to WAL → lost on reopen | `durable_restore_persists_unique_constraint_across_reopen` |
| Old `.albk` (no new field) panics/breaks | `read_artifact_accepts_legacy_v5_format` (v5 → v6 upgrade, schema constraints preserved, unique defaults empty) |

## AC evidence

| Acceptance criterion | Evidence |
|---|---|
| Unique constraint survives backup→restore | `roundtrip_preserves_and_enforces_unique_constraint` ✅ |
| …and stays **enforced** (dup rejected) | same test asserts `UniqueViolation` ✅ |
| Zero-constraint DB round-trips cleanly | `roundtrip_with_no_unique_constraints_is_clean` ✅ |
| Unique + type/required both survive | `roundtrip_preserves_unique_and_schema_constraints_together` ✅ |
| Backward-compat: old artifact restores, no panic | `read_artifact_accepts_legacy_v5_format` + existing v1–v4 tests ✅ |
| Durable restore persists across reopen | `durable_restore_persists_unique_constraint_across_reopen` ✅ |

```
running 12 tests
test durable_restore_persists_unique_constraint_across_reopen ... ok
test roundtrip_preserves_and_enforces_unique_constraint ... ok
test roundtrip_preserves_unique_and_schema_constraints_together ... ok
test roundtrip_with_no_unique_constraints_is_clean ... ok
test backup_creates_artifact ... ok
test roundtrip_preserves_current_state ... ok
test roundtrip_preserves_bitemporal_history ... ok
test roundtrip_with_cold_storage_configured ... ok
test restore_rejects_bad_version ... ok
test restore_rejects_corrupt_magic ... ok
test restore_rejects_nonempty_target ... ok
test prop_roundtrip_observationally_equivalent ... ok
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

test result (storage::backup unit): ok. 18 passed; 0 failed  (incl. read_artifact_accepts_legacy_v5_format)
test result (uniqueness_constraints): ok. 27 passed; 0 failed
test result (cargo test --lib): ok. 4145 passed; 0 failed
```

## Encryption / rotation preservation note
Per coordination guidance, this change does **not** alter any encryption/rotation behavior. The `.albk` write path (`encode_artifact` → `atomic_write`) has no encryption/rotation layer today; the new field lives entirely inside the existing bitcode payload, so encryption-state work (#3616) is orthogonal and untouched.

## Gate status
- `cargo fmt --all` ✅ (reverted one unrelated pre-existing whitespace fmt drift in `tests/sql_integration.rs` to keep the diff scoped)
- `cargo clippy --all-targets --all-features -- -D warnings` ✅ clean
- `cargo clippy --all-targets --no-default-features -- -D warnings` — fails **only** on the pre-existing, unrelated `src/db/snapshot.rs:451` `needless_return` (verified verbatim on clean `origin/trunk`, not touched by this diff, out of scope per task). This diff introduces **zero** new clippy warnings in either set.
- `cargo check --no-default-features --tests` ✅ (only a pre-existing unused-import warning in `tests/snapshot_pin.rs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Evgi2AgnwjwMSgBArxg9BV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Evgi2AgnwjwMSgBArxg9BV)_