### PR TITLE
feat(errors): structured details for schema-constraint MCP/HTTP errors (#3378)

### DIFF
--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -955,6 +955,80 @@ pub enum ConstraintError {
     },
 }
 
+impl ConstraintError {
+    /// Structured, machine-readable `details` for the schema-constraint
+    /// (Issue #3378) variants, shared by the MCP (#3234) and HTTP error
+    /// surfaces so both render byte-identical metadata under `error.details`.
+    ///
+    /// Returns `Some(..)` only for the schema-constraint variants —
+    /// [`Self::TypeViolation`], [`Self::MissingRequiredKey`], and
+    /// [`Self::NonConformingOnEnable`]. The uniqueness variants
+    /// ([`Self::UniqueViolation`] / [`Self::DuplicateOnEnable`] /
+    /// [`Self::UnsupportedKeyType`]) return `None`: their surface-specific
+    /// `details` (e.g. the MCP `UniqueViolation`'s `existing_node_id` plus
+    /// legacy top-level fields) are still built at their existing call sites,
+    /// so this method does not change their behavior.
+    ///
+    /// Every payload is **bounded**: `missing_keys` is exactly the declared
+    /// required keys that were absent, `NonConformingOnEnable`'s `sample_ids`
+    /// and each violation's `sample_ids` are already capped at
+    /// [`crate::core::constraint::MAX_CONFORMANCE_SAMPLE_IDS`], and the
+    /// aggregated `violations` list is one entry per distinct
+    /// `(property, reason)` — never a per-entity dump.
+    pub fn structured_details(&self) -> Option<serde_json::Value> {
+        use serde_json::json;
+        match self {
+            ConstraintError::TypeViolation {
+                entity_kind,
+                label,
+                property,
+                expected_type,
+                actual_type,
+            } => Some(json!({
+                "entity_kind": entity_kind,
+                "label": label,
+                "property": property,
+                "expected_type": expected_type,
+                "actual_type": actual_type,
+            })),
+            ConstraintError::MissingRequiredKey {
+                entity_kind,
+                label,
+                missing_keys,
+            } => Some(json!({
+                "entity_kind": entity_kind,
+                "label": label,
+                // Always a JSON array, even for a single missing key, so a
+                // caller can iterate uniformly.
+                "missing_keys": missing_keys,
+            })),
+            ConstraintError::NonConformingOnEnable {
+                entity_kind,
+                label,
+                violations,
+                total_non_conforming,
+                sample_ids,
+            } => Some(json!({
+                "entity_kind": entity_kind,
+                "label": label,
+                "total_non_conforming": total_non_conforming,
+                "sample_ids": sample_ids,
+                "violations": violations
+                    .iter()
+                    .map(|v| json!({
+                        "property": v.property,
+                        "reason": v.reason,
+                        "sample_ids": v.sample_ids,
+                    }))
+                    .collect::<Vec<_>>(),
+            })),
+            ConstraintError::UniqueViolation { .. }
+            | ConstraintError::DuplicateOnEnable { .. }
+            | ConstraintError::UnsupportedKeyType { .. } => None,
+        }
+    }
+}
+
 /// Errors related to vector operations and validation.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum VectorError {

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -150,9 +150,62 @@ pub enum AletheiaHttpError {
         /// The configured `max_in_flight_queries` cap that was reached.
         cap: usize,
     },
