### PR TITLE
WAL: runtime-installable keyring presence (plaintext → encrypted) — #3616 PR2

### DIFF
--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -347,6 +347,21 @@ pub struct ConcurrentWalSystem {
     /// `writer` mutex, and the install stores into it inside the seal→reopen
     /// hand-off (see [`Self::install_wal_keyring`]).
     wal_keyring: Arc<ArcSwapOption<crate::encryption::wal_encryption::WalKeyring>>,
+    /// Serializes runtime keyring installs (Issue #3616 PR2) so two concurrent
+    /// installers cannot both observe the cell as `None`, both pass the presence
+    /// check, and both run seal->store->reopen -- the second silently replacing
+    /// the first keyring and producing an undecryptable segment. This mutex is
+    /// held for the entire [`Self::install_wal_keyring`] body (presence check +
+    /// seal + store + reopen) so a second concurrent installer blocks, then
+    /// observes `Some`, and returns the existing rejection `Err`.
+    ///
+    /// Why a dedicated field: it is a private LEAF, taken only at the very top of
+    /// install. The hot path (`append`/`flush`) never touches it, so it adds zero
+    /// steady-state overhead; and because install itself never calls into
+    /// `historical`/`current_timestamp`/cold, it is never held across any lock
+    /// ordered after `wal` -- it merely wraps the presence check and the
+    /// coordinator-`writer`-guarded seal->store->reopen hand-off.
+    install_lock: Mutex<()>,
 }
 
 impl ConcurrentWalSystem {
@@ -473,6 +488,7 @@ impl ConcurrentWalSystem {
             consecutive_flush_errors,
             tolerate_torn_tail: config.tolerate_torn_tail,
             wal_keyring,
+            install_lock: Mutex::new(()),
         })
     }
 
