### PR TITLE
⚡ Bolt: Remove intermediate vector allocation for tombstone ids

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,6 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+**[Tombstone ID Collection Optimization]**
+**Learning:** In transaction application, `tombstone_ids` were collected into an intermediate `Vec<u64>` just to be converted back into an iterator using `.into_iter()`. We can directly pass the `impl Iterator<Item = u64>` mapped over the slice iterator.
+**Action:** Remove intermediate `.collect::<Vec<_>>().into_iter()` chains and adjust function signatures to accept `&mut impl Iterator<Item = T>` instead of concrete `std::vec::IntoIter<T>`.

--- a/src/api/transaction/write/apply.rs
+++ b/src/api/transaction/write/apply.rs
@@ -426,7 +426,7 @@ pub(crate) fn apply_single_write(
     write: &crate::api::transaction::BufferedWrite,
     commit_timestamp: Timestamp,
     historical: &mut HistoricalStorage,
-    tombstone_ids: &mut std::vec::IntoIter<u64>,
+    tombstone_ids: &mut impl Iterator<Item = u64>,
     num_deletes: usize,
 ) -> Result<()> {
     match write {
@@ -694,11 +694,7 @@ pub(crate) fn apply_changes<'a>(
     // so the identical ids are recorded in the WAL and applied here. We simply
     // replay them in the same buffer order they were generated and logged.
     let num_deletes = closing_version_ids.len();
-    let mut tombstone_ids = closing_version_ids
-        .iter()
-        .map(|v| v.as_u64())
-        .collect::<Vec<u64>>()
-        .into_iter();
+    let mut tombstone_ids = closing_version_ids.iter().map(|v| v.as_u64());
 
     for write in tx.buffer.operations() {
         apply_single_write(

--- a/tests/sql_integration.rs
+++ b/tests/sql_integration.rs
@@ -1055,7 +1055,7 @@ mod select_edges {
             "node B target sorts second descending"
         );
     }
-  
+
     #[test]
     fn select_edges_collect_structured_edges() {
         // Issue #3626: the edge-shaped structured projection. `SELECT * FROM edges`


### PR DESCRIPTION
💡 What: Switched from collecting `tombstone_ids` into a `Vec<u64>` and then back into an iterator (`.into_iter()`) to simply passing an `impl Iterator<Item = u64>` mapped directly over the slice iterator. 
🎯 Why: An unnecessary heap allocation and immediate de-allocation was occurring during transaction application for every commit that included deletes/retractions.
📊 Impact: Removes one heap allocation per commit containing a node/edge deletion.
🔬 Measurement: Run `cargo bench` (if available) or verify via `cargo test --lib api::transaction::write::tests`.

---
*PR created automatically by Jules for task [7226407209313448680](https://jules.google.com/task/7226407209313448680) started by @madmax983*