### PR TITLE
fix: trunk-unbreaker — clear three pre-existing tree-wide gate failures

### DIFF
--- a/src/db/snapshot.rs
+++ b/src/db/snapshot.rs
@@ -448,7 +448,7 @@ impl SnapshotRegistry {
         #[cfg(not(feature = "serde"))]
         {
             let _ = path;
-            return Ok(());
+            Ok(())
         }
 
         #[cfg(feature = "serde")]

--- a/tests/snapshot_pin.rs
+++ b/tests/snapshot_pin.rs
@@ -4,12 +4,14 @@
 //! the resulting handle are deterministic and reproducible regardless of any
 //! writes that land afterward.
 
+#[cfg(feature = "simulation")]
+use aletheiadb::WriteOps;
 use aletheiadb::core::error::Error;
 use aletheiadb::core::graph::{Edge, Node};
 use aletheiadb::core::id::{EdgeId, NodeId};
 use aletheiadb::core::temporal::time;
 use aletheiadb::db::snapshot::Snapshot;
-use aletheiadb::{AletheiaDB, PropertyMapBuilder, WriteOps};
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
 use serde_json::json;
 
 /// The canonical durable config places the snapshot sidecar inside the index

--- a/tests/sql_integration.rs
+++ b/tests/sql_integration.rs
@@ -1055,7 +1055,7 @@ mod select_edges {
             "node B target sorts second descending"
         );
     }
-  
+
     #[test]
     fn select_edges_collect_structured_edges() {
         // Issue #3626: the edge-shaped structured projection. `SELECT * FROM edges`


### PR DESCRIPTION
## Trunk-unbreaker: clear three pre-existing gate failures

Three lint/format violations were already present on `trunk` and were failing
CI gates **tree-wide** (independent of any feature work). Each is fixed with a
single-line change; no behavior changes.

### Before / After

| # | Gate that was red on trunk | Location | Before | After |
|---|----------------------------|----------|--------|-------|
| 1 | `cargo clippy/check --no-default-features` (needless_return) | `src/db/snapshot.rs:451` | `return Ok(());` inside the `#[cfg(not(feature = "serde"))]` block trips `clippy::needless_return` | tail expression `Ok(())` |
| 2 | `cargo clippy --all-targets -- -D warnings` (default features, unused_imports) | `tests/snapshot_pin.rs:12` | `use aletheiadb::{AletheiaDB, PropertyMapBuilder, WriteOps};` — `WriteOps` is unused under default features | `WriteOps` import **feature-gated** (see note) |
| 3 | `cargo fmt --all --check` | `tests/sql_integration.rs:1058` | trailing whitespace (`  `) on a blank line | whitespace stripped |

**Before:** the four clippy/check gates plus `cargo fmt --all --check` could not
all pass on a clean `trunk` checkout — #1 broke the `--no-default-features`
clippy/check gates, #2 broke the default-features clippy gate, and #3 broke the
fmt gate. **After:** all five gates are clean.

### The three changes

1. **`src/db/snapshot.rs:451`** — `return Ok(());` → `Ok(())` (it is the final
   statement of the `#[cfg(not(feature = "serde"))]` block, so the bare tail
   expression is equivalent).
2. **`tests/snapshot_pin.rs:12`** — the `WriteOps` import is **feature-gated, not
   deleted**:
   ```rust
   #[cfg(feature = "simulation")]
   use aletheiadb::WriteOps;
   use aletheiadb::{AletheiaDB, PropertyMapBuilder};
   ```
   `WriteOps` is genuinely unused under default features (hence the clippy
   warning), but the `#[cfg(feature = "simulation")]` test
   `snapshot_resolves_correct_version_across_restart_same_microsecond`
   (`tests/snapshot_pin.rs:856`) calls `WriteOps`-provided `create_node` /
   `update_node` on `WriteTransaction`. Deleting the import outright would break
   the `--all-features` build (E0599/E0282); feature-gating clears the
   default-features lint **and** keeps `--all-features` compiling — exactly what
   clippy's all-features help suggests.
3. **`tests/sql_integration.rs:1058`** — trailing whitespace removed by
   `cargo fmt`.

### Verbatim passing output — all five gates (EXIT=0)

```
=== GATE1: clippy default ===
    Checking aletheiadb v0.3.0 (/home/user/AletheiaDB)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.45s
GATE1_EXIT=0
=== GATE2: clippy --no-default-features ===
    Checking aletheiadb v0.3.0 (/home/user/AletheiaDB)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.43s
GATE2_EXIT=0
=== GATE3: check --no-default-features --tests ===
    Checking aletheiadb v0.3.0 (/home/user/AletheiaDB)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.49s
GATE3_EXIT=0
=== GATE4: clippy --all-features ===
    Checking aletheiadb v0.3.0 (/home/user/AletheiaDB)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.26s
GATE4_EXIT=0
=== GATE5: fmt --check ===
GATE5_EXIT=0
```

Gate commands:
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --no-default-features -- -D warnings`
- `cargo check --no-default-features --tests`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`

---
_Generated by [Claude Code](https://claude.ai/code/session_017MLuLxMyM1vhUXLFQTMn1E)_