### PR TITLE
feat(crypto-shred): seal-at-write / unseal-at-read property-path integration (#3359 PR-1b)

### DIFF
--- a/docs/plans/2026-07-16-gdpr-crypto-shred.md
+++ b/docs/plans/2026-07-16-gdpr-crypto-shred.md
@@ -162,6 +162,71 @@ Pre-erasure `AS OF` still returns structure (ids, temporal coords, label, topolo
     meaningful to measure at the foundation level.
 
 **Coordination boundary:** the encryption-migration successor session owns `src/encryption` + `src/storage/wal` keyring code and #3616 PRs 2–4; slice 1 deliberately avoids those files; slices 3 and 5 require coordinator-brokered coordination before touching `wal_encryption.rs` / `rotation.rs` / `reencrypt.rs`.
+
+## PR-1b delivered / deferred (property-path integration)
+
+**Delivered in PR-1b** (wires the PR-1a cryptographic core into the live
+data path — no `src/encryption/`, `rotation.rs`, `wal_encryption.rs`, or
+`reencrypt.rs` edits):
+
+- **Reverse designation index** on `SubjectKeyring`
+  (`HashMap<(is_node,u64), Vec<subject_id>>`): maintained in `upsert` (so it
+  grows with `designate`'s merge/new arms), rebuilt in `load_from_sidecar`, left
+  intact by `erase_in_memory`/`force_erased` (so reads still report erased).
+  Plus lock-free gates `has_active` / `has_any` (AtomicBool) so a database with
+  no active designations pays zero per-write cost and one with no designations
+  at all pays zero per-read cost.
+- **Seal at write:** `apply_node_write` / `apply_edge_write` rebind `properties`
+  through a single `seal_map` at the top, so BOTH the current and historical
+  tiers receive **byte-identical** sealed-envelope ciphertext (one seal, random
+  nonce shared). `WriteTransaction` carries a prepared `SealingContext`
+  (`Arc<CryptoShredState>` + memoized wrap cipher + algorithm), populated in
+  `write_transaction()` only when active designations exist (gated
+  `#[cfg(feature="audit-export")]`). Reserved keys (`__aletheia_*` / `__shred_*`,
+  incl. the `__aletheia_ns` namespace marker) are never sealed — free via
+  `should_seal_key`. Write-site context binds `entity_id ‖ property_key`. A
+  sealed `Vector` becomes `Bytes`, so `try_index_vector`'s `as_vector()` gate
+  naturally **excludes designated embeddings from the shared HNSW** (no
+  `try_index_vector` change).
+- **Unseal at read:** `AletheiaDB::materialize_shred` + `unseal_node_view` /
+  `unseal_edge_view`, hooked at `get_node` / `get_edge` (current fast path) and
+  `get_node_at_time` / `get_edge_at_time` (point-in-time). Active subjects →
+  plaintext in place; erased subjects → opaque ciphertext left untouched +
+  `ShredStatus::Erased{subject_id}` recorded in a side-channel `ShredStatusMap`
+  (NOT a `PropertyValue` variant, NOT a wire change). The **restore path**
+  (`restore_property_map`) stays a pure ciphertext passthrough — never unsealed
+  there (no keyring / interner-guard hazard).
+- **MCP erased marker:** `property_value_to_json` renders a surviving `SUBJ`
+  envelope for a known subject as `{"type":"sealed","erased":<bool>,"subject_id":<id>}`
+  (mirrors the #3220 vector-elision descriptor); a `Bytes` value whose subject
+  the keyring does not recognize renders as ordinary bytes.
+- **Erase op unchanged from PR-1a** (key destruction + durable keyring
+  Erased-state + signed attestation). **No `db.write` tombstone added here.**
+
+**Deferred (explicitly out of PR-1b):**
+
+- **WAL-transaction erasure tombstone + changefeed observability** → a
+  **#3413-aligned follow-up**. It needs a WAL-format extension to survive crash
+  recovery, and emitting it from `erase()` would take `historical`/`wal` while
+  the keyring `Mutex` is held, inverting the lock order (seams §6). The durable
+  keyring Erased record IS the erasure record for now.
+- **Cold-tier + `.albk` sentinel completeness** → **slice 3** (the PR-1b
+  sentinel byte-scan covers only the in-scope hot tiers: WAL segments,
+  index-persistence files incl. usearch `.bin`, current-tier persisted files,
+  checkpoint if present — NOT cold redb or `.albk`).
+- **Chain-leaf ciphertext binding (AC4)** → **slice 2**.
+- **Exhaustive every-query-path unseal** → the Rust unseal hook covers the
+  primary single-entity boundaries (`get_node`, `get_edge`,
+  `get_node_at_time`, `get_edge_at_time`). Paths that still return **raw sealed
+  `Bytes`** (opaque ciphertext — safe, never plaintext, just not yet
+  unsealed/marked at the Rust level): `with_node` (zero-copy borrow),
+  `list_nodes` / `list_edges`, adjacency (`get_outgoing_edges` /
+  `get_incoming_edges`), `traverse`, `find_nodes_at_time`, the query executor
+  (`iterators.rs`) and `read_tx` reconstructs. For all of these the MCP funnel
+  still renders the erased descriptor for any envelope that reaches it, so an
+  erased value is never surfaced as plaintext on the MCP surface. Extending the
+  Rust unseal hook to these is a follow-up.
+
 ## AC4 disclosure — sealed-property verify semantics
 
 The provenance hash chain's per-version leaf (`version_leaf`,

--- a/src/api/transaction/write/apply.rs
+++ b/src/api/transaction/write/apply.rs
@@ -88,6 +88,12 @@ pub(crate) fn apply_node_write(
     historical: &mut HistoricalStorage,
     provenance: Option<Arc<Provenance>>,
 ) -> Result<()> {
+    // GDPR crypto-shred (Issue #3359, PR-1b): `properties` here already carry any
+    // sealed `SUBJ` envelopes — sealing happens once on the write buffer in
+    // `commit_with_timestamp_inner` (post-validation, pre-WAL), so the WAL
+    // segment, the current tier below, and the historical tier below all receive
+    // byte-identical ciphertext. Do NOT seal again here (it would double-seal).
+
     // Create node with pending metadata (commit_timestamp finalized after full apply_changes).
     // Using uncommitted here prevents phantom visibility if apply_changes fails partway through.
     let metadata = VersionMetadata::uncommitted(tx.tx_id);
@@ -149,6 +155,10 @@ pub(crate) fn apply_edge_write(
     historical: &mut HistoricalStorage,
     provenance: Option<Arc<Provenance>>,
 ) -> Result<()> {
+    // GDPR crypto-shred (Issue #3359, PR-1b): `properties` already carry any
+    // sealed envelopes (sealed on the write buffer in `commit_with_timestamp_inner`
+    // before WAL logging). Do NOT seal again here.
+
     // Create edge with pending metadata (commit_timestamp finalized after full apply_changes).
     let metadata = VersionMetadata::uncommitted(tx.tx_id);
     let edge = Edge::with_metadata(

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -131,6 +131,15 @@ pub struct WriteTransaction {
     /// matching subscribers AFTER the commit is durable, applied, and visible — outside
     /// every write-path lock (the broadcaster's lock is a leaf).
     pub(crate) changefeed: Option<Arc<crate::core::changefeed_subscription::ChangefeedBroadcaster>>,
+
+    /// GDPR crypto-shred sealing context (Issue #3359, PR-1b). `None` unless the
+    /// parent database has at least one **active** erasure designation, so a
+    /// database that never used crypto-shred pays nothing. When present, the
+    /// apply hook (`apply_node_write`/`apply_edge_write`) replaces designated
+    /// property values with sealed `SUBJ` envelopes before they reach either the
+    /// current or the historical tier.
+    #[cfg(feature = "audit-export")]
+    pub(crate) sealing: Option<crate::db::crypto_shred::SealingContext>,
 }
 
 impl WriteTransaction {
@@ -271,6 +280,8 @@ impl WriteTransaction {
             in_flight: None,
             cas_preconditions: Vec::new(),
             changefeed: None,
+            #[cfg(feature = "audit-export")]
+            sealing: None,
         }
     }
 
@@ -300,6 +311,58 @@ impl WriteTransaction {
     ) -> Self {
         self.changefeed = Some(broadcaster);
         self
+    }
+
+    /// Attach the GDPR crypto-shred sealing context (Issue #3359, PR-1b, called
+    /// by the DB layer when the database has active designations). When set, the
+    /// apply hook seals designated property values before persisting them.
+    #[cfg(feature = "audit-export")]
+    pub(crate) fn with_sealing_context(
+        mut self,
+        sealing: crate::db::crypto_shred::SealingContext,
+    ) -> Self {
+        self.sealing = Some(sealing);
+        self
+    }
+
+    /// Seal designated property values in the write buffer (Issue #3359, PR-1b).
+    ///
+    /// Called from `commit_with_timestamp_inner` AFTER validation + constraint
+    /// checks (which must see plaintext values) but BEFORE WAL logging and apply,
+    /// so the WAL segment, the current tier, and the historical tier all receive
+    /// **byte-identical** sealed ciphertext (each envelope is sealed exactly once;
+    /// its random per-encryption nonce is shared across every tier). No-op when no
+    /// sealing context is attached (no active designation) or when no buffered
+    /// entity carries a designated key.
+    ///
+    /// # Errors
+    /// Propagates the seal error (fail-closed: a seal failure aborts the commit
+    /// rather than persisting plaintext of erasable data).
+    #[cfg(feature = "audit-export")]
+    pub(crate) fn seal_buffer(&mut self) -> Result<()> {
+        use super::BufferedWrite as BW;
+        // Cheap clone (two Arc + a Copy enum) so we can borrow the buffer mutably.
+        let Some(ctx) = self.sealing.clone() else {
+            return Ok(());
+        };
+        for op in self.buffer.operations_mut() {
+            let (is_node, entity_id) = match op {
+                BW::CreateNode { node_id, .. } | BW::UpdateNode { node_id, .. } => {
+                    (true, node_id.as_u64())
+                }
+                BW::CreateEdge { edge_id, .. } | BW::UpdateEdge { edge_id, .. } => {
+                    (false, edge_id.as_u64())
+                }
+                // Deletes/retracts re-persist already-sealed bytes read back from
+                // storage — no re-seal needed.
+                _ => continue,
+            };
+            if let Some(props_ref) = op.properties_mut() {
+                let props = std::mem::take(props_ref);
+                *props_ref = ctx.seal_map(is_node, entity_id, props)?;
+            }
+        }
+        Ok(())
     }
 
     /// Get transaction metadata.
@@ -450,6 +513,16 @@ impl WriteTransaction {
         } else {
             None
         };
+
+        // GDPR crypto-shred (Issue #3359, PR-1b): seal designated property values
+        // in the buffer AFTER validation + constraint checks (which must see
+        // plaintext) but BEFORE WAL logging + apply, so every tier (WAL segment,
+        // current, historical) records byte-identical sealed ciphertext. Runs
+        // outside the `current_timestamp` critical section, keeping the keyring
+        // lock off the timestamp-held path. Fail-closed. No-op without an active
+        // designation.
+        #[cfg(feature = "audit-export")]
+        self.seal_buffer()?;
 
         // Issue #3406: pre-generate the closing (delete tombstone / retraction)
         // version ids BEFORE WAL logging, so the SAME ids are both (a) recorded

--- a/src/api/transaction/write_buffer.rs
+++ b/src/api/transaction/write_buffer.rs
@@ -172,6 +172,20 @@ impl BufferedWrite {
         }
     }
 
+    /// Return a mutable reference to the properties map if the operation has one
+    /// (Issue #3359, PR-1b: in-place crypto-shred sealing of the buffer before
+    /// WAL logging).
+    #[cfg(feature = "audit-export")]
+    pub(crate) fn properties_mut(&mut self) -> Option<&mut PropertyMap> {
+        match self {
+            Self::CreateNode { properties, .. } => Some(properties),
+            Self::UpdateNode { properties, .. } => Some(properties),
+            Self::CreateEdge { properties, .. } => Some(properties),
+            Self::UpdateEdge { properties, .. } => Some(properties),
+            _ => None,
+        }
+    }
+
     /// Check if this is a node operation
     pub fn is_node_operation(&self) -> bool {
         matches!(
@@ -364,6 +378,13 @@ impl WriteBuffer {
     /// Get all operations in order
     pub fn operations(&self) -> &[BufferedWrite] {
         &self.operations
+    }
+
+    /// Mutable access to all operations in order (Issue #3359, PR-1b: in-place
+    /// crypto-shred sealing of buffered property maps before WAL logging).
+    #[cfg(feature = "audit-export")]
+    pub(crate) fn operations_mut(&mut self) -> &mut [BufferedWrite] {
+        &mut self.operations
     }
 
     /// Check if a node has been modified in this buffer

--- a/src/db/crypto_shred/api.rs
+++ b/src/db/crypto_shred/api.rs
@@ -4,11 +4,17 @@
 //! encryption config and delegate to [`super::CryptoShredState`]. No live
 //! data-path integration here — that is PR-1b.
 
+use std::sync::Arc;
+
+use crate::core::graph::{Edge, Node};
+use crate::core::property::PropertyMap;
 use crate::db::AletheiaDB;
 use crate::encryption::{Cipher, KeyDerivation, create_cipher};
 
 use super::error::CryptoShredError;
-use super::{DesignationTarget, ErasureAttestation, SubjectId, SubjectKey};
+use super::{
+    DesignationTarget, ErasureAttestation, SealingContext, ShredStatusMap, SubjectId, SubjectKey,
+};
 
 /// HKDF component label for the subject-wrapping DEK. Yields HKDF info string
 /// `aletheiadb-subject-wrap-dek-v1` (see `KeyDerivation::derive_dek`).
@@ -106,5 +112,82 @@ impl AletheiaDB {
     #[must_use]
     pub fn erasure_attestation_public_key(&self) -> crate::audit::AuditPublicKey {
         self.crypto_shred.attestation_public_key()
+    }
+
+    // ---- PR-1b live data-path integration -------------------------------------
+
+    /// Build a prepared [`SealingContext`] for a write transaction, or `None`
+    /// when there is nothing to seal (no active designation) — the cheap common
+    /// case. Fail-closed: when active designations exist but the subject-wrapping
+    /// cipher cannot be built (e.g. encryption misconfigured), returns `Err` so
+    /// the write aborts rather than silently persisting plaintext.
+    pub(crate) fn sealing_context(&self) -> Result<Option<SealingContext>, CryptoShredError> {
+        if !self.crypto_shred.has_active_designations() {
+            return Ok(None);
+        }
+        let cfg = self
+            .encryption_config
+            .as_ref()
+            .ok_or(CryptoShredError::EncryptionNotConfigured)?;
+        let wrap = self
+            .crypto_shred
+            .cached_wrap_cipher(|| self.subject_wrap_cipher())?;
+        Ok(Some(SealingContext::new(
+            Arc::clone(&self.crypto_shred),
+            wrap,
+            cfg.algorithm,
+        )))
+    }
+
+    /// Materialize sealed property values on read (PR-1b read hook).
+    ///
+    /// Unseal active-subject envelopes to plaintext in place; leave erased ones
+    /// as opaque ciphertext and report them via the returned [`ShredStatusMap`].
+    /// Cheap no-op (returns the map untouched) when the database has never had
+    /// any designation. Building the subject-wrapping cipher (needed only to
+    /// unwrap active DEKs on a cache miss) is memoized; a failure to build it
+    /// leaves values opaque rather than fabricating plaintext.
+    pub(crate) fn materialize_shred(
+        &self,
+        entity_id: u64,
+        props: PropertyMap,
+    ) -> (PropertyMap, ShredStatusMap) {
+        if !self.crypto_shred.has_any_designations() {
+            return (props, ShredStatusMap::new());
+        }
+        let Some(cfg) = self.encryption_config.as_ref() else {
+            return (props, ShredStatusMap::new());
+        };
+        let wrap = match self
+            .crypto_shred
+            .cached_wrap_cipher(|| self.subject_wrap_cipher())
+        {
+            Ok(w) => w,
+            Err(_) => return (props, ShredStatusMap::new()),
+        };
+        self.crypto_shred
+            .unseal_map(entity_id, props, wrap.as_ref(), cfg.algorithm)
+    }
+
+    /// Unseal a node's designated properties for a read boundary (PR-1b).
+    #[must_use]
+    pub(crate) fn unseal_node_view(&self, mut node: Node) -> Node {
+        if !self.crypto_shred.has_any_designations() {
+            return node;
+        }
+        let (props, _status) = self.materialize_shred(node.id.as_u64(), node.properties);
+        node.properties = props;
+        node
+    }
+
+    /// Unseal an edge's designated properties for a read boundary (PR-1b).
+    #[must_use]
+    pub(crate) fn unseal_edge_view(&self, mut edge: Edge) -> Edge {
+        if !self.crypto_shred.has_any_designations() {
+            return edge;
+        }
+        let (props, _status) = self.materialize_shred(edge.id.as_u64(), edge.properties);
+        edge.properties = props;
+        edge
     }
 }

--- a/src/db/crypto_shred/integration_tests.rs
+++ b/src/db/crypto_shred/integration_tests.rs
@@ -1,0 +1,547 @@
+//! Crypto-shred **property-path integration** tests (Issue #3359, slice PR-1b).
+//!
+//! These exercise the live seal-at-write / unseal-at-read data path wired in
+//! PR-1b: an end-to-end cold-restart round trip, the silent-bypass sentinel
+//! byte-scan across every in-scope persisted tier, blast-radius isolation,
+//! `__aletheia_ns` coexistence, HNSW exclusion of designated embeddings, the
+//! MCP erased-marker shape, a no-deadlock concurrency check, and the
+//! non-designated zero-regression guarantee.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::config::{AletheiaDBConfig, WalConfigBuilder};
+use crate::core::property::{PropertyMapBuilder, PropertyValue};
+use crate::db::AletheiaDB;
+use crate::encryption::config::EncryptionConfig;
+use crate::index::vector::{DistanceMetric, HnswConfig};
+use crate::storage::index_persistence::PersistenceConfig;
+
+use super::DesignationTarget;
+
+// ── helpers ────────────────────────────────────────────────────────
+
+/// A distinctive plaintext sentinel that must NEVER appear in any persisted
+/// artifact once its subject is sealed/erased.
+const SENTINEL: &str = "SENTINEL_GDPR_a9f3c1e7b2d64051_PLAINTEXT_MUST_NOT_LEAK";
+
+/// Build a persistent, encrypted config rooted at `root`.
+fn enc_config(root: &Path) -> AletheiaDBConfig {
+    let key_file = root.join("mek.key");
+    if !key_file.exists() {
+        crate::encryption::FileKeyProvider::generate_key_file(&key_file).unwrap();
+    }
+    AletheiaDBConfig::builder()
+        .wal(WalConfigBuilder::new().wal_dir(root.join("wal")).build())
+        .persistence(PersistenceConfig {
+            enabled: true,
+            data_dir: root.join("data"),
+            load_on_startup: true,
+            ..Default::default()
+        })
+        .encryption(EncryptionConfig::file_based(&key_file))
+        .build()
+}
+
+fn enc_db(root: &Path) -> AletheiaDB {
+    AletheiaDB::with_unified_config(enc_config(root)).unwrap()
+}
+
+/// A distinctive embedding whose raw little-endian float bytes we also scan for.
+fn sentinel_embedding() -> Vec<f32> {
+    vec![0.111_111_f32, 0.222_222, 0.333_333, 0.444_444]
+}
+
+/// The raw LE byte encoding of an embedding, as it would appear in a plaintext
+/// vector index / property store if it were ever persisted un-sealed.
+fn embedding_bytes(v: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(v.len() * 4);
+    for f in v {
+        out.extend_from_slice(&f.to_le_bytes());
+    }
+    out
+}
+
+/// Recursively assert no persisted file under `dir` contains `needle`.
+///
+/// Reusable silent-bypass guard (AC5 for the in-scope hot tiers): after
+/// designate + seal-at-write + erase, EVERY reachable artifact (WAL segments,
+/// index-persistence files incl. usearch `.bin`, current-tier persisted files,
+/// checkpoint) must be free of the designated plaintext. The MEK key file is
+/// skipped (it is key material, never a data artifact, and never carries the
+/// sentinel).
+fn assert_no_designated_plaintext(dir: &Path, needle: &[u8]) {
+    assert!(!needle.is_empty(), "needle must be non-empty");
+    let mut stack = vec![dir.to_path_buf()];
+    let mut scanned = 0usize;
+    while let Some(path) = stack.pop() {
+        let meta = match std::fs::metadata(&path) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if meta.is_dir() {
+            if let Ok(entries) = std::fs::read_dir(&path) {
+                for e in entries.flatten() {
+                    stack.push(e.path());
+                }
+            }
+            continue;
+        }
+        // Skip the MEK key file — key material, not a data artifact.
+        if path.file_name().is_some_and(|n| n == "mek.key") {
+            continue;
+        }
+        let bytes = match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        scanned += 1;
+        let hit = bytes.windows(needle.len()).any(|w| w == needle);
+        assert!(
+            !hit,
+            "designated plaintext leaked into persisted artifact: {}",
+            path.display()
+        );
+    }
+    assert!(scanned > 0, "scan found no files under {}", dir.display());
+}
+
+// ── E2E: seal at write, unseal at read, survive cold restart ───────
+
+#[test]
+fn e2e_seal_write_unseal_read_survives_cold_restart_then_erase() {
+    let dir = tempfile::tempdir().unwrap();
+    let embedding = sentinel_embedding();
+
+    // Phase 1: designate a whole node + write the sentinel + a designated
+    // embedding, so the persisted version is sealed at write time.
+    let node_id;
+    {
+        let db = enc_db(dir.path());
+        db.enable_vector_index("embedding", HnswConfig::new(4, DistanceMetric::Cosine))
+            .unwrap();
+
+        // Create a placeholder (no sentinel), capture its id, THEN designate and
+        // replace so the sealed version carries the sentinel. This is robust to
+        // whatever id the generator assigns.
+        node_id = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("stage", "placeholder")
+                    .build(),
+            )
+            .unwrap();
+        db.designate_subject(
+            "subject-A",
+            vec![DesignationTarget::WholeNode(node_id.as_u64())],
+        )
+        .unwrap();
+        db.replace_node(
+            node_id,
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("email", SENTINEL)
+                .insert_vector("embedding", &embedding)
+                .build(),
+        )
+        .unwrap();
+
+        // In-process read already returns plaintext (key present).
+        let node = db.get_node(node_id).unwrap();
+        assert_eq!(
+            node.properties.get("email"),
+            Some(&PropertyValue::from(SENTINEL.to_string())),
+            "active-subject read must unseal to plaintext"
+        );
+        drop(db);
+    }
+
+    // Phase 2: reopen COLD — key still present, read returns plaintext.
+    {
+        let db = enc_db(dir.path());
+        let node = db.get_node(node_id).unwrap();
+        assert_eq!(
+            node.properties.get("email"),
+            Some(&PropertyValue::from(SENTINEL.to_string())),
+            "cold reopen with key present must return plaintext"
+        );
+        // The embedding round-trips as plaintext through the read boundary too.
+        assert!(
+            node.properties
+                .get("embedding")
+                .and_then(|v| v.as_vector())
+                .is_some(),
+            "designated embedding must unseal back to a Vector on read"
+        );
+        drop(db);
+    }
+
+    // Phase 3: erase the subject, reopen COLD — read returns the erased marker,
+    // NEVER the sentinel.
+    {
+        let db = enc_db(dir.path());
+        db.erase_subject("subject-A").unwrap();
+        drop(db);
+    }
+    {
+        let db = enc_db(dir.path());
+        let node = db.get_node(node_id).unwrap();
+        // The value is an opaque sealed envelope now (never the sentinel).
+        match node.properties.get("email") {
+            Some(PropertyValue::Bytes(b)) => {
+                assert!(
+                    super::envelope::is_envelope(b),
+                    "erased value stays a SUBJ envelope"
+                );
+                assert_ne!(
+                    b.as_ref(),
+                    SENTINEL.as_bytes(),
+                    "erased read must never surface the plaintext sentinel"
+                );
+            }
+            other => panic!("expected opaque sealed bytes after erase, got {other:?}"),
+        }
+        // The side-channel reports the erasure explicitly (never fabricated).
+        let (_props, status) = db.materialize_shred(node_id.as_u64(), node.properties.clone());
+        assert!(
+            matches!(
+                status.get("email"),
+                Some(super::ShredStatus::Erased { subject_id }) if subject_id == "subject-A"
+            ),
+            "materialize_shred must report ShredStatus::Erased for the erased key"
+        );
+        drop(db);
+    }
+
+    // The sentinel plaintext (and raw embedding floats) must be absent from EVERY
+    // in-scope persisted artifact.
+    assert_no_designated_plaintext(dir.path(), SENTINEL.as_bytes());
+    assert_no_designated_plaintext(dir.path(), &embedding_bytes(&embedding));
+}
+
+// ── Sentinel byte-scan: silent-bypass guard even BEFORE erase ──────
+
+#[test]
+fn sealed_plaintext_never_hits_any_tier_pre_or_post_erase() {
+    let dir = tempfile::tempdir().unwrap();
+    let node_id;
+    {
+        let db = enc_db(dir.path());
+        node_id = db
+            .create_node("Doc", PropertyMapBuilder::new().insert("k", "v").build())
+            .unwrap();
+        db.designate_subject("S", vec![DesignationTarget::WholeNode(node_id.as_u64())])
+            .unwrap();
+        db.replace_node(
+            node_id,
+            "Doc",
+            PropertyMapBuilder::new().insert("secret", SENTINEL).build(),
+        )
+        .unwrap();
+        drop(db);
+    }
+    // Even while the subject is still ACTIVE, no tier holds the plaintext — the
+    // seal happened at write, before any tier saw the value.
+    assert_no_designated_plaintext(dir.path(), SENTINEL.as_bytes());
+
+    {
+        let db = enc_db(dir.path());
+        db.erase_subject("S").unwrap();
+        drop(db);
+    }
+    assert_no_designated_plaintext(dir.path(), SENTINEL.as_bytes());
+}
+
+// ── Blast radius: erase A leaves B byte-identical ──────────────────
+
+#[test]
+fn blast_radius_erase_a_leaves_b_intact() {
+    let dir = tempfile::tempdir().unwrap();
+    let sentinel_b = "SUBJECT_B_PLAINTEXT_stays_readable_7f1e";
+    let (id_a, id_b);
+    {
+        let db = enc_db(dir.path());
+        id_a = db
+            .create_node("Person", PropertyMapBuilder::new().insert("s", "p").build())
+            .unwrap();
+        id_b = db
+            .create_node("Person", PropertyMapBuilder::new().insert("s", "p").build())
+            .unwrap();
+        db.designate_subject("A", vec![DesignationTarget::WholeNode(id_a.as_u64())])
+            .unwrap();
+        db.designate_subject("B", vec![DesignationTarget::WholeNode(id_b.as_u64())])
+            .unwrap();
+        db.replace_node(
+            id_a,
+            "Person",
+            PropertyMapBuilder::new().insert("email", SENTINEL).build(),
+        )
+        .unwrap();
+        db.replace_node(
+            id_b,
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("email", sentinel_b)
+                .build(),
+        )
+        .unwrap();
+        db.erase_subject("A").unwrap();
+        drop(db);
+    }
+    let db = enc_db(dir.path());
+    // B is untouched: reads back byte-identical plaintext.
+    let node_b = db.get_node(id_b).unwrap();
+    assert_eq!(
+        node_b.properties.get("email"),
+        Some(&PropertyValue::from(sentinel_b.to_string())),
+        "erasing A must not affect B's plaintext"
+    );
+    // A reads the erased marker (never the sentinel).
+    let node_a = db.get_node(id_a).unwrap();
+    let (_p, status) = db.materialize_shred(id_a.as_u64(), node_a.properties);
+    assert!(matches!(
+        status.get("email"),
+        Some(super::ShredStatus::Erased { .. })
+    ));
+    // A's sentinel absent everywhere; B's plaintext DOES persist (it was not
+    // sealed under A, and B is still active so its stored bytes are B-sealed —
+    // NOT the raw sentinel_b; assert only A's leak-freedom here).
+    assert_no_designated_plaintext(dir.path(), SENTINEL.as_bytes());
+}
+
+// ── __aletheia_ns coexistence: namespace marker stays cleartext ────
+
+#[test]
+fn namespace_marker_coexists_with_sealing() {
+    let dir = tempfile::tempdir().unwrap();
+    let node_id;
+    {
+        let db = enc_db(dir.path());
+        node_id = db
+            .create_node("Person", PropertyMapBuilder::new().insert("k", "v").build())
+            .unwrap();
+        db.designate_subject("NS", vec![DesignationTarget::WholeNode(node_id.as_u64())])
+            .unwrap();
+        // Write via the namespace-stamping path so `__aletheia_ns` rides along.
+        db.replace_node(
+            node_id,
+            "Person",
+            PropertyMapBuilder::new().insert("email", SENTINEL).build(),
+        )
+        .unwrap();
+        drop(db);
+    }
+    let db = enc_db(dir.path());
+    let node = db.get_node(node_id).unwrap();
+    // The designated user property is sealed-then-unsealed to plaintext.
+    assert_eq!(
+        node.properties.get("email"),
+        Some(&PropertyValue::from(SENTINEL.to_string()))
+    );
+    // Any reserved key present must remain cleartext (never a SUBJ envelope).
+    for (key, value) in node.properties.iter() {
+        let key_str = crate::core::interning::GLOBAL_INTERNER
+            .resolve_with(*key, |s| s.to_string())
+            .unwrap();
+        if super::designation::is_reserved_key(&key_str)
+            && let PropertyValue::Bytes(b) = value
+        {
+            assert!(
+                !super::envelope::is_envelope(b),
+                "reserved key {key_str} must never be sealed"
+            );
+        }
+    }
+    drop(db);
+}
+
+// ── HNSW exclusion: designated embedding is not searchable ─────────
+
+#[test]
+fn designated_embedding_excluded_from_hnsw() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = enc_db(dir.path());
+    db.enable_vector_index("embedding", HnswConfig::new(4, DistanceMetric::Cosine))
+        .unwrap();
+    let embedding = sentinel_embedding();
+
+    // Non-designated node A with the embedding -> indexed.
+    let id_a = db
+        .create_node(
+            "Doc",
+            PropertyMapBuilder::new()
+                .insert("name", "A")
+                .insert_vector("embedding", &embedding)
+                .build(),
+        )
+        .unwrap();
+
+    // Designated node D: placeholder -> designate -> replace with embedding, so
+    // the sealed vector never enters the plaintext HNSW.
+    let id_d = db
+        .create_node("Doc", PropertyMapBuilder::new().insert("name", "D").build())
+        .unwrap();
+    db.designate_subject("D", vec![DesignationTarget::WholeNode(id_d.as_u64())])
+        .unwrap();
+    db.replace_node(
+        id_d,
+        "Doc",
+        PropertyMapBuilder::new()
+            .insert("name", "D")
+            .insert_vector("embedding", &embedding)
+            .build(),
+    )
+    .unwrap();
+
+    // Query node Q (non-designated) with the same embedding.
+    let id_q = db
+        .create_node(
+            "Doc",
+            PropertyMapBuilder::new()
+                .insert("name", "Q")
+                .insert_vector("embedding", &embedding)
+                .build(),
+        )
+        .unwrap();
+
+    let results = db
+        .similarity_search(crate::db::SimilarityQuery::from_node(id_q).k(10))
+        .unwrap();
+    let ids: Vec<_> = results.iter().map(|(id, _)| *id).collect();
+    assert!(ids.contains(&id_a), "non-designated A must be searchable");
+    assert!(
+        !ids.contains(&id_d),
+        "designated D's embedding must be excluded from the plaintext HNSW"
+    );
+}
+
+// ── MCP erased-marker shape ────────────────────────────────────────
+
+#[cfg(feature = "mcp-server")]
+#[test]
+fn mcp_renders_erased_marker_for_erased_designated_property() {
+    let dir = tempfile::tempdir().unwrap();
+    let node_id;
+    {
+        let db = enc_db(dir.path());
+        node_id = db
+            .create_node("Person", PropertyMapBuilder::new().insert("k", "v").build())
+            .unwrap();
+        db.designate_subject("E", vec![DesignationTarget::WholeNode(node_id.as_u64())])
+            .unwrap();
+        db.replace_node(
+            node_id,
+            "Person",
+            PropertyMapBuilder::new().insert("email", SENTINEL).build(),
+        )
+        .unwrap();
+        db.erase_subject("E").unwrap();
+        drop(db);
+    }
+    let db = Arc::new(enc_db(dir.path()));
+    let server = crate::mcp::AletheiaMcpServer::new(Arc::clone(&db));
+    let node = db.get_node(node_id).unwrap();
+    let json = server.property_map_to_json_for_test(&node.properties, false);
+    let email = json.get("email").expect("email key present");
+    assert_eq!(email.get("type").and_then(|v| v.as_str()), Some("sealed"));
+    assert_eq!(email.get("erased").and_then(|v| v.as_bool()), Some(true));
+    assert_eq!(email.get("subject_id").and_then(|v| v.as_str()), Some("E"));
+    // Structure survives: it is still a JSON object, never the plaintext.
+    assert!(!format!("{json:?}").contains(SENTINEL));
+}
+
+// ── No deadlock: designated write concurrent with read ─────────────
+
+#[test]
+fn concurrent_designated_write_and_read_no_deadlock() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Arc::new(enc_db(dir.path()));
+    let seed = db
+        .create_node("Person", PropertyMapBuilder::new().insert("s", "p").build())
+        .unwrap();
+    db.designate_subject("C", vec![DesignationTarget::WholeNode(seed.as_u64())])
+        .unwrap();
+    db.replace_node(
+        seed,
+        "Person",
+        PropertyMapBuilder::new().insert("email", SENTINEL).build(),
+    )
+    .unwrap();
+
+    let writer_db = Arc::clone(&db);
+    let writer = std::thread::spawn(move || {
+        for i in 0..50 {
+            let id = writer_db
+                .create_node(
+                    "Person",
+                    PropertyMapBuilder::new().insert("i", i as i64).build(),
+                )
+                .unwrap();
+            writer_db
+                .designate_subject(
+                    format!("C{i}"),
+                    vec![DesignationTarget::WholeNode(id.as_u64())],
+                )
+                .unwrap();
+            writer_db
+                .replace_node(
+                    id,
+                    "Person",
+                    PropertyMapBuilder::new().insert("email", SENTINEL).build(),
+                )
+                .unwrap();
+        }
+    });
+    let reader_db = Arc::clone(&db);
+    let reader = std::thread::spawn(move || {
+        for _ in 0..200 {
+            let node = reader_db.get_node(seed).unwrap();
+            assert_eq!(
+                node.properties.get("email"),
+                Some(&PropertyValue::from(SENTINEL.to_string()))
+            );
+        }
+    });
+    writer.join().unwrap();
+    reader.join().unwrap();
+}
+
+// ── Non-designated zero-regression ─────────────────────────────────
+
+#[test]
+fn non_designated_write_read_is_unchanged() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = enc_db(dir.path());
+    let id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "plain-alice")
+                .insert("age", 30_i64)
+                .build(),
+        )
+        .unwrap();
+    let node = db.get_node(id).unwrap();
+    // Values are exactly as written — no envelope, no transformation.
+    assert_eq!(
+        node.properties.get("name"),
+        Some(&PropertyValue::from("plain-alice".to_string()))
+    );
+    assert_eq!(node.properties.get("age"), Some(&PropertyValue::Int(30)));
+    // The side-channel is empty (nothing sealed/erased).
+    let (_p, status) = db.materialize_shred(id.as_u64(), node.properties.clone());
+    assert!(
+        status.is_empty(),
+        "non-designated read yields no shred status"
+    );
+    // No value in a non-designated node is a SUBJ envelope.
+    for value in node.properties.values() {
+        if let PropertyValue::Bytes(b) = value {
+            assert!(
+                !super::envelope::is_envelope(b),
+                "a non-designated write must never produce a sealed envelope"
+            );
+        }
+    }
+}

--- a/src/db/crypto_shred/keyring.rs
+++ b/src/db/crypto_shred/keyring.rs
@@ -110,6 +110,14 @@ pub struct SubjectKeyring {
     entries: BTreeMap<String, SubjectEntry>,
     /// Unwrapped-DEK cache; entries dropped (and thus zeroized) on erase.
     cache: HashMap<String, SubjectKey>,
+    /// Reverse designation index: `(is_node, entity_id) -> subject ids` (PR-1b).
+    ///
+    /// Lets the write/read hooks answer "which subject(s) seal this entity?"
+    /// in O(1) instead of scanning every subject's designation set. In-memory
+    /// only (rebuilt from `entries` on load). Erased subjects are **retained**
+    /// in this index so the read hook can still report an erased marker for a
+    /// value whose key was destroyed.
+    designation_index: HashMap<(bool, u64), Vec<String>>,
 }
 
 impl std::fmt::Debug for SubjectKeyring {
@@ -149,7 +157,39 @@ impl SubjectKeyring {
 
     /// Insert or replace a subject entry.
     pub fn upsert(&mut self, entry: SubjectEntry) {
+        self.index_entry(&entry);
         self.entries.insert(entry.subject_id.clone(), entry);
+    }
+
+    /// Fold one entry's designation targets into the reverse index (idempotent).
+    ///
+    /// Designations only ever grow in v1 (merge adds targets; erase retains
+    /// them), so a plain additive re-index with per-key dedup is sufficient and
+    /// never leaves a stale mapping.
+    fn index_entry(&mut self, entry: &SubjectEntry) {
+        for target in &entry.designation {
+            let key = (target.is_node(), target.entity_id());
+            let bucket = self.designation_index.entry(key).or_default();
+            if !bucket.iter().any(|s| s == &entry.subject_id) {
+                bucket.push(entry.subject_id.clone());
+            }
+        }
+    }
+
+    /// The subject ids that designate `(is_node, entity_id)`, in insertion order.
+    #[must_use]
+    pub fn subjects_for_entity(&self, is_node: bool, entity_id: u64) -> &[String] {
+        self.designation_index
+            .get(&(is_node, entity_id))
+            .map_or(&[], Vec::as_slice)
+    }
+
+    /// Whether any subject is currently `Active`.
+    #[must_use]
+    pub fn any_active(&self) -> bool {
+        self.entries
+            .values()
+            .any(|e| e.state == SubjectState::Active)
     }
 
     /// Cache an unwrapped DEK for a subject.
@@ -228,10 +268,13 @@ impl SubjectKeyring {
         }
     }
 
-    /// Replace all entries from a loaded sidecar (cache is left empty).
+    /// Replace all entries from a loaded sidecar (cache is left empty), and
+    /// rebuild the in-memory reverse designation index from scratch.
     fn load_from_sidecar(&mut self, sidecar: SubjectKeyringSidecar) {
         self.entries.clear();
+        self.designation_index.clear();
         for entry in sidecar.entries {
+            self.index_entry(&entry);
             self.entries.insert(entry.subject_id.clone(), entry);
         }
     }

--- a/src/db/crypto_shred/mod.rs
+++ b/src/db/crypto_shred/mod.rs
@@ -33,11 +33,15 @@
 //! irreversible even for a holder of the MEK.
 
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 use zeroize::Zeroizing;
 
 use crate::audit::{AuditPublicKey, AuditSigningKey};
+use crate::core::property::{PropertyMap, PropertyMapBuilder, PropertyValue};
+use crate::encryption::Cipher;
+use crate::encryption::factory::{Algorithm, algorithm_from_id, create_cipher};
 
 pub mod api;
 pub mod attestation;
@@ -50,12 +54,104 @@ pub mod subject;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+mod integration_tests;
+
 pub use attestation::ErasureAttestation;
 pub use designation::DesignationTarget;
 pub use error::CryptoShredError;
 pub use subject::{SubjectId, SubjectKey};
 
 use keyring::{BREADCRUMB_FILENAME, SubjectKeyring};
+
+/// Crypto-shred status of a single materialized property value (PR-1b).
+///
+/// Surfaced as a **side-channel** from the db read boundary alongside the
+/// (possibly-unsealed) [`PropertyMap`] — it is deliberately NOT a
+/// [`PropertyValue`] variant and NOT a wire-format change. A property is
+/// [`ShredStatus::Plaintext`] when it carried no sealed envelope, or when its
+/// subject is still active and the value was unsealed in place. It is
+/// [`ShredStatus::Erased`] when the value is a sealed envelope whose subject key
+/// has been destroyed — the plaintext is permanently unrecoverable and the read
+/// hook leaves the opaque ciphertext in place rather than fabricating a value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShredStatus {
+    /// Not sealed, or unsealed in place (subject active).
+    Plaintext,
+    /// Sealed under a subject whose key was destroyed (unrecoverable).
+    Erased {
+        /// The erasure subject the value belonged to.
+        subject_id: String,
+    },
+}
+
+/// Per-property crypto-shred status keyed by property key (PR-1b).
+///
+/// Only carries entries that are **not** plain plaintext (i.e. erased sealed
+/// values); an absent key means [`ShredStatus::Plaintext`]. Empty when nothing
+/// on the read was sealed/erased, so a non-designated read allocates nothing.
+pub type ShredStatusMap = std::collections::HashMap<String, ShredStatus>;
+
+/// A prepared sealing context threaded onto a [`crate::api::transaction::WriteTransaction`]
+/// (PR-1b write plumbing).
+///
+/// Built once per write transaction — only when the database has at least one
+/// active designation — from the shared [`CryptoShredState`], the memoized
+/// subject-wrapping cipher, and the configured AEAD algorithm. Cloning is cheap
+/// (two `Arc` clones + a `Copy` enum), so attaching it to a transaction is
+/// effectively free; a database with no active designations attaches `None` and
+/// pays nothing.
+#[derive(Clone)]
+pub struct SealingContext {
+    state: Arc<CryptoShredState>,
+    wrap_cipher: Arc<dyn Cipher>,
+    algorithm: Algorithm,
+}
+
+impl std::fmt::Debug for SealingContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SealingContext")
+            .field("algorithm", &self.algorithm)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SealingContext {
+    /// Construct a sealing context from its parts.
+    #[must_use]
+    pub(crate) fn new(
+        state: Arc<CryptoShredState>,
+        wrap_cipher: Arc<dyn Cipher>,
+        algorithm: Algorithm,
+    ) -> Self {
+        Self {
+            state,
+            wrap_cipher,
+            algorithm,
+        }
+    }
+
+    /// Seal the designated property values of an entity (see
+    /// [`CryptoShredState::seal_map`]). Fast path when the entity carries no
+    /// designated key: the map is returned unchanged.
+    ///
+    /// # Errors
+    /// Propagates [`CryptoShredState::seal_map`]'s error (fail-closed).
+    pub(crate) fn seal_map(
+        &self,
+        is_node: bool,
+        entity_id: u64,
+        props: PropertyMap,
+    ) -> Result<PropertyMap, CryptoShredError> {
+        self.state.seal_map(
+            is_node,
+            entity_id,
+            props,
+            self.wrap_cipher.as_ref(),
+            self.algorithm,
+        )
+    }
+}
 
 /// AAD domain-separation prefix binding a wrapped subject DEK to its subject id
 /// and key version.
@@ -67,13 +163,29 @@ const WRAP_AAD_DOMAIN: &[u8] = b"aletheiadb-subject-wrap-dek-v1";
 /// downgrade (presenting a wrap blob under the wrong version) is caught by the
 /// AEAD auth check once rotation lands. Both the wrap (in `designate`) and the
 /// unwrap (in `subject_key`) sides must build this identically.
-fn wrap_aad(subject_id: &SubjectId, key_version: u32) -> Vec<u8> {
+fn wrap_aad(subject_id: &str, key_version: u32) -> Vec<u8> {
     let subj = subject_id.as_bytes();
     let mut aad = Vec::with_capacity(WRAP_AAD_DOMAIN.len() + 4 + subj.len());
     aad.extend_from_slice(WRAP_AAD_DOMAIN);
     aad.extend_from_slice(&key_version.to_le_bytes());
     aad.extend_from_slice(subj);
     aad
+}
+
+/// Build the sealed-envelope **write-site context** binding a value to its
+/// entity id and property key (PR-1b).
+///
+/// Folded into the envelope AEAD AAD (alongside subject id + key version) so a
+/// sealed value cannot be relocated to a different `(entity, key)` slot within
+/// the same subject without a loud AEAD auth failure. The seal (write) and
+/// unseal (read) sites MUST build this identically: `entity_id` little-endian
+/// followed by the raw property-key bytes.
+fn seal_context(entity_id: u64, key: &str) -> Vec<u8> {
+    let kb = key.as_bytes();
+    let mut ctx = Vec::with_capacity(8 + kb.len());
+    ctx.extend_from_slice(&entity_id.to_le_bytes());
+    ctx.extend_from_slice(kb);
+    ctx
 }
 
 /// Per-database crypto-shred state: the in-memory keyring, its durable paths,
@@ -92,6 +204,21 @@ pub struct CryptoShredState {
     /// Ed25519 key used to sign erasure attestations. Sourced from the audit
     /// signing-key env var when set, else freshly generated for this process.
     signing_key: AuditSigningKey,
+    /// Lock-free fast-path gate (PR-1b): `true` iff at least one subject is
+    /// `Active`. The write hook consults this **without** locking so a database
+    /// with no active designations pays zero per-transaction cost.
+    has_active: AtomicBool,
+    /// Lock-free fast-path gate (PR-1b): `true` iff at least one subject exists
+    /// (active OR erased). The read hook consults this without locking so a
+    /// database that never used crypto-shred pays zero per-read cost.
+    has_any: AtomicBool,
+    /// Memoized subject-wrapping cipher (PR-1b). Built lazily on the first
+    /// seal/unseal from the database's encryption config and reused for the
+    /// process lifetime. Safe to cache because the subject-wrapping DEK is a
+    /// deterministic `HKDF(MEK, "subject-wrap")` and v1 crypto-shred does not
+    /// rotate the MEK (subject-keyring re-wrap on rotation is deferred to a
+    /// later slice, which must invalidate this cache).
+    wrap_cipher: Mutex<Option<Arc<dyn Cipher>>>,
 }
 
 impl std::fmt::Debug for CryptoShredState {
@@ -148,11 +275,16 @@ impl CryptoShredState {
             None => SubjectKeyring::new(),
         };
 
+        let has_active = keyring.any_active();
+        let has_any = !keyring.is_empty();
         let state = Self {
             keyring: Mutex::new(keyring),
             keyring_path,
             breadcrumb_path,
             signing_key,
+            has_active: AtomicBool::new(has_active),
+            has_any: AtomicBool::new(has_any),
+            wrap_cipher: Mutex::new(None),
         };
 
         state.recover_from_breadcrumb()?;
@@ -175,6 +307,7 @@ impl CryptoShredState {
             let mut keyring = self.lock_keyring();
             keyring.force_erased(&subject_id, now);
             keyring::save_keyring(keyring_path, &keyring)?;
+            self.refresh_gates(&keyring);
         }
         keyring::clear_breadcrumb(breadcrumb_path);
         Ok(())
@@ -199,6 +332,25 @@ impl CryptoShredState {
         self.keyring
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Recompute the lock-free fast-path gates from a locked keyring guard.
+    /// Called after any mutation that can change active/any state.
+    fn refresh_gates(&self, guard: &SubjectKeyring) {
+        self.has_active.store(guard.any_active(), Ordering::Relaxed);
+        self.has_any.store(!guard.is_empty(), Ordering::Relaxed);
+    }
+
+    /// Whether any subject is currently `Active` (lock-free write-path gate).
+    #[must_use]
+    pub(crate) fn has_active_designations(&self) -> bool {
+        self.has_active.load(Ordering::Relaxed)
+    }
+
+    /// Whether any subject exists at all (lock-free read-path gate).
+    #[must_use]
+    pub(crate) fn has_any_designations(&self) -> bool {
+        self.has_any.load(Ordering::Relaxed)
     }
 
     /// The durable keyring path, if any.
@@ -253,7 +405,7 @@ impl CryptoShredState {
         } else {
             // New subject: random DEK, wrapped under the subject-wrapping cipher.
             let dek = SubjectKey::generate();
-            let wrap_aad = wrap_aad(subject_id, INITIAL_SUBJECT_KEY_VERSION);
+            let wrap_aad = wrap_aad(subject_id.as_str(), INITIAL_SUBJECT_KEY_VERSION);
             let wrapped = wrap_cipher
                 .encrypt(dek.expose_bytes(), &wrap_aad)
                 .map_err(|e| CryptoShredError::Crypto(e.to_string()))?;
@@ -282,6 +434,7 @@ impl CryptoShredState {
         if let Some(path) = self.keyring_path() {
             keyring::save_keyring(path, &guard)?;
         }
+        self.refresh_gates(&guard);
         Ok(())
     }
 
@@ -296,14 +449,34 @@ impl CryptoShredState {
         subject_id: &SubjectId,
         wrap_cipher: &dyn crate::encryption::Cipher,
     ) -> Result<SubjectKey, CryptoShredError> {
+        let mut guard = self.lock_keyring();
+        Self::dek_from_guard(&mut guard, subject_id.as_str(), wrap_cipher)
+    }
+
+    /// Fetch a subject's unwrapped DEK from an **already-locked** keyring guard.
+    ///
+    /// Checks the unwrapped-DEK cache first, else unwraps the stored wrapped blob
+    /// with `wrap_cipher` and caches the result. Kept `&mut guard`-based (not
+    /// `&self`) so the seal/unseal hot paths, which already hold the keyring lock
+    /// to consult the reverse index, never re-lock (`std::sync::Mutex` is not
+    /// reentrant — re-locking would deadlock).
+    ///
+    /// # Errors
+    /// - [`CryptoShredError::NotDesignated`] if the subject is unknown.
+    /// - [`CryptoShredError::SubjectErased`] if the subject was erased (key gone).
+    /// - [`CryptoShredError::Crypto`] on unwrap / AEAD failure.
+    fn dek_from_guard(
+        guard: &mut SubjectKeyring,
+        subject_id: &str,
+        wrap_cipher: &dyn crate::encryption::Cipher,
+    ) -> Result<SubjectKey, CryptoShredError> {
         use keyring::SubjectState;
 
-        let mut guard = self.lock_keyring();
-        if let Some(cached) = guard.cached_key(subject_id.as_str()) {
+        if let Some(cached) = guard.cached_key(subject_id) {
             return Ok(cached.clone());
         }
         let entry = guard
-            .get(subject_id.as_str())
+            .get(subject_id)
             .ok_or_else(|| CryptoShredError::NotDesignated(subject_id.to_string()))?;
         if entry.state == SubjectState::Erased {
             return Err(CryptoShredError::SubjectErased(subject_id.to_string()));
@@ -316,7 +489,8 @@ impl CryptoShredState {
         // lands in a Zeroizing<Vec<u8>>, and the fixed-size array we hand to
         // SubjectKey is built inside a Zeroizing<[u8;N]> — neither is left in a
         // plain buffer that could survive on the stack/heap after use.
-        let aad = wrap_aad(subject_id, wrapped.key_version);
+        let key_version = wrapped.key_version;
+        let aad = wrap_aad(subject_id, key_version);
         let raw = Zeroizing::new(
             wrap_cipher
                 .decrypt(&wrapped.wrapped, &aad)
@@ -330,7 +504,7 @@ impl CryptoShredState {
         let mut bytes = Zeroizing::new([0u8; subject::SUBJECT_KEY_LEN]);
         bytes.copy_from_slice(&raw);
         let key = SubjectKey::from_bytes(bytes);
-        guard.cache_key(subject_id.as_str(), key.clone());
+        guard.cache_key(subject_id, key.clone());
         Ok(key)
     }
 
@@ -393,16 +567,25 @@ impl CryptoShredState {
         let attestation =
             ErasureAttestation::sign(self.signing_key(), subject_id.as_str(), entity_count, now);
         guard.erase_in_memory(subject_id.as_str(), now, attestation.to_record());
+        self.refresh_gates(&guard);
 
         // Rewrite the keyring durably so the wrapped blob is physically gone.
         if let Some(path) = self.keyring_path() {
             keyring::save_keyring(path, &guard)?;
         }
 
-        // PR-1b SEAM: record the erasure tombstone as a normal write transaction
-        // here (subject id + entity/version counts + timestamp, no properties),
-        // riding the existing is_tombstone machinery. Deferred out of PR-1a so
-        // this slice stays free of live data-path integration.
+        // NOTE (PR-1b): the durable keyring record above IS the erasure record —
+        // an erased subject's key is physically gone and its state is `Erased`,
+        // fail-closed across restart. A WAL-transaction erasure *tombstone*
+        // (subject id + entity/version counts + timestamp, riding the
+        // `is_tombstone` machinery) plus changefeed observability is deliberately
+        // DEFERRED to a #3413-aligned follow-up: emitting it needs a WAL-format
+        // extension to survive crash recovery, and doing it here would force
+        // `db.write(...)` — acquiring `historical`/`wal` — while this method holds
+        // the keyring `Mutex`, inverting the lock order (the keyring lock must be
+        // *released before* the write-path primitives are taken; see the
+        // lock-order note in CLAUDE.md / seams §6). So erase does NOT call
+        // `db.write` in this slice — no lock-order change is required.
 
         // (e) Clear the breadcrumb — erase is complete.
         if let Some(bc) = self.breadcrumb_path() {
@@ -426,5 +609,222 @@ impl CryptoShredState {
         self.lock_keyring()
             .get(subject_id)
             .is_some_and(|e| e.state == keyring::SubjectState::Erased)
+    }
+
+    /// Return the memoized subject-wrapping cipher, building it once via `build`
+    /// on first use (see the `wrap_cipher` field doc for the caching rationale).
+    ///
+    /// # Errors
+    /// Propagates `build`'s error (e.g. encryption not configured).
+    pub(crate) fn cached_wrap_cipher(
+        &self,
+        build: impl FnOnce() -> Result<Box<dyn Cipher>, CryptoShredError>,
+    ) -> Result<Arc<dyn Cipher>, CryptoShredError> {
+        let mut guard = self
+            .wrap_cipher
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(existing) = guard.as_ref() {
+            return Ok(Arc::clone(existing));
+        }
+        let cipher: Arc<dyn Cipher> = Arc::from(build()?);
+        *guard = Some(Arc::clone(&cipher));
+        Ok(cipher)
+    }
+
+    /// Seal the designated property values of an entity into `SUBJ` envelopes
+    /// (PR-1b write hook).
+    ///
+    /// For every property key that an **active** subject designates (via the
+    /// reverse index), the value is replaced with a sealed-envelope
+    /// [`PropertyValue::Bytes`]. Engine-reserved keys (`__aletheia_*` /
+    /// `__shred_*`) are never sealed (short-circuited by
+    /// [`designation::should_seal_key`]). Erased subjects do **not** re-seal
+    /// (their key is gone); their entities' new writes stay plaintext. The
+    /// returned map must be routed **byte-identically** to both the current and
+    /// historical tiers (seal exactly once — the envelope carries a random
+    /// per-encryption nonce).
+    ///
+    /// # Errors
+    /// [`CryptoShredError::Crypto`] on DEK unwrap / AEAD seal failure. Fail-closed:
+    /// a seal error aborts the enclosing write rather than persisting plaintext.
+    pub(crate) fn seal_map(
+        &self,
+        is_node: bool,
+        entity_id: u64,
+        props: PropertyMap,
+        wrap_cipher: &dyn Cipher,
+        algorithm: Algorithm,
+    ) -> Result<PropertyMap, CryptoShredError> {
+        use crate::core::interning::GLOBAL_INTERNER;
+        use crate::core::property::PropertyKey;
+
+        let mut guard = self.lock_keyring();
+        let subjects: Vec<String> = guard.subjects_for_entity(is_node, entity_id).to_vec();
+        if subjects.is_empty() {
+            return Ok(props);
+        }
+
+        // Plan which keys to seal (resolve interned keys to owned strings first,
+        // so re-interning via the builder never nests inside a resolve guard).
+        struct SealItem {
+            key: PropertyKey,
+            key_str: String,
+            value: PropertyValue,
+            subject_id: String,
+            key_version: u32,
+        }
+        let mut plan: Vec<SealItem> = Vec::new();
+        for (key, value) in props.iter() {
+            // Resolve the interned key to an owned String via `resolve_with` (no
+            // owned-Arc deprecation, and — critically — we never re-enter the
+            // interner while a resolve guard is held: `insert_by_key` below takes
+            // the already-interned key, it does not re-intern a string).
+            let Some(key_str) = GLOBAL_INTERNER.resolve_with(*key, |s| s.to_string()) else {
+                continue;
+            };
+            if designation::is_reserved_key(&key_str) {
+                continue;
+            }
+            for subject_id in &subjects {
+                let Some(entry) = guard.get(subject_id) else {
+                    continue;
+                };
+                if entry.state != keyring::SubjectState::Active {
+                    continue;
+                }
+                if designation::any_should_seal(&entry.designation, is_node, entity_id, &key_str) {
+                    let key_version = entry
+                        .wrapped_key
+                        .as_ref()
+                        .map_or(keyring::INITIAL_SUBJECT_KEY_VERSION, |w| w.key_version);
+                    plan.push(SealItem {
+                        key: *key,
+                        key_str,
+                        value: value.clone(),
+                        subject_id: subject_id.clone(),
+                        key_version,
+                    });
+                    break;
+                }
+            }
+        }
+
+        if plan.is_empty() {
+            return Ok(props);
+        }
+
+        let mut builder = PropertyMapBuilder::from_map(props);
+        for item in plan {
+            let dek = Self::dek_from_guard(&mut guard, &item.subject_id, wrap_cipher)?;
+            let cipher = create_cipher(algorithm, &Zeroizing::new(*dek.expose_bytes()));
+            let context = seal_context(entity_id, &item.key_str);
+            let sealed = envelope::seal_property_value(
+                &item.value,
+                &item.subject_id,
+                item.key_version,
+                &context,
+                cipher.as_ref(),
+            )?;
+            builder =
+                builder.insert_by_key(item.key, PropertyValue::Bytes(std::sync::Arc::from(sealed)));
+        }
+        Ok(builder.build())
+    }
+
+    /// Materialize sealed property values on read (PR-1b read hook).
+    ///
+    /// For each `SUBJ` envelope whose subject the keyring knows: if the subject
+    /// is **active**, unseal to plaintext in place; if it is **erased**, leave the
+    /// opaque ciphertext untouched and record [`ShredStatus::Erased`] in the
+    /// returned side-channel — never fabricated, never silently dropped. A
+    /// `Bytes` value that merely *looks* like an envelope but whose subject is
+    /// unknown, or that fails to unseal under an active subject (tamper /
+    /// corruption), is left byte-untouched (opaque ciphertext, never plaintext).
+    ///
+    /// Returns the (possibly-transformed) map plus a [`ShredStatusMap`] carrying
+    /// only the erased keys (empty allocation-free when nothing was sealed).
+    pub(crate) fn unseal_map(
+        &self,
+        entity_id: u64,
+        props: PropertyMap,
+        wrap_cipher: &dyn Cipher,
+        algorithm_hint: Algorithm,
+    ) -> (PropertyMap, ShredStatusMap) {
+        use crate::core::interning::GLOBAL_INTERNER;
+        use crate::core::property::PropertyKey;
+
+        let mut statuses = ShredStatusMap::new();
+        let mut guard = self.lock_keyring();
+
+        // Collect envelope-bearing keys whose subject the keyring recognizes.
+        struct SealedItem {
+            key: PropertyKey,
+            key_str: String,
+            header: envelope::EnvelopeHeader,
+            bytes: std::sync::Arc<[u8]>,
+        }
+        let mut sealed: Vec<SealedItem> = Vec::new();
+        for (key, value) in props.iter() {
+            let PropertyValue::Bytes(b) = value else {
+                continue;
+            };
+            if !envelope::is_envelope(b) {
+                continue;
+            }
+            let Ok(header) = envelope::parse_header(b) else {
+                continue;
+            };
+            if guard.get(&header.subject_id).is_none() {
+                // Looks like an envelope but no such subject — treat as opaque
+                // user bytes, never as ours.
+                continue;
+            }
+            let Some(key_str) = GLOBAL_INTERNER.resolve_with(*key, |s| s.to_string()) else {
+                continue;
+            };
+            sealed.push(SealedItem {
+                key: *key,
+                key_str,
+                header,
+                bytes: std::sync::Arc::clone(b),
+            });
+        }
+
+        if sealed.is_empty() {
+            return (props, statuses);
+        }
+
+        let mut builder = PropertyMapBuilder::from_map(props);
+        for item in sealed {
+            let is_erased = guard
+                .get(&item.header.subject_id)
+                .is_some_and(|e| e.state == keyring::SubjectState::Erased);
+            if is_erased {
+                // Key destroyed: leave opaque ciphertext, report erased.
+                statuses.insert(
+                    item.key_str,
+                    ShredStatus::Erased {
+                        subject_id: item.header.subject_id,
+                    },
+                );
+                continue;
+            }
+            // Active subject: unseal to plaintext. On any failure leave the
+            // opaque ciphertext (never fabricate a plaintext value).
+            let Ok(dek) = Self::dek_from_guard(&mut guard, &item.header.subject_id, wrap_cipher)
+            else {
+                continue;
+            };
+            let algorithm = algorithm_from_id(item.header.algorithm_id).unwrap_or(algorithm_hint);
+            let cipher = create_cipher(algorithm, &Zeroizing::new(*dek.expose_bytes()));
+            let context = seal_context(entity_id, &item.key_str);
+            if let Ok(value) =
+                envelope::unseal_property_value(&item.bytes, &context, cipher.as_ref())
+            {
+                builder = builder.insert_by_key(item.key, value);
+            }
+        }
+        (builder.build(), statuses)
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -82,7 +82,8 @@ pub use crate::storage::backup::BackupSummary;
 pub use constraint_builder::UniqueConstraintBuilder;
 #[cfg(feature = "audit-export")]
 pub use crypto_shred::{
-    CryptoShredError, DesignationTarget, ErasureAttestation, SubjectId, SubjectKey,
+    CryptoShredError, DesignationTarget, ErasureAttestation, ShredStatus, ShredStatusMap,
+    SubjectId, SubjectKey,
 };
 pub use extent::{LabelExtent, TemporalExtent, TimeBounds};
 pub use lineage::{FactStatus, LineageView, LineageViewEntry};

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -1005,7 +1005,13 @@ impl AletheiaDB {
     /// This uses the fast path (current storage) for O(1) lookup.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_node(&self, node_id: NodeId) -> Result<Node> {
-        self.current.get_node(node_id).record_error_metric()
+        let node = self.current.get_node(node_id).record_error_metric()?;
+        // GDPR crypto-shred (Issue #3359, PR-1b): unseal designated properties on
+        // read (active subjects -> plaintext; erased -> opaque ciphertext). No-op
+        // unless the database has designations.
+        #[cfg(feature = "audit-export")]
+        let node = self.unseal_node_view(node);
+        Ok(node)
     }
 
     /// Access a node without cloning, executing a closure on the node data.
@@ -1037,7 +1043,12 @@ impl AletheiaDB {
     /// Get the current state of an edge.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_edge(&self, edge_id: EdgeId) -> Result<Edge> {
-        self.current.get_edge(edge_id).record_error_metric()
+        let edge = self.current.get_edge(edge_id).record_error_metric()?;
+        // GDPR crypto-shred (Issue #3359, PR-1b): unseal designated properties on
+        // read. No-op unless the database has designations.
+        #[cfg(feature = "audit-export")]
+        let edge = self.unseal_edge_view(edge);
+        Ok(edge)
     }
 
     /// Scan all nodes with a specific label, returning an iterator over node IDs.

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -103,10 +103,16 @@ impl AletheiaDB {
         #[cfg(feature = "observability")]
         let _span = crate::observability::temporal_query_span("get_node_at_time").entered();
 
-        self.historical
+        let node = self
+            .historical
             .read()
             .get_node_at_time(node_id, valid_time, transaction_time)
-            .record_error_metric()
+            .record_error_metric()?;
+        // GDPR crypto-shred (Issue #3359, PR-1b): unseal designated properties on
+        // the point-in-time read boundary. No-op unless the DB has designations.
+        #[cfg(feature = "audit-export")]
+        let node = self.unseal_node_view(node);
+        Ok(node)
     }
 
     /// Get an edge as it existed at a specific point in bi-temporal space.
@@ -123,10 +129,16 @@ impl AletheiaDB {
         #[cfg(feature = "observability")]
         let _span = crate::observability::temporal_query_span("get_edge_at_time").entered();
 
-        self.historical
+        let edge = self
+            .historical
             .read()
             .get_edge_at_time(edge_id, valid_time, transaction_time)
-            .record_error_metric()
+            .record_error_metric()?;
+        // GDPR crypto-shred (Issue #3359, PR-1b): unseal designated properties on
+        // the point-in-time read boundary. No-op unless the DB has designations.
+        #[cfg(feature = "audit-export")]
+        let edge = self.unseal_edge_view(edge);
+        Ok(edge)
     }
 
     /// Get multiple nodes as they existed at a specific point in bi-temporal space.

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -241,7 +241,7 @@ impl AletheiaDB {
             self.visibility_manager.register_active(tx_id);
             let snapshot = self.visibility_manager.capture_snapshot(snapshot_timestamp);
 
-            Ok(WriteTransaction::new_with_clock_observed_at(
+            let tx = WriteTransaction::new_with_clock_observed_at(
                 tx_id,
                 snapshot,
                 Arc::clone(&self.current),
@@ -257,7 +257,15 @@ impl AletheiaDB {
             )
             .with_constraint_registry(Arc::clone(&self.constraint_registry))
             .with_in_flight_tracker(Arc::clone(&self.in_flight))
-            .with_changefeed(Arc::clone(&self.changefeed)))
+            .with_changefeed(Arc::clone(&self.changefeed));
+            // GDPR crypto-shred (Issue #3359, PR-1b): attach the seal context when
+            // the database has active designations (fail-closed on cipher-build).
+            #[cfg(feature = "audit-export")]
+            let tx = match self.sealing_context()? {
+                Some(ctx) => tx.with_sealing_context(ctx),
+                None => tx,
+            };
+            Ok(tx)
         })();
         result.record_error_metric()
     }
@@ -486,7 +494,7 @@ impl AletheiaDB {
 
             let durability = options.effective_durability(self.default_durability);
 
-            Ok(WriteTransaction::new_with_durability_and_clock_observed_at(
+            let tx = WriteTransaction::new_with_durability_and_clock_observed_at(
                 tx_id,
                 snapshot,
                 Arc::clone(&self.current),
@@ -503,7 +511,15 @@ impl AletheiaDB {
             )
             .with_constraint_registry(Arc::clone(&self.constraint_registry))
             .with_in_flight_tracker(Arc::clone(&self.in_flight))
-            .with_changefeed(Arc::clone(&self.changefeed)))
+            .with_changefeed(Arc::clone(&self.changefeed));
+            // GDPR crypto-shred (Issue #3359, PR-1b): attach the seal context when
+            // the database has active designations (fail-closed on cipher-build).
+            #[cfg(feature = "audit-export")]
+            let tx = match self.sealing_context()? {
+                Some(ctx) => tx.with_sealing_context(ctx),
+                None => tx,
+            };
+            Ok(tx)
         })();
         result.record_error_metric()
     }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1298,6 +1298,17 @@ impl AletheiaMcpServer {
         }
     }
 
+    /// Test-only accessor for the private JSON serializer (crypto-shred PR-1b
+    /// erased-marker test lives in `db::crypto_shred::integration_tests`).
+    #[cfg(test)]
+    pub(crate) fn property_map_to_json_for_test(
+        &self,
+        props: &PropertyMap,
+        include_vectors: bool,
+    ) -> HashMap<String, serde_json::Value> {
+        self.property_map_to_json(props, include_vectors)
+    }
+
     fn property_map_to_json(
         &self,
         props: &PropertyMap,
@@ -1329,6 +1340,18 @@ impl AletheiaMcpServer {
             PropertyValue::Float(f) => json!(*f),
             PropertyValue::String(s) => serde_json::Value::String(s.to_string()),
             PropertyValue::Bytes(b) => {
+                // GDPR crypto-shred (Issue #3359, PR-1b): a sealed `SUBJ` envelope
+                // that reaches the MCP funnel belongs to a known erasure subject.
+                // Active-subject values are already unsealed to plaintext at the db
+                // read boundary, so a surviving envelope is (almost always) erased —
+                // render the erased descriptor (analogous to the #3220 vector-elision
+                // shape) instead of leaking opaque ciphertext as base64. A `Bytes`
+                // value whose subject the keyring does not recognize is treated as
+                // ordinary user bytes.
+                #[cfg(feature = "audit-export")]
+                if let Some(descriptor) = self.sealed_value_descriptor(b) {
+                    return descriptor;
+                }
                 serde_json::Value::String(base64::engine::general_purpose::STANDARD.encode(b))
             }
             PropertyValue::Array(arr) => serde_json::Value::Array(
@@ -1363,6 +1386,32 @@ impl AletheiaMcpServer {
                 }
             }
         }
+    }
+
+    /// If `bytes` is a sealed crypto-shred `SUBJ` envelope for a subject the
+    /// keyring recognizes, return its MCP descriptor (Issue #3359, PR-1b);
+    /// otherwise `None` (render as ordinary bytes). An erased subject yields
+    /// `{"type":"sealed","erased":true,"subject_id":<id>}`; an active subject
+    /// that somehow reached here un-unsealed yields `erased:false` — never the
+    /// plaintext and never the raw ciphertext.
+    #[cfg(feature = "audit-export")]
+    fn sealed_value_descriptor(&self, bytes: &[u8]) -> Option<serde_json::Value> {
+        use crate::db::crypto_shred::envelope;
+        if !envelope::is_envelope(bytes) {
+            return None;
+        }
+        let header = envelope::parse_header(bytes).ok()?;
+        let erased = self.db.crypto_shred.is_erased(&header.subject_id);
+        let active = self.db.crypto_shred.is_active(&header.subject_id);
+        if !erased && !active {
+            // Not a subject we know — treat as ordinary user bytes.
+            return None;
+        }
+        Some(json!({
+            "type": "sealed",
+            "erased": erased,
+            "subject_id": header.subject_id,
+        }))
     }
 
     pub(crate) fn json_to_property_map(


### PR DESCRIPTION
## GDPR crypto-shred — PR-1b (property-path integration)

Wires the **already-merged** PR-1a cryptographic core (`src/db/crypto_shred/`) into AletheiaDB's live data path. Draft — stays draft.

### Before / After (plain language)

**Before:** designating an entity/property then reading it back still returned the **plaintext**, and the plaintext also sat in every tier — so erasing a subject left the data trivially recoverable from the WAL, index files, and current state.

**After:** designated property values are **sealed at write** into self-describing `SUBJ` envelopes *before any tier sees them*, across the hot (current) + historical tiers → WAL segment + index-persistence. Designated embeddings are **excluded from the plaintext HNSW** (a sealed `Vector` becomes `Bytes`, so `try_index_vector`'s `as_vector()` gate skips it). After `erase_subject`, every tier holds only **undecryptable ciphertext**, and reads return an **explicit erased marker** (`ShredStatus::Erased` in Rust; `{"type":"sealed","erased":true,"subject_id":…}` in MCP) — never fabricated, never the plaintext.

### How

- **Reverse designation index** on `SubjectKeyring` (`(is_node,id) → subject ids`), maintained in `upsert`, rebuilt on `load_from_sidecar`, retained across `erase`; lock-free `has_active`/`has_any` gates → **zero per-op cost** when a DB has no (active) designations.
- **Seal once on the write buffer** in `commit_with_timestamp_inner`, **after** validation/constraints (which must see plaintext) but **before** WAL logging + apply — so the WAL segment, current tier, and historical tier all record **byte-identical** ciphertext (one seal, one shared random nonce; the chain leaf will bind these bytes in slice 2). `WriteTransaction` carries a prepared `SealingContext` (`Arc<CryptoShredState>` + memoized wrap cipher + algorithm), attached in `write_transaction()` only when active designations exist. Fail-closed. Reserved keys (incl. `__aletheia_ns`) never sealed.
- **Unseal at read:** `materialize_shred` + `unseal_node_view`/`unseal_edge_view`, hooked at `get_node`/`get_edge` and `get_node_at_time`/`get_edge_at_time`. Active → plaintext in place; erased → opaque ciphertext + `ShredStatus::Erased` side-channel (not a `PropertyValue` variant, no wire change). Restore path stays a pure ciphertext passthrough.
- **MCP funnel:** `property_value_to_json` renders a surviving envelope for a known subject as the erased/sealed descriptor.
- All gated under the existing `audit-export` cfg.

### Deferrals (documented in `docs/plans/2026-07-16-gdpr-crypto-shred.md`)

- **WAL-transaction erasure tombstone + changefeed observability** → **#3413**-aligned follow-up (needs a WAL-format extension; emitting it from `erase()` would invert the keyring-lock / write-path lock order). The durable keyring Erased record is the erasure record for now — erase does **not** call `db.write`.
- **Chain-leaf ciphertext binding (AC4)** → slice 2.
- **Cold-tier + `.albk` sentinel completeness** → slice 3 (the PR-1b byte-scan covers WAL / index / current / checkpoint only).
- **Exhaustive every-query-path unseal** → the Rust hook covers the primary single-entity boundaries; paths still returning raw sealed `Bytes` (opaque ciphertext, never plaintext) are listed in the design doc, and the MCP funnel still renders the erased marker for any envelope that reaches it.

### Gate evidence

- `cargo fmt --all --check` → clean.
- `cargo clippy --all-targets --features config-toml,mcp-server,sharding-rpc,simulation -- -D warnings` → `Finished` (0 warnings).
- `cargo clippy --all-targets --all-features -- -D warnings` → `Finished` (0 warnings).
- `cargo clippy --all-targets --no-default-features -- -D warnings` → my code clean; only the pre-existing trunk lint `namespace.rs:336 needless_return` remains (handled by a separate unbreaker PR — not touched here).
- `cargo check --no-default-features --tests` → `Finished`.
- Standalone feature checks (`mcp-server`, `encryption`) → `Finished`.
- **Full library test suite: `test result: ok. 4202 passed; 0 failed; 3 ignored`** (includes all 31 crypto-shred tests: 23 foundation + 8 new integration).
- The full integration-binary `cargo test` is **disk-blocked in this environment** (compiling all ~50 test binaries exhausts the 28 GB scratch disk — `ld: No space left on device`); `clippy --all-targets` above already compiled every test target cleanly.

### Tests

E2E cold-restart round trip; reusable **sentinel byte-scan** (zero designated plaintext across WAL/index/current/checkpoint, both pre- and post-erase); blast radius (erase A leaves B byte-identical); `__aletheia_ns` coexistence; HNSW exclusion; MCP erased-marker shape; no-deadlock concurrency; non-designated zero-regression.

Does **not** touch `src/encryption/`, `rotation.rs`, `wal_encryption.rs`, or `reencrypt.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTu9hwjNh5FKc2ksJVXf9b

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTu9hwjNh5FKc2ksJVXf9b)_