+
+    /// A schema-constraint violation surfaced from the db layer (Issue #3378),
+    /// pre-classified into the unified #3234 envelope so the HTTP body carries
+    /// the same `code`/`retriable`/`details` as the MCP surface. Built via
+    /// [`Self::from_db_error`]; every other db error keeps its prior HTTP
+    /// mapping (a 400 `BadRequest`), so this is purely additive for the
+    /// type/required-key/non-conforming cases.
+    #[error("{message}")]
+    SchemaConstraint {
+        /// The #3234 code string (`CONSTRAINT_VIOLATION` | `FAILED_PRECONDITION`).
+        code: &'static str,
+        /// HTTP status derived from the code (`409` / `412`).
+        status: StatusCode,
+        /// Free-text message: the db error's `Display` (preserved verbatim).
+        message: String,
+        /// Structured metadata from [`crate::core::error::ConstraintError::structured_details`].
+        details: Option<Value>,
+    },
 }
 
 impl AletheiaHttpError {
+    /// Classify a db-layer [`Error`](crate::core::error::Error) surfaced from a
+    /// write handler into the HTTP error envelope. Schema-constraint violations
+    /// (Issue #3378) map to the dedicated [`Self::SchemaConstraint`] variant so
+    /// the response carries the same `code`/`details` as the MCP surface; every
+    /// other error preserves the prior write-path mapping (`400 BadRequest`
+    /// with the free-text message), so this is a purely additive change for the
+    /// constraint cases.
+    #[must_use]
+    pub(crate) fn from_db_error(e: &crate::core::error::Error) -> Self {
+        use crate::core::error::ConstraintError as CE;
+        match e.as_constraint() {
+            // A type/required-key violation is the constraint rejecting *this*
+            // write → CONSTRAINT_VIOLATION, rendered `409 Conflict`.
+            Some(ce @ (CE::TypeViolation { .. } | CE::MissingRequiredKey { .. })) => {
+                Self::SchemaConstraint {
+                    code: "CONSTRAINT_VIOLATION",
+                    status: StatusCode::CONFLICT,
+                    message: e.to_string(),
+                    details: ce.structured_details(),
+                }
+            }
+            // Non-conformance on enable is a state problem the caller must fix
+            // first → FAILED_PRECONDITION, rendered `412 Precondition Failed`.
+            Some(ce @ CE::NonConformingOnEnable { .. }) => Self::SchemaConstraint {
+                code: "FAILED_PRECONDITION",
+                status: StatusCode::PRECONDITION_FAILED,
+                message: e.to_string(),
+                details: ce.structured_details(),
+            },
+            // Uniqueness variants and every non-constraint error keep the prior
+            // write-path mapping unchanged (a 400 BadRequest).
+            _ => Self::BadRequest(e.to_string()),
+        }
+    }
+
     fn status(&self) -> StatusCode {
         match self {
             Self::BadRequest(_) | Self::QueryParse(_) => StatusCode::BAD_REQUEST,
@@ -161,6 +214,9 @@ impl AletheiaHttpError {
             Self::Unauthorized => StatusCode::UNAUTHORIZED,
             Self::PermissionDenied { .. } => StatusCode::FORBIDDEN,
             Self::InvalidLimitOverride(_) => StatusCode::UNPROCESSABLE_ENTITY,
+            // A pre-classified schema-constraint violation carries its own
+            // status (409 CONSTRAINT_VIOLATION / 412 FAILED_PRECONDITION).
+            Self::SchemaConstraint { status, .. } => *status,
             // Transient overload → 503 Service Unavailable (retriable).
             Self::InFlightCapacityExceeded { .. } => StatusCode::SERVICE_UNAVAILABLE,
             Self::ResourceLimitExceeded(e) => match e.dimension {
@@ -232,6 +288,10 @@ impl AletheiaHttpError {
                 "reason": "in_flight_query_cap",
                 "max_in_flight_queries": cap,
             })),
+            // A schema-constraint violation forwards the structured details
+            // built by the shared core classifier (Issue #3378), so the HTTP
+            // body is byte-shape-identical to the MCP surface.
+            Self::SchemaConstraint { details, .. } => details.clone(),
             _ => None,
         }
     }
@@ -252,6 +312,8 @@ impl AletheiaHttpError {
             Self::PermissionDenied { .. } => "PERMISSION_DENIED",
             Self::ResourceLimitExceeded(_) => "RESOURCE_EXHAUSTED",
             Self::InFlightCapacityExceeded { .. } => "UNAVAILABLE",
+            // The #3234 code was fixed when the variant was classified.
+            Self::SchemaConstraint { code, .. } => code,
         }
     }
 
@@ -483,6 +545,93 @@ mod tests {
         );
         assert_eq!(body["error"]["code"], "INVALID_ARGUMENT");
         assert_eq!(body["error"]["message"], "nope");
+        assert_eq!(body["error"]["retriable"], false);
+        assert!(body["error"].get("details").is_none());
+    }
+
+    /// Issue #3378: a schema type violation surfaced from a write handler is
+    /// classified into the unified #3234 envelope — `409 CONSTRAINT_VIOLATION`,
+    /// `retriable: false`, and structured `details` byte-shape-identical to the
+    /// MCP surface (`expected_type`/`actual_type`).
+    #[tokio::test]
+    async fn schema_type_violation_renders_nested_constraint_violation_with_details() {
+        use crate::core::error::ConstraintError;
+        let db_err: crate::core::error::Error = ConstraintError::TypeViolation {
+            entity_kind: "node".into(),
+            label: "Person".into(),
+            property: "age".into(),
+            expected_type: "int",
+            actual_type: "string",
+        }
+        .into();
+        let http_err = AletheiaHttpError::from_db_error(&db_err);
+        let (status, body) = body_json(http_err).await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert!(
+            body.get("success").is_none(),
+            "flat `success` field dropped"
+        );
+        assert_eq!(body["error"]["code"], "CONSTRAINT_VIOLATION");
+        assert_eq!(body["error"]["retriable"], false);
+        // Message free text is preserved verbatim from the db error.
+        assert_eq!(body["error"]["message"], db_err.to_string());
+        assert_eq!(body["error"]["details"]["entity_kind"], "node");
+        assert_eq!(body["error"]["details"]["label"], "Person");
+        assert_eq!(body["error"]["details"]["property"], "age");
+        assert_eq!(body["error"]["details"]["expected_type"], "int");
+        assert_eq!(body["error"]["details"]["actual_type"], "string");
+    }
+
+    /// Parity guard: the HTTP `error.details` payload is exactly the shared
+    /// core [`ConstraintError::structured_details`] output — the same single
+    /// source of truth the MCP `from_db_error` mapping uses — so the two
+    /// surfaces can never drift. Also covers the `missing_keys`-is-an-array
+    /// contract and the `FAILED_PRECONDITION` (412) rung.
+    #[tokio::test]
+    async fn schema_constraint_http_details_match_shared_core_source() {
+        use crate::core::error::ConstraintError;
+
+        // MissingRequiredKey → CONSTRAINT_VIOLATION (409), details.missing_keys array.
+        let missing: crate::core::error::Error = ConstraintError::MissingRequiredKey {
+            entity_kind: "edge".into(),
+            label: "KNOWS".into(),
+            missing_keys: vec!["since".into()],
+        }
+        .into();
+        let expected = missing.as_constraint().unwrap().structured_details();
+        let (status, body) = body_json(AletheiaHttpError::from_db_error(&missing)).await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(body["error"]["code"], "CONSTRAINT_VIOLATION");
+        assert!(body["error"]["details"]["missing_keys"].is_array());
+        assert_eq!(Some(&body["error"]["details"]), expected.as_ref());
+
+        // NonConformingOnEnable → FAILED_PRECONDITION (412), bounded report.
+        let non_conforming: crate::core::error::Error = ConstraintError::NonConformingOnEnable {
+            entity_kind: "node".into(),
+            label: "Person".into(),
+            violations: vec![],
+            total_non_conforming: 3,
+            sample_ids: vec![1, 2, 3],
+        }
+        .into();
+        let expected = non_conforming.as_constraint().unwrap().structured_details();
+        let (status, body) = body_json(AletheiaHttpError::from_db_error(&non_conforming)).await;
+        assert_eq!(status, StatusCode::PRECONDITION_FAILED);
+        assert_eq!(body["error"]["code"], "FAILED_PRECONDITION");
+        assert_eq!(body["error"]["retriable"], false);
+        assert_eq!(body["error"]["details"]["total_non_conforming"], 3);
+        assert_eq!(Some(&body["error"]["details"]), expected.as_ref());
+    }
+
+    /// A non-constraint db error keeps the prior write-path mapping unchanged:
+    /// a `400 BadRequest` with no `details` (no behavior change outside the
+    /// schema-constraint cases).
+    #[tokio::test]
+    async fn from_db_error_preserves_bad_request_for_non_constraint_errors() {
+        let db_err = crate::core::error::Error::other("boom");
+        let (status, body) = body_json(AletheiaHttpError::from_db_error(&db_err)).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["code"], "INVALID_ARGUMENT");
         assert_eq!(body["error"]["retriable"], false);
         assert!(body["error"].get("details").is_none());
     }

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -327,7 +327,10 @@ async fn handle_create_node(
     blocking(move || {
         let node_id = db
             .create_node_with_options(&label, props, write_options_for(principal.as_deref()))
-            .map_err(|e| AletheiaHttpError::BadRequest(e.to_string()))?;
+            // Issue #3378: a schema-constraint violation renders with the
+            // structured #3234 envelope (code/details); every other write
+            // error keeps the prior 400 BadRequest mapping.
+            .map_err(|e| AletheiaHttpError::from_db_error(&e))?;
         let node = db
             .get_node(node_id)
             .map_err(|e| AletheiaHttpError::Internal(e.to_string()))?;
@@ -640,7 +643,8 @@ async fn handle_bulk_create_nodes(
                 }
                 Ok::<_, crate::core::error::Error>(ids)
             })
-            .map_err(|e| AletheiaHttpError::BadRequest(e.to_string()))?;
+            // Issue #3378: forward schema-constraint details on the bulk path too.
+            .map_err(|e| AletheiaHttpError::from_db_error(&e))?;
 
         let mut created = Vec::with_capacity(created_ids.len());
         for id in created_ids {
@@ -706,7 +710,8 @@ async fn handle_bulk_update_nodes(
                 }
                 Ok::<_, crate::core::error::Error>(ids)
             })
