### PR TITLE
fix: trunk lint unbreakers #2 (namespace.rs needless_return + config.rs fmt)

### DIFF
--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -593,13 +593,13 @@ impl AletheiaDB {
                 crate::db::snapshot::registry_path_for(&config.persistence),
             )?);
 
-           // Namespace registry (Issue #3349): durable sidecar at
+            // Namespace registry (Issue #3349): durable sidecar at
             // `{data_dir}/namespaces.json` when index persistence is enabled,
             // in-memory-only otherwise. Loaded here so registrations survive restart.
             let namespaces = Arc::new(crate::db::namespace::NamespaceRegistry::open(
                 crate::db::namespace::registry_path_for(&config.persistence),
             )?);
-            
+
             // GDPR crypto-shred (Issue #3359): load the durable per-subject
             // keyring fail-closed and run breadcrumb crash-recovery. Co-located
             // with the schema-constraint sidecar in the data root `{D}`;

--- a/src/db/namespace.rs
+++ b/src/db/namespace.rs
@@ -333,7 +333,7 @@ impl NamespaceRegistry {
         #[cfg(not(feature = "serde"))]
         {
             let _ = path;
-            return Ok(());
+            Ok(())
         }
         #[cfg(feature = "serde")]
         {


### PR DESCRIPTION
Two pre-existing-on-trunk breaks (landed with #3662/#3665) that fail CI on every open PR. Fixed minimally, one line each, no logic change.

1. **`needless_return` in `src/db/namespace.rs`** — a `return Ok(());` inside a `#[cfg(not(feature = "serde"))]` block, caught by `cargo clippy --all-targets --no-default-features -- -D warnings`. Converted to a tail expression `Ok(())`.
2. **fmt/whitespace violation in `src/db/config.rs`** — an indentation + trailing-whitespace break that fails `cargo fmt --all -- --check`. Fixed by running `cargo fmt`.

Diff is scoped to exactly these two files.

**Flagged merge-first** — unblocks lint CI on all open PRs.

Gates run locally (isolated target dir), all clean:
- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --all-targets --no-default-features -- -D warnings` — clean
- `cargo clippy --all-targets --features sql,cypher -- -D warnings` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSV3pRgK97oJKz3DQjzFk6

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSV3pRgK97oJKz3DQjzFk6)_