### PR TITLE
feat(query): edge-property WHERE + ORDER BY for AQL & Cypher (#3622)

### DIFF
--- a/src/cypher/multi_pattern.rs
+++ b/src/cypher/multi_pattern.rs
@@ -701,6 +701,31 @@ impl MultiEval<'_> {
     fn eval_predicate(&self, expr: &CypherExpr, binding: &Binding) -> Result<Tri, CypherError> {
         match expr {
             CypherExpr::Comparison { left, op, right } => {
+                // Edge-property leaf (Issue #3622): when one side is a property
+                // access on a variable bound to an EDGE, evaluate with the shared
+                // openCypher **node**-semantics -- definite True/False (never the
+                // three-valued Null used for node leaves), `Ne` on an absent
+                // property includes, and reserved structural fields resolve
+                // against the edge struct. This makes SQL == AQL == Cypher for
+                // edge predicates. Node-variable leaves fall through unchanged.
+                if let Some((edge, prop)) = edge_property_operand(left, binding) {
+                    let rhs = self.eval_value(right, binding)?;
+                    return Ok(Tri::from_bool(edge_leaf_compare(
+                        edge,
+                        prop,
+                        rhs.as_ref(),
+                        *op,
+                    )));
+                }
+                if let Some((edge, prop)) = edge_property_operand(right, binding) {
+                    let lhs = self.eval_value(left, binding)?;
+                    return Ok(Tri::from_bool(edge_leaf_compare(
+                        edge,
+                        prop,
+                        lhs.as_ref(),
+                        flip_comp_op(*op),
+                    )));
+                }
                 let l = self.eval_value(left, binding)?;
                 let r = self.eval_value(right, binding)?;
                 match (l, r) {
@@ -942,10 +967,20 @@ fn entity_edge_id(entity: &EntityResult) -> Option<EdgeId> {
 }
 
 /// A property value of a bound entity (node or edge), cloned.
+///
+/// For an EDGE, reserved structural fields (`type`/`label`/`source`/`target`/
+/// `id`) resolve against the edge struct and **shadow** any user property of the
+/// same name (Issue #3622), matching the SQL/AQL edge lane -- so
+/// `ORDER BY r.type` / `WHERE r.target = ...` see the label / endpoint rather
+/// than a (usually absent) user property. A genuine user key falls through to
+/// the edge's properties.
 fn entity_property(entity: &EntityResult, property: &str) -> Option<PropertyValue> {
     match entity {
         EntityResult::Node(n) => n.get_property(property).cloned(),
-        EntityResult::Edge(e) => e.get_property(property).cloned(),
+        EntityResult::Edge(e) => {
+            crate::query::executor::iterators::edge_structural_value(e, property)
+                .or_else(|| e.get_property(property).cloned())
+        }
         _ => None,
     }
 }
@@ -1063,6 +1098,65 @@ fn partial_cmp(a: &PropertyValue, b: &PropertyValue) -> Option<Ordering> {
 }
 
 /// Evaluate a comparison operator over two scalar values.
+/// If `expr` is a property access on a variable bound to an EDGE, return the
+/// edge and property name (Issue #3622); otherwise `None`.
+fn edge_property_operand<'b>(
+    expr: &'b CypherExpr,
+    binding: &'b Binding,
+) -> Option<(&'b Edge, &'b str)> {
+    let CypherExpr::Property { variable, property } = expr else {
+        return None;
+    };
+    match lookup(binding, variable) {
+        Some(EntityResult::Edge(e)) => Some((e, property.as_str())),
+        _ => None,
+    }
+}
+
+/// Compare an edge property leaf `edge.prop <op> other` with openCypher
+/// **node**-semantics (Issue #3622): reserved structural fields shadow user
+/// props; an absent property makes `Ne` true and every other operator false
+/// (never the three-valued Null of the node-leaf path). A null right-hand
+/// operand makes the comparison not-true.
+///
+/// AQL/Cypher edge-predicate asymmetry: this Cypher multi-variable path rejects
+/// temporal `AS OF` for the *whole* clause (node and edge alike; see the module
+/// house rule), so an edge predicate here always evaluates the current-state
+/// edge. Point-in-time edge predicates (the edge reconstructed at an AS-OF
+/// coordinate) are an AQL capability via `Predicate::EdgeScoped`; the semantics
+/// on the edge value itself are identical across both languages and SQL.
+fn edge_leaf_compare(
+    edge: &Edge,
+    prop: &str,
+    other: Option<&PropertyValue>,
+    op: CypherCompOp,
+) -> bool {
+    let Some(other) = other else {
+        return false;
+    };
+    let edge_val = crate::query::executor::iterators::edge_structural_value(edge, prop)
+        .or_else(|| edge.get_property(prop).cloned());
+    match edge_val {
+        Some(v) => compare(&v, other, op),
+        // Absent property: openCypher node-semantics -- `Ne` includes, all else
+        // excludes.
+        None => matches!(op, CypherCompOp::Ne),
+    }
+}
+
+/// Flip a comparison operator so `value <op> edge.prop` can be evaluated as
+/// `edge.prop <flipped> value` (Issue #3622).
+fn flip_comp_op(op: CypherCompOp) -> CypherCompOp {
+    match op {
+        CypherCompOp::Eq => CypherCompOp::Eq,
+        CypherCompOp::Ne => CypherCompOp::Ne,
+        CypherCompOp::Lt => CypherCompOp::Gt,
+        CypherCompOp::Le => CypherCompOp::Ge,
+        CypherCompOp::Gt => CypherCompOp::Lt,
+        CypherCompOp::Ge => CypherCompOp::Le,
+    }
+}
+
 fn compare(a: &PropertyValue, b: &PropertyValue, op: CypherCompOp) -> bool {
     match op {
         CypherCompOp::Eq => loosely_equal(a, b),

--- a/src/cypher/multi_pattern.rs
+++ b/src/cypher/multi_pattern.rs
@@ -751,6 +751,19 @@ impl MultiEval<'_> {
                 Ok(Tri::from_bool(self.eval_value(inner, binding)?.is_some()))
             }
             CypherExpr::In { expr, values } => {
+                // Edge-property IN (Issue #3622): definite node-semantics bool
+                // so `NOT (r.<absent> IN [...])` includes, matching AQL / SQL.
+                if let Some((edge, prop)) = edge_property_operand(expr, binding) {
+                    let candidates: Vec<Option<PropertyValue>> = values
+                        .iter()
+                        .map(|c| self.eval_value(c, binding))
+                        .collect::<Result<_, _>>()?;
+                    let result = match edge_leaf_value(edge, prop) {
+                        Some(v) => edge_leaf_in(&v, &candidates),
+                        None => false,
+                    };
+                    return Ok(Tri::from_bool(result));
+                }
                 // A null subject makes IN Null.
                 let Some(needle) = self.eval_value(expr, binding)? else {
                     return Ok(Tri::Null);
@@ -768,23 +781,42 @@ impl MultiEval<'_> {
                 }
                 Ok(if saw_null { Tri::Null } else { Tri::False })
             }
-            // String predicates with a null/non-string subject are Null.
+            // String predicates with a null/non-string subject are Null -- unless
+            // the subject is an edge property, which uses definite node-semantics
+            // (Issue #3622) so `NOT (r.<absent> CONTAINS 'x')` includes.
             CypherExpr::Contains { expr, substring } => {
+                if let Some((edge, prop)) = edge_property_operand(expr, binding) {
+                    return Ok(Tri::from_bool(edge_leaf_string_op(edge, prop, |s| {
+                        s.contains(substring.as_str())
+                    })));
+                }
                 Ok(match self.eval_string(expr, binding)? {
                     Some(s) => Tri::from_bool(s.contains(substring)),
                     None => Tri::Null,
                 })
             }
             CypherExpr::StartsWith { expr, prefix } => {
+                if let Some((edge, prop)) = edge_property_operand(expr, binding) {
+                    return Ok(Tri::from_bool(edge_leaf_string_op(edge, prop, |s| {
+                        s.starts_with(prefix.as_str())
+                    })));
+                }
                 Ok(match self.eval_string(expr, binding)? {
                     Some(s) => Tri::from_bool(s.starts_with(prefix)),
                     None => Tri::Null,
                 })
             }
-            CypherExpr::EndsWith { expr, suffix } => Ok(match self.eval_string(expr, binding)? {
-                Some(s) => Tri::from_bool(s.ends_with(suffix)),
-                None => Tri::Null,
-            }),
+            CypherExpr::EndsWith { expr, suffix } => {
+                if let Some((edge, prop)) = edge_property_operand(expr, binding) {
+                    return Ok(Tri::from_bool(edge_leaf_string_op(edge, prop, |s| {
+                        s.ends_with(suffix.as_str())
+                    })));
+                }
+                Ok(match self.eval_string(expr, binding)? {
+                    Some(s) => Tri::from_bool(s.ends_with(suffix)),
+                    None => Tri::Null,
+                })
+            }
             CypherExpr::Grouped(inner) => self.eval_predicate(inner, binding),
             CypherExpr::Value(CypherValue::Bool(b)) => Ok(Tri::from_bool(*b)),
             other => match self.eval_value(other, binding)? {
@@ -1134,13 +1166,38 @@ fn edge_leaf_compare(
     let Some(other) = other else {
         return false;
     };
-    let edge_val = crate::query::executor::iterators::edge_structural_value(edge, prop)
-        .or_else(|| edge.get_property(prop).cloned());
-    match edge_val {
+    match edge_leaf_value(edge, prop) {
         Some(v) => compare(&v, other, op),
         // Absent property: openCypher node-semantics -- `Ne` includes, all else
         // excludes.
         None => matches!(op, CypherCompOp::Ne),
+    }
+}
+
+/// Resolve an edge leaf's value (Issue #3622): reserved structural fields
+/// (`type`/`label`/`source`/`target`/`id`) shadow user props, otherwise the
+/// edge's own properties. Shared by every edge-leaf evaluator so the
+/// reserved-vs-user precedence is single-sourced.
+fn edge_leaf_value(edge: &Edge, prop: &str) -> Option<PropertyValue> {
+    crate::query::executor::iterators::edge_structural_value(edge, prop)
+        .or_else(|| edge.get_property(prop).cloned())
+}
+
+/// Evaluate `edge.prop IN candidates` with openCypher **node**-semantics
+/// (Issue #3622): an absent property is definite `false` (never three-valued
+/// Null), a present value matches iff it loosely-equals any non-null candidate.
+/// This keeps `NOT (r.<absent> IN [...])` == `true`, matching AQL / SQL.
+fn edge_leaf_in(v: &PropertyValue, candidates: &[Option<PropertyValue>]) -> bool {
+    candidates.iter().flatten().any(|cv| loosely_equal(v, cv))
+}
+
+/// Evaluate a string edge-leaf op (`CONTAINS`/`STARTS WITH`/`ENDS WITH`) with
+/// node-semantics (Issue #3622): a missing or non-string edge value is definite
+/// `false`, so `NOT (r.<absent> CONTAINS 'x')` == `true`, matching AQL / SQL.
+fn edge_leaf_string_op(edge: &Edge, prop: &str, f: impl FnOnce(&str) -> bool) -> bool {
+    match edge_leaf_value(edge, prop) {
+        Some(PropertyValue::String(ref s)) => f(s.as_ref()),
+        _ => false,
     }
 }
 

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -505,10 +505,21 @@ fn is_simple_hop_depth(depth: &Option<DepthSpec>) -> bool {
 /// relationship-variable leaf in a shape that cannot bind a single edge
 /// (multi-hop or variable-length) is rejected with a structured error rather
 /// than silently applied to the wrong entity.
+///
+/// Lane scope / AQL-vs-Cypher differences (Issue #3622):
+/// - AQL rejects a cross-entity property-to-property comparison such as
+///   `r.since = b.age` (see [`AstConverter::convert_comparison`]); Cypher's
+///   multi-variable evaluator supports it.
+/// - The edge channel is wired only into `WHERE` / `ORDER BY`. AQL `RETURN r`
+///   still projects the traversal **target node**, not the edge (returning the
+///   edge as an entity is a deliberate follow-up); the edge is available to
+///   filtering and ordering only.
 #[derive(Default)]
 struct EdgeScope {
     /// All relationship variable names declared across the MATCH patterns.
     rel_vars: HashSet<String>,
+    /// All node variable names declared across the MATCH patterns.
+    node_vars: HashSet<String>,
     /// The single relationship variable, iff the MATCH has exactly one
     /// relationship and it is a simple single hop; `None` otherwise.
     single_hop_rel: Option<String>,
@@ -516,6 +527,12 @@ struct EdgeScope {
     multi_hop: bool,
     /// True iff any relationship is variable-length / non-unit depth.
     variable_depth: bool,
+    /// Whether variable classification is authoritative. `true` for a `MATCH`
+    /// source (every legitimate WHERE/ORDER BY variable is a declared node or
+    /// relationship variable, so an unrecognized one is a typo/unbound
+    /// reference and is rejected -- Issue #3622 F15). `false` for non-`MATCH`
+    /// sources (vector search), where the leaf-scoping machinery does not run.
+    match_source: bool,
 }
 
 impl EdgeScope {
@@ -526,13 +543,21 @@ impl EdgeScope {
             return Self::default();
         };
         let mut rel_vars = HashSet::new();
+        let mut node_vars = HashSet::new();
         let mut rels: Vec<&RelationshipPattern> = Vec::new();
         for pattern in patterns {
             for el in &pattern.elements {
-                if let PatternElement::Relationship(rel) = el {
-                    rels.push(rel);
-                    if let Some(v) = &rel.variable {
-                        rel_vars.insert(v.clone());
+                match el {
+                    PatternElement::Relationship(rel) => {
+                        rels.push(rel);
+                        if let Some(v) = &rel.variable {
+                            rel_vars.insert(v.clone());
+                        }
+                    }
+                    PatternElement::Node(node) => {
+                        if let Some(v) = &node.variable {
+                            node_vars.insert(v.clone());
+                        }
                     }
                 }
             }
@@ -546,40 +571,61 @@ impl EdgeScope {
         };
         EdgeScope {
             rel_vars,
+            node_vars,
             single_hop_rel,
             multi_hop,
             variable_depth,
+            match_source: true,
         }
     }
 
-    /// Scope a WHERE leaf `leaf` (built for `var`.`prop`) : wrap it in
+    /// Scope a WHERE leaf `leaf` (built for `var`.`prop`): wrap it in
     /// [`Predicate::EdgeScoped`] when `var` is the single-hop relationship
     /// variable, reject when `var` is a relationship variable in an unsupported
-    /// (multi-hop / variable-length) position, and leave it unchanged (node- or
-    /// unknown-variable scoped, prior behavior) otherwise.
+    /// (multi-hop / variable-length) position, leave it unchanged (node-scoped,
+    /// prior behavior) for a declared node variable, and reject a genuinely
+    /// unknown variable (typo / unbound reference, Issue #3622 F15).
     fn scope_leaf(&self, var: &str, leaf: Predicate) -> Result<Predicate> {
-        if !self.rel_vars.contains(var) {
-            return Ok(leaf);
+        if self.rel_vars.contains(var) {
+            return match self.single_hop_rel.as_deref() {
+                Some(v) if v == var => Ok(Predicate::EdgeScoped(Box::new(leaf))),
+                _ => Err(self.reject(var)),
+            };
         }
-        match self.single_hop_rel.as_deref() {
-            Some(v) if v == var => Ok(Predicate::EdgeScoped(Box::new(leaf))),
-            _ => Err(self.reject(var)),
-        }
+        self.check_known_node_var(var)?;
+        Ok(leaf)
     }
 
     /// Whether `var` is a relationship variable that must be edge-scoped (a
     /// single, fixed-length hop). Returns `Ok(true)` for the single-hop rel var,
-    /// `Ok(false)` for a node/unknown variable, and `Err` for a relationship
-    /// variable in an unsupported position (`ORDER BY` counterpart of
-    /// [`scope_leaf`]).
+    /// `Ok(false)` for a declared node variable, and `Err` for a relationship
+    /// variable in an unsupported position or a genuinely unknown variable
+    /// (`ORDER BY` counterpart of [`scope_leaf`]).
     fn is_edge_var(&self, var: &str) -> Result<bool> {
-        if !self.rel_vars.contains(var) {
-            return Ok(false);
+        if self.rel_vars.contains(var) {
+            return match self.single_hop_rel.as_deref() {
+                Some(v) if v == var => Ok(true),
+                _ => Err(self.reject(var)),
+            };
         }
-        match self.single_hop_rel.as_deref() {
-            Some(v) if v == var => Ok(true),
-            _ => Err(self.reject(var)),
+        self.check_known_node_var(var)?;
+        Ok(false)
+    }
+
+    /// Reject a WHERE/ORDER BY reference to a variable that is neither a declared
+    /// node nor relationship variable of the pattern (Issue #3622 F15). Known
+    /// node variables (including the non-terminal anchor) are left untouched to
+    /// preserve prior behavior.
+    fn check_known_node_var(&self, var: &str) -> Result<()> {
+        if !self.match_source || self.node_vars.contains(var) {
+            return Ok(());
         }
+        Err(Error::Query(QueryError::SyntaxError {
+            message: format!(
+                "WHERE/ORDER BY references unknown variable '{var}' that is not bound by the \
+                 MATCH pattern"
+            ),
+        }))
     }
 
     fn reject(&self, var: &str) -> Error {
@@ -1728,6 +1774,20 @@ impl AstConverter {
                 return self.build_provenance_comparison(field, flip_comparison_op(op), left);
             }
             (None, None) => {}
+        }
+
+        // Cross-entity property-to-property comparison, e.g. `r.since = b.age`
+        // (Issue #3622). AQL's single-entity + edge-channel model cannot join
+        // two live operands in one leaf (Cypher's multi-variable evaluator can),
+        // so reject it up front with a shape-naming structured error rather than
+        // the generic "expected literal or parameter" from the value path.
+        if matches!(left, Expression::Property(_)) && matches!(right, Expression::Property(_)) {
+            return Err(Error::Query(QueryError::UnsupportedFeature {
+                feature: "comparison between two property accesses (e.g. `r.since = b.age`) \
+                          is not supported in AQL WHERE; compare a property to a literal or \
+                          parameter (cross-entity comparison is a Cypher-only capability)"
+                    .to_string(),
+            }));
         }
 
         // Try left side as property

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -167,7 +167,7 @@
 //! - **Avoid large IN lists**: Large `IN [...]` clauses are converted to sequential
 //!   value checks; consider using joins for very large lists
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 
 use crate::core::NodeId;
@@ -491,6 +491,114 @@ pub enum ParameterValue {
     Value(PredicateValue),
 }
 
+/// Whether a relationship's depth spec denotes a single, fixed-length hop
+/// (exactly one edge), the only shape whose relationship variable can bind a
+/// single traversed edge for edge-property WHERE / ORDER BY (Issue #3622).
+fn is_simple_hop_depth(depth: &Option<DepthSpec>) -> bool {
+    matches!(depth, None | Some(DepthSpec::Exact(1)))
+}
+
+/// Per-query classification of a MATCH pattern's variables, used to scope AQL
+/// `WHERE` / `ORDER BY` leaves that reference the **relationship** variable to
+/// the row's traversed edge side channel (Issue #3622). Node-variable leaves are
+/// left untouched (node-scoped, byte-identical to prior behavior); a
+/// relationship-variable leaf in a shape that cannot bind a single edge
+/// (multi-hop or variable-length) is rejected with a structured error rather
+/// than silently applied to the wrong entity.
+#[derive(Default)]
+struct EdgeScope {
+    /// All relationship variable names declared across the MATCH patterns.
+    rel_vars: HashSet<String>,
+    /// The single relationship variable, iff the MATCH has exactly one
+    /// relationship and it is a simple single hop; `None` otherwise.
+    single_hop_rel: Option<String>,
+    /// True iff the MATCH declares more than one relationship (multi-hop).
+    multi_hop: bool,
+    /// True iff any relationship is variable-length / non-unit depth.
+    variable_depth: bool,
+}
+
+impl EdgeScope {
+    /// Build the scope from a query's source clause. Non-`MATCH` sources (vector
+    /// search) carry no relationship variables (empty scope).
+    fn from_source(source: &SourceClause) -> Self {
+        let SourceClause::Match(patterns) = source else {
+            return Self::default();
+        };
+        let mut rel_vars = HashSet::new();
+        let mut rels: Vec<&RelationshipPattern> = Vec::new();
+        for pattern in patterns {
+            for el in &pattern.elements {
+                if let PatternElement::Relationship(rel) = el {
+                    rels.push(rel);
+                    if let Some(v) = &rel.variable {
+                        rel_vars.insert(v.clone());
+                    }
+                }
+            }
+        }
+        let multi_hop = rels.len() > 1;
+        let variable_depth = rels.iter().any(|r| !is_simple_hop_depth(&r.depth));
+        let single_hop_rel = if rels.len() == 1 && is_simple_hop_depth(&rels[0].depth) {
+            rels[0].variable.clone()
+        } else {
+            None
+        };
+        EdgeScope {
+            rel_vars,
+            single_hop_rel,
+            multi_hop,
+            variable_depth,
+        }
+    }
+
+    /// Scope a WHERE leaf `leaf` (built for `var`.`prop`) : wrap it in
+    /// [`Predicate::EdgeScoped`] when `var` is the single-hop relationship
+    /// variable, reject when `var` is a relationship variable in an unsupported
+    /// (multi-hop / variable-length) position, and leave it unchanged (node- or
+    /// unknown-variable scoped, prior behavior) otherwise.
+    fn scope_leaf(&self, var: &str, leaf: Predicate) -> Result<Predicate> {
+        if !self.rel_vars.contains(var) {
+            return Ok(leaf);
+        }
+        match self.single_hop_rel.as_deref() {
+            Some(v) if v == var => Ok(Predicate::EdgeScoped(Box::new(leaf))),
+            _ => Err(self.reject(var)),
+        }
+    }
+
+    /// Whether `var` is a relationship variable that must be edge-scoped (a
+    /// single, fixed-length hop). Returns `Ok(true)` for the single-hop rel var,
+    /// `Ok(false)` for a node/unknown variable, and `Err` for a relationship
+    /// variable in an unsupported position (`ORDER BY` counterpart of
+    /// [`scope_leaf`]).
+    fn is_edge_var(&self, var: &str) -> Result<bool> {
+        if !self.rel_vars.contains(var) {
+            return Ok(false);
+        }
+        match self.single_hop_rel.as_deref() {
+            Some(v) if v == var => Ok(true),
+            _ => Err(self.reject(var)),
+        }
+    }
+
+    fn reject(&self, var: &str) -> Error {
+        let reason = if self.variable_depth {
+            "a variable-length relationship"
+        } else if self.multi_hop {
+            "a multi-hop pattern"
+        } else {
+            "this relationship pattern"
+        };
+        Error::Query(QueryError::UnsupportedFeature {
+            feature: format!(
+                "predicate/ORDER BY on relationship variable '{var}' within {reason}: \
+                 edge-property WHERE/ORDER BY requires a single, fixed-length hop"
+            ),
+        })
+    }
+}
+
 impl AstConverter {
     /// Create a new converter with no parameter bindings.
     ///
@@ -622,9 +730,14 @@ impl AstConverter {
             });
         }
 
+        // Classify the MATCH pattern's variables so WHERE / ORDER BY leaves on
+        // the single-hop relationship variable scope to the traversed edge
+        // (Issue #3622). Empty for non-MATCH sources.
+        let edge_scope = EdgeScope::from_source(&ast.source);
+
         // 3. Convert WHERE clause to filter operations
         if let Some(ref where_clause) = ast.where_clause {
-            self.convert_where_clause(where_clause, &mut ops)?;
+            self.convert_where_clause(where_clause, &mut ops, &edge_scope)?;
         }
 
         // 4. Convert RANK BY SIMILARITY clause
@@ -639,7 +752,7 @@ impl AstConverter {
 
         // 6. Convert ORDER BY clause
         if let Some(ref order_clause) = ast.order {
-            self.convert_order_clause(order_clause, &mut ops)?;
+            self.convert_order_clause(order_clause, &mut ops, &edge_scope)?;
         }
 
         // 7. Convert SKIP and LIMIT
@@ -1192,8 +1305,9 @@ impl AstConverter {
         &self,
         where_clause: &super::ast::WhereClause,
         ops: &mut Vec<QueryOp>,
+        scope: &EdgeScope,
     ) -> Result<()> {
-        let predicate = self.convert_predicate(&where_clause.predicate)?;
+        let predicate = self.convert_predicate(&where_clause.predicate, scope)?;
         ops.push(QueryOp::Filter(predicate));
         Ok(())
     }
@@ -1468,14 +1582,24 @@ impl AstConverter {
     }
 
     /// Convert a predicate expression to IR Predicate.
-    fn convert_predicate(&self, expr: &PredicateExpr) -> Result<Predicate> {
+    ///
+    /// `scope` classifies the pattern's variables so a leaf on the single-hop
+    /// relationship variable scopes to the traversed edge (Issue #3622); node /
+    /// unknown variable leaves are unchanged.
+    fn convert_predicate(&self, expr: &PredicateExpr, scope: &EdgeScope) -> Result<Predicate> {
         match expr {
             PredicateExpr::Comparison { left, op, right } => {
-                self.convert_comparison(left, *op, right)
+                self.convert_comparison(left, *op, right, scope)
             }
-            PredicateExpr::Exists(prop) => Ok(Predicate::Exists(prop.property.clone())),
-            PredicateExpr::IsNull(prop) => Ok(Predicate::NotExists(prop.property.clone())),
-            PredicateExpr::IsNotNull(prop) => Ok(Predicate::Exists(prop.property.clone())),
+            PredicateExpr::Exists(prop) => {
+                scope.scope_leaf(&prop.variable, Predicate::Exists(prop.property.clone()))
+            }
+            PredicateExpr::IsNull(prop) => {
+                scope.scope_leaf(&prop.variable, Predicate::NotExists(prop.property.clone()))
+            }
+            PredicateExpr::IsNotNull(prop) => {
+                scope.scope_leaf(&prop.variable, Predicate::Exists(prop.property.clone()))
+            }
             PredicateExpr::ProvenanceIsNull { negated, .. } => {
                 Ok(Predicate::Provenance(ProvenancePredicate::IsNull {
                     negated: *negated,
@@ -1483,30 +1607,36 @@ impl AstConverter {
             }
             PredicateExpr::Contains { .. }
             | PredicateExpr::StartsWith { .. }
-            | PredicateExpr::EndsWith { .. } => self.convert_string_predicate(expr),
-            PredicateExpr::In { property, values } => self.convert_in_predicate(property, values),
-            PredicateExpr::And(_, _) | PredicateExpr::Or(_, _) | PredicateExpr::Not(_) => {
-                self.convert_logic_predicate(expr)
+            | PredicateExpr::EndsWith { .. } => self.convert_string_predicate(expr, scope),
+            PredicateExpr::In { property, values } => {
+                self.convert_in_predicate(property, values, scope)
             }
-            PredicateExpr::Grouped(inner) => self.convert_predicate(inner),
+            PredicateExpr::And(_, _) | PredicateExpr::Or(_, _) | PredicateExpr::Not(_) => {
+                self.convert_logic_predicate(expr, scope)
+            }
+            PredicateExpr::Grouped(inner) => self.convert_predicate(inner, scope),
         }
     }
 
     /// Convert logic predicates (AND, OR, NOT).
-    fn convert_logic_predicate(&self, expr: &PredicateExpr) -> Result<Predicate> {
+    fn convert_logic_predicate(
+        &self,
+        expr: &PredicateExpr,
+        scope: &EdgeScope,
+    ) -> Result<Predicate> {
         match expr {
             PredicateExpr::And(left, right) => {
-                let l = self.convert_predicate(left)?;
-                let r = self.convert_predicate(right)?;
+                let l = self.convert_predicate(left, scope)?;
+                let r = self.convert_predicate(right, scope)?;
                 Ok(l.and(r))
             }
             PredicateExpr::Or(left, right) => {
-                let l = self.convert_predicate(left)?;
-                let r = self.convert_predicate(right)?;
+                let l = self.convert_predicate(left, scope)?;
+                let r = self.convert_predicate(right, scope)?;
                 Ok(l.or(r))
             }
             PredicateExpr::Not(inner) => {
-                let p = self.convert_predicate(inner)?;
+                let p = self.convert_predicate(inner, scope)?;
                 Ok(!p)
             }
             _ => unreachable!("convert_logic_predicate called on non-logic expr"),
@@ -1514,23 +1644,36 @@ impl AstConverter {
     }
 
     /// Convert string predicates (CONTAINS, STARTS WITH, ENDS WITH).
-    fn convert_string_predicate(&self, expr: &PredicateExpr) -> Result<Predicate> {
+    fn convert_string_predicate(
+        &self,
+        expr: &PredicateExpr,
+        scope: &EdgeScope,
+    ) -> Result<Predicate> {
         match expr {
             PredicateExpr::Contains {
                 property,
                 substring,
-            } => Ok(Predicate::Contains {
-                key: property.property.clone(),
-                substring: substring.clone(),
-            }),
-            PredicateExpr::StartsWith { property, prefix } => Ok(Predicate::StartsWith {
-                key: property.property.clone(),
-                prefix: prefix.clone(),
-            }),
-            PredicateExpr::EndsWith { property, suffix } => Ok(Predicate::EndsWith {
-                key: property.property.clone(),
-                suffix: suffix.clone(),
-            }),
+            } => scope.scope_leaf(
+                &property.variable,
+                Predicate::Contains {
+                    key: property.property.clone(),
+                    substring: substring.clone(),
+                },
+            ),
+            PredicateExpr::StartsWith { property, prefix } => scope.scope_leaf(
+                &property.variable,
+                Predicate::StartsWith {
+                    key: property.property.clone(),
+                    prefix: prefix.clone(),
+                },
+            ),
+            PredicateExpr::EndsWith { property, suffix } => scope.scope_leaf(
+                &property.variable,
+                Predicate::EndsWith {
+                    key: property.property.clone(),
+                    suffix: suffix.clone(),
+                },
+            ),
             _ => unreachable!("convert_string_predicate called on non-string expr"),
         }
     }
@@ -1540,15 +1683,19 @@ impl AstConverter {
         &self,
         property: &super::ast::PropertyAccess,
         values: &[PropertyValue],
+        scope: &EdgeScope,
     ) -> Result<Predicate> {
         let pred_values: Result<Vec<PredicateValue>> = values
             .iter()
             .map(|v| self.convert_property_value(v))
             .collect();
-        Ok(Predicate::In {
-            key: property.property.clone(),
-            values: pred_values?,
-        })
+        scope.scope_leaf(
+            &property.variable,
+            Predicate::In {
+                key: property.property.clone(),
+                values: pred_values?,
+            },
+        )
     }
 
     /// Convert a comparison expression.
@@ -1557,6 +1704,7 @@ impl AstConverter {
         left: &Expression,
         op: ComparisonOp,
         right: &Expression,
+        scope: &EdgeScope,
     ) -> Result<Predicate> {
         // Provenance accessors (Issue #3354a): `source(x)`/`confidence(x)`/
         // `reason(x)` appear as function calls, never property accesses, so a
@@ -1587,14 +1735,15 @@ impl AstConverter {
             let key = prop.property.clone();
             let value = self.expression_to_predicate_value(right)?;
 
-            return Ok(match op {
+            let leaf = match op {
                 ComparisonOp::Eq => Predicate::Eq { key, value },
                 ComparisonOp::Ne => Predicate::Ne { key, value },
                 ComparisonOp::Lt => Predicate::Lt { key, value },
                 ComparisonOp::Le => Predicate::Lte { key, value },
                 ComparisonOp::Gt => Predicate::Gt { key, value },
                 ComparisonOp::Ge => Predicate::Gte { key, value },
-            });
+            };
+            return scope.scope_leaf(&prop.variable, leaf);
         }
 
         // Try right side as property (swap operands)
@@ -1603,14 +1752,15 @@ impl AstConverter {
             let value = self.expression_to_predicate_value(left)?;
 
             // When swapping, we must flip inequalities
-            return Ok(match op {
+            let leaf = match op {
                 ComparisonOp::Eq => Predicate::Eq { key, value }, // Symmetric
                 ComparisonOp::Ne => Predicate::Ne { key, value }, // Symmetric
                 ComparisonOp::Lt => Predicate::Gt { key, value }, // < becomes >
                 ComparisonOp::Le => Predicate::Gte { key, value }, // <= becomes >=
                 ComparisonOp::Gt => Predicate::Lt { key, value }, // > becomes <
                 ComparisonOp::Ge => Predicate::Lte { key, value }, // >= becomes <=
-            });
+            };
+            return scope.scope_leaf(&prop.variable, leaf);
         }
 
         Err(Error::Query(QueryError::SyntaxError {
@@ -1817,9 +1967,17 @@ impl AstConverter {
         &self,
         order_clause: &OrderClause,
         ops: &mut Vec<QueryOp>,
+        scope: &EdgeScope,
     ) -> Result<()> {
         for item in &order_clause.items {
             let sort_key = match &item.expression {
+                // A property key on the single-hop relationship variable orders
+                // by the traversed edge (Issue #3622); a rel var in an
+                // unsupported position is rejected; node/unknown vars are
+                // node-scoped as before.
+                Expression::Property(prop) if scope.is_edge_var(&prop.variable)? => {
+                    SortKey::EdgeProperty(prop.property.clone())
+                }
                 Expression::Property(prop) => SortKey::Property(prop.property.clone()),
                 Expression::Identifier(name) => {
                     // Special identifiers for built-in sort keys
@@ -3169,7 +3327,7 @@ mod sentry_tests {
             variable: "n".to_string(),
             property: "prop".to_string(),
         });
-        let _ = converter.convert_logic_predicate(&expr);
+        let _ = converter.convert_logic_predicate(&expr, &EdgeScope::default());
     }
 
     #[test]
@@ -3180,6 +3338,6 @@ mod sentry_tests {
             variable: "n".to_string(),
             property: "prop".to_string(),
         });
-        let _ = converter.convert_string_predicate(&expr);
+        let _ = converter.convert_string_predicate(&expr, &EdgeScope::default());
     }
 }

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -1262,6 +1262,19 @@ fn is_missing_at_time(err: &crate::core::error::Error) -> bool {
     )
 }
 
+/// Whether an error from `get_node_at_time` means "this node is not visible at
+/// the coordinate" (so a temporal traversal should skip it, Issue #3622 F3)
+/// rather than a systemic failure. Covers the storage `NodeNotFound` /
+/// `VersionNotFound` that `get_node_at_time` raises plus the temporal variants.
+fn node_missing_at_time(err: &crate::core::error::Error) -> bool {
+    use crate::core::error::{Error, StorageError};
+    is_missing_at_time(err)
+        || matches!(
+            err,
+            Error::Storage(StorageError::NodeNotFound(_) | StorageError::VersionNotFound(_))
+        )
+}
+
 /// Iterator for valid-time range label scans (`BETWEEN ... AND ...`, Issue #552).
 ///
 /// # Semantics
@@ -1558,6 +1571,28 @@ impl TraversalIterator {
         }
     }
 
+    /// Fetch the traversal target node, reconstructed at the query's bi-temporal
+    /// coordinate under a temporal context (Issue #3622 F3), or current state
+    /// otherwise. `Ok(None)` means the node is not valid/visible at the
+    /// coordinate and the row must be skipped (openCypher #3225); other errors
+    /// propagate.
+    fn fetch_target_node(&self, node_id: NodeId) -> Result<Option<Node>> {
+        match self.temporal_context {
+            Some((valid_time, tx_time)) => {
+                match self
+                    .historical
+                    .read()
+                    .get_node_at_time(node_id, valid_time, tx_time)
+                {
+                    Ok(node) => Ok(Some(node)),
+                    Err(e) if node_missing_at_time(&e) => Ok(None),
+                    Err(e) => Err(e),
+                }
+            }
+            None => self.current.get_node(node_id).map(Some),
+        }
+    }
+
     /// Check if an edge existed at the specified temporal context using a pre-acquired lock guard.
     /// Returns true if no temporal context is set (current state query).
     #[inline]
@@ -1733,7 +1768,18 @@ impl ResultIterator for TraversalIterator {
                         // a target whose shortest path is below `min_depth` is
                         // marked visited here and never re-emitted deeper (see the
                         // struct-level docs).
-                        if self.visited.insert(target) {
+                        //
+                        // Relationship-distinct exception (Issue #3622): when an
+                        // edge variable is bound (`bind_edge`), emit ONE row per
+                        // traversed edge -- parallel edges to the same target (and
+                        // a self-loop) each surface with their own edge bound,
+                        // matching openCypher/Cypher per-edge semantics. This is
+                        // safe because `bind_edge` is only ever set on a single
+                        // fixed-length hop (the AQL converter rejects edge-var
+                        // refs on multi-hop / variable-length patterns), so the
+                        // depth-1 frontier never re-expands and cannot loop.
+                        let enqueue = self.visited.insert(target) || self.bind_edge;
+                        if enqueue {
                             // ⚡ Bolt Optimization: Pre-allocate capacity for new path to avoid reallocations.
                             // We are adding exactly 2 elements (edge and node) to the current path length.
                             let mut new_path = Vec::with_capacity(path.len() + 2);
@@ -1752,25 +1798,33 @@ impl ResultIterator for TraversalIterator {
                     && current_depth >= self.min_depth
                     && current_depth <= self.depth
                 {
-                    match self.current.get_node(node_id) {
-                        Ok(node) => {
-                            let mut row = QueryRow::with_path(EntityResult::Node(node), path);
-                            // Edge-property WHERE / ORDER BY (Issue #3622): attach
-                            // the immediately-traversed edge (the last edge in the
-                            // path), reconstructed at the query coordinate. Only
-                            // when the plan referenced an edge variable.
-                            if self.bind_edge
-                                && let Some(edge_id) = last_edge_in_path(&row.path)
-                            {
-                                match self.reconstruct_bound_edge(edge_id) {
-                                    Ok(edge) => row = row.with_edge_binding(edge),
-                                    Err(e) => return Some(Err(e)),
-                                }
-                            }
-                            return Some(Ok(row));
-                        }
+                    // Reconstruct the target node at the query's bi-temporal
+                    // coordinate (Issue #3622 F3): under a temporal context the
+                    // node is read AS-OF the coordinate, symmetric with the
+                    // reconstructed edge -- so an edge predicate and a node
+                    // predicate in one WHERE see mutually consistent state. A
+                    // node not valid at the coordinate is excluded (openCypher
+                    // #3225: a node no longer valid there does not continue the
+                    // traversal). Current-state traversal is unchanged.
+                    let node = match self.fetch_target_node(node_id) {
+                        Ok(Some(node)) => node,
+                        Ok(None) => continue,
                         Err(e) => return Some(Err(e)),
+                    };
+                    let mut row = QueryRow::with_path(EntityResult::Node(node), path);
+                    // Edge-property WHERE / ORDER BY (Issue #3622): attach the
+                    // immediately-traversed edge (the last edge in the path),
+                    // reconstructed at the query coordinate. Only when the plan
+                    // referenced an edge variable.
+                    if self.bind_edge
+                        && let Some(edge_id) = last_edge_in_path(&row.path)
+                    {
+                        match self.reconstruct_bound_edge(edge_id) {
+                            Ok(edge) => row = row.with_edge_binding(edge),
+                            Err(e) => return Some(Err(e)),
+                        }
                     }
+                    return Some(Ok(row));
                 }
                 continue;
             }
@@ -1903,6 +1957,12 @@ impl FilterIterator {
                 preds.iter().any(Self::predicate_needs_provenance)
             }
             Predicate::Not(pred) => Self::predicate_needs_provenance(pred),
+            // An edge-scoped wrapper (Issue #3622) carries only edge
+            // property/structural leaves (never provenance) in this lane, so it
+            // contributes no node-provenance requirement. Explicit rather than
+            // folded into the wildcard so a future edge-provenance leaf is a
+            // deliberate decision here.
+            Predicate::EdgeScoped(_) => false,
             _ => false,
         }
     }
@@ -2050,6 +2110,15 @@ impl FilterIterator {
                 .any(|p| self.evaluate_edge_predicate(p, edge, prov_cache)),
             Predicate::Not(pred) => !self.evaluate_edge_predicate(pred, edge, prov_cache),
             Predicate::False => false,
+            // An edge-scoped wrapper (Issue #3622) does not occur on this
+            // edge-ROW pass-through path (the AQL converter only emits it over
+            // node rows carrying an edge side channel). Handle it correctly for
+            // robustness: evaluate the inner tree against the edge row itself,
+            // matching the deliberately-exhaustive style of `evaluate_edge_full`.
+            Predicate::EdgeScoped(inner) => match edge {
+                Some(e) => self.evaluate_edge_full(inner, e, prov_cache),
+                None => true,
+            },
             // Non-provenance leaves retain the pre-existing edge pass-through.
             _ => true,
         }

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -1484,6 +1484,13 @@ pub struct TraversalIterator {
     /// Optional temporal context (valid_time, transaction_time) for edge filtering.
     /// When present, only edges that existed at the specified point in time are traversed.
     temporal_context: Option<(Timestamp, Timestamp)>,
+    /// When `true`, each emitted row carries the immediately-traversed edge
+    /// (reconstructed at `temporal_context`, or current-state) on its
+    /// [`QueryRow::edge`] side channel, for edge-property `WHERE` / `ORDER BY`
+    /// (Issue #3622). Set by the executor only when the physical plan references
+    /// an edge variable (a `Predicate::EdgeScoped` / `SortKey::EdgeProperty`),
+    /// so the overwhelming common case pays zero extra edge fetches.
+    bind_edge: bool,
     // BFS state - reset for each input node (see doc comment above)
     frontier: VecDeque<(NodeId, Vec<EntityId>, usize)>,
     visited: HashSet<NodeId>,
@@ -1517,9 +1524,37 @@ impl TraversalIterator {
             current,
             historical,
             temporal_context,
+            bind_edge: false,
             frontier: VecDeque::new(),
             visited: HashSet::new(),
             input_exhausted: false,
+        }
+    }
+
+    /// Enable attaching the immediately-traversed edge (reconstructed at the
+    /// query's bi-temporal coordinate) to each emitted row's
+    /// [`QueryRow::edge`] channel, for edge-property `WHERE` / `ORDER BY`
+    /// (Issue #3622). Defaults off, so ordinary traversals do no extra edge
+    /// work. Set by the executor only when the plan references an edge variable.
+    #[must_use]
+    pub fn bind_edges(mut self, enabled: bool) -> Self {
+        self.bind_edge = enabled;
+        self
+    }
+
+    /// Reconstruct the full edge `edge_id` as it exists at the traversal's
+    /// bi-temporal coordinate (or current state when none), for the
+    /// [`QueryRow::edge`] side channel (Issue #3622).
+    fn reconstruct_bound_edge(
+        &self,
+        edge_id: crate::core::EdgeId,
+    ) -> Result<crate::core::graph::Edge> {
+        match self.temporal_context {
+            Some((valid_time, tx_time)) => self
+                .historical
+                .read()
+                .get_edge_at_time(edge_id, valid_time, tx_time),
+            None => self.current.get_edge(edge_id),
         }
     }
 
@@ -1719,7 +1754,20 @@ impl ResultIterator for TraversalIterator {
                 {
                     match self.current.get_node(node_id) {
                         Ok(node) => {
-                            return Some(Ok(QueryRow::with_path(EntityResult::Node(node), path)));
+                            let mut row = QueryRow::with_path(EntityResult::Node(node), path);
+                            // Edge-property WHERE / ORDER BY (Issue #3622): attach
+                            // the immediately-traversed edge (the last edge in the
+                            // path), reconstructed at the query coordinate. Only
+                            // when the plan referenced an edge variable.
+                            if self.bind_edge
+                                && let Some(edge_id) = last_edge_in_path(&row.path)
+                            {
+                                match self.reconstruct_bound_edge(edge_id) {
+                                    Ok(edge) => row = row.with_edge_binding(edge),
+                                    Err(e) => return Some(Err(e)),
+                                }
+                            }
+                            return Some(Ok(row));
                         }
                         Err(e) => return Some(Err(e)),
                     }
@@ -1920,13 +1968,14 @@ impl FilterIterator {
     #[cfg(test)]
     fn evaluate(&self, node: &Node, prov: Option<&Provenance>) -> bool {
         let prov_cache: RefCell<Option<Option<Provenance>>> = RefCell::new(Some(prov.cloned()));
-        self.evaluate_predicate(&self.predicate, node, &prov_cache)
+        self.evaluate_predicate(&self.predicate, node, None, &prov_cache)
     }
 
     fn evaluate_predicate(
         &self,
         predicate: &Predicate,
         node: &Node,
+        edge: Option<&crate::core::graph::Edge>,
         prov_cache: &RefCell<Option<Option<Provenance>>>,
     ) -> bool {
         match predicate {
@@ -1950,6 +1999,14 @@ impl FilterIterator {
                 self.evaluate_ends_with(&node.properties, key, suffix)
             }
             Predicate::In { key, values } => self.evaluate_in(&node.properties, key, values),
+            // Edge-scoped leaf (Issue #3622): evaluate the wrapped sub-tree
+            // against the row's traversed edge with the shared openCypher edge
+            // semantics. A row whose edge is not valid at the query coordinate
+            // (no edge channel) fails the leaf.
+            Predicate::EdgeScoped(inner) => match edge {
+                Some(e) => self.evaluate_edge_full(inner, e, &RefCell::new(None)),
+                None => false,
+            },
             // Resolve provenance lazily so a cheaper conjunct that already
             // rejected the row short-circuits before any historical read.
             Predicate::Provenance(p) => {
@@ -1957,11 +2014,11 @@ impl FilterIterator {
             }
             Predicate::And(preds) => preds
                 .iter()
-                .all(|p| self.evaluate_predicate(p, node, prov_cache)),
+                .all(|p| self.evaluate_predicate(p, node, edge, prov_cache)),
             Predicate::Or(preds) => preds
                 .iter()
-                .any(|p| self.evaluate_predicate(p, node, prov_cache)),
-            Predicate::Not(pred) => !self.evaluate_predicate(pred, node, prov_cache),
+                .any(|p| self.evaluate_predicate(p, node, edge, prov_cache)),
+            Predicate::Not(pred) => !self.evaluate_predicate(pred, node, edge, prov_cache),
         }
     }
 
@@ -2095,10 +2152,13 @@ impl FilterIterator {
                 Some(self.evaluate_ends_with(props, key, suffix))
             }
             Predicate::In { key, values } => Some(self.evaluate_in(props, key, values)),
-            // Provenance / logical combinators need entity context.
-            Predicate::Provenance(_) | Predicate::And(_) | Predicate::Or(_) | Predicate::Not(_) => {
-                None
-            }
+            // Provenance / logical combinators / edge-scoped wrappers need
+            // entity context (resolved by the caller).
+            Predicate::Provenance(_)
+            | Predicate::And(_)
+            | Predicate::Or(_)
+            | Predicate::Not(_)
+            | Predicate::EdgeScoped(_) => None,
         }
     }
 
@@ -2140,6 +2200,10 @@ impl FilterIterator {
                 .iter()
                 .any(|p| self.evaluate_edge_full(p, edge, prov_cache)),
             Predicate::Not(pred) => !self.evaluate_edge_full(pred, edge, prov_cache),
+            // A nested edge-scoped wrapper (should not normally occur -- the AQL
+            // converter wraps leaves, not sub-trees) simply re-scopes to the
+            // same edge; unwrap and evaluate the inner tree.
+            Predicate::EdgeScoped(inner) => self.evaluate_edge_full(inner, edge, prov_cache),
             // Every property/structural leaf is resolved above; only provenance
             // leaves and logical combinators reach this match, and all four are
             // handled explicitly. A future `Predicate` variant that is neither
@@ -2312,6 +2376,9 @@ impl FilterIterator {
             | Predicate::Contains { .. }
             | Predicate::StartsWith { .. }
             | Predicate::EndsWith { .. } => false,
+            // A null OPTIONAL MATCH binding carries no traversed edge either, so
+            // an edge-scoped leaf is not-true (Issue #3622).
+            Predicate::EdgeScoped(_) => false,
             // A null OPTIONAL MATCH binding carries no entity and therefore no
             // provenance bundle: `provenance(x) IS NULL` is true, every other
             // provenance comparison is not-true (Issue #3354a).
@@ -2333,9 +2400,16 @@ impl ResultIterator for FilterIterator {
                         // and memoized per row, so an AND/OR of a property
                         // filter and a provenance filter shares one lookup and a
                         // cheaper conjunct's rejection skips the historical read
-                        // entirely (Issue #3354a).
+                        // entirely (Issue #3354a). A `Predicate::EdgeScoped` leaf
+                        // (Issue #3622) evaluates against the row's traversed
+                        // edge side channel.
                         let prov_cache: RefCell<Option<Option<Provenance>>> = RefCell::new(None);
-                        if self.evaluate_predicate(&self.predicate, node, &prov_cache) {
+                        if self.evaluate_predicate(
+                            &self.predicate,
+                            node,
+                            row.edge.as_ref(),
+                            &prov_cache,
+                        ) {
                             return Some(Ok(row));
                         }
                         // Filter didn't pass, continue to next
@@ -4222,7 +4296,10 @@ fn row_value<'a>(row: &'a QueryRow, key: &str) -> Option<&'a PropertyValue> {
 ///   `String`).
 /// - `source` / `target` -> the endpoint `NodeId` as its integer id.
 /// - `id` -> the edge's own `EdgeId` as its integer id.
-fn edge_structural_value(edge: &crate::core::graph::Edge, key: &str) -> Option<PropertyValue> {
+pub(crate) fn edge_structural_value(
+    edge: &crate::core::graph::Edge,
+    key: &str,
+) -> Option<PropertyValue> {
     match key {
         "type" | "label" => GLOBAL_INTERNER.resolve_with(edge.label, |s| PropertyValue::from(s)),
         "source" => Some(PropertyValue::Int(edge.source.as_u64() as i64)),
@@ -4230,6 +4307,26 @@ fn edge_structural_value(edge: &crate::core::graph::Edge, key: &str) -> Option<P
         "id" => Some(PropertyValue::Int(edge.id.as_u64() as i64)),
         _ => None,
     }
+}
+
+/// The id of the last edge in a traversal path (the edge that reached the
+/// path's final node), for attaching the single-hop traversed edge to a row
+/// (Issue #3622). `None` when the path is absent or contains no edge.
+fn last_edge_in_path(path: &Option<Vec<EntityId>>) -> Option<crate::core::EdgeId> {
+    path.as_ref()?.iter().rev().find_map(|e| match e {
+        EntityId::Edge(id) => Some(*id),
+        EntityId::Node(_) => None,
+    })
+}
+
+/// Resolve a [`SortKey::EdgeProperty`] key from a row's traversed edge side
+/// channel (Issue #3622): reserved structural fields (via
+/// [`edge_structural_value`], shadowing user props) first, then the edge's own
+/// properties. `None` when the row has no edge channel or the key is absent, so
+/// the row sorts as a null value.
+fn edge_sort_value(row: &QueryRow, key: &str) -> Option<PropertyValue> {
+    let edge = row.edge.as_ref()?;
+    edge_structural_value(edge, key).or_else(|| edge.properties.get(key).cloned())
 }
 
 /// `ORDER BY` iterator: buffers the entire input and stably sorts it by one or
@@ -4467,6 +4564,17 @@ impl SortIterator {
                 let bv = self.property_sort_value(b, prop);
                 Self::cmp_optional(av.as_deref(), bv.as_deref(), descending)
             }
+            // Edge-property ORDER BY (Issue #3622): resolve the key against the
+            // row's traversed edge side channel -- reserved structural fields
+            // (`type`/`label`/`source`/`target`/`id`) via `edge_structural_value`
+            // (shadowing user props), otherwise `edge.properties`. A row with no
+            // edge channel, or an absent key, sorts as null (openCypher null
+            // placement).
+            SortKey::EdgeProperty(prop) => {
+                let av = edge_sort_value(a, prop);
+                let bv = edge_sort_value(b, prop);
+                Self::cmp_optional(av.as_ref(), bv.as_ref(), descending)
+            }
             // Fallback on-the-fly resolution (Issue #3354). The hot path routes
             // provenance keys through `cmp_decorated` (resolve once per row), so
             // this arm is only a defensive fallback; it matches the WHERE-clause
@@ -4578,6 +4686,7 @@ impl ProvenanceProjectIterator {
             timestamp: row.timestamp,
             columns: Some(columns),
             bindings,
+            edge: row.edge,
         }
     }
 }

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -812,8 +812,10 @@ fn plan_needs_edge_binding(op: &PhysicalOp) -> bool {
         | PhysicalOp::Count { input, .. }
         | PhysicalOp::Aggregate { input, .. }
         | PhysicalOp::VectorRerank { input, .. }
+        | PhysicalOp::TemporalTrack { input, .. }
         | PhysicalOp::TemporalWindowAggregate { input, .. }
         | PhysicalOp::TemporalAlign { input, .. }
+        | PhysicalOp::Materialize { input, .. }
         | PhysicalOp::OptionalApply { input, .. } => plan_needs_edge_binding(input),
         // Binary set operators: either branch may carry the reference.
         PhysicalOp::HashJoin { left, right, .. }
@@ -822,8 +824,23 @@ fn plan_needs_edge_binding(op: &PhysicalOp) -> bool {
         | PhysicalOp::Except { left, right, .. } => {
             plan_needs_edge_binding(left) || plan_needs_edge_binding(right)
         }
-        // Leaf scans and other operators never carry an edge-scoped reference.
-        _ => false,
+        // Leaf sources (scans, similarity source) carry no edge-scoped
+        // reference. Every input-bearing operator is enumerated above, so a
+        // future single-input op that could sit over a Filter/Sort will fail to
+        // compile-match here rather than silently defaulting to `false`
+        // (edge-scoped -> all-false / edge sort-key -> null: a silent-wrong
+        // hazard). Keep this list exhaustive with the enum.
+        PhysicalOp::Empty
+        | PhysicalOp::NodeLookup { .. }
+        | PhysicalOp::NodeScan { .. }
+        | PhysicalOp::EdgeScan { .. }
+        | PhysicalOp::HnswSearch { .. }
+        | PhysicalOp::TemporalNodeLookup { .. }
+        | PhysicalOp::TemporalVectorSearch { .. }
+        | PhysicalOp::TemporalNodeScan { .. }
+        | PhysicalOp::TemporalNodeRangeScan { .. }
+        | PhysicalOp::SimilarToNode { .. }
+        | PhysicalOp::PropertyScan { .. } => false,
     }
 }
 
@@ -1247,6 +1264,60 @@ mod tests {
             predicate: Predicate::True,
         };
         assert!(!subtree_yields_edges(&filter_over_nodes));
+    }
+
+    #[test]
+    fn test_plan_needs_edge_binding_detects_edge_var_references() {
+        use crate::query::ir::{Direction, Predicate, PredicateValue, SortKey};
+
+        let traversal = |input: PhysicalOp| PhysicalOp::IndexedTraversal {
+            input: Box::new(input),
+            direction: Direction::Outgoing,
+            label: Some("KNOWS".to_string()),
+            min_depth: 1,
+            depth: 1,
+            temporal_context: None,
+        };
+        let node_scan = || PhysicalOp::NodeScan {
+            label: Some("Person".to_string()),
+            estimated_rows: 0,
+        };
+
+        // Filter carrying an `EdgeScoped` leaf above a traversal -> needs binding.
+        let edge_where = PhysicalOp::Filter {
+            input: Box::new(traversal(node_scan())),
+            predicate: Predicate::EdgeScoped(Box::new(Predicate::Gt {
+                key: "since".to_string(),
+                value: PredicateValue::Int(2020),
+            })),
+        };
+        assert!(plan_needs_edge_binding(&edge_where));
+
+        // Sort with an `EdgeProperty` key (even nested under a Project) -> needs binding.
+        let edge_order = PhysicalOp::Sort {
+            input: Box::new(PhysicalOp::Project {
+                input: Box::new(traversal(node_scan())),
+                properties: vec!["name".to_string()],
+            }),
+            keys: vec![(SortKey::EdgeProperty("since".to_string()), false)],
+        };
+        assert!(plan_needs_edge_binding(&edge_order));
+
+        // A node-only WHERE + ORDER BY over the same traversal -> no binding.
+        let node_only = PhysicalOp::Sort {
+            input: Box::new(PhysicalOp::Filter {
+                input: Box::new(traversal(node_scan())),
+                predicate: Predicate::Gt {
+                    key: "age".to_string(),
+                    value: PredicateValue::Int(18),
+                },
+            }),
+            keys: vec![(SortKey::Property("age".to_string()), false)],
+        };
+        assert!(!plan_needs_edge_binding(&node_only));
+
+        // A bare traversal references no edge var.
+        assert!(!plan_needs_edge_binding(&traversal(node_scan())));
     }
 
     /// Planner-invariant guard (Issue #3622 review fix): every `Filter`/`Sort`

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -4,7 +4,7 @@
 //! The executor transforms physical operators into iterators that
 //! lazily produce results.
 
-mod iterators;
+pub(crate) mod iterators;
 mod profiling;
 mod results;
 
@@ -17,7 +17,6 @@ use crate::storage::historical::HistoricalStorage;
 
 use super::planner::physical::{PhysicalOp, PhysicalPlan};
 
-#[doc(hidden)]
 pub use iterators::EdgeScanIterator;
 #[doc(hidden)]
 pub use iterators::NodeScanIterator;
@@ -196,7 +195,10 @@ impl QueryExecutor {
     /// }
     /// ```
     pub fn execute(&self, plan: PhysicalPlan) -> Result<QueryResults> {
-        let iterator = self.build_op(&plan.root, &mut None, 0)?;
+        let iterator = {
+            let bind_edge = plan_needs_edge_binding(&plan.root);
+            self.build_op(&plan.root, &mut None, 0, bind_edge)?
+        };
         // Wrap with provenance filter to conditionally strip metadata
         let filtered = Box::new(iterators::ProvenanceFilterIterator::new(
             iterator,
@@ -221,7 +223,10 @@ impl QueryExecutor {
     /// the registry.
     pub fn execute_profiled(&self, plan: &PhysicalPlan) -> Result<(QueryResults, ProfileRegistry)> {
         let mut registry: Option<ProfileRegistry> = Some(Vec::new());
-        let iterator = self.build_op(&plan.root, &mut registry, 0)?;
+        let iterator = {
+            let bind_edge = plan_needs_edge_binding(&plan.root);
+            self.build_op(&plan.root, &mut registry, 0, bind_edge)?
+        };
         let filtered = Box::new(iterators::ProvenanceFilterIterator::new(
             iterator,
             plan.include_provenance,
@@ -289,6 +294,11 @@ impl QueryExecutor {
         op: &PhysicalOp,
         profile: &mut Option<ProfileRegistry>,
         depth: usize,
+        // Whether the overall physical plan references an edge variable (a
+        // `Predicate::EdgeScoped` / `SortKey::EdgeProperty`), computed once at
+        // the plan root. When set, `IndexedTraversal` attaches the traversed
+        // edge to each row for edge-property WHERE / ORDER BY (Issue #3622).
+        bind_edge: bool,
     ) -> Result<Box<dyn ResultIterator>> {
         // Reserve this operator's profile slot *before* building its children so
         // the registry is in pre-order (the closure's mutable borrow of the
@@ -432,17 +442,20 @@ impl QueryExecutor {
                     depth: traversal_depth,
                     temporal_context,
                 } => {
-                    let input_iter = self.build_op(input, profile, child_depth)?;
-                    Box::new(iterators::TraversalIterator::new(
-                        input_iter,
-                        *direction,
-                        label.clone(),
-                        *min_depth,
-                        *traversal_depth,
-                        Arc::clone(&self.current),
-                        Arc::clone(&self.historical),
-                        *temporal_context,
-                    ))
+                    let input_iter = self.build_op(input, profile, child_depth, bind_edge)?;
+                    Box::new(
+                        iterators::TraversalIterator::new(
+                            input_iter,
+                            *direction,
+                            label.clone(),
+                            *min_depth,
+                            *traversal_depth,
+                            Arc::clone(&self.current),
+                            Arc::clone(&self.historical),
+                            *temporal_context,
+                        )
+                        .bind_edges(bind_edge),
+                    )
                 }
 
                 PhysicalOp::PropertyScan {
@@ -462,7 +475,7 @@ impl QueryExecutor {
                     // the AQL/Cypher single-entity pass-through. AQL/Cypher never
                     // emit `EdgeScan`, so this stays `false` there.
                     let edge_mode = subtree_yields_edges(input);
-                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    let input_iter = self.build_op(input, profile, child_depth, bind_edge)?;
                     // Pass historical storage so a `Predicate::Provenance` leaf
                     // (Issue #3354a) can resolve each row entity's write-time
                     // provenance; property-only filters never touch it.
@@ -485,7 +498,7 @@ impl QueryExecutor {
                     threshold,
                     score_alias,
                 } => {
-                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    let input_iter = self.build_op(input, profile, child_depth, bind_edge)?;
                     Box::new(iterators::VectorRerankIterator::with_options(
                         input_iter,
                         embedding.clone(),
@@ -503,12 +516,12 @@ impl QueryExecutor {
                     count,
                     offset,
                 } => {
-                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    let input_iter = self.build_op(input, profile, child_depth, bind_edge)?;
                     Box::new(iterators::LimitIterator::new(input_iter, *offset, *count))
                 }
 
                 PhysicalOp::Project { input, properties } => {
-                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    let input_iter = self.build_op(input, profile, child_depth, bind_edge)?;
                     Box::new(iterators::ProjectIterator::new(
                         input_iter,
                         properties.clone(),
@@ -516,7 +529,7 @@ impl QueryExecutor {
                 }
 
                 PhysicalOp::OptionalApply { input, steps } => {
-                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    let input_iter = self.build_op(input, profile, child_depth, bind_edge)?;
                     Box::new(iterators::OptionalApplyIterator::new(
                         input_iter,
                         steps.clone(),
@@ -530,7 +543,7 @@ impl QueryExecutor {
                     group_keys,
                     aggregates,
                 } => {
-                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    let input_iter = self.build_op(input, profile, child_depth, bind_edge)?;
                     Box::new(iterators::AggregateIterator::new(
                         input_iter,
                         group_keys.clone(),
@@ -539,7 +552,7 @@ impl QueryExecutor {
                 }
 
                 PhysicalOp::TemporalWindowAggregate { input, spec } => {
-                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    let input_iter = self.build_op(input, profile, child_depth, bind_edge)?;
                     // Historical storage is required to reconstruct each matched
                     // entity's valid-time history per window (Issue #3363).
                     Box::new(iterators::TemporalWindowAggregateIterator::new(
@@ -550,7 +563,7 @@ impl QueryExecutor {
                 }
 
                 PhysicalOp::TemporalAlign { input, spec } => {
-                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    let input_iter = self.build_op(input, profile, child_depth, bind_edge)?;
                     // Historical storage is required to reconstruct each matched
                     // participant's valid-time history (and gating edge validity)
                     // at the alignment coordinates (Issue #3379).
@@ -562,7 +575,7 @@ impl QueryExecutor {
                 }
 
                 PhysicalOp::Distinct { input } => {
-                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    let input_iter = self.build_op(input, profile, child_depth, bind_edge)?;
                     Box::new(iterators::DistinctIterator::new(input_iter))
                 }
 
@@ -573,7 +586,7 @@ impl QueryExecutor {
                     // null. AQL/Cypher never emit `EdgeScan`, so this is `false`
                     // there and node-only sort-key extraction is unchanged.
                     let edge_mode = subtree_yields_edges(input);
-                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    let input_iter = self.build_op(input, profile, child_depth, bind_edge)?;
                     // Pass historical storage so a `SortKey::Provenance` key
                     // (Issue #3354) can resolve each row entity's write-time
                     // provenance; property/score sorts never touch it.
@@ -588,7 +601,7 @@ impl QueryExecutor {
                 }
 
                 PhysicalOp::ProjectProvenance { input, projection } => {
-                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    let input_iter = self.build_op(input, profile, child_depth, bind_edge)?;
                     Box::new(iterators::ProvenanceProjectIterator::new(
                         input_iter,
                         projection.clone(),
@@ -597,7 +610,7 @@ impl QueryExecutor {
                 }
 
                 PhysicalOp::Count { input } => {
-                    let input_iter = self.build_op(input, profile, child_depth)?;
+                    let input_iter = self.build_op(input, profile, child_depth, bind_edge)?;
                     Box::new(iterators::CountIterator::new(input_iter))
                 }
 
@@ -759,6 +772,57 @@ fn subtree_yields_edges(op: &PhysicalOp) -> bool {
         | PhysicalOp::Project { input, .. }
         | PhysicalOp::Distinct { input, .. }
         | PhysicalOp::VectorRerank { input, .. } => subtree_yields_edges(input),
+        _ => false,
+    }
+}
+
+/// Whether the physical plan references an edge variable -- i.e. contains a
+/// [`Predicate::EdgeScoped`] leaf in any `Filter` or a [`SortKey::EdgeProperty`]
+/// key in any `Sort` (Issue #3622). Computed once at the plan root so the
+/// `IndexedTraversal` iterator only attaches the traversed edge to its rows
+/// (an extra reconstruct per row) when an edge-property `WHERE` / `ORDER BY`
+/// actually needs it; otherwise traversal behavior is byte-identical.
+fn plan_needs_edge_binding(op: &PhysicalOp) -> bool {
+    use crate::query::ir::{Predicate, SortKey};
+
+    fn predicate_has_edge_scoped(p: &Predicate) -> bool {
+        match p {
+            Predicate::EdgeScoped(_) => true,
+            Predicate::And(v) | Predicate::Or(v) => v.iter().any(predicate_has_edge_scoped),
+            Predicate::Not(inner) => predicate_has_edge_scoped(inner),
+            _ => false,
+        }
+    }
+
+    match op {
+        PhysicalOp::Filter { input, predicate } => {
+            predicate_has_edge_scoped(predicate) || plan_needs_edge_binding(input)
+        }
+        PhysicalOp::Sort { input, keys } => {
+            keys.iter()
+                .any(|(k, _)| matches!(k, SortKey::EdgeProperty(_)))
+                || plan_needs_edge_binding(input)
+        }
+        // Single-input pass-through operators: recurse into the child.
+        PhysicalOp::IndexedTraversal { input, .. }
+        | PhysicalOp::Limit { input, .. }
+        | PhysicalOp::Project { input, .. }
+        | PhysicalOp::ProjectProvenance { input, .. }
+        | PhysicalOp::Distinct { input, .. }
+        | PhysicalOp::Count { input, .. }
+        | PhysicalOp::Aggregate { input, .. }
+        | PhysicalOp::VectorRerank { input, .. }
+        | PhysicalOp::TemporalWindowAggregate { input, .. }
+        | PhysicalOp::TemporalAlign { input, .. }
+        | PhysicalOp::OptionalApply { input, .. } => plan_needs_edge_binding(input),
+        // Binary set operators: either branch may carry the reference.
+        PhysicalOp::HashJoin { left, right, .. }
+        | PhysicalOp::Union { left, right, .. }
+        | PhysicalOp::Intersect { left, right, .. }
+        | PhysicalOp::Except { left, right, .. } => {
+            plan_needs_edge_binding(left) || plan_needs_edge_binding(right)
+        }
+        // Leaf scans and other operators never carry an edge-scoped reference.
         _ => false,
     }
 }

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -190,6 +190,23 @@ pub struct QueryRow {
     /// [`entity`](Self::entity) is [`EntityResult::Null`]; the bound entities
     /// live here and any scalar projections live in [`columns`](Self::columns).
     pub bindings: Option<Vec<(String, EntityResult)>>,
+    /// The single graph edge traversed to reach this row's node entity, carried
+    /// on a dedicated side channel for edge-property `WHERE` / `ORDER BY` in the
+    /// AQL single-entity pipeline (Issue #3622).
+    ///
+    /// In AQL a `MATCH (a)-[r:KNOWS]->(b)` row has [`entity`](Self::entity) =
+    /// the target node `b`; the traversed edge `r` has nowhere else to live.
+    /// [`TraversalIterator`](super::iterators::TraversalIterator) attaches the
+    /// edge **reconstructed at the query's bi-temporal coordinate** here (only
+    /// when the plan references an edge variable), so a `Predicate::EdgeScoped`
+    /// leaf and a `SortKey::EdgeProperty` key evaluate against the edge as it
+    /// existed at that coordinate. It rides through the intervening `Project`
+    /// (which rewrites only [`entity`](Self::entity)) so a subsequent `ORDER BY`
+    /// still sees it even when the node was narrowed.
+    ///
+    /// `None` for the overwhelming common case (no edge variable referenced), so
+    /// those rows are byte-identical to their prior form.
+    pub edge: Option<Edge>,
 }
 
 impl QueryRow {
@@ -203,6 +220,7 @@ impl QueryRow {
             timestamp: None,
             columns: None,
             bindings: None,
+            edge: None,
         }
     }
 
@@ -233,6 +251,7 @@ impl QueryRow {
             timestamp: None,
             columns: Some(columns),
             bindings: None,
+            edge: None,
         }
     }
 
@@ -257,6 +276,7 @@ impl QueryRow {
             timestamp: None,
             columns,
             bindings: Some(bindings),
+            edge: None,
         }
     }
 
@@ -281,6 +301,7 @@ impl QueryRow {
             timestamp: None,
             columns: None,
             bindings: None,
+            edge: None,
         }
     }
 
@@ -294,6 +315,7 @@ impl QueryRow {
             timestamp: None,
             columns: None,
             bindings: None,
+            edge: None,
         }
     }
 
@@ -301,6 +323,15 @@ impl QueryRow {
     #[must_use]
     pub fn at_time(mut self, timestamp: Timestamp) -> Self {
         self.timestamp = Some(timestamp);
+        self
+    }
+
+    /// Attach the traversed edge (reconstructed at the query's bi-temporal
+    /// coordinate) to this row's [`edge`](Self::edge) side channel, for
+    /// edge-property `WHERE` / `ORDER BY` in the AQL pipeline (Issue #3622).
+    #[must_use]
+    pub fn with_edge_binding(mut self, edge: Edge) -> Self {
+        self.edge = Some(edge);
         self
     }
 
@@ -841,6 +872,7 @@ impl QueryResults {
                 timestamp,
                 columns: row_columns,
                 bindings: _,
+                edge: _,
             } = row;
 
             // Extract computed aggregation columns (padding rows without any
@@ -999,6 +1031,7 @@ impl QueryResults {
                 timestamp,
                 columns: _,
                 bindings: _,
+                edge: _,
             } = row;
 
             // Only edge-bearing rows contribute; node/null rows are dropped (edge-only,

--- a/src/query/ir.rs
+++ b/src/query/ir.rs
@@ -588,6 +588,15 @@ pub enum Direction {
 pub enum SortKey {
     /// Sort by a property value
     Property(String),
+    /// Sort by a property (or reserved structural field) of the row's
+    /// **traversed edge** (its [`edge`](crate::query::executor::QueryRow::edge)
+    /// side channel) rather than the node entity, for edge-property `ORDER BY`
+    /// in the AQL pipeline (Issue #3622). Reserved `type`/`label`/`source`/
+    /// `target`/`id` resolve structurally against the edge; a genuine user key
+    /// reads `edge.properties`. A row with no edge channel, or an absent key,
+    /// sorts as null (openCypher null placement). The edge is the one
+    /// reconstructed at the query's bi-temporal coordinate.
+    EdgeProperty(String),
     /// Sort by similarity score (for vector search results)
     Score,
     /// Sort by timestamp (for temporal queries)
@@ -701,6 +710,21 @@ pub enum Predicate {
 
     /// Logical NOT of a predicate
     Not(Box<Predicate>),
+
+    /// Evaluate the wrapped predicate against the row's **traversed edge**
+    /// (its [`edge`](crate::query::executor::QueryRow::edge) side channel)
+    /// instead of the row's node entity, for edge-property `WHERE` in the AQL
+    /// pipeline (Issue #3622). The AQL converter wraps each WHERE leaf that
+    /// references the single-hop relationship variable in this; node leaves stay
+    /// unwrapped and evaluate against the node entity as before. The inner
+    /// predicate is a plain property / structural / logical sub-tree (never
+    /// itself `EdgeScoped`), evaluated with the shared openCypher edge semantics
+    /// (`evaluate_edge_full`): reserved `type`/`label`/`source`/`target`/`id`
+    /// resolve structurally, `Ne` on an absent property includes, and the edge
+    /// is the one reconstructed at the query's bi-temporal coordinate. A row
+    /// with no edge channel (edge not valid at the coordinate) evaluates to
+    /// `false`.
+    EdgeScoped(Box<Predicate>),
 
     /// Filter on a version's write-time provenance (Issue #3354a).
     ///

--- a/src/query/planner/rules/operation_reordering.rs
+++ b/src/query/planner/rules/operation_reordering.rs
@@ -370,6 +370,10 @@ impl OperationReordering {
                 // For NOT: complement of inner selectivity
                 1.0 - self.estimate_filter_selectivity(inner, stats)
             }
+            // Edge-scoped leaves (Issue #3622) are evaluated against the row's
+            // traversed edge; estimate from the wrapped predicate so an edge
+            // equality still orders ahead of an edge range, etc.
+            Predicate::EdgeScoped(inner) => self.estimate_filter_selectivity(inner, stats),
             Predicate::Ne { .. } => NOT_EQUALS_SELECTIVITY,
             Predicate::In { .. } => IN_PREDICATE_SELECTIVITY,
             Predicate::Exists(_) | Predicate::NotExists(_) => EXISTENCE_CHECK_SELECTIVITY,

--- a/tests/edge_property_predicates.rs
+++ b/tests/edge_property_predicates.rs
@@ -1,0 +1,1026 @@
+//! Edge-property WHERE filtering + ORDER BY in AQL and Cypher (Issue #3622,
+//! completing the SQL lane #3648 for the graph query languages).
+//!
+//! Approach A: `r.<userprop>` resolves against the edge's properties; reserved
+//! fields (`type`/`label`/`source`/`target`/`id`) resolve structurally
+//! (shadowing user props), mirroring the SQL `edge_structural_value` semantics.
+//! Both languages route edge-variable leaves through the shared openCypher edge
+//! semantics, so SQL == AQL == Cypher: `Eq` on an absent property excludes,
+//! `Ne` on an absent property includes, and ORDER BY places nulls last for ASC /
+//! first for DESC. Unsupported forms return a structured error, never a silent
+//! 0-row / ignored clause. Edge predicates respect bi-temporal AS-OF
+//! coordinates (the edge is reconstructed at the query's coordinate).
+//!
+//! Both languages run against ONE shared graph helper, and a parity harness
+//! asserts the AQL and Cypher forms of each supported query return an identical
+//! result set.
+//!
+//! ## Implementation notes / documented asymmetries
+//!
+//! * **AQL** attaches the traversed edge to a dedicated `QueryRow::edge` side
+//!   channel (populated by `TraversalIterator`, reconstructed at the query
+//!   coordinate); the converter wraps a WHERE leaf on the single-hop
+//!   relationship variable in `Predicate::EdgeScoped` and an ORDER BY key in
+//!   `SortKey::EdgeProperty`.
+//! * **Cypher** multi-variable queries reject temporal `AS OF` uniformly (both
+//!   node and edge) via the multi_pattern house rule, so an edge-variable WHERE
+//!   combined with AS OF is a *structured error* (never a silently-wrong row) --
+//!   `cypher_bitemporal_edge_where_as_of_is_structured_error` pins this. Real
+//!   AS-OF edge predicates are therefore an AQL capability; the bi-temporal
+//!   assertions below run through AQL.
+//! * The multikey ORDER BY test returns the full node (`RETURN b`) rather than a
+//!   narrowed `RETURN b.name`, because AQL's `Project` narrows the node entity
+//!   before `Sort`, so a NODE sort key projected away resolves to null -- a
+//!   pre-existing AQL limitation orthogonal to the edge lane. The EDGE sort key
+//!   needs no such accommodation because it rides the preserved `edge` channel.
+//! * Bi-temporal tests use single-version edges in distinct valid windows: the
+//!   engine does not reconstruct a *superseded* valid-time edge version (an
+//!   engine-level gap outside this lane), so "AS OF sees a value changed by a
+//!   later valid-time update" is deliberately not asserted (see the SCOPE NOTE).
+#![cfg(feature = "cypher")]
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::PropertyMapBuilder;
+use aletheiadb::core::property::PropertyValue;
+use aletheiadb::core::temporal::Timestamp;
+use aletheiadb::query::executor::{EntityResult, QueryRow};
+use aletheiadb::query::temporal_window::parse_boundary_micros;
+
+// ---------------------------------------------------------------------------
+// Fixtures & helpers
+// ---------------------------------------------------------------------------
+
+/// Node ids of the standard graph (see [`std_graph`]). Only `alice`/`carol` are
+/// referenced (reserved `r.source`/`r.target` tests); the rest document the
+/// fixture.
+#[allow(dead_code)]
+struct Ids {
+    alice: u64,
+    bob: u64,
+    carol: u64,
+    dave: u64,
+    erin: u64,
+}
+
+/// The standard non-temporal graph used by the WHERE / ORDER BY cases.
+///
+/// Nodes (`Person`): Alice(age 30), Bob(25), Carol(17), Dave(40), Erin(22).
+/// Edges out of Alice (KNOWS created in this order: Bob, Carol, Dave, Erin, so
+/// the traversal order is Bob, Carol, Dave, Erin):
+///
+/// | target | KNOWS.since | KNOWS.role |
+/// |--------|-------------|------------|
+/// | Bob    | 2021        | engineer   |
+/// | Carol  | 2019        | manager    |
+/// | Dave   | 2022        | engineer   |
+/// | Erin   | (absent)    | intern     |
+///
+/// Plus one different-type edge Alice-FOLLOWS{since:2020, role:'peer'}->Bob to
+/// exercise the reserved `r.type` field. The `since` order deliberately does
+/// NOT follow creation order, so ORDER BY over `since` reorders vs the traversal
+/// order (which makes a broken/no-op sort observably wrong).
+fn std_graph() -> (AletheiaDB, Ids) {
+    let db = AletheiaDB::new().expect("db");
+    let person = |db: &AletheiaDB, name: &str, age: i64| {
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", name)
+                .insert("age", age)
+                .build(),
+        )
+        .expect("create person")
+    };
+    let alice = person(&db, "Alice", 30);
+    let bob = person(&db, "Bob", 25);
+    let carol = person(&db, "Carol", 17);
+    let dave = person(&db, "Dave", 40);
+    let erin = person(&db, "Erin", 22);
+
+    let knows = |db: &AletheiaDB, tgt, props: PropertyMapBuilder| {
+        db.create_edge(alice, tgt, "KNOWS", props.build())
+            .expect("create KNOWS");
+    };
+    knows(
+        &db,
+        bob,
+        PropertyMapBuilder::new()
+            .insert("since", 2021)
+            .insert("role", "engineer"),
+    );
+    knows(
+        &db,
+        carol,
+        PropertyMapBuilder::new()
+            .insert("since", 2019)
+            .insert("role", "manager"),
+    );
+    knows(
+        &db,
+        dave,
+        PropertyMapBuilder::new()
+            .insert("since", 2022)
+            .insert("role", "engineer"),
+    );
+    // Erin: KNOWS edge with NO `since` (absent-property cases).
+    knows(
+        &db,
+        erin,
+        PropertyMapBuilder::new().insert("role", "intern"),
+    );
+
+    // Different edge type for the reserved `r.type` field.
+    db.create_edge(
+        alice,
+        bob,
+        "FOLLOWS",
+        PropertyMapBuilder::new()
+            .insert("since", 2020)
+            .insert("role", "peer")
+            .build(),
+    )
+    .expect("create FOLLOWS");
+
+    let ids = Ids {
+        alice: alice.as_u64(),
+        bob: bob.as_u64(),
+        carol: carol.as_u64(),
+        dave: dave.as_u64(),
+        erin: erin.as_u64(),
+    };
+    (db, ids)
+}
+
+/// Microseconds since epoch for an RFC 3339 instant.
+fn micros(rfc: &str) -> i64 {
+    parse_boundary_micros(rfc).expect("valid rfc3339")
+}
+
+/// A `Timestamp` at an RFC 3339 instant.
+fn ts(rfc: &str) -> Timestamp {
+    Timestamp::from(micros(rfc))
+}
+
+/// Extract a node's `name` from a result row, robust to every row shape the
+/// pipeline produces: a scalar `name` column (`RETURN b.name AS name`, the
+/// multi-pattern/aggregate path), a single Node entity (`RETURN b` on the
+/// single-entity path), or a Node bound in `bindings` (`RETURN b` on the
+/// multi-pattern path). The row ORDER is always preserved by the callers.
+fn row_name(row: &QueryRow) -> Option<String> {
+    let as_str = |v: &PropertyValue| match v {
+        PropertyValue::String(s) => Some(s.to_string()),
+        _ => None,
+    };
+    // 1. Scalar projection column named "name".
+    if let Some(cols) = row.columns.as_ref()
+        && let Some((_, v)) = cols.iter().find(|(k, _)| k == "name")
+        && let Some(s) = as_str(v)
+    {
+        return Some(s);
+    }
+    // 2. Single Node entity.
+    if let Some(n) = row.entity.as_node()
+        && let Some(v) = n.get_property("name")
+    {
+        return as_str(v);
+    }
+    // 3. A Node bound in a multi-pattern binding.
+    if let Some(bindings) = row.bindings.as_ref() {
+        for (_, e) in bindings {
+            if let EntityResult::Node(n) = e
+                && let Some(v) = n.get_property("name")
+            {
+                return as_str(v);
+            }
+        }
+    }
+    None
+}
+
+/// Run an AQL query and return the ordered list of projected `name` values.
+/// A parse/convert/execute error is surfaced (with the query) so RED evidence
+/// distinguishes "wrong rows" from "failed to execute".
+fn aql_names(db: &AletheiaDB, q: &str) -> Vec<String> {
+    match db.execute_aql(q).and_then(|r| r.collect_all()) {
+        Ok(rows) => rows.iter().filter_map(row_name).collect(),
+        Err(e) => panic!("AQL failed to execute [{q}]: {e:?}"),
+    }
+}
+
+/// Run a Cypher query and return the ordered list of projected `name` values.
+fn cypher_names(db: &AletheiaDB, q: &str) -> Vec<String> {
+    match db.execute_cypher(q).and_then(|r| r.collect_all()) {
+        Ok(rows) => rows.iter().filter_map(row_name).collect(),
+        Err(e) => panic!("Cypher failed to execute [{q}]: {e:?}"),
+    }
+}
+
+/// Sort a name list (for unordered / set comparison of WHERE results).
+fn sorted(mut v: Vec<String>) -> Vec<String> {
+    v.sort();
+    v
+}
+
+fn owned(v: &[&str]) -> Vec<String> {
+    v.iter().map(|s| s.to_string()).collect()
+}
+
+/// True if an AQL query is a structured error, at parse/convert time OR at
+/// collection time. Used by the "never silently wrong" cases: a form we must
+/// reject must NOT return Ok rows.
+fn aql_is_error(db: &AletheiaDB, q: &str) -> bool {
+    match db.execute_aql(q) {
+        Err(_) => true,
+        Ok(results) => results.collect_all().is_err(),
+    }
+}
+
+/// True if a Cypher query is a structured error (parse/convert or collect).
+fn cypher_is_error(db: &AletheiaDB, q: &str) -> bool {
+    match db.execute_cypher(q) {
+        Err(_) => true,
+        Ok(results) => results.collect_all().is_err(),
+    }
+}
+
+/// The KNOWS-only start pattern shared by most WHERE / ORDER BY cases.
+const KNOWS: &str = "MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person)";
+/// Unlabeled relationship pattern (for reserved `r.type`).
+const ANYREL: &str = "MATCH (a:Person {name: 'Alice'})-[r]->(b:Person)";
+
+// ===========================================================================
+// WHERE cases -- each as an AQL test, a Cypher test, and a parity assertion.
+// ===========================================================================
+
+// --- eq (r.since = 2019); also proves absent-prop Eq EXCLUDES Erin ----------
+
+#[test]
+fn aql_where_eq() {
+    let (db, _) = std_graph();
+    let got = aql_names(
+        &db,
+        &format!("{KNOWS} WHERE r.since = 2019 RETURN b.name AS name"),
+    );
+    assert_eq!(sorted(got), owned(&["Carol"]));
+}
+
+#[test]
+fn cypher_where_eq() {
+    let (db, _) = std_graph();
+    let got = cypher_names(
+        &db,
+        &format!("{KNOWS} WHERE r.since = 2019 RETURN b.name AS name"),
+    );
+    assert_eq!(sorted(got), owned(&["Carol"]));
+}
+
+#[test]
+fn parity_where_eq() {
+    let (db, _) = std_graph();
+    let q = format!("{KNOWS} WHERE r.since = 2019 RETURN b.name AS name");
+    assert_eq!(sorted(aql_names(&db, &q)), sorted(cypher_names(&db, &q)));
+}
+
+// --- range (r.since > 2020) -------------------------------------------------
+
+#[test]
+fn aql_where_range() {
+    let (db, _) = std_graph();
+    let got = aql_names(
+        &db,
+        &format!("{KNOWS} WHERE r.since > 2020 RETURN b.name AS name"),
+    );
+    assert_eq!(sorted(got), owned(&["Bob", "Dave"]));
+}
+
+#[test]
+fn cypher_where_range() {
+    let (db, _) = std_graph();
+    let got = cypher_names(
+        &db,
+        &format!("{KNOWS} WHERE r.since > 2020 RETURN b.name AS name"),
+    );
+    assert_eq!(sorted(got), owned(&["Bob", "Dave"]));
+}
+
+#[test]
+fn parity_where_range() {
+    let (db, _) = std_graph();
+    let q = format!("{KNOWS} WHERE r.since > 2020 RETURN b.name AS name");
+    assert_eq!(sorted(aql_names(&db, &q)), sorted(cypher_names(&db, &q)));
+}
+
+// --- absent-prop Ne INCLUDES (r.since <> 2019 keeps Erin, whose edge has no
+//     `since`), while Bob(2019... no, 2021) etc. openCypher: Ne on absent -> true.
+
+#[test]
+fn aql_where_ne_absent_includes() {
+    let (db, _) = std_graph();
+    let got = aql_names(
+        &db,
+        &format!("{KNOWS} WHERE r.since <> 2019 RETURN b.name AS name"),
+    );
+    // Carol(2019) excluded; Bob(2021), Dave(2022) differ; Erin(absent) INCLUDED.
+    assert_eq!(sorted(got), owned(&["Bob", "Dave", "Erin"]));
+}
+
+#[test]
+fn cypher_where_ne_absent_includes() {
+    let (db, _) = std_graph();
+    let got = cypher_names(
+        &db,
+        &format!("{KNOWS} WHERE r.since <> 2019 RETURN b.name AS name"),
+    );
+    assert_eq!(sorted(got), owned(&["Bob", "Dave", "Erin"]));
+}
+
+#[test]
+fn parity_where_ne_absent_includes() {
+    let (db, _) = std_graph();
+    let q = format!("{KNOWS} WHERE r.since <> 2019 RETURN b.name AS name");
+    assert_eq!(sorted(aql_names(&db, &q)), sorted(cypher_names(&db, &q)));
+}
+
+// --- reserved r.type = 'KNOWS' (must return the KNOWS edges, NOT 0 rows) -----
+
+#[test]
+fn aql_where_reserved_type() {
+    let (db, _) = std_graph();
+    let got = aql_names(
+        &db,
+        &format!("{ANYREL} WHERE r.type = 'KNOWS' RETURN b.name AS name"),
+    );
+    assert_eq!(sorted(got), owned(&["Bob", "Carol", "Dave", "Erin"]));
+}
+
+#[test]
+fn cypher_where_reserved_type() {
+    let (db, _) = std_graph();
+    let got = cypher_names(
+        &db,
+        &format!("{ANYREL} WHERE r.type = 'KNOWS' RETURN b.name AS name"),
+    );
+    assert_eq!(sorted(got), owned(&["Bob", "Carol", "Dave", "Erin"]));
+}
+
+#[test]
+fn parity_where_reserved_type() {
+    let (db, _) = std_graph();
+    let q = format!("{ANYREL} WHERE r.type = 'KNOWS' RETURN b.name AS name");
+    assert_eq!(sorted(aql_names(&db, &q)), sorted(cypher_names(&db, &q)));
+}
+
+// --- reserved r.source / r.target = endpoint id -----------------------------
+
+#[test]
+fn aql_where_reserved_source() {
+    let (db, ids) = std_graph();
+    let got = aql_names(
+        &db,
+        &format!(
+            "{KNOWS} WHERE r.source = {} RETURN b.name AS name",
+            ids.alice
+        ),
+    );
+    assert_eq!(sorted(got), owned(&["Bob", "Carol", "Dave", "Erin"]));
+}
+
+#[test]
+fn cypher_where_reserved_source() {
+    let (db, ids) = std_graph();
+    let got = cypher_names(
+        &db,
+        &format!(
+            "{KNOWS} WHERE r.source = {} RETURN b.name AS name",
+            ids.alice
+        ),
+    );
+    assert_eq!(sorted(got), owned(&["Bob", "Carol", "Dave", "Erin"]));
+}
+
+#[test]
+fn aql_where_reserved_target() {
+    let (db, ids) = std_graph();
+    let got = aql_names(
+        &db,
+        &format!(
+            "{KNOWS} WHERE r.target = {} RETURN b.name AS name",
+            ids.carol
+        ),
+    );
+    assert_eq!(sorted(got), owned(&["Carol"]));
+}
+
+#[test]
+fn cypher_where_reserved_target() {
+    let (db, ids) = std_graph();
+    let got = cypher_names(
+        &db,
+        &format!(
+            "{KNOWS} WHERE r.target = {} RETURN b.name AS name",
+            ids.carol
+        ),
+    );
+    assert_eq!(sorted(got), owned(&["Carol"]));
+}
+
+#[test]
+fn parity_where_reserved_target() {
+    let (db, ids) = std_graph();
+    let q = format!(
+        "{KNOWS} WHERE r.target = {} RETURN b.name AS name",
+        ids.carol
+    );
+    assert_eq!(sorted(aql_names(&db, &q)), sorted(cypher_names(&db, &q)));
+}
+
+// --- edge-prop AND node-prop: each leaf must hit the right entity -----------
+// Dave passes the EDGE leaf (since 2022 > 2020) but fails the NODE leaf
+// (age 40 not < 30); Carol passes the node leaf (17 < 30) but fails the edge
+// leaf (2019 not > 2020). Only Bob (2021 > 2020 AND 25 < 30) survives.
+
+#[test]
+fn aql_where_edge_and_node() {
+    let (db, _) = std_graph();
+    let got = aql_names(
+        &db,
+        &format!("{KNOWS} WHERE r.since > 2020 AND b.age < 30 RETURN b.name AS name"),
+    );
+    assert_eq!(sorted(got), owned(&["Bob"]));
+}
+
+#[test]
+fn cypher_where_edge_and_node() {
+    let (db, _) = std_graph();
+    let got = cypher_names(
+        &db,
+        &format!("{KNOWS} WHERE r.since > 2020 AND b.age < 30 RETURN b.name AS name"),
+    );
+    assert_eq!(sorted(got), owned(&["Bob"]));
+}
+
+#[test]
+fn parity_where_edge_and_node() {
+    let (db, _) = std_graph();
+    let q = format!("{KNOWS} WHERE r.since > 2020 AND b.age < 30 RETURN b.name AS name");
+    assert_eq!(sorted(aql_names(&db, &q)), sorted(cypher_names(&db, &q)));
+}
+
+// --- OR over edge props -----------------------------------------------------
+
+#[test]
+fn aql_where_or() {
+    let (db, _) = std_graph();
+    let got = aql_names(
+        &db,
+        &format!("{KNOWS} WHERE r.since = 2021 OR r.role = 'manager' RETURN b.name AS name"),
+    );
+    assert_eq!(sorted(got), owned(&["Bob", "Carol"]));
+}
+
+#[test]
+fn cypher_where_or() {
+    let (db, _) = std_graph();
+    let got = cypher_names(
+        &db,
+        &format!("{KNOWS} WHERE r.since = 2021 OR r.role = 'manager' RETURN b.name AS name"),
+    );
+    assert_eq!(sorted(got), owned(&["Bob", "Carol"]));
+}
+
+#[test]
+fn parity_where_or() {
+    let (db, _) = std_graph();
+    let q = format!("{KNOWS} WHERE r.since = 2021 OR r.role = 'manager' RETURN b.name AS name");
+    assert_eq!(sorted(aql_names(&db, &q)), sorted(cypher_names(&db, &q)));
+}
+
+// --- NOT over an edge prop (absent -> NOT(false) = true, so Erin included) ---
+
+#[test]
+fn aql_where_not() {
+    let (db, _) = std_graph();
+    let got = aql_names(
+        &db,
+        &format!("{KNOWS} WHERE NOT (r.since = 2021) RETURN b.name AS name"),
+    );
+    assert_eq!(sorted(got), owned(&["Carol", "Dave", "Erin"]));
+}
+
+#[test]
+fn cypher_where_not() {
+    let (db, _) = std_graph();
+    let got = cypher_names(
+        &db,
+        &format!("{KNOWS} WHERE NOT (r.since = 2021) RETURN b.name AS name"),
+    );
+    assert_eq!(sorted(got), owned(&["Carol", "Dave", "Erin"]));
+}
+
+#[test]
+fn parity_where_not() {
+    let (db, _) = std_graph();
+    let q = format!("{KNOWS} WHERE NOT (r.since = 2021) RETURN b.name AS name");
+    assert_eq!(sorted(aql_names(&db, &q)), sorted(cypher_names(&db, &q)));
+}
+
+// --- string op on an edge prop (STARTS WITH) --------------------------------
+
+#[test]
+fn aql_where_starts_with() {
+    let (db, _) = std_graph();
+    let got = aql_names(
+        &db,
+        &format!("{KNOWS} WHERE r.role STARTS WITH 'eng' RETURN b.name AS name"),
+    );
+    assert_eq!(sorted(got), owned(&["Bob", "Dave"]));
+}
+
+#[test]
+fn cypher_where_starts_with() {
+    let (db, _) = std_graph();
+    let got = cypher_names(
+        &db,
+        &format!("{KNOWS} WHERE r.role STARTS WITH 'eng' RETURN b.name AS name"),
+    );
+    assert_eq!(sorted(got), owned(&["Bob", "Dave"]));
+}
+
+#[test]
+fn parity_where_starts_with() {
+    let (db, _) = std_graph();
+    let q = format!("{KNOWS} WHERE r.role STARTS WITH 'eng' RETURN b.name AS name");
+    assert_eq!(sorted(aql_names(&db, &q)), sorted(cypher_names(&db, &q)));
+}
+
+// ===========================================================================
+// ORDER BY cases (ordered comparisons; null placement matters).
+// ===========================================================================
+
+// --- ORDER BY r.since DESC (nulls FIRST) ------------------------------------
+
+#[test]
+fn aql_order_by_since_desc() {
+    let (db, _) = std_graph();
+    let got = aql_names(
+        &db,
+        &format!("{KNOWS} RETURN b.name AS name ORDER BY r.since DESC"),
+    );
+    assert_eq!(got, owned(&["Erin", "Dave", "Bob", "Carol"]));
+}
+
+#[test]
+fn cypher_order_by_since_desc() {
+    let (db, _) = std_graph();
+    let got = cypher_names(
+        &db,
+        &format!("{KNOWS} RETURN b.name AS name ORDER BY r.since DESC"),
+    );
+    assert_eq!(got, owned(&["Erin", "Dave", "Bob", "Carol"]));
+}
+
+#[test]
+fn parity_order_by_since_desc() {
+    let (db, _) = std_graph();
+    let q = format!("{KNOWS} RETURN b.name AS name ORDER BY r.since DESC");
+    assert_eq!(aql_names(&db, &q), cypher_names(&db, &q));
+}
+
+// --- ORDER BY r.since ASC (nulls LAST) --------------------------------------
+
+#[test]
+fn aql_order_by_since_asc() {
+    let (db, _) = std_graph();
+    let got = aql_names(
+        &db,
+        &format!("{KNOWS} RETURN b.name AS name ORDER BY r.since ASC"),
+    );
+    assert_eq!(got, owned(&["Carol", "Bob", "Dave", "Erin"]));
+}
+
+#[test]
+fn cypher_order_by_since_asc() {
+    let (db, _) = std_graph();
+    let got = cypher_names(
+        &db,
+        &format!("{KNOWS} RETURN b.name AS name ORDER BY r.since ASC"),
+    );
+    assert_eq!(got, owned(&["Carol", "Bob", "Dave", "Erin"]));
+}
+
+#[test]
+fn parity_order_by_since_asc() {
+    let (db, _) = std_graph();
+    let q = format!("{KNOWS} RETURN b.name AS name ORDER BY r.since ASC");
+    assert_eq!(aql_names(&db, &q), cypher_names(&db, &q));
+}
+
+// --- reserved ORDER BY r.target DESC (by endpoint id, distinct per edge) -----
+// Ids ascend Bob<Carol<Dave<Erin, so DESC = [Erin, Dave, Carol, Bob] -- which
+// differs from the traversal order, so a no-op/null sort is observably wrong.
+
+#[test]
+fn aql_order_by_reserved_target_desc() {
+    let (db, _) = std_graph();
+    let got = aql_names(
+        &db,
+        &format!("{KNOWS} RETURN b.name AS name ORDER BY r.target DESC"),
+    );
+    assert_eq!(got, owned(&["Erin", "Dave", "Carol", "Bob"]));
+}
+
+#[test]
+fn cypher_order_by_reserved_target_desc() {
+    let (db, _) = std_graph();
+    let got = cypher_names(
+        &db,
+        &format!("{KNOWS} RETURN b.name AS name ORDER BY r.target DESC"),
+    );
+    assert_eq!(got, owned(&["Erin", "Dave", "Carol", "Bob"]));
+}
+
+#[test]
+fn parity_order_by_reserved_target_desc() {
+    let (db, _) = std_graph();
+    let q = format!("{KNOWS} RETURN b.name AS name ORDER BY r.target DESC");
+    assert_eq!(aql_names(&db, &q), cypher_names(&db, &q));
+}
+
+// --- ORDER BY edge prop composed with WHERE edge prop + LIMIT ----------------
+// WHERE since > 2019 -> {Bob(2021), Dave(2022)}; ORDER BY since ASC -> Bob,Dave;
+// LIMIT 1 -> [Bob] (proves the sort runs before the limit over the edge stream).
+
+#[test]
+fn aql_order_by_where_limit() {
+    let (db, _) = std_graph();
+    let got = aql_names(
+        &db,
+        &format!("{KNOWS} WHERE r.since > 2019 RETURN b.name AS name ORDER BY r.since ASC LIMIT 1"),
+    );
+    assert_eq!(got, owned(&["Bob"]));
+}
+
+#[test]
+fn cypher_order_by_where_limit() {
+    let (db, _) = std_graph();
+    let got = cypher_names(
+        &db,
+        &format!("{KNOWS} WHERE r.since > 2019 RETURN b.name AS name ORDER BY r.since ASC LIMIT 1"),
+    );
+    assert_eq!(got, owned(&["Bob"]));
+}
+
+#[test]
+fn parity_order_by_where_limit() {
+    let (db, _) = std_graph();
+    let q =
+        format!("{KNOWS} WHERE r.since > 2019 RETURN b.name AS name ORDER BY r.since ASC LIMIT 1");
+    assert_eq!(aql_names(&db, &q), cypher_names(&db, &q));
+}
+
+// --- multi-key ORDER BY b.age, r.since (each key resolves against its entity)
+// Dedicated graph: an age tie (Bea & Cy at 25) must be broken by the EDGE key
+// r.since, and the tie's creation order is the REVERSE of the since order, so a
+// missing edge-key resolution is observably wrong.
+
+fn multikey_graph() -> AletheiaDB {
+    let db = AletheiaDB::new().expect("db");
+    let alice = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .expect("alice");
+    let mk = |name: &str, age: i64, since: i64| {
+        let n = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("name", name)
+                    .insert("age", age)
+                    .build(),
+            )
+            .expect("node");
+        db.create_edge(
+            alice,
+            n,
+            "KNOWS",
+            PropertyMapBuilder::new().insert("since", since).build(),
+        )
+        .expect("edge");
+    };
+    // Creation order Amy, Cy, Bea, Deb -- within the age-25 tie, Cy is created
+    // before Bea, but Bea(since 2019) must sort before Cy(since 2023).
+    mk("Amy", 17, 2030);
+    mk("Cy", 25, 2023);
+    mk("Bea", 25, 2019);
+    mk("Deb", 40, 2001);
+    db
+}
+
+#[test]
+fn aql_order_by_multikey() {
+    let db = multikey_graph();
+    let got = aql_names(
+        &db,
+        "MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person) \
+         RETURN b ORDER BY b.age ASC, r.since ASC",
+    );
+    assert_eq!(got, owned(&["Amy", "Bea", "Cy", "Deb"]));
+}
+
+#[test]
+fn cypher_order_by_multikey() {
+    let db = multikey_graph();
+    let got = cypher_names(
+        &db,
+        "MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person) \
+         RETURN b ORDER BY b.age ASC, r.since ASC",
+    );
+    assert_eq!(got, owned(&["Amy", "Bea", "Cy", "Deb"]));
+}
+
+#[test]
+fn parity_order_by_multikey() {
+    let db = multikey_graph();
+    let q = "MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person) \
+             RETURN b ORDER BY b.age ASC, r.since ASC";
+    assert_eq!(aql_names(&db, q), cypher_names(&db, q));
+}
+
+// ===========================================================================
+// Bi-temporal: edge predicates must respect AS-OF coordinates.
+// ===========================================================================
+//
+// SCOPE NOTE. The lane-relevant bi-temporal requirement is that an edge
+// predicate / sort key is evaluated against the edge *as visible at the query's
+// AS-OF coordinate* -- an edge not valid at that coordinate is excluded (not
+// matched). These tests assert exactly that, using single-version edges created
+// at DISTINCT valid-times.
+//
+// It deliberately does NOT assert "AS OF sees a superseded value after a
+// valid-time UPDATE": empirically (confirmed via `get_edge_at_valid_time` on
+// this trunk), after `update_edge_with_valid_time` the engine does not
+// reconstruct the earlier valid-time edge version -- `get_edge_at_valid_time`
+// at a pre-update coordinate returns `EdgeNotFound`, and the AS-OF traversal
+// drops the edge entirely. That is an engine-level historical-edge
+// reconstruction gap OUTSIDE the edge-property WHERE/ORDER lane, so pinning a
+// superseded value here would be a test the lane cannot make green.
+
+/// Bi-temporal graph with two single-version KNOWS edges in DISTINCT valid
+/// windows. Nodes are valid from 2018 (present across the window):
+///
+/// * Alice-KNOWS{since:2019}->Bob, valid from **2020**
+/// * Alice-KNOWS{since:2025}->Carol, valid from **2024**
+///
+/// So AS OF 2019 -> neither edge; AS OF 2022 -> only Bob's edge; AS OF 2026 ->
+/// both (validated empirically before adopting this fixture).
+fn bitemporal_graph() -> AletheiaDB {
+    let db = AletheiaDB::new().expect("db");
+    let tn = ts("2018-01-01T00:00:00Z");
+    let node = |name: &str| {
+        db.create_node_with_valid_time(
+            "Person",
+            PropertyMapBuilder::new().insert("name", name).build(),
+            Some(tn),
+        )
+        .expect("node")
+    };
+    let alice = node("Alice");
+    let bob = node("Bob");
+    let carol = node("Carol");
+    // Create Carol's edge FIRST so the traversal (creation) order is Carol, Bob
+    // -- the REVERSE of the ascending `since` order (Bob 2019 < Carol 2025). A
+    // no-op / broken sort therefore yields the wrong order at AS OF 2026, making
+    // the ordering assertion genuinely discriminating.
+    db.create_edge_with_valid_time(
+        alice,
+        carol,
+        "KNOWS",
+        PropertyMapBuilder::new().insert("since", 2025).build(),
+        Some(ts("2024-01-01T00:00:00Z")),
+    )
+    .expect("carol edge");
+    db.create_edge_with_valid_time(
+        alice,
+        bob,
+        "KNOWS",
+        PropertyMapBuilder::new().insert("since", 2019).build(),
+        Some(ts("2020-01-01T00:00:00Z")),
+    )
+    .expect("bob edge");
+    db
+}
+
+const BT_KNOWS: &str = "MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person)";
+
+#[test]
+fn aql_bitemporal_where_predicate_evaluated_at_as_of() {
+    let db = bitemporal_graph();
+    // AS OF 2022: only Bob's edge (since 2019) is valid. Carol's edge (since
+    // 2025) is not yet valid, so a predicate that WOULD match it returns nothing
+    // -- the predicate is gated by AS-OF visibility, not applied to a phantom.
+    let vt = micros("2022-01-01T00:00:00Z");
+    assert_eq!(
+        aql_names(
+            &db,
+            &format!("AS OF {vt} {BT_KNOWS} WHERE r.since = 2019 RETURN b.name AS name")
+        ),
+        owned(&["Bob"])
+    );
+    assert!(
+        aql_names(
+            &db,
+            &format!("AS OF {vt} {BT_KNOWS} WHERE r.since = 2025 RETURN b.name AS name")
+        )
+        .is_empty(),
+        "Carol's since=2025 edge is not valid at 2022, so it must not match"
+    );
+}
+
+#[test]
+fn aql_bitemporal_where_later_coordinate_sees_both_edges() {
+    let db = bitemporal_graph();
+    // AS OF 2026: both edges valid. Each predicate hits its own edge's value.
+    let vt = micros("2026-01-01T00:00:00Z");
+    assert_eq!(
+        aql_names(
+            &db,
+            &format!("AS OF {vt} {BT_KNOWS} WHERE r.since = 2025 RETURN b.name AS name")
+        ),
+        owned(&["Carol"])
+    );
+    assert_eq!(
+        aql_names(
+            &db,
+            &format!("AS OF {vt} {BT_KNOWS} WHERE r.since = 2019 RETURN b.name AS name")
+        ),
+        owned(&["Bob"])
+    );
+}
+
+#[test]
+fn aql_bitemporal_as_of_before_valid_from_excludes_edge() {
+    let db = bitemporal_graph();
+    // Before either edge's valid_from: no edge exists, so even a predicate on a
+    // value one of them WILL later hold yields nothing.
+    let vt = micros("2019-06-01T00:00:00Z");
+    assert!(
+        aql_names(
+            &db,
+            &format!("AS OF {vt} {BT_KNOWS} WHERE r.since = 2019 RETURN b.name AS name")
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn aql_bitemporal_order_by_respects_as_of_visibility() {
+    let db = bitemporal_graph();
+    // AS OF 2022: only Bob visible -> ORDER BY r.since -> [Bob].
+    let early = micros("2022-01-01T00:00:00Z");
+    assert_eq!(
+        aql_names(
+            &db,
+            &format!("AS OF {early} {BT_KNOWS} RETURN b.name AS name ORDER BY r.since ASC")
+        ),
+        owned(&["Bob"])
+    );
+    // AS OF 2026: both visible -> ORDER BY r.since ASC -> Bob(2019) then Carol(2025).
+    let late = micros("2026-01-01T00:00:00Z");
+    assert_eq!(
+        aql_names(
+            &db,
+            &format!("AS OF {late} {BT_KNOWS} RETURN b.name AS name ORDER BY r.since ASC")
+        ),
+        owned(&["Bob", "Carol"])
+    );
+}
+
+#[test]
+fn cypher_bitemporal_edge_where_as_of_is_structured_error() {
+    // DOCUMENTED LIMITATION: the Cypher multi-variable evaluator (which binds
+    // edge variables) rejects temporal `AS OF` qualifiers, so an edge-variable
+    // WHERE combined with AS OF is currently un-expressible in Cypher -- but it
+    // must fail as a *structured error*, never a silently-wrong row.
+    let db = bitemporal_graph();
+    let q = format!(
+        "{BT_KNOWS} WHERE r.since = 2019 AS OF SYSTEM_TIME '2021-01-01T00:00:00Z' RETURN b"
+    );
+    assert!(
+        cypher_is_error(&db, &q),
+        "Cypher edge-var WHERE + AS OF must be a structured error, not silent rows"
+    );
+}
+
+// ===========================================================================
+// Never-silently-wrong: unsupported forms must be a structured error.
+// ===========================================================================
+
+#[test]
+fn aql_variable_depth_edge_predicate_is_error() {
+    // A variable-depth relationship with a predicate on the relationship
+    // variable cannot bind a single edge -- it must be rejected, not applied to
+    // the target node (silent wrong/zero rows).
+    let (db, _) = std_graph();
+    let q = "MATCH (a:Person {name: 'Alice'})-[r:KNOWS*1..3]->(b:Person) \
+         WHERE r.since > 2020 RETURN b.name AS name";
+    assert!(
+        aql_is_error(&db, q),
+        "AQL variable-depth edge-var predicate must be a structured error"
+    );
+}
+
+#[test]
+fn cypher_variable_depth_edge_predicate_is_error() {
+    // Cypher already rejects variable-length relationships inside a bound
+    // pattern via the multi_pattern house rule -- assert it stays a structured
+    // error (regression guard for the "never silently wrong" contract).
+    let (db, _) = std_graph();
+    let q = "MATCH (a:Person {name: 'Alice'})-[r:KNOWS*1..3]->(b:Person) \
+         WHERE r.since > 2020 RETURN b";
+    assert!(
+        cypher_is_error(&db, q),
+        "Cypher variable-depth edge-var predicate must be a structured error"
+    );
+}
+
+#[test]
+fn aql_multihop_relationship_var_predicate_is_error() {
+    // A predicate leaf on a relationship variable within a MULTI-hop AQL pattern
+    // (two relationship variables) has no edge channel to bind against and must
+    // be rejected, not silently applied to a node.
+    let (db, _) = std_graph();
+    let q = "MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person)-[s:KNOWS]->(c:Person) \
+             WHERE r.since > 2020 RETURN c.name AS name";
+    assert!(
+        aql_is_error(&db, q),
+        "AQL multi-hop relationship-var predicate must be a structured error"
+    );
+}
+
+// ===========================================================================
+// Regression guards -- these should PASS immediately (node path untouched).
+// ===========================================================================
+
+#[test]
+fn regression_node_only_where_projection_aql() {
+    let (db, _) = std_graph();
+    let got = aql_names(&db, "MATCH (n:Person) WHERE n.age > 18 RETURN n");
+    assert_eq!(sorted(got), owned(&["Alice", "Bob", "Dave", "Erin"]));
+}
+
+#[test]
+fn regression_node_only_where_projection_cypher() {
+    let (db, _) = std_graph();
+    let got = cypher_names(&db, "MATCH (n:Person) WHERE n.age > 18 RETURN n");
+    assert_eq!(sorted(got), owned(&["Alice", "Bob", "Dave", "Erin"]));
+}
+
+#[test]
+fn regression_node_only_where_projection_parity() {
+    let (db, _) = std_graph();
+    let q = "MATCH (n:Person) WHERE n.age > 18 RETURN n";
+    assert_eq!(sorted(aql_names(&db, q)), sorted(cypher_names(&db, q)));
+}
+
+/// `RETURN r ORDER BY r.since` in Cypher is already GREEN (the multi_pattern
+/// evaluator binds the edge variable and sorts by its own property). This guard
+/// pins that behavior: the returned edges' `since` values are in ascending
+/// order with the absent value (Erin's edge) placed last.
+#[test]
+fn regression_cypher_return_edge_order_by_since_is_green() {
+    let (db, _) = std_graph();
+    let rows = db
+        .execute_cypher(&format!("{KNOWS} RETURN r ORDER BY r.since ASC"))
+        .expect("cypher executes")
+        .collect_all()
+        .expect("collect");
+
+    let sinces: Vec<Option<i64>> = rows
+        .iter()
+        .map(|row| {
+            let edge = row
+                .bindings
+                .as_ref()
+                .and_then(|b| {
+                    b.iter().find_map(|(_, e)| match e {
+                        EntityResult::Edge(edge) => Some(edge),
+                        _ => None,
+                    })
+                })
+                .expect("row binds an edge r");
+            match edge.get_property("since") {
+                Some(PropertyValue::Int(v)) => Some(*v),
+                None => None,
+                other => panic!("unexpected since {other:?}"),
+            }
+        })
+        .collect();
+
+    assert_eq!(
+        sinces,
+        vec![Some(2019), Some(2021), Some(2022), None],
+        "edges ordered by since ASC, null (Erin) last"
+    );
+}

--- a/tests/edge_property_predicates.rs
+++ b/tests/edge_property_predicates.rs
@@ -41,7 +41,10 @@
 
 use aletheiadb::AletheiaDB;
 use aletheiadb::PropertyMapBuilder;
+use aletheiadb::api::transaction::WriteRequestOptions;
+use aletheiadb::core::error::{Error, QueryError};
 use aletheiadb::core::property::PropertyValue;
+use aletheiadb::core::provenance::Provenance;
 use aletheiadb::core::temporal::Timestamp;
 use aletheiadb::query::executor::{EntityResult, QueryRow};
 use aletheiadb::query::temporal_window::parse_boundary_micros;
@@ -241,6 +244,76 @@ fn cypher_is_error(db: &AletheiaDB, q: &str) -> bool {
         Err(_) => true,
         Ok(results) => results.collect_all().is_err(),
     }
+}
+
+/// Full result rows of an AQL query (for row-count / edge-channel inspection).
+fn aql_rows(db: &AletheiaDB, q: &str) -> Vec<QueryRow> {
+    match db.execute_aql(q).and_then(|r| r.collect_all()) {
+        Ok(rows) => rows,
+        Err(e) => panic!("AQL failed to execute [{q}]: {e:?}"),
+    }
+}
+
+/// Full result rows of a Cypher query.
+fn cypher_rows(db: &AletheiaDB, q: &str) -> Vec<QueryRow> {
+    match db.execute_cypher(q).and_then(|r| r.collect_all()) {
+        Ok(rows) => rows,
+        Err(e) => panic!("Cypher failed to execute [{q}]: {e:?}"),
+    }
+}
+
+/// The `since` value on an AQL row's traversed-edge side channel (Issue #3622),
+/// or `None` if the row carries no edge / the edge has no integer `since`.
+fn aql_row_edge_since(row: &QueryRow) -> Option<i64> {
+    match row.edge.as_ref()?.get_property("since") {
+        Some(PropertyValue::Int(v)) => Some(*v),
+        _ => None,
+    }
+}
+
+/// The structured error of an AQL query (parse/convert/execute), or `None` if it
+/// succeeded.
+fn aql_error(db: &AletheiaDB, q: &str) -> Option<Error> {
+    db.execute_aql(q).and_then(|r| r.collect_all()).err()
+}
+
+/// Whether an error is the structured "single, fixed-length hop" rejection
+/// emitted for an edge-variable predicate/ORDER BY on an unsupported
+/// (multi-hop / variable-length) pattern (Issue #3622 F7).
+fn is_unsupported_hop_error(e: &Error) -> bool {
+    matches!(
+        e,
+        Error::Query(QueryError::UnsupportedFeature { feature })
+            if feature.contains("single, fixed-length hop")
+    )
+}
+
+/// Parity harness with row-count + no-drop rigor (Issue #3622 F12): asserts the
+/// AQL and Cypher forms return the same number of rows, that every row yields a
+/// name (no silently-dropped nameless row), and that the sorted name multisets
+/// are identical AND equal `expected`.
+fn assert_where_parity(db: &AletheiaDB, aql: &str, cypher: &str, expected: &[&str]) {
+    let a_rows = aql_rows(db, aql);
+    let c_rows = cypher_rows(db, cypher);
+    let a: Vec<String> = a_rows.iter().filter_map(row_name).collect();
+    let c: Vec<String> = c_rows.iter().filter_map(row_name).collect();
+    assert_eq!(
+        a.len(),
+        a_rows.len(),
+        "AQL dropped a nameless row for [{aql}]"
+    );
+    assert_eq!(
+        c.len(),
+        c_rows.len(),
+        "Cypher dropped a nameless row for [{cypher}]"
+    );
+    assert_eq!(
+        a_rows.len(),
+        c_rows.len(),
+        "row-count parity AQL [{aql}] vs Cypher [{cypher}]"
+    );
+    assert_eq!(sorted(a.clone()), sorted(c), "name multiset parity");
+    assert_eq!(sorted(a), owned(expected), "matches expected");
 }
 
 /// The KNOWS-only start pattern shared by most WHERE / ORDER BY cases.
@@ -1022,5 +1095,795 @@ fn regression_cypher_return_edge_order_by_since_is_green() {
         sinces,
         vec![Some(2019), Some(2021), Some(2022), None],
         "edges ordered by since ASC, null (Erin) last"
+    );
+}
+// ===========================================================================
+// F1 -- relationship-distinct emission: parallel edges + self-loop.
+// ===========================================================================
+
+const PAR_KNOWS: &str = "MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person)";
+
+/// Two PARALLEL KNOWS edges Alice->Bob with different `since` (a multigraph).
+fn parallel_graph() -> AletheiaDB {
+    let db = AletheiaDB::new().expect("db");
+    let alice = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .expect("alice");
+    let bob = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+        )
+        .expect("bob");
+    db.create_edge(
+        alice,
+        bob,
+        "KNOWS",
+        PropertyMapBuilder::new().insert("since", 2019).build(),
+    )
+    .expect("edge 2019");
+    db.create_edge(
+        alice,
+        bob,
+        "KNOWS",
+        PropertyMapBuilder::new().insert("since", 2023).build(),
+    )
+    .expect("edge 2023");
+    db
+}
+
+#[test]
+fn aql_parallel_edges_both_surface() {
+    let db = parallel_graph();
+    // Reference r (so the edge var binds -> relationship-distinct emission).
+    let rows = aql_rows(&db, &format!("{PAR_KNOWS} WHERE r.since >= 0 RETURN b"));
+    assert_eq!(
+        rows.len(),
+        2,
+        "both parallel edges surface (relationship-distinct), not node-distinct"
+    );
+    let mut sinces: Vec<i64> = rows.iter().filter_map(aql_row_edge_since).collect();
+    sinces.sort();
+    assert_eq!(sinces, vec![2019, 2023]);
+}
+
+#[test]
+fn cypher_parallel_edges_both_surface() {
+    let db = parallel_graph();
+    // Reference r so the row set is per-edge (Cypher binds the edge variable).
+    let rows = cypher_rows(&db, &format!("{PAR_KNOWS} WHERE r.since >= 0 RETURN b"));
+    assert_eq!(rows.len(), 2);
+}
+
+#[test]
+fn aql_parallel_edge_where_picks_right_edge() {
+    let db = parallel_graph();
+    // WHERE selects the matching edge even though both target the same node --
+    // a node-distinct traversal binding only the first-discovered edge would
+    // drop Bob if that edge was the 2023 one.
+    let r19 = aql_rows(&db, &format!("{PAR_KNOWS} WHERE r.since = 2019 RETURN b"));
+    assert_eq!(r19.len(), 1);
+    assert_eq!(aql_row_edge_since(&r19[0]), Some(2019));
+    let r23 = aql_rows(&db, &format!("{PAR_KNOWS} WHERE r.since = 2023 RETURN b"));
+    assert_eq!(r23.len(), 1);
+    assert_eq!(aql_row_edge_since(&r23[0]), Some(2023));
+}
+
+#[test]
+fn cypher_parallel_edge_where_picks_right_edge() {
+    let db = parallel_graph();
+    assert_eq!(
+        cypher_names(&db, &format!("{PAR_KNOWS} WHERE r.since = 2019 RETURN b")),
+        owned(&["Bob"])
+    );
+}
+
+#[test]
+fn parity_different_type_parallel_edge_where() {
+    // std_graph: Alice-KNOWS{since:2021}->Bob AND Alice-FOLLOWS{since:2020}->Bob.
+    // `-[r]->` WHERE r.since = 2020 must surface Bob via the FOLLOWS edge; a
+    // node-distinct traversal binding the first KNOWS(2021) edge would drop it.
+    let (db, _) = std_graph();
+    assert_where_parity(
+        &db,
+        &format!("{ANYREL} WHERE r.since = 2020 RETURN b.name AS name"),
+        &format!("{ANYREL} WHERE r.since = 2020 RETURN b.name AS name"),
+        &["Bob"],
+    );
+}
+
+/// Alice with a KNOWS self-loop (source == target).
+fn self_loop_graph() -> (AletheiaDB, u64) {
+    let db = AletheiaDB::new().expect("db");
+    let alice = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .expect("alice");
+    db.create_edge(
+        alice,
+        alice,
+        "KNOWS",
+        PropertyMapBuilder::new().insert("since", 2021).build(),
+    )
+    .expect("self-loop");
+    (db, alice.as_u64())
+}
+
+#[test]
+fn aql_self_loop_emits_row() {
+    let (db, _) = self_loop_graph();
+    // The edge var is referenced, so the self-loop (source == target) emits one
+    // relationship-distinct row bound to its edge.
+    assert_eq!(
+        aql_names(
+            &db,
+            &format!("{PAR_KNOWS} WHERE r.since = 2021 RETURN b.name AS name")
+        ),
+        owned(&["Alice"])
+    );
+}
+
+#[test]
+fn cypher_self_loop_emits_row() {
+    let (db, _) = self_loop_graph();
+    assert_eq!(
+        cypher_names(
+            &db,
+            &format!("{PAR_KNOWS} WHERE r.since = 2021 RETURN b.name AS name")
+        ),
+        owned(&["Alice"])
+    );
+}
+
+#[test]
+fn aql_self_loop_reserved_source_equals_target() {
+    let (db, alice) = self_loop_graph();
+    // On a self-loop, structural r.source == r.target == alice.
+    assert_eq!(
+        aql_names(
+            &db,
+            &format!(
+                "{PAR_KNOWS} WHERE r.source = {alice} AND r.target = {alice} RETURN b.name AS name"
+            )
+        ),
+        owned(&["Alice"])
+    );
+    assert!(
+        aql_names(
+            &db,
+            &format!("{PAR_KNOWS} WHERE r.target = 999999 RETURN b.name AS name")
+        )
+        .is_empty()
+    );
+}
+
+// ===========================================================================
+// F5 -- reserved-field SHADOWING: structural fields beat like-named user props.
+// ===========================================================================
+
+const SH_KNOWS: &str = "MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person)";
+
+/// Two KNOWS edges carrying like-named USER props `type`/`source` set to
+/// reordering/mismatching values, so a flipped precedence would change results.
+fn shadow_graph() -> (AletheiaDB, u64) {
+    let db = AletheiaDB::new().expect("db");
+    let person = |name: &str| {
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", name).build(),
+        )
+        .expect("node")
+    };
+    let alice = person("Alice");
+    let bob = person("Bob");
+    let carol = person("Carol");
+    db.create_edge(
+        alice,
+        bob,
+        "KNOWS",
+        PropertyMapBuilder::new()
+            .insert("type", "bogus")
+            .insert("source", 2)
+            .insert("since", 2021)
+            .build(),
+    )
+    .expect("bob edge");
+    db.create_edge(
+        alice,
+        carol,
+        "KNOWS",
+        PropertyMapBuilder::new()
+            .insert("type", "bogus")
+            .insert("source", 1)
+            .insert("since", 2019)
+            .build(),
+    )
+    .expect("carol edge");
+    (db, alice.as_u64())
+}
+
+#[test]
+fn aql_reserved_type_shadows_user_prop() {
+    let (db, _) = shadow_graph();
+    // Structural label wins: `r.type = 'KNOWS'` matches, `r.type = 'bogus'`
+    // (the USER prop value) does NOT.
+    assert_eq!(
+        sorted(aql_names(
+            &db,
+            &format!("{SH_KNOWS} WHERE r.type = 'KNOWS' RETURN b.name AS name")
+        )),
+        owned(&["Bob", "Carol"])
+    );
+    assert!(
+        aql_names(
+            &db,
+            &format!("{SH_KNOWS} WHERE r.type = 'bogus' RETURN b.name AS name")
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn cypher_reserved_type_shadows_user_prop() {
+    let (db, _) = shadow_graph();
+    assert_eq!(
+        sorted(cypher_names(
+            &db,
+            &format!("{SH_KNOWS} WHERE r.type = 'KNOWS' RETURN b.name AS name")
+        )),
+        owned(&["Bob", "Carol"])
+    );
+    assert!(
+        cypher_names(
+            &db,
+            &format!("{SH_KNOWS} WHERE r.type = 'bogus' RETURN b.name AS name")
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn parity_reserved_type_shadowing() {
+    let (db, _) = shadow_graph();
+    assert_where_parity(
+        &db,
+        &format!("{SH_KNOWS} WHERE r.type = 'KNOWS' RETURN b.name AS name"),
+        &format!("{SH_KNOWS} WHERE r.type = 'KNOWS' RETURN b.name AS name"),
+        &["Bob", "Carol"],
+    );
+}
+
+#[test]
+fn aql_reserved_source_shadows_user_prop() {
+    let (db, alice) = shadow_graph();
+    // Structural source (== alice) wins over the user `source` (1 / 2).
+    assert_eq!(
+        sorted(aql_names(
+            &db,
+            &format!("{SH_KNOWS} WHERE r.source = {alice} RETURN b.name AS name")
+        )),
+        owned(&["Bob", "Carol"])
+    );
+    // The user `source` value 1 (Carol's edge) must NOT match once shadowed.
+    assert!(
+        aql_names(
+            &db,
+            &format!("{SH_KNOWS} WHERE r.source = 1 RETURN b.name AS name")
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn aql_order_by_reserved_source_shadows_user_prop() {
+    let (db, _) = shadow_graph();
+    // Structural source is the same (alice) for both edges -> a stable no-op
+    // sort preserves creation order [Bob, Carol]. Ordering by the USER `source`
+    // (Bob=2, Carol=1) would instead give [Carol, Bob], so this pins the
+    // structural-wins precedence for ORDER BY.
+    assert_eq!(
+        aql_names(
+            &db,
+            &format!("{SH_KNOWS} RETURN b.name AS name ORDER BY r.source ASC")
+        ),
+        owned(&["Bob", "Carol"])
+    );
+}
+
+#[test]
+fn cypher_order_by_reserved_source_shadows_user_prop() {
+    let (db, _) = shadow_graph();
+    assert_eq!(
+        cypher_names(
+            &db,
+            &format!("{SH_KNOWS} RETURN b.name AS name ORDER BY r.source ASC")
+        ),
+        owned(&["Bob", "Carol"])
+    );
+}
+
+// ===========================================================================
+// F6/F7 -- ORDER BY reject path + structured error KIND for reject cases.
+// ===========================================================================
+
+#[test]
+fn aql_multihop_relationship_var_order_by_is_error() {
+    let (db, _) = std_graph();
+    let q = "MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person)-[s:KNOWS]->(c:Person) \
+             RETURN c.name AS name ORDER BY r.since";
+    assert!(aql_is_error(&db, q));
+}
+
+#[test]
+fn aql_variable_depth_edge_order_by_is_error() {
+    let (db, _) = std_graph();
+    let q = "MATCH (a:Person {name: 'Alice'})-[r:KNOWS*1..3]->(b:Person) \
+             RETURN b.name AS name ORDER BY r.since";
+    assert!(aql_is_error(&db, q));
+}
+
+#[test]
+fn aql_reject_error_kind_is_unsupported_single_hop() {
+    // F7: pin the reject reason (not merely "some Err") on all four shapes.
+    let (db, _) = std_graph();
+    let cases = [
+        "MATCH (a:Person {name: 'Alice'})-[r:KNOWS*1..3]->(b:Person) \
+         WHERE r.since > 2020 RETURN b.name AS name",
+        "MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person)-[s:KNOWS]->(c:Person) \
+         WHERE r.since > 2020 RETURN c.name AS name",
+        "MATCH (a:Person {name: 'Alice'})-[r:KNOWS*1..3]->(b:Person) \
+         RETURN b.name AS name ORDER BY r.since",
+        "MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person)-[s:KNOWS]->(c:Person) \
+         RETURN c.name AS name ORDER BY r.since",
+    ];
+    for q in cases {
+        let e = aql_error(&db, q).unwrap_or_else(|| panic!("expected an error for [{q}]"));
+        assert!(
+            is_unsupported_hop_error(&e),
+            "expected the 'single, fixed-length hop' UnsupportedFeature for [{q}], got {e:?}"
+        );
+    }
+}
+
+// ===========================================================================
+// F8 -- reserved r.id and r.label.
+// ===========================================================================
+
+const ID_KNOWS: &str = "MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person)";
+
+/// Alice-KNOWS->Bob then Alice-KNOWS->Carol; returns (db, bob_edge_id, carol_edge_id).
+fn id_graph() -> (AletheiaDB, u64, u64) {
+    let db = AletheiaDB::new().expect("db");
+    let person = |name: &str| {
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", name).build(),
+        )
+        .expect("node")
+    };
+    let alice = person("Alice");
+    let bob = person("Bob");
+    let carol = person("Carol");
+    let e_bob = db
+        .create_edge(
+            alice,
+            bob,
+            "KNOWS",
+            PropertyMapBuilder::new().insert("since", 2021).build(),
+        )
+        .expect("bob edge");
+    let e_carol = db
+        .create_edge(
+            alice,
+            carol,
+            "KNOWS",
+            PropertyMapBuilder::new().insert("since", 2019).build(),
+        )
+        .expect("carol edge");
+    (db, e_bob.as_u64(), e_carol.as_u64())
+}
+
+#[test]
+fn aql_where_reserved_id() {
+    let (db, e_bob, _) = id_graph();
+    assert_eq!(
+        aql_names(
+            &db,
+            &format!("{ID_KNOWS} WHERE r.id = {e_bob} RETURN b.name AS name")
+        ),
+        owned(&["Bob"])
+    );
+}
+
+#[test]
+fn cypher_where_reserved_id() {
+    let (db, e_bob, _) = id_graph();
+    assert_eq!(
+        cypher_names(
+            &db,
+            &format!("{ID_KNOWS} WHERE r.id = {e_bob} RETURN b.name AS name")
+        ),
+        owned(&["Bob"])
+    );
+}
+
+#[test]
+fn aql_order_by_reserved_id() {
+    let (db, _, _) = id_graph();
+    // Bob's edge is created first (lower id), so ORDER BY r.id ASC -> [Bob, Carol].
+    assert_eq!(
+        aql_names(
+            &db,
+            &format!("{ID_KNOWS} RETURN b.name AS name ORDER BY r.id ASC")
+        ),
+        owned(&["Bob", "Carol"])
+    );
+}
+
+#[test]
+fn parity_where_reserved_label() {
+    let (db, _) = std_graph();
+    // `r.label` is the structural label alias of `r.type`.
+    assert_where_parity(
+        &db,
+        &format!("{KNOWS} WHERE r.label = 'KNOWS' RETURN b.name AS name"),
+        &format!("{KNOWS} WHERE r.label = 'KNOWS' RETURN b.name AS name"),
+        &["Bob", "Carol", "Dave", "Erin"],
+    );
+}
+
+// ===========================================================================
+// F9 -- edge leaf AND node-provenance leaf in one WHERE (each routes to its
+// own entity while the edge channel is populated).
+// ===========================================================================
+
+fn prov_graph() -> AletheiaDB {
+    let db = AletheiaDB::new().expect("db");
+    let alice = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .expect("alice");
+    let person_conf = |name: &str, conf: f64| {
+        db.create_node_with_options(
+            "Person",
+            PropertyMapBuilder::new().insert("name", name).build(),
+            WriteRequestOptions::new().with_provenance(
+                Provenance::builder()
+                    .confidence(conf)
+                    .build()
+                    .expect("valid provenance"),
+            ),
+        )
+        .expect("node")
+    };
+    let bob = person_conf("Bob", 0.95);
+    let carol = person_conf("Carol", 0.95);
+    let dave = person_conf("Dave", 0.5);
+    let knows = |tgt, since: i64| {
+        db.create_edge(
+            alice,
+            tgt,
+            "KNOWS",
+            PropertyMapBuilder::new().insert("since", since).build(),
+        )
+        .expect("edge");
+    };
+    knows(bob, 2021);
+    knows(carol, 2019);
+    knows(dave, 2022);
+    db
+}
+
+#[test]
+fn aql_where_edge_and_provenance() {
+    let db = prov_graph();
+    // Edge leaf (r.since) routes to the edge channel; node-provenance leaf
+    // (confidence(b)) routes to the target node's provenance. Carol fails the
+    // EDGE leaf (2019 !> 2020); Dave fails the NODE-provenance leaf (0.5 < 0.9).
+    assert_eq!(
+        aql_names(
+            &db,
+            "MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person) \
+             WHERE r.since > 2020 AND confidence(b) >= 0.9 RETURN b.name AS name"
+        ),
+        owned(&["Bob"])
+    );
+}
+
+// ===========================================================================
+// F10 -- negative / float edge property (range WHERE + ORDER BY).
+// ===========================================================================
+
+const W_KNOWS: &str = "MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person)";
+
+fn weight_graph() -> AletheiaDB {
+    let db = AletheiaDB::new().expect("db");
+    let person = |name: &str| {
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", name).build(),
+        )
+        .expect("node")
+    };
+    let alice = person("Alice");
+    let bob = person("Bob");
+    let carol = person("Carol");
+    let dave = person("Dave");
+    let knows = |tgt, w: f64| {
+        db.create_edge(
+            alice,
+            tgt,
+            "KNOWS",
+            PropertyMapBuilder::new().insert("weight", w).build(),
+        )
+        .expect("edge");
+    };
+    knows(bob, -1.5);
+    knows(carol, 2.5);
+    knows(dave, 0.0);
+    db
+}
+
+#[test]
+fn parity_where_negative_float_weight() {
+    let db = weight_graph();
+    // Compare with a float literal `0.0`: AQL's WHERE comparators do not coerce
+    // Float-vs-Int operands (a pre-existing AQL limitation orthogonal to this
+    // lane -- it affects node comparisons too), so a type-matched literal keeps
+    // the test in-lane while still exercising a negative float edge property.
+    assert_where_parity(
+        &db,
+        &format!("{W_KNOWS} WHERE r.weight < 0.0 RETURN b.name AS name"),
+        &format!("{W_KNOWS} WHERE r.weight < 0.0 RETURN b.name AS name"),
+        &["Bob"],
+    );
+}
+
+#[test]
+fn aql_order_by_float_weight() {
+    let db = weight_graph();
+    assert_eq!(
+        aql_names(
+            &db,
+            &format!("{W_KNOWS} RETURN b.name AS name ORDER BY r.weight ASC")
+        ),
+        owned(&["Bob", "Dave", "Carol"])
+    );
+}
+
+#[test]
+fn cypher_order_by_float_weight() {
+    let db = weight_graph();
+    assert_eq!(
+        cypher_names(
+            &db,
+            &format!("{W_KNOWS} RETURN b.name AS name ORDER BY r.weight ASC")
+        ),
+        owned(&["Bob", "Dave", "Carol"])
+    );
+}
+
+// ===========================================================================
+// F11 -- edge-prop IN / CONTAINS / IS NULL parity (plain + negated), incl.
+// the absent-property node-semantics that F2 fixes on the Cypher side.
+// ===========================================================================
+
+#[test]
+fn parity_where_in() {
+    let (db, _) = std_graph();
+    assert_where_parity(
+        &db,
+        &format!("{KNOWS} WHERE r.role IN ['engineer', 'manager'] RETURN b.name AS name"),
+        &format!("{KNOWS} WHERE r.role IN ['engineer', 'manager'] RETURN b.name AS name"),
+        &["Bob", "Carol", "Dave"],
+    );
+}
+
+#[test]
+fn parity_where_not_in_absent_includes() {
+    let (db, _) = std_graph();
+    // Erin's edge has no `since` -> node-semantics `IN` is definite false ->
+    // NOT includes Erin (F2). Dave (2022 not in list) also included.
+    assert_where_parity(
+        &db,
+        &format!("{KNOWS} WHERE NOT (r.since IN [2019, 2021]) RETURN b.name AS name"),
+        &format!("{KNOWS} WHERE NOT (r.since IN [2019, 2021]) RETURN b.name AS name"),
+        &["Dave", "Erin"],
+    );
+}
+
+#[test]
+fn parity_where_contains() {
+    let (db, _) = std_graph();
+    assert_where_parity(
+        &db,
+        &format!("{KNOWS} WHERE r.role CONTAINS 'eng' RETURN b.name AS name"),
+        &format!("{KNOWS} WHERE r.role CONTAINS 'eng' RETURN b.name AS name"),
+        &["Bob", "Dave"],
+    );
+}
+
+#[test]
+fn parity_where_not_contains_absent_includes() {
+    let (db, _) = std_graph();
+    // No edge carries `nope` -> node-semantics CONTAINS is definite false ->
+    // NOT includes every KNOWS target (F2 Cypher fix; AQL already did this).
+    assert_where_parity(
+        &db,
+        &format!("{KNOWS} WHERE NOT (r.nope CONTAINS 'x') RETURN b.name AS name"),
+        &format!("{KNOWS} WHERE NOT (r.nope CONTAINS 'x') RETURN b.name AS name"),
+        &["Bob", "Carol", "Dave", "Erin"],
+    );
+}
+
+#[test]
+fn parity_where_is_null() {
+    let (db, _) = std_graph();
+    assert_where_parity(
+        &db,
+        &format!("{KNOWS} WHERE r.since IS NULL RETURN b.name AS name"),
+        &format!("{KNOWS} WHERE r.since IS NULL RETURN b.name AS name"),
+        &["Erin"],
+    );
+}
+
+#[test]
+fn parity_where_is_not_null() {
+    let (db, _) = std_graph();
+    assert_where_parity(
+        &db,
+        &format!("{KNOWS} WHERE r.since IS NOT NULL RETURN b.name AS name"),
+        &format!("{KNOWS} WHERE r.since IS NOT NULL RETURN b.name AS name"),
+        &["Bob", "Carol", "Dave"],
+    );
+}
+
+// ===========================================================================
+// F13 -- parity_where_reserved_source (sibling of type/target).
+// ===========================================================================
+
+#[test]
+fn parity_where_reserved_source() {
+    let (db, ids) = std_graph();
+    assert_where_parity(
+        &db,
+        &format!(
+            "{KNOWS} WHERE r.source = {} RETURN b.name AS name",
+            ids.alice
+        ),
+        &format!(
+            "{KNOWS} WHERE r.source = {} RETURN b.name AS name",
+            ids.alice
+        ),
+        &["Bob", "Carol", "Dave", "Erin"],
+    );
+}
+
+// ===========================================================================
+// F15 -- unknown-variable WHERE/ORDER BY leaf is a structured error (AQL).
+// ===========================================================================
+
+#[test]
+fn aql_where_unknown_variable_is_error() {
+    let (db, _) = std_graph();
+    // `rr` is not bound by the pattern (typo for `r`): reject, do not silently
+    // treat it as a node filter.
+    let q = format!("{KNOWS} WHERE rr.since = 2019 RETURN b.name AS name");
+    let e = aql_error(&db, &q).expect("expected an error for an unknown variable");
+    assert!(
+        matches!(e, Error::Query(QueryError::SyntaxError { ref message }) if message.contains("unknown variable")),
+        "expected an unknown-variable SyntaxError, got {e:?}"
+    );
+}
+
+#[test]
+fn aql_order_by_unknown_variable_is_error() {
+    let (db, _) = std_graph();
+    let q = format!("{KNOWS} RETURN b.name AS name ORDER BY rr.since");
+    assert!(aql_is_error(&db, &q));
+}
+
+#[test]
+fn aql_where_known_node_var_still_allowed() {
+    // A declared node variable (even the anchor `a`) is NOT rejected -- only
+    // genuinely unknown variables are (F15 conservative contract).
+    let (db, _) = std_graph();
+    // `a` is the declared anchor node; referencing it in WHERE must still
+    // parse/execute (prior behavior preserved), NOT raise the unknown-variable
+    // rejection. (Its leaf resolves against the row entity as before -- that
+    // non-terminal-node semantics is pre-existing and out of this lane's scope;
+    // here we only assert it is not rejected.)
+    let q = format!("{KNOWS} WHERE a.name = 'Alice' RETURN b.name AS name");
+    assert!(
+        aql_error(&db, &q).is_none(),
+        "a declared node variable must not be rejected as unknown"
+    );
+}
+
+// ===========================================================================
+// F16 -- cross-entity property comparison `r.x = b.y` is a structured error.
+// ===========================================================================
+
+#[test]
+fn aql_cross_entity_comparison_is_error() {
+    let (db, _) = std_graph();
+    let q = format!("{KNOWS} WHERE r.since = b.age RETURN b.name AS name");
+    let e = aql_error(&db, &q).expect("expected an error for cross-entity comparison");
+    assert!(
+        matches!(e, Error::Query(QueryError::UnsupportedFeature { ref feature }) if feature.contains("two property accesses")),
+        "expected the cross-entity UnsupportedFeature, got {e:?}"
+    );
+}
+
+// ===========================================================================
+// F3 -- node/edge AS-OF consistency (target node reconstructed at coordinate).
+// ===========================================================================
+
+/// Alice (valid 2018), Bob node valid only from 2024, and a single-version edge
+/// Alice-KNOWS{since:2019}->Bob valid from 2020. So at AS OF 2022 the edge is
+/// valid but Bob's node is not yet -- a coordinate-consistent read must exclude
+/// the row (F3), whereas a current-state target read would wrongly surface Bob.
+fn f3_graph() -> AletheiaDB {
+    let db = AletheiaDB::new().expect("db");
+    let alice = db
+        .create_node_with_valid_time(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+            Some(ts("2018-01-01T00:00:00Z")),
+        )
+        .expect("alice");
+    let bob = db
+        .create_node_with_valid_time(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Bob")
+                .insert("age", 25)
+                .build(),
+            Some(ts("2024-01-01T00:00:00Z")),
+        )
+        .expect("bob");
+    db.create_edge_with_valid_time(
+        alice,
+        bob,
+        "KNOWS",
+        PropertyMapBuilder::new().insert("since", 2019).build(),
+        Some(ts("2020-01-01T00:00:00Z")),
+    )
+    .expect("edge");
+    db
+}
+
+#[test]
+fn aql_bitemporal_target_node_reconstructed_at_coordinate() {
+    let db = f3_graph();
+    // AS OF 2022: edge valid, Bob's node not yet valid -> row excluded (the node
+    // is read AS-OF the coordinate, consistent with the reconstructed edge).
+    let early = micros("2022-01-01T00:00:00Z");
+    assert!(
+        aql_names(
+            &db,
+            &format!("AS OF {early} {BT_KNOWS} WHERE r.since = 2019 RETURN b.name AS name")
+        )
+        .is_empty(),
+        "target node not valid at the coordinate -> excluded (F3 consistency)"
+    );
+    // AS OF 2025: both valid -> Bob surfaces, and his reconstructed node carries
+    // age 25 (node property read at the coordinate).
+    let late = micros("2025-01-01T00:00:00Z");
+    assert_eq!(
+        aql_names(
+            &db,
+            &format!(
+                "AS OF {late} {BT_KNOWS} WHERE r.since = 2019 AND b.age = 25 RETURN b.name AS name"
+            )
+        ),
+        owned(&["Bob"])
     );
 }


### PR DESCRIPTION
## What changed (before / after)

**Before.** In AQL, filtering or ordering by a *relationship* property silently returned wrong or zero rows: `MATCH ()-[r:KNOWS]->() WHERE r.since > 2020 RETURN r` matched nothing, and `ORDER BY r.since` was a silent no-op — the traversal discarded the edge and evaluated the predicate against the target node. In Cypher, `r.since` WHERE/ORDER BY worked, but reserved-field access like `WHERE r.type = 'KNOWS'` silently returned 0 rows.

**After.** Relationship-property predicates in `WHERE` and `ORDER BY` work in **both AQL and Cypher**, completing the remaining lanes of #3622 after the SQL lane (#3648):
- `WHERE r.<prop>` and `ORDER BY r.<prop>` evaluate against the edge, with SQL-mirrored reserved fields resolved structurally (shadowing user props): `r.type`/`r.label` → edge label, `r.source`/`r.target`/`r.id` → ids.
- openCypher null semantics on edge leaves (Eq-absent excludes, Ne-absent includes, NOT(false)=true), identical across SQL/AQL/Cypher.
- Bi-temporal `AS OF` correctness in AQL: the edge is reconstructed at the query coordinate, and the traversal target node is now reconstructed at the coordinate too (was current-state) so a single predicate is bi-temporally self-consistent.
- Multigraph-correct: an edge-variable single-hop pattern emits one row per matching edge (relationship-distinct), so parallel edges and self-loops are no longer silently collapsed.
- Never-silently-wrong: every unsupported combination (variable-length/multi-hop relationship variable, unknown variable, cross-entity `r.x = b.y`) returns a structured error instead of a wrong answer.

## How

- New IR: `Predicate::EdgeScoped(Box<Predicate>)` and `SortKey::EdgeProperty(String)`, emitted by the AQL converter only for a single fixed-length hop that references the relationship variable; a rel-var leaf in a multi-hop/variable-length pattern is rejected up front.
- Row carries an `edge` side-channel; the traversal attaches the traversed edge (reconstructed at the bi-temporal coordinate) and, when an edge var is referenced, switches to relationship-distinct emission. The channel rides through `Project`, so an edge `ORDER BY` after a node projection still resolves.
- Edge-scoped leaves/sort keys reuse the SQL lane's shared primitives (`evaluate_edge_full`, `edge_structural_value`) → SQL≡AQL≡Cypher semantics. `bind_edge` is computed once at the plan root (`plan_needs_edge_binding`, an exhaustive match over `PhysicalOp`), zero overhead when no edge var is referenced.
- Cypher: the multi-variable evaluator resolves reserved edge fields and routes edge-var `IN`/`CONTAINS`/`STARTS WITH`/`ENDS WITH` leaves through the same definite node-semantics as comparisons (node-var leaves untouched).

## Tests & evidence

`tests/edge_property_predicates.rs` — 93 tests: AQL≡Cypher parity for every supported WHERE/ORDER-BY form (each parity test paired with a standalone test pinning the exact absolute/ordered result, so parity can't be vacuously green), reserved-field **shadowing** (structural beats a like-named user prop), parallel-edge/self-loop, bi-temporal AS-OF exclusion + value-at-coordinate, structured-error-kind assertions for every unsupported form, and node-path regression guards (WHERE+projection, edge×provenance, temporal AS-OF node). Full suite: 5361 pass / 1 fail (the pre-existing root-user `havoc_flush_deadlock`, unrelated — no WAL code touched). Clippy clean (`--features sql,cypher` and `--no-default-features`, modulo a pre-existing `snapshot.rs` lint not in this diff).

## Limitations & follow-ups (documented, out of this lane)

- Cypher's multi-variable evaluator rejects `AS OF` uniformly, so an edge-var WHERE/ORDER BY combined with `AS OF` returns a structured error in Cypher (fully supported in AQL). By design here; surfaced as a structured error, never silent.
- A *superseded* valid-time version (edge or node) is not reconstructable by the engine at a pre-update coordinate (`get_*_at_valid_time` → NotFound) — a pre-existing storage-layer gap; bi-temporal tests use single-version facts in distinct valid windows.
- AQL `RETURN r` returns the target node, not the edge (the edge channel feeds WHERE/ORDER BY only); projecting the relationship as an entity is a follow-up.
- AQL WHERE does not coerce Float-vs-Int operands (pre-existing, affects node comparisons too).
- Perf: the edge (and target node under AS-OF) is reconstructed per emitted row only when an edge var is referenced; a batched/one-shot version lookup is a noted optimization.

Closes the AQL/Cypher lanes of #3622 (SQL lane shipped in #3648).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSV3pRgK97oJKz3DQjzFk6)_