@@ -867,14 +883,28 @@ impl ConcurrentWalSystem {
     // the plaintext → encrypted enable engine landing in #3616 PR3. Until then the
     // only caller is the concurrency-test suite, so the non-test lib build sees it
     // as unused — allow that here rather than block the seam on its future driver.
+    // TODO(#3616 PR3): remove this allow once the enable engine calls install_wal_keyring.
     #[allow(dead_code)]
     pub(crate) fn install_wal_keyring(
         &self,
         keyring: crate::encryption::wal_encryption::WalKeyring,
     ) -> Result<()> {
+        // Serialize the ENTIRE install — presence check, seal, store, reopen —
+        // under a dedicated leaf mutex. Without it, the presence check below runs
+        // outside the coordinator `writer` mutex while the store happens inside the
+        // seal→reopen hand-off, so two concurrent installers could both observe
+        // `None`, both pass the check, and both run seal→store→reopen — the second
+        // silently replacing the first keyring and producing an undecryptable
+        // segment. Holding this guard for the whole body makes a second concurrent
+        // installer block here, then observe `Some`, and take the rejection path.
+        let _install_guard = self.install_lock.lock().unwrap_or_else(|e| e.into_inner());
+
         // Reject a double-install: presence is a one-way None → Some transition.
-        // Checked before the seal so an already-encrypted WAL is never re-rolled.
+        // Checked (under the install lock) before the seal so an already-encrypted
+        // WAL is never re-rolled.
         if self.wal_keyring.load().is_some() {
+            // TODO(#3616 PR3): when surfaced via MCP, map this precondition to
+            // FAILED_PRECONDITION rather than the default WalError→INTERNAL.
             return Err(Error::Storage(StorageError::WalError {
                 reason: "a WAL keyring is already installed; runtime install only \
                          supports the plaintext → encrypted (None → Some) transition \
@@ -1153,6 +1183,10 @@ mod tests {
 
     // ── Issue #3616 PR2: runtime WAL keyring install (plaintext → encrypted) ──
 
+    // NOTE: `seed` is a CIPHER SEED (distinguishes one test cipher's key bytes
+    // from another), NOT a key_version. `WalKeyring::single` always stamps
+    // INITIAL_WAL_KEY_VERSION (== 1) as the on-disk key_version regardless of the
+    // seed, which is why T3 asserts the post-install cohort is "key_version 1".
     fn wal_keyring(seed: u8) -> crate::encryption::wal_encryption::WalKeyring {
         crate::encryption::wal_encryption::WalKeyring::single(wal_test_cipher(seed))
     }
@@ -1258,6 +1292,9 @@ mod tests {
         wal.flush().unwrap();
 
         let total = threads * per_thread;
+        // In-process recovery via the live system's shared keyring cell (same
+        // in-process limitation as `append_hammer_across_force_roll_loses_nothing`
+        // — a full process-restart reopen is out of scope for this seam test).
         let entries = wal.read_from(LSN::initial()).unwrap();
         let mut ids = recovered_ids(&entries);
         ids.sort_unstable();
@@ -1307,12 +1344,113 @@ mod tests {
             "a mixed plaintext+encrypted directory is not wholly one key_version"
         );
 
+        // POSITIVE proof the install actually produced an encrypted (v16) segment
+        // on disk — not merely flipped the in-memory flag while still writing
+        // plaintext. `!all_segments_use_key_version(1)` above is satisfied by the
+        // surviving pre-install PLAINTEXT segments alone, so it cannot prove the
+        // "mixed-format" claim; the max stamped key_version across the directory
+        // being `Some(1)` requires at least one keyversioned v16 segment to exist.
+        assert_eq!(
+            crate::storage::wal::segment_reader::max_key_version_in_dir(dir.path()),
+            Some(1),
+            "the post-install cohort must be written as an encrypted v16 segment \
+             stamped key_version 1 (INITIAL_WAL_KEY_VERSION), proving the mixed format"
+        );
+
         let entries = wal.read_from(LSN::initial()).unwrap();
         assert_eq!(
             recovered_ids(&entries),
             (1..=10).collect::<Vec<_>>(),
             "both plaintext and encrypted cohorts recover in order"
         );
+    }
+
+    /// Encryption-at-rest negative control (FIX B, Issue #3616 PR2 review).
+    /// The five install tests before this one are all satisfied by the surviving
+    /// pre-install PLAINTEXT segments — none POSITIVELY assert that a post-install
+    /// segment is actually v16-encrypted on disk, so an install that flipped the
+    /// in-memory flag but kept writing plaintext (a future shared-cell desync)
+    /// would pass them all. This test closes that blind spot two ways:
+    ///
+    /// 1. POSITIVE: at least one on-disk segment header is
+    ///    `WAL_VERSION_ENCRYPTED_KEYVERSIONED` (v16), proven via the reader's own
+    ///    header-only scan (`max_key_version_in_dir` returns `Some(1)`).
+    /// 2. STRONGEST: re-reading the WAL directory with NO keyring must NOT recover
+    ///    the post-install cohort as plaintext (it is genuinely undecryptable),
+    ///    while the pre-install cohort still reads back as plaintext v13.
+    #[test]
+    fn install_keyring_post_install_segment_is_encrypted_at_rest() {
+        use crate::storage::wal::segment_reader::{
+            max_key_version_in_dir, read_entries_from_dir_with_keyring,
+        };
+
+        let dir = tempdir().unwrap();
+        let mut config = ConcurrentWalSystemConfig::new(dir.path());
+        config.durability_mode = DurabilityMode::Synchronous;
+        let wal = ConcurrentWalSystem::new(config).unwrap();
+
+        // Pre-install cohort → plaintext v13 segment(s).
+        for id in 1..=4 {
+            wal.append(create_test_operation(id)).unwrap();
+        }
+        wal.flush().unwrap();
+        assert_eq!(
+            max_key_version_in_dir(dir.path()),
+            None,
+            "before install, no segment carries a stamped key_version (all plaintext)"
+        );
+
+        wal.install_wal_keyring(wal_keyring(7)).unwrap();
+
+        // Post-install cohort → encrypted v16 segment(s).
+        for id in 5..=8 {
+            wal.append(create_test_operation(id)).unwrap();
+        }
+        wal.flush().unwrap();
+
+        // (1) POSITIVE v16-at-rest proof: a keyversioned segment now exists on
+        // disk, stamped INITIAL_WAL_KEY_VERSION (1). A desync that kept writing
+        // plaintext would leave this `None`.
+        assert_eq!(
+            max_key_version_in_dir(dir.path()),
+            Some(1),
+            "the post-install cohort must be an encrypted v16 segment on disk"
+        );
+
+        // Full recovery WITH the keyring reads every cohort back in order.
+        let entries = wal.read_from(LSN::initial()).unwrap();
+        assert_eq!(
+            recovered_ids(&entries),
+            (1..=8).collect::<Vec<_>>(),
+            "with the keyring, both plaintext and encrypted cohorts recover in order"
+        );
+
+        // (2) STRONGEST proof: re-read the SAME directory with NO keyring. The
+        // post-install (v16) cohort must NOT be recoverable-as-plaintext — either
+        // the read errors (undecryptable) or it returns only the plaintext prefix.
+        // The pre-install (v13) cohort is plaintext and reads transparently.
+        match read_entries_from_dir_with_keyring(dir.path(), LSN::initial(), None, true) {
+            Ok(no_key_entries) => {
+                let ids = recovered_ids(&no_key_entries);
+                for id in 1..=4 {
+                    assert!(
+                        ids.contains(&id),
+                        "pre-install plaintext record {id} must still read without a keyring"
+                    );
+                }
+                for id in 5..=8 {
+                    assert!(
+                        !ids.contains(&id),
+                        "post-install record {id} must NOT be recoverable as plaintext \
+                         without the keyring (it is encrypted at rest)"
+                    );
+                }
+            }
+            Err(_) => {
+                // Undecryptable without the keyring is itself proof of
+                // encryption-at-rest for the post-install cohort.
+            }
+        }
     }
 
     /// T4 — double install rejected. Installing a second keyring when one is
@@ -1374,30 +1512,144 @@ mod tests {
             let stop = Arc::clone(&stop);
             let barrier = Arc::clone(&barrier);
             handles.push(std::thread::spawn(move || {
+                // Per-thread record of which cell states this loader observed, so
+                // after join we can prove the None→Some store is actually seen
+                // across threads (not merely that a load never tore). The bare
+                // `k.current().is_some()` check alone can never fail, so it cannot
+                // catch a store that is never observed.
+                let mut saw_none = false;
+                let mut saw_some = false;
                 barrier.wait();
                 while !stop.load(AtOrd::Relaxed) {
-                    // Any observed keyring must be fully valid (never torn):
-                    // a Some always has a resolvable current generation.
-                    if let Some(k) = wal.wal_keyring() {
-                        assert!(
-                            k.current().is_some(),
-                            "a loaded keyring must be fully-constructed (current generation present)"
-                        );
+                    match wal.wal_keyring() {
+                        None => saw_none = true,
+                        Some(k) => {
+                            saw_some = true;
+                            // Any observed keyring must be fully valid (never
+                            // torn): a Some always has a resolvable current gen.
+                            assert!(
+                                k.current().is_some(),
+                                "a loaded keyring must be fully-constructed (current generation present)"
+                            );
+                        }
                     }
                 }
+                (saw_none, saw_some)
             }));
         }
 
         barrier.wait();
+        // Let the loaders spin on the pre-install `None` first, so that state is
+        // observed before the store flips it.
+        std::thread::sleep(std::time::Duration::from_millis(5));
         // Hammer the store against the concurrent loads.
         wal.install_wal_keyring(wal_keyring(7)).unwrap();
+        // Keep the loaders running long enough to observe the post-install `Some`.
+        std::thread::sleep(std::time::Duration::from_millis(5));
         stop.store(true, AtOrd::Relaxed);
+
+        let mut any_saw_none = false;
+        let mut any_saw_some = false;
         for h in handles {
-            h.join().unwrap();
+            let (saw_none, saw_some) = h.join().unwrap();
+            any_saw_none |= saw_none;
+            any_saw_some |= saw_some;
         }
+        assert!(
+            any_saw_none,
+            "loaders must have observed the pre-install None state"
+        );
+        assert!(
+            any_saw_some,
+            "loaders must have observed the post-install Some state \
+             (proving the store is seen across threads)"
+        );
         assert!(
             wal.wal_keyring().is_some(),
             "install must be visible after store"
+        );
+    }
+
+    /// FIX A (Issue #3616 PR2 review) — concurrent double-install TOCTOU. Two
+    /// threads race `install_wal_keyring` on the same system. Without the install
+    /// lock both could observe `None`, both pass the presence check, and both run
+    /// seal→store→reopen — the second silently replacing the first keyring and
+    /// producing an undecryptable segment. With the lock, EXACTLY one returns
+    /// `Ok` and one returns `Err`, no data is lost, and the survivor keyring
+    /// decrypts the post-install cohort (no undecryptable segment).
+    #[test]
+    fn install_keyring_concurrent_double_install_rejected() {
+        use std::sync::Barrier;
+        use std::sync::atomic::{AtomicUsize, Ordering as AtOrd};
+
+        let dir = tempdir().unwrap();
+        let mut config = ConcurrentWalSystemConfig::new(dir.path());
+        config.durability_mode = DurabilityMode::Synchronous;
+        let wal = Arc::new(ConcurrentWalSystem::new(config).unwrap());
+
+        // A few acknowledged appends before the install (plaintext v13).
+        for id in 1..=3 {
+            wal.append(create_test_operation(id)).unwrap();
+        }
+        wal.flush().unwrap();
+
+        let ok_count = Arc::new(AtomicUsize::new(0));
+        let err_count = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(2));
+
+        let mut handles = Vec::new();
+        for seed in [7u8, 9u8] {
+            let wal = Arc::clone(&wal);
+            let ok_count = Arc::clone(&ok_count);
+            let err_count = Arc::clone(&err_count);
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                match wal.install_wal_keyring(wal_keyring(seed)) {
+                    Ok(()) => ok_count.fetch_add(1, AtOrd::Relaxed),
+                    Err(_) => err_count.fetch_add(1, AtOrd::Relaxed),
+                };
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // Exactly one installer wins; the other is rejected (never a silent
+        // second seal→store→reopen).
+        assert_eq!(
+            ok_count.load(AtOrd::Relaxed),
+            1,
+            "exactly one concurrent install must succeed"
+        );
+        assert_eq!(
+            err_count.load(AtOrd::Relaxed),
+            1,
+            "exactly one concurrent install must be rejected"
+        );
+        assert!(wal.is_encrypted(), "the survivor keyring must be installed");
+
+        // Post-install cohort is written under the survivor keyring (encrypted
+        // v16 at rest).
+        for id in 4..=6 {
+            wal.append(create_test_operation(id)).unwrap();
+        }
+        wal.flush().unwrap();
+        assert_eq!(
+            crate::storage::wal::segment_reader::max_key_version_in_dir(dir.path()),
+            Some(1),
+            "the post-install cohort must be an encrypted v16 segment (survivor keyring), \
+             not an undecryptable segment from a double seal→store→reopen"
+        );
+
+        // Every acknowledged append recovers in order, and the survivor keyring
+        // decrypts the post-install cohort.
+        let entries = wal.read_from(LSN::initial()).unwrap();
+        assert_eq!(
+            recovered_ids(&entries),
+            (1..=6).collect::<Vec<_>>(),
+            "no acknowledged append is lost and the survivor keyring decrypts the \
+             post-install cohort"
         );
     }
 

--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -49,6 +49,8 @@ use std::sync::{Condvar, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+use arc_swap::ArcSwapOption;
+
 use super::concurrent::{ConcurrentWal, ConcurrentWalConfig};
 use super::flush_coordinator::{FlushCoordinator, FlushCoordinatorConfig, FlushStats};
 use super::group_commit::GroupCommitCoordinator;
@@ -330,14 +332,21 @@ pub struct ConcurrentWalSystem {
     /// Crash-torn-tail recovery policy applied by [`Self::read_from`]
     /// (Issue #3433).
     tolerate_torn_tail: bool,
-    /// Optional WAL DEK keyring for encryption at rest (Issue #3617). Retained
-    /// so [`Self::read_from`] can decrypt encrypted segments during recovery
-    /// replay — dispatching per segment on its `key_version` so a mixed
-    /// old-DEK/new-DEK directory (an in-flight full-MEK rotation) replays
-    /// correctly. The flush coordinator holds a clone (shared `Arc` state), so
-    /// advancing the current generation here is observed by the write path
-    /// immediately.
-    wal_keyring: Option<crate::encryption::wal_encryption::WalKeyring>,
+    /// Optional WAL DEK keyring for encryption at rest, held in a runtime-swappable
+    /// presence cell (Issues #3617, #3616). Retained so [`Self::read_from`] can
+    /// decrypt encrypted segments during recovery replay — dispatching per segment
+    /// on its `key_version` so a mixed old-DEK/new-DEK directory (an in-flight
+    /// full-MEK rotation) replays correctly.
+    ///
+    /// The cell is a single `Arc<ArcSwapOption<..>>` **shared** (Arc-cloned) with
+    /// the flush coordinator's config, so a runtime install (`None` → `Some`, Issue
+    /// #3616 PR2) or a rotation's inner-generation advance (Issue #3617) is observed
+    /// by both the write path (flush) and the recovery/`is_encrypted` path at once.
+    /// Off-lock readers (`read_from`, `is_encrypted`, `wal_keyring`) `load()` it
+    /// lock-free; the write path's reads stay serialized under the coordinator
+    /// `writer` mutex, and the install stores into it inside the seal→reopen
+    /// hand-off (see [`Self::install_wal_keyring`]).
+    wal_keyring: Arc<ArcSwapOption<crate::encryption::wal_encryption::WalKeyring>>,
 }
 
 impl ConcurrentWalSystem {
@@ -364,13 +373,17 @@ impl ConcurrentWalSystem {
         // segments decrypt exactly as before) so new segments stamp the real
         // version and `current_version` reports it. `None` reproduces prior
         // behavior exactly.
-        let wal_keyring = config.wal_cipher.clone().map(|cipher| {
+        let initial_keyring = config.wal_cipher.clone().map(|cipher| {
             use crate::encryption::wal_encryption::WalKeyring;
             match config.wal_key_version {
                 Some(v) => WalKeyring::single_versioned(cipher, v),
                 None => WalKeyring::single(cipher),
             }
         });
+        // One shared presence cell, cloned (Arc-cloned, same underlying cell) into
+        // both the system and the coordinator so a runtime install or rotation is
+        // observed by both the flush and recovery paths (Issues #3616, #3617).
+        let wal_keyring = Arc::new(ArcSwapOption::from(initial_keyring.map(Arc::new)));
 
         // Create FlushCoordinator config
         let coordinator_config = FlushCoordinatorConfig {
@@ -383,7 +396,7 @@ impl ConcurrentWalSystem {
                 DurabilityMode::Synchronous | DurabilityMode::GroupCommit { .. }
             ),
             write_buffer_size: config.write_buffer_size,
-            wal_keyring: wal_keyring.clone(),
+            wal_keyring: Arc::clone(&wal_keyring),
         };
 
         let wal = Arc::new(ConcurrentWal::new(wal_config)?);
@@ -805,17 +818,79 @@ impl ConcurrentWalSystem {
     /// undecryptable. Never exposes the cipher or any key material.
     #[must_use]
     pub(crate) fn is_encrypted(&self) -> bool {
-        self.wal_keyring.is_some()
+        self.wal_keyring.load().is_some()
     }
 
-    /// The WAL DEK keyring, if this WAL is encrypted (Issue #3617).
+    /// The WAL DEK keyring, if this WAL is encrypted (Issues #3617, #3616).
     ///
-    /// Exposed so the full-MEK rotation driver can install the new WAL DEK
-    /// generation before force-rolling the active segment. Never returns key
-    /// material directly — only the shared, redacting-`Debug` keyring handle.
+    /// Exposed so the full-MEK rotation driver can advance the WAL DEK generation
+    /// before force-rolling the active segment. Returns a clone of the shared
+    /// keyring handle (a cheap `Arc` clone that shares the same inner
+    /// generations), so a caller's `add_generation` is observed by every holder.
+    /// Never returns key material directly — only the redacting-`Debug` handle.
     #[must_use]
-    pub(crate) fn wal_keyring(&self) -> Option<&crate::encryption::wal_encryption::WalKeyring> {
-        self.wal_keyring.as_ref()
+    pub(crate) fn wal_keyring(&self) -> Option<crate::encryption::wal_encryption::WalKeyring> {
+        self.wal_keyring.load_full().map(|k| (*k).clone())
+    }
+
+    /// Install a WAL DEK keyring at runtime, flipping a live plaintext WAL to
+    /// encrypted (Issue #3616 PR2). This is the structural seam the plaintext →
+    /// encrypted enable engine drives.
+    ///
+    /// # Transition
+    ///
+    /// Only the `None` → `Some` transition is supported here. Installing when a
+    /// keyring is already present is **rejected** with a structured error (never
+    /// a silent replace, so no data is lost): rotation (`Some` → `Some'`) is the
+    /// job of the keyring's own [`add_generation`], not this seam.
+    ///
+    /// # Crash-consistency / concurrency
+    ///
+    /// You cannot append encrypted (v16) frames into an already-open plaintext
+    /// (v13) segment, so the install runs as the `advance` closure inside the
+    /// existing seal→reopen hand-off ([`Self::seal_active_segment_for_rotation`]):
+    /// it drains + fsyncs in-flight ring-buffer entries into the current plaintext
+    /// segment, seals it, stores the keyring into the shared presence cell, then
+    /// opens a fresh segment which is now written in the encrypted keyversioned
+    /// format. Because the store happens **between** seal and reopen while holding
+    /// the coordinator `writer` mutex, no `flush()` can interleave: every segment's
+    /// header and frames use one consistent keyring state, and every acknowledged
+    /// append is preserved across the flip.
+    ///
+    /// The store closure obeys the same lock-order contract as a rotation
+    /// `advance`: it only mutates the in-memory presence cell and must not acquire
+    /// any lock ordered after `wal` (no cold flush, no `historical`,
+    /// no `current_timestamp`).
+    ///
+    /// [`add_generation`]: crate::encryption::wal_encryption::WalKeyring::add_generation
+    // PR2 (#3616) ships this structural install seam; its production consumer is
+    // the plaintext → encrypted enable engine landing in #3616 PR3. Until then the
+    // only caller is the concurrency-test suite, so the non-test lib build sees it
+    // as unused — allow that here rather than block the seam on its future driver.
+    #[allow(dead_code)]
+    pub(crate) fn install_wal_keyring(
+        &self,
+        keyring: crate::encryption::wal_encryption::WalKeyring,
+    ) -> Result<()> {
+        // Reject a double-install: presence is a one-way None → Some transition.
+        // Checked before the seal so an already-encrypted WAL is never re-rolled.
+        if self.wal_keyring.load().is_some() {
+            return Err(Error::Storage(StorageError::WalError {
+                reason: "a WAL keyring is already installed; runtime install only \
+                         supports the plaintext → encrypted (None → Some) transition \
+                         (key rotation is a separate operation)"
+                    .to_string(),
+            }));
+        }
+
+        let cell = Arc::clone(&self.wal_keyring);
+        let new_keyring = Arc::new(keyring);
+        // Store into the shared cell strictly between sealing the plaintext
+        // segment and opening the fresh (now encrypted) one, under the writer
+        // mutex — the atomic hand-off point.
+        self.seal_active_segment_for_rotation(move || {
+            cell.store(Some(new_keyring));
+        })
     }
 
     /// Whether every on-disk WAL segment is stamped with `key_version` — the
@@ -877,10 +952,13 @@ impl ConcurrentWalSystem {
         // segments cannot be decoded without it, so an encryption-at-rest
         // database replaying its WAL tail after a crash must decrypt here.
         // Passing `None` (no encryption) preserves plaintext behavior exactly.
+        // Snapshot the shared presence cell for the duration of the read. Holding
+        // the guard keeps the loaded keyring alive while the reader borrows it.
+        let keyring_guard = self.wal_keyring.load();
         crate::storage::wal::segment_reader::read_entries_from_dir_with_keyring(
             self.wal_dir(),
             start_lsn,
-            self.wal_keyring.as_ref(),
+            keyring_guard.as_ref().map(|k| k.as_ref()),
             self.tolerate_torn_tail,
         )
     }
@@ -1071,6 +1149,256 @@ mod tests {
         );
         assert_eq!(*ids.first().unwrap(), 1);
         assert_eq!(*ids.last().unwrap(), total);
+    }
+
+    // ── Issue #3616 PR2: runtime WAL keyring install (plaintext → encrypted) ──
+
+    fn wal_keyring(seed: u8) -> crate::encryption::wal_encryption::WalKeyring {
+        crate::encryption::wal_encryption::WalKeyring::single(wal_test_cipher(seed))
+    }
+
+    fn recovered_ids(entries: &[crate::storage::wal::WalEntry]) -> Vec<u64> {
+        entries
+            .iter()
+            .filter_map(|e| match &e.operation {
+                WalOperation::CreateNode { node_id, .. } => Some(node_id.as_u64()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// T1 — None→Some transition: a fresh plaintext WAL reports `is_encrypted()
+    /// == false`; after `install_wal_keyring` it reports `true`; a record
+    /// appended after the install reads back correctly, and pre-install records
+    /// still recover (mixed plaintext/encrypted directory).
+    #[test]
+    fn install_keyring_none_to_some_transition() {
+        let dir = tempdir().unwrap();
+        let mut config = ConcurrentWalSystemConfig::new(dir.path());
+        config.durability_mode = DurabilityMode::Synchronous;
+        let wal = ConcurrentWalSystem::new(config).unwrap();
+
+        assert!(
+            !wal.is_encrypted(),
+            "a fresh plaintext WAL must not be encrypted"
+        );
+        wal.append(create_test_operation(1)).unwrap();
+        wal.append(create_test_operation(2)).unwrap();
+
+        wal.install_wal_keyring(wal_keyring(7)).unwrap();
+        assert!(
+            wal.is_encrypted(),
+            "installing a keyring must flip the WAL to encrypted"
+        );
+
+        // A record appended after the install lands in the fresh encrypted
+        // segment and must read back correctly.
+        wal.append(create_test_operation(3)).unwrap();
+        wal.flush().unwrap();
+
+        let entries = wal.read_from(LSN::initial()).unwrap();
+        assert_eq!(
+            recovered_ids(&entries),
+            vec![1, 2, 3],
+            "pre-install plaintext and post-install encrypted records both recover in order"
+        );
+    }
+
+    /// T2 — concurrent appenders during install lose nothing. N appender threads
+    /// hammer while one thread installs a keyring mid-storm (mirrors
+    /// `append_hammer_across_force_roll_loses_nothing`). Every acknowledged
+    /// append must recover, none lost, none unreadable, no hang.
+    #[test]
+    fn install_keyring_during_concurrent_appends_loses_nothing() {
+        use std::sync::Barrier;
+        use std::sync::atomic::{AtomicU64, Ordering as AtOrd};
+
+        let dir = tempdir().unwrap();
+        let mut config = ConcurrentWalSystemConfig::new(dir.path());
+        config.durability_mode = DurabilityMode::GroupCommit {
+            max_batch_size: 16,
+            max_delay_ms: 2,
+        };
+        // Starts PLAINTEXT — the install flips it to encrypted mid-storm.
+        let wal = Arc::new(ConcurrentWalSystem::new(config).unwrap());
+
+        let threads = 4u64;
+        let per_thread = 200u64;
+        let next_id = Arc::new(AtomicU64::new(1));
+        let barrier = Arc::new(Barrier::new(threads as usize + 1));
+
+        let mut handles = Vec::new();
+        for _ in 0..threads {
+            let wal = Arc::clone(&wal);
+            let next_id = Arc::clone(&next_id);
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..per_thread {
+                    let id = next_id.fetch_add(1, AtOrd::Relaxed);
+                    let (_lsn, handle) = wal
+                        .wal
+                        .append_with_handle(create_test_operation(id))
+                        .unwrap();
+                    let _ = wal.commit();
+                    let _ = handle.wait();
+                }
+            }));
+        }
+
+        // Release the appenders, then install a keyring partway through.
+        barrier.wait();
+        std::thread::sleep(std::time::Duration::from_millis(3));
+        wal.install_wal_keyring(wal_keyring(7)).unwrap();
+        assert!(wal.is_encrypted());
+
+        for h in handles {
+            h.join().unwrap();
+        }
+        wal.flush().unwrap();
+
+        let total = threads * per_thread;
+        let entries = wal.read_from(LSN::initial()).unwrap();
+        let mut ids = recovered_ids(&entries);
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(
+            ids.len() as u64,
+            total,
+            "every acknowledged entry across the install must recover (none lost, none unreadable)"
+        );
+        assert_eq!(*ids.first().unwrap(), 1);
+        assert_eq!(*ids.last().unwrap(), total);
+    }
+
+    /// T3 — install-then-roll ordering / mixed-format recovery. Records written
+    /// before install live in plaintext (v13) segments; records after install
+    /// live in encrypted (v16) segment(s). A full recovery reads BOTH cohorts
+    /// back correctly in order, and the on-disk directory really is mixed-format.
+    #[test]
+    fn install_keyring_mixed_format_recovery() {
+        let dir = tempdir().unwrap();
+        let mut config = ConcurrentWalSystemConfig::new(dir.path());
+        config.durability_mode = DurabilityMode::Synchronous;
+        let wal = ConcurrentWalSystem::new(config).unwrap();
+
+        // Pre-install cohort → plaintext segment(s).
+        for id in 1..=5 {
+            wal.append(create_test_operation(id)).unwrap();
+        }
+        wal.flush().unwrap();
+        assert!(
+            !wal.all_segments_use_key_version(1),
+            "pre-install segments must be plaintext (no key_version stamp)"
+        );
+
+        wal.install_wal_keyring(wal_keyring(9)).unwrap();
+
+        // Post-install cohort → encrypted v16 segment(s).
+        for id in 6..=10 {
+            wal.append(create_test_operation(id)).unwrap();
+        }
+        wal.flush().unwrap();
+
+        // The directory now holds BOTH plaintext and encrypted segments, so no
+        // single key_version covers every segment.
+        assert!(
+            !wal.all_segments_use_key_version(1),
+            "a mixed plaintext+encrypted directory is not wholly one key_version"
+        );
+
+        let entries = wal.read_from(LSN::initial()).unwrap();
+        assert_eq!(
+            recovered_ids(&entries),
+            (1..=10).collect::<Vec<_>>(),
+            "both plaintext and encrypted cohorts recover in order"
+        );
+    }
+
+    /// T4 — double install rejected. Installing a second keyring when one is
+    /// already present returns a structured error (not a silent replace) and
+    /// loses no data.
+    #[test]
+    fn install_keyring_twice_is_rejected() {
+        let dir = tempdir().unwrap();
+        let mut config = ConcurrentWalSystemConfig::new(dir.path());
+        config.durability_mode = DurabilityMode::Synchronous;
+        let wal = ConcurrentWalSystem::new(config).unwrap();
+
+        wal.append(create_test_operation(1)).unwrap();
+        wal.install_wal_keyring(wal_keyring(7)).unwrap();
+        wal.append(create_test_operation(2)).unwrap();
+
+        let err = wal
+            .install_wal_keyring(wal_keyring(9))
+            .expect_err("a second install must be rejected, not silently applied");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("keyring") || msg.contains("already"),
+            "rejection error should explain a keyring is already present, got: {msg}"
+        );
+
+        // Still encrypted and no data lost.
+        assert!(wal.is_encrypted());
+        wal.append(create_test_operation(3)).unwrap();
+        wal.flush().unwrap();
+        let entries = wal.read_from(LSN::initial()).unwrap();
+        assert_eq!(
+            recovered_ids(&entries),
+            vec![1, 2, 3],
+            "a rejected double-install must not lose or corrupt any records"
+        );
+    }
+
+    /// T5 — no torn reads on the presence cell. Concurrent loaders read the cell
+    /// while one thread stores into it (via install); a load must always yield
+    /// either the old `None` or a fully-valid `Some`, never a partial/invalid
+    /// keyring.
+    #[test]
+    fn install_keyring_no_torn_reads_on_cell() {
+        use std::sync::Barrier;
+        use std::sync::atomic::{AtomicBool, Ordering as AtOrd};
+
+        let dir = tempdir().unwrap();
+        let mut config = ConcurrentWalSystemConfig::new(dir.path());
+        config.durability_mode = DurabilityMode::Synchronous;
+        let wal = Arc::new(ConcurrentWalSystem::new(config).unwrap());
+
+        let loaders = 6usize;
+        let stop = Arc::new(AtomicBool::new(false));
+        let barrier = Arc::new(Barrier::new(loaders + 1));
+
+        let mut handles = Vec::new();
+        for _ in 0..loaders {
+            let wal = Arc::clone(&wal);
+            let stop = Arc::clone(&stop);
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                while !stop.load(AtOrd::Relaxed) {
+                    // Any observed keyring must be fully valid (never torn):
+                    // a Some always has a resolvable current generation.
+                    if let Some(k) = wal.wal_keyring() {
+                        assert!(
+                            k.current().is_some(),
+                            "a loaded keyring must be fully-constructed (current generation present)"
+                        );
+                    }
+                }
+            }));
+        }
+
+        barrier.wait();
+        // Hammer the store against the concurrent loads.
+        wal.install_wal_keyring(wal_keyring(7)).unwrap();
+        stop.store(true, AtOrd::Relaxed);
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert!(
+            wal.wal_keyring().is_some(),
+            "install must be visible after store"
+        );
     }
 
     #[test]

--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -49,6 +49,7 @@ use super::segment_reader::{
     WAL_VERSION_STRING_LABELS,
 };
 use crate::encryption::wal_encryption::WalKeyring;
+use arc_swap::ArcSwapOption;
 
 /// Metadata about a WAL segment's LSN range.
 ///
@@ -124,16 +125,24 @@ pub struct FlushCoordinatorConfig {
     /// Write buffer size for segment files.
     pub write_buffer_size: usize,
     /// Optional WAL DEK keyring for encrypting WAL entries before writing to
-    /// disk (Issue #3617).
+    /// disk, held in a runtime-swappable presence cell (Issues #3617, #3616).
     ///
-    /// When set, entries are encrypted (4-byte length-prefixed) under the
-    /// keyring's CURRENT generation and fresh segments use the keyversioned
-    /// (v16) header stamping that generation's `key_version`; a full-MEK
-    /// rotation advances the current generation so subsequent segments are
-    /// written under the new DEK while legacy/old-DEK segments still replay
-    /// under the retained old generation. When `None`, segments use the
+    /// When the cell holds a keyring, entries are encrypted (4-byte
+    /// length-prefixed) under its CURRENT generation and fresh segments use the
+    /// keyversioned (v16) header stamping that generation's `key_version`; a
+    /// full-MEK rotation advances the current generation so subsequent segments
+    /// are written under the new DEK while legacy/old-DEK segments still replay
+    /// under the retained old generation. When empty (`None`), segments use the
     /// plaintext (v13) format (backward compatible).
-    pub wal_keyring: Option<WalKeyring>,
+    ///
+    /// This is the **same** `Arc<ArcSwapOption<..>>` cell shared with the owning
+    /// [`ConcurrentWalSystem`](super::concurrent_system::ConcurrentWalSystem), so a
+    /// runtime install (`None` → `Some`, Issue #3616 PR2) performed through the
+    /// system is observed here on the write path immediately. All write-path reads
+    /// happen under the coordinator `writer` mutex, and the install stores into the
+    /// cell inside the seal→reopen hand-off, so the (segment header, encrypting
+    /// cipher) pair is always consistent.
+    pub wal_keyring: Arc<ArcSwapOption<WalKeyring>>,
 }
 
 impl std::fmt::Debug for FlushCoordinatorConfig {
@@ -145,7 +154,7 @@ impl std::fmt::Debug for FlushCoordinatorConfig {
             .field("flush_interval_ms", &self.flush_interval_ms)
             .field("sync_on_flush", &self.sync_on_flush)
             .field("write_buffer_size", &self.write_buffer_size)
-            .field("wal_keyring", &self.wal_keyring)
+            .field("wal_keyring", &*self.wal_keyring.load())
             .finish()
     }
 }
@@ -159,7 +168,7 @@ impl Default for FlushCoordinatorConfig {
             flush_interval_ms: 10, // 10ms
             sync_on_flush: true,
             write_buffer_size: 64 * 1024, // 64 KB
-            wal_keyring: None,
+            wal_keyring: Arc::new(ArcSwapOption::from(None)),
         }
     }
 }
@@ -444,7 +453,7 @@ impl FlushCoordinator {
     /// advances it — all serialized under the coordinator `writer` mutex so the
     /// (segment header, encrypting cipher) pair is always consistent.
     fn current_write_format(&self) -> (u8, Option<u32>) {
-        match &self.config.wal_keyring {
+        match self.config.wal_keyring.load().as_ref() {
             Some(keyring) => (
                 WAL_VERSION_ENCRYPTED_KEYVERSIONED,
                 Some(keyring.current_version()),
@@ -881,6 +890,7 @@ impl FlushCoordinator {
             let batch_cipher = self
                 .config
                 .wal_keyring
+                .load()
                 .as_ref()
                 .and_then(|k| k.current())
                 .map(|(cipher, _version)| cipher);


### PR DESCRIPTION
## Before / After (plain language)

**Before.** The WAL DEK keyring _presence_ was an `Option` held **by value** in two construction-fixed fields — `ConcurrentWalSystem.wal_keyring` and `FlushCoordinatorConfig.wal_keyring`. Whether a WAL was plaintext or encrypted was decided **once, at construction**, and could never change. The keyring _content_ was already interior-mutable (rotation's `add_generation`), but its _presence_ was not — the structural blocker called out in the #3616 4-PR plan.

**After.** The presence is runtime-installable: a live **plaintext** WAL can have a keyring installed (`None → Some`) and, from that point on, seals its next segment in the encrypted (v16 keyversioned) format — crash-consistently and without losing any acknowledged write. This is the structural prerequisite the plaintext→encrypted **enable engine** (PR3) will drive. No behavior changes for a WAL that starts encrypted or stays plaintext.

## How

- **One shared cell.** The two by-value `Option` fields are replaced by a single `Arc<ArcSwapOption<WalKeyring>>`, **Arc-cloned** (same underlying cell) into both the system (`concurrent_system.rs:349`) and the flush coordinator (`flush_coordinator.rs:145`). An install through the system is therefore observed by the flush path (`current_write_format` @ `flush_coordinator.rs:455`, `batch_cipher` @ `:890`) **and** the recovery/introspection path (`read_from`, `is_encrypted` @ `concurrent_system.rs:836`, `wal_keyring` @ `:848`) at once. All reads `load()` the cell; the plaintext (`None`) branch stays a single atomic load.
- **Seal-gated install seam.** New `ConcurrentWalSystem::install_wal_keyring(keyring)` (`concurrent_system.rs:888`) runs the `store(Some(..))` as the `advance` closure inside the **existing** `seal_active_segment_for_rotation` (`:960`) → `seal_active_segment_and_reopen` hand-off: it drains + fsyncs in-flight ring-buffer entries into the current plaintext segment, seals it, stores the keyring into the shared cell, then reopens a fresh segment now written in the v16 keyversioned format. Because the store happens **between** seal and reopen while holding the coordinator `writer` mutex, no `flush()` can interleave — every segment's header and frames use one consistent keyring state, so there is never a plaintext-header/encrypted-frame split. (You cannot append encrypted frames into an already-open plaintext v13 segment, which is why the roll is mandatory.)
- **`None → Some` only.** Installing when a keyring is already present is **rejected** with a structured `WalError` (never a silent replace, no data loss). The presence check and the seal→store→reopen are serialized under a dedicated `install_lock` leaf mutex (`concurrent_system.rs:364`, held for the whole body @ `:900`), closing the double-install TOCTOU. `Some → Some'` (rotation) remains `WalKeyring::add_generation`, unchanged.
- **Lock order preserved.** The install holds only the `writer` mutex (a leaf under `wal`) plus the `install_lock` leaf, and never calls back into `historical`/cold/`current_timestamp`, mirroring the rotation `advance` contract.

**No on-disk format change (reuses #3617 v16 container; EVEN-parity invariant preserved).** No new segment version bytes are added; installing just starts emitting the already-defined even v16 container. The regression test `v15_reserved_gap_version_is_rejected` (`segment_reader.rs:3179`) stays green.

## Acceptance-criteria evidence map (#3616 PR2)

#3616 has no enumerated AC list; the PR2 scope is isolated from the coordinator-approved 4-PR plan documented in #3657 ("WAL runtime keyring-install — interior-mutable `wal_keyring`, the structural blocker"). Every criterion in PR2 scope is **met**; the one item marked not-in-scope is by-design (the production caller is PR3).

| # | PR2 acceptance criterion | Status | Evidence (test / file:line, all green) |
|---|--------------------------|--------|----------------------------------------|
| 1 | Runtime-installable keyring presence `None → Some` on a live plaintext WAL; thereafter seals encrypted v16 | **Met** | `install_wal_keyring` seam `concurrent_system.rs:888`; shared `Arc<ArcSwapOption>` cell `:349` + `flush_coordinator.rs:145`. Test `install_keyring_none_to_some_transition` (`:1209`): `is_encrypted()` false→true, post-install record reads back, pre-install records still recover |
| 2 | Concurrency safety — concurrent appenders during install lose nothing | **Met** | `install_keyring_during_concurrent_appends_loses_nothing` (`:1246`): 4 threads × 200 appends hammering while one thread installs mid-storm; every acknowledged append recovers, none lost/unreadable, no hang |
| 3 | Install-then-roll ordering — seal plaintext v13 → store keyring → reopen v16 (mixed-format recovery) | **Met** | Store runs as `advance` closure inside `seal_active_segment_for_rotation` (`:921`, `:960`). `install_keyring_mixed_format_recovery` (`:1316`): v13 + v16 cohorts recover in order; directory verified genuinely mixed-format |
| 4 | No torn reads on the presence cell | **Met** | `ArcSwapOption` load/store. `install_keyring_no_torn_reads_on_cell` (`:1496`): concurrent loaders during the store always observe old `None` or a fully-valid `Some`, never a partial/invalid keyring |
| 5 | `None → Some` only — double-install rejected (no silent replace / data loss), including the concurrent race | **Met** | Presence guard `:905` under `install_lock` (`:364`, held `:900`). `install_keyring_twice_is_rejected` (`:1460`, sequential) + `install_keyring_concurrent_double_install_rejected` (`:1581`, `Barrier`-synchronized race): exactly 1 `Ok` / 1 `Err`, survivor keyring decrypts, no data lost |
| 6 | Encryption-at-rest — post-install segment genuinely v16-encrypted, undecryptable without the keyring | **Met** | `install_keyring_post_install_segment_is_encrypted_at_rest` (`:1382`): `max_key_version_in_dir` None→`Some(1)`; negative control — post-install cohort is NOT recoverable-as-plaintext without the keyring, pre-install plaintext still reads |
| 7 | EVEN-parity / on-disk format preserved (reuses #3617 v16, no new version byte) | **Met** | No new version bytes; `current_write_format` (`flush_coordinator.rs:455`) selects the already-defined even v16. Regression `v15_reserved_gap_version_is_rejected` (`segment_reader.rs:3179`) stays green |
| 8 | Lock order respected — install holds only `writer` (+ `install_lock`) leaf under `wal`, no callback into `historical`/cold/`current_timestamp` | **Met** | Store runs as the `advance` closure holding only the coordinator `writer` mutex (`:892`–`:924`); mirrors the rotation `advance` contract; no cross-primitive acquisition (static / code-review) |
| 9 | Hot-path no-regression on the plaintext path | **Met** | Plaintext branch is a single `ArcSwapOption::load()` → `None` (one atomic acquire, no lock/alloc); append→ring-buffer path untouched. Bench (below) sits in the documented Synchronous band. A clean-trunk A/B was not possible on the disk-constrained runner; no regression is possible by construction |
| 10 | Production caller of the install seam | **Not-in-scope-for-PR2 (by design)** | `#[allow(dead_code)]` on `install_wal_keyring` (`concurrent_system.rs:887`) with `TODO(#3616 PR3)`; the enable engine + CLI that drives it lands in #3616 PR3. Not a gap |

**No genuine PR2-scope AC is unmet.**

## Code-review fixes applied (2)

1. **Double-install TOCTOU → `install_lock`.** The original presence check ran outside the coordinator `writer` mutex while the store happened inside the seal→reopen hand-off, so two concurrent installers could both observe `None`, both pass the check, and both seal→store→reopen — the second silently replacing the first keyring and producing an undecryptable segment. Fixed by serializing the entire install (check + seal + store + reopen) under a dedicated `install_lock` leaf mutex (HEAD `1a52dbc`). Regression-covered by `install_keyring_concurrent_double_install_rejected`.
2. **Encryption-at-rest negative control added.** New `install_keyring_post_install_segment_is_encrypted_at_rest` proves the post-install cohort is a real v16 segment on disk (`max_key_version_in_dir` → `Some(1)`) AND is not recoverable-as-plaintext without the keyring — a strictly stronger assertion than "recovers with the keyring."

## Tests (7 added; std threads + `Arc` + `Barrier`, mirroring `append_hammer_across_force_roll_loses_nothing`)

All in `src/storage/wal/concurrent_system.rs` tests. Confirmed **red** first (`install_wal_keyring` absent → E0599), then **green**:

| # | Test | Asserts |
|---|------|---------|
| T1 | `install_keyring_none_to_some_transition` | fresh plaintext WAL `is_encrypted()==false` → install → `true`; a record appended after install reads back; pre-install records still recover |
| T2 | `install_keyring_during_concurrent_appends_loses_nothing` | 4 threads × 200 appends hammering while one thread installs mid-storm; every acknowledged append recovers, none lost/unreadable, no hang |
| T3 | `install_keyring_mixed_format_recovery` | pre-install cohort in plaintext v13 segments + post-install cohort in encrypted v16 segments; full recovery reads both in order; directory really is mixed-format |
| T4 | `install_keyring_twice_is_rejected` | second install returns structured error (not a silent replace); no data lost |
| T5 | `install_keyring_no_torn_reads_on_cell` | concurrent loaders during the store always observe old `None` or a fully-valid `Some`, never a partial/invalid keyring |
| T6 | `install_keyring_concurrent_double_install_rejected` | two `Barrier`-synchronized threads race the install; exactly one `Ok` / one `Err`; survivor keyring decrypts the post-install cohort |
| T7 | `install_keyring_post_install_segment_is_encrypted_at_rest` | post-install segment is v16 on disk and NOT recoverable-as-plaintext without the keyring (encryption-at-rest negative control) |

Pass evidence (re-run on this branch @ `1a52dbc`):
```
$ cargo test --lib install_keyring
running 7 tests
test storage::wal::concurrent_system::tests::install_keyring_mixed_format_recovery ... ok
test storage::wal::concurrent_system::tests::install_keyring_concurrent_double_install_rejected ... ok
test storage::wal::concurrent_system::tests::install_keyring_no_torn_reads_on_cell ... ok
test storage::wal::concurrent_system::tests::install_keyring_none_to_some_transition ... ok
test storage::wal::concurrent_system::tests::install_keyring_twice_is_rejected ... ok
test storage::wal::concurrent_system::tests::install_keyring_post_install_segment_is_encrypted_at_rest ... ok
test storage::wal::concurrent_system::tests::install_keyring_during_concurrent_appends_loses_nothing ... ok
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 4148 filtered out

$ cargo test --lib v15_reserved
running 1 test
test storage::wal::segment_reader::tests::v15_reserved_gap_version_is_rejected ... ok   (parity invariant)
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4154 filtered out
```

## Gate results

- `cargo test --lib` — **4150 passed, 0 failed, 3 ignored** (includes all WAL unit tests, T1–T7, the v15 parity regression, rotation tests), plus targeted integration batches covering WAL/encryption/recovery and DB/persistence — all green except one environmental uid-0 failure (`regression_flush_corruption::test_metadata_corruption_on_error` relies on `set_mode(0o500)` which root bypasses; unrelated to this diff).
- `cargo clippy --all-targets --features config-toml,mcp-server,sharding-rpc,simulation -- -D warnings` — **pass**
- `cargo clippy --all-targets --all-features -- -D warnings` — **pass**
- `cargo check --no-default-features --tests` — **pass**
- `cargo fmt --all --check` — **pass for every file this PR touches** (`concurrent_system.rs`, `flush_coordinator.rs`). See the CI note below.

## Known pre-existing CI note (not introduced by this PR)

The repo-wide `cargo fmt --all -- --check` currently fails on **trailing whitespace at `tests/sql_integration.rs:1055`/`1058`** (a blank line with two trailing spaces). This is **on `origin/trunk`**, introduced by commit `c3c2981` ("feat(query): real edge-property WHERE/ORDER BY for SQL FROM edges (#3622) (#3648)"), and is **untouched by this PR** — `git diff origin/trunk...HEAD -- tests/sql_integration.rs` is empty. Trunk's own most recent CI **"Linting"** job is already red at the "Check formatting" step for exactly this reason (run 29540409396). Because this branch inherits the file unchanged, **PR #3669's "Linting" check will also go red on the same pre-existing whitespace** until it is fixed on trunk — it is not a regression from this change and does not touch any code path here. (Left unfixed here deliberately; a one-line trunk fix or a rebase-after-trunk-fix clears it.)

## Hot-path bench (no regression on the plaintext path)

`cargo bench --features config-toml,mcp-server,sharding-rpc,simulation --bench durability_modes -- 'wal_append|wal_throughput'` (post-change, plaintext `None` keyring, Synchronous mode):

```
wal_append/create_node   time: [584.13 µs 604.03 µs 628.87 µs]
wal_append/create_edge   time: [535.64 µs 552.60 µs 574.91 µs]
wal_append/update_node   time: [614.13 µs 748.07 µs 963.92 µs]   (wide — shared-runner noise)
wal_throughput/batch_1000_operations
                         time: [824.60 µs 898.52 µs 964.12 µs]
                         thrpt: [1.04 Melem/s 1.11 Melem/s 1.21 Melem/s]
```

These sit in the documented Synchronous-mode band (~600/sec, ~1.5 ms). The plaintext path **cannot** regress by construction: the append→ring-buffer hot path never touched the keyring and is unchanged; the two flush-path keyring reads already ran under the `writer` mutex and now do one extra `ArcSwapOption::load()` returning `None` (a single atomic acquire, no lock, no allocation), dwarfed by the fsync+write that dominates a Synchronous flush.

---

Implements **#3616 PR2** (of the 4-PR encryption-migration plan). Foundation PR: #3657. The production consumer of `install_wal_keyring` (the enable engine + CLI) lands in #3616 PR3, so the seam is currently `#[allow(dead_code)]` with a rationale comment. Kept as **draft** pending the trunk fmt fix / rebase.