### PR TITLE
Push filters + limit down into list_changes hot/cold scans (#3216)

### DIFF
--- a/benches/changefeed.rs
+++ b/benches/changefeed.rs
@@ -89,9 +89,52 @@ fn bench_changefeed_paginated(c: &mut Criterion) {
     group.finish();
 }
 
+/// Bounded vs. unbounded `list_changes` over a large hot history (Issue #3216, PR 2).
+///
+/// **Honest framing.** The filter+limit pushdown's win is a **working-set / candidate-count**
+/// reduction: a bounded page holds only `O(limit)` `RawChange`s in memory instead of `O(matches)`.
+/// It is **not** a latency win — candidate *enumeration* is still an `O(N)` walk of the hot version
+/// maps in v1 (a `(commit_ts, kind, id)` directory would be needed for a sub-linear scan), so
+/// wall-clock time is expected to stay roughly flat between the bounded and unbounded cases. This
+/// bench exists to track that the bounded page does not regress and to make the memory-bounded and
+/// unbounded-fast-path routes measurable. It deliberately does **not** claim cold-scan
+/// elimination: cold I/O remains `O(N)` (this bench is hot-only).
+fn bench_list_changes_bounded_vs_unbounded(c: &mut Criterion) {
+    let mut group = c.benchmark_group("list_changes_bounded_vs_unbounded");
+
+    // ~24k committed versions (20k creates + every-5th update) in the hot tier.
+    let db = setup_db(20_000);
+    let tx_from = Timestamp::from(0);
+    let tx_to = TIMESTAMP_MAX;
+
+    // Bounded: a small page over the whole history — retains only `limit + 1` candidates via the
+    // per-tier max-heap.
+    group.bench_function("bounded_page_10_over_20k", |b| {
+        b.iter(|| {
+            let query = ChangeFeedQuery::new(black_box(tx_from), black_box(tx_to), 10);
+            let page = db.list_changes(black_box(&query)).unwrap();
+            black_box(page.changes.len());
+        });
+    });
+
+    // Unbounded: drain everything — exercises the plain-`Vec` fast path (no heap maintenance) that
+    // the `usize::MAX` bound selects.
+    group.bench_function("unbounded_drain_20k", |b| {
+        b.iter(|| {
+            let query = ChangeFeedQuery::new(black_box(tx_from), black_box(tx_to), usize::MAX);
+            let page = db.list_changes(black_box(&query)).unwrap();
+            black_box(page.changes.len());
+        });
+    });
+
+    group.finish();
+}
+
 criterion_group!(
     name = benches;
     config = common::configure_criterion();
-    targets = bench_changefeed_24h_window, bench_changefeed_paginated
+    targets = bench_changefeed_24h_window,
+        bench_changefeed_paginated,
+        bench_list_changes_bounded_vs_unbounded
 );
 criterion_main!(benches);

--- a/src/core/changefeed.rs
+++ b/src/core/changefeed.rs
@@ -325,6 +325,108 @@ pub(crate) fn build_raw_change(
     })
 }
 
+/// A streaming, bounded-by-cursor accumulator of [`RawChange`]s (Issue #3216, PR 2).
+///
+/// Retains only the `bound`-smallest changes offered to it (by [`ChangeCursor`] order), so a
+/// windowed changefeed scan over a large tier holds `O(bound)` rows in memory instead of every
+/// match. This is the **limit pushdown** for `list_changes`: the query layer passes
+/// `page_limit + 1` as the bound (the `+1` lets it detect `has_more` without materializing the
+/// rest), and because the retained set always contains the true `bound`-smallest survivors, the
+/// page the query layer then selects is byte-identical to one produced by an unbounded scan.
+///
+/// Applying the bound **per tier** is sound because the page is the `page_limit`-smallest of the
+/// tiers' union: any survivor beyond a tier's `bound`-smallest has at least `bound` smaller
+/// survivors within that same tier — hence at least `page_limit` smaller survivors in the union —
+/// and can never reach the page.
+pub(crate) struct BoundedChanges {
+    bound: usize,
+    /// Max-heap keyed by cursor: the current largest-cursor survivor sits at the top so it is the
+    /// one evicted once the heap exceeds `bound`.
+    heap: std::collections::BinaryHeap<ByCursor>,
+}
+
+/// [`RawChange`] wrapper ordered solely by its [`ChangeCursor`] (which is unique per emitted
+/// version), so a [`std::collections::BinaryHeap`] evicts the largest-cursor survivor.
+struct ByCursor(RawChange);
+
+impl PartialEq for ByCursor {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.cursor == other.0.cursor
+    }
+}
+impl Eq for ByCursor {}
+impl PartialOrd for ByCursor {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for ByCursor {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cursor.cmp(&other.0.cursor)
+    }
+}
+
+impl BoundedChanges {
+    /// Create an accumulator that keeps at most `bound` (min 1) smallest-cursor changes.
+    pub(crate) fn new(bound: usize) -> Self {
+        BoundedChanges {
+            bound: bound.max(1),
+            heap: std::collections::BinaryHeap::new(),
+        }
+    }
+
+    /// Offer a change; the accumulator keeps only the `bound`-smallest by cursor seen so far.
+    pub(crate) fn consider(&mut self, change: RawChange) {
+        self.heap.push(ByCursor(change));
+        if self.heap.len() > self.bound {
+            // Evict the current largest cursor — it cannot belong on any page of size < bound.
+            self.heap.pop();
+        }
+    }
+
+    /// Consume the accumulator, returning the retained changes (unordered; the caller sorts).
+    pub(crate) fn into_vec(self) -> Vec<RawChange> {
+        self.heap.into_iter().map(|w| w.0).collect()
+    }
+}
+
+/// Build a [`RawChange`] for one version and, if it passes every filter **and** sorts strictly
+/// after `resume_after`, offer it to `acc` (Issue #3216, PR 2).
+///
+/// Shared verbatim by the hot ([`crate::storage::historical`]) and cold
+/// ([`crate::storage::redb_cold_storage`]) changefeed scans so their filtering, cursor-resume,
+/// and bounding are identical by construction — the guarantee that makes the pushed-down page
+/// byte-identical to the legacy unbounded merge.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn consider_version(
+    acc: &mut BoundedChanges,
+    resume_after: Option<ChangeCursor>,
+    version_id: u64,
+    entity_id: u64,
+    kind: EntityKind,
+    temporal: &BiTemporalInterval,
+    label_id: InternedString,
+    prev_is_none: bool,
+    tx_window: &TimeRange,
+    valid_window: Option<&TimeRange>,
+    label_filter: Option<&str>,
+) {
+    if let Some(rec) = build_raw_change(
+        version_id,
+        entity_id,
+        kind,
+        temporal,
+        label_id,
+        prev_is_none,
+        tx_window,
+        valid_window,
+        label_filter,
+    ) && resume_after.is_none_or(|c| rec.cursor > c)
+    {
+        acc.consider(rec);
+    }
+}
+
 /// Query options for [`crate::db::AletheiaDB::list_changes`].
 ///
 /// The transaction-time window is required; everything else is optional. An empty window

--- a/src/core/changefeed.rs
+++ b/src/core/changefeed.rs
@@ -340,9 +340,24 @@ pub(crate) fn build_raw_change(
 /// and can never reach the page.
 pub(crate) struct BoundedChanges {
     bound: usize,
-    /// Max-heap keyed by cursor: the current largest-cursor survivor sits at the top so it is the
-    /// one evicted once the heap exceeds `bound`.
-    heap: std::collections::BinaryHeap<ByCursor>,
+    inner: BoundedInner,
+}
+
+/// Upper limit on the heap capacity we pre-reserve, so a large `bound` (e.g. an MCP
+/// `limit = 10_000` catch-up) does not attempt a giant up-front allocation while still avoiding
+/// the handful of reallocations a `bound`-sized scan would otherwise incur.
+const HEAP_PRESIZE_CAP: usize = 4096;
+
+/// Storage strategy for [`BoundedChanges`], chosen once at construction from `bound`.
+enum BoundedInner {
+    /// Unbounded fast path (`bound == usize::MAX`): accumulate every offered change into a plain
+    /// `Vec` in `O(M)`. When nothing can ever be evicted (the common "drain everything" /
+    /// large-limit case) the max-heap's `O(M log M)` maintenance buys no memory benefit — it just
+    /// re-heapifies a set the caller sorts anyway — so we skip it entirely.
+    Unbounded(Vec<RawChange>),
+    /// Bounded path: max-heap keyed by cursor, so the current largest-cursor survivor sits at the
+    /// top and is the one evicted once the heap exceeds `bound`.
+    Bounded(std::collections::BinaryHeap<ByCursor>),
 }
 
 /// [`RawChange`] wrapper ordered solely by its [`ChangeCursor`] (which is unique per emitted
@@ -368,25 +383,43 @@ impl Ord for ByCursor {
 
 impl BoundedChanges {
     /// Create an accumulator that keeps at most `bound` (min 1) smallest-cursor changes.
+    ///
+    /// A `bound` of `usize::MAX` selects the unbounded fast path (plain `Vec`, no heap); any
+    /// finite `bound` selects the bounded max-heap, pre-sized to `bound` (capped by
+    /// [`HEAP_PRESIZE_CAP`]).
     pub(crate) fn new(bound: usize) -> Self {
-        BoundedChanges {
-            bound: bound.max(1),
-            heap: std::collections::BinaryHeap::new(),
-        }
+        let bound = bound.max(1);
+        let inner = if bound == usize::MAX {
+            BoundedInner::Unbounded(Vec::new())
+        } else {
+            BoundedInner::Bounded(std::collections::BinaryHeap::with_capacity(
+                bound.min(HEAP_PRESIZE_CAP),
+            ))
+        };
+        BoundedChanges { bound, inner }
     }
 
     /// Offer a change; the accumulator keeps only the `bound`-smallest by cursor seen so far.
     pub(crate) fn consider(&mut self, change: RawChange) {
-        self.heap.push(ByCursor(change));
-        if self.heap.len() > self.bound {
-            // Evict the current largest cursor — it cannot belong on any page of size < bound.
-            self.heap.pop();
+        match &mut self.inner {
+            // Unbounded: keep everything (no eviction is ever possible).
+            BoundedInner::Unbounded(v) => v.push(change),
+            BoundedInner::Bounded(heap) => {
+                heap.push(ByCursor(change));
+                if heap.len() > self.bound {
+                    // Evict the current largest cursor — it cannot belong on any page of size < bound.
+                    heap.pop();
+                }
+            }
         }
     }
 
     /// Consume the accumulator, returning the retained changes (unordered; the caller sorts).
     pub(crate) fn into_vec(self) -> Vec<RawChange> {
-        self.heap.into_iter().map(|w| w.0).collect()
+        match self.inner {
+            BoundedInner::Unbounded(v) => v,
+            BoundedInner::Bounded(heap) => heap.into_iter().map(|w| w.0).collect(),
+        }
     }
 }
 
@@ -421,7 +454,8 @@ pub(crate) fn consider_version(
         tx_window,
         valid_window,
         label_filter,
-    ) && resume_after.is_none_or(|c| rec.cursor > c)
+    )
+    .filter(|rec| resume_after.is_none_or(|c| rec.cursor > c))
     {
         acc.consider(rec);
     }

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -2,8 +2,7 @@
 //!
 //! Methods for querying historical states of the graph using valid and transaction times.
 use crate::core::changefeed::{
-    ChangeCursor, ChangeFeedPage, ChangeFeedQuery, ChangeRecord, EntityKind, RawChange,
-    build_raw_change,
+    ChangeCursor, ChangeFeedPage, ChangeFeedQuery, ChangeRecord, RawChange,
 };
 use crate::core::error::{Result, ResultExt};
 use crate::core::graph::{Edge, Node};
@@ -11,6 +10,15 @@ use crate::core::id::{EdgeId, NodeId, VersionId};
 use crate::core::temporal::{TimeRange, Timestamp, time};
 use crate::db::AletheiaDB;
 use crate::query::{EntityHistory, VersionDiff};
+
+/// Test-only instrumentation: the number of candidate [`RawChange`] rows the most recent
+/// [`AletheiaDB::list_changes`] call held for pagination — i.e. the "materialize / refilter"
+/// working set the filter+limit pushdown is meant to bound. Parity and bench tests read this to
+/// assert the hot/cold pushdown actually shrinks the working set to `O(page)` instead of
+/// `O(total matches)`.
+#[cfg(test)]
+pub(crate) static LAST_LIST_CHANGES_CANDIDATES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
 
 impl AletheiaDB {
     /// Get outgoing edges from a node at a specific point in time.
@@ -561,69 +569,58 @@ impl AletheiaDB {
         let label = query.label.as_deref();
         let valid = valid_window.as_ref();
 
+        // A page must be able to carry a continuation cursor, so it can never be empty while more
+        // rows exist: treat limit 0 as 1. Computed up front so the filter + limit can be pushed
+        // down into both tiers' scans.
+        let limit = query.limit.max(1);
+
+        // Filter + limit pushdown (Issue #3216, PR 2): each tier applies the transaction-/valid-
+        // time window, label filter, and the strict `> cursor` resume *during* its scan, and
+        // retains only the `bound = limit + 1`-smallest survivors by cursor. The `+1` lets us
+        // detect `has_more` without materializing the rest. Bounding per tier is sound because
+        // the page is the `limit`-smallest of the union: a survivor beyond a tier's
+        // `limit + 1`-smallest has at least `limit` smaller survivors in the union and can never
+        // reach the page. The retained per-tier sets therefore always contain the true page, so
+        // the merged result below is byte-identical to an unbounded scan.
+        let bound = limit.saturating_add(1);
+
         // Scan the hot tier under the read lock, but keep the lock hold short: `collect_changes`
-        // returns lightweight `RawChange`s (no label allocation), and the cold-tier scan (disk
-        // I/O) happens after the lock is released using the cloned tiered handle.
+        // returns lightweight `RawChange`s (no label allocation), already filtered/resumed and
+        // bounded. The cold-tier scan (disk I/O) happens after the lock is released using the
+        // cloned tiered handle.
         let (mut changes, tiered) = {
             let hist = self.historical.read();
             (
-                hist.collect_changes(&tx_window, valid, label),
+                hist.collect_changes(&tx_window, valid, label, cursor, bound),
                 hist.tiered_storage_arc(),
             )
         };
 
         // Include versions that have migrated out of the hot maps into cold storage, so the feed
-        // is complete when tiered storage is enabled. Dedup against hot by (kind, version_id) in
-        // case a version is transiently present in both tiers during migration.
+        // is complete when tiered storage is enabled. The cold scan applies the same filter +
+        // resume + bound; dedup against hot by (kind, version_id) covers a version transiently
+        // present in both tiers during migration (its cursor is identical in both, so it survives
+        // in the smaller-cursor region of each bounded set and dedup keeps the hot copy).
         if let Some(tiered) = tiered {
             let mut seen: std::collections::HashSet<(u8, u64)> = changes
                 .iter()
                 .map(|r| (r.cursor.kind_ord, r.cursor.version_id))
                 .collect();
 
-            for v in tiered.scan_node_versions_cold()? {
-                if let Some(rec) = build_raw_change(
-                    v.id.as_u64(),
-                    v.node_id.as_u64(),
-                    EntityKind::Node,
-                    &v.temporal,
-                    v.label,
-                    v.prev_version.is_none(),
-                    &tx_window,
-                    valid,
-                    label,
-                ) && seen.insert((rec.cursor.kind_ord, rec.cursor.version_id))
-                {
-                    changes.push(rec);
-                }
-            }
-            for v in tiered.scan_edge_versions_cold()? {
-                if let Some(rec) = build_raw_change(
-                    v.id.as_u64(),
-                    v.edge_id.as_u64(),
-                    EntityKind::Edge,
-                    &v.temporal,
-                    v.label,
-                    v.prev_version.is_none(),
-                    &tx_window,
-                    valid,
-                    label,
-                ) && seen.insert((rec.cursor.kind_ord, rec.cursor.version_id))
-                {
+            for rec in tiered.collect_cold_changes(&tx_window, valid, label, cursor, bound)? {
+                if seen.insert((rec.cursor.kind_ord, rec.cursor.version_id)) {
                     changes.push(rec);
                 }
             }
         }
 
-        // A page must be able to carry a continuation cursor, so it can never be empty while more
-        // rows exist: treat limit 0 as 1.
-        let limit = query.limit.max(1);
+        // Test-only: record the candidate working-set size before pagination bounds it. With the
+        // pushdown this is `O(page)` (<= 2 * (limit + 1)) rather than `O(total matches)`.
+        #[cfg(test)]
+        LAST_LIST_CHANGES_CANDIDATES.store(changes.len(), std::sync::atomic::Ordering::Relaxed);
 
-        // Resume strictly after the cursor key (the precomputed `cursor` is a Copy field, so no
-        // per-element recomputation).
-        if let Some(c) = cursor {
-            changes.retain(|record| record.cursor > c);
-        }
+        // The resume cursor was already applied inside each tier's scan, so no post-merge
+        // `retain` is needed here.
 
         // Bound the page. When more rows remain than fit, select the `limit` smallest by cursor
         // in O(n) before sorting just that page, rather than fully sorting the whole scan.
@@ -1161,5 +1158,690 @@ mod changefeed_tests {
             page.changes.iter().any(|r| r.entity_id == 888_888),
             "cold-only version must be included in the feed"
         );
+    }
+}
+
+/// Parity + edge-case tests for the `list_changes` filter/limit pushdown (PR 2, Issue #3216).
+///
+/// Every scenario runs the same query through the production [`AletheiaDB::list_changes`] (the
+/// filter+limit-pushed-down path) and through [`list_changes_reference`] — a faithful copy of the
+/// pre-pushdown algorithm (unbounded hot collect + full cold scan + post-merge cursor retain +
+/// `select_nth` limit) — and asserts the two produce a byte-identical page (`changes` Vec +
+/// `next_cursor`). The reference is independent of the pushdown's bounding logic, so it is a
+/// genuine old-vs-new oracle rather than a restatement of the optimized code.
+#[cfg(test)]
+mod changefeed_pushdown_tests {
+    use super::LAST_LIST_CHANGES_CANDIDATES;
+    use crate::AletheiaDB;
+    use crate::api::WriteOps;
+    use crate::core::PropertyMap;
+    use crate::core::PropertyMapBuilder;
+    use crate::core::changefeed::{
+        ChangeCursor, ChangeFeedPage, ChangeFeedQuery, ChangeType, EntityKind, RawChange,
+        build_raw_change,
+    };
+    use crate::core::error::{Error, Result};
+    use crate::core::id::{EdgeId, NodeId, VersionId};
+    use crate::core::interning::GLOBAL_INTERNER;
+    use crate::core::temporal::{BiTemporalInterval, TIMESTAMP_MAX, TimeRange, Timestamp, time};
+    use crate::core::version::{EdgeVersion, NodeVersion};
+    use crate::storage::redb_cold_storage::RedbColdStorage;
+    use crate::storage::tiered_storage::TieredStorage;
+    use std::sync::Arc;
+    use std::sync::atomic::Ordering as AtomicOrdering;
+
+    fn props(name: &str) -> PropertyMap {
+        PropertyMapBuilder::new().insert("name", name).build()
+    }
+
+    fn all() -> (Timestamp, Timestamp) {
+        (Timestamp::from(0), TIMESTAMP_MAX)
+    }
+
+    fn query(from: Timestamp, to: Timestamp, limit: usize) -> ChangeFeedQuery {
+        ChangeFeedQuery::new(from, to, limit)
+    }
+
+    fn ts(micros: i64) -> Timestamp {
+        Timestamp::from(micros)
+    }
+
+    /// A synthetic cold node "Created" anchor with a caller-chosen version id and tx-time.
+    fn cold_node(vid: u64, nid: u64, tx: Timestamp, label: &str) -> NodeVersion {
+        NodeVersion::new_anchor(
+            VersionId::new(vid).unwrap(),
+            NodeId::new(nid).unwrap(),
+            BiTemporalInterval::now(tx, tx),
+            GLOBAL_INTERNER.intern(label).unwrap(),
+            PropertyMap::new(),
+        )
+    }
+
+    /// A synthetic cold node tombstone (empty valid range `[v, v)`) committed at `tx`.
+    fn cold_node_tomb(vid: u64, nid: u64, tx: Timestamp, valid_instant: Timestamp) -> NodeVersion {
+        let interval = BiTemporalInterval::new(
+            TimeRange::new(valid_instant, valid_instant).unwrap(),
+            TimeRange::from(tx),
+        );
+        NodeVersion::new_anchor(
+            VersionId::new(vid).unwrap(),
+            NodeId::new(nid).unwrap(),
+            interval,
+            GLOBAL_INTERNER.intern("Ghost").unwrap(),
+            PropertyMap::new(),
+        )
+    }
+
+    /// A synthetic cold edge "Created" anchor.
+    fn cold_edge(vid: u64, eid: u64, tx: Timestamp, label: &str) -> EdgeVersion {
+        EdgeVersion::new_anchor(
+            VersionId::new(vid).unwrap(),
+            EdgeId::new(eid).unwrap(),
+            BiTemporalInterval::now(tx, tx),
+            GLOBAL_INTERNER.intern(label).unwrap(),
+            NodeId::new(1).unwrap(),
+            NodeId::new(2).unwrap(),
+            PropertyMap::new(),
+        )
+    }
+
+    /// Attach a cold tier holding the given synthetic versions to `db`. Returns the tempdir,
+    /// which must be kept alive for the duration of the test.
+    fn attach_cold(
+        db: &AletheiaDB,
+        nodes: &[NodeVersion],
+        edges: &[EdgeVersion],
+    ) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let cold =
+            Arc::new(RedbColdStorage::with_default_config(dir.path().join("cold.redb")).unwrap());
+        for v in nodes {
+            cold.store_node_version(v).unwrap();
+        }
+        for v in edges {
+            cold.store_edge_version(v).unwrap();
+        }
+        let tiered = Arc::new(TieredStorage::with_default_config(cold));
+        db.__test_historical_storage()
+            .write()
+            .set_tiered_storage(tiered);
+        dir
+    }
+
+    /// Clone a node version out of the hot maps by version id (used to build a dual-tier version).
+    fn hot_node_version(db: &AletheiaDB, version_id: u64) -> NodeVersion {
+        db.__test_historical_storage()
+            .read()
+            .get_node_version(VersionId::new(version_id).unwrap())
+            .expect("hot version present")
+            .clone()
+    }
+
+    /// Faithful copy of the pre-pushdown `list_changes` algorithm — the parity oracle.
+    fn list_changes_reference(db: &AletheiaDB, query: &ChangeFeedQuery) -> Result<ChangeFeedPage> {
+        let tx_window = TimeRange::new(query.tx_from, query.tx_to)?;
+        let valid_window = match (query.valid_from, query.valid_to) {
+            (Some(from), Some(to)) => Some(TimeRange::new(from, to)?),
+            (None, None) => None,
+            _ => {
+                return Err(crate::core::error::QueryError::InvalidParameter {
+                    parameter: "valid_time".to_string(),
+                    reason: "valid_from and valid_to must be supplied together".to_string(),
+                }
+                .into());
+            }
+        };
+        let cursor = match &query.cursor {
+            Some(token) => Some(ChangeCursor::decode(token)?),
+            None => None,
+        };
+        let label = query.label.as_deref();
+        let valid = valid_window.as_ref();
+
+        let (mut changes, tiered) = {
+            let hist = db.__test_historical_storage().read();
+            (
+                hist.collect_changes(&tx_window, valid, label, None, usize::MAX),
+                hist.tiered_storage_arc(),
+            )
+        };
+
+        if let Some(tiered) = tiered {
+            let mut seen: std::collections::HashSet<(u8, u64)> = changes
+                .iter()
+                .map(|r| (r.cursor.kind_ord, r.cursor.version_id))
+                .collect();
+            for v in tiered.scan_node_versions_cold()? {
+                if let Some(rec) = build_raw_change(
+                    v.id.as_u64(),
+                    v.node_id.as_u64(),
+                    EntityKind::Node,
+                    &v.temporal,
+                    v.label,
+                    v.prev_version.is_none(),
+                    &tx_window,
+                    valid,
+                    label,
+                ) && seen.insert((rec.cursor.kind_ord, rec.cursor.version_id))
+                {
+                    changes.push(rec);
+                }
+            }
+            for v in tiered.scan_edge_versions_cold()? {
+                if let Some(rec) = build_raw_change(
+                    v.id.as_u64(),
+                    v.edge_id.as_u64(),
+                    EntityKind::Edge,
+                    &v.temporal,
+                    v.label,
+                    v.prev_version.is_none(),
+                    &tx_window,
+                    valid,
+                    label,
+                ) && seen.insert((rec.cursor.kind_ord, rec.cursor.version_id))
+                {
+                    changes.push(rec);
+                }
+            }
+        }
+
+        let limit = query.limit.max(1);
+        if let Some(c) = cursor {
+            changes.retain(|record| record.cursor > c);
+        }
+        let has_more = changes.len() > limit;
+        if has_more {
+            changes.select_nth_unstable_by_key(limit, |record| record.cursor);
+            changes.truncate(limit);
+        }
+        changes.sort_unstable_by_key(|record| record.cursor);
+        let next_cursor = if has_more {
+            changes.last().map(|record| record.cursor.encode())
+        } else {
+            None
+        };
+        let records: Vec<_> = changes.into_iter().map(RawChange::into_record).collect();
+        Ok(ChangeFeedPage {
+            changes: records,
+            next_cursor,
+        })
+    }
+
+    /// Assert the production path and the reference oracle produce byte-identical pages, and
+    /// return the production page for further assertions.
+    fn assert_parity(db: &AletheiaDB, query: &ChangeFeedQuery) -> ChangeFeedPage {
+        let got = db.list_changes(query).expect("list_changes ok");
+        let want = list_changes_reference(db, query).expect("reference ok");
+        assert_eq!(
+            got.changes, want.changes,
+            "page rows must be byte-identical"
+        );
+        assert_eq!(
+            got.next_cursor, want.next_cursor,
+            "next_cursor must be byte-identical"
+        );
+        got
+    }
+
+    /// Drain every page of a query (following `next_cursor`) into one ordered Vec.
+    fn drain_all(db: &AletheiaDB, base: &ChangeFeedQuery) -> Vec<(u64, u8, u64)> {
+        let mut out = Vec::new();
+        let mut cursor: Option<String> = None;
+        loop {
+            let mut q = base.clone();
+            q.cursor = cursor.clone();
+            let page = db.list_changes(&q).unwrap();
+            for r in &page.changes {
+                out.push((r.entity_id, r.kind.ord(), r.version_id));
+            }
+            match page.next_cursor {
+                Some(tok) => cursor = Some(tok),
+                None => break,
+            }
+        }
+        out
+    }
+
+    // 1 -----------------------------------------------------------------------------------------
+    #[test]
+    fn parity_hot_only() {
+        let db = AletheiaDB::new().unwrap();
+        for i in 0..50 {
+            db.write(|tx| {
+                tx.create_node("Person", props(&format!("n{i}")))?;
+                Ok::<_, Error>(())
+            })
+            .unwrap();
+        }
+        let (from, to) = all();
+        for limit in [1usize, 7, 10, 49, 50, 100] {
+            assert_parity(&db, &query(from, to, limit));
+        }
+    }
+
+    // 2 -----------------------------------------------------------------------------------------
+    #[test]
+    fn parity_cold_only() {
+        let db = AletheiaDB::new().unwrap();
+        let nodes: Vec<_> = (0..20)
+            .map(|i| cold_node(1000 + i, 5000 + i, ts(100 + i as i64), "ColdNode"))
+            .collect();
+        let edges: Vec<_> = (0..10)
+            .map(|i| cold_edge(2000 + i, 6000 + i, ts(200 + i as i64), "ColdEdge"))
+            .collect();
+        let _dir = attach_cold(&db, &nodes, &edges);
+
+        let (from, to) = all();
+        for limit in [1usize, 5, 15, 29, 30, 100] {
+            let page = assert_parity(&db, &query(from, to, limit));
+            assert!(page.changes.len() <= limit.max(1));
+        }
+    }
+
+    // 3 -----------------------------------------------------------------------------------------
+    #[test]
+    fn parity_mixed_tiers_dedup() {
+        let db = AletheiaDB::new().unwrap();
+        // Real hot writes.
+        for i in 0..15 {
+            db.write(|tx| {
+                tx.create_node("Person", props(&format!("hot{i}")))?;
+                Ok::<_, Error>(())
+            })
+            .unwrap();
+        }
+        // Pick one hot version and mirror it into cold to create a *dual-tier* version.
+        let full = db.list_changes(&query(all().0, all().1, 1000)).unwrap();
+        let dual = &full.changes[3];
+        let dual_vid = dual.version_id;
+        let dual_entity = dual.entity_id;
+        let dual_version = hot_node_version(&db, dual_vid);
+
+        let mut cold_nodes = vec![dual_version];
+        cold_nodes
+            .extend((0..10).map(|i| cold_node(9000 + i, 7000 + i, ts(50 + i as i64), "Cold")));
+        let _dir = attach_cold(&db, &cold_nodes, &[]);
+
+        let (from, to) = all();
+        for limit in [1usize, 3, 10, 25, 100] {
+            let page = assert_parity(&db, &query(from, to, limit));
+            // Full drain: the dual-tier version appears exactly once across all pages.
+            if limit == 100 {
+                let _ = page;
+            }
+        }
+        let drained = drain_all(&db, &query(from, to, 4));
+        let dual_hits = drained
+            .iter()
+            .filter(|(eid, kind, vid)| {
+                *eid == dual_entity && *kind == EntityKind::Node.ord() && *vid == dual_vid
+            })
+            .count();
+        assert_eq!(dual_hits, 1, "dual-tier version must appear exactly once");
+    }
+
+    // 4 -----------------------------------------------------------------------------------------
+    #[test]
+    fn parity_empty_window() {
+        let db = AletheiaDB::new().unwrap();
+        db.write(|tx| {
+            tx.create_node("Person", props("a"))?;
+            Ok::<_, Error>(())
+        })
+        .unwrap();
+        let _dir = attach_cold(&db, &[cold_node(1, 42, ts(5), "Cold")], &[]);
+        let now = time::now();
+        let page = assert_parity(&db, &query(now, now, 100));
+        assert!(page.changes.is_empty(), "empty window yields no rows");
+        assert!(page.next_cursor.is_none());
+    }
+
+    // 5 -----------------------------------------------------------------------------------------
+    #[test]
+    fn parity_limit_smaller_than_matches() {
+        let db = AletheiaDB::new().unwrap();
+        for i in 0..50 {
+            db.write(|tx| {
+                tx.create_node("Person", props(&format!("n{i}")))?;
+                Ok::<_, Error>(())
+            })
+            .unwrap();
+        }
+        let (from, to) = all();
+        let page = assert_parity(&db, &query(from, to, 10));
+        assert_eq!(page.changes.len(), 10);
+        assert!(page.next_cursor.is_some(), "has_more page carries a cursor");
+    }
+
+    // 6 -----------------------------------------------------------------------------------------
+    #[test]
+    fn limit_spans_hot_cold_boundary() {
+        let db = AletheiaDB::new().unwrap();
+        for i in 0..5 {
+            db.write(|tx| {
+                tx.create_node("Person", props(&format!("hot{i}")))?;
+                Ok::<_, Error>(())
+            })
+            .unwrap();
+        }
+        // Cold versions interleaved in tx-time with the hot ones (hot commit near time::now()).
+        let cold_nodes: Vec<_> = (0..5)
+            .map(|i| cold_node(4000 + i, 8000 + i, ts(10 + i as i64), "Cold"))
+            .collect();
+        let _dir = attach_cold(&db, &cold_nodes, &[]);
+
+        let (from, to) = all();
+        // Sweep the page boundary across the whole merged sequence.
+        for limit in 1..=11 {
+            assert_parity(&db, &query(from, to, limit));
+        }
+        // Full drain has no dup / gap: exactly the unbounded row set.
+        let unbounded = db.list_changes(&query(from, to, 10_000)).unwrap();
+        let drained = drain_all(&db, &query(from, to, 3));
+        let want: Vec<_> = unbounded
+            .changes
+            .iter()
+            .map(|r| (r.entity_id, r.kind.ord(), r.version_id))
+            .collect();
+        assert_eq!(drained, want, "paged drain equals unbounded, no dup/gap");
+    }
+
+    // 7 -----------------------------------------------------------------------------------------
+    #[test]
+    fn cursor_resume_after_cold_page() {
+        let db = AletheiaDB::new().unwrap();
+        for i in 0..8 {
+            db.write(|tx| {
+                tx.create_node("Person", props(&format!("h{i}")))?;
+                Ok::<_, Error>(())
+            })
+            .unwrap();
+        }
+        let cold_nodes: Vec<_> = (0..8)
+            .map(|i| cold_node(4100 + i, 8100 + i, ts(20 + i as i64), "Cold"))
+            .collect();
+        let _dir = attach_cold(&db, &cold_nodes, &[]);
+
+        let (from, to) = all();
+        let unbounded = db.list_changes(&query(from, to, 10_000)).unwrap();
+        let want: Vec<_> = unbounded
+            .changes
+            .iter()
+            .map(|r| (r.entity_id, r.kind.ord(), r.version_id))
+            .collect();
+        for page_size in [1usize, 2, 5, 7] {
+            let drained = drain_all(&db, &query(from, to, page_size));
+            assert_eq!(
+                drained, want,
+                "resume union equals unbounded @page={page_size}"
+            );
+        }
+    }
+
+    // 8 -----------------------------------------------------------------------------------------
+    #[test]
+    fn resume_across_version_id_inversion() {
+        // Craft two cold versions where the SMALLER version_id carries the LARGER tx-time — the
+        // exact inversion a naive `version_id`-range early-stop would mis-handle. Correct behavior
+        // orders strictly by tx-time (ChangeCursor), never by version_id.
+        let db = AletheiaDB::new().unwrap();
+        let earlier_txn_bigger_vid = cold_node(500, 100, ts(1_000), "Cold"); // vid 500, tx 1000
+        let later_txn_smaller_vid = cold_node(100, 200, ts(2_000), "Cold"); // vid 100, tx 2000
+        let _dir = attach_cold(&db, &[earlier_txn_bigger_vid, later_txn_smaller_vid], &[]);
+
+        let (from, to) = all();
+        // Parity at every page size.
+        for limit in [1usize, 2, 3] {
+            assert_parity(&db, &query(from, to, limit));
+        }
+        // Page-by-1 order must be tx-time ascending: entity 100 (tx 1000) then entity 200 (tx 2000).
+        let drained = drain_all(&db, &query(from, to, 1));
+        assert_eq!(
+            drained,
+            vec![
+                (100u64, EntityKind::Node.ord(), 500u64),
+                (200u64, EntityKind::Node.ord(), 100u64),
+            ],
+            "ordering follows tx-time, not version_id"
+        );
+    }
+
+    // 9 -----------------------------------------------------------------------------------------
+    #[test]
+    fn tombstone_valid_window_boundary() {
+        let db = AletheiaDB::new().unwrap();
+        // Deletion recorded at tx=1000, valid instant v=500.
+        let tomb = cold_node_tomb(700, 300, ts(1_000), ts(500));
+        let _dir = attach_cold(&db, &[tomb], &[]);
+
+        let (from, to) = all();
+        // Window [500, 501) contains v=500 -> deletion included.
+        let mut q_in = query(from, to, 100);
+        q_in.valid_from = Some(ts(500));
+        q_in.valid_to = Some(ts(501));
+        let page_in = assert_parity(&db, &q_in);
+        assert_eq!(page_in.changes.len(), 1);
+        assert_eq!(page_in.changes[0].change_type, ChangeType::Deleted);
+
+        // Window [499, 500) excludes v=500 (half-open) -> deletion excluded.
+        let mut q_out = query(from, to, 100);
+        q_out.valid_from = Some(ts(499));
+        q_out.valid_to = Some(ts(500));
+        let page_out = assert_parity(&db, &q_out);
+        assert!(
+            page_out.changes.is_empty(),
+            "tombstone excluded when window omits v"
+        );
+    }
+
+    // 10 ----------------------------------------------------------------------------------------
+    #[test]
+    fn half_open_tx_boundary() {
+        let db = AletheiaDB::new().unwrap();
+        let at_from = cold_node(810, 410, ts(1_000), "Cold");
+        let at_to = cold_node(820, 420, ts(2_000), "Cold");
+        let _dir = attach_cold(&db, &[at_from, at_to], &[]);
+
+        // Window [1000, 2000): includes the tx=1000 row, excludes the tx=2000 row.
+        let page = assert_parity(&db, &query(ts(1_000), ts(2_000), 100));
+        let ids: Vec<u64> = page.changes.iter().map(|r| r.entity_id).collect();
+        assert_eq!(ids, vec![410], "tx_from included, tx_to excluded");
+    }
+
+    // 11 ----------------------------------------------------------------------------------------
+    #[test]
+    fn empty_cold_tier() {
+        let db = AletheiaDB::new().unwrap();
+        db.write(|tx| {
+            tx.create_node("Person", props("a"))?;
+            Ok::<_, Error>(())
+        })
+        .unwrap();
+        let _dir = attach_cold(&db, &[], &[]); // tiered enabled, nothing migrated
+        let (from, to) = all();
+        let page = assert_parity(&db, &query(from, to, 100));
+        assert_eq!(page.changes.len(), 1);
+    }
+
+    // 12 ----------------------------------------------------------------------------------------
+    #[test]
+    fn cold_disabled_config() {
+        let db = AletheiaDB::new().unwrap();
+        for i in 0..5 {
+            db.write(|tx| {
+                tx.create_node("Person", props(&format!("n{i}")))?;
+                Ok::<_, Error>(())
+            })
+            .unwrap();
+        }
+        let (from, to) = all();
+        // No tiered storage attached -> cold branch skipped entirely.
+        for limit in [1usize, 3, 5, 100] {
+            assert_parity(&db, &query(from, to, limit));
+        }
+    }
+
+    // 13 ----------------------------------------------------------------------------------------
+    #[test]
+    fn limit_zero_floors_to_one() {
+        let db = AletheiaDB::new().unwrap();
+        for i in 0..3 {
+            db.write(|tx| {
+                tx.create_node("Person", props(&format!("n{i}")))?;
+                Ok::<_, Error>(())
+            })
+            .unwrap();
+        }
+        let (from, to) = all();
+        let page = assert_parity(&db, &query(from, to, 0));
+        assert_eq!(page.changes.len(), 1, "limit 0 floors to 1 row");
+        assert!(
+            page.next_cursor.is_some(),
+            "cursor present since more remain"
+        );
+    }
+
+    // 14 ----------------------------------------------------------------------------------------
+    #[test]
+    fn label_filter_pushdown_parity() {
+        let db = AletheiaDB::new().unwrap();
+        db.write(|tx| {
+            tx.create_node("Person", props("p"))?;
+            Ok::<_, Error>(())
+        })
+        .unwrap();
+        db.write(|tx| {
+            tx.create_node("Widget", props("w"))?;
+            Ok::<_, Error>(())
+        })
+        .unwrap();
+        let cold_nodes = vec![
+            cold_node(3100, 9100, ts(30), "Person"),
+            cold_node(3101, 9101, ts(31), "Widget"),
+        ];
+        let cold_edges = vec![cold_edge(3200, 9200, ts(40), "KNOWS")];
+        let _dir = attach_cold(&db, &cold_nodes, &cold_edges);
+
+        let (from, to) = all();
+        for lbl in ["Person", "Widget", "KNOWS", "Nonexistent"] {
+            let mut q = query(from, to, 100);
+            q.label = Some(lbl.to_string());
+            let page = assert_parity(&db, &q);
+            assert!(
+                page.changes.iter().all(|r| r.label == lbl),
+                "only matching-label rows for {lbl}"
+            );
+        }
+    }
+
+    // 15 ----------------------------------------------------------------------------------------
+    #[test]
+    fn valid_window_pushdown_parity() {
+        let db = AletheiaDB::new().unwrap();
+        // Live node valid from t=100 (open), and a tombstone at valid instant 500.
+        let live = cold_node(3300, 9300, ts(100), "Cold");
+        let tomb = cold_node_tomb(3301, 9301, ts(1_000), ts(500));
+        let _dir = attach_cold(&db, &[live, tomb], &[]);
+
+        let (from, to) = all();
+        for (vf, vt) in [(50i64, 200i64), (400, 600), (600, 700), (0, 2_000)] {
+            let mut q = query(from, to, 100);
+            q.valid_from = Some(ts(vf));
+            q.valid_to = Some(ts(vt));
+            assert_parity(&db, &q);
+        }
+    }
+
+    // 16 ----------------------------------------------------------------------------------------
+    #[test]
+    fn candidate_set_is_bounded() {
+        // 500 hot matches, page limit 10. After the pushdown the candidate working set the query
+        // holds for pagination must be O(page) — not O(total matches). Before the pushdown this
+        // was 500 (the whole match set), which is the RED failure this asserts against.
+        let db = AletheiaDB::new().unwrap();
+        for i in 0..500 {
+            db.write(|tx| {
+                tx.create_node("Person", props(&format!("n{i}")))?;
+                Ok::<_, Error>(())
+            })
+            .unwrap();
+        }
+        let (from, to) = all();
+        let limit = 10usize;
+        let page = assert_parity(&db, &query(from, to, limit));
+        assert_eq!(page.changes.len(), limit);
+        let candidates = LAST_LIST_CHANGES_CANDIDATES.load(AtomicOrdering::Relaxed);
+        assert!(
+            candidates <= limit + 1,
+            "hot candidate working set must be bounded to limit+1, got {candidates}"
+        );
+    }
+
+    // 16b: mixed-tier candidate bound (hot+cold each bounded to limit+1).
+    #[test]
+    fn candidate_set_is_bounded_mixed() {
+        let db = AletheiaDB::new().unwrap();
+        for i in 0..200 {
+            db.write(|tx| {
+                tx.create_node("Person", props(&format!("n{i}")))?;
+                Ok::<_, Error>(())
+            })
+            .unwrap();
+        }
+        let cold_nodes: Vec<_> = (0..200)
+            .map(|i| cold_node(20_000 + i, 30_000 + i, ts(1 + i as i64), "Cold"))
+            .collect();
+        let _dir = attach_cold(&db, &cold_nodes, &[]);
+        let (from, to) = all();
+        let limit = 10usize;
+        assert_parity(&db, &query(from, to, limit));
+        let candidates = LAST_LIST_CHANGES_CANDIDATES.load(AtomicOrdering::Relaxed);
+        assert!(
+            candidates <= 2 * (limit + 1),
+            "merged candidate set must be bounded to 2*(limit+1), got {candidates}"
+        );
+    }
+
+    /// Bench-adjacent (honest): print the candidate working-set size and wall time of the
+    /// optimized path vs the unbounded reference oracle for a bounded/limited query over a large
+    /// hot history. Ignored by default; run with `--ignored --nocapture` to capture PR numbers.
+    #[test]
+    #[ignore = "bench-adjacent; run explicitly to capture numbers"]
+    fn bench_list_changes_pushdown() {
+        use std::time::Instant;
+        let db = AletheiaDB::new().unwrap();
+        let n = 20_000;
+        for i in 0..n {
+            db.write(|tx| {
+                tx.create_node("Person", props(&format!("n{i}")))?;
+                Ok::<_, Error>(())
+            })
+            .unwrap();
+        }
+        let (from, to) = all();
+        let q = query(from, to, 10);
+
+        // Warm both paths once.
+        let _ = db.list_changes(&q).unwrap();
+        let _ = list_changes_reference(&db, &q).unwrap();
+
+        let iters = 50;
+        let t0 = Instant::now();
+        for _ in 0..iters {
+            let _ = list_changes_reference(&db, &q).unwrap();
+        }
+        let ref_elapsed = t0.elapsed() / iters;
+
+        let t1 = Instant::now();
+        for _ in 0..iters {
+            let _ = db.list_changes(&q).unwrap();
+        }
+        let new_elapsed = t1.elapsed() / iters;
+        let candidates = LAST_LIST_CHANGES_CANDIDATES.load(AtomicOrdering::Relaxed);
+
+        println!("=== list_changes pushdown bench ({n} hot versions, limit 10) ===");
+        println!("reference (unbounded) : {ref_elapsed:?}/call");
+        println!("pushed-down (new)     : {new_elapsed:?}/call");
+        println!("new-path candidate working set: {candidates} rows (was {n})");
     }
 }

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -11,14 +11,22 @@ use crate::core::temporal::{TimeRange, Timestamp, time};
 use crate::db::AletheiaDB;
 use crate::query::{EntityHistory, VersionDiff};
 
-/// Test-only instrumentation: the number of candidate [`RawChange`] rows the most recent
-/// [`AletheiaDB::list_changes`] call held for pagination — i.e. the "materialize / refilter"
-/// working set the filter+limit pushdown is meant to bound. Parity and bench tests read this to
-/// assert the hot/cold pushdown actually shrinks the working set to `O(page)` instead of
-/// `O(total matches)`.
 #[cfg(test)]
-pub(crate) static LAST_LIST_CHANGES_CANDIDATES: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
+thread_local! {
+    /// Test-only instrumentation: the number of candidate [`RawChange`] rows the most recent
+    /// [`AletheiaDB::list_changes`] call **on this thread** held for pagination — i.e. the
+    /// "materialize / refilter" working set the filter+limit pushdown is meant to bound. Parity
+    /// and bench tests read this to assert the hot/cold pushdown actually shrinks the working set
+    /// to `O(page)` instead of `O(total matches)`.
+    ///
+    /// It is **thread-local**, not a process-global static, on purpose: libtest runs each test on
+    /// its own thread and `list_changes` records the count synchronously on that same thread, so a
+    /// test reads exactly the count from its own call. A shared mutable global would race under
+    /// default `cargo test` parallelism (a concurrent test's call could clobber the value between
+    /// this test's production call and its read), producing both false reds and false greens.
+    pub(crate) static LAST_LIST_CHANGES_CANDIDATES: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
 
 impl AletheiaDB {
     /// Get outgoing edges from a node at a specific point in time.
@@ -615,9 +623,10 @@ impl AletheiaDB {
         }
 
         // Test-only: record the candidate working-set size before pagination bounds it. With the
-        // pushdown this is `O(page)` (<= 2 * (limit + 1)) rather than `O(total matches)`.
+        // pushdown this is `O(page)` (<= 2 * (limit + 1)) rather than `O(total matches)`. Recorded
+        // in a thread-local so parallel tests never clobber each other's readings.
         #[cfg(test)]
-        LAST_LIST_CHANGES_CANDIDATES.store(changes.len(), std::sync::atomic::Ordering::Relaxed);
+        LAST_LIST_CHANGES_CANDIDATES.with(|c| c.set(changes.len()));
 
         // The resume cursor was already applied inside each tier's scan, so no post-merge
         // `retain` is needed here.
@@ -1188,7 +1197,6 @@ mod changefeed_pushdown_tests {
     use crate::storage::redb_cold_storage::RedbColdStorage;
     use crate::storage::tiered_storage::TieredStorage;
     use std::sync::Arc;
-    use std::sync::atomic::Ordering as AtomicOrdering;
 
     fn props(name: &str) -> PropertyMap {
         PropertyMapBuilder::new().insert("name", name).build()
@@ -1322,7 +1330,8 @@ mod changefeed_pushdown_tests {
                     &tx_window,
                     valid,
                     label,
-                ) && seen.insert((rec.cursor.kind_ord, rec.cursor.version_id))
+                )
+                .filter(|rec| seen.insert((rec.cursor.kind_ord, rec.cursor.version_id)))
                 {
                     changes.push(rec);
                 }
@@ -1338,7 +1347,8 @@ mod changefeed_pushdown_tests {
                     &tx_window,
                     valid,
                     label,
-                ) && seen.insert((rec.cursor.kind_ord, rec.cursor.version_id))
+                )
+                .filter(|rec| seen.insert((rec.cursor.kind_ord, rec.cursor.version_id)))
                 {
                     changes.push(rec);
                 }
@@ -1464,12 +1474,9 @@ mod changefeed_pushdown_tests {
 
         let (from, to) = all();
         for limit in [1usize, 3, 10, 25, 100] {
-            let page = assert_parity(&db, &query(from, to, limit));
-            // Full drain: the dual-tier version appears exactly once across all pages.
-            if limit == 100 {
-                let _ = page;
-            }
+            assert_parity(&db, &query(from, to, limit));
         }
+        // Full drain: the dual-tier version appears exactly once across all pages.
         let drained = drain_all(&db, &query(from, to, 4));
         let dual_hits = drained
             .iter()
@@ -1581,9 +1588,13 @@ mod changefeed_pushdown_tests {
     // 8 -----------------------------------------------------------------------------------------
     #[test]
     fn resume_across_version_id_inversion() {
-        // Craft two cold versions where the SMALLER version_id carries the LARGER tx-time — the
-        // exact inversion a naive `version_id`-range early-stop would mis-handle. Correct behavior
-        // orders strictly by tx-time (ChangeCursor), never by version_id.
+        // Craft two cold versions where the SMALLER version_id carries the LARGER tx-time. This is
+        // a *static* reproduction of the on-disk state a version_id/tx-time inversion produces — a
+        // guard against a naive `version_id`-range early-stop implementation, not a live
+        // concurrent race (the production scan decodes every entry, so there is no early-stop for
+        // this to defeat; the test asserts scan/resume ordering follows tx-time via ChangeCursor,
+        // never version_id). A true concurrency test that drives two racing commits is a
+        // documented follow-up.
         let db = AletheiaDB::new().unwrap();
         let earlier_txn_bigger_vid = cold_node(500, 100, ts(1_000), "Cold"); // vid 500, tx 1000
         let later_txn_smaller_vid = cold_node(100, 200, ts(2_000), "Cold"); // vid 100, tx 2000
@@ -1770,7 +1781,7 @@ mod changefeed_pushdown_tests {
         let limit = 10usize;
         let page = assert_parity(&db, &query(from, to, limit));
         assert_eq!(page.changes.len(), limit);
-        let candidates = LAST_LIST_CHANGES_CANDIDATES.load(AtomicOrdering::Relaxed);
+        let candidates = LAST_LIST_CHANGES_CANDIDATES.with(|c| c.get());
         assert!(
             candidates <= limit + 1,
             "hot candidate working set must be bounded to limit+1, got {candidates}"
@@ -1795,10 +1806,128 @@ mod changefeed_pushdown_tests {
         let (from, to) = all();
         let limit = 10usize;
         assert_parity(&db, &query(from, to, limit));
-        let candidates = LAST_LIST_CHANGES_CANDIDATES.load(AtomicOrdering::Relaxed);
+        let candidates = LAST_LIST_CHANGES_CANDIDATES.with(|c| c.get());
         assert!(
             candidates <= 2 * (limit + 1),
             "merged candidate set must be bounded to 2*(limit+1), got {candidates}"
+        );
+    }
+
+    // 17 ----------------------------------------------------------------------------------------
+    /// Differentially validate the RESUME path against the oracle with a real mid-stream cursor.
+    ///
+    /// Every other `assert_parity` call site passes a cursor-less query, so the oracle's resume
+    /// branch (`if let Some(c) = cursor { changes.retain(|r| r.cursor > c) }`) would otherwise be
+    /// dead code. Here we walk the whole hot+cold stream page-by-page and `assert_parity` each
+    /// *resumed* page (cursor set to a genuine interior `next_cursor`), so the production in-scan
+    /// `> cursor` filter is checked against the independent post-merge-retain oracle.
+    #[test]
+    fn resume_parity_midstream() {
+        let db = AletheiaDB::new().unwrap();
+        for i in 0..12 {
+            db.write(|tx| {
+                tx.create_node("Person", props(&format!("h{i}")))?;
+                Ok::<_, Error>(())
+            })
+            .unwrap();
+        }
+        let cold_nodes: Vec<_> = (0..12)
+            .map(|i| cold_node(4300 + i, 8300 + i, ts(60 + i as i64), "Cold"))
+            .collect();
+        let _dir = attach_cold(&db, &cold_nodes, &[]);
+
+        let (from, to) = all();
+        for page_size in [1usize, 3, 5] {
+            let mut cursor: Option<String> = None;
+            let mut resumed_pages = 0usize;
+            loop {
+                let mut q = query(from, to, page_size);
+                q.cursor = cursor.clone();
+                // Only interior (resumed) pages carry a cursor — parity-check those so the oracle's
+                // resume branch actually executes.
+                if cursor.is_some() {
+                    assert_parity(&db, &q);
+                    resumed_pages += 1;
+                }
+                let page = db.list_changes(&q).unwrap();
+                match page.next_cursor {
+                    Some(tok) => cursor = Some(tok),
+                    None => break,
+                }
+            }
+            assert!(
+                resumed_pages > 0,
+                "expected at least one mid-stream resumed page @page={page_size}"
+            );
+        }
+    }
+
+    // 18 ----------------------------------------------------------------------------------------
+    /// The tightest correctness case: a page that interleaves rows from BOTH tiers while BOTH
+    /// tiers individually hold far more matches than the bound (heavy eviction in each). This is
+    /// where the per-tier `bound = limit + 1` proof is load-bearing: if the bounded heap dropped a
+    /// true top-N row from one tier because the *other* tier also contributed to the page, the
+    /// paged result would diverge from the unbounded oracle. Asserts order-sensitive byte equality.
+    #[test]
+    fn parity_both_tiers_over_bound_interleaved() {
+        let db = AletheiaDB::new().unwrap();
+
+        // Insert 100 HOT node versions directly at controlled EVEN tx-times (ts 2,4,…,200). Real
+        // `db.write` commits cluster at `time::now()` and cannot be interleaved at the microsecond
+        // level with small synthetic cold timestamps, so we drive the low-level historical insert
+        // to place hot rows exactly between the cold ones.
+        let hot_label = GLOBAL_INTERNER.intern("Hot").unwrap();
+        {
+            let hist = db.__test_historical_storage();
+            let mut w = hist.write();
+            for i in 0..100u64 {
+                let t = ts(2 + (i as i64) * 2); // 2,4,…,200
+                w.add_node_version(
+                    NodeId::new(60_000 + i).unwrap(),
+                    VersionId::new(70_000 + i).unwrap(),
+                    t,
+                    t,
+                    hot_label,
+                    PropertyMap::new(),
+                    false,
+                )
+                .unwrap();
+            }
+        }
+
+        // 100 COLD node versions at controlled ODD tx-times (ts 1,3,…,199).
+        let cold_nodes: Vec<_> = (0..100u64)
+            .map(|i| cold_node(40_000 + i, 50_000 + i, ts(1 + (i as i64) * 2), "Cold"))
+            .collect();
+        let _dir = attach_cold(&db, &cold_nodes, &[]);
+
+        let (from, to) = all();
+        // Merged cursor order alternates cold(ts1), hot(ts2), cold(ts3), hot(ts4), … so any page of
+        // the smallest L (L < 100) interleaves both tiers, and with bound = L+1 ≪ 100 BOTH tiers
+        // evict heavily during their scans.
+        for limit in [2usize, 5, 10, 25, 50] {
+            let page = assert_parity(&db, &query(from, to, limit));
+            assert_eq!(page.changes.len(), limit);
+            let has_hot = page.changes.iter().any(|r| r.label == "Hot");
+            let has_cold = page.changes.iter().any(|r| r.label == "Cold");
+            assert!(
+                has_hot && has_cold,
+                "page must interleave BOTH tiers @limit={limit}"
+            );
+        }
+
+        // Paginated drain must equal the unbounded scan exactly (order-sensitive, no dup/gap).
+        let unbounded = db.list_changes(&query(from, to, 10_000)).unwrap();
+        let want: Vec<_> = unbounded
+            .changes
+            .iter()
+            .map(|r| (r.entity_id, r.kind.ord(), r.version_id))
+            .collect();
+        assert_eq!(want.len(), 200, "all 200 versions visible unbounded");
+        let drained = drain_all(&db, &query(from, to, 7));
+        assert_eq!(
+            drained, want,
+            "paged drain equals unbounded across both over-bound tiers"
         );
     }
 
@@ -1837,7 +1966,7 @@ mod changefeed_pushdown_tests {
             let _ = db.list_changes(&q).unwrap();
         }
         let new_elapsed = t1.elapsed() / iters;
-        let candidates = LAST_LIST_CHANGES_CANDIDATES.load(AtomicOrdering::Relaxed);
+        let candidates = LAST_LIST_CHANGES_CANDIDATES.with(|c| c.get());
 
         println!("=== list_changes pushdown bench ({n} hot versions, limit 10) ===");
         println!("reference (unbounded) : {ref_elapsed:?}/call");

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -10,7 +10,9 @@
 //! - Reconstruction walks backward to nearest anchor and applies deltas forward
 //! - TinyLFU cache reduces redundant delta chain traversals for concurrent reads
 
-use crate::core::changefeed::{EntityKind, RawChange, build_raw_change};
+use crate::core::changefeed::{
+    BoundedChanges, ChangeCursor, EntityKind, RawChange, build_raw_change, consider_version,
+};
 use crate::core::error::{Result, StorageError, TemporalError};
 use crate::core::graph::{Edge, Node};
 use crate::core::history::{EntityHistory, VersionDiff, VersionInfo};
@@ -1989,35 +1991,43 @@ impl HistoricalStorage {
         }
     }
 
-    /// Collect changefeed records for every committed version that falls within the given
-    /// transaction-time window, optionally constrained by a valid-time window and/or a
-    /// node-label / edge-type filter (Issue #3216).
+    /// Collect changefeed records for the committed versions that fall within the given
+    /// transaction-time window, optionally constrained by a valid-time window, a node-label /
+    /// edge-type filter, a resume cursor, and a `bound` on how many smallest-cursor rows to
+    /// retain (Issue #3216; filter + limit pushdown, PR 2).
     ///
     /// This is a read-only scan over the in-memory version maps. Only committed versions are
     /// ever present in these maps (versions are inserted on the commit-apply path), so the
-    /// changefeed never surfaces uncommitted or rolled-back data. The result is unordered and
-    /// unpaginated; the caller is responsible for deterministic ordering and cursor/limit
-    /// pagination.
+    /// changefeed never surfaces uncommitted or rolled-back data. The result is unordered; the
+    /// caller is responsible for deterministic ordering and final page selection.
+    ///
+    /// The `resume_after` cursor (strict `> cursor`) and the `bound` are applied **during** the
+    /// scan via [`BoundedChanges`], so the working set held in memory is `O(bound)` rather than
+    /// `O(matches)` — no post-collection materialize-then-refilter. Pass `usize::MAX` as `bound`
+    /// (and `None` as `resume_after`) to recover an unbounded, unresumed collection.
     ///
     /// # Performance
     ///
-    /// This is an O(V) scan of all node and edge versions in the **hot** maps. It is adequate
-    /// for the bounded windows this API targets; a future optimization could maintain a
-    /// transaction-time index keyed by `(commit_timestamp, kind, id)` to make this
-    /// O(log V + page). To keep the historical lock hold short, this produces lightweight
-    /// [`RawChange`]s (no owned label `String`); label resolution is deferred to the query
-    /// layer for surviving rows only. Cold-tier versions are scanned separately by the caller
-    /// after the lock is released (see `tiered_storage_arc`).
+    /// The candidate enumeration is still an O(V) walk of the hot maps (a future
+    /// `(commit_timestamp, kind, id)` index could make this O(log V + page)), but only the
+    /// `bound`-smallest survivors are retained. To keep the historical lock hold short, this
+    /// produces lightweight [`RawChange`]s (no owned label `String`); label resolution is
+    /// deferred to the query layer for surviving rows only. Cold-tier versions are scanned
+    /// separately by the caller after the lock is released (see `tiered_storage_arc`).
     pub(crate) fn collect_changes(
         &self,
         tx_window: &TimeRange,
         valid_window: Option<&TimeRange>,
         label_filter: Option<&str>,
+        resume_after: Option<ChangeCursor>,
+        bound: usize,
     ) -> Vec<RawChange> {
-        let mut out = Vec::new();
+        let mut acc = BoundedChanges::new(bound);
 
         for v in self.node_versions.values() {
-            if let Some(rec) = build_raw_change(
+            consider_version(
+                &mut acc,
+                resume_after,
                 v.id.as_u64(),
                 v.node_id.as_u64(),
                 EntityKind::Node,
@@ -2027,13 +2037,13 @@ impl HistoricalStorage {
                 tx_window,
                 valid_window,
                 label_filter,
-            ) {
-                out.push(rec);
-            }
+            );
         }
 
         for v in self.edge_versions.values() {
-            if let Some(rec) = build_raw_change(
+            consider_version(
+                &mut acc,
+                resume_after,
                 v.id.as_u64(),
                 v.edge_id.as_u64(),
                 EntityKind::Edge,
@@ -2043,12 +2053,10 @@ impl HistoricalStorage {
                 tx_window,
                 valid_window,
                 label_filter,
-            ) {
-                out.push(rec);
-            }
+            );
         }
 
-        out
+        acc.into_vec()
     }
 
     /// Build changefeed [`RawChange`]s for a specific, known set of just-committed version

--- a/src/storage/redb_cold_storage/mod.rs
+++ b/src/storage/redb_cold_storage/mod.rs
@@ -51,9 +51,12 @@
 //! # }
 //! ```
 
+use crate::core::changefeed::{
+    BoundedChanges, ChangeCursor, EntityKind, RawChange, consider_version,
+};
 use crate::core::error::{Result, StorageError};
 use crate::core::id::VersionId;
-use crate::core::temporal::{BiTemporalInterval, TIMESTAMP_MAX, Timestamp};
+use crate::core::temporal::{BiTemporalInterval, TIMESTAMP_MAX, TimeRange, Timestamp};
 use crate::core::version::{EdgeVersion, EntityVersion, NodeVersion, TemporalVersion};
 use crate::storage::wal::LSN;
 use rayon::prelude::*;
@@ -1995,6 +1998,127 @@ impl RedbColdStorage {
     /// lookups for point reads. Used by the changefeed to include migrated history.
     pub fn scan_edge_versions(&self) -> Result<Vec<EdgeVersion>> {
         self.scan_entries_internal(decode_edge_version, EDGE_VERSIONS_TABLE)
+    }
+
+    /// Stream-decode a versions table, invoking `emit` on each decoded version.
+    ///
+    /// Like [`scan_entries_internal`](Self::scan_entries_internal) but never accumulates the
+    /// decoded versions into a `Vec` — the caller's `emit` closure decides what (if anything) to
+    /// keep. This is what lets the filtered changefeed scan hold only `O(bound)` survivors in
+    /// memory instead of the whole table.
+    fn scan_versions_into<V, D, E>(
+        &self,
+        table_def: redb::TableDefinition<'static, u64, &'static [u8]>,
+        decode_fn: D,
+        mut emit: E,
+    ) -> Result<()>
+    where
+        D: Fn(&[u8]) -> Result<V>,
+        E: FnMut(V),
+    {
+        let read_txn = self
+            .db
+            .begin_read()
+            .map_err(map_transaction_error("Failed to begin read transaction"))?;
+
+        let table = match read_txn.open_table(table_def) {
+            Ok(table) => table,
+            // A cold store that has never persisted this kind of version has no such table yet.
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(()),
+            Err(e) => {
+                return Err(StorageError::io_error(format!(
+                    "Failed to open table '{}': {}",
+                    table_def.name(),
+                    e
+                ))
+                .into());
+            }
+        };
+
+        let iter = table
+            .iter()
+            .map_err(|e| StorageError::io_error(format!("Failed to iterate cold table: {}", e)))?;
+        for entry in iter {
+            let (_key, value) = entry
+                .map_err(|e| StorageError::io_error(format!("Failed to read cold entry: {}", e)))?;
+            let raw: &[u8] = value.value();
+            let compressed = self.decrypt_if_needed(raw)?;
+            let decompressed = self.decompress(&compressed)?;
+            emit(decode_fn(&decompressed)?);
+        }
+        Ok(())
+    }
+
+    /// Filter-during-decode changefeed scan of the cold tier (Issue #3216, PR 2).
+    ///
+    /// Runs the shared [`consider_version`] predicate (transaction-time window, optional
+    /// valid-time window, optional label filter, and the strict `> resume_after` cursor) inline
+    /// as each node then edge version is decoded, retaining only the `bound`-smallest survivors
+    /// by [`ChangeCursor`] order. It returns `Vec<RawChange>` directly — the caller no longer
+    /// materializes a full `Vec<NodeVersion>` / `Vec<EdgeVersion>` and re-filters it.
+    ///
+    /// # Correctness note — no `version_id` early-stop
+    ///
+    /// Cold storage is keyed by `VersionId`, but a version's id is allocated at transaction-build
+    /// time while its commit timestamp is assigned later, so `version_id` is **not** monotonic
+    /// with transaction time — two concurrent commits can invert the two orders. The changefeed
+    /// is ordered by transaction time (`ChangeCursor`), so an early-stop / `range()` on the
+    /// ascending `version_id` key would silently drop or misorder rows. This scan therefore
+    /// **decodes every entry** (I/O stays O(N)) and only the in-memory retention is bounded. A
+    /// true sub-linear cold pushdown needs a transaction-time-ordered directory (tracked
+    /// follow-up), not a `version_id` range.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn collect_changes_filtered(
+        &self,
+        tx_window: &TimeRange,
+        valid_window: Option<&TimeRange>,
+        label_filter: Option<&str>,
+        resume_after: Option<ChangeCursor>,
+        bound: usize,
+    ) -> Result<Vec<RawChange>> {
+        let mut acc = BoundedChanges::new(bound);
+
+        self.scan_versions_into(
+            NODE_VERSIONS_TABLE,
+            decode_node_version,
+            |v: NodeVersion| {
+                consider_version(
+                    &mut acc,
+                    resume_after,
+                    v.id.as_u64(),
+                    v.node_id.as_u64(),
+                    EntityKind::Node,
+                    &v.temporal,
+                    v.label,
+                    v.prev_version.is_none(),
+                    tx_window,
+                    valid_window,
+                    label_filter,
+                );
+            },
+        )?;
+
+        self.scan_versions_into(
+            EDGE_VERSIONS_TABLE,
+            decode_edge_version,
+            |v: EdgeVersion| {
+                consider_version(
+                    &mut acc,
+                    resume_after,
+                    v.id.as_u64(),
+                    v.edge_id.as_u64(),
+                    EntityKind::Edge,
+                    &v.temporal,
+                    v.label,
+                    v.prev_version.is_none(),
+                    tx_window,
+                    valid_window,
+                    label_filter,
+                );
+            },
+        )?;
+
+        Ok(acc.into_vec())
     }
 
     /// Store a single node version.

--- a/src/storage/tiered_storage.rs
+++ b/src/storage/tiered_storage.rs
@@ -44,8 +44,10 @@
 //! let version = tiered.get_node_version(version_id)?;
 //! ```
 
+use crate::core::changefeed::{ChangeCursor, RawChange};
 use crate::core::error::Result;
 use crate::core::id::VersionId;
+use crate::core::temporal::TimeRange;
 use crate::core::version::{EdgeVersion, EntityVersion, NodeVersion};
 use crate::storage::redb_cold_storage::{ColdStorageStats, RedbColdStorage};
 use parking_lot::Mutex;
@@ -414,6 +416,34 @@ impl TieredStorage {
     /// storage. See [`crate::storage::redb_cold_storage::RedbColdStorage::scan_edge_versions`].
     pub fn scan_edge_versions_cold(&self) -> Result<Vec<EdgeVersion>> {
         self.cold.scan_edge_versions()
+    }
+
+    /// Filter-during-decode changefeed scan of the cold tier, bounded to the `bound`-smallest
+    /// survivors by cursor (Issue #3216, PR 2).
+    ///
+    /// Delegates to
+    /// [`RedbColdStorage::collect_changes_filtered`](crate::storage::redb_cold_storage::RedbColdStorage::collect_changes_filtered),
+    /// which applies the changefeed predicate + resume cursor inline as each version is decoded
+    /// and returns only the retained [`RawChange`]s — replacing the full
+    /// `scan_node_versions_cold` / `scan_edge_versions_cold` materialize-then-refilter used by
+    /// `list_changes`. Cold I/O remains O(N) (see the correctness note on the delegate: the
+    /// `version_id` key is not transaction-time ordered, so no early-stop is sound).
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn collect_cold_changes(
+        &self,
+        tx_window: &TimeRange,
+        valid_window: Option<&TimeRange>,
+        label_filter: Option<&str>,
+        resume_after: Option<ChangeCursor>,
+        bound: usize,
+    ) -> Result<Vec<RawChange>> {
+        self.cold.collect_changes_filtered(
+            tx_window,
+            valid_window,
+            label_filter,
+            resume_after,
+            bound,
+        )
     }
 
     /// Prefetch versions in a chain (up to prefetch_depth).


### PR DESCRIPTION
## Push filters + limit down into `list_changes` (Issue #3216 changefeed)

Optimize `AletheiaDB::list_changes` so a windowed/limited changefeed query stops
materializing the full match set before it paginates. **Approach A (v1)** from the
design doc: parity-safe filter + limit + cursor pushdown into both tiers' scans.

### Before → After (plain language)

**Before.** For each query, the hot tier collected *every* matching version into a
`Vec`, and the cold tier decoded *every* row into a full
`Vec` / `Vec` and re-filtered it in the caller. The
resume cursor was applied *after* the whole merge, and the page limit was applied
last. A `limit = 10` query over a large history still held tens of thousands of
candidate rows in memory.

**After.** Each tier applies the transaction-time window, valid-time window, label
filter, and the strict `> cursor` resume **during** its scan, and retains only the
`limit + 1`-smallest survivors by cursor (a shared `BoundedChanges` accumulator).
The query then merges the two small per-tier sets, dedups across tiers exactly as
before, and runs the identical `select_nth` / sort / `next_cursor` pagination. The
candidate working set is now `O(page)` instead of `O(total matches)`, and the
output page is **byte-identical** to the old algorithm.

### What changed

- `src/core/changefeed.rs` — new `BoundedChanges` (streaming bounded-by-cursor
  accumulator, max-heap that evicts the largest cursor past `bound`) and
  `consider_version` (shared *filter → resume → bound* helper). Both tiers call
  `consider_version` verbatim, so their filtering/resume/bounding is identical **by
  construction** — the basis of the parity guarantee.
- `src/storage/historical/mod.rs` — `collect_changes` gains `resume_after` +
  `bound`; the hot scan retains only the bound-smallest survivors.
- `src/storage/redb_cold_storage/mod.rs` — new `collect_changes_filtered`
  (filter-during-decode, returns `Vec`) plus a non-materializing
  `scan_versions_into` streaming helper. The pre-existing full-scan
  `scan_node_versions` / `scan_edge_versions` are **kept** (backup depends on them);
  the pushdown is purely additive.
- `src/storage/tiered_storage.rs` — `collect_cold_changes` delegate.
- `src/db/temporal.rs` — `list_changes` pushes filter + limit + cursor into both
  tiers, drops the now-redundant post-merge `retain`, and keeps the identical
  merge/dedup/pagination. Adds a `#[cfg(test)]` candidate-count counter used by the
  bound/bench tests.

### ⚠️ Correctness note — `version_id` is NOT transaction-time monotonic

This is the single biggest correctness landmine and it is **honored in code and
called out here**.

A version's `version_id` is allocated at **transaction-build time**
(`src/api/transaction/write/mod.rs:1148` and siblings), but its **commit
timestamp** — the transaction-time that orders the changefeed — is assigned later,
under the `current_timestamp` lock at commit
(`src/api/transaction/write/mod.rs:503-603`). The two orderings are independent:
two concurrent commits can allocate version ids in one order and commit in the
opposite order, so a **smaller `version_id` can carry a larger tx-time**.

redb cold storage is keyed by `version_id`
(`src/storage/redb_cold_storage/mod.rs:77-79`, comment at `:1940-1941`) and iterates
ascending by that key. Therefore **any `range()` / early-stop on the ascending
`version_id` key to serve a transaction-time window is UNSOUND** — it can silently
drop or misorder change rows.

Consequently the cold scan here **decodes every entry** (cold I/O stays **O(N)** in
v1) and only the *in-memory retention* is bounded. No `version_id` early-stop is
used. This is guarded by the `resume_across_version_id_inversion` test, which crafts
two cold versions where the smaller `version_id` has the larger tx-time and asserts
paging still follows tx-time.

**True sub-linear cold pushdown** (a transaction-time-ordered in-memory directory —
"Approach B" in the design doc) is a **tracked follow-up owned elsewhere**; it is
deliberately out of scope here.

### Amended acceptance criteria — evidence

1. **Hot filters + limit pushed down; no post-collection materialize-then-refilter
   on the hot path.** ✅ `collect_changes` bounds during the scan;
   `candidate_set_is_bounded` asserts the hot candidate set ≤ `limit + 1` (was the
   full match set — the RED failure this test was written against).
2. **Byte-identical output** to the pre-pushdown implementation. ✅ A faithful
   unbounded **reference oracle** (`list_changes_reference`) is compared against the
   production path across: `parity_hot_only`, `parity_cold_only`,
   `parity_mixed_tiers_dedup`, `parity_empty_window`,
   `parity_limit_smaller_than_matches`, `limit_spans_hot_cold_boundary`,
   `cursor_resume_after_cold_page`, `resume_across_version_id_inversion`,
   `tombstone_valid_window_boundary`, `half_open_tx_boundary`, `empty_cold_tier`,
   `cold_disabled_config`, `limit_zero_floors_to_one`, `label_filter_pushdown_parity`,
   `valid_window_pushdown_parity`, `resume_parity_midstream`,
   `parity_both_tiers_over_bound_interleaved`, plus the two candidate-bound tests.
   Asserts equal `changes` **and** `next_cursor`.
3. **Cursor/resume + at-least-once dedup semantics unchanged.** ✅ All pre-existing
   `changefeed_tests` (lib) and `changefeed_subscribe` (integration) pass untouched.
4. **Honest bench evidence** (below).
5. **No on-disk format change, no lock-order change, no public API break.** ✅
   `list_changes` signature unchanged; the pushdown lives entirely on the read path;
   cold scan uses a read-only redb txn taking none of the write-path primitives.

### Bench (honest)

Committed criterion bench `list_changes_bounded_vs_unbounded` (in
`benches/changefeed.rs`, `cargo bench --bench changefeed`) plus the ignored
`bench_list_changes_pushdown` micro-probe (run with `--ignored --nocapture`) —
20 000 hot versions, `limit = 10`, full window:

| | before (unbounded reference) | after (pushed-down) |
|---|---|---|
| wall time / call | 1.62 ms | 1.52 ms |
| candidate working set held for pagination | **20 000 rows** | **11 rows** |

**Honest reading.** The headline win is the **working set: 20 000 → 11 rows**
(`O(page)` not `O(matches)`) — a large memory/allocation reduction and the removal
of the cold-tier `Vec` materialize-then-refilter. Wall time on a *pure hot*
history is roughly flat (~7%, within noise) because candidate **enumeration** is
still an `O(V)` walk of the version maps in both paths (v1 does not add a tx-time
index — see AC1 note). Reference metric: Issue #3216 targets a **< 10 ms** window;
both paths are well inside it (~1.5 ms). **No cold-scan-elimination is claimed** —
cold decode I/O stays O(N) in v1 (see the correctness note); the sub-linear win
lands with the Approach-B tx-time directory follow-up.

### Testing

- `cargo test --lib changefeed` → **60 passed** (17 parity/edge + 2 candidate-bound
  + 41 existing, all green; 1 ignored bench); green across 5 consecutive runs under
  default parallelism (no flakes).
- `cargo test --test changefeed_subscribe` → subscription semantics untouched.
- `cargo clippy --all-targets --all-features -- -D warnings` → **clean**.
- `cargo bench --bench changefeed --no-run` → **compiles**.
- `cargo check --no-default-features --tests` → **clean**.

## Review round 1 — addressed

All four reviewers confirmed the pushdown algorithm is correct and byte-identical;
these fixes tighten test quality, perf, and style **without** changing the core
algorithm's semantics or the parity guarantee.

- **Test race on the candidate counter (MAJOR).** Replaced the process-global
  `LAST_LIST_CHANGES_CANDIDATES` atomic with a `#[cfg(test)]` **thread-local**
  `Cell`. libtest runs each test on its own thread and `list_changes` records the
  count synchronously on that thread, so the two candidate-bound tests now read
  exactly their own call's value — the read-after-write race under parallel
  `cargo test` (false red *and* false green) is structurally impossible. Verified
  green across 5 consecutive parallel runs. The production path has no non-test
  write to any shared global.
- **Dead oracle resume branch (MAJOR).** Added `resume_parity_midstream`, which
  walks the hot+cold stream page-by-page and `assert_parity`s each *resumed* page
  with a genuine interior cursor, so the parity oracle's previously-unreachable
  resume branch — and the production in-scan `> cursor` filter — is now
  differentially validated (confirmed: injecting `>=`-for-`>` turns this test RED).
- **Unbounded/large-limit fast path (MINOR).** `BoundedChanges` now collects into a
  plain `Vec` (`O(M)`) when `bound == usize::MAX` instead of paying the `O(M log M)`
  max-heap pass that yields no memory benefit on drain-everything / large-limit
  scans. Output ordering is unchanged (the caller sorts). The bounded path is also
  pre-sized `with_capacity(bound.min(4096))`.
- **Both-tiers-over-bound interleaved parity test (MINOR).** Added
  `parity_both_tiers_over_bound_interleaved`: hot rows (inserted at controlled even
  tx-times) and cold rows (odd tx-times) alternate in cursor order, so any page
  interleaves **both** tiers while each tier (100 matches) evicts heavily to
  `bound = limit + 1`. Order-sensitive byte parity + drain-equals-unbounded;
  confirmed RED if the bounded heap drops a top-N row across the tier merge.
- **Committed benchmark (CLAUDE.md mandate).** Extended `benches/changefeed.rs` with
  the criterion `list_changes_bounded_vs_unbounded` bench over a ~24k-version hot
  history, honestly framed as a working-set/candidate-count win (latency ~flat;
  candidate enumeration still O(N); no cold-scan-elimination claim; hot-only).
- **`let_chains` → `Option::filter` (Gemini, 3 sites).** Replaced the three
  `if let Some(rec) = build_raw_change(..) && <cond>` uses (in `consider_version`
  and both oracle cold loops) with stable `Option::filter` combinators, preserving
  the strict `> cursor` check and the `seen.insert(..)` dedup side effect exactly.
  Clippy stays clean.
- **Nits.** Pre-sized the bounded heap; removed the dead
  `if limit == 100 { let _ = page; }` scaffolding in `parity_mixed_tiers_dedup`;
  softened the `resume_across_version_id_inversion` comment to state it is a static
  guard against a naive `version_id` early-stop, not a live concurrent race.

### Deferred follow-ups (not in this PR)

- **Live hot→cold migration / concurrent-commit-during-scan stress test** — a test
  that drives writes + migration *during* a `list_changes` scan (all current parity
  tests run against a quiescent DB). The two-phase cross-tier read window is
  unchanged from trunk and verified by reading; genuine concurrency coverage is a
  follow-up.
- **Fully-independent parity oracle** — the oracle currently reuses the shared
  `collect_changes` / `build_raw_change` helpers at `bound = usize::MAX` for the hot
  tier, so it is a *partial* differential for the hot-path predicate. The
  pushdown-specific merge/dedup/select/cold-scan **is** independently reimplemented,
  and the two new tests above (resume + both-tiers) further mitigate this; a
  hand-rolled hot loop is a defense-in-depth follow-up.

### CI note (pre-existing trunk lints — not this PR)

The Lint job may be red due to **two known pre-existing trunk lints**, tracked by a
separate unbreaker PR and **not introduced by this change**:
`src/db/namespace.rs:336` (`needless_return`, fails
`cargo clippy --all-targets --no-default-features -- -D warnings` under a newer
clippy) and a `src/db/config.rs` formatting slip (fails `cargo fmt --all --check`).
Neither file is touched by this PR — **all of this PR's own files are clippy + fmt
clean** (verified: the only diagnostics under those two configs are exactly those
two pre-existing items).