### PR TITLE
refactor(query): consolidate edge-predicate helpers + Cow sort path (follow-up to #3622)

### DIFF
--- a/src/cypher/converter.rs
+++ b/src/cypher/converter.rs
@@ -74,11 +74,13 @@ fn cypher_comp_to_provenance_cmp(op: CypherCompOp) -> ProvenanceCmp {
     }
 }
 
-/// Flip a Cypher comparison operator when its operands are swapped, so an
-/// accessor on the right-hand side (`0.9 <= confidence(x)`) lowers identically
-/// to the accessor-on-left form (`confidence(x) >= 0.9`). Equality/inequality
-/// are symmetric (Issue #3354b).
-fn flip_cypher_comp_op(op: CypherCompOp) -> CypherCompOp {
+/// Flip a Cypher comparison operator when its operands are swapped, so
+/// `value <op> x` evaluates identically to `x <flipped> value` (an accessor on
+/// the right-hand side lowers like the accessor-on-left form). Equality/
+/// inequality are symmetric (Issue #3354b). Shared by every Cypher operand-swap
+/// site (provenance lowering, vector-score comparison, and the edge-property
+/// evaluator, Issue #3622).
+pub(crate) fn flip_cypher_comp_op(op: CypherCompOp) -> CypherCompOp {
     match op {
         CypherCompOp::Eq => CypherCompOp::Eq,
         CypherCompOp::Ne => CypherCompOp::Ne,
@@ -2192,7 +2194,7 @@ impl CypherConverter {
             }
             (_, CypherExpr::FunctionCall { name, args, .. }) if is_vector_function(name) => {
                 // `value <cmp> score` == `score <flipped-cmp> value`.
-                (name, args, flip_comparison(*op))
+                (name, args, flip_cypher_comp_op(*op))
             }
             _ => return Ok(None),
         };
@@ -2343,18 +2345,6 @@ fn score_comparison_for(op: CypherCompOp) -> Option<ScoreComparison> {
         CypherCompOp::Lt => Some(ScoreComparison::Lt),
         CypherCompOp::Le => Some(ScoreComparison::Le),
         CypherCompOp::Eq | CypherCompOp::Ne => None,
-    }
-}
-
-/// Flip a comparison operator so `value <op> score` becomes `score <flipped> value`.
-fn flip_comparison(op: CypherCompOp) -> CypherCompOp {
-    match op {
-        CypherCompOp::Gt => CypherCompOp::Lt,
-        CypherCompOp::Ge => CypherCompOp::Le,
-        CypherCompOp::Lt => CypherCompOp::Gt,
-        CypherCompOp::Le => CypherCompOp::Ge,
-        CypherCompOp::Eq => CypherCompOp::Eq,
-        CypherCompOp::Ne => CypherCompOp::Ne,
     }
 }
 

--- a/src/cypher/multi_pattern.rs
+++ b/src/cypher/multi_pattern.rs
@@ -723,7 +723,7 @@ impl MultiEval<'_> {
                         edge,
                         prop,
                         lhs.as_ref(),
-                        flip_comp_op(*op),
+                        super::converter::flip_cypher_comp_op(*op),
                     )));
                 }
                 let l = self.eval_value(left, binding)?;
@@ -1177,10 +1177,15 @@ fn edge_leaf_compare(
 /// Resolve an edge leaf's value (Issue #3622): reserved structural fields
 /// (`type`/`label`/`source`/`target`/`id`) shadow user props, otherwise the
 /// edge's own properties. Shared by every edge-leaf evaluator so the
-/// reserved-vs-user precedence is single-sourced.
-fn edge_leaf_value(edge: &Edge, prop: &str) -> Option<PropertyValue> {
-    crate::query::executor::iterators::edge_structural_value(edge, prop)
-        .or_else(|| edge.get_property(prop).cloned())
+/// reserved-vs-user precedence is single-sourced. Returns a [`Cow`] so a user
+/// property is borrowed (no clone); only a synthesized structural value is
+/// owned.
+fn edge_leaf_value<'a>(edge: &'a Edge, prop: &str) -> Option<std::borrow::Cow<'a, PropertyValue>> {
+    use std::borrow::Cow;
+    if let Some(v) = crate::query::executor::iterators::edge_structural_value(edge, prop) {
+        return Some(Cow::Owned(v));
+    }
+    edge.get_property(prop).map(Cow::Borrowed)
 }
 
 /// Evaluate `edge.prop IN candidates` with openCypher **node**-semantics
@@ -1195,22 +1200,9 @@ fn edge_leaf_in(v: &PropertyValue, candidates: &[Option<PropertyValue>]) -> bool
 /// node-semantics (Issue #3622): a missing or non-string edge value is definite
 /// `false`, so `NOT (r.<absent> CONTAINS 'x')` == `true`, matching AQL / SQL.
 fn edge_leaf_string_op(edge: &Edge, prop: &str, f: impl FnOnce(&str) -> bool) -> bool {
-    match edge_leaf_value(edge, prop) {
-        Some(PropertyValue::String(ref s)) => f(s.as_ref()),
+    match edge_leaf_value(edge, prop).as_deref() {
+        Some(PropertyValue::String(s)) => f(s.as_ref()),
         _ => false,
-    }
-}
-
-/// Flip a comparison operator so `value <op> edge.prop` can be evaluated as
-/// `edge.prop <flipped> value` (Issue #3622).
-fn flip_comp_op(op: CypherCompOp) -> CypherCompOp {
-    match op {
-        CypherCompOp::Eq => CypherCompOp::Eq,
-        CypherCompOp::Ne => CypherCompOp::Ne,
-        CypherCompOp::Lt => CypherCompOp::Gt,
-        CypherCompOp::Le => CypherCompOp::Ge,
-        CypherCompOp::Gt => CypherCompOp::Lt,
-        CypherCompOp::Ge => CypherCompOp::Le,
     }
 }
 

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -586,14 +586,11 @@ impl EdgeScope {
     /// prior behavior) for a declared node variable, and reject a genuinely
     /// unknown variable (typo / unbound reference, Issue #3622 F15).
     fn scope_leaf(&self, var: &str, leaf: Predicate) -> Result<Predicate> {
-        if self.rel_vars.contains(var) {
-            return match self.single_hop_rel.as_deref() {
-                Some(v) if v == var => Ok(Predicate::EdgeScoped(Box::new(leaf))),
-                _ => Err(self.reject(var)),
-            };
+        if self.is_edge_var(var)? {
+            Ok(Predicate::EdgeScoped(Box::new(leaf)))
+        } else {
+            Ok(leaf)
         }
-        self.check_known_node_var(var)?;
-        Ok(leaf)
     }
 
     /// Whether `var` is a relationship variable that must be edge-scoped (a

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -4392,10 +4392,19 @@ fn last_edge_in_path(path: &Option<Vec<EntityId>>) -> Option<crate::core::EdgeId
 /// channel (Issue #3622): reserved structural fields (via
 /// [`edge_structural_value`], shadowing user props) first, then the edge's own
 /// properties. `None` when the row has no edge channel or the key is absent, so
-/// the row sorts as a null value.
-fn edge_sort_value(row: &QueryRow, key: &str) -> Option<PropertyValue> {
+/// the row sorts as a null value. Returns a [`Cow`] so a user property is
+/// borrowed (no clone per comparison); only a synthesized structural value is
+/// owned.
+fn edge_sort_value<'a>(
+    row: &'a QueryRow,
+    key: &str,
+) -> Option<std::borrow::Cow<'a, PropertyValue>> {
+    use std::borrow::Cow;
     let edge = row.edge.as_ref()?;
-    edge_structural_value(edge, key).or_else(|| edge.properties.get(key).cloned())
+    if let Some(v) = edge_structural_value(edge, key) {
+        return Some(Cow::Owned(v));
+    }
+    edge.properties.get(key).map(Cow::Borrowed)
 }
 
 /// `ORDER BY` iterator: buffers the entire input and stably sorts it by one or
@@ -4642,7 +4651,7 @@ impl SortIterator {
             SortKey::EdgeProperty(prop) => {
                 let av = edge_sort_value(a, prop);
                 let bv = edge_sort_value(b, prop);
-                Self::cmp_optional(av.as_ref(), bv.as_ref(), descending)
+                Self::cmp_optional(av.as_deref(), bv.as_deref(), descending)
             }
             // Fallback on-the-fly resolution (Issue #3354). The hot path routes
             // provenance keys through `cmp_decorated` (resolve once per row), so


### PR DESCRIPTION
Pure cleanup of the edge-property WHERE/ORDER BY code merged in #3667 (#3622). No behavior change; full suite green.

## What

- **Consolidate the third `CypherCompOp` operand-flip copy** into one shared `pub(crate) flip_cypher_comp_op`: delete `flip_comp_op` (`multi_pattern`) and the duplicate `flip_comparison` (`cypher/converter`), pointing every swap site (provenance lowering, vector-score comparison, edge-property evaluator) at the single helper.
- **Collapse `EdgeScope::scope_leaf` into `is_edge_var`**, removing the duplicated rel-var / node-var / unknown-var classification.
- **Return `Cow` from `edge_sort_value` and `edge_leaf_value`** (+ borrow in `edge_leaf_string_op`) so a user edge property is no longer cloned on every sort comparison / predicate evaluation — only a synthesized structural value (`type`/`label`/`source`/`target`/`id`) is owned.

## Evidence

- Net −12 lines across 4 files (`src/cypher/converter.rs`, `src/cypher/multi_pattern.rs`, `src/query/converter.rs`, `src/query/executor/iterators.rs`).
- `cargo fmt --all`, `cargo clippy --lib --features sql,cypher -- -D warnings`, `cargo check --no-default-features --tests` — clean.
- `cargo clippy --lib --no-default-features -- -D warnings` — clean except a pre-existing `src/db/namespace.rs` `unneeded return` lint (a `#[cfg(not(feature = "serde"))]` block, not in this diff).
- Full `cargo test --features sql,cypher`: 5415 pass / 1 fail (the pre-existing root-user `havoc_flush_deadlock`, unrelated).

Follow-up to #3622 / #3667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSV3pRgK97oJKz3DQjzFk6)_