-            .map_err(|e| AletheiaHttpError::BadRequest(e.to_string()))?;
+            // Issue #3378: forward schema-constraint details on the bulk path too.
+            .map_err(|e| AletheiaHttpError::from_db_error(&e))?;
 
         let mut updated = Vec::with_capacity(updated_ids.len());
         for id in updated_ids {

--- a/src/mcp/error.rs
+++ b/src/mcp/error.rs
@@ -190,13 +190,24 @@ impl McpError {
     /// This is the single boundary mapping from the library's `thiserror`
     /// taxonomy to the stable MCP codes; the message is always
     /// `e.to_string()`, preserving the pre-#3234 free text verbatim.
+    ///
+    /// Schema-constraint violations (Issue #3378) additionally carry their
+    /// structured `details` here — `TypeViolation`'s `expected_type`/
+    /// `actual_type`, `MissingRequiredKey`'s `missing_keys`, and
+    /// `NonConformingOnEnable`'s bounded violation report — so a caller can
+    /// self-repair without parsing the free-text `message`. This mirrors the
+    /// `UniqueViolation` precedent (whose `existing_node_id` details are built
+    /// at the `server::db_error` call site, along with its legacy top-level
+    /// fields); that path is unchanged because
+    /// [`ConstraintError::structured_details`] returns `None` for it.
     pub fn from_db_error(e: &Error) -> Self {
         let (code, retriable) = classify_db_error(e);
+        let details = e.as_constraint().and_then(|ce| ce.structured_details());
         Self {
             code,
             message: e.to_string(),
             retriable,
-            details: None,
+            details,
         }
     }
 }
@@ -706,6 +717,132 @@ mod tests {
         let (code, retriable) = classify_constraint_error(&non_conforming);
         assert_eq!(code, McpErrorCode::FailedPrecondition);
         assert!(!retriable);
+    }
+
+    #[test]
+    fn type_violation_carries_expected_and_actual_type_details() {
+        // Issue #3378: a TypeViolation surfaces `expected_type`/`actual_type`
+        // under `error.details` (CONSTRAINT_VIOLATION, non-retriable), so a
+        // caller can self-repair without parsing the free-text message.
+        let e: Error = ConstraintError::TypeViolation {
+            entity_kind: "node".into(),
+            label: "Person".into(),
+            property: "age".into(),
+            expected_type: "int",
+            actual_type: "string",
+        }
+        .into();
+        let err = McpError::from_db_error(&e);
+        assert_eq!(err.code(), McpErrorCode::ConstraintViolation);
+        assert!(!err.is_retriable());
+        // Message free text is preserved verbatim.
+        assert_eq!(err.message(), e.to_string());
+        let json = err.to_json();
+        assert_eq!(json["code"], "CONSTRAINT_VIOLATION");
+        assert_eq!(json["retriable"], false);
+        assert_eq!(json["details"]["entity_kind"], "node");
+        assert_eq!(json["details"]["label"], "Person");
+        assert_eq!(json["details"]["property"], "age");
+        // The type tokens are the stable DeclaredType/PropertyValue names.
+        assert_eq!(json["details"]["expected_type"], "int");
+        assert_eq!(json["details"]["actual_type"], "string");
+    }
+
+    #[test]
+    fn missing_required_key_details_are_always_an_array() {
+        // A single missing key must still serialize as a JSON array, so a
+        // caller can iterate uniformly (Issue #3378).
+        let single: Error = ConstraintError::MissingRequiredKey {
+            entity_kind: "edge".into(),
+            label: "KNOWS".into(),
+            missing_keys: vec!["since".into()],
+        }
+        .into();
+        let json = McpError::from_db_error(&single).to_json();
+        assert_eq!(json["code"], "CONSTRAINT_VIOLATION");
+        assert_eq!(json["retriable"], false);
+        assert_eq!(json["details"]["entity_kind"], "edge");
+        assert_eq!(json["details"]["label"], "KNOWS");
+        assert!(
+            json["details"]["missing_keys"].is_array(),
+            "missing_keys must be an array even for one key"
+        );
+        assert_eq!(
+            json["details"]["missing_keys"],
+            serde_json::json!(["since"])
+        );
+
+        // Multiple missing keys are all reported, in order.
+        let multi: Error = ConstraintError::MissingRequiredKey {
+            entity_kind: "node".into(),
+            label: "Person".into(),
+            missing_keys: vec!["name".into(), "age".into()],
+        }
+        .into();
+        let json = McpError::from_db_error(&multi).to_json();
+        assert_eq!(
+            json["details"]["missing_keys"],
+            serde_json::json!(["name", "age"])
+        );
+    }
+
+    #[test]
+    fn non_conforming_on_enable_details_are_bounded() {
+        // Issue #3378: NonConformingOnEnable is FAILED_PRECONDITION and
+        // surfaces a *bounded* structured report — a per-(property,reason)
+        // aggregated violations list plus a capped id sample, never a raw
+        // per-entity id dump.
+        use crate::core::constraint::ConformanceViolation;
+        let e: Error = ConstraintError::NonConformingOnEnable {
+            entity_kind: "node".into(),
+            label: "Person".into(),
+            violations: vec![ConformanceViolation {
+                entity_kind: "node".into(),
+                label: "Person".into(),
+                property: Some("age".into()),
+                reason: "expected type int, got string".into(),
+                sample_ids: vec![1, 2, 3],
+            }],
+            total_non_conforming: 42,
+            sample_ids: vec![1, 2, 3, 4, 5],
+        }
+        .into();
+        let err = McpError::from_db_error(&e);
+        assert_eq!(err.code(), McpErrorCode::FailedPrecondition);
+        assert!(!err.is_retriable());
+        let json = err.to_json();
+        assert_eq!(json["code"], "FAILED_PRECONDITION");
+        assert_eq!(json["retriable"], false);
+        assert_eq!(json["details"]["entity_kind"], "node");
+        assert_eq!(json["details"]["label"], "Person");
+        assert_eq!(json["details"]["total_non_conforming"], 42);
+        assert_eq!(
+            json["details"]["sample_ids"],
+            serde_json::json!([1, 2, 3, 4, 5])
+        );
+        let violations = json["details"]["violations"].as_array().unwrap();
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0]["property"], "age");
+        assert_eq!(violations[0]["reason"], "expected type int, got string");
+        assert_eq!(violations[0]["sample_ids"], serde_json::json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn unique_violation_details_are_not_built_by_from_db_error() {
+        // The UniqueViolation `details` (existing_node_id + legacy top-level
+        // fields) are built at the `server::db_error` call site, NOT here, so
+        // `from_db_error` must leave `details` unset for it — the existing
+        // behavior is unchanged by the schema-constraint work.
+        let e: Error = ConstraintError::UniqueViolation {
+            label: "Person".into(),
+            property: "email".into(),
+            value: "a".into(),
+            existing_node_id: NodeId::new(1).unwrap(),
+        }
+        .into();
+        let err = McpError::from_db_error(&e);
+        assert_eq!(err.code(), McpErrorCode::ConstraintViolation);
+        assert!(err.to_json().get("details").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Structured `details` for schema-constraint MCP/HTTP errors (Issue #3378)

### Before / After (plain language)

**Before.** A schema type/required-key violation came back to an LLM/caller as a `#3234` code + **free text only** — to self-repair it had to *parse the English message*:

```json
{"error":{"code":"CONSTRAINT_VIOLATION",
          "message":"Type constraint violation on node Person.age: expected int, got string",
          "retriable":false}}
```

**After.** The same errors carry machine-readable `details`, mirroring the `UniqueViolation` (`details.existing_node_id`) and #3209 DETACH (`details.connected_edges`) precedents:

```json
{"error":{"code":"CONSTRAINT_VIOLATION",
          "message":"Type constraint violation on node Person.age: expected int, got string",
          "retriable":false,
          "details":{"entity_kind":"node","label":"Person","property":"age",
                     "expected_type":"int","actual_type":"string"}}}
```

- `TypeViolation` → `details.expected_type` + `details.actual_type` (+ entity_kind/label/property)
- `MissingRequiredKey` → `details.missing_keys` (always a JSON array, even for one key)
- `NonConformingOnEnable` → bounded report: `total_non_conforming`, capped `sample_ids`, and a per-`(property, reason)` aggregated `violations` list (each with its own capped `sample_ids`) — never a raw per-entity id dump.

`message` free text, `code`, and `retriable:false` are **unchanged** — purely additive.

### How

- **Single source of truth** (`src/core/error.rs`): new `ConstraintError::structured_details() -> Option<serde_json::Value>`. `Some(..)` only for the three schema-constraint variants; `None` for the uniqueness variants so their existing surface-specific `details` are untouched. The variants already carried every field needed — no field additions.
- **MCP** (`src/mcp/error.rs`): `McpError::from_db_error` attaches `e.as_constraint().and_then(|ce| ce.structured_details())`. The exhaustive `classify_constraint_error` match is **kept exhaustive** (no wildcard) so a future variant still forces a compile error. Codes unchanged.
- **HTTP** (`src/http/error.rs`, `handlers.rs`): the HTTP surface has its **own** error enum and does **not** import the (feature-gated) MCP classifier — so it did **not** inherit details "for free" (confirmed: `http-server` does not enable `mcp-server`, and `mcp` is `#[cfg(feature = "mcp-server")]`). Added a pre-classified `AletheiaHttpError::SchemaConstraint` variant + `AletheiaHttpError::from_db_error` reusing the same shared-core `structured_details`, and routed the write handlers' (`create_node`, `bulk_create_nodes`, `bulk_update_nodes`) constraint errors to it. Every **non-constraint** write error keeps its prior `400 BadRequest` mapping (no behavior change); schema constraints render `409` (CONSTRAINT_VIOLATION) / `412` (FAILED_PRECONDITION), byte-shape-identical to MCP.

### Approach tradeoffs

1. **Raw variant fields vs a normalized struct** — surfaced variant fields directly as a `serde_json` object, matching the `UniqueViolation`/DETACH precedent's naming; no new public struct to version.
2. **Where the builder lives** — `http-server` does not enable `mcp-server`, so MCP's `McpError` is not importable from HTTP. A single core method on `ConstraintError` guarantees the two surfaces cannot drift (asserted by a parity test) instead of duplicating the payload builder in each surface.
3. **MCP: centralize in `from_db_error` vs special-case `server::db_error`** — centralized in the `#3234` mapping; the `UniqueViolation` path (which builds its own details + legacy top-level fields downstream) is left exactly as-is.

### Risks as tests

- Type-token serialization (`"int"`/`"string"`, from `DeclaredType`/`PropertyValue`): `type_violation_carries_expected_and_actual_type_details`.
- `missing_keys` is an array even for one key: `missing_required_key_details_are_always_an_array` (one- and two-key cases).
- `NonConformingOnEnable` bounded, not a 50k-id dump: `non_conforming_on_enable_details_are_bounded`.
- `message` preserved verbatim / `retriable:false` / codes unchanged: asserted across MCP + HTTP tests.
- `UniqueViolation` behavior unchanged: `unique_violation_details_are_not_built_by_from_db_error`.
- Non-constraint HTTP write errors unchanged (still `400`): `from_db_error_preserves_bad_request_for_non_constraint_errors`.

### HTTP-parity confirmation

`schema_constraint_http_details_match_shared_core_source` asserts the rendered HTTP `error.details` equals `ConstraintError::structured_details()` byte-for-byte — the same single source the MCP mapping consumes — so MCP and HTTP cannot drift. It covers the `missing_keys`-array contract and the `412 FAILED_PRECONDITION` rung; `schema_type_violation_renders_nested_constraint_violation_with_details` covers the `409` type-violation rung end-to-end through the rendered body.

### AC evidence (test output)

`cargo test --features mcp-server,http-server --lib error::` — **52 passed, 0 failed**, including the new tests:

```
test http::error::tests::from_db_error_preserves_bad_request_for_non_constraint_errors ... ok
test http::error::tests::schema_type_violation_renders_nested_constraint_violation_with_details ... ok
test http::error::tests::schema_constraint_http_details_match_shared_core_source ... ok
test mcp::error::tests::missing_required_key_details_are_always_an_array ... ok
test mcp::error::tests::non_conforming_on_enable_details_are_bounded ... ok
test mcp::error::tests::type_violation_carries_expected_and_actual_type_details ... ok
test mcp::error::tests::unique_violation_details_are_not_built_by_from_db_error ... ok
test mcp::error::tests::schema_constraint_errors_classify_per_contract ... ok
...
test result: ok. 52 passed; 0 failed; 0 ignored; 0 measured; 4754 filtered out
```

### Gate results

- `cargo fmt --all` — clean.
- `cargo clippy --all-targets --all-features -- -D warnings` — **clean** (`Finished`, exit 0).
- `cargo clippy --all-targets --no-default-features -- -D warnings` — fails **only** on the known pre-existing trunk break `src/db/snapshot.rs:451` (`needless_return`), owned by another lane and untouched here. My no-default-features footprint is `core/error.rs` only, which produced **zero** new lints.
- `cargo check --no-default-features --tests` — **`Finished`** (the lone `WriteOps` unused-import warning is in the unrelated `snapshot_pin` integration test, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Evgi2AgnwjwMSgBArxg9BV)_