### PR TITLE
Namespaces PR2: storage/query threading (membership index, scoped reads, traversal boundary) — #3349

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -60,7 +60,7 @@ pub use lineage::{
     LineageClosure, LineageEntry, LineageError, LineageQueryOptions, LineageRecord, LineageRef,
     LineageStore,
 };
-pub use namespace::{NAMESPACE_KEY, Namespace, NamespaceError};
+pub use namespace::{NAMESPACE_KEY, Namespace, NamespaceError, NamespaceScope};
 pub use property::{PropertyKey, PropertyMap, PropertyMapBuilder, PropertyValue};
 pub use provenance::{
     Provenance, ProvenanceBuilder, ProvenanceError, ProvenanceFilter, ProvenanceFilterError,

--- a/src/core/namespace.rs
+++ b/src/core/namespace.rs
@@ -34,8 +34,14 @@
 //! **elided** from every user-facing property view and surfaced instead as a
 //! first-class `namespace` field.
 
+use crate::core::hasher::IdentityHasher;
 use crate::core::interning::GLOBAL_INTERNER;
 use crate::core::property::{PropertyMap, PropertyMapBuilder, PropertyValue};
+use dashmap::DashMap;
+use std::hash::BuildHasherDefault;
+use std::sync::Arc;
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 /// The engine-owned property key under which an entity's namespace rides along
 /// its property map. Reserved: rejected on user writes, elided from user-facing
@@ -293,6 +299,22 @@ impl NamespaceScope {
         }
     }
 
+    /// Resolve this scope to interned [`NamespaceId`]s for fast per-edge
+    /// membership probing (Issue #3349, PR2), or `None` for [`All`](Self::All)
+    /// (which is a no-op filter). Resolve **once per query** and reuse across all
+    /// edges/candidates so the interner's string lookup is paid once, not per
+    /// edge. An empty [`List`](Self::List) resolves to `Some(vec![])`, a
+    /// match-nothing scope (it should already have been rejected by
+    /// `validate_scope`).
+    #[must_use]
+    pub fn resolved_ids(&self) -> Option<Vec<NamespaceId>> {
+        match self {
+            NamespaceScope::All => None,
+            NamespaceScope::Single(ns) => Some(vec![intern_namespace(ns)]),
+            NamespaceScope::List(list) => Some(list.iter().map(intern_namespace).collect()),
+        }
+    }
+
     /// The concrete namespaces named by this scope, or `None` for
     /// [`All`](Self::All) (which names no finite set). Deduplicated iteration
     /// helper for callers that enumerate members per namespace.
@@ -313,6 +335,101 @@ impl NamespaceScope {
             }
         }
     }
+}
+
+// ============================================================================
+// Namespace interning (Issue #3349, PR2 — performance)
+// ============================================================================
+
+/// A small, copyable interned handle for a namespace name (Issue #3349, PR2).
+///
+/// Scoped reads probe the secondary membership index (`ns_nodes` / `ns_edges`)
+/// once per candidate edge/node. Keying that index by a `u32` id — hashed with
+/// [`IdentityHasher`] — turns each probe into an integer hash + shard lookup,
+/// eliminating the per-edge `String` hashing that keying by
+/// [`Namespace`] (a heap string) incurred. A scope is resolved to its ids
+/// **once** (via [`NamespaceScope::resolved_ids`]) and then reused across every
+/// edge of a traversal, so the interner's own string lookup is paid once per
+/// query, not once per edge.
+///
+/// The id is a pure in-memory acceleration handle: it is derived from the
+/// durable ride-along namespace string, never persisted, and stable within a
+/// process for a given name (the same name always interns to the same id
+/// regardless of the hydration path — write, WAL replay, index-persistence
+/// load, cold rehydration — because there is a single derivation site,
+/// [`intern_namespace`]).
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+pub struct NamespaceId(u32);
+
+impl NamespaceId {
+    /// The raw interned id.
+    #[inline]
+    #[must_use]
+    pub fn as_u32(self) -> u32 {
+        self.0
+    }
+}
+
+/// Process-global namespace interner: name ⇄ [`NamespaceId`]. Namespaces are few
+/// (one per agent/session), so no capacity cap is imposed.
+struct NamespaceInterner {
+    /// name → id
+    forward: DashMap<Box<str>, u32>,
+    /// id → name (for reverse resolution in cold paths, e.g. per-namespace stats)
+    reverse: DashMap<u32, Arc<str>, BuildHasherDefault<IdentityHasher>>,
+    next: AtomicU32,
+}
+
+impl NamespaceInterner {
+    fn new() -> Self {
+        NamespaceInterner {
+            forward: DashMap::new(),
+            reverse: DashMap::with_hasher(BuildHasherDefault::default()),
+            next: AtomicU32::new(0),
+        }
+    }
+
+    fn intern(&self, name: &str) -> NamespaceId {
+        // Fast path: already interned (no allocation).
+        if let Some(id) = self.forward.get(name) {
+            return NamespaceId(*id);
+        }
+        // Slow path: reserve an id under the entry write lock so two threads
+        // interning the same new name agree on one id.
+        use dashmap::mapref::entry::Entry;
+        match self.forward.entry(name.into()) {
+            Entry::Occupied(e) => NamespaceId(*e.get()),
+            Entry::Vacant(v) => {
+                let id = self.next.fetch_add(1, Ordering::Relaxed);
+                self.reverse.insert(id, Arc::from(name));
+                v.insert(id);
+                NamespaceId(id)
+            }
+        }
+    }
+
+    fn resolve(&self, id: NamespaceId) -> Option<Arc<str>> {
+        self.reverse.get(&id.0).map(|e| Arc::clone(e.value()))
+    }
+}
+
+static NAMESPACE_INTERNER: LazyLock<NamespaceInterner> = LazyLock::new(NamespaceInterner::new);
+
+/// Intern a namespace to its process-stable [`NamespaceId`] (Issue #3349, PR2).
+#[inline]
+#[must_use]
+pub fn intern_namespace(namespace: &Namespace) -> NamespaceId {
+    NAMESPACE_INTERNER.intern(namespace.as_str())
+}
+
+/// Resolve a [`NamespaceId`] back to its [`Namespace`] (cold path — used only by
+/// per-namespace stats/schema enumeration). Returns `None` for an id that was
+/// never interned in this process.
+#[must_use]
+pub fn resolve_namespace_id(id: NamespaceId) -> Option<Namespace> {
+    NAMESPACE_INTERNER
+        .resolve(id)
+        .and_then(|s| Namespace::new(s.as_ref()).ok())
 }
 
 // ============================================================================

--- a/src/core/namespace.rs
+++ b/src/core/namespace.rs
@@ -219,6 +219,103 @@ pub enum NamespaceError {
 }
 
 // ============================================================================
+// Read scope (Issue #3349, PR2)
+// ============================================================================
+
+/// A namespace read scope: which namespaces a scoped read is allowed to see
+/// (Issue #3349).
+///
+/// - [`Single`](Self::Single): exactly one namespace.
+/// - [`List`](Self::List): the **union** of a non-empty set of namespaces
+///   (a read sees entities in any of them and may traverse within and between
+///   them).
+/// - [`All`](Self::All): every namespace — no filtering (the `all`
+///   read-selector keyword).
+///
+/// The default scope is `Single(`[`Namespace::DEFAULT`]`)`, so an omitted
+/// scope reproduces exact single-agent back-compat over `default`-namespace
+/// data.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NamespaceScope {
+    /// Exactly one namespace.
+    Single(Namespace),
+    /// The union of a non-empty list of namespaces.
+    List(Vec<Namespace>),
+    /// Every namespace (no filtering).
+    All,
+}
+
+impl Default for NamespaceScope {
+    /// The default scope is the `default` namespace only — exact back-compat
+    /// for omitted-scope reads over legacy / single-agent data.
+    fn default() -> Self {
+        NamespaceScope::Single(Namespace::default())
+    }
+}
+
+impl NamespaceScope {
+    /// A scope over exactly one namespace.
+    #[must_use]
+    pub fn single(namespace: Namespace) -> Self {
+        NamespaceScope::Single(namespace)
+    }
+
+    /// A scope over every namespace (no filtering).
+    #[must_use]
+    pub fn all() -> Self {
+        NamespaceScope::All
+    }
+
+    /// A union scope over a non-empty list of namespaces.
+    ///
+    /// # Errors
+    ///
+    /// [`NamespaceError::InvalidName`] (→ MCP `INVALID_ARGUMENT`) with an empty
+    /// `name` when `namespaces` is empty — an empty scope would silently match
+    /// nothing, which the never-silently-wrong contract forbids.
+    pub fn list(namespaces: Vec<Namespace>) -> Result<Self, NamespaceError> {
+        if namespaces.is_empty() {
+            return Err(NamespaceError::InvalidName {
+                name: String::new(),
+                reason: "namespace scope list must not be empty".to_string(),
+            });
+        }
+        Ok(NamespaceScope::List(namespaces))
+    }
+
+    /// Whether `namespace` is inside this scope.
+    #[must_use]
+    pub fn contains(&self, namespace: &Namespace) -> bool {
+        match self {
+            NamespaceScope::All => true,
+            NamespaceScope::Single(ns) => ns == namespace,
+            NamespaceScope::List(list) => list.iter().any(|ns| ns == namespace),
+        }
+    }
+
+    /// The concrete namespaces named by this scope, or `None` for
+    /// [`All`](Self::All) (which names no finite set). Deduplicated iteration
+    /// helper for callers that enumerate members per namespace.
+    #[must_use]
+    pub fn explicit_namespaces(&self) -> Option<Vec<Namespace>> {
+        match self {
+            NamespaceScope::All => None,
+            NamespaceScope::Single(ns) => Some(vec![ns.clone()]),
+            NamespaceScope::List(list) => {
+                let mut seen = std::collections::BTreeSet::new();
+                let mut out = Vec::with_capacity(list.len());
+                for ns in list {
+                    if seen.insert(ns.clone()) {
+                        out.push(ns.clone());
+                    }
+                }
+                Some(out)
+            }
+        }
+    }
+}
+
+// ============================================================================
 // Ride-along read/write helpers
 // ============================================================================
 

--- a/src/core/namespace.rs
+++ b/src/core/namespace.rs
@@ -315,6 +315,34 @@ impl NamespaceScope {
         }
     }
 
+    /// Resolve this scope to interned ids **once per query**, carrying the
+    /// single-namespace case inline (Issue #3349, PR2 performance hoist).
+    ///
+    /// Prefer this over [`resolved_ids`](Self::resolved_ids) on the scoped read
+    /// hot paths (traversal boundary, source-leaf filter): the result is built
+    /// once at the start of a scoped read and threaded down into every per-edge /
+    /// per-row membership check, so no probe re-derives ids (no interner string
+    /// lookup) or re-allocates. A [`Single`](Self::Single) scope — and a
+    /// one-element [`List`](Self::List) — resolves to
+    /// [`ResolvedScope::Single`], a single inline [`NamespaceId`] with no `Vec` /
+    /// `Arc` allocation, turning the per-edge check into a single integer
+    /// compare. An empty `List` (which `validate_scope` already rejects) resolves
+    /// to an empty [`ResolvedScope::List`], a match-nothing scope.
+    #[must_use]
+    pub fn resolve(&self) -> ResolvedScope {
+        match self {
+            NamespaceScope::All => ResolvedScope::All,
+            NamespaceScope::Single(ns) => ResolvedScope::Single(intern_namespace(ns)),
+            NamespaceScope::List(list) => match list.as_slice() {
+                // A one-element union takes the inline single-namespace fast path.
+                [one] => ResolvedScope::Single(intern_namespace(one)),
+                // Two or more (or the already-rejected empty) resolve to a shared
+                // id set scanned with `any`.
+                many => ResolvedScope::List(many.iter().map(intern_namespace).collect()),
+            },
+        }
+    }
+
     /// The concrete namespaces named by this scope, or `None` for
     /// [`All`](Self::All) (which names no finite set). Deduplicated iteration
     /// helper for callers that enumerate members per namespace.
@@ -430,6 +458,61 @@ pub fn resolve_namespace_id(id: NamespaceId) -> Option<Namespace> {
     NAMESPACE_INTERNER
         .resolve(id)
         .and_then(|s| Namespace::new(s.as_ref()).ok())
+}
+
+/// A [`NamespaceScope`] resolved to interned [`NamespaceId`]s **once per query**
+/// (Issue #3349, PR2 performance hoist).
+///
+/// Built once via [`NamespaceScope::resolve`] at the start of a scoped read and
+/// threaded down into every source-leaf filter and the traversal boundary, so
+/// the per-edge / per-row membership check never re-derives ids (no interner
+/// string lookup) nor allocates. The single-namespace case — a
+/// [`Single`](NamespaceScope::Single) scope or a one-element
+/// [`List`](NamespaceScope::List) — is carried **inline** as one
+/// [`NamespaceId`] (no `Vec` / `Arc` allocation), so its per-edge check is a
+/// single integer compare rather than a set scan.
+///
+/// Cloning is cheap: `All` is a unit, `Single` copies a `u32`, and `List`
+/// bumps an `Arc` refcount — so the executor can hand a fresh clone to every
+/// source-leaf iterator without re-resolving.
+#[derive(Clone, Debug)]
+pub enum ResolvedScope {
+    /// `All` — no filtering (matches every namespace).
+    All,
+    /// Exactly one namespace (from `Single` or a one-element `List`): the
+    /// per-edge check is a single integer compare.
+    Single(NamespaceId),
+    /// A union of two or more namespaces: membership is a scan over this small,
+    /// shareable id set. May be empty (the already-rejected empty `List`), in
+    /// which case it matches nothing.
+    List(Arc<[NamespaceId]>),
+}
+
+impl ResolvedScope {
+    /// Whether this resolved scope imposes no filter (i.e. is [`All`](Self::All)).
+    #[inline]
+    #[must_use]
+    pub fn is_all(&self) -> bool {
+        matches!(self, ResolvedScope::All)
+    }
+
+    /// Whether an entity is in scope, given a `probe` that answers "is the
+    /// entity a member of namespace `id`?".
+    ///
+    /// [`All`](Self::All) short-circuits to `true` without probing;
+    /// [`Single`](Self::Single) runs exactly one probe (the inlined
+    /// single-integer-compare fast path); [`List`](Self::List) scans its (small)
+    /// id set with `any`. A namespace is immutable and an entity lives in exactly
+    /// one, so a single positive probe is conclusive.
+    #[inline]
+    #[must_use]
+    pub fn contains_by<F: Fn(NamespaceId) -> bool>(&self, probe: F) -> bool {
+        match self {
+            ResolvedScope::All => true,
+            ResolvedScope::Single(id) => probe(*id),
+            ResolvedScope::List(ids) => ids.iter().any(|id| probe(*id)),
+        }
+    }
 }
 
 // ============================================================================

--- a/src/cypher/converter.rs
+++ b/src/cypher/converter.rs
@@ -488,6 +488,8 @@ impl CypherConverter {
                     ops,
                     temporal_context,
                     hints: QueryHints::default(),
+                    // Cypher namespace scoping is a follow-up (PR2b).
+                    scope: None,
                 })
             }
             // A standalone `UNWIND` produces scalar rows, not stored entities,

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -593,13 +593,13 @@ impl AletheiaDB {
                 crate::db::snapshot::registry_path_for(&config.persistence),
             )?);
 
-           // Namespace registry (Issue #3349): durable sidecar at
+            // Namespace registry (Issue #3349): durable sidecar at
             // `{data_dir}/namespaces.json` when index persistence is enabled,
             // in-memory-only otherwise. Loaded here so registrations survive restart.
             let namespaces = Arc::new(crate::db::namespace::NamespaceRegistry::open(
                 crate::db::namespace::registry_path_for(&config.persistence),
             )?);
-            
+
             // GDPR crypto-shred (Issue #3359): load the durable per-subject
             // keyring fail-closed and run breadcrumb crash-recovery. Co-located
             // with the schema-constraint sidecar in the data root `{D}`;

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -149,6 +149,36 @@ fn wire_temporal_indexes(db: &AletheiaDB) {
     hist.rebuild_temporal_index_from_versions();
 }
 
+/// Reconcile the namespace registry with the entities actually present after a
+/// load (Issue #3349, PR2). Every namespace that holds at least one node or edge
+/// in the rebuilt membership index is ensured-registered, so a scoped read
+/// naming it validates (rather than returning `NOT_FOUND`) after a load path
+/// that populates entities without the `namespaces.json` sidecar — notably
+/// `.albk` restore, whose payload carries the ride-along namespace on each
+/// entity but not the registry sidecar.
+///
+/// Idempotent and off the hot path: on a durable reopen (sidecar already loaded)
+/// every name is already registered, so this is a cheap no-op scan. A per-name
+/// persist failure never bricks startup — the entity data is already loaded and
+/// the membership index is authoritative for isolation.
+///
+/// v1 caveat: an *empty* explicitly-created namespace (registered but holding no
+/// entities) is not carried across `.albk` restore, because the registry sidecar
+/// is not part of the backup payload; folding the registry into the payload is a
+/// deliberate follow-up (`// TODO(#3349)`).
+fn reconcile_namespace_registry(db: &AletheiaDB) {
+    for ns in db.current.populated_namespaces() {
+        if let Err(_e) = db.namespaces.ensure_registered(&ns) {
+            #[cfg(feature = "observability")]
+            tracing::warn!(
+                namespace = %ns,
+                error = %_e,
+                "failed to auto-register namespace during load reconciliation"
+            );
+        }
+    }
+}
+
 impl AletheiaDB {
     /// Create a new **ephemeral** in-memory database.
     ///
@@ -927,6 +957,7 @@ impl AletheiaDB {
             }
 
             wire_temporal_indexes(&db);
+            reconcile_namespace_registry(&db);
 
             // Initialize cold storage if enabled
             if enable_cold_storage && let Some(cold_storage_path) = cold_storage_path {
@@ -1127,6 +1158,7 @@ impl AletheiaDB {
             };
             seed_startup_current_timestamp(&db)?;
             wire_temporal_indexes(&db);
+            reconcile_namespace_registry(&db);
 
             Ok(db)
         })();

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -48,6 +48,8 @@ pub mod graph_view;
 pub mod lineage;
 /// Agent-scoped memory namespaces: registry + namespaced entity creation (Issue #3349).
 pub mod namespace;
+/// Namespace-scoped reads and traversal (Issue #3349, PR2).
+pub mod namespace_query;
 /// Basic graph operations (CRUD).
 pub mod ops;
 /// Point-in-time restore (PITR) to a transaction-time coordinate (Issue #3374).
@@ -87,6 +89,7 @@ pub use crypto_shred::{
 pub use extent::{LabelExtent, TemporalExtent, TimeBounds};
 pub use lineage::{FactStatus, LineageView, LineageViewEntry};
 pub use namespace::NamespaceInfo;
+pub use namespace_query::NamespaceCount;
 pub use ops::NodesAtTime;
 pub use pitr::{PitrCoord, PitrPlan, PitrTarget};
 pub use schema::{EdgeTypeSchema, GraphSchema, LabelSchema, SchemaInstant};

--- a/src/db/namespace.rs
+++ b/src/db/namespace.rs
@@ -333,7 +333,7 @@ impl NamespaceRegistry {
         #[cfg(not(feature = "serde"))]
         {
             let _ = path;
-            return Ok(());
+            Ok(())
         }
         #[cfg(feature = "serde")]
         {

--- a/src/db/namespace_query.rs
+++ b/src/db/namespace_query.rs
@@ -24,7 +24,7 @@
 use crate::core::error::{Error, Result, StorageError};
 use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, NodeId};
-use crate::core::namespace::{Namespace, NamespaceError, NamespaceId, NamespaceScope};
+use crate::core::namespace::{Namespace, NamespaceError, NamespaceScope, ResolvedScope};
 use crate::core::temporal::Timestamp;
 use crate::db::AletheiaDB;
 use crate::db::ops::NodesAtTime;
@@ -76,37 +76,21 @@ impl AletheiaDB {
     }
 
     /// O(1) membership probe: is the current node `node_id` inside the
-    /// **pre-resolved** scope `resolved` (Issue #3349, PR2)? `None` = `All`
-    /// (matches everything). The scope is resolved to interned ids **once** per
-    /// query (via [`NamespaceScope::resolved_ids`]) and reused across every edge,
-    /// so the per-edge boundary check is an integer-hashed membership probe with
-    /// no property load, no `Namespace` allocation, and no string hashing.
-    fn scope_contains_current_node(
-        &self,
-        node_id: NodeId,
-        resolved: Option<&[NamespaceId]>,
-    ) -> bool {
-        match resolved {
-            None => true,
-            Some(ids) => ids
-                .iter()
-                .any(|id| self.current.node_in_namespace_id(node_id, *id)),
-        }
+    /// **pre-resolved** scope `resolved` (Issue #3349, PR2)?
+    /// [`ResolvedScope::All`] matches everything. The scope is resolved to
+    /// interned ids **once** per query (via [`NamespaceScope::resolve`]) and
+    /// reused across every edge, so the per-edge boundary check is an
+    /// integer-hashed membership probe with no property load, no `Namespace`
+    /// allocation, and no string hashing — and, for a single-namespace scope, a
+    /// single integer compare with no set scan.
+    fn scope_contains_current_node(&self, node_id: NodeId, resolved: &ResolvedScope) -> bool {
+        resolved.contains_by(|id| self.current.node_in_namespace_id(node_id, id))
     }
 
     /// O(1) membership probe for a current edge against the pre-resolved scope.
     /// See [`scope_contains_current_node`](Self::scope_contains_current_node).
-    fn scope_contains_current_edge(
-        &self,
-        edge_id: EdgeId,
-        resolved: Option<&[NamespaceId]>,
-    ) -> bool {
-        match resolved {
-            None => true,
-            Some(ids) => ids
-                .iter()
-                .any(|id| self.current.edge_in_namespace_id(edge_id, *id)),
-        }
+    fn scope_contains_current_edge(&self, edge_id: EdgeId, resolved: &ResolvedScope) -> bool {
+        resolved.contains_by(|id| self.current.edge_in_namespace_id(edge_id, id))
     }
 
     /// Get a node only if it is visible in `scope` (Issue #3349).
@@ -255,15 +239,15 @@ impl AletheiaDB {
     ) -> Result<Vec<NodeId>> {
         self.validate_scope(scope)?;
         // Resolve the scope to interned ids ONCE, then reuse across every edge —
-        // the per-edge probe is then an integer hash, not a string hash
-        // (Issue #3349, PR2 performance).
-        let resolved = scope.resolved_ids();
-        let resolved = resolved.as_deref();
+        // the per-edge probe is then an integer hash, not a string hash, and a
+        // single-namespace scope carries its one id inline for a single-compare
+        // check (Issue #3349, PR2 performance hoist).
+        let resolved = scope.resolve();
         // The traversal must start from an in-scope node; otherwise the caller
         // could probe out-of-scope adjacency. An out-of-scope (or non-existent)
         // start is reported as not-found, exactly like `get_node_scoped`. The
         // O(1) membership probe avoids loading the start node's properties.
-        if !self.scope_contains_current_node(start, resolved) {
+        if !self.scope_contains_current_node(start, &resolved) {
             return Err(StorageError::NodeNotFound(start).into());
         }
 
@@ -289,13 +273,13 @@ impl AletheiaDB {
                 // target node's namespace ∈ scope. Namespace is immutable, so the
                 // current-state membership index is authoritative for the
                 // (current-state) traversal.
-                if !self.scope_contains_current_edge(edge_id, resolved) {
+                if !self.scope_contains_current_edge(edge_id, &resolved) {
                     continue;
                 }
                 let Ok(target) = self.current.get_edge_target(edge_id) else {
                     continue;
                 };
-                if !self.scope_contains_current_node(target, resolved) {
+                if !self.scope_contains_current_node(target, &resolved) {
                     continue;
                 }
                 if seen.insert(target) {

--- a/src/db/namespace_query.rs
+++ b/src/db/namespace_query.rs
@@ -24,7 +24,7 @@
 use crate::core::error::{Error, Result, StorageError};
 use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, NodeId};
-use crate::core::namespace::{Namespace, NamespaceError, NamespaceScope};
+use crate::core::namespace::{Namespace, NamespaceError, NamespaceId, NamespaceScope};
 use crate::core::temporal::Timestamp;
 use crate::db::AletheiaDB;
 use crate::db::ops::NodesAtTime;
@@ -42,50 +42,70 @@ impl AletheiaDB {
     ///   ([`NamespaceScope::list`]); this method also rejects a `List` that
     ///   was built by other means and is empty.
     pub(crate) fn validate_scope(&self, scope: &NamespaceScope) -> Result<()> {
-        if let NamespaceScope::List(list) = scope
-            && list.is_empty()
-        {
-            return Err(Error::Namespace(NamespaceError::InvalidName {
-                name: String::new(),
-                reason: "namespace scope list must not be empty".to_string(),
-            }));
-        }
-        let Some(namespaces) = scope.explicit_namespaces() else {
-            return Ok(()); // `All` names no finite set — nothing to check.
-        };
-        for ns in namespaces {
-            if self.namespaces.get(ns.as_str()).is_none() {
-                return Err(Error::Namespace(NamespaceError::NotFound {
-                    namespace: ns.into_string(),
-                }));
+        // Allocation-free (Issue #3349, PR2 performance): probe the registry
+        // directly per named namespace rather than materializing (and cloning)
+        // the `explicit_namespaces()` vec on the scoped hot path.
+        match scope {
+            NamespaceScope::All => Ok(()),
+            NamespaceScope::Single(ns) => self.check_namespace_registered(ns),
+            NamespaceScope::List(list) => {
+                if list.is_empty() {
+                    return Err(Error::Namespace(NamespaceError::InvalidName {
+                        name: String::new(),
+                        reason: "namespace scope list must not be empty".to_string(),
+                    }));
+                }
+                for ns in list {
+                    self.check_namespace_registered(ns)?;
+                }
+                Ok(())
             }
+        }
+    }
+
+    /// Registry membership check for a single namespace. The implicit `default`
+    /// always resolves.
+    #[inline]
+    fn check_namespace_registered(&self, ns: &Namespace) -> Result<()> {
+        if self.namespaces.get(ns.as_str()).is_none() {
+            return Err(Error::Namespace(NamespaceError::NotFound {
+                namespace: ns.as_str().to_string(),
+            }));
         }
         Ok(())
     }
 
-    /// O(1) membership probe: is the current node `node_id` inside `scope`,
-    /// using the secondary membership index (no property load, no `Namespace`
-    /// allocation)? [`NamespaceScope::All`] matches everything. Used by the hot
-    /// scoped-traversal loop so a per-edge boundary check is a hash probe.
-    fn scope_contains_current_node(&self, node_id: NodeId, scope: &NamespaceScope) -> bool {
-        match scope {
-            NamespaceScope::All => true,
-            NamespaceScope::Single(ns) => self.current.node_in_namespace(node_id, ns),
-            NamespaceScope::List(list) => list
+    /// O(1) membership probe: is the current node `node_id` inside the
+    /// **pre-resolved** scope `resolved` (Issue #3349, PR2)? `None` = `All`
+    /// (matches everything). The scope is resolved to interned ids **once** per
+    /// query (via [`NamespaceScope::resolved_ids`]) and reused across every edge,
+    /// so the per-edge boundary check is an integer-hashed membership probe with
+    /// no property load, no `Namespace` allocation, and no string hashing.
+    fn scope_contains_current_node(
+        &self,
+        node_id: NodeId,
+        resolved: Option<&[NamespaceId]>,
+    ) -> bool {
+        match resolved {
+            None => true,
+            Some(ids) => ids
                 .iter()
-                .any(|ns| self.current.node_in_namespace(node_id, ns)),
+                .any(|id| self.current.node_in_namespace_id(node_id, *id)),
         }
     }
 
-    /// O(1) membership probe for a current edge. See
-    /// [`scope_contains_current_node`](Self::scope_contains_current_node).
-    fn scope_contains_current_edge(&self, edge_id: EdgeId, scope: &NamespaceScope) -> bool {
-        match scope {
-            NamespaceScope::All => true,
-            NamespaceScope::Single(ns) => self.current.edge_in_namespace(edge_id, ns),
-            NamespaceScope::List(list) => list
+    /// O(1) membership probe for a current edge against the pre-resolved scope.
+    /// See [`scope_contains_current_node`](Self::scope_contains_current_node).
+    fn scope_contains_current_edge(
+        &self,
+        edge_id: EdgeId,
+        resolved: Option<&[NamespaceId]>,
+    ) -> bool {
+        match resolved {
+            None => true,
+            Some(ids) => ids
                 .iter()
-                .any(|ns| self.current.edge_in_namespace(edge_id, ns)),
+                .any(|id| self.current.edge_in_namespace_id(edge_id, *id)),
         }
     }
 
@@ -192,12 +212,15 @@ impl AletheiaDB {
     ) -> Result<Vec<NodeId>> {
         self.validate_scope(scope)?;
         let mut ids = self.find_nodes_by_property(label, property_key, property_value);
-        // `All` names every namespace, so there is nothing to filter — skip the
-        // per-node load/clone entirely.
-        if !matches!(scope, NamespaceScope::All) {
-            ids.retain(|id| match self.get_node(*id) {
-                Ok(node) => scope.contains(&node.namespace()),
-                Err(_) => false,
+        // `All` (`resolved_ids() == None`) names every namespace, so there is
+        // nothing to filter. Otherwise filter via the O(1) interned-id membership
+        // probe rather than cloning a whole `Node` just to read its namespace
+        // (Issue #3349 B2).
+        if let Some(allowed) = scope.resolved_ids() {
+            ids.retain(|id| {
+                allowed
+                    .iter()
+                    .any(|ns_id| self.current.node_in_namespace_id(*id, *ns_id))
             });
         }
         ids.sort_unstable();
@@ -231,11 +254,16 @@ impl AletheiaDB {
         scope: &NamespaceScope,
     ) -> Result<Vec<NodeId>> {
         self.validate_scope(scope)?;
+        // Resolve the scope to interned ids ONCE, then reuse across every edge —
+        // the per-edge probe is then an integer hash, not a string hash
+        // (Issue #3349, PR2 performance).
+        let resolved = scope.resolved_ids();
+        let resolved = resolved.as_deref();
         // The traversal must start from an in-scope node; otherwise the caller
         // could probe out-of-scope adjacency. An out-of-scope (or non-existent)
         // start is reported as not-found, exactly like `get_node_scoped`. The
         // O(1) membership probe avoids loading the start node's properties.
-        if !self.scope_contains_current_node(start, scope) {
+        if !self.scope_contains_current_node(start, resolved) {
             return Err(StorageError::NodeNotFound(start).into());
         }
 
@@ -261,13 +289,13 @@ impl AletheiaDB {
                 // target node's namespace ∈ scope. Namespace is immutable, so the
                 // current-state membership index is authoritative for the
                 // (current-state) traversal.
-                if !self.scope_contains_current_edge(edge_id, scope) {
+                if !self.scope_contains_current_edge(edge_id, resolved) {
                     continue;
                 }
                 let Ok(target) = self.current.get_edge_target(edge_id) else {
                     continue;
                 };
-                if !self.scope_contains_current_node(target, scope) {
+                if !self.scope_contains_current_node(target, resolved) {
                     continue;
                 }
                 if seen.insert(target) {

--- a/src/db/namespace_query.rs
+++ b/src/db/namespace_query.rs
@@ -1,0 +1,288 @@
+//! Namespace-scoped reads and traversal (Issue #3349, PR2).
+//!
+//! These are the read counterpart to PR1's namespaced writes: a
+//! [`NamespaceScope`] filters which entities a read may see, and — for
+//! traversal — which edges it may cross. The scope is enforced against the
+//! **immutable** namespace recorded on each entity (PR1's ride-along
+//! property), accelerated by the secondary membership index maintained in
+//! [`CurrentIndexes`](crate::index::CurrentIndexes).
+//!
+//! # Isolation semantics (design §4)
+//!
+//! - **Entity filter:** a read scoped to `S` returns only entities whose
+//!   namespace ∈ `S` ([`NamespaceScope::All`] ⇒ no filter).
+//! - **Traversal boundary:** from an in-scope node an edge is followed only if
+//!   the **edge's own namespace ∈ S AND the target node's namespace ∈ S**. An
+//!   edge whose namespace is outside `S` is never crossed, so a scope can never
+//!   silently leak across the boundary. A union scope follows within and
+//!   between exactly its listed namespaces.
+//!
+//! Omitting a scope (using [`NamespaceScope::default`], i.e.
+//! `Single(default)`) reproduces exact single-agent back-compat over
+//! `default`-namespace data.
+
+use crate::core::error::{Error, Result, StorageError};
+use crate::core::graph::{Edge, Node};
+use crate::core::id::{EdgeId, NodeId};
+use crate::core::namespace::{Namespace, NamespaceError, NamespaceScope};
+use crate::db::AletheiaDB;
+use std::collections::{BTreeSet, VecDeque};
+
+impl AletheiaDB {
+    /// Validate a read scope against the namespace registry (Issue #3349).
+    ///
+    /// # Errors
+    ///
+    /// - [`NamespaceError::NotFound`] (→ MCP `NOT_FOUND`, with the offending
+    ///   `namespace` in the error) when the scope names a namespace that is
+    ///   not registered. The implicit `default` always resolves.
+    /// - An empty list scope is rejected at construction
+    ///   ([`NamespaceScope::list`]); this method also rejects a `List` that
+    ///   was built by other means and is empty.
+    pub(crate) fn validate_scope(&self, scope: &NamespaceScope) -> Result<()> {
+        if let NamespaceScope::List(list) = scope
+            && list.is_empty()
+        {
+            return Err(Error::Namespace(NamespaceError::InvalidName {
+                name: String::new(),
+                reason: "namespace scope list must not be empty".to_string(),
+            }));
+        }
+        let Some(namespaces) = scope.explicit_namespaces() else {
+            return Ok(()); // `All` names no finite set — nothing to check.
+        };
+        for ns in namespaces {
+            if self.namespaces.get(ns.as_str()).is_none() {
+                return Err(Error::Namespace(NamespaceError::NotFound {
+                    namespace: ns.into_string(),
+                }));
+            }
+        }
+        Ok(())
+    }
+
+    /// Get a node only if it is visible in `scope` (Issue #3349).
+    ///
+    /// Returns the node when its (immutable) namespace ∈ `scope`, otherwise
+    /// [`StorageError::NodeNotFound`] — a node outside the scope is
+    /// indistinguishable from a missing one, so a scoped caller can never learn
+    /// that an out-of-scope node exists.
+    ///
+    /// # Errors
+    ///
+    /// - `NOT_FOUND` if the node does not exist or is not in `scope`.
+    /// - `NOT_FOUND` / `INVALID_ARGUMENT` if `scope` is invalid
+    ///   (see [`validate_scope`](Self::validate_scope)).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn get_node_scoped(&self, node_id: NodeId, scope: &NamespaceScope) -> Result<Node> {
+        self.validate_scope(scope)?;
+        let node = self.get_node(node_id)?;
+        if scope.contains(&node.namespace()) {
+            Ok(node)
+        } else {
+            Err(StorageError::NodeNotFound(node_id).into())
+        }
+    }
+
+    /// Get an edge only if it is visible in `scope` (Issue #3349).
+    ///
+    /// # Errors
+    ///
+    /// - `NOT_FOUND` if the edge does not exist or is not in `scope`.
+    /// - `NOT_FOUND` / `INVALID_ARGUMENT` if `scope` is invalid.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn get_edge_scoped(&self, edge_id: EdgeId, scope: &NamespaceScope) -> Result<Edge> {
+        self.validate_scope(scope)?;
+        let edge = self.get_edge(edge_id)?;
+        if scope.contains(&edge.namespace()) {
+            Ok(edge)
+        } else {
+            Err(StorageError::EdgeNotFound(edge_id).into())
+        }
+    }
+
+    /// List node ids visible in `scope`, optionally filtered by `label`
+    /// (Issue #3349). The scoped counterpart of a `list_nodes` scan.
+    ///
+    /// Fast for an explicit scope: candidates come from the membership index,
+    /// not a full property scan. Results are sorted by node id for
+    /// deterministic pagination.
+    ///
+    /// # Errors
+    ///
+    /// `NOT_FOUND` / `INVALID_ARGUMENT` if `scope` is invalid.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn list_nodes_scoped(
+        &self,
+        label: Option<&str>,
+        scope: &NamespaceScope,
+    ) -> Result<Vec<NodeId>> {
+        self.validate_scope(scope)?;
+        let mut ids: Vec<NodeId> = match scope.explicit_namespaces() {
+            // Explicit scope: enumerate members via the index.
+            Some(namespaces) => {
+                let mut set = BTreeSet::new();
+                for ns in &namespaces {
+                    set.extend(self.current.namespace_node_ids(ns));
+                }
+                set.into_iter().collect()
+            }
+            // `All`: no namespace filter — every current node is a candidate.
+            None => self.get_all_node_ids(),
+        };
+        if let Some(label) = label {
+            let want = crate::core::interning::GLOBAL_INTERNER.intern(label)?;
+            ids.retain(|id| {
+                self.current
+                    .get_node_label(*id)
+                    .map(|l| l == want)
+                    .unwrap_or(false)
+            });
+        }
+        ids.sort_unstable();
+        Ok(ids)
+    }
+
+    /// Find node ids by label + property value, filtered to `scope`
+    /// (Issue #3349). The scoped counterpart of
+    /// [`find_nodes_by_property`](Self::find_nodes_by_property).
+    ///
+    /// # Errors
+    ///
+    /// `NOT_FOUND` / `INVALID_ARGUMENT` if `scope` is invalid.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn find_nodes_by_property_scoped(
+        &self,
+        label: &str,
+        property_key: &str,
+        property_value: &crate::core::property::PropertyValue,
+        scope: &NamespaceScope,
+    ) -> Result<Vec<NodeId>> {
+        self.validate_scope(scope)?;
+        let mut ids = self.find_nodes_by_property(label, property_key, property_value);
+        ids.retain(|id| match self.get_node(*id) {
+            Ok(node) => scope.contains(&node.namespace()),
+            Err(_) => false,
+        });
+        ids.sort_unstable();
+        Ok(ids)
+    }
+
+    /// Breadth-first traversal from `start`, honoring the namespace scope
+    /// **boundary** (Issue #3349, design §4 / test T4).
+    ///
+    /// Follows outgoing edges only. An edge is crossed only when BOTH the
+    /// edge's own namespace ∈ `scope` AND the target node's namespace ∈
+    /// `scope`; a target node outside `scope` stops traversal there. With a
+    /// union scope, traversal proceeds within and between exactly the listed
+    /// namespaces. `edge_label` optionally restricts which relationship type is
+    /// followed.
+    ///
+    /// Returns the distinct set of nodes reachable within `max_depth` hops
+    /// (excluding `start`), sorted by node id. `max_depth == 0` returns an
+    /// empty vec.
+    ///
+    /// # Errors
+    ///
+    /// - `NOT_FOUND` if `start` does not exist or is itself outside `scope`.
+    /// - `NOT_FOUND` / `INVALID_ARGUMENT` if `scope` is invalid.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn traverse_scoped(
+        &self,
+        start: NodeId,
+        edge_label: Option<&str>,
+        max_depth: usize,
+        scope: &NamespaceScope,
+    ) -> Result<Vec<NodeId>> {
+        self.validate_scope(scope)?;
+        // The traversal must start from an in-scope node; otherwise the caller
+        // could probe out-of-scope adjacency. An out-of-scope start is
+        // reported as not-found, exactly like `get_node_scoped`.
+        let start_node = self.get_node(start)?;
+        if !scope.contains(&start_node.namespace()) {
+            return Err(StorageError::NodeNotFound(start).into());
+        }
+
+        let mut visited: BTreeSet<NodeId> = BTreeSet::new();
+        let mut queue: VecDeque<(NodeId, usize)> = VecDeque::new();
+        queue.push_back((start, 0));
+        let mut seen: BTreeSet<NodeId> = BTreeSet::new();
+        seen.insert(start);
+
+        while let Some((node, depth)) = queue.pop_front() {
+            if depth >= max_depth {
+                continue;
+            }
+            let edge_ids = match edge_label {
+                Some(label) => self.get_outgoing_edges_with_label(node, label),
+                None => self.get_outgoing_edges(node),
+            };
+            for edge_id in edge_ids {
+                let Ok(edge) = self.get_edge(edge_id) else {
+                    continue;
+                };
+                // Boundary rule: the edge's own namespace must be in scope.
+                if !scope.contains(&edge.namespace()) {
+                    continue;
+                }
+                let target = edge.target;
+                // ...and the target node must exist AND be in scope.
+                let Ok(target_node) = self.get_node(target) else {
+                    continue;
+                };
+                if !scope.contains(&target_node.namespace()) {
+                    continue;
+                }
+                if seen.insert(target) {
+                    queue.push_back((target, depth + 1));
+                }
+                visited.insert(target);
+            }
+        }
+        Ok(visited.into_iter().collect())
+    }
+
+    /// Per-namespace current node/edge counts (Issue #3349, design §8).
+    ///
+    /// Returns one entry per namespace that is either **registered** or holds
+    /// at least one entity, sorted by namespace name (the implicit `default`
+    /// sorts first only if its name sorts first — it is included whenever it
+    /// has members or is listed). Counts are O(1) membership-index reads.
+    #[must_use]
+    pub fn namespace_counts(&self) -> Vec<NamespaceCount> {
+        // Union of registered namespaces and namespaces that currently hold
+        // entities, so an empty-but-registered namespace still appears and a
+        // populated-but-unregistered one is never dropped.
+        let mut names: BTreeSet<Namespace> = self.current.populated_namespaces();
+        for info in self.namespaces.list() {
+            if let Ok(ns) = Namespace::new(&info.name) {
+                names.insert(ns);
+            } else if info.name == Namespace::DEFAULT {
+                names.insert(Namespace::default());
+            }
+        }
+        names
+            .into_iter()
+            .map(|ns| NamespaceCount {
+                node_count: self.current.namespace_node_count(&ns),
+                edge_count: self.current.namespace_edge_count(&ns),
+                name: ns.into_string(),
+            })
+            .collect()
+    }
+}
+
+/// Per-namespace current entity counts (Issue #3349), produced by
+/// [`AletheiaDB::namespace_counts`] and surfaced in
+/// [`DatabaseStats`](crate::db::DatabaseStats) / schema.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[non_exhaustive]
+pub struct NamespaceCount {
+    /// The namespace name.
+    pub name: String,
+    /// Current-state node count in this namespace (O(1) membership read).
+    pub node_count: usize,
+    /// Current-state edge count in this namespace (O(1) membership read).
+    pub edge_count: usize,
+}

--- a/src/db/namespace_query.rs
+++ b/src/db/namespace_query.rs
@@ -25,8 +25,10 @@ use crate::core::error::{Error, Result, StorageError};
 use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, NodeId};
 use crate::core::namespace::{Namespace, NamespaceError, NamespaceScope};
+use crate::core::temporal::Timestamp;
 use crate::db::AletheiaDB;
-use std::collections::{BTreeSet, VecDeque};
+use crate::db::ops::NodesAtTime;
+use std::collections::{BTreeSet, HashSet, VecDeque};
 
 impl AletheiaDB {
     /// Validate a read scope against the namespace registry (Issue #3349).
@@ -59,6 +61,32 @@ impl AletheiaDB {
             }
         }
         Ok(())
+    }
+
+    /// O(1) membership probe: is the current node `node_id` inside `scope`,
+    /// using the secondary membership index (no property load, no `Namespace`
+    /// allocation)? [`NamespaceScope::All`] matches everything. Used by the hot
+    /// scoped-traversal loop so a per-edge boundary check is a hash probe.
+    fn scope_contains_current_node(&self, node_id: NodeId, scope: &NamespaceScope) -> bool {
+        match scope {
+            NamespaceScope::All => true,
+            NamespaceScope::Single(ns) => self.current.node_in_namespace(node_id, ns),
+            NamespaceScope::List(list) => list
+                .iter()
+                .any(|ns| self.current.node_in_namespace(node_id, ns)),
+        }
+    }
+
+    /// O(1) membership probe for a current edge. See
+    /// [`scope_contains_current_node`](Self::scope_contains_current_node).
+    fn scope_contains_current_edge(&self, edge_id: EdgeId, scope: &NamespaceScope) -> bool {
+        match scope {
+            NamespaceScope::All => true,
+            NamespaceScope::Single(ns) => self.current.edge_in_namespace(edge_id, ns),
+            NamespaceScope::List(list) => list
+                .iter()
+                .any(|ns| self.current.edge_in_namespace(edge_id, ns)),
+        }
     }
 
     /// Get a node only if it is visible in `scope` (Issue #3349).
@@ -119,13 +147,17 @@ impl AletheiaDB {
     ) -> Result<Vec<NodeId>> {
         self.validate_scope(scope)?;
         let mut ids: Vec<NodeId> = match scope.explicit_namespaces() {
-            // Explicit scope: enumerate members via the index.
+            // Explicit scope: enumerate members via the index. NodeIds are
+            // globally unique and namespaces are disjoint (a node lives in
+            // exactly one), and `explicit_namespaces()` already dedups the ns
+            // list — so a flat extend needs no set dedup; the final
+            // `sort_unstable` gives deterministic order.
             Some(namespaces) => {
-                let mut set = BTreeSet::new();
+                let mut ids = Vec::new();
                 for ns in &namespaces {
-                    set.extend(self.current.namespace_node_ids(ns));
+                    ids.extend(self.current.namespace_node_ids(ns));
                 }
-                set.into_iter().collect()
+                ids
             }
             // `All`: no namespace filter — every current node is a candidate.
             None => self.get_all_node_ids(),
@@ -160,10 +192,14 @@ impl AletheiaDB {
     ) -> Result<Vec<NodeId>> {
         self.validate_scope(scope)?;
         let mut ids = self.find_nodes_by_property(label, property_key, property_value);
-        ids.retain(|id| match self.get_node(*id) {
-            Ok(node) => scope.contains(&node.namespace()),
-            Err(_) => false,
-        });
+        // `All` names every namespace, so there is nothing to filter — skip the
+        // per-node load/clone entirely.
+        if !matches!(scope, NamespaceScope::All) {
+            ids.retain(|id| match self.get_node(*id) {
+                Ok(node) => scope.contains(&node.namespace()),
+                Err(_) => false,
+            });
+        }
         ids.sort_unstable();
         Ok(ids)
     }
@@ -196,18 +232,20 @@ impl AletheiaDB {
     ) -> Result<Vec<NodeId>> {
         self.validate_scope(scope)?;
         // The traversal must start from an in-scope node; otherwise the caller
-        // could probe out-of-scope adjacency. An out-of-scope start is
-        // reported as not-found, exactly like `get_node_scoped`.
-        let start_node = self.get_node(start)?;
-        if !scope.contains(&start_node.namespace()) {
+        // could probe out-of-scope adjacency. An out-of-scope (or non-existent)
+        // start is reported as not-found, exactly like `get_node_scoped`. The
+        // O(1) membership probe avoids loading the start node's properties.
+        if !self.scope_contains_current_node(start, scope) {
             return Err(StorageError::NodeNotFound(start).into());
         }
 
-        let mut visited: BTreeSet<NodeId> = BTreeSet::new();
-        let mut queue: VecDeque<(NodeId, usize)> = VecDeque::new();
-        queue.push_back((start, 0));
+        // A single `seen` set does double duty: it dedups the BFS frontier AND
+        // is the emitted set. `start` is inserted up front so it is never
+        // re-enqueued nor emitted, then removed just before returning.
         let mut seen: BTreeSet<NodeId> = BTreeSet::new();
         seen.insert(start);
+        let mut queue: VecDeque<(NodeId, usize)> = VecDeque::new();
+        queue.push_back((start, 0));
 
         while let Some((node, depth)) = queue.pop_front() {
             if depth >= max_depth {
@@ -218,16 +256,294 @@ impl AletheiaDB {
                 None => self.get_outgoing_edges(node),
             };
             for edge_id in edge_ids {
-                let Ok(edge) = self.get_edge(edge_id) else {
+                // Boundary rule via O(1) membership probes (no full edge/node
+                // reconstruction): the edge's own namespace ∈ scope AND the
+                // target node's namespace ∈ scope. Namespace is immutable, so the
+                // current-state membership index is authoritative for the
+                // (current-state) traversal.
+                if !self.scope_contains_current_edge(edge_id, scope) {
+                    continue;
+                }
+                let Ok(target) = self.current.get_edge_target(edge_id) else {
                     continue;
                 };
-                // Boundary rule: the edge's own namespace must be in scope.
+                if !self.scope_contains_current_node(target, scope) {
+                    continue;
+                }
+                if seen.insert(target) {
+                    queue.push_back((target, depth + 1));
+                }
+            }
+        }
+        seen.remove(&start);
+        Ok(seen.into_iter().collect())
+    }
+
+    /// The set of current node ids in an **explicit** scope, drawn from the
+    /// membership index; `None` for [`NamespaceScope::All`] (no filter needed).
+    ///
+    /// Used to build a cheap `Fn(&NodeId) -> bool` scope predicate for
+    /// filter-complete vector search (T6) without a per-candidate property load.
+    fn scope_allowed_node_ids(&self, scope: &NamespaceScope) -> Option<HashSet<NodeId>> {
+        scope.explicit_namespaces().map(|namespaces| {
+            let mut allowed = HashSet::new();
+            for ns in &namespaces {
+                allowed.extend(self.current.namespace_node_ids(ns));
+            }
+            allowed
+        })
+    }
+
+    /// Filter-complete k-NN from an existing node's embedding, restricted to
+    /// `scope` (Issue #3349, PR2 / test T6).
+    ///
+    /// Returns the top-`k` most-similar nodes whose (immutable) namespace ∈
+    /// `scope`. The search **over-fetches** candidates until it has `k` genuinely
+    /// in-scope results (or the index is exhausted) — never "take `k`, then drop
+    /// the out-of-scope ones leaving fewer than `k`". Scores and ordering of the
+    /// returned in-scope results are identical to an unscoped search. The query
+    /// node is excluded.
+    ///
+    /// The namespace filter is applied only to candidates the vector index
+    /// actually returns; it makes **no assumption about why a vector might be
+    /// absent** from the index (e.g. a crypto-shredded embedding is simply never
+    /// a candidate). For [`NamespaceScope::All`] this is exactly the unscoped
+    /// search.
+    ///
+    /// # Errors
+    ///
+    /// - `NOT_FOUND` / `INVALID_ARGUMENT` if `scope` is invalid.
+    /// - The vector-search errors of the underlying index (no index enabled,
+    ///   query node missing or lacking the indexed vector).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn find_similar_scoped(
+        &self,
+        query_node_id: NodeId,
+        k: usize,
+        scope: &NamespaceScope,
+    ) -> Result<Vec<(NodeId, f32)>> {
+        self.validate_scope(scope)?;
+        match self.scope_allowed_node_ids(scope) {
+            Some(allowed) => {
+                self.current
+                    .find_similar_by_node_with_predicate(query_node_id, k, move |id| {
+                        allowed.contains(id)
+                    })
+            }
+            // `All`: no namespace filter (identical to the unscoped search).
+            None => self
+                .current
+                .find_similar_by_node_with_predicate(query_node_id, k, |_| true),
+        }
+    }
+
+    /// Filter-complete k-NN from a raw embedding, restricted to `scope`
+    /// (Issue #3349, PR2 / test T6). The embedding counterpart of
+    /// [`find_similar_scoped`](Self::find_similar_scoped) — see it for the
+    /// filter-completeness and absent-vector guarantees.
+    ///
+    /// # Errors
+    ///
+    /// - `NOT_FOUND` / `INVALID_ARGUMENT` if `scope` is invalid.
+    /// - The vector-search errors of the underlying index (no index enabled,
+    ///   embedding dimension mismatch).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn find_similar_by_embedding_scoped(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        scope: &NamespaceScope,
+    ) -> Result<Vec<(NodeId, f32)>> {
+        self.validate_scope(scope)?;
+        match self.scope_allowed_node_ids(scope) {
+            Some(allowed) => {
+                self.current
+                    .find_similar_by_embedding_with_predicate(embedding, k, move |id| {
+                        allowed.contains(id)
+                    })
+            }
+            None => self
+                .current
+                .find_similar_by_embedding_with_predicate(embedding, k, |_| true),
+        }
+    }
+
+    /// Get a node reconstructed at a bi-temporal point, visible only in `scope`
+    /// (Issue #3349, PR2 / test T7).
+    ///
+    /// The point-in-time reconstruction runs **first**, then the namespace filter
+    /// applies to the reconstructed node. Because a namespace is immutable across
+    /// an entity's whole history, membership is constant — the reconstructed node
+    /// carries exactly the namespace it was created in, so a past query is
+    /// unaffected by later writes.
+    ///
+    /// # Errors
+    ///
+    /// - `NOT_FOUND` if the node did not exist at that point or is not in `scope`.
+    /// - `NOT_FOUND` / `INVALID_ARGUMENT` if `scope` is invalid.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn get_node_at_time_scoped(
+        &self,
+        node_id: NodeId,
+        valid_time: Timestamp,
+        transaction_time: Timestamp,
+        scope: &NamespaceScope,
+    ) -> Result<Node> {
+        self.validate_scope(scope)?;
+        let node = self.get_node_at_time(node_id, valid_time, transaction_time)?;
+        if scope.contains(&node.namespace()) {
+            Ok(node)
+        } else {
+            Err(StorageError::NodeNotFound(node_id).into())
+        }
+    }
+
+    /// Get an edge reconstructed at a bi-temporal point, visible only in `scope`
+    /// (Issue #3349, PR2 / test T7). See
+    /// [`get_node_at_time_scoped`](Self::get_node_at_time_scoped).
+    ///
+    /// # Errors
+    ///
+    /// - `NOT_FOUND` if the edge did not exist at that point or is not in `scope`.
+    /// - `NOT_FOUND` / `INVALID_ARGUMENT` if `scope` is invalid.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn get_edge_at_time_scoped(
+        &self,
+        edge_id: EdgeId,
+        valid_time: Timestamp,
+        transaction_time: Timestamp,
+        scope: &NamespaceScope,
+    ) -> Result<Edge> {
+        self.validate_scope(scope)?;
+        let edge = self.get_edge_at_time(edge_id, valid_time, transaction_time)?;
+        if scope.contains(&edge.namespace()) {
+            Ok(edge)
+        } else {
+            Err(StorageError::EdgeNotFound(edge_id).into())
+        }
+    }
+
+    /// Point-in-time node find by label, restricted to `scope` (Issue #3349,
+    /// PR2 / test T7). The scoped counterpart of
+    /// [`find_nodes_at_time`](Self::find_nodes_at_time): each candidate is
+    /// reconstructed at `(valid_time, transaction_time)` first, then filtered by
+    /// its (immutable) namespace.
+    ///
+    /// # Errors
+    ///
+    /// `NOT_FOUND` / `INVALID_ARGUMENT` if `scope` is invalid.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn find_nodes_at_time_scoped(
+        &self,
+        label: &str,
+        valid_time: Timestamp,
+        transaction_time: Timestamp,
+        scope: &NamespaceScope,
+    ) -> Result<NodesAtTime> {
+        self.validate_scope(scope)?;
+        let mut result = self.find_nodes_at_time(label, valid_time, transaction_time)?;
+        if !matches!(scope, NamespaceScope::All) {
+            result
+                .nodes
+                .retain(|node| scope.contains(&node.namespace()));
+        }
+        Ok(result)
+    }
+
+    /// Point-in-time node find by label + property, restricted to `scope`
+    /// (Issue #3349, PR2 / test T7). See
+    /// [`find_nodes_at_time_scoped`](Self::find_nodes_at_time_scoped).
+    ///
+    /// # Errors
+    ///
+    /// `NOT_FOUND` / `INVALID_ARGUMENT` if `scope` is invalid.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn find_nodes_by_property_at_scoped(
+        &self,
+        label: &str,
+        property_key: &str,
+        property_value: &crate::core::property::PropertyValue,
+        valid_time: Timestamp,
+        transaction_time: Timestamp,
+        scope: &NamespaceScope,
+    ) -> Result<NodesAtTime> {
+        self.validate_scope(scope)?;
+        let mut result = self.find_nodes_by_property_at(
+            label,
+            property_key,
+            property_value,
+            valid_time,
+            transaction_time,
+        )?;
+        if !matches!(scope, NamespaceScope::All) {
+            result
+                .nodes
+                .retain(|node| scope.contains(&node.namespace()));
+        }
+        Ok(result)
+    }
+
+    /// Breadth-first traversal from `start` **as of** a bi-temporal point,
+    /// honoring the namespace scope boundary (Issue #3349, PR2 / test T7).
+    ///
+    /// Composes [`traverse_scoped`](Self::traverse_scoped)'s boundary semantics
+    /// with point-in-time reconstruction: an edge is crossed only if it existed
+    /// at `(valid_time, transaction_time)` AND its namespace ∈ `scope` AND the
+    /// target node, reconstructed at that point, exists and has namespace ∈
+    /// `scope`. Node/edge state (including namespace, which is immutable) reflects
+    /// that coordinate, so a past query is unaffected by later writes.
+    ///
+    /// Candidate edges come from the current adjacency index and are then
+    /// filtered by point-in-time visibility (mirroring the executor's AS OF
+    /// traversal, #3225): recalling a since-deleted edge requires anchoring both
+    /// dimensions before its deletion.
+    ///
+    /// # Errors
+    ///
+    /// - `NOT_FOUND` if `start` did not exist at that point or is outside `scope`.
+    /// - `NOT_FOUND` / `INVALID_ARGUMENT` if `scope` is invalid.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn traverse_scoped_as_of(
+        &self,
+        start: NodeId,
+        edge_label: Option<&str>,
+        max_depth: usize,
+        valid_time: Timestamp,
+        transaction_time: Timestamp,
+        scope: &NamespaceScope,
+    ) -> Result<Vec<NodeId>> {
+        self.validate_scope(scope)?;
+        // The start node must exist at the coordinate AND be in scope.
+        let start_node = self.get_node_at_time(start, valid_time, transaction_time)?;
+        if !scope.contains(&start_node.namespace()) {
+            return Err(StorageError::NodeNotFound(start).into());
+        }
+
+        let mut seen: BTreeSet<NodeId> = BTreeSet::new();
+        seen.insert(start);
+        let mut queue: VecDeque<(NodeId, usize)> = VecDeque::new();
+        queue.push_back((start, 0));
+
+        while let Some((node, depth)) = queue.pop_front() {
+            if depth >= max_depth {
+                continue;
+            }
+            let edge_ids = match edge_label {
+                Some(label) => self.get_outgoing_edges_with_label(node, label),
+                None => self.get_outgoing_edges(node),
+            };
+            for edge_id in edge_ids {
+                // Point-in-time edge reconstruction: an edge not visible at the
+                // coordinate is skipped, exactly like the AS OF executor.
+                let Ok(edge) = self.get_edge_at_time(edge_id, valid_time, transaction_time) else {
+                    continue;
+                };
                 if !scope.contains(&edge.namespace()) {
                     continue;
                 }
                 let target = edge.target;
-                // ...and the target node must exist AND be in scope.
-                let Ok(target_node) = self.get_node(target) else {
+                let Ok(target_node) = self.get_node_at_time(target, valid_time, transaction_time)
+                else {
                     continue;
                 };
                 if !scope.contains(&target_node.namespace()) {
@@ -236,10 +552,10 @@ impl AletheiaDB {
                 if seen.insert(target) {
                     queue.push_back((target, depth + 1));
                 }
-                visited.insert(target);
             }
         }
-        Ok(visited.into_iter().collect())
+        seen.remove(&start);
+        Ok(seen.into_iter().collect())
     }
 
     /// Per-namespace current node/edge counts (Issue #3349, design §8).
@@ -255,10 +571,11 @@ impl AletheiaDB {
         // populated-but-unregistered one is never dropped.
         let mut names: BTreeSet<Namespace> = self.current.populated_namespaces();
         for info in self.namespaces.list() {
+            // Every registered name (including the implicit `default`) is a valid
+            // namespace, so `Namespace::new` always succeeds here; a malformed
+            // registry entry is simply skipped rather than panicking.
             if let Ok(ns) = Namespace::new(&info.name) {
                 names.insert(ns);
-            } else if info.name == Namespace::DEFAULT {
-                names.insert(Namespace::default());
             }
         }
         names

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -122,6 +122,15 @@ impl AletheiaDB {
             // query by value.
             let scope = query.scope.clone();
 
+            // Validate the scope before planning/executing (Issue #3349 A3):
+            // an unknown namespace is a `NOT_FOUND` (not a silently empty
+            // result), and an empty `List` scope built via
+            // `QueryBuilder::in_namespaces([])` is an `INVALID_ARGUMENT` (not a
+            // silent unscoped-all). `All`/omitted scope validate trivially.
+            if let Some(scope) = &scope {
+                self.validate_scope(scope)?;
+            }
+
             // Use cached statistics for cost-based optimization
             // Statistics are shared across all queries for this database instance
             let planner = QueryPlanner::new(Arc::clone(&self.stats), Arc::clone(&self.current));

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -116,14 +116,23 @@ impl AletheiaDB {
             let _span =
                 crate::observability::query_execute_span("query.execute", "hybrid").entered();
 
+            // Namespace scope (Issue #3349, PR2) is orthogonal to planning: the
+            // planner ignores it and the executor applies it as an entity filter
+            // (and traversal boundary). Lift it out before the plan consumes the
+            // query by value.
+            let scope = query.scope.clone();
+
             // Use cached statistics for cost-based optimization
             // Statistics are shared across all queries for this database instance
             let planner = QueryPlanner::new(Arc::clone(&self.stats), Arc::clone(&self.current));
             let physical_plan = planner.plan(query)?;
 
             // Execute the plan
-            let executor =
+            let mut executor =
                 QueryExecutor::new(Arc::clone(&self.current), Arc::clone(&self.historical));
+            if let Some(scope) = scope {
+                executor = executor.with_namespace_scope(scope);
+            }
 
             executor.execute(physical_plan)
         })();

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -91,6 +91,12 @@ pub struct GraphSchema {
     pub sampled: bool,
     /// The bi-temporal instant this schema reflects, or `None` for current state.
     pub as_of: Option<SchemaInstant>,
+    /// Per-namespace current node/edge counts (Issue #3349). Populated for the
+    /// current-state [`AletheiaDB::schema`]; **empty** for
+    /// [`AletheiaDB::schema_as_of`] (the namespace membership index is a
+    /// current-state acceleration structure, so a point-in-time namespace
+    /// breakdown is a deliberate follow-up).
+    pub namespaces: Vec<crate::db::namespace_query::NamespaceCount>,
 }
 
 /// Accumulates per-label/per-type counts and the union of property keys
@@ -160,6 +166,7 @@ impl AletheiaDB {
             false,
             None,
             &self.constraint_registry,
+            self.namespace_counts(),
         ))
     }
 
@@ -232,6 +239,8 @@ impl AletheiaDB {
                 transaction_time,
             }),
             &self.constraint_registry,
+            // Namespace breakdown is current-state only; empty for AS OF.
+            Vec::new(),
         ))
     }
 }
@@ -287,6 +296,7 @@ fn build_schema(
     sampled: bool,
     as_of: Option<SchemaInstant>,
     registry: &ConstraintRegistry,
+    namespaces: Vec<crate::db::namespace_query::NamespaceCount>,
 ) -> GraphSchema {
     let mut total_nodes = 0;
     let mut node_labels: Vec<LabelSchema> = node_acc
@@ -343,6 +353,7 @@ fn build_schema(
         total_edges,
         sampled,
         as_of,
+        namespaces,
     }
 }
 

--- a/src/db/stats.rs
+++ b/src/db/stats.rs
@@ -71,6 +71,19 @@ pub struct DatabaseStats {
     /// Tamper-evident provenance hash chain status (Issue #3351). `enabled:
     /// false` with all-`None` fields when the chain is not configured.
     pub chain: ProvenanceChainStats,
+    /// Per-namespace current node/edge counts (Issue #3349). One entry per
+    /// registered or populated namespace, sorted by name; O(1) membership-index
+    /// reads. Empty on a database that only uses the implicit `default`
+    /// namespace with no explicit registrations (the `default` entry is still
+    /// present when it holds entities).
+    ///
+    /// **Not serialized in PR2**: surfacing this block through the MCP/HTTP
+    /// `database_stats` JSON is deliberately deferred to PR3 (the coordinated
+    /// surface slice), so the wire shape is unchanged here. The field is fully
+    /// populated on the Rust `AletheiaDB::stats()` value; only serialization is
+    /// skipped. PR3 removes this `skip` and updates the shape-stability test.
+    #[cfg_attr(feature = "serde", serde(skip_serializing))]
+    pub namespaces: Vec<crate::db::namespace_query::NamespaceCount>,
 }
 
 /// Status of the opt-in provenance hash chain (Issue #3351).
@@ -376,6 +389,9 @@ impl AletheiaDB {
             },
         };
 
+        // Per-namespace counts (Issue #3349): O(1) membership-index reads.
+        let namespaces = self.namespace_counts();
+
         DatabaseStats {
             current: CurrentStateStats {
                 node_count: current_stats.node_count,
@@ -385,6 +401,7 @@ impl AletheiaDB {
             cold_storage,
             wal,
             chain,
+            namespaces,
         }
     }
 }

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -710,6 +710,27 @@ impl CurrentIndexes {
             .unwrap_or_default()
     }
 
+    /// Whether `node_id` currently lives in `namespace` (Issue #3349, PR2).
+    ///
+    /// O(1) membership test against the secondary index — no property load, no
+    /// `Namespace` allocation — so a scoped traversal's per-edge boundary check
+    /// is a hash probe rather than a full node reconstruction.
+    #[inline]
+    pub fn node_in_namespace(&self, node_id: NodeId, namespace: &Namespace) -> bool {
+        self.ns_nodes
+            .get(namespace)
+            .is_some_and(|members| members.contains(&node_id))
+    }
+
+    /// Whether `edge_id` currently lives in `namespace` (Issue #3349, PR2). The
+    /// edge counterpart of [`node_in_namespace`](Self::node_in_namespace).
+    #[inline]
+    pub fn edge_in_namespace(&self, edge_id: EdgeId, namespace: &Namespace) -> bool {
+        self.ns_edges
+            .get(namespace)
+            .is_some_and(|members| members.contains(&edge_id))
+    }
+
     /// Number of nodes currently in `namespace` (O(1) set-length read).
     #[inline]
     pub fn namespace_node_count(&self, namespace: &Namespace) -> usize {

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -7,9 +7,10 @@
 use crate::core::graph::{Edge, Node, NodeHeader};
 use crate::core::id::{EdgeId, NodeId};
 use crate::core::interning::InternedString;
+use crate::core::namespace::Namespace;
 use crate::index::adjacency::AdjacencyEntry;
 use crate::index::incremental_adjacency::{CompactionScheduler, IncrementalAdjacencyIndex};
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread::JoinHandle;
@@ -73,6 +74,26 @@ pub struct CurrentIndexes {
     /// the storage's own id generator is never advanced and cannot bound a
     /// scan.
     max_node_id: AtomicU64,
+    /// Secondary namespace → member-node membership index (Issue #3349, PR2).
+    ///
+    /// A derived, **non-persisted** acceleration structure mapping each
+    /// namespace to the set of node ids that currently live in it, so a
+    /// namespace-scoped read can enumerate members without a full property
+    /// scan. The durable ground truth is the reserved ride-along property on
+    /// each node ([`crate::core::namespace::NAMESPACE_KEY`]); this index is
+    /// rebuilt for free at load / WAL-replay because every node insertion
+    /// funnels through [`insert_node`](Self::insert_node).
+    ///
+    /// # Lock discipline
+    ///
+    /// This is a **leaf** in the lock-acquisition order: a lock-free `DashMap`
+    /// of lock-free `DashSet`s, mutated only inside
+    /// `insert_node`/`remove_node`, and it never calls back into `historical`,
+    /// `wal`, or `current_timestamp`.
+    ns_nodes: DashMap<Namespace, DashSet<NodeId>>,
+    /// Secondary namespace → member-edge membership index (Issue #3349, PR2).
+    /// The edge counterpart of [`ns_nodes`](Self::ns_nodes); see its docs.
+    ns_edges: DashMap<Namespace, DashSet<EdgeId>>,
 }
 
 impl CurrentIndexes {
@@ -90,6 +111,8 @@ impl CurrentIndexes {
             outgoing_compaction: None,
             incoming_compaction: None,
             max_node_id: AtomicU64::new(0),
+            ns_nodes: DashMap::new(),
+            ns_edges: DashMap::new(),
         }
     }
 
@@ -118,6 +141,8 @@ impl CurrentIndexes {
             outgoing_compaction: Some((outgoing_scheduler, outgoing_handle)),
             incoming_compaction: Some((incoming_scheduler, incoming_handle)),
             max_node_id: AtomicU64::new(0),
+            ns_nodes: DashMap::new(),
+            ns_edges: DashMap::new(),
         }
     }
 
@@ -173,8 +198,15 @@ impl CurrentIndexes {
         // node visibility itself is governed by the DashMap insert below.
         self.max_node_id
             .fetch_max(node.id.as_u64().wrapping_add(1), Ordering::Relaxed);
+        // Maintain the namespace membership index (Issue #3349). Read the
+        // namespace off the node before moving it into the map. The insert is
+        // idempotent, so re-inserting on an in-place update is a no-op (the
+        // namespace is immutable for the life of the entity).
+        let node_id = node.id;
+        let ns = node.namespace();
         self.nodes.insert(node.id, node);
         self.node_headers.insert(header.id, header);
+        self.ns_nodes.entry(ns).or_default().insert(node_id);
     }
 
     /// Exclusive upper bound on the node id space: `max(id ever inserted) + 1`.
@@ -213,11 +245,14 @@ impl CurrentIndexes {
             }
             Entry::Vacant(e) => {
                 // New edge: insert into both edge map and adjacency
+                let ns = edge.namespace();
                 e.insert(edge);
                 self.outgoing
                     .insert(source, AdjacencyEntry::new(target, edge_id, label));
                 self.incoming
                     .insert(target, AdjacencyEntry::new(source, edge_id, label));
+                // Maintain the namespace membership index (Issue #3349).
+                self.ns_edges.entry(ns).or_default().insert(edge_id);
             }
         }
     }
@@ -583,6 +618,10 @@ impl CurrentIndexes {
     pub fn remove_node(&self, id: NodeId) -> Option<Node> {
         self.nodes.remove(&id).map(|(_, node)| {
             self.node_headers.remove(&id);
+            // Drop the node from its namespace membership set (Issue #3349).
+            if let Some(members) = self.ns_nodes.get(&node.namespace()) {
+                members.remove(&id);
+            }
             node
         })
     }
@@ -633,6 +672,10 @@ impl CurrentIndexes {
             // Mark as deleted in both adjacency indexes (O(1))
             self.outgoing.delete(id);
             self.incoming.delete(id);
+            // Drop the edge from its namespace membership set (Issue #3349).
+            if let Some(members) = self.ns_edges.get(&edge.namespace()) {
+                members.remove(&id);
+            }
             edge
         })
     }
@@ -641,6 +684,64 @@ impl CurrentIndexes {
     #[inline]
     pub fn node_count(&self) -> usize {
         self.nodes.len()
+    }
+
+    // ========================================================================
+    // Namespace membership index (Issue #3349, PR2)
+    // ========================================================================
+
+    /// Node ids currently in `namespace`, from the secondary membership index.
+    ///
+    /// O(members) with no property scan. Returns an empty vec for a namespace
+    /// with no members. Order is unspecified (DashSet iteration); callers that
+    /// need determinism should sort.
+    pub fn namespace_node_ids(&self, namespace: &Namespace) -> Vec<NodeId> {
+        self.ns_nodes
+            .get(namespace)
+            .map(|members| members.iter().map(|e| *e.key()).collect())
+            .unwrap_or_default()
+    }
+
+    /// Edge ids currently in `namespace`, from the secondary membership index.
+    pub fn namespace_edge_ids(&self, namespace: &Namespace) -> Vec<EdgeId> {
+        self.ns_edges
+            .get(namespace)
+            .map(|members| members.iter().map(|e| *e.key()).collect())
+            .unwrap_or_default()
+    }
+
+    /// Number of nodes currently in `namespace` (O(1) set-length read).
+    #[inline]
+    pub fn namespace_node_count(&self, namespace: &Namespace) -> usize {
+        self.ns_nodes
+            .get(namespace)
+            .map_or(0, |members| members.len())
+    }
+
+    /// Number of edges currently in `namespace` (O(1) set-length read).
+    #[inline]
+    pub fn namespace_edge_count(&self, namespace: &Namespace) -> usize {
+        self.ns_edges
+            .get(namespace)
+            .map_or(0, |members| members.len())
+    }
+
+    /// Every namespace that currently holds at least one node or edge, from
+    /// the membership index. Used to enumerate populated namespaces for
+    /// per-namespace stats/schema without a full entity scan.
+    pub fn populated_namespaces(&self) -> std::collections::BTreeSet<Namespace> {
+        let mut out = std::collections::BTreeSet::new();
+        for entry in self.ns_nodes.iter() {
+            if !entry.value().is_empty() {
+                out.insert(entry.key().clone());
+            }
+        }
+        for entry in self.ns_edges.iter() {
+            if !entry.value().is_empty() {
+                out.insert(entry.key().clone());
+            }
+        }
+        out
     }
 
     /// Get the number of edges.

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -5,15 +5,22 @@
 //! that must be extremely fast.
 
 use crate::core::graph::{Edge, Node, NodeHeader};
+use crate::core::hasher::IdentityHasher;
 use crate::core::id::{EdgeId, NodeId};
 use crate::core::interning::InternedString;
-use crate::core::namespace::Namespace;
+use crate::core::namespace::{Namespace, NamespaceId, intern_namespace, resolve_namespace_id};
 use crate::index::adjacency::AdjacencyEntry;
 use crate::index::incremental_adjacency::{CompactionScheduler, IncrementalAdjacencyIndex};
 use dashmap::{DashMap, DashSet};
+use std::hash::BuildHasherDefault;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread::JoinHandle;
+
+/// Hasher builder for the [`NamespaceId`]-keyed membership index. The key is a
+/// `u32`, so identity hashing (Issue #3349, PR2) avoids SipHash overhead on the
+/// per-edge scoped-read probe.
+type NsHasher = BuildHasherDefault<IdentityHasher>;
 
 // Note: AdjacencyGuard was removed in favor of MergedAdjacencyGuard from incremental_adjacency.
 // The new guard supports merging frozen CSR + delta buffer on-the-fly.
@@ -90,10 +97,16 @@ pub struct CurrentIndexes {
     /// of lock-free `DashSet`s, mutated only inside
     /// `insert_node`/`remove_node`, and it never calls back into `historical`,
     /// `wal`, or `current_timestamp`.
-    ns_nodes: DashMap<Namespace, DashSet<NodeId>>,
+    ///
+    /// Keyed by the interned [`NamespaceId`] (Issue #3349, PR2 performance) so
+    /// each per-edge scoped-read probe is an integer (identity) hash rather than
+    /// a heap-string hash. The inner member set is likewise identity-hashed (its
+    /// keys are `NodeId`s — already unique u64s), so the per-edge `contains`
+    /// probe is a plain integer hash, not SipHash.
+    ns_nodes: DashMap<NamespaceId, DashSet<NodeId, NsHasher>, NsHasher>,
     /// Secondary namespace → member-edge membership index (Issue #3349, PR2).
     /// The edge counterpart of [`ns_nodes`](Self::ns_nodes); see its docs.
-    ns_edges: DashMap<Namespace, DashSet<EdgeId>>,
+    ns_edges: DashMap<NamespaceId, DashSet<EdgeId, NsHasher>, NsHasher>,
 }
 
 impl CurrentIndexes {
@@ -111,8 +124,8 @@ impl CurrentIndexes {
             outgoing_compaction: None,
             incoming_compaction: None,
             max_node_id: AtomicU64::new(0),
-            ns_nodes: DashMap::new(),
-            ns_edges: DashMap::new(),
+            ns_nodes: DashMap::with_hasher(BuildHasherDefault::default()),
+            ns_edges: DashMap::with_hasher(BuildHasherDefault::default()),
         }
     }
 
@@ -141,8 +154,8 @@ impl CurrentIndexes {
             outgoing_compaction: Some((outgoing_scheduler, outgoing_handle)),
             incoming_compaction: Some((incoming_scheduler, incoming_handle)),
             max_node_id: AtomicU64::new(0),
-            ns_nodes: DashMap::new(),
-            ns_edges: DashMap::new(),
+            ns_nodes: DashMap::with_hasher(BuildHasherDefault::default()),
+            ns_edges: DashMap::with_hasher(BuildHasherDefault::default()),
         }
     }
 
@@ -203,10 +216,15 @@ impl CurrentIndexes {
         // idempotent, so re-inserting on an in-place update is a no-op (the
         // namespace is immutable for the life of the entity).
         let node_id = node.id;
-        let ns = node.namespace();
+        // Derive the interned namespace id from the node's durable ride-along
+        // string (Issue #3349, PR2). This is the single derivation site for the
+        // node membership index, so every hydration path (write, WAL replay,
+        // index-persistence load, cold rehydration) that funnels through
+        // `insert_node` produces the identical id for the same namespace.
+        let ns_id = intern_namespace(&node.namespace());
         self.nodes.insert(node.id, node);
         self.node_headers.insert(header.id, header);
-        self.ns_nodes.entry(ns).or_default().insert(node_id);
+        self.ns_nodes.entry(ns_id).or_default().insert(node_id);
     }
 
     /// Exclusive upper bound on the node id space: `max(id ever inserted) + 1`.
@@ -245,14 +263,16 @@ impl CurrentIndexes {
             }
             Entry::Vacant(e) => {
                 // New edge: insert into both edge map and adjacency
-                let ns = edge.namespace();
+                // Single derivation site for the edge membership index id
+                // (Issue #3349, PR2); see `insert_node`.
+                let ns_id = intern_namespace(&edge.namespace());
                 e.insert(edge);
                 self.outgoing
                     .insert(source, AdjacencyEntry::new(target, edge_id, label));
                 self.incoming
                     .insert(target, AdjacencyEntry::new(source, edge_id, label));
                 // Maintain the namespace membership index (Issue #3349).
-                self.ns_edges.entry(ns).or_default().insert(edge_id);
+                self.ns_edges.entry(ns_id).or_default().insert(edge_id);
             }
         }
     }
@@ -619,8 +639,8 @@ impl CurrentIndexes {
         self.nodes.remove(&id).map(|(_, node)| {
             self.node_headers.remove(&id);
             // Drop the node from its namespace membership set (Issue #3349).
-            let ns = node.namespace();
-            let now_empty = match self.ns_nodes.get(&ns) {
+            let ns_id = intern_namespace(&node.namespace());
+            let now_empty = match self.ns_nodes.get(&ns_id) {
                 Some(members) => {
                     members.remove(&id);
                     members.is_empty()
@@ -633,7 +653,7 @@ impl CurrentIndexes {
             // shard write lock — so a concurrent insert racing the reclaim never
             // removes a set that has just become non-empty.
             if now_empty {
-                self.ns_nodes.remove_if(&ns, |_, set| set.is_empty());
+                self.ns_nodes.remove_if(&ns_id, |_, set| set.is_empty());
             }
             node
         })
@@ -686,8 +706,8 @@ impl CurrentIndexes {
             self.outgoing.delete(id);
             self.incoming.delete(id);
             // Drop the edge from its namespace membership set (Issue #3349).
-            let ns = edge.namespace();
-            let now_empty = match self.ns_edges.get(&ns) {
+            let ns_id = intern_namespace(&edge.namespace());
+            let now_empty = match self.ns_edges.get(&ns_id) {
                 Some(members) => {
                     members.remove(&id);
                     members.is_empty()
@@ -698,7 +718,7 @@ impl CurrentIndexes {
             // guard is dropped before `remove_if`, which re-checks under the shard
             // write lock so a concurrent insert never loses its set.
             if now_empty {
-                self.ns_edges.remove_if(&ns, |_, set| set.is_empty());
+                self.ns_edges.remove_if(&ns_id, |_, set| set.is_empty());
             }
             edge
         })
@@ -721,7 +741,7 @@ impl CurrentIndexes {
     /// need determinism should sort.
     pub fn namespace_node_ids(&self, namespace: &Namespace) -> Vec<NodeId> {
         self.ns_nodes
-            .get(namespace)
+            .get(&intern_namespace(namespace))
             .map(|members| members.iter().map(|e| *e.key()).collect())
             .unwrap_or_default()
     }
@@ -729,20 +749,32 @@ impl CurrentIndexes {
     /// Edge ids currently in `namespace`, from the secondary membership index.
     pub fn namespace_edge_ids(&self, namespace: &Namespace) -> Vec<EdgeId> {
         self.ns_edges
-            .get(namespace)
+            .get(&intern_namespace(namespace))
             .map(|members| members.iter().map(|e| *e.key()).collect())
             .unwrap_or_default()
     }
 
     /// Whether `node_id` currently lives in `namespace` (Issue #3349, PR2).
     ///
-    /// O(1) membership test against the secondary index — no property load, no
-    /// `Namespace` allocation — so a scoped traversal's per-edge boundary check
-    /// is a hash probe rather than a full node reconstruction.
+    /// Convenience wrapper that interns `namespace` and delegates to
+    /// [`node_in_namespace_id`](Self::node_in_namespace_id). Hot loops that probe
+    /// the same scope repeatedly should intern once (via
+    /// [`NamespaceScope::resolved_ids`](crate::core::namespace::NamespaceScope::resolved_ids))
+    /// and call the `_id` form to avoid re-interning per candidate.
     #[inline]
     pub fn node_in_namespace(&self, node_id: NodeId, namespace: &Namespace) -> bool {
+        self.node_in_namespace_id(node_id, intern_namespace(namespace))
+    }
+
+    /// Whether `node_id` currently lives in the interned namespace `ns_id`
+    /// (Issue #3349, PR2). O(1): an identity-hashed outer probe plus a set
+    /// membership test — no property load, no `Namespace` allocation, no string
+    /// hashing — so a scoped traversal's per-edge boundary check is two integer
+    /// hash probes.
+    #[inline]
+    pub fn node_in_namespace_id(&self, node_id: NodeId, ns_id: NamespaceId) -> bool {
         self.ns_nodes
-            .get(namespace)
+            .get(&ns_id)
             .is_some_and(|members| members.contains(&node_id))
     }
 
@@ -750,8 +782,16 @@ impl CurrentIndexes {
     /// edge counterpart of [`node_in_namespace`](Self::node_in_namespace).
     #[inline]
     pub fn edge_in_namespace(&self, edge_id: EdgeId, namespace: &Namespace) -> bool {
+        self.edge_in_namespace_id(edge_id, intern_namespace(namespace))
+    }
+
+    /// Whether `edge_id` currently lives in the interned namespace `ns_id`
+    /// (Issue #3349, PR2). The edge counterpart of
+    /// [`node_in_namespace_id`](Self::node_in_namespace_id).
+    #[inline]
+    pub fn edge_in_namespace_id(&self, edge_id: EdgeId, ns_id: NamespaceId) -> bool {
         self.ns_edges
-            .get(namespace)
+            .get(&ns_id)
             .is_some_and(|members| members.contains(&edge_id))
     }
 
@@ -759,7 +799,7 @@ impl CurrentIndexes {
     #[inline]
     pub fn namespace_node_count(&self, namespace: &Namespace) -> usize {
         self.ns_nodes
-            .get(namespace)
+            .get(&intern_namespace(namespace))
             .map_or(0, |members| members.len())
     }
 
@@ -767,7 +807,7 @@ impl CurrentIndexes {
     #[inline]
     pub fn namespace_edge_count(&self, namespace: &Namespace) -> usize {
         self.ns_edges
-            .get(namespace)
+            .get(&intern_namespace(namespace))
             .map_or(0, |members| members.len())
     }
 
@@ -777,13 +817,17 @@ impl CurrentIndexes {
     pub fn populated_namespaces(&self) -> std::collections::BTreeSet<Namespace> {
         let mut out = std::collections::BTreeSet::new();
         for entry in self.ns_nodes.iter() {
-            if !entry.value().is_empty() {
-                out.insert(entry.key().clone());
+            if !entry.value().is_empty()
+                && let Some(ns) = resolve_namespace_id(*entry.key())
+            {
+                out.insert(ns);
             }
         }
         for entry in self.ns_edges.iter() {
-            if !entry.value().is_empty() {
-                out.insert(entry.key().clone());
+            if !entry.value().is_empty()
+                && let Some(ns) = resolve_namespace_id(*entry.key())
+            {
+                out.insert(ns);
             }
         }
         out

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -619,8 +619,21 @@ impl CurrentIndexes {
         self.nodes.remove(&id).map(|(_, node)| {
             self.node_headers.remove(&id);
             // Drop the node from its namespace membership set (Issue #3349).
-            if let Some(members) = self.ns_nodes.get(&node.namespace()) {
-                members.remove(&id);
+            let ns = node.namespace();
+            let now_empty = match self.ns_nodes.get(&ns) {
+                Some(members) => {
+                    members.remove(&id);
+                    members.is_empty()
+                }
+                None => false,
+            };
+            // Reclaim a fully-drained namespace set so the outer DashMap does not
+            // retain empty entries (Issue #3349 A6). The read guard above is
+            // dropped before `remove_if`, which re-checks emptiness under the
+            // shard write lock — so a concurrent insert racing the reclaim never
+            // removes a set that has just become non-empty.
+            if now_empty {
+                self.ns_nodes.remove_if(&ns, |_, set| set.is_empty());
             }
             node
         })
@@ -673,8 +686,19 @@ impl CurrentIndexes {
             self.outgoing.delete(id);
             self.incoming.delete(id);
             // Drop the edge from its namespace membership set (Issue #3349).
-            if let Some(members) = self.ns_edges.get(&edge.namespace()) {
-                members.remove(&id);
+            let ns = edge.namespace();
+            let now_empty = match self.ns_edges.get(&ns) {
+                Some(members) => {
+                    members.remove(&id);
+                    members.is_empty()
+                }
+                None => false,
+            };
+            // Reclaim a fully-drained namespace set (Issue #3349 A6); the read
+            // guard is dropped before `remove_if`, which re-checks under the shard
+            // write lock so a concurrent insert never loses its set.
+            if now_empty {
+                self.ns_edges.remove_if(&ns, |_, set| set.is_empty());
             }
             edge
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,8 +126,8 @@ pub use core::temporal::time;
 pub use core::{
     BiTemporalInterval, ChangeFeedPage, ChangeFeedQuery, ChangeFilter, ChangeRecord, ChangeType,
     ChangefeedBroadcaster, ChangefeedConfig, Edge, EdgeId, EntityId, EntityKind, GLOBAL_INTERNER,
-    InternedString, NAMESPACE_KEY, Namespace, NamespaceError, Node, NodeHeader, NodeId,
-    PropertyKey, PropertyMap, PropertyMapBuilder, PropertyValue, Provenance, RecvError,
+    InternedString, NAMESPACE_KEY, Namespace, NamespaceError, NamespaceScope, Node, NodeHeader,
+    NodeId, PropertyKey, PropertyMap, PropertyMapBuilder, PropertyValue, Provenance, RecvError,
     StringInterner, Subscription, TimeRange, Timestamp, VersionId,
 };
 
@@ -138,9 +138,9 @@ pub use core::error::{
 pub use db::{
     AletheiaDB, BackupSummary, ColdStorageDetails, ColdStorageTierStats, CurrentStateStats,
     DatabaseStats, EdgeTypeSchema, FactStatus, GraphSchema, HistoricalDepthStats, LabelExtent,
-    LabelSchema, LineageView, LineageViewEntry, NamespaceInfo, PitrCoord, PitrPlan, PitrTarget,
-    SchemaInstant, SimilarityQuery, SimilaritySource, TemporalExtent, TierAccessStats, TimeBounds,
-    UniqueConstraintBuilder, VectorIndexBuilder, WalStateStats,
+    LabelSchema, LineageView, LineageViewEntry, NamespaceCount, NamespaceInfo, PitrCoord, PitrPlan,
+    PitrTarget, SchemaInstant, SimilarityQuery, SimilaritySource, TemporalExtent, TierAccessStats,
+    TimeBounds, UniqueConstraintBuilder, VectorIndexBuilder, WalStateStats,
 };
 pub use index::{
     AdjacencyIndex, CurrentIndexes, TemporalIndexes,

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -177,6 +177,17 @@ impl QueryBuilder<state::Initial> {
     ///
     /// Uses the default "embedding" property and Cosine distance.
     /// For custom properties or metrics, use [`find_similar_builder()`](Self::find_similar_builder).
+    ///
+    /// **Namespace scope caveat (Issue #3349, PR2):** when combined with
+    /// [`in_namespace`](Self::in_namespace)/[`in_namespaces`](Self::in_namespaces),
+    /// the executor performs the index k-NN first and then **post-filters** the
+    /// `k` results to the scope, so a scoped vector search here may return
+    /// **fewer than `k`** in-scope rows. For a filter-complete k-NN that
+    /// over-fetches to guarantee `k` genuinely in-scope results, use
+    /// [`AletheiaDB::find_similar_scoped`](crate::AletheiaDB::find_similar_scoped)
+    /// /
+    /// [`find_similar_by_embedding_scoped`](crate::AletheiaDB::find_similar_by_embedding_scoped)
+    /// instead.
     #[must_use]
     pub fn find_similar(
         self,
@@ -851,8 +862,9 @@ impl<S: QueryState> QueryBuilder<S> {
     /// forbids. Because the builder cannot surface an error, the empty-list
     /// intent is preserved as an empty [`NamespaceScope::List`] and rejected with
     /// `INVALID_ARGUMENT` when the query is executed
-    /// (`execute_query`/`execute_query_profiled` call `validate_scope`). It must
-    /// never silently degrade to the unscoped (all-namespaces) path.
+    /// ([`execute`](Self::execute) → `AletheiaDB::execute_query` calls
+    /// `validate_scope`). It must never silently degrade to the unscoped
+    /// (all-namespaces) path.
     #[must_use]
     pub fn in_namespaces(mut self, namespaces: impl IntoIterator<Item = Namespace>) -> Self {
         let list: Vec<Namespace> = namespaces.into_iter().collect();

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -846,15 +846,21 @@ impl<S: QueryState> QueryBuilder<S> {
     /// Scope the query to the **union** of a non-empty list of namespaces
     /// (Issue #3349, PR2). See [`in_namespace`](Self::in_namespace).
     ///
-    /// An empty list is treated as "no scope" (namespace-agnostic), matching the
-    /// never-silently-empty contract: an empty union would otherwise match
-    /// nothing. Pass at least one namespace to actually scope.
+    /// An empty list is an **invalid** scope, not "no scope": an empty union
+    /// would silently match nothing, which the never-silently-wrong contract
+    /// forbids. Because the builder cannot surface an error, the empty-list
+    /// intent is preserved as an empty [`NamespaceScope::List`] and rejected with
+    /// `INVALID_ARGUMENT` when the query is executed
+    /// (`execute_query`/`execute_query_profiled` call `validate_scope`). It must
+    /// never silently degrade to the unscoped (all-namespaces) path.
     #[must_use]
     pub fn in_namespaces(mut self, namespaces: impl IntoIterator<Item = Namespace>) -> Self {
         let list: Vec<Namespace> = namespaces.into_iter().collect();
-        // An empty list is not a valid scope (it would silently match nothing),
-        // so `list()` errors and we leave the query unscoped.
-        self.scope = NamespaceScope::list(list).ok();
+        // Preserve the empty-list intent (do NOT collapse to `None`, which would
+        // mean "unscoped / all namespaces"). An empty `List` is a distinct,
+        // match-nothing scope that the execute path validates and rejects as
+        // INVALID_ARGUMENT (Issue #3349 A2).
+        self.scope = Some(NamespaceScope::List(list));
         self
     }
 

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -54,6 +54,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use crate::core::NodeId;
+use crate::core::namespace::{Namespace, NamespaceScope};
 use crate::core::temporal::{TimeRange, Timestamp};
 use crate::core::vector::DistanceMetric as VectorMetric;
 use crate::index::vector::DistanceMetric;
@@ -70,6 +71,12 @@ pub struct Query {
     pub(crate) temporal_context: Option<TemporalContext>,
     /// Query hints for optimization
     pub(crate) hints: QueryHints,
+    /// Namespace scope (Issue #3349, PR2). `None` reproduces prior,
+    /// namespace-agnostic behavior exactly. When set, the executor filters
+    /// produced entities — start nodes, traversal results, and ranked results —
+    /// to those whose (immutable) namespace ∈ scope, and traversal never crosses
+    /// an out-of-scope edge or bridges through an out-of-scope node.
+    pub(crate) scope: Option<NamespaceScope>,
 }
 
 impl Query {
@@ -137,6 +144,7 @@ pub struct QueryBuilder<S: QueryState> {
     ops: Vec<QueryOp>,
     temporal_context: Option<TemporalContext>,
     hints: QueryHints,
+    scope: Option<NamespaceScope>,
     _phantom: PhantomData<S>,
 }
 
@@ -148,6 +156,7 @@ impl QueryBuilder<state::Initial> {
             ops: Vec::new(),
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
             _phantom: PhantomData,
         }
     }
@@ -816,6 +825,48 @@ impl<S: QueryState> QueryBuilder<S> {
         let query = self.build();
         db.execute_query(query)
     }
+    /// Scope the query to a single namespace (Issue #3349, PR2).
+    ///
+    /// Results — start nodes, traversal results, and ranked results — are
+    /// filtered to entities whose (immutable) namespace equals `namespace`, and
+    /// traversal never crosses an out-of-scope edge or bridges through an
+    /// out-of-scope node. Omitting the scope reproduces prior behavior exactly.
+    ///
+    /// Note: for a filter-complete index-backed k-NN (`k` guaranteed in-scope
+    /// results even under a highly selective scope), prefer
+    /// [`AletheiaDB::find_similar_scoped`](crate::AletheiaDB::find_similar_scoped);
+    /// the builder applies scope as a post-filter, so an index-search start
+    /// (`find_similar`/`similar_to`) may yield fewer than `k` in-scope rows.
+    #[must_use]
+    pub fn in_namespace(mut self, namespace: Namespace) -> Self {
+        self.scope = Some(NamespaceScope::single(namespace));
+        self
+    }
+
+    /// Scope the query to the **union** of a non-empty list of namespaces
+    /// (Issue #3349, PR2). See [`in_namespace`](Self::in_namespace).
+    ///
+    /// An empty list is treated as "no scope" (namespace-agnostic), matching the
+    /// never-silently-empty contract: an empty union would otherwise match
+    /// nothing. Pass at least one namespace to actually scope.
+    #[must_use]
+    pub fn in_namespaces(mut self, namespaces: impl IntoIterator<Item = Namespace>) -> Self {
+        let list: Vec<Namespace> = namespaces.into_iter().collect();
+        // An empty list is not a valid scope (it would silently match nothing),
+        // so `list()` errors and we leave the query unscoped.
+        self.scope = NamespaceScope::list(list).ok();
+        self
+    }
+
+    /// Scope the query to every namespace (Issue #3349, PR2) — i.e. no namespace
+    /// filtering, the `all` selector. Useful to make cross-namespace intent
+    /// explicit at a call site.
+    #[must_use]
+    pub fn in_all_namespaces(mut self) -> Self {
+        self.scope = Some(NamespaceScope::all());
+        self
+    }
+
     /// Build the final query
     #[must_use]
     pub fn build(self) -> Query {
@@ -823,6 +874,7 @@ impl<S: QueryState> QueryBuilder<S> {
             ops: self.ops,
             temporal_context: self.temporal_context,
             hints: self.hints,
+            scope: self.scope,
         }
     }
 
@@ -833,6 +885,7 @@ impl<S: QueryState> QueryBuilder<S> {
             ops: self.ops,
             temporal_context: self.temporal_context,
             hints: self.hints,
+            scope: self.scope,
             _phantom: PhantomData,
         }
     }

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -759,6 +759,9 @@ impl AstConverter {
                 ops,
                 temporal_context,
                 hints,
+                // AQL/Cypher namespace scoping is a follow-up (PR2b); the
+                // converter never scopes today (Issue #3349).
+                scope: None,
             });
         }
 
@@ -773,6 +776,9 @@ impl AstConverter {
                 ops,
                 temporal_context,
                 hints,
+                // AQL/Cypher namespace scoping is a follow-up (PR2b); the
+                // converter never scopes today (Issue #3349).
+                scope: None,
             });
         }
 
@@ -818,6 +824,8 @@ impl AstConverter {
             ops,
             temporal_context,
             hints,
+            // AQL/Cypher namespace scoping is a follow-up (PR2b).
+            scope: None,
         })
     }
 

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -14,7 +14,7 @@ use tracing;
 use crate::core::error::Result;
 use crate::core::graph::Node;
 use crate::core::interning::GLOBAL_INTERNER;
-use crate::core::namespace::{NamespaceId, NamespaceScope};
+use crate::core::namespace::{NamespaceScope, ResolvedScope};
 use crate::core::property::{PropertyMap, PropertyValue};
 use crate::core::provenance::Provenance;
 use crate::core::vector::DistanceMetric as VectorMetric;
@@ -1510,11 +1510,12 @@ pub struct TraversalIterator {
     /// namespace ∉ scope — so an out-of-scope node is never reached, emitted, or
     /// used as a bridge. `None` ⇒ prior namespace-agnostic behavior.
     scope: Option<Arc<NamespaceScope>>,
-    /// The attached scope resolved to interned ids once (Issue #3349, PR2), so
-    /// the current-state boundary check is a per-edge integer-hash membership
-    /// probe rather than a per-edge string hash. `None` when no restricting scope
-    /// is attached or the scope is `All`.
-    resolved_scope: Option<Vec<NamespaceId>>,
+    /// The attached scope resolved to interned ids **once** at execute start and
+    /// threaded in (Issue #3349, PR2), so the current-state boundary check is a
+    /// per-edge integer-hash membership probe (a single integer compare for a
+    /// single-namespace scope) rather than a per-edge string hash.
+    /// [`ResolvedScope::All`] (or no attached scope) is a no-op boundary.
+    resolved_scope: ResolvedScope,
     // BFS state - reset for each input node (see doc comment above)
     frontier: VecDeque<(NodeId, Vec<EntityId>, usize)>,
     visited: HashSet<NodeId>,
@@ -1550,7 +1551,7 @@ impl TraversalIterator {
             temporal_context,
             bind_edge: false,
             scope: None,
-            resolved_scope: None,
+            resolved_scope: ResolvedScope::All,
             frontier: VecDeque::new(),
             visited: HashSet::new(),
             input_exhausted: false,
@@ -1562,10 +1563,16 @@ impl TraversalIterator {
     /// target node whose namespace ∉ scope is never enqueued (so it is neither
     /// emitted nor used to bridge deeper). [`NamespaceScope::All`] is a no-op.
     #[must_use]
-    pub fn with_namespace_scope(mut self, scope: Arc<NamespaceScope>) -> Self {
-        // Pre-resolve to interned ids once so the current-state boundary check
-        // (Issue #3349, PR2) avoids per-edge string hashing.
-        self.resolved_scope = scope.resolved_ids();
+    pub fn with_namespace_scope(
+        mut self,
+        scope: Arc<NamespaceScope>,
+        resolved: ResolvedScope,
+    ) -> Self {
+        // The scope was already resolved to interned ids once at execute start
+        // (Issue #3349, PR2 hoist); we only store the pre-resolved handle here so
+        // the current-state boundary check avoids per-edge string hashing (and,
+        // for a single-namespace scope, is a single integer compare).
+        self.resolved_scope = resolved;
         self.scope = Some(scope);
         self
     }
@@ -1587,9 +1594,8 @@ impl TraversalIterator {
         // reconstruction. Two interned-id hash probes per edge (the scope was
         // resolved to ids once in `with_namespace_scope`).
         if self.temporal_context.is_none() {
-            let resolved = self.resolved_scope.as_deref();
-            return scope_contains_current_edge(&self.current, edge_id, resolved)
-                && scope_contains_current_node(&self.current, target, resolved);
+            return scope_contains_current_edge(&self.current, edge_id, &self.resolved_scope)
+                && scope_contains_current_node(&self.current, target, &self.resolved_scope);
         }
         // Temporal traversal: reconstruct the edge and target AS-OF the
         // coordinate so a since-deleted-but-then-valid edge is judged by its
@@ -1924,19 +1930,16 @@ impl ResultIterator for TraversalIterator {
 
 /// Whether the current edge `edge_id` is inside the **pre-resolved** scope
 /// `resolved` (Issue #3349, PR2), via O(1) interned-id membership probes.
-/// `None` = `All` (matches everything). Resolving the scope to ids once (per
-/// iterator / per traversal) and reusing them avoids per-edge string hashing.
+/// [`ResolvedScope::All`] matches everything. The scope is resolved to ids once
+/// at execute start (per query) and threaded down, so this per-edge check does
+/// no string hashing — and, for a single-namespace scope, is a single integer
+/// compare with no set scan.
 fn scope_contains_current_edge(
     current: &CurrentStorage,
     edge_id: EdgeId,
-    resolved: Option<&[NamespaceId]>,
+    resolved: &ResolvedScope,
 ) -> bool {
-    match resolved {
-        None => true,
-        Some(ids) => ids
-            .iter()
-            .any(|id| current.edge_in_namespace_id(edge_id, *id)),
-    }
+    resolved.contains_by(|id| current.edge_in_namespace_id(edge_id, id))
 }
 
 /// Whether the current node `node_id` is inside the pre-resolved scope
@@ -1944,25 +1947,21 @@ fn scope_contains_current_edge(
 fn scope_contains_current_node(
     current: &CurrentStorage,
     node_id: NodeId,
-    resolved: Option<&[NamespaceId]>,
+    resolved: &ResolvedScope,
 ) -> bool {
-    match resolved {
-        None => true,
-        Some(ids) => ids
-            .iter()
-            .any(|id| current.node_in_namespace_id(node_id, *id)),
-    }
+    resolved.contains_by(|id| current.node_in_namespace_id(node_id, id))
 }
 
 /// Namespace-scope entity filter (Issue #3349, PR2).
 ///
 /// Drops rows whose primary entity's (immutable) namespace ∉ scope, so a scoped
 /// [`QueryBuilder`](crate::query::QueryBuilder) query returns only in-scope
-/// entities. It is applied at the very end of the pipeline, over start nodes,
-/// traversal results, and ranked results alike. The traversal *boundary* (never
-/// bridging through an out-of-scope node) is enforced upstream in
-/// [`TraversalIterator`], so this filter only has to reject out-of-scope
-/// terminal entities.
+/// entities. It wraps the **source leaves** that produce entities (scans, id
+/// lookups, property/vector sources), so every downstream operator — LIMIT/SKIP,
+/// ORDER BY, DISTINCT, aggregation, COUNT — already sees only in-scope rows. The
+/// traversal *boundary* (never bridging through an out-of-scope node) is enforced
+/// separately in [`TraversalIterator`], so this filter only has to reject
+/// out-of-scope terminal entities.
 ///
 /// Rows that carry no single scoped entity — a null binding, or an aggregation /
 /// multi-variable computed row — pass through unchanged (namespace scoping of
@@ -1973,21 +1972,24 @@ pub struct ScopeFilterIterator {
     input: Box<dyn ResultIterator>,
     scope: Arc<NamespaceScope>,
     current: Arc<CurrentStorage>,
-    /// The scope resolved to interned ids once at construction (Issue #3349, PR2)
-    /// so the id-only branches probe by integer id without per-row string
-    /// hashing. `None` = `All` (no filter).
-    resolved: Option<Vec<NamespaceId>>,
+    /// The scope resolved to interned ids **once** at execute start and threaded
+    /// in (Issue #3349, PR2 hoist), so the id-only branches probe by integer id
+    /// without per-row string hashing — a single integer compare for a
+    /// single-namespace scope. [`ResolvedScope::All`] is a no-op filter.
+    resolved: ResolvedScope,
 }
 
 impl ScopeFilterIterator {
-    /// Wrap `input`, keeping only rows whose entity is in `scope`.
+    /// Wrap `input`, keeping only rows whose entity is in `scope`. `resolved` is
+    /// the scope pre-resolved to interned ids once at execute start (Issue #3349,
+    /// PR2 hoist) and shared into every source-leaf filter.
     #[must_use]
     pub fn new(
         input: Box<dyn ResultIterator>,
         scope: Arc<NamespaceScope>,
+        resolved: ResolvedScope,
         current: Arc<CurrentStorage>,
     ) -> Self {
-        let resolved = scope.resolved_ids();
         ScopeFilterIterator {
             input,
             scope,
@@ -2017,10 +2019,10 @@ impl ScopeFilterIterator {
             EntityResult::Node(node) => self.scope.contains(&node.namespace()),
             EntityResult::Edge(edge) => self.scope.contains(&edge.namespace()),
             EntityResult::NodeId(id) => {
-                scope_contains_current_node(&self.current, *id, self.resolved.as_deref())
+                scope_contains_current_node(&self.current, *id, &self.resolved)
             }
             EntityResult::EdgeId(id) => {
-                scope_contains_current_edge(&self.current, *id, self.resolved.as_deref())
+                scope_contains_current_edge(&self.current, *id, &self.resolved)
             }
             // A null binding or a computed (aggregate / multi-variable) row has
             // no single scoped entity — pass it through unchanged.
@@ -2769,6 +2771,18 @@ pub struct OptionalApplyIterator {
     steps: Vec<crate::query::planner::physical::OptionalPhysicalStep>,
     current: Arc<CurrentStorage>,
     historical: Arc<RwLock<HistoricalStorage>>,
+    /// Optional namespace scope (Issue #3349, PR2). Threaded from the executor so
+    /// the sub-pipeline built per seed row (its `Scan` source leaf and every
+    /// `Traverse` hop) honors the same scope boundary as the outer plan — else a
+    /// scoped `OPTIONAL MATCH` would leak cross-namespace bindings. `None` ⇒ prior
+    /// namespace-agnostic behavior. Unreachable until PR3 wires Cypher/AQL scope
+    /// to `OPTIONAL MATCH`, but wired here (defense in depth) so it can never be
+    /// silently wrong.
+    scope: Option<Arc<NamespaceScope>>,
+    /// The attached `scope` resolved to interned ids once (Issue #3349, PR2), so
+    /// the sub-pipeline's per-edge/per-row checks avoid re-resolving. `All` when
+    /// no restricting scope is attached.
+    resolved_scope: ResolvedScope,
     /// True when the first step is a Scan (leading OPTIONAL MATCH form).
     standalone: bool,
     /// The sub-pipeline currently being drained (one per seed row).
@@ -2791,6 +2805,24 @@ impl OptionalApplyIterator {
         current: Arc<CurrentStorage>,
         historical: Arc<RwLock<HistoricalStorage>>,
     ) -> Self {
+        Self::with_namespace_scope(input, steps, current, historical, None, ResolvedScope::All)
+    }
+
+    /// Create an OptionalApplyIterator whose sub-pipeline honors a namespace
+    /// scope (Issue #3349, PR2). `scope` is the outer plan's scope and `resolved`
+    /// its once-resolved interned-id form; both are threaded into the per-seed
+    /// sub-pipeline so its source leaf and traversal hops are scope-bounded. A
+    /// `None` / [`ResolvedScope::All`] scope reproduces the namespace-agnostic
+    /// behavior of [`new`](Self::new).
+    #[must_use]
+    pub fn with_namespace_scope(
+        input: Box<dyn ResultIterator>,
+        steps: Vec<crate::query::planner::physical::OptionalPhysicalStep>,
+        current: Arc<CurrentStorage>,
+        historical: Arc<RwLock<HistoricalStorage>>,
+        scope: Option<Arc<NamespaceScope>>,
+        resolved: ResolvedScope,
+    ) -> Self {
         use crate::query::planner::physical::OptionalPhysicalStep;
         let standalone = matches!(steps.first(), Some(OptionalPhysicalStep::Scan { .. }));
         Self {
@@ -2798,12 +2830,21 @@ impl OptionalApplyIterator {
             steps,
             current,
             historical,
+            scope,
+            resolved_scope: resolved,
             standalone,
             inner: None,
             inner_matched: false,
             done: false,
             current_seed: None,
         }
+    }
+
+    /// The attached scope only if it actually restricts (present and not `All`).
+    fn restricting_scope(&self) -> Option<&Arc<NamespaceScope>> {
+        self.scope
+            .as_ref()
+            .filter(|s| !matches!(s.as_ref(), NamespaceScope::All))
     }
 
     /// Build the optional sub-pipeline for one seed row (or, for the
@@ -2819,11 +2860,22 @@ impl OptionalApplyIterator {
         for step in &self.steps {
             iter = match step {
                 OptionalPhysicalStep::Scan { label } => {
-                    // Source step (standalone form): replaces the seed input.
-                    Box::new(NodeScanIterator::new(
+                    // Source step (standalone form): replaces the seed input. When
+                    // scoped (Issue #3349, PR2), wrap it in the source-leaf
+                    // namespace filter exactly as the main pipeline does.
+                    let mut scan: Box<dyn ResultIterator> = Box::new(NodeScanIterator::new(
                         label.clone(),
                         Arc::clone(&self.current),
-                    ))
+                    ));
+                    if let Some(scope) = self.restricting_scope() {
+                        scan = Box::new(ScopeFilterIterator::new(
+                            scan,
+                            Arc::clone(scope),
+                            self.resolved_scope.clone(),
+                            Arc::clone(&self.current),
+                        ));
+                    }
+                    scan
                 }
                 OptionalPhysicalStep::Traverse {
                     direction,
@@ -2831,16 +2883,25 @@ impl OptionalApplyIterator {
                     min_depth,
                     depth,
                     temporal_context,
-                } => Box::new(TraversalIterator::new(
-                    iter,
-                    *direction,
-                    label.clone(),
-                    *min_depth,
-                    *depth,
-                    Arc::clone(&self.current),
-                    Arc::clone(&self.historical),
-                    *temporal_context,
-                )),
+                } => {
+                    let mut traversal = TraversalIterator::new(
+                        iter,
+                        *direction,
+                        label.clone(),
+                        *min_depth,
+                        *depth,
+                        Arc::clone(&self.current),
+                        Arc::clone(&self.historical),
+                        *temporal_context,
+                    );
+                    // Namespace boundary (Issue #3349, PR2): a scoped optional
+                    // traversal never crosses an out-of-scope edge/node.
+                    if let Some(scope) = self.restricting_scope() {
+                        traversal = traversal
+                            .with_namespace_scope(Arc::clone(scope), self.resolved_scope.clone());
+                    }
+                    Box::new(traversal)
+                }
                 OptionalPhysicalStep::Filter(predicate) => {
                     Box::new(FilterIterator::with_historical(
                         iter,

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -1976,20 +1976,31 @@ impl ScopeFilterIterator {
     }
 
     /// Whether `row`'s entity is visible under the scope.
+    ///
+    /// Full `Node`/`Edge` rows carry their own (immutable) namespace, read
+    /// directly — this is temporally correct because every mainline source
+    /// (current *and* point-in-time: `TemporalNode*`/`VectorResult` iterators)
+    /// emits a fully reconstructed entity, and a reconstructed entity carries
+    /// exactly the namespace it held at that coordinate.
+    ///
+    /// The id-only (`NodeId`/`EdgeId`) branches resolve membership via the O(1)
+    /// current-state membership index (no whole-entity clone; Issue #3349 B2).
+    /// This is a **current-state** probe: it would wrongly drop a since-deleted
+    /// id-only row under an `AS OF` read. That is safe because no mainline source
+    /// emits an id-only row in a temporal context — every temporal source emits a
+    /// full reconstructed `Node`/`Edge`, which is handled by the branches above
+    /// (Issue #3349 A5). If a future id-only temporal source is added, resolve it
+    /// via the historical path here instead.
     fn row_in_scope(&self, row: &QueryRow) -> bool {
         match &row.entity {
             EntityResult::Node(node) => self.scope.contains(&node.namespace()),
             EntityResult::Edge(edge) => self.scope.contains(&edge.namespace()),
-            EntityResult::NodeId(id) => self
-                .current
-                .get_node(*id)
-                .map(|n| self.scope.contains(&n.namespace()))
-                .unwrap_or(false),
-            EntityResult::EdgeId(id) => self
-                .current
-                .get_edge(*id)
-                .map(|e| self.scope.contains(&e.namespace()))
-                .unwrap_or(false),
+            EntityResult::NodeId(id) => {
+                scope_contains_current_node(&self.current, *id, &self.scope)
+            }
+            EntityResult::EdgeId(id) => {
+                scope_contains_current_edge(&self.current, *id, &self.scope)
+            }
             // A null binding or a computed (aggregate / multi-variable) row has
             // no single scoped entity — pass it through unchanged.
             EntityResult::Null => true,

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -14,7 +14,7 @@ use tracing;
 use crate::core::error::Result;
 use crate::core::graph::Node;
 use crate::core::interning::GLOBAL_INTERNER;
-use crate::core::namespace::NamespaceScope;
+use crate::core::namespace::{NamespaceId, NamespaceScope};
 use crate::core::property::{PropertyMap, PropertyValue};
 use crate::core::provenance::Provenance;
 use crate::core::vector::DistanceMetric as VectorMetric;
@@ -1510,6 +1510,11 @@ pub struct TraversalIterator {
     /// namespace ∉ scope — so an out-of-scope node is never reached, emitted, or
     /// used as a bridge. `None` ⇒ prior namespace-agnostic behavior.
     scope: Option<Arc<NamespaceScope>>,
+    /// The attached scope resolved to interned ids once (Issue #3349, PR2), so
+    /// the current-state boundary check is a per-edge integer-hash membership
+    /// probe rather than a per-edge string hash. `None` when no restricting scope
+    /// is attached or the scope is `All`.
+    resolved_scope: Option<Vec<NamespaceId>>,
     // BFS state - reset for each input node (see doc comment above)
     frontier: VecDeque<(NodeId, Vec<EntityId>, usize)>,
     visited: HashSet<NodeId>,
@@ -1545,6 +1550,7 @@ impl TraversalIterator {
             temporal_context,
             bind_edge: false,
             scope: None,
+            resolved_scope: None,
             frontier: VecDeque::new(),
             visited: HashSet::new(),
             input_exhausted: false,
@@ -1557,6 +1563,9 @@ impl TraversalIterator {
     /// emitted nor used to bridge deeper). [`NamespaceScope::All`] is a no-op.
     #[must_use]
     pub fn with_namespace_scope(mut self, scope: Arc<NamespaceScope>) -> Self {
+        // Pre-resolve to interned ids once so the current-state boundary check
+        // (Issue #3349, PR2) avoids per-edge string hashing.
+        self.resolved_scope = scope.resolved_ids();
         self.scope = Some(scope);
         self
     }
@@ -1575,10 +1584,12 @@ impl TraversalIterator {
         }
         // Fast path (current-state traversal): namespace is immutable, so the
         // O(1) membership index is authoritative — no full edge/node
-        // reconstruction. Two hash probes per edge.
+        // reconstruction. Two interned-id hash probes per edge (the scope was
+        // resolved to ids once in `with_namespace_scope`).
         if self.temporal_context.is_none() {
-            return scope_contains_current_edge(&self.current, edge_id, scope)
-                && scope_contains_current_node(&self.current, target, scope);
+            let resolved = self.resolved_scope.as_deref();
+            return scope_contains_current_edge(&self.current, edge_id, resolved)
+                && scope_contains_current_node(&self.current, target, resolved);
         }
         // Temporal traversal: reconstruct the edge and target AS-OF the
         // coordinate so a since-deleted-but-then-valid edge is judged by its
@@ -1911,31 +1922,35 @@ impl ResultIterator for TraversalIterator {
     }
 }
 
-/// Whether the current edge `edge_id` is inside `scope`, via O(1) membership
-/// probes (Issue #3349, PR2). [`NamespaceScope::All`] matches everything.
+/// Whether the current edge `edge_id` is inside the **pre-resolved** scope
+/// `resolved` (Issue #3349, PR2), via O(1) interned-id membership probes.
+/// `None` = `All` (matches everything). Resolving the scope to ids once (per
+/// iterator / per traversal) and reusing them avoids per-edge string hashing.
 fn scope_contains_current_edge(
     current: &CurrentStorage,
     edge_id: EdgeId,
-    scope: &NamespaceScope,
+    resolved: Option<&[NamespaceId]>,
 ) -> bool {
-    match scope {
-        NamespaceScope::All => true,
-        NamespaceScope::Single(ns) => current.edge_in_namespace(edge_id, ns),
-        NamespaceScope::List(list) => list.iter().any(|ns| current.edge_in_namespace(edge_id, ns)),
+    match resolved {
+        None => true,
+        Some(ids) => ids
+            .iter()
+            .any(|id| current.edge_in_namespace_id(edge_id, *id)),
     }
 }
 
-/// Whether the current node `node_id` is inside `scope`, via O(1) membership
-/// probes (Issue #3349, PR2). See [`scope_contains_current_edge`].
+/// Whether the current node `node_id` is inside the pre-resolved scope
+/// `resolved` (Issue #3349, PR2). See [`scope_contains_current_edge`].
 fn scope_contains_current_node(
     current: &CurrentStorage,
     node_id: NodeId,
-    scope: &NamespaceScope,
+    resolved: Option<&[NamespaceId]>,
 ) -> bool {
-    match scope {
-        NamespaceScope::All => true,
-        NamespaceScope::Single(ns) => current.node_in_namespace(node_id, ns),
-        NamespaceScope::List(list) => list.iter().any(|ns| current.node_in_namespace(node_id, ns)),
+    match resolved {
+        None => true,
+        Some(ids) => ids
+            .iter()
+            .any(|id| current.node_in_namespace_id(node_id, *id)),
     }
 }
 
@@ -1958,6 +1973,10 @@ pub struct ScopeFilterIterator {
     input: Box<dyn ResultIterator>,
     scope: Arc<NamespaceScope>,
     current: Arc<CurrentStorage>,
+    /// The scope resolved to interned ids once at construction (Issue #3349, PR2)
+    /// so the id-only branches probe by integer id without per-row string
+    /// hashing. `None` = `All` (no filter).
+    resolved: Option<Vec<NamespaceId>>,
 }
 
 impl ScopeFilterIterator {
@@ -1968,10 +1987,12 @@ impl ScopeFilterIterator {
         scope: Arc<NamespaceScope>,
         current: Arc<CurrentStorage>,
     ) -> Self {
+        let resolved = scope.resolved_ids();
         ScopeFilterIterator {
             input,
             scope,
             current,
+            resolved,
         }
     }
 
@@ -1996,10 +2017,10 @@ impl ScopeFilterIterator {
             EntityResult::Node(node) => self.scope.contains(&node.namespace()),
             EntityResult::Edge(edge) => self.scope.contains(&edge.namespace()),
             EntityResult::NodeId(id) => {
-                scope_contains_current_node(&self.current, *id, &self.scope)
+                scope_contains_current_node(&self.current, *id, self.resolved.as_deref())
             }
             EntityResult::EdgeId(id) => {
-                scope_contains_current_edge(&self.current, *id, &self.scope)
+                scope_contains_current_edge(&self.current, *id, self.resolved.as_deref())
             }
             // A null binding or a computed (aggregate / multi-variable) row has
             // no single scoped entity — pass it through unchanged.

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -14,6 +14,7 @@ use tracing;
 use crate::core::error::Result;
 use crate::core::graph::Node;
 use crate::core::interning::GLOBAL_INTERNER;
+use crate::core::namespace::NamespaceScope;
 use crate::core::property::{PropertyMap, PropertyValue};
 use crate::core::provenance::Provenance;
 use crate::core::vector::DistanceMetric as VectorMetric;
@@ -1504,6 +1505,11 @@ pub struct TraversalIterator {
     /// an edge variable (a `Predicate::EdgeScoped` / `SortKey::EdgeProperty`),
     /// so the overwhelming common case pays zero extra edge fetches.
     bind_edge: bool,
+    /// Optional namespace scope (Issue #3349, PR2). When set, the traversal never
+    /// crosses an edge whose namespace ∉ scope, nor enqueues a target node whose
+    /// namespace ∉ scope — so an out-of-scope node is never reached, emitted, or
+    /// used as a bridge. `None` ⇒ prior namespace-agnostic behavior.
+    scope: Option<Arc<NamespaceScope>>,
     // BFS state - reset for each input node (see doc comment above)
     frontier: VecDeque<(NodeId, Vec<EntityId>, usize)>,
     visited: HashSet<NodeId>,
@@ -1538,10 +1544,50 @@ impl TraversalIterator {
             historical,
             temporal_context,
             bind_edge: false,
+            scope: None,
             frontier: VecDeque::new(),
             visited: HashSet::new(),
             input_exhausted: false,
         }
+    }
+
+    /// Attach a namespace scope (Issue #3349, PR2) so the traversal honors the
+    /// scope boundary: an edge whose namespace ∉ scope is never crossed, and a
+    /// target node whose namespace ∉ scope is never enqueued (so it is neither
+    /// emitted nor used to bridge deeper). [`NamespaceScope::All`] is a no-op.
+    #[must_use]
+    pub fn with_namespace_scope(mut self, scope: Arc<NamespaceScope>) -> Self {
+        self.scope = Some(scope);
+        self
+    }
+
+    /// Whether crossing to `target` over `edge_id` is permitted by the namespace
+    /// scope boundary (Issue #3349, PR2). Returns `true` when no restricting
+    /// scope is attached (fetching nothing). When a scope is attached, the edge
+    /// and target are reconstructed at the query coordinate and both their
+    /// (immutable) namespaces must be in scope.
+    fn boundary_allows(&self, edge_id: EdgeId, target: NodeId) -> bool {
+        let Some(scope) = &self.scope else {
+            return true;
+        };
+        if matches!(scope.as_ref(), NamespaceScope::All) {
+            return true;
+        }
+        // Fast path (current-state traversal): namespace is immutable, so the
+        // O(1) membership index is authoritative — no full edge/node
+        // reconstruction. Two hash probes per edge.
+        if self.temporal_context.is_none() {
+            return scope_contains_current_edge(&self.current, edge_id, scope)
+                && scope_contains_current_node(&self.current, target, scope);
+        }
+        // Temporal traversal: reconstruct the edge and target AS-OF the
+        // coordinate so a since-deleted-but-then-valid edge is judged by its
+        // historical state (the membership index only reflects current state).
+        match self.reconstruct_bound_edge(edge_id) {
+            Ok(edge) if scope.contains(&edge.namespace()) => {}
+            _ => return false,
+        }
+        matches!(self.fetch_target_node(target), Ok(Some(node)) if scope.contains(&node.namespace()))
     }
 
     /// Enable attaching the immediately-traversed edge (reconstructed at the
@@ -1761,6 +1807,15 @@ impl ResultIterator for TraversalIterator {
                 if current_depth < self.depth {
                     let neighbors = self.get_neighbors(node_id);
                     for (target, edge_id) in neighbors {
+                        // Namespace scope boundary (Issue #3349, PR2): skip this
+                        // edge entirely when the edge's or the target's namespace
+                        // is out of scope, so an out-of-scope node is never
+                        // enqueued (never emitted, never a bridge). Skipping
+                        // *before* `visited.insert` means the same target can
+                        // still be reached over a different, in-scope edge.
+                        if !self.boundary_allows(edge_id, target) {
+                            continue;
+                        }
                         // Node-distinct / shortest-path reachability: a node is
                         // enqueued (and thus later emitted) once, at its shortest
                         // BFS depth. This also makes cyclic graphs terminate. It
@@ -1851,6 +1906,108 @@ impl ResultIterator for TraversalIterator {
                         return None;
                     }
                 }
+            }
+        }
+    }
+}
+
+/// Whether the current edge `edge_id` is inside `scope`, via O(1) membership
+/// probes (Issue #3349, PR2). [`NamespaceScope::All`] matches everything.
+fn scope_contains_current_edge(
+    current: &CurrentStorage,
+    edge_id: EdgeId,
+    scope: &NamespaceScope,
+) -> bool {
+    match scope {
+        NamespaceScope::All => true,
+        NamespaceScope::Single(ns) => current.edge_in_namespace(edge_id, ns),
+        NamespaceScope::List(list) => list.iter().any(|ns| current.edge_in_namespace(edge_id, ns)),
+    }
+}
+
+/// Whether the current node `node_id` is inside `scope`, via O(1) membership
+/// probes (Issue #3349, PR2). See [`scope_contains_current_edge`].
+fn scope_contains_current_node(
+    current: &CurrentStorage,
+    node_id: NodeId,
+    scope: &NamespaceScope,
+) -> bool {
+    match scope {
+        NamespaceScope::All => true,
+        NamespaceScope::Single(ns) => current.node_in_namespace(node_id, ns),
+        NamespaceScope::List(list) => list.iter().any(|ns| current.node_in_namespace(node_id, ns)),
+    }
+}
+
+/// Namespace-scope entity filter (Issue #3349, PR2).
+///
+/// Drops rows whose primary entity's (immutable) namespace ∉ scope, so a scoped
+/// [`QueryBuilder`](crate::query::QueryBuilder) query returns only in-scope
+/// entities. It is applied at the very end of the pipeline, over start nodes,
+/// traversal results, and ranked results alike. The traversal *boundary* (never
+/// bridging through an out-of-scope node) is enforced upstream in
+/// [`TraversalIterator`], so this filter only has to reject out-of-scope
+/// terminal entities.
+///
+/// Rows that carry no single scoped entity — a null binding, or an aggregation /
+/// multi-variable computed row — pass through unchanged (namespace scoping of
+/// aggregates is out of PR2 scope). An id-only entity is resolved against
+/// current storage to read its namespace; if it can no longer be loaded it is
+/// dropped (indistinguishable, to a scoped caller, from out-of-scope).
+pub struct ScopeFilterIterator {
+    input: Box<dyn ResultIterator>,
+    scope: Arc<NamespaceScope>,
+    current: Arc<CurrentStorage>,
+}
+
+impl ScopeFilterIterator {
+    /// Wrap `input`, keeping only rows whose entity is in `scope`.
+    #[must_use]
+    pub fn new(
+        input: Box<dyn ResultIterator>,
+        scope: Arc<NamespaceScope>,
+        current: Arc<CurrentStorage>,
+    ) -> Self {
+        ScopeFilterIterator {
+            input,
+            scope,
+            current,
+        }
+    }
+
+    /// Whether `row`'s entity is visible under the scope.
+    fn row_in_scope(&self, row: &QueryRow) -> bool {
+        match &row.entity {
+            EntityResult::Node(node) => self.scope.contains(&node.namespace()),
+            EntityResult::Edge(edge) => self.scope.contains(&edge.namespace()),
+            EntityResult::NodeId(id) => self
+                .current
+                .get_node(*id)
+                .map(|n| self.scope.contains(&n.namespace()))
+                .unwrap_or(false),
+            EntityResult::EdgeId(id) => self
+                .current
+                .get_edge(*id)
+                .map(|e| self.scope.contains(&e.namespace()))
+                .unwrap_or(false),
+            // A null binding or a computed (aggregate / multi-variable) row has
+            // no single scoped entity — pass it through unchanged.
+            EntityResult::Null => true,
+        }
+    }
+}
+
+impl ResultIterator for ScopeFilterIterator {
+    fn next(&mut self) -> Option<Result<QueryRow>> {
+        loop {
+            match self.input.next()? {
+                Ok(row) => {
+                    if self.row_in_scope(&row) {
+                        return Some(Ok(row));
+                    }
+                    // otherwise skip and pull the next row
+                }
+                Err(e) => return Some(Err(e)),
             }
         }
     }

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -12,6 +12,7 @@ use parking_lot::RwLock;
 use std::sync::Arc;
 
 use crate::core::error::Result;
+use crate::core::namespace::NamespaceScope;
 use crate::storage::current::CurrentStorage;
 use crate::storage::historical::HistoricalStorage;
 
@@ -123,6 +124,11 @@ pub struct QueryExecutor {
     historical: Arc<RwLock<HistoricalStorage>>,
     /// Execution configuration (used for timeout/parallelism in future)
     _config: ExecutionConfig,
+    /// Optional namespace scope (Issue #3349, PR2). When set, the executor
+    /// filters produced entities to those whose namespace ∈ scope and threads
+    /// the boundary into graph traversal. `Arc` so it can be cheaply shared into
+    /// the traversal iterator. `None` ⇒ prior namespace-agnostic behavior.
+    scope: Option<Arc<NamespaceScope>>,
 }
 
 impl QueryExecutor {
@@ -132,6 +138,7 @@ impl QueryExecutor {
             current,
             historical,
             _config: ExecutionConfig::default(),
+            scope: None,
         }
     }
 
@@ -145,7 +152,24 @@ impl QueryExecutor {
             current,
             historical,
             _config: config,
+            scope: None,
         }
+    }
+
+    /// Attach a namespace scope (Issue #3349, PR2). Produced entities are
+    /// filtered to those in scope and graph traversal honors the scope boundary
+    /// (an out-of-scope edge or node is never crossed). [`NamespaceScope::All`]
+    /// is a no-op filter. See [`QueryBuilder::in_namespace`](crate::query::QueryBuilder::in_namespace).
+    #[must_use]
+    pub fn with_namespace_scope(mut self, scope: NamespaceScope) -> Self {
+        self.scope = Some(Arc::new(scope));
+        self
+    }
+
+    /// Whether the attached scope actually restricts results (i.e. is present and
+    /// not [`NamespaceScope::All`]).
+    fn scope_is_restricting(&self) -> bool {
+        matches!(&self.scope, Some(s) if !matches!(s.as_ref(), NamespaceScope::All))
     }
 
     /// Execute a physical plan and return results.
@@ -199,12 +223,32 @@ impl QueryExecutor {
             let bind_edge = plan_needs_edge_binding(&plan.root);
             self.build_op(&plan.root, &mut None, 0, bind_edge)?
         };
+        let iterator = self.wrap_scope_filter(iterator);
         // Wrap with provenance filter to conditionally strip metadata
         let filtered = Box::new(iterators::ProvenanceFilterIterator::new(
             iterator,
             plan.include_provenance,
         ));
         Ok(QueryResults::new(filtered))
+    }
+
+    /// Wrap `iterator` in a namespace-scope entity filter (Issue #3349, PR2) when
+    /// a restricting scope is attached; otherwise return it unchanged so the
+    /// namespace-agnostic path pays nothing. This drops produced nodes/edges
+    /// whose namespace ∉ scope — the traversal boundary itself is enforced deeper
+    /// (in `TraversalIterator`) so an out-of-scope bridge node is never even
+    /// reached.
+    fn wrap_scope_filter(&self, iterator: Box<dyn ResultIterator>) -> Box<dyn ResultIterator> {
+        match &self.scope {
+            Some(scope) if self.scope_is_restricting() => {
+                Box::new(iterators::ScopeFilterIterator::new(
+                    iterator,
+                    Arc::clone(scope),
+                    Arc::clone(&self.current),
+                ))
+            }
+            _ => iterator,
+        }
     }
 
     /// Execute a physical plan with per-operator profiling instrumentation
@@ -227,6 +271,7 @@ impl QueryExecutor {
             let bind_edge = plan_needs_edge_binding(&plan.root);
             self.build_op(&plan.root, &mut registry, 0, bind_edge)?
         };
+        let iterator = self.wrap_scope_filter(iterator);
         let filtered = Box::new(iterators::ProvenanceFilterIterator::new(
             iterator,
             plan.include_provenance,
@@ -443,19 +488,26 @@ impl QueryExecutor {
                     temporal_context,
                 } => {
                     let input_iter = self.build_op(input, profile, child_depth, bind_edge)?;
-                    Box::new(
-                        iterators::TraversalIterator::new(
-                            input_iter,
-                            *direction,
-                            label.clone(),
-                            *min_depth,
-                            *traversal_depth,
-                            Arc::clone(&self.current),
-                            Arc::clone(&self.historical),
-                            *temporal_context,
-                        )
-                        .bind_edges(bind_edge),
+                    let mut traversal = iterators::TraversalIterator::new(
+                        input_iter,
+                        *direction,
+                        label.clone(),
+                        *min_depth,
+                        *traversal_depth,
+                        Arc::clone(&self.current),
+                        Arc::clone(&self.historical),
+                        *temporal_context,
                     )
+                    .bind_edges(bind_edge);
+                    // Namespace boundary (Issue #3349, PR2): when a restricting
+                    // scope is attached, the traversal never crosses an
+                    // out-of-scope edge nor bridges through an out-of-scope node.
+                    if self.scope_is_restricting()
+                        && let Some(scope) = &self.scope
+                    {
+                        traversal = traversal.with_namespace_scope(Arc::clone(scope));
+                    }
+                    Box::new(traversal)
                 }
 
                 PhysicalOp::PropertyScan {

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -223,32 +223,16 @@ impl QueryExecutor {
             let bind_edge = plan_needs_edge_binding(&plan.root);
             self.build_op(&plan.root, &mut None, 0, bind_edge)?
         };
-        let iterator = self.wrap_scope_filter(iterator);
+        // Namespace scope (Issue #3349, PR2) is enforced at the source operators
+        // during `build_op` (see `maybe_scope_source`), so everything downstream --
+        // LIMIT/SKIP, ORDER BY, aggregation, COUNT -- already sees only in-scope
+        // rows. No outermost post-filter is applied here.
         // Wrap with provenance filter to conditionally strip metadata
         let filtered = Box::new(iterators::ProvenanceFilterIterator::new(
             iterator,
             plan.include_provenance,
         ));
         Ok(QueryResults::new(filtered))
-    }
-
-    /// Wrap `iterator` in a namespace-scope entity filter (Issue #3349, PR2) when
-    /// a restricting scope is attached; otherwise return it unchanged so the
-    /// namespace-agnostic path pays nothing. This drops produced nodes/edges
-    /// whose namespace ∉ scope — the traversal boundary itself is enforced deeper
-    /// (in `TraversalIterator`) so an out-of-scope bridge node is never even
-    /// reached.
-    fn wrap_scope_filter(&self, iterator: Box<dyn ResultIterator>) -> Box<dyn ResultIterator> {
-        match &self.scope {
-            Some(scope) if self.scope_is_restricting() => {
-                Box::new(iterators::ScopeFilterIterator::new(
-                    iterator,
-                    Arc::clone(scope),
-                    Arc::clone(&self.current),
-                ))
-            }
-            _ => iterator,
-        }
     }
 
     /// Execute a physical plan with per-operator profiling instrumentation
@@ -271,7 +255,7 @@ impl QueryExecutor {
             let bind_edge = plan_needs_edge_binding(&plan.root);
             self.build_op(&plan.root, &mut registry, 0, bind_edge)?
         };
-        let iterator = self.wrap_scope_filter(iterator);
+        // Scope is applied at the source operators (see `maybe_scope_source`).
         let filtered = Box::new(iterators::ProvenanceFilterIterator::new(
             iterator,
             plan.include_provenance,
@@ -689,11 +673,51 @@ impl QueryExecutor {
                 }
             };
 
+        // Namespace scope (Issue #3349, PR2): push the scope filter down onto the
+        // SOURCE operators (scans, lookups, property/vector sources) rather than
+        // applying it as an outermost post-filter. Wrapping the leaf that produces
+        // entities guarantees every downstream operator -- LIMIT/SKIP, ORDER BY,
+        // DISTINCT, aggregation, and COUNT -- sees only in-scope rows, so a scoped
+        // `count()` reports the scoped cardinality (not the global one) and a
+        // scoped `LIMIT n` returns up to `n` *in-scope* rows (not `n` pre-filter
+        // rows of which some are then dropped). Graph traversal is deliberately
+        // NOT wrapped here: `IndexedTraversal` enforces the boundary at build time
+        // (never bridging an out-of-scope edge/node) and its own input source is
+        // wrapped by this same recursion, so its start node is scope-checked
+        // (Issue #3349 A4) and its emitted targets are already in-scope.
+        let iter = self.maybe_scope_source(op, iter);
+
         // Instrument this operator when profiling.
         Ok(match handle {
             Some(h) => Box::new(ProfilingIterator::new(iter, h)),
             None => iter,
         })
+    }
+
+    /// Wrap a **source-leaf** operator's iterator in the namespace-scope entity
+    /// filter (Issue #3349, PR2) when a restricting scope is attached; otherwise
+    /// return it unchanged so the namespace-agnostic path pays nothing.
+    ///
+    /// Only leaf operators that *produce* entities are wrapped (scans, id
+    /// lookups, property scans, and vector/temporal sources). Intermediate and
+    /// combining operators are never wrapped: their entity rows always originate
+    /// at a wrapped source (or at an already-boundary-filtered traversal), so
+    /// double-filtering is avoided. See [`is_scoped_source_leaf`].
+    fn maybe_scope_source(
+        &self,
+        op: &PhysicalOp,
+        iter: Box<dyn ResultIterator>,
+    ) -> Box<dyn ResultIterator> {
+        match &self.scope {
+            Some(scope) if self.scope_is_restricting() && is_scoped_source_leaf(op) => {
+                Box::new(iterators::ScopeFilterIterator::new(
+                    iter,
+                    Arc::clone(scope),
+                    Arc::clone(&self.current),
+                ))
+            }
+            _ => iter,
+        }
     }
 
     fn execute_hnsw_search(
@@ -815,6 +839,35 @@ impl QueryExecutor {
 /// including binary set ops, aggregation, and node/temporal scans -- is treated
 /// as not edge-typed, so the conservative default is the existing pass-through /
 /// node-only behavior.
+/// Whether `op` is a **source leaf** that produces entity rows directly from
+/// storage and therefore must have the namespace scope filter applied to it
+/// (Issue #3349, PR2). These are the scans, id lookups, property scans, and
+/// vector/temporal sources. Every entity row in a plan originates at one of
+/// these leaves (or at a boundary-filtered [`PhysicalOp::IndexedTraversal`],
+/// which is handled separately and is intentionally excluded here), so wrapping
+/// exactly these leaves pushes the scope filter below LIMIT/SKIP/ORDER BY/COUNT
+/// without any double-filtering.
+///
+/// `Empty` produces no rows, so it is not wrapped. `IndexedTraversal` is
+/// excluded (it enforces the boundary at build time and its own input source is
+/// wrapped by the recursion). Combining/intermediate operators are excluded
+/// because their inputs are already scoped.
+fn is_scoped_source_leaf(op: &PhysicalOp) -> bool {
+    matches!(
+        op,
+        PhysicalOp::NodeLookup { .. }
+            | PhysicalOp::NodeScan { .. }
+            | PhysicalOp::EdgeScan { .. }
+            | PhysicalOp::HnswSearch { .. }
+            | PhysicalOp::TemporalNodeLookup { .. }
+            | PhysicalOp::TemporalVectorSearch { .. }
+            | PhysicalOp::TemporalNodeScan { .. }
+            | PhysicalOp::TemporalNodeRangeScan { .. }
+            | PhysicalOp::SimilarToNode { .. }
+            | PhysicalOp::PropertyScan { .. }
+    )
+}
+
 fn subtree_yields_edges(op: &PhysicalOp) -> bool {
     match op {
         PhysicalOp::EdgeScan { .. } => true,

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -12,7 +12,7 @@ use parking_lot::RwLock;
 use std::sync::Arc;
 
 use crate::core::error::Result;
-use crate::core::namespace::NamespaceScope;
+use crate::core::namespace::{NamespaceScope, ResolvedScope};
 use crate::storage::current::CurrentStorage;
 use crate::storage::historical::HistoricalStorage;
 
@@ -129,6 +129,12 @@ pub struct QueryExecutor {
     /// the boundary into graph traversal. `Arc` so it can be cheaply shared into
     /// the traversal iterator. `None` ⇒ prior namespace-agnostic behavior.
     scope: Option<Arc<NamespaceScope>>,
+    /// The attached `scope` resolved to interned ids **once** (Issue #3349, PR2
+    /// hoist), computed in [`with_namespace_scope`](Self::with_namespace_scope)
+    /// and cheaply cloned into every source-leaf filter and the traversal
+    /// boundary so no per-source/per-hop probe re-derives ids or allocates.
+    /// [`ResolvedScope::All`] when no restricting scope is attached.
+    resolved_scope: ResolvedScope,
 }
 
 impl QueryExecutor {
@@ -139,6 +145,7 @@ impl QueryExecutor {
             historical,
             _config: ExecutionConfig::default(),
             scope: None,
+            resolved_scope: ResolvedScope::All,
         }
     }
 
@@ -153,6 +160,7 @@ impl QueryExecutor {
             historical,
             _config: config,
             scope: None,
+            resolved_scope: ResolvedScope::All,
         }
     }
 
@@ -162,6 +170,10 @@ impl QueryExecutor {
     /// is a no-op filter. See [`QueryBuilder::in_namespace`](crate::query::QueryBuilder::in_namespace).
     #[must_use]
     pub fn with_namespace_scope(mut self, scope: NamespaceScope) -> Self {
+        // Resolve the scope to interned ids ONCE here (Issue #3349, PR2 hoist),
+        // then thread cheap clones into each source-leaf filter and the traversal
+        // boundary, rather than re-resolving per source/per traversal.
+        self.resolved_scope = scope.resolve();
         self.scope = Some(Arc::new(scope));
         self
     }
@@ -489,7 +501,8 @@ impl QueryExecutor {
                     if self.scope_is_restricting()
                         && let Some(scope) = &self.scope
                     {
-                        traversal = traversal.with_namespace_scope(Arc::clone(scope));
+                        traversal = traversal
+                            .with_namespace_scope(Arc::clone(scope), self.resolved_scope.clone());
                     }
                     Box::new(traversal)
                 }
@@ -566,12 +579,30 @@ impl QueryExecutor {
 
                 PhysicalOp::OptionalApply { input, steps } => {
                     let input_iter = self.build_op(input, profile, child_depth, bind_edge)?;
-                    Box::new(iterators::OptionalApplyIterator::new(
-                        input_iter,
-                        steps.clone(),
-                        Arc::clone(&self.current),
-                        Arc::clone(&self.historical),
-                    ))
+                    // Namespace scope (Issue #3349, PR2): thread the scope into the
+                    // OPTIONAL MATCH sub-pipeline so its source leaf and traversal
+                    // hops are scope-bounded, matching the main pipeline (defense
+                    // in depth — unreachable until PR3 wires Cypher/AQL scope to
+                    // OPTIONAL MATCH, but never silently wrong). The unscoped path
+                    // uses the plain constructor and pays nothing.
+                    match (self.scope_is_restricting(), &self.scope) {
+                        (true, Some(scope)) => {
+                            Box::new(iterators::OptionalApplyIterator::with_namespace_scope(
+                                input_iter,
+                                steps.clone(),
+                                Arc::clone(&self.current),
+                                Arc::clone(&self.historical),
+                                Some(Arc::clone(scope)),
+                                self.resolved_scope.clone(),
+                            ))
+                        }
+                        _ => Box::new(iterators::OptionalApplyIterator::new(
+                            input_iter,
+                            steps.clone(),
+                            Arc::clone(&self.current),
+                            Arc::clone(&self.historical),
+                        )),
+                    }
                 }
 
                 PhysicalOp::Aggregate {
@@ -713,6 +744,7 @@ impl QueryExecutor {
                 Box::new(iterators::ScopeFilterIterator::new(
                     iter,
                     Arc::clone(scope),
+                    self.resolved_scope.clone(),
                     Arc::clone(&self.current),
                 ))
             }

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -1257,6 +1257,7 @@ mod tests {
             }],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         assert!(planner.plan(query).is_err());
@@ -1283,6 +1284,7 @@ mod tests {
             ops: vec![QueryOp::Filter(Predicate::True)],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         assert!(planner.plan(query).is_err());
@@ -1339,6 +1341,7 @@ mod tests {
             ops: vec![QueryOp::Limit(10)],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         assert!(planner.plan(query).is_err());
@@ -1407,6 +1410,7 @@ mod tests {
             ops: vec![QueryOp::ScanNodes { label: None }, QueryOp::Count],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let plan = planner.plan(query).unwrap();
@@ -1420,6 +1424,7 @@ mod tests {
             ops: vec![QueryOp::Count],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         assert!(planner.plan(query).is_err());
@@ -1433,6 +1438,7 @@ mod tests {
             ops: vec![QueryOp::ScanNodes { label: None }, QueryOp::Distinct],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let plan = planner.plan(query).unwrap();
@@ -1450,6 +1456,7 @@ mod tests {
             ],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let plan = planner.plan(query).unwrap();
@@ -1503,6 +1510,7 @@ mod tests {
             ops: vec![],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         assert!(planner.plan(query).is_err());
@@ -1523,6 +1531,7 @@ mod tests {
             }],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         assert!(planner.plan(query).is_err());
@@ -1535,6 +1544,7 @@ mod tests {
             ops: vec![QueryOp::Distinct],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         assert!(planner.plan(query).is_err());
@@ -1547,6 +1557,7 @@ mod tests {
             ops: vec![QueryOp::Project(vec!["name".to_string()])],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         assert!(planner.plan(query).is_err());
@@ -1637,6 +1648,7 @@ mod tests {
             ],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let plan = planner.plan(query).unwrap();
@@ -1673,6 +1685,7 @@ mod tests {
             ],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let plan = planner.plan(query).unwrap();
@@ -1689,6 +1702,7 @@ mod tests {
             }],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let result = planner.plan(query);
@@ -1708,6 +1722,7 @@ mod tests {
             }],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let result = planner.plan(query);
@@ -1724,6 +1739,7 @@ mod tests {
             }],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let result = planner.plan(query);
@@ -1740,6 +1756,7 @@ mod tests {
             }],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let result = planner.plan(query);
@@ -1774,6 +1791,7 @@ mod tests {
             }],
             temporal_context: Some(TemporalContext::as_of(now, now)),
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let plan = planner.plan(query).unwrap();
@@ -1797,6 +1815,7 @@ mod tests {
             }],
             temporal_context: Some(TemporalContext::as_of_transaction_time(now)),
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let plan = planner.plan(query).unwrap();
@@ -1815,6 +1834,7 @@ mod tests {
             }],
             temporal_context: Some(TemporalContext::valid_time_between(range)),
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let plan = planner.plan(query).unwrap();
@@ -1836,6 +1856,7 @@ mod tests {
             }],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let plan = planner.plan(query).unwrap();
@@ -1855,6 +1876,7 @@ mod tests {
             }],
             temporal_context: Some(TemporalContext::transaction_time_between(range)),
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let err = planner.plan(query).unwrap_err();
@@ -1879,6 +1901,7 @@ mod tests {
             }],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         // Add temporal context
@@ -1896,6 +1919,7 @@ mod tests {
             ops: vec![QueryOp::FilterLabel("Person".to_string())],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let result = planner.plan(query);
@@ -1911,6 +1935,7 @@ mod tests {
             ops: vec![QueryOp::Skip(10)],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let result = planner.plan(query);
@@ -1948,6 +1973,7 @@ mod tests {
             }],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let plan = planner.plan(query).unwrap();
@@ -1977,6 +2003,7 @@ mod tests {
             }],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let plan = planner.plan(query).unwrap();
@@ -2235,6 +2262,7 @@ mod tests {
             ],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let plan = planner.plan(query).unwrap();
@@ -2254,6 +2282,7 @@ mod tests {
             ops: vec![QueryOp::ScanEdges { edge_type: None }, QueryOp::Limit(5)],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let plan = planner.plan(query).unwrap();
@@ -2289,6 +2318,7 @@ mod tests {
             ],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let plan = planner.plan(query).unwrap();
@@ -2344,6 +2374,7 @@ mod tests {
             ],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let plan = planner.plan(query).unwrap();
@@ -2391,6 +2422,7 @@ mod tests {
             }],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let plan = planner.plan(query).unwrap();
@@ -2423,6 +2455,7 @@ mod tests {
             ],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let err = planner.plan(query).unwrap_err();
@@ -2447,6 +2480,7 @@ mod tests {
             }],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let err = planner.plan(query).unwrap_err();
@@ -2472,6 +2506,7 @@ mod tests {
             ],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let err = planner.plan(query).unwrap_err();
@@ -2500,6 +2535,7 @@ mod tests {
             }],
             temporal_context: None,
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let err = planner.plan(query).unwrap_err();
@@ -2527,6 +2563,7 @@ mod tests {
             ],
             temporal_context: Some(TemporalContext::as_of(1000.into(), 2000.into())),
             hints: QueryHints::default(),
+            scope: None,
         };
 
         let plan = planner.plan(query).unwrap();

--- a/src/sql/converter.rs
+++ b/src/sql/converter.rs
@@ -173,6 +173,8 @@ impl SqlConverter {
             // Temporal context is set by convert_sql() after extraction
             temporal_context: None,
             hints: QueryHints::default(),
+            // SQL namespace scoping is a follow-up (PR2b); no scope today.
+            scope: None,
         })
     }
 

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -1126,6 +1126,29 @@ impl CurrentStorage {
         self.indexes.namespace_edge_ids(namespace)
     }
 
+    /// Whether `node_id` currently lives in `namespace` (Issue #3349, PR2). O(1)
+    /// membership probe — no property load — for scoped-traversal boundary checks.
+    #[inline]
+    pub fn node_in_namespace(
+        &self,
+        node_id: NodeId,
+        namespace: &crate::core::namespace::Namespace,
+    ) -> bool {
+        self.indexes.node_in_namespace(node_id, namespace)
+    }
+
+    /// Whether `edge_id` currently lives in `namespace` (Issue #3349, PR2). O(1)
+    /// membership probe — no property load. See
+    /// [`node_in_namespace`](Self::node_in_namespace).
+    #[inline]
+    pub fn edge_in_namespace(
+        &self,
+        edge_id: EdgeId,
+        namespace: &crate::core::namespace::Namespace,
+    ) -> bool {
+        self.indexes.edge_in_namespace(edge_id, namespace)
+    }
+
     /// Number of nodes currently in `namespace` (O(1) membership-set read).
     #[inline]
     pub fn namespace_node_count(&self, namespace: &crate::core::namespace::Namespace) -> usize {
@@ -1499,6 +1522,59 @@ impl CurrentStorage {
         let (_, index, config) = self.get_vector_index_internal(Some(property_name))?;
         Self::validate_embedding_dimensions(query, &config)?;
         index.search_with_filter(query, k, predicate)
+    }
+
+    /// Filter-complete k-NN from an existing node's embedding on the **default**
+    /// vector index (Issue #3349, PR2 / test T6).
+    ///
+    /// Resolves the default vector property and the query node's embedding, then
+    /// delegates to the index's [`search_with_filter`](crate::index::VectorIndex::search_with_filter),
+    /// which **over-fetches** candidates until it has `k` results satisfying
+    /// `predicate` (or the index is exhausted) — so a namespace-scoped caller
+    /// never receives fewer than `k` in-scope results when that many exist. The
+    /// query node itself is always excluded (folded into the predicate), so
+    /// callers pass only their scope predicate.
+    ///
+    /// The predicate is deliberately **ignorant of why a vector is absent** from
+    /// the index: it is called only for candidates the index actually returns, so
+    /// a vector excluded from the index for any reason (e.g. a crypto-shredded
+    /// embedding) simply never reaches the predicate — this method makes no
+    /// assumption about vector presence.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn find_similar_by_node_with_predicate<F>(
+        &self,
+        query_node_id: NodeId,
+        k: usize,
+        predicate: F,
+    ) -> Result<Vec<(NodeId, f32)>>
+    where
+        F: Fn(&NodeId) -> bool + Send + Sync,
+    {
+        let (prop_name, index, _) = self.get_vector_index_internal(None)?;
+        let query_vector = self.get_node_vector(query_node_id, &prop_name)?;
+        index.search_with_filter(&query_vector, k, move |id| {
+            *id != query_node_id && predicate(id)
+        })
+    }
+
+    /// Filter-complete k-NN from a raw embedding on the **default** vector index
+    /// (Issue #3349, PR2 / test T6). Like
+    /// [`find_similar_by_node_with_predicate`](Self::find_similar_by_node_with_predicate)
+    /// but the query is an externally-supplied embedding (no node exclusion). See
+    /// that method for the filter-completeness and absent-vector guarantees.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn find_similar_by_embedding_with_predicate<F>(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        predicate: F,
+    ) -> Result<Vec<(NodeId, f32)>>
+    where
+        F: Fn(&NodeId) -> bool + Send + Sync,
+    {
+        let (_, index, config) = self.get_vector_index_internal(None)?;
+        Self::validate_embedding_dimensions(embedding, &config)?;
+        index.search_with_filter(embedding, k, predicate)
     }
 
     // ========================================================================

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -1137,6 +1137,19 @@ impl CurrentStorage {
         self.indexes.node_in_namespace(node_id, namespace)
     }
 
+    /// Whether `node_id` currently lives in the interned namespace `ns_id`
+    /// (Issue #3349, PR2 performance). The pre-interned hot-path form of
+    /// [`node_in_namespace`](Self::node_in_namespace) — no per-call string
+    /// hashing.
+    #[inline]
+    pub fn node_in_namespace_id(
+        &self,
+        node_id: NodeId,
+        ns_id: crate::core::namespace::NamespaceId,
+    ) -> bool {
+        self.indexes.node_in_namespace_id(node_id, ns_id)
+    }
+
     /// Whether `edge_id` currently lives in `namespace` (Issue #3349, PR2). O(1)
     /// membership probe — no property load. See
     /// [`node_in_namespace`](Self::node_in_namespace).
@@ -1147,6 +1160,18 @@ impl CurrentStorage {
         namespace: &crate::core::namespace::Namespace,
     ) -> bool {
         self.indexes.edge_in_namespace(edge_id, namespace)
+    }
+
+    /// Whether `edge_id` currently lives in the interned namespace `ns_id`
+    /// (Issue #3349, PR2 performance). The pre-interned hot-path form of
+    /// [`edge_in_namespace`](Self::edge_in_namespace).
+    #[inline]
+    pub fn edge_in_namespace_id(
+        &self,
+        edge_id: EdgeId,
+        ns_id: crate::core::namespace::NamespaceId,
+    ) -> bool {
+        self.indexes.edge_in_namespace_id(edge_id, ns_id)
     }
 
     /// Number of nodes currently in `namespace` (O(1) membership-set read).

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -1113,6 +1113,39 @@ impl CurrentStorage {
         self.indexes.node_count()
     }
 
+    /// Node ids currently in `namespace`, from the secondary membership index
+    /// (Issue #3349). O(members), no property scan.
+    #[inline]
+    pub fn namespace_node_ids(&self, namespace: &crate::core::namespace::Namespace) -> Vec<NodeId> {
+        self.indexes.namespace_node_ids(namespace)
+    }
+
+    /// Edge ids currently in `namespace`, from the secondary membership index.
+    #[inline]
+    pub fn namespace_edge_ids(&self, namespace: &crate::core::namespace::Namespace) -> Vec<EdgeId> {
+        self.indexes.namespace_edge_ids(namespace)
+    }
+
+    /// Number of nodes currently in `namespace` (O(1) membership-set read).
+    #[inline]
+    pub fn namespace_node_count(&self, namespace: &crate::core::namespace::Namespace) -> usize {
+        self.indexes.namespace_node_count(namespace)
+    }
+
+    /// Number of edges currently in `namespace` (O(1) membership-set read).
+    #[inline]
+    pub fn namespace_edge_count(&self, namespace: &crate::core::namespace::Namespace) -> usize {
+        self.indexes.namespace_edge_count(namespace)
+    }
+
+    /// Every namespace currently holding at least one node or edge.
+    #[inline]
+    pub fn populated_namespaces(
+        &self,
+    ) -> std::collections::BTreeSet<crate::core::namespace::Namespace> {
+        self.indexes.populated_namespaces()
+    }
+
     /// Get an exclusive upper bound on node ids present in current storage.
     ///
     /// Used by the query executor's full-scan iterator to bound a lazy id sweep

--- a/tests/namespaces_pr2.rs
+++ b/tests/namespaces_pr2.rs
@@ -1,0 +1,329 @@
+//! Namespaces PR2 — storage/query threading integration tests (Issue #3349).
+//!
+//! Covers the design doc's T4 (traversal isolation), T5 (read isolation), T8
+//! (per-namespace stats/schema), membership-index integrity across
+//! create/delete + restart/replay, and omitted-scope back-compat.
+
+use aletheiadb::core::error::StorageError;
+use aletheiadb::{
+    AletheiaDB, Error, Namespace, NamespaceError, NamespaceScope, PropertyMapBuilder, PropertyValue,
+};
+use std::collections::BTreeMap;
+
+fn props(name: &str) -> aletheiadb::PropertyMap {
+    PropertyMapBuilder::new().insert("name", name).build()
+}
+
+fn ns(name: &str) -> Namespace {
+    Namespace::new(name).unwrap()
+}
+
+/// Group current nodes by namespace via a full scan (the ground truth the
+/// membership index must match).
+fn node_counts_by_scan(db: &AletheiaDB) -> BTreeMap<String, usize> {
+    let mut out = BTreeMap::new();
+    for id in db.get_all_node_ids() {
+        if let Ok(node) = db.get_node(id) {
+            *out.entry(node.namespace().into_string()).or_insert(0) += 1;
+        }
+    }
+    out
+}
+
+// ============================================================================
+// T4 — traversal isolation (edge.ns ∈ S AND target.ns ∈ S).
+// ============================================================================
+
+#[test]
+fn t4_edge_to_other_namespace_not_followed_under_single_scope() {
+    let db = AletheiaDB::new().unwrap();
+    let a = db
+        .create_node_in_namespace("Person", props("A"), "agent:a")
+        .unwrap();
+    let b = db
+        .create_node_in_namespace("Person", props("B"), "agent:b")
+        .unwrap();
+    // Cross-namespace edge (legal); edge itself lives in agent:a.
+    db.create_edge_in_namespace(a, b, "KNOWS", props(""), "agent:a")
+        .unwrap();
+
+    // Scope {a}: target b's namespace ∉ scope ⇒ not followed.
+    let reachable = db
+        .traverse_scoped(a, None, 5, &NamespaceScope::single(ns("agent:a")))
+        .unwrap();
+    assert!(
+        !reachable.contains(&b),
+        "b must not be reachable under scope {{a}}"
+    );
+
+    // Scope {a, b}: now followed.
+    let scope_ab = NamespaceScope::list(vec![ns("agent:a"), ns("agent:b")]).unwrap();
+    let reachable = db.traverse_scoped(a, None, 5, &scope_ab).unwrap();
+    assert!(
+        reachable.contains(&b),
+        "b must be reachable under scope {{a,b}}"
+    );
+}
+
+#[test]
+fn t4_edge_whose_namespace_out_of_scope_never_crossed() {
+    let db = AletheiaDB::new().unwrap();
+    // Both endpoints in agent:a, but the EDGE lives in `shared`.
+    let a1 = db
+        .create_node_in_namespace("Person", props("a1"), "agent:a")
+        .unwrap();
+    let a2 = db
+        .create_node_in_namespace("Person", props("a2"), "agent:a")
+        .unwrap();
+    db.create_edge_in_namespace(a1, a2, "KNOWS", props(""), "shared")
+        .unwrap();
+
+    // Scope {a}: edge.ns == shared ∉ scope ⇒ never crossed even though the
+    // target node IS in scope.
+    let reachable = db
+        .traverse_scoped(a1, None, 5, &NamespaceScope::single(ns("agent:a")))
+        .unwrap();
+    assert!(
+        !reachable.contains(&a2),
+        "a2 unreachable when the connecting edge's namespace is out of scope"
+    );
+
+    // Scope {a, shared}: edge.ns ∈ scope AND target.ns ∈ scope ⇒ crossed.
+    let scope = NamespaceScope::list(vec![ns("agent:a"), ns("shared")]).unwrap();
+    let reachable = db.traverse_scoped(a1, None, 5, &scope).unwrap();
+    assert!(
+        reachable.contains(&a2),
+        "a2 reachable once the edge namespace is in scope"
+    );
+}
+
+#[test]
+fn t4_union_scope_follows_within_and_between() {
+    let db = AletheiaDB::new().unwrap();
+    let a1 = db
+        .create_node_in_namespace("Person", props("a1"), "agent:a")
+        .unwrap();
+    let sh = db
+        .create_node_in_namespace("Doc", props("sh"), "shared")
+        .unwrap();
+    // Edge from a to shared, living in `shared`.
+    db.create_edge_in_namespace(a1, sh, "USES", props(""), "shared")
+        .unwrap();
+
+    let scope = NamespaceScope::list(vec![ns("agent:a"), ns("shared")]).unwrap();
+    let reachable = db.traverse_scoped(a1, None, 5, &scope).unwrap();
+    assert!(
+        reachable.contains(&sh),
+        "union scope follows between a and shared"
+    );
+}
+
+// ============================================================================
+// T5 — read isolation (scoped get/list/find never return out-of-scope).
+// ============================================================================
+
+#[test]
+fn t5_scoped_reads_never_return_other_namespace() {
+    let db = AletheiaDB::new().unwrap();
+    let a_alice = db
+        .create_node_in_namespace("Person", props("Alice"), "agent:a")
+        .unwrap();
+    let b_alice = db
+        .create_node_in_namespace("Person", props("Alice"), "agent:b")
+        .unwrap();
+
+    let scope_a = NamespaceScope::single(ns("agent:a"));
+
+    // get: B's Alice is NotFound under scope A.
+    assert!(db.get_node_scoped(a_alice, &scope_a).is_ok());
+    assert!(matches!(
+        db.get_node_scoped(b_alice, &scope_a),
+        Err(Error::Storage(StorageError::NodeNotFound(_)))
+    ));
+
+    // list: only A's node.
+    let listed = db.list_nodes_scoped(Some("Person"), &scope_a).unwrap();
+    assert!(listed.contains(&a_alice));
+    assert!(!listed.contains(&b_alice));
+
+    // find_by_property: only A's Alice.
+    let found = db
+        .find_nodes_by_property_scoped("Person", "name", &PropertyValue::from("Alice"), &scope_a)
+        .unwrap();
+    assert_eq!(found, vec![a_alice]);
+}
+
+#[test]
+fn t5_unknown_namespace_scope_is_not_found() {
+    let db = AletheiaDB::new().unwrap();
+    let a = db
+        .create_node_in_namespace("Person", props("A"), "agent:a")
+        .unwrap();
+    // "ghost" was never registered nor written.
+    let scope = NamespaceScope::single(ns("ghost"));
+    assert!(matches!(
+        db.get_node_scoped(a, &scope),
+        Err(Error::Namespace(NamespaceError::NotFound { .. }))
+    ));
+    assert!(matches!(
+        db.list_nodes_scoped(None, &scope),
+        Err(Error::Namespace(NamespaceError::NotFound { .. }))
+    ));
+}
+
+#[test]
+fn t5_empty_scope_list_is_invalid_argument() {
+    // Constructor rejects an empty list.
+    assert!(matches!(
+        NamespaceScope::list(vec![]),
+        Err(NamespaceError::InvalidName { .. })
+    ));
+    // And validation rejects a manually-built empty List.
+    let db = AletheiaDB::new().unwrap();
+    let empty = NamespaceScope::List(vec![]);
+    assert!(matches!(
+        db.list_nodes_scoped(None, &empty),
+        Err(Error::Namespace(NamespaceError::InvalidName { .. }))
+    ));
+}
+
+// ============================================================================
+// T8 — per-namespace stats & schema counts.
+// ============================================================================
+
+#[test]
+fn t8_per_namespace_counts_in_stats_and_schema() {
+    let db = AletheiaDB::new().unwrap();
+    let a1 = db
+        .create_node_in_namespace("Person", props("a1"), "agent:a")
+        .unwrap();
+    let a2 = db
+        .create_node_in_namespace("Person", props("a2"), "agent:a")
+        .unwrap();
+    let _b1 = db
+        .create_node_in_namespace("Person", props("b1"), "agent:b")
+        .unwrap();
+    let _d1 = db.create_node("Person", props("d1")).unwrap();
+    db.create_edge_in_namespace(a1, a2, "KNOWS", props(""), "agent:a")
+        .unwrap();
+
+    let by_name = |v: &[aletheiadb::NamespaceCount], name: &str| -> (usize, usize) {
+        v.iter()
+            .find(|c| c.name == name)
+            .map(|c| (c.node_count, c.edge_count))
+            .unwrap_or((0, 0))
+    };
+
+    let stats = db.stats();
+    assert_eq!(by_name(&stats.namespaces, "agent:a"), (2, 1));
+    assert_eq!(by_name(&stats.namespaces, "agent:b"), (1, 0));
+    assert_eq!(by_name(&stats.namespaces, "default"), (1, 0));
+
+    let schema = db.schema().unwrap();
+    assert_eq!(by_name(&schema.namespaces, "agent:a"), (2, 1));
+    assert_eq!(by_name(&schema.namespaces, "agent:b"), (1, 0));
+    assert_eq!(by_name(&schema.namespaces, "default"), (1, 0));
+}
+
+// ============================================================================
+// Membership-index integrity vs full scan (create + delete).
+// ============================================================================
+
+#[test]
+fn membership_index_matches_scan_after_creates_and_deletes() {
+    let db = AletheiaDB::new().unwrap();
+    let a1 = db
+        .create_node_in_namespace("Person", props("a1"), "agent:a")
+        .unwrap();
+    let _a2 = db
+        .create_node_in_namespace("Person", props("a2"), "agent:a")
+        .unwrap();
+    let b1 = db
+        .create_node_in_namespace("Person", props("b1"), "agent:b")
+        .unwrap();
+    let _d1 = db.create_node("Person", props("d1")).unwrap();
+
+    // Delete one from agent:a and one from agent:b.
+    db.delete_node_with_valid_time(a1, None).unwrap();
+    db.delete_node_with_valid_time(b1, None).unwrap();
+
+    let scan = node_counts_by_scan(&db);
+    let index: BTreeMap<String, usize> = db
+        .namespace_counts()
+        .into_iter()
+        .filter(|c| c.node_count > 0)
+        .map(|c| (c.name, c.node_count))
+        .collect();
+    assert_eq!(index, scan, "membership index must match a full scan");
+}
+
+// ============================================================================
+// Membership-index rebuilt after restart / WAL replay.
+// ============================================================================
+
+#[test]
+fn membership_index_rebuilt_after_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("db");
+
+    let a = {
+        let db = AletheiaDB::open(&path).unwrap();
+        let a = db
+            .create_node_in_namespace("Person", props("A"), "agent:a")
+            .unwrap();
+        let _b = db
+            .create_node_in_namespace("Person", props("B"), "agent:b")
+            .unwrap();
+        drop(db);
+        a
+    };
+
+    // Reopen: the membership index is rebuilt from the durable ride-along
+    // property during load, so scoped reads still isolate correctly.
+    let db = AletheiaDB::open(&path).unwrap();
+    let scope_a = NamespaceScope::single(ns("agent:a"));
+    let listed = db.list_nodes_scoped(Some("Person"), &scope_a).unwrap();
+    assert_eq!(
+        listed,
+        vec![a],
+        "only agent:a's node visible under scope {{a}}"
+    );
+
+    let count = |name: &str| {
+        db.namespace_counts()
+            .into_iter()
+            .find(|c| c.name == name)
+            .map(|c| c.node_count)
+            .unwrap_or(0)
+    };
+    assert_eq!(count("agent:a"), 1);
+    assert_eq!(count("agent:b"), 1);
+}
+
+// ============================================================================
+// Back-compat: omitted-scope reads over default data are unchanged.
+// ============================================================================
+
+#[test]
+fn back_compat_default_scope_matches_unscoped() {
+    let db = AletheiaDB::new().unwrap();
+    let n1 = db.create_node("Person", props("one")).unwrap();
+    let n2 = db.create_node("Person", props("two")).unwrap();
+
+    let default_scope = NamespaceScope::default();
+    let mut scoped = db.list_nodes_scoped(None, &default_scope).unwrap();
+    scoped.sort_unstable();
+    let mut all = db.get_all_node_ids();
+    all.sort_unstable();
+    assert_eq!(scoped, all, "default-scope list equals the full node set");
+
+    // Scoped get over default data equals plain get.
+    assert_eq!(
+        db.get_node_scoped(n1, &default_scope).unwrap().id,
+        db.get_node(n1).unwrap().id
+    );
+    assert_eq!(
+        db.get_node_scoped(n2, &default_scope).unwrap().id,
+        db.get_node(n2).unwrap().id
+    );
+}

--- a/tests/namespaces_pr2_review.rs
+++ b/tests/namespaces_pr2_review.rs
@@ -1,0 +1,584 @@
+//! Namespaces PR2 — review-pass test additions (Issue #3349, PR2 review).
+//!
+//! Block C from the adversarial-review fix list. These live in their own test
+//! binary (separate process) rather than in `namespaces_pr2_threading.rs` so
+//! their write/backup/restore load does not run in-process alongside that
+//! binary's 2×2K interleaved isolation soak — the soak hammers the process-wide
+//! string interners, and piling additional concurrent interning load into the
+//! same process surfaces a pre-existing global-interner race unrelated to
+//! namespaces. Isolating these tests in a separate binary keeps both stable.
+//!
+//! Coverage:
+//! - C1  traverse_scoped_as_of honors the TIME coordinate (not just boundary)
+//! - C2  out-of-scope traversal start => NodeNotFound / empty (A4)
+//! - C3  scoped LIMIT/count operate on in-scope rows (A1)
+//! - C4  scoped edge reads (current + point-in-time)
+//! - C5  edge membership after delete + after restart
+//! - C6  scoped k-NN order/scores match filtered-unscoped
+//! - C7  union scope follows within AND between namespaces
+//! - C8  find_nodes_by_property_at_scoped
+//! - C9  empty in_namespaces([]) is INVALID_ARGUMENT, not unscoped-all (A2)
+//! - C10 QueryBuilder unknown namespace => NOT_FOUND (A3)
+//! - C11 backup/restore: node+edge namespace + scoped reads survive
+//! - B1  interned-ns id consistent across all hydration paths
+
+use aletheiadb::core::error::StorageError;
+use aletheiadb::core::namespace::NamespaceError;
+use aletheiadb::core::temporal::time;
+use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
+use aletheiadb::{AletheiaDB, Error, Namespace, NamespaceScope, PropertyMapBuilder, PropertyValue};
+use std::collections::BTreeSet;
+
+fn ns(name: &str) -> Namespace {
+    Namespace::new(name).unwrap()
+}
+
+fn vec_props(name: &str, embedding: &[f32]) -> aletheiadb::PropertyMap {
+    PropertyMapBuilder::new()
+        .insert("name", name)
+        .insert_vector("embedding", embedding)
+        .build()
+}
+
+fn props(name: &str) -> aletheiadb::PropertyMap {
+    PropertyMapBuilder::new().insert("name", name).build()
+}
+
+fn result_node_ids(db: &AletheiaDB, query: aletheiadb::query::Query) -> BTreeSet<u64> {
+    db.execute_query(query)
+        .unwrap()
+        .collect_all()
+        .unwrap()
+        .into_iter()
+        .filter_map(|row| row.entity.node_id())
+        .map(|id| id.as_u64())
+        .collect()
+}
+
+// ============================================================================
+// Block C — review-pass test additions (Issue #3349, PR2 review).
+// ============================================================================
+
+/// C1: `traverse_scoped_as_of` honors the *time* coordinate, not just the
+/// namespace boundary. An edge/target created AFTER the captured coordinate is
+/// excluded when anchoring at `t`; a later coordinate `t2` includes it.
+#[test]
+fn c1_traverse_scoped_as_of_honors_time() {
+    let db = AletheiaDB::new().unwrap();
+    let a1 = db
+        .create_node_in_namespace("Person", props("a1"), "agent:a")
+        .unwrap();
+    let a2 = db
+        .create_node_in_namespace("Person", props("a2"), "agent:a")
+        .unwrap();
+    db.create_edge_in_namespace(a1, a2, "KNOWS", props(""), "agent:a")
+        .unwrap();
+    // Capture t BEFORE the second edge/target exist.
+    let t = time::now();
+
+    // Now add a later in-scope target a3 and edge a1->a3.
+    let a3 = db
+        .create_node_in_namespace("Person", props("a3"), "agent:a")
+        .unwrap();
+    db.create_edge_in_namespace(a1, a3, "KNOWS", props(""), "agent:a")
+        .unwrap();
+    let t2 = time::now();
+
+    let scope_a = NamespaceScope::single(ns("agent:a"));
+
+    // As-of t: only a2 is reachable; a3 and its edge did not exist yet.
+    let at_t: BTreeSet<_> = db
+        .traverse_scoped_as_of(a1, Some("KNOWS"), 5, t, t, &scope_a)
+        .unwrap()
+        .into_iter()
+        .collect();
+    assert!(at_t.contains(&a2), "a2 reachable as-of t");
+    assert!(
+        !at_t.contains(&a3),
+        "a3 created AFTER t must be excluded (temporal restriction, not just boundary)"
+    );
+
+    // As-of t2: both a2 and a3 are reachable.
+    let at_t2: BTreeSet<_> = db
+        .traverse_scoped_as_of(a1, Some("KNOWS"), 5, t2, t2, &scope_a)
+        .unwrap()
+        .into_iter()
+        .collect();
+    assert!(at_t2.contains(&a2));
+    assert!(
+        at_t2.contains(&a3),
+        "a3 reachable as-of t2 (after its creation)"
+    );
+}
+
+/// C2: an out-of-scope start node is `NodeNotFound` for `traverse_scoped`, and
+/// yields an empty result set through the QueryBuilder executor (A4).
+#[test]
+fn c2_out_of_scope_start_is_not_found() {
+    let db = AletheiaDB::new().unwrap();
+    let a1 = db
+        .create_node_in_namespace("Person", props("a1"), "agent:a")
+        .unwrap();
+    // Register agent:b so scoping to it is valid (not an unknown-ns NOT_FOUND).
+    db.create_node_in_namespace("Person", props("b1"), "agent:b")
+        .unwrap();
+
+    let scope_b = NamespaceScope::single(ns("agent:b"));
+    // traverse_scoped: out-of-scope start (a1 ∈ agent:a) => NodeNotFound.
+    assert!(matches!(
+        db.traverse_scoped(a1, Some("KNOWS"), 3, &scope_b),
+        Err(Error::Storage(StorageError::NodeNotFound(_)))
+    ));
+
+    // Builder: scoping the a1 traversal to agent:b drops the start => empty.
+    let q = db
+        .query()
+        .start(a1)
+        .traverse("KNOWS")
+        .in_namespace(ns("agent:b"))
+        .build();
+    assert!(
+        result_node_ids(&db, q).is_empty(),
+        "out-of-scope start yields no traversal rows via the builder"
+    );
+}
+
+/// C3: a scoped QueryBuilder scan applies the scope BELOW `LIMIT` and `count()`
+/// (A1). `LIMIT n` returns up to `n` IN-SCOPE rows (not `n` pre-filter rows), and
+/// a scoped count reports the SCOPED cardinality, not the global one.
+#[test]
+fn c3_scoped_limit_and_count_operate_on_in_scope_rows() {
+    let db = AletheiaDB::new().unwrap();
+    // Create the out-of-scope (agent:b) nodes FIRST so they have the lowest ids
+    // and would be taken first by an unscoped scan — the pre-fix outermost
+    // post-filter would then LIMIT to those and drop them, under-counting.
+    for i in 0..5 {
+        db.create_node_in_namespace("Doc", props(&format!("b{i}")), "agent:b")
+            .unwrap();
+    }
+    let mut a_ids = BTreeSet::new();
+    for i in 0..3 {
+        a_ids.insert(
+            db.create_node_in_namespace("Doc", props(&format!("a{i}")), "agent:a")
+                .unwrap()
+                .as_u64(),
+        );
+    }
+
+    let scope_a = || ns("agent:a");
+
+    // LIMIT 2 under scope A: exactly 2 rows, all agent:a.
+    let q = db
+        .query()
+        .scan_label("Doc")
+        .in_namespace(scope_a())
+        .limit(2)
+        .build();
+    let ids = result_node_ids(&db, q);
+    assert_eq!(
+        ids.len(),
+        2,
+        "LIMIT 2 must yield 2 IN-SCOPE rows, not fewer"
+    );
+    assert!(
+        ids.iter().all(|id| a_ids.contains(id)),
+        "every LIMIT-ed row must be in agent:a"
+    );
+
+    // Scoped count() == 3 (the agent:a cardinality), not 8 (global).
+    let scoped_count = db.query().scan_label("Doc").in_namespace(scope_a()).build();
+    assert_eq!(
+        db.execute_query(scoped_count).unwrap().count_all().unwrap(),
+        3,
+        "scoped count() must report the scoped cardinality, not the global one"
+    );
+}
+
+/// C4: scoped edge reads — an edge in agent:a is visible under scope {a} and
+/// NotFound under scope {b}, for both current-state and point-in-time reads.
+#[test]
+fn c4_scoped_edge_reads() {
+    let db = AletheiaDB::new().unwrap();
+    let a1 = db
+        .create_node_in_namespace("Person", props("a1"), "agent:a")
+        .unwrap();
+    let a2 = db
+        .create_node_in_namespace("Person", props("a2"), "agent:a")
+        .unwrap();
+    // Register agent:b.
+    db.create_node_in_namespace("Person", props("b1"), "agent:b")
+        .unwrap();
+    let e = db
+        .create_edge_in_namespace(a1, a2, "KNOWS", props(""), "agent:a")
+        .unwrap();
+    let t = time::now();
+
+    let scope_a = NamespaceScope::single(ns("agent:a"));
+    let scope_b = NamespaceScope::single(ns("agent:b"));
+
+    assert_eq!(db.get_edge_scoped(e, &scope_a).unwrap().id, e);
+    assert!(matches!(
+        db.get_edge_scoped(e, &scope_b),
+        Err(Error::Storage(StorageError::EdgeNotFound(_)))
+    ));
+
+    assert_eq!(db.get_edge_at_time_scoped(e, t, t, &scope_a).unwrap().id, e);
+    assert!(matches!(
+        db.get_edge_at_time_scoped(e, t, t, &scope_b),
+        Err(Error::Storage(StorageError::EdgeNotFound(_)))
+    ));
+}
+
+/// C5: edge membership index is correct after a delete and is rebuilt after a
+/// restart (WAL replay / index load).
+#[test]
+fn c5_edge_membership_after_delete_and_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("db");
+
+    let (a1, a2, ea) = {
+        let db = AletheiaDB::open(&path).unwrap();
+        let a1 = db
+            .create_node_in_namespace("Person", props("a1"), "agent:a")
+            .unwrap();
+        let a2 = db
+            .create_node_in_namespace("Person", props("a2"), "agent:a")
+            .unwrap();
+        let b1 = db
+            .create_node_in_namespace("Person", props("b1"), "agent:b")
+            .unwrap();
+        let b2 = db
+            .create_node_in_namespace("Person", props("b2"), "agent:b")
+            .unwrap();
+        let ea = db
+            .create_edge_in_namespace(a1, a2, "KNOWS", props(""), "agent:a")
+            .unwrap();
+        let _eb = db
+            .create_edge_in_namespace(b1, b2, "KNOWS", props(""), "agent:b")
+            .unwrap();
+
+        let edge_count = |name: &str| {
+            db.namespace_counts()
+                .into_iter()
+                .find(|c| c.name == name)
+                .map(|c| c.edge_count)
+                .unwrap_or(0)
+        };
+        assert_eq!(edge_count("agent:a"), 1);
+        assert_eq!(edge_count("agent:b"), 1);
+
+        // Delete the agent:a edge: its membership entry drains to zero.
+        db.delete_edge_with_valid_time(ea, None).unwrap();
+        assert_eq!(
+            edge_count("agent:a"),
+            0,
+            "deleted edge leaves the a-set empty"
+        );
+        assert_eq!(edge_count("agent:b"), 1);
+        drop(db);
+        (a1, a2, ea)
+    };
+    let _ = (a1, a2, ea);
+
+    // Reopen: edge membership rebuilt from the durable ride-along. The surviving
+    // agent:b edge is scoped correctly; the deleted agent:a edge stays gone.
+    let db = AletheiaDB::open(&path).unwrap();
+    let edge_count = |name: &str| {
+        db.namespace_counts()
+            .into_iter()
+            .find(|c| c.name == name)
+            .map(|c| c.edge_count)
+            .unwrap_or(0)
+    };
+    assert_eq!(
+        edge_count("agent:a"),
+        0,
+        "deleted edge stays gone after restart"
+    );
+    assert_eq!(
+        edge_count("agent:b"),
+        1,
+        "surviving edge rebuilt after restart"
+    );
+}
+
+/// C6: scoped k-NN returns the NEAREST in-scope neighbors in similarity order
+/// with scores identical to the unscoped ranking filtered to the scope.
+#[test]
+fn c6_scoped_knn_order_and_scores_match_filtered_unscoped() {
+    let db = AletheiaDB::new().unwrap();
+    db.enable_vector_index("embedding", HnswConfig::new(4, DistanceMetric::Cosine))
+        .unwrap();
+
+    let q = db
+        .create_node_in_namespace("Doc", vec_props("q", &[1.0, 0.0, 0.0, 0.0]), "agent:a")
+        .unwrap();
+    // Interleave a and b nodes at varying distances.
+    let mut a_nodes = BTreeSet::new();
+    for i in 0..12 {
+        let spread = 0.01 + i as f32 * 0.01;
+        let id = db
+            .create_node_in_namespace(
+                "Doc",
+                vec_props(&format!("a{i}"), &[1.0 - spread, spread, 0.0, 0.0]),
+                "agent:a",
+            )
+            .unwrap();
+        a_nodes.insert(id);
+        db.create_node_in_namespace(
+            "Doc",
+            vec_props(
+                &format!("b{i}"),
+                &[1.0 - spread * 0.5, 0.0, spread * 0.5, 0.0],
+            ),
+            "agent:b",
+        )
+        .unwrap();
+    }
+
+    let k = 5;
+    let scope_a = NamespaceScope::single(ns("agent:a"));
+    let scoped = db.find_similar_scoped(q, k, &scope_a).unwrap();
+
+    // Expected: the full unscoped ranking, filtered to agent:a, top-k.
+    let expected: Vec<(u64, f32)> = db
+        .find_similar_scoped(q, 1_000, &NamespaceScope::all())
+        .unwrap()
+        .into_iter()
+        .filter(|(id, _)| a_nodes.contains(id))
+        .take(k)
+        .map(|(id, s)| (id.as_u64(), s))
+        .collect();
+
+    let got: Vec<(u64, f32)> = scoped.iter().map(|(id, s)| (id.as_u64(), *s)).collect();
+    assert_eq!(got.len(), k, "scoped k-NN returns k in-scope results");
+    for ((gid, gs), (eid, es)) in got.iter().zip(expected.iter()) {
+        assert_eq!(
+            gid, eid,
+            "scoped k-NN order matches filtered unscoped order"
+        );
+        assert!(
+            (gs - es).abs() < 1e-6,
+            "scoped score {gs} matches unscoped score {es} for node {gid}"
+        );
+    }
+}
+
+/// C7: a union scope follows edges WITHIN each listed namespace (and between
+/// them), not only cross-namespace edges.
+#[test]
+fn c7_union_scope_follows_within_and_between() {
+    let db = AletheiaDB::new().unwrap();
+    let a1 = db
+        .create_node_in_namespace("Person", props("a1"), "agent:a")
+        .unwrap();
+    let a2 = db
+        .create_node_in_namespace("Person", props("a2"), "agent:a")
+        .unwrap();
+    let s1 = db
+        .create_node_in_namespace("Person", props("s1"), "shared")
+        .unwrap();
+    let s2 = db
+        .create_node_in_namespace("Person", props("s2"), "shared")
+        .unwrap();
+    // within-A edge, within-shared edge, and a between edge a2 -> s1.
+    db.create_edge_in_namespace(a1, a2, "KNOWS", props(""), "agent:a")
+        .unwrap();
+    db.create_edge_in_namespace(s1, s2, "KNOWS", props(""), "shared")
+        .unwrap();
+    db.create_edge_in_namespace(a2, s1, "KNOWS", props(""), "shared")
+        .unwrap();
+
+    let union = NamespaceScope::list(vec![ns("agent:a"), ns("shared")]).unwrap();
+    let reachable: BTreeSet<_> = db
+        .traverse_scoped(a1, Some("KNOWS"), 5, &union)
+        .unwrap()
+        .into_iter()
+        .collect();
+    // within-A (a1->a2), between (a2->s1), within-shared (s1->s2) all followed.
+    assert!(reachable.contains(&a2), "within-A edge followed");
+    assert!(reachable.contains(&s1), "between-namespace edge followed");
+    assert!(reachable.contains(&s2), "within-shared edge followed");
+}
+
+/// C8: `find_nodes_by_property_at_scoped` reconstructs point-in-time nodes then
+/// filters by (immutable) namespace.
+#[test]
+fn c8_find_nodes_by_property_at_scoped() {
+    let db = AletheiaDB::new().unwrap();
+    let a_alice = db
+        .create_node_in_namespace("Person", props("Alice"), "agent:a")
+        .unwrap();
+    let _b_alice = db
+        .create_node_in_namespace("Person", props("Alice"), "agent:b")
+        .unwrap();
+    let t = time::now();
+
+    let scope_a = NamespaceScope::single(ns("agent:a"));
+    let alice = PropertyValue::from("Alice");
+    let found = db
+        .find_nodes_by_property_at_scoped("Person", "name", &alice, t, t, &scope_a)
+        .unwrap();
+    let ids: BTreeSet<_> = found.nodes.iter().map(|n| n.id).collect();
+    assert!(ids.contains(&a_alice), "agent:a's Alice is found");
+    assert_eq!(
+        ids.len(),
+        1,
+        "agent:b's Alice is filtered out by scope {{a}}"
+    );
+}
+
+/// C9 (A2): an empty `in_namespaces([])` is NOT unscoped-all — it is rejected as
+/// INVALID_ARGUMENT at execution, never silently matching everything.
+#[test]
+fn c9_empty_in_namespaces_is_invalid_argument_not_unscoped() {
+    let db = AletheiaDB::new().unwrap();
+    db.create_node_in_namespace("Person", props("a1"), "agent:a")
+        .unwrap();
+    db.create_node_in_namespace("Person", props("b1"), "agent:b")
+        .unwrap();
+
+    let q = db
+        .query()
+        .scan_label("Person")
+        .in_namespaces(Vec::<Namespace>::new())
+        .build();
+    match db.execute_query(q) {
+        Err(Error::Namespace(NamespaceError::InvalidName { .. })) => {}
+        Err(other) => panic!("empty in_namespaces([]) must be INVALID_ARGUMENT, got {other:?}"),
+        Ok(_) => panic!("empty in_namespaces([]) must be INVALID_ARGUMENT, not unscoped-all Ok"),
+    }
+}
+
+/// C10 (A3): scoping a QueryBuilder query to an unknown namespace is NOT_FOUND,
+/// not a silently-empty result.
+#[test]
+fn c10_querybuilder_unknown_namespace_is_not_found() {
+    let db = AletheiaDB::new().unwrap();
+    db.create_node_in_namespace("Person", props("a1"), "agent:a")
+        .unwrap();
+
+    let q = db
+        .query()
+        .scan_label("Person")
+        .in_namespace(ns("agent:does-not-exist"))
+        .build();
+    match db.execute_query(q) {
+        Err(Error::Namespace(NamespaceError::NotFound { namespace })) => {
+            assert_eq!(namespace, "agent:does-not-exist");
+        }
+        Err(other) => panic!("unknown namespace must be NOT_FOUND, got {other:?}"),
+        Ok(_) => panic!("unknown namespace must be NOT_FOUND, not a silently-empty Ok"),
+    }
+}
+
+/// C11 (T9): a backup→restore round-trip preserves node AND edge namespaces and
+/// rebuilds the membership index, so scoped reads still isolate after restore.
+#[test]
+fn c11_backup_restore_scoped_reads_survive() {
+    let dir = tempfile::tempdir().unwrap();
+    let backup_path = dir.path().join("snap.albk");
+
+    let (a1, a2, e) = {
+        let db = AletheiaDB::new().unwrap();
+        let a1 = db
+            .create_node_in_namespace("Person", props("a1"), "agent:a")
+            .unwrap();
+        let a2 = db
+            .create_node_in_namespace("Person", props("a2"), "agent:a")
+            .unwrap();
+        let _b1 = db
+            .create_node_in_namespace("Person", props("b1"), "agent:b")
+            .unwrap();
+        let e = db
+            .create_edge_in_namespace(a1, a2, "KNOWS", props(""), "agent:a")
+            .unwrap();
+        db.backup(&backup_path).unwrap();
+        (a1, a2, e)
+    };
+
+    let restored = AletheiaDB::restore(&backup_path).unwrap();
+    let scope_a = NamespaceScope::single(ns("agent:a"));
+    let scope_b = NamespaceScope::single(ns("agent:b"));
+
+    // Node namespace survives + membership index rebuilt: scoped list isolates.
+    let listed: BTreeSet<_> = restored
+        .list_nodes_scoped(Some("Person"), &scope_a)
+        .unwrap()
+        .into_iter()
+        .collect();
+    assert_eq!(
+        listed,
+        BTreeSet::from([a1, a2]),
+        "agent:a nodes visible after restore"
+    );
+
+    // Edge namespace survives + membership index rebuilt: scoped edge read +
+    // scoped traversal both work post-restore.
+    assert_eq!(restored.get_edge_scoped(e, &scope_a).unwrap().id, e);
+    assert!(matches!(
+        restored.get_edge_scoped(e, &scope_b),
+        Err(Error::Storage(StorageError::EdgeNotFound(_)))
+    ));
+    let reachable = restored
+        .traverse_scoped(a1, Some("KNOWS"), 3, &scope_a)
+        .unwrap();
+    assert!(
+        reachable.contains(&a2),
+        "scoped traversal works after restore"
+    );
+}
+
+/// B1 guard: a namespace's interned membership id is derived identically on
+/// EVERY hydration path, so a node/edge hydrated via a fresh write, via WAL
+/// replay + index load (restart), and via backup→restore all yield the same
+/// scoped-read result.
+#[test]
+fn b1_interned_ns_consistent_across_hydration_paths() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("db");
+    let backup_path = dir.path().join("snap.albk");
+
+    let (a1, a2, e) = {
+        let db = AletheiaDB::open(&db_path).unwrap();
+        let a1 = db
+            .create_node_in_namespace("Person", props("a1"), "agent:planner")
+            .unwrap();
+        let a2 = db
+            .create_node_in_namespace("Person", props("a2"), "agent:planner")
+            .unwrap();
+        let e = db
+            .create_edge_in_namespace(a1, a2, "KNOWS", props(""), "agent:planner")
+            .unwrap();
+        db.backup(&backup_path).unwrap();
+        drop(db);
+        (a1, a2, e)
+    };
+
+    let scope = NamespaceScope::single(ns("agent:planner"));
+    let check = |db: &AletheiaDB, label: &str| {
+        // Same scoped-read outcome on every hydration path.
+        let mut listed = db.list_nodes_scoped(Some("Person"), &scope).unwrap();
+        listed.sort_unstable();
+        assert_eq!(listed, vec![a1, a2], "{label}: nodes scoped-visible");
+        assert_eq!(
+            db.get_edge_scoped(e, &scope).unwrap().id,
+            e,
+            "{label}: edge scoped-visible"
+        );
+        assert!(
+            db.traverse_scoped(a1, Some("KNOWS"), 2, &scope)
+                .unwrap()
+                .contains(&a2),
+            "{label}: traversal honors membership"
+        );
+    };
+
+    // Path 1: WAL replay + index load (reopen the durable db).
+    let reopened = AletheiaDB::open(&db_path).unwrap();
+    check(&reopened, "restart/WAL-replay");
+
+    // Path 2: backup → restore into a fresh database.
+    let restored = AletheiaDB::restore(&backup_path).unwrap();
+    check(&restored, "backup/restore");
+}

--- a/tests/namespaces_pr2_threading.rs
+++ b/tests/namespaces_pr2_threading.rs
@@ -1,0 +1,506 @@
+//! Namespaces PR2 — vector / temporal / QueryBuilder threading + isolation soak
+//! (Issue #3349). Complements `namespaces_pr2.rs` (T4/T5/T8) with:
+//!
+//! - **T6** filter-complete namespace-scoped vector k-NN (`find_similar_scoped`).
+//! - **T7** scope × as_of bi-temporal composition (`*_at_time_scoped`,
+//!   `find_nodes_at_time_scoped`, `traverse_scoped_as_of`).
+//! - **QueryBuilder** `.in_namespace()` / `.in_namespaces()` /
+//!   `.in_all_namespaces()` executor threading.
+//! - a **gating** 2×2K interleaved isolation soak.
+//! - **informational** (`#[ignore]`d) T11 soak and T12 perf harnesses that can be
+//!   run on demand (`cargo test --release -- --ignored`).
+
+use aletheiadb::core::error::StorageError;
+use aletheiadb::core::temporal::time;
+use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
+use aletheiadb::{AletheiaDB, Error, Namespace, NamespaceScope, PropertyMapBuilder, PropertyValue};
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+fn ns(name: &str) -> Namespace {
+    Namespace::new(name).unwrap()
+}
+
+fn vec_props(name: &str, embedding: &[f32]) -> aletheiadb::PropertyMap {
+    PropertyMapBuilder::new()
+        .insert("name", name)
+        .insert_vector("embedding", embedding)
+        .build()
+}
+
+fn props(name: &str) -> aletheiadb::PropertyMap {
+    PropertyMapBuilder::new().insert("name", name).build()
+}
+
+// ============================================================================
+// T6 — filter-complete namespace-scoped vector k-NN.
+// ============================================================================
+
+/// Scoped k-NN returns exactly `k` in-scope results, none from another
+/// namespace, even when the closest neighbors overall live out of scope — which
+/// is only possible if the search over-fetches (filter-complete), rather than
+/// taking `k` then dropping the out-of-scope ones.
+#[test]
+fn t6_scoped_knn_is_filter_complete_and_never_leaks() {
+    let db = AletheiaDB::new().unwrap();
+    db.enable_vector_index("embedding", HnswConfig::new(4, DistanceMetric::Cosine))
+        .unwrap();
+
+    // Query anchor lives in agent:a with embedding pointing "east".
+    let q = db
+        .create_node_in_namespace("Doc", vec_props("q", &[1.0, 0.0, 0.0, 0.0]), "agent:a")
+        .unwrap();
+
+    // Seed MANY out-of-scope (agent:b) near-neighbors that are *closer* to q
+    // than most in-scope nodes — these occupy the top of an unscoped ranking, so
+    // a naive "take k then filter" would return < k in-scope results.
+    let mut b_nodes = BTreeSet::new();
+    for i in 0..20 {
+        let jitter = i as f32 * 0.0005;
+        let id = db
+            .create_node_in_namespace(
+                "Doc",
+                vec_props(&format!("b{i}"), &[1.0 - jitter, jitter, 0.0, 0.0]),
+                "agent:b",
+            )
+            .unwrap();
+        b_nodes.insert(id);
+    }
+
+    // In-scope (agent:a) nodes, deliberately a bit further from q than the b's.
+    let mut a_nodes = BTreeSet::new();
+    for i in 0..10 {
+        let spread = 0.02 + i as f32 * 0.01;
+        let id = db
+            .create_node_in_namespace(
+                "Doc",
+                vec_props(&format!("a{i}"), &[1.0 - spread, 0.0, spread, 0.0]),
+                "agent:a",
+            )
+            .unwrap();
+        a_nodes.insert(id);
+    }
+
+    let k = 5;
+    let scope_a = NamespaceScope::single(ns("agent:a"));
+    let results = db.find_similar_scoped(q, k, &scope_a).unwrap();
+
+    // Filter-complete: exactly k results despite the closer out-of-scope crowd.
+    assert_eq!(
+        results.len(),
+        k,
+        "scoped k-NN must over-fetch to return k in-scope results"
+    );
+    // Never leaks: every result is in agent:a, none from agent:b, never q.
+    for (id, _score) in &results {
+        assert!(a_nodes.contains(id), "result {id} must be an agent:a node");
+        assert!(!b_nodes.contains(id), "result {id} leaked from agent:b");
+        assert_ne!(*id, q, "query node must be excluded");
+    }
+
+    // Prove over-fetch happened: an unscoped search of the same k is dominated by
+    // agent:b, so the scoped result set is disjoint from it.
+    let unscoped = db
+        .find_similar_scoped(q, k, &NamespaceScope::all())
+        .unwrap();
+    let unscoped_has_b = unscoped.iter().any(|(id, _)| b_nodes.contains(id));
+    assert!(
+        unscoped_has_b,
+        "sanity: unscoped top-k should include the closer agent:b nodes"
+    );
+}
+
+#[test]
+fn t6_scoped_knn_by_embedding_scopes_and_over_fetches() {
+    let db = AletheiaDB::new().unwrap();
+    db.enable_vector_index("embedding", HnswConfig::new(4, DistanceMetric::Cosine))
+        .unwrap();
+
+    let mut a_nodes = BTreeSet::new();
+    for i in 0..8 {
+        let spread = 0.02 + i as f32 * 0.01;
+        a_nodes.insert(
+            db.create_node_in_namespace(
+                "Doc",
+                vec_props(&format!("a{i}"), &[1.0 - spread, 0.0, spread, 0.0]),
+                "agent:a",
+            )
+            .unwrap(),
+        );
+    }
+    for i in 0..20 {
+        let jitter = i as f32 * 0.0005;
+        db.create_node_in_namespace(
+            "Doc",
+            vec_props(&format!("b{i}"), &[1.0 - jitter, jitter, 0.0, 0.0]),
+            "agent:b",
+        )
+        .unwrap();
+    }
+
+    let query = [1.0f32, 0.0, 0.0, 0.0];
+    let k = 4;
+    let results = db
+        .find_similar_by_embedding_scoped(&query, k, &NamespaceScope::single(ns("agent:a")))
+        .unwrap();
+    assert_eq!(results.len(), k, "must return k in-scope results");
+    for (id, _) in &results {
+        assert!(a_nodes.contains(id), "result {id} must be agent:a");
+    }
+}
+
+// ============================================================================
+// T7 — scope × as_of bi-temporal composition.
+// ============================================================================
+
+#[test]
+fn t7_scoped_point_in_time_reads_compose_and_past_is_stable() {
+    let db = AletheiaDB::new().unwrap();
+
+    // t0: agent:a has Alice; agent:b has its own Alice.
+    let a_alice = db
+        .create_node_in_namespace("Person", props("Alice"), "agent:a")
+        .unwrap();
+    let _b_alice = db
+        .create_node_in_namespace("Person", props("Alice"), "agent:b")
+        .unwrap();
+    let t1 = time::now();
+
+    // Later writes must NOT change the answer to a query anchored at t1.
+    let _a_bob = db
+        .create_node_in_namespace("Person", props("Bob"), "agent:a")
+        .unwrap();
+
+    let scope_a = NamespaceScope::single(ns("agent:a"));
+
+    // get_node_at_time_scoped: a_alice visible in scope A at t1.
+    let got = db
+        .get_node_at_time_scoped(a_alice, t1, t1, &scope_a)
+        .unwrap();
+    assert_eq!(got.id, a_alice);
+
+    // Point-in-time find scoped to A at t1: only Alice existed then in A (Bob was
+    // created after t1), and B's Alice is never in scope A.
+    let found = db
+        .find_nodes_at_time_scoped("Person", t1, t1, &scope_a)
+        .unwrap();
+    let names: BTreeSet<String> = found
+        .nodes
+        .iter()
+        .map(|n| {
+            n.properties
+                .get("name")
+                .and_then(PropertyValue::as_str)
+                .unwrap_or("")
+                .to_string()
+        })
+        .collect();
+    assert_eq!(
+        names,
+        BTreeSet::from(["Alice".to_string()]),
+        "as-of t1 + scope A sees only A's Alice; later Bob and B's Alice excluded"
+    );
+    let ids: BTreeSet<_> = found.nodes.iter().map(|n| n.id).collect();
+    assert!(ids.contains(&a_alice));
+
+    // Namespace filter runs after reconstruction: B's node is NotFound in scope A.
+    let b_alice2 = db
+        .create_node_in_namespace("Person", props("Carol"), "agent:b")
+        .unwrap();
+    let t2 = time::now();
+    assert!(matches!(
+        db.get_node_at_time_scoped(b_alice2, t2, t2, &scope_a),
+        Err(Error::Storage(StorageError::NodeNotFound(_)))
+    ));
+}
+
+#[test]
+fn t7_traverse_scoped_as_of_honors_boundary_and_time() {
+    let db = AletheiaDB::new().unwrap();
+    let a1 = db
+        .create_node_in_namespace("Person", props("a1"), "agent:a")
+        .unwrap();
+    let a2 = db
+        .create_node_in_namespace("Person", props("a2"), "agent:a")
+        .unwrap();
+    let b1 = db
+        .create_node_in_namespace("Person", props("b1"), "agent:b")
+        .unwrap();
+    // In-scope edge a1->a2 (agent:a) and cross-namespace edge a1->b1 (agent:a).
+    db.create_edge_in_namespace(a1, a2, "KNOWS", props(""), "agent:a")
+        .unwrap();
+    db.create_edge_in_namespace(a1, b1, "KNOWS", props(""), "agent:a")
+        .unwrap();
+    let t = time::now();
+
+    // As-of t, scope {a}: a2 reachable, b1's namespace ∉ scope ⇒ not crossed.
+    let scope_a = NamespaceScope::single(ns("agent:a"));
+    let reachable = db
+        .traverse_scoped_as_of(a1, None, 5, t, t, &scope_a)
+        .unwrap();
+    assert!(
+        reachable.contains(&a2),
+        "a2 reachable as-of t under scope a"
+    );
+    assert!(
+        !reachable.contains(&b1),
+        "b1 not crossed (target ns ∉ scope)"
+    );
+
+    // Union scope {a,b}: now b1 is reachable too.
+    let scope_ab = NamespaceScope::list(vec![ns("agent:a"), ns("agent:b")]).unwrap();
+    let reachable = db
+        .traverse_scoped_as_of(a1, None, 5, t, t, &scope_ab)
+        .unwrap();
+    assert!(reachable.contains(&a2));
+    assert!(reachable.contains(&b1));
+}
+
+// ============================================================================
+// QueryBuilder namespace surface.
+// ============================================================================
+
+fn result_node_ids(db: &AletheiaDB, query: aletheiadb::query::Query) -> BTreeSet<u64> {
+    db.execute_query(query)
+        .unwrap()
+        .collect_all()
+        .unwrap()
+        .into_iter()
+        .filter_map(|row| row.entity.node_id())
+        .map(|id| id.as_u64())
+        .collect()
+}
+
+#[test]
+fn querybuilder_in_namespace_filters_start_and_traversal() {
+    let db = AletheiaDB::new().unwrap();
+    let a1 = db
+        .create_node_in_namespace("Person", props("a1"), "agent:a")
+        .unwrap();
+    let a2 = db
+        .create_node_in_namespace("Person", props("a2"), "agent:a")
+        .unwrap();
+    let b1 = db
+        .create_node_in_namespace("Person", props("b1"), "agent:b")
+        .unwrap();
+    db.create_edge_in_namespace(a1, a2, "KNOWS", props(""), "agent:a")
+        .unwrap();
+    // Cross-namespace edge a1 -> b1, living in agent:a.
+    db.create_edge_in_namespace(a1, b1, "KNOWS", props(""), "agent:a")
+        .unwrap();
+
+    // Traverse from a1 scoped to agent:a: reaches a2, never bridges to b1.
+    let q = db
+        .query()
+        .start(a1)
+        .traverse("KNOWS")
+        .in_namespace(ns("agent:a"))
+        .build();
+    let ids = result_node_ids(&db, q);
+    assert!(ids.contains(&a2.as_u64()), "a2 in scope a is returned");
+    assert!(
+        !ids.contains(&b1.as_u64()),
+        "b1 (agent:b) must not be returned under scope a"
+    );
+
+    // in_all_namespaces: both neighbors returned.
+    let q = db
+        .query()
+        .start(a1)
+        .traverse("KNOWS")
+        .in_all_namespaces()
+        .build();
+    let ids = result_node_ids(&db, q);
+    assert!(ids.contains(&a2.as_u64()));
+    assert!(ids.contains(&b1.as_u64()), "all-namespaces sees b1 too");
+}
+
+#[test]
+fn querybuilder_in_namespace_filters_start_node() {
+    let db = AletheiaDB::new().unwrap();
+    let a1 = db
+        .create_node_in_namespace("Person", props("a1"), "agent:a")
+        .unwrap();
+
+    // Starting from a1 but scoping to agent:b returns nothing (a1 ∉ b).
+    let q = db.query().start(a1).in_namespace(ns("agent:b")).build();
+    let ids = result_node_ids(&db, q);
+    assert!(ids.is_empty(), "a1 is not visible under scope agent:b");
+
+    // Scoping to agent:a returns a1.
+    let q = db.query().start(a1).in_namespace(ns("agent:a")).build();
+    let ids = result_node_ids(&db, q);
+    assert_eq!(ids, BTreeSet::from([a1.as_u64()]));
+}
+
+#[test]
+fn querybuilder_in_namespaces_union_scan() {
+    let db = AletheiaDB::new().unwrap();
+    let a1 = db
+        .create_node_in_namespace("Person", props("a1"), "agent:a")
+        .unwrap();
+    let b1 = db
+        .create_node_in_namespace("Person", props("b1"), "agent:b")
+        .unwrap();
+    let _c1 = db
+        .create_node_in_namespace("Person", props("c1"), "agent:c")
+        .unwrap();
+
+    let q = db
+        .query()
+        .scan_label("Person")
+        .in_namespaces([ns("agent:a"), ns("agent:b")])
+        .build();
+    let ids = result_node_ids(&db, q);
+    assert_eq!(ids, BTreeSet::from([a1.as_u64(), b1.as_u64()]));
+}
+
+// ============================================================================
+// GATING soak — 2×2K interleaved writes, zero cross-namespace contamination.
+// ============================================================================
+
+#[test]
+fn soak_2x2k_interleaved_writes_zero_contamination() {
+    let db = Arc::new(AletheiaDB::new().unwrap());
+    let per_thread = 2_000usize;
+
+    let clients = [("agent:planner", "P"), ("agent:researcher", "R")];
+    let handles: Vec<_> = clients
+        .iter()
+        .map(|(namespace, tag)| {
+            let db = Arc::clone(&db);
+            let namespace = namespace.to_string();
+            let tag = tag.to_string();
+            std::thread::spawn(move || {
+                for i in 0..per_thread {
+                    db.create_node_in_namespace("Memory", props(&format!("{tag}-{i}")), &namespace)
+                        .unwrap();
+                }
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    // Post-hoc scoped reads: each namespace holds exactly its own 2000, none from
+    // the other.
+    for (namespace, _tag) in &clients {
+        let scope = NamespaceScope::single(ns(namespace));
+        let listed = db.list_nodes_scoped(Some("Memory"), &scope).unwrap();
+        assert_eq!(
+            listed.len(),
+            per_thread,
+            "namespace {namespace} must hold exactly {per_thread} nodes"
+        );
+        // Every listed node actually belongs to this namespace.
+        for id in listed {
+            assert_eq!(db.get_node(id).unwrap().namespace().as_str(), *namespace);
+        }
+    }
+
+    // Counts corroborate via the membership index.
+    let count = |name: &str| {
+        db.namespace_counts()
+            .into_iter()
+            .find(|c| c.name == name)
+            .map(|c| c.node_count)
+            .unwrap_or(0)
+    };
+    assert_eq!(count("agent:planner"), per_thread);
+    assert_eq!(count("agent:researcher"), per_thread);
+}
+
+// ============================================================================
+// INFORMATIONAL (not gating) — T11 larger soak + T12 perf harness.
+// Run with: cargo test --release -- --ignored --nocapture
+// ============================================================================
+
+#[test]
+#[ignore = "informational T11 soak (AC8): run on demand with --release --ignored"]
+fn t11_soak_20k_interleaved_writes_informational() {
+    let db = Arc::new(AletheiaDB::new().unwrap());
+    let per_thread = 20_000usize;
+    let clients = ["agent:a", "agent:b"];
+    let handles: Vec<_> = clients
+        .iter()
+        .map(|namespace| {
+            let db = Arc::clone(&db);
+            let namespace = namespace.to_string();
+            std::thread::spawn(move || {
+                for i in 0..per_thread {
+                    db.create_node_in_namespace("Memory", props(&format!("{i}")), &namespace)
+                        .unwrap();
+                }
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().unwrap();
+    }
+    for namespace in &clients {
+        let scope = NamespaceScope::single(ns(namespace));
+        let listed = db.list_nodes_scoped(Some("Memory"), &scope).unwrap();
+        assert_eq!(listed.len(), per_thread, "{namespace} isolation at 20K");
+    }
+    eprintln!("T11 soak: 2x{per_thread} interleaved writes, 0 contamination");
+}
+
+#[test]
+#[ignore = "informational T12 perf: run on demand with --release --ignored --nocapture"]
+fn t12_scoped_single_hop_p99_informational() {
+    use std::time::Instant;
+
+    let p99 = |mut v: Vec<u128>| -> f64 {
+        v.sort_unstable();
+        v[((v.len() as f64 * 0.99) as usize).min(v.len() - 1)] as f64
+    };
+
+    // Like-for-like: the SAME traversal method with vs without a restricting
+    // scope. `All` runs the identical BFS machinery (dedup set, queue, adjacency
+    // scan, zero-copy target lookup) but short-circuits the namespace check;
+    // `single` adds `validate_scope` + two O(1) membership probes per edge. Their
+    // ratio isolates the *cost of scoping* (not the traversal API vs a raw loop).
+    let scope_a = NamespaceScope::single(ns("agent:a"));
+    let scope_all = NamespaceScope::all();
+
+    // Measure the scoping overhead at two fan-outs: the canonical single-edge
+    // hop (the literal "<1µs single-hop" target) and a wide 1000-edge fan-out
+    // (amplifies per-edge probe cost).
+    for fanout in [1usize, 1_000usize] {
+        let db = AletheiaDB::new().unwrap();
+        let a1 = db
+            .create_node_in_namespace("Person", props("a1"), "agent:a")
+            .unwrap();
+        for i in 0..fanout {
+            let n = db
+                .create_node_in_namespace("Person", props(&format!("n{i}")), "agent:a")
+                .unwrap();
+            db.create_edge_in_namespace(a1, n, "KNOWS", props(""), "agent:a")
+                .unwrap();
+        }
+
+        let iters = 5_000usize;
+        let mut unscoped = Vec::with_capacity(iters);
+        let mut scoped = Vec::with_capacity(iters);
+        for _ in 0..500 {
+            let _ = db.traverse_scoped(a1, Some("KNOWS"), 1, &scope_all);
+            let _ = db.traverse_scoped(a1, Some("KNOWS"), 1, &scope_a);
+        }
+        for _ in 0..iters {
+            let t = Instant::now();
+            std::hint::black_box(db.traverse_scoped(a1, Some("KNOWS"), 1, &scope_all)).ok();
+            unscoped.push(t.elapsed().as_nanos());
+            let t = Instant::now();
+            std::hint::black_box(db.traverse_scoped(a1, Some("KNOWS"), 1, &scope_a)).ok();
+            scoped.push(t.elapsed().as_nanos());
+        }
+        let u = p99(unscoped);
+        let s = p99(scoped);
+        eprintln!(
+            "T12 like-for-like p99 (fan-out {fanout}): unscoped(All)={u:.0}ns \
+             scoped(single)={s:.0}ns ratio={:.3} (target <= 1.20)",
+            s / u
+        );
+    }
+}

--- a/tests/namespaces_pr2_threading.rs
+++ b/tests/namespaces_pr2_threading.rs
@@ -321,6 +321,11 @@ fn querybuilder_in_namespace_filters_start_node() {
     let a1 = db
         .create_node_in_namespace("Person", props("a1"), "agent:a")
         .unwrap();
+    // Register agent:b (auto-registered on write) so scoping to it is a valid,
+    // non-matching scope rather than an unknown-namespace NOT_FOUND (Issue #3349
+    // A3 — see `querybuilder_unknown_namespace_is_not_found` for that path).
+    db.create_node_in_namespace("Person", props("b1"), "agent:b")
+        .unwrap();
 
     // Starting from a1 but scoping to agent:b returns nothing (a1 ∉ b).
     let q = db.query().start(a1).in_namespace(ns("agent:b")).build();


### PR DESCRIPTION
## Namespaces PR2 — storage/query threading — #3349

Builds on the merged **PR1 core model** (#3662). Threads the namespace axis through current-state storage and the read/query layer.

Foundational threading (secondary membership index, `NamespaceScope`, scoped Rust reads, traversal boundary, per-namespace counts, structured errors, T6 vector k-NN, T7 bi-temporal composition, QueryBuilder namespace surface) landed in earlier revisions — see prior commits. Subsequent revisions folded in the **review-pass correctness fixes (Block A)**, the **interned-namespace performance work (Block B)**, and **expanded test coverage (Block C)**. This latest revision adds the **once-per-query scope-resolution hoist (Block B, item b)** and three small **final review-pass nits**, then merges current `trunk`.

---

## Review-pass revision

### Block A — correctness / isolation
- **A1 — scope pushed to the SOURCE operators.** The namespace scope filter is applied on the source-leaf operators (scans, id lookups, property/vector/temporal sources) via `maybe_scope_source`/`is_scoped_source_leaf` in the executor, not as an outermost post-filter. Everything downstream — `LIMIT`/`SKIP`/`ORDER BY`/`DISTINCT`/aggregation/`COUNT` — now sees only in-scope rows, so a scoped `count()` reports the SCOPED cardinality and a scoped `LIMIT n` returns up to n *in-scope* rows. The outermost `wrap_scope_filter` was removed.
- **A2 — `in_namespaces([])` no longer degrades to unscoped-all.** The empty-list intent is preserved as an empty `NamespaceScope::List` (`src/query/builder.rs`) rather than collapsing to `None`.
- **A3 — `validate_scope` on the builder/execute path.** `execute_query` (`src/db/query.rs`) validates the scope before planning, so an unknown namespace → `NOT_FOUND` and an empty list → `INVALID_ARGUMENT` (AC6), never a silently-empty success.
- **A4 — traversal scope-checks the START node.** An out-of-scope / non-existent start → `NodeNotFound`.
- **A5 — id-only temporal rows** use the O(1) membership probe (documented reachability).
- **A6 — empty DashSet reclaimed** from `ns_nodes`/`ns_edges` on drain (`remove_if` re-checks emptiness under the shard write lock so a concurrent insert never loses its set).

### Block B — performance (interned namespace ids + once-per-query hoist)
Root cause of the pre-fix ~1.9× scoped single-hop p99 was per-edge `DashMap` membership probes (string hashing + shard lock) plus per-call scope-validation allocations.
- **B1** — process-global namespace interner + copyable `NamespaceId(u32)`. The membership index (`ns_nodes`/`ns_edges`) is keyed by `NamespaceId`, identity-hashed on both the outer (u32) and inner (u64 NodeId/EdgeId) maps → per-edge boundary check is integer hashes, no SipHash. **The interned id is derived at the single membership-maintenance site (`insert_node`/`insert_edge` in `src/index/current.rs`)** from the entity&#39;s durable ride-along namespace, so **every hydration path — write, WAL replay, index-persistence load, cold rehydration — funnels through the same choke point and yields the identical id** (no in-memory struct change, no stale cached id). This also keeps the change OUT of the write-transaction path.
- **B2** — O(1) membership probes (`node_in_namespace_id`/`edge_in_namespace_id`) replace full-entity clones in `find_nodes_by_property_scoped` and the id-only branches; `validate_scope` is allocation-free.
- **B (item b) — once-per-query scope-resolution hoist.** A query&#39;s `NamespaceScope` is now resolved to interned ids **exactly once** at execute start (new `ResolvedScope` in `src/core/namespace.rs`, built by `NamespaceScope::resolve()`), instead of re-deriving it per source-leaf and per traversal. The executor stores the resolved handle and threads cheap clones into every `ScopeFilterIterator` and the `TraversalIterator` boundary; `traverse_scoped` (the direct-API T12 path) resolves once and reuses. The **single-namespace case** — a `Single` scope, or a one-element `List` — is carried **inline** as one `NamespaceId` (no `Vec`/`Arc` allocation), so the per-edge/per-row check is a **single integer compare** (`ResolvedScope::contains_by`) rather than an `.any()` over a heap `Vec`. Structural hoist only; unscoped/default reads unchanged (no scope attached ⇒ `ResolvedScope::All`, no wrapping, no allocation).

### Block C — tests (`tests/namespaces_pr2_review.rs` + `tests/namespaces_pr2_threading.rs`)
C1 traverse-as_of-time · C2 out-of-scope start → NotFound · C3 scoped LIMIT/SKIP + scoped count() · C4 edge-scoped reads · C5 edge membership after delete + restart · C6 T6 order/score · C7 T4 union-within · C8 `find_nodes_by_property_at_scoped` · C9 empty `in_namespaces([])` pinned → INVALID_ARGUMENT · C10 unknown-ns → NOT_FOUND · C11 `.albk` backup/restore namespace survival · B1 interned-id consistency across write / WAL-replay / backup-restore.

### Final review-pass nits (this revision)
- **2a — OPTIONAL MATCH sub-pipeline is now scope-threaded (defense in depth).** `OptionalApplyIterator`&#39;s per-seed sub-pipeline previously built its `NodeScan`/`Traverse` steps WITHOUT the namespace scope. Unreachable today (no scoped query carries an `OptionalApply` — `QueryBuilder` has no `optional`, AQL sets `scope: None`, Cypher scope unwired), but it WOULD leak cross-namespace bindings once PR3 wires Cypher/AQL scope to `OPTIONAL MATCH`. Given the item-(b) plumbing this was a clean thread, so the scope + its resolved handle are now passed into the sub-pipeline (`OptionalApplyIterator::with_namespace_scope`) and its source leaf + traversal hops are scope-bounded. Never silently wrong.
- **2b(i)** — `src/query/builder.rs` doc referenced a nonexistent `execute_query_profiled`; corrected to the real `execute` → `AletheiaDB::execute_query` validation path.
- **2b(ii)** — `ScopeFilterIterator` doc updated: it wraps SOURCE leaves (not "the very end of the pipeline").
- **2c — QueryBuilder scoped vector search ≤k caveat (pre-existing, documented).** The executor `HnswSearch` path (`QueryBuilder.find_similar(...).in_namespace(...)`) POST-filters the index k-NN to the scope, so it may return **fewer than `k`** in-scope rows — unlike the `find_similar_scoped` / `find_similar_by_embedding_scoped` API, which over-fetches for filter-completeness. This is pre-existing (not a regression); a doc comment now discloses it on `QueryBuilder::find_similar` and points to the filter-complete API. The executor HNSW path itself is unchanged (out of scope).

---

## Re-measured T12 (release, like-for-like `traverse_scoped(single)` vs `traverse_scoped(All)` on the same BFS machinery)

| fan-out | unscoped(All) | scoped(single) | ratio | prior |
|---|---|---|---|---|
| 1 (single-hop) | 499 ns | **757 ns** | **1.517×** | 1.77× |
| 1000 | 191.5 µs | 267.0 µs | **1.394×** | 1.39× |

### Amended acceptance targets (coordinator ruling)
- **Scoped single-hop latency — ABSOLUTE target < 1 µs — MET.** Re-measured **757 ns** for a true single hop (scoped `single`), comfortably sub-µs.
- **Ratio ≤ 1.5× at fan-out ≥ 1000 — MET.** Re-measured **1.394×** (was 1.39×; the item-(b) inline single-id path is within noise here because at high fan-out the cost is the per-edge membership-index probe itself, not the iterator/allocation machinery the hoist removes).
- **Tiny fan-out ratio target — explicitly DROPPED (physics).** A correctness-required namespace-membership check (one `validate_scope` registry probe + two O(1) membership probes) cannot fit inside the ~92 ns of headroom that a ≤1.2× ratio would allow on a ~461–499 ns base op. Honest measured fan-out-1 ratio: **1.517×** (improved from 1.77× — the item-(b) hoist removed the per-call `resolved_ids()` `Vec` allocation by carrying the single namespace id inline).
- **Unscoped reads byte-for-byte unaffected — HARD requirement, proven.** The default (no-scope) read path never attaches a scope, never touches the interner or membership index, and never wraps a source leaf or traversal; `ResolvedScope::All` is an immediate no-op. `get_node`/`get_edge`/`traverse` core is structurally unchanged. Only `*_scoped` reads / scoped `QueryBuilder` queries and write-path index maintenance touch the new code.

---

## Guarantees (unchanged)
- **No WAL-format / `WAL_VERSION` change.**
- **No MCP tool-registry change** — `tests/parity/inventory.json` mcp stays **58**; `security/rbac.rs` / `app.rs` untouched.
- `DatabaseStats.namespaces` stays `#[serde(skip_serializing)]` (MCP exposure is PR3) — preserved through the `trunk` merge below.
- Membership index remains a lock leaf.

## Trunk merge (this revision)
Merged current `origin/trunk` (`10f4c6bd`). The only content conflict was `src/db/stats.rs`, resolved **keep-both**: trunk&#39;s new `changefeed: ChangefeedStats` field (+ its `ChangefeedStats`/`PrincipalSubscriptionStat` structs and `stats()` population, Issue #3678) sits alongside PR2&#39;s `namespaces` field, which retains `#[serde(skip_serializing)]`. `test_database_stats_key_sets_are_stable` passes unchanged (the skip-serialized `namespaces` field is correctly absent from the JSON key set; trunk&#39;s `changefeed` key is present). No GDPR-owned file (`src/api/transaction/write/mod.rs`, `write_buffer.rs`, `src/db/{ops,temporal,transaction,mod}.rs`) had a conflict.

## Gates (fresh isolated build, post-merge)
`cargo fmt --all --check` clean · clippy (named feature set `config-toml,mcp-server,sharding-rpc,simulation` / `--all-features` / `--no-default-features`) all `-D warnings` clean · `cargo check --no-default-features --tests` clean · `cargo test --features mcp-server --no-fail-fast` — lib 4820/0, all namespace suites green (`namespaces_pr2` 10/10, `namespaces_pr2_review` 12/12, `namespaces_pr2_threading` 8/8 +2 informational ignored T11/T12). Failures: the two **pre-existing known-OK** (`test_flush_deadlock_on_io_error`, `test_metadata_corruption_on_error`) plus one **trunk-introduced parallel-isolation flake** pulled in by the merge — `changefeed_config_default_and_override_from_unified_config` (`tests/changefeed_subscribe.rs`, Issue #3678) shares a *relative* `aletheiadb/wal/` default-config WAL dir with sibling tests and corrupts under parallel `cargo test`; it **passes in isolation and single-threaded (20/20)** and is unrelated to this PR&#39;s namespace/stats changes (trunk-owned test hermeticity — flagged as a follow-up, not fixed here).

Refs #3349.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3mvy2HNA1SWx6DTDcZe7x)_