### PR TITLE
feat(changefeed): event-driven await long-poll — no worker pin, prompt slot release (#3673)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,9 @@ tower = { version = "0.5", optional = true }
 tower-http = { version = "0.6", optional = true, features = ["cors", "trace", "set-header"] }
 
 # Embedding generation dependencies (all optional via feature flags)
-tokio = { version = "1.52", features = ["rt-multi-thread", "macros"], optional = true }
+# `sync` (Notify) + `time` (sleep/select) power the event-driven changefeed
+# long-poll wait (Issue #3673); harmless when tokio is pulled by another feature.
+tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "sync", "time"], optional = true }
 embed_anything = { version = "0.6.7", optional = true }
 # embed_anything 0.6.7 accepts candle ^0.9.1 but does not build against 0.9.2's
 # wider CpuStorage enum yet. Keep these pins until upstream handles the new variants.

--- a/crates/aletheia-server/src/changefeed_stream.rs
+++ b/crates/aletheia-server/src/changefeed_stream.rs
@@ -207,6 +207,12 @@ pub async fn changes_stream(
                 // `closed()` at once, so we stop and drop the subscription without
                 // waiting for the next record or the keepalive tick.
                 biased;
+                // If a record's `recv_async` and `tx.closed()` are ready on the
+                // same poll, disconnect wins and that final in-flight batch is
+                // dropped with the subscription. This is intentional and matches
+                // the SSE at-least-once contract: the client resumes from the
+                // last cursor it actually received via `list_changes` +
+                // `resume_token`, so nothing is silently lost.
                 _ = tx.closed() => return,
                 res = sub.recv_async(STREAM_POLL_INTERVAL) => match res {
                     // Keepalive tick with nothing buffered: loop (the SSE

--- a/crates/aletheia-server/src/changefeed_stream.rs
+++ b/crates/aletheia-server/src/changefeed_stream.rs
@@ -15,15 +15,20 @@
 //!    the `await_changes` long-poll tool (`#[api_doc(mcp)]`), delegating to
 //!    [`AletheiaMcpServer::await_changes`](aletheiadb::mcp::AletheiaMcpServer::await_changes).
 //!
-//! Both are [`ReadClass`]. The runtime-protection strategy differs by surface:
-//! these **HTTP** handlers offload the blocking `recv_timeout` long-poll onto a
-//! `spawn_blocking` worker so it never starves the async runtime. The **native
-//! MCP** `await_changes` tool (invoked directly over stdio, not through this
-//! HTTP projection) instead uses a `block_in_place` runtime bridge inside
-//! `AletheiaMcpServer::await_changes` for the same protection (it has no
-//! `spawn_blocking` boundary to rely on). Note the idle SSE reap latency is
-//! bounded by [`STREAM_POLL_INTERVAL`] (~15s) after a client disconnects — an
-//! actively-delivering feed cleans up immediately when its receiver drops.
+//! Both are [`ReadClass`]. Both wait **event-driven** (Issue #3673): they await
+//! the changefeed via [`Subscription::recv_async`](aletheiadb::core::changefeed_subscription::Subscription::recv_async)
+//! — a `tokio::sync::Notify` wait — instead of parking a `spawn_blocking` /
+//! `block_in_place` worker on the synchronous `recv_timeout`. A suspended
+//! long-poll therefore pins **zero** runtime threads, and because each handler
+//! future is dropped when its client disconnects, the underlying
+//! `Subscription` drops immediately — freeing the per-principal slot without
+//! waiting out `timeout_ms` (await) or up to one [`STREAM_POLL_INTERVAL`] (SSE).
+//! The SSE worker additionally races `tx.closed()` so an *idle* disconnected
+//! stream is reaped at once rather than on the next keepalive tick. The native
+//! stdio MCP `await_changes` tool is likewise routed through the async dispatch;
+//! its per-call disconnect release is best-effort (stdio has no per-call
+//! connection-closed future) and bounded by `timeout_ms` as a backstop, but the
+//! worker-pin is gone there too.
 
 use std::convert::Infallible;
 use std::time::Duration;
@@ -41,9 +46,11 @@ use tokio_stream::wrappers::ReceiverStream;
 use crate::security::{Authorized, ReadClass};
 use crate::state::ServerState;
 
-/// How long each `recv_timeout` poll blocks before looping to re-check liveness
-/// and let the SSE keep-alive fire. Bounded so a disconnected idle client is
-/// reaped within one interval rather than pinning a subscription indefinitely.
+/// Coarse keepalive re-loop interval for the SSE worker's `recv_async` wait
+/// (Issue #3673). Since a client disconnect is now caught event-driven via
+/// `tx.closed()` and new data via the `Notify` signal, this is no longer the
+/// disconnect-reap bound — it merely wakes the loop periodically alongside the
+/// SSE keep-alive; a disconnect is reaped in well under one interval.
 const STREAM_POLL_INTERVAL: Duration = Duration::from_secs(15);
 
 /// Parse an MCP tool method's JSON string result into a [`Value`] for the HTTP
@@ -187,39 +194,48 @@ pub async fn changes_stream(
         .map_err(map_subscribe_err)?;
 
     let (tx, rx) = tokio::sync::mpsc::channel::<Result<Event, Infallible>>(16);
-    tokio::task::spawn_blocking(move || {
+    // Event-driven async worker (Issue #3673): wait on the changefeed via the
+    // `recv_async` Notify path and race it against `tx.closed()`, so a client
+    // disconnect wakes the worker IMMEDIATELY (dropping `sub` → deregistering the
+    // subscription and freeing its per-principal slot) instead of lingering up to
+    // one `STREAM_POLL_INTERVAL` (~15s) as the old `spawn_blocking` +
+    // `recv_timeout` poll loop did. No thread is pinned for the wait.
+    tokio::spawn(async move {
         loop {
-            match sub.recv_timeout(STREAM_POLL_INTERVAL) {
-                // Idle timeout: keep looping (the SSE keep-alive covers the wire),
-                // but stop if the client has gone so we don't pin the subscription.
-                Ok(recs) if recs.is_empty() => {
-                    if tx.is_closed() {
-                        return;
-                    }
-                }
-                Ok(recs) => {
-                    for record in &recs {
-                        let event = match Event::default().json_data(change_record_json(record)) {
-                            Ok(ev) => ev,
-                            // A record that will not serialize is skipped rather
-                            // than tearing down the whole stream.
-                            Err(_) => continue,
-                        };
-                        if tx.blocking_send(Ok(event)).is_err() {
-                            return;
+            tokio::select! {
+                // Disconnect wins the race (biased): the receiver dropping resolves
+                // `closed()` at once, so we stop and drop the subscription without
+                // waiting for the next record or the keepalive tick.
+                biased;
+                _ = tx.closed() => return,
+                res = sub.recv_async(STREAM_POLL_INTERVAL) => match res {
+                    // Keepalive tick with nothing buffered: loop (the SSE
+                    // keep-alive covers the wire).
+                    Ok(recs) if recs.is_empty() => {}
+                    Ok(recs) => {
+                        for record in &recs {
+                            let event = match Event::default().json_data(change_record_json(record)) {
+                                Ok(ev) => ev,
+                                // A record that will not serialize is skipped rather
+                                // than tearing down the whole stream.
+                                Err(_) => continue,
+                            };
+                            if tx.send(Ok(event)).await.is_err() {
+                                return;
+                            }
                         }
                     }
-                }
-                Err(RecvError::Lagged { resume_token }) => {
-                    let payload = match &resume_token {
-                        Some(token) => json!({ "resume_token": token }),
-                        None => json!({}),
-                    };
-                    if let Ok(event) = Event::default().event("lagged").json_data(payload) {
-                        let _ = tx.blocking_send(Ok(event));
+                    Err(RecvError::Lagged { resume_token }) => {
+                        let payload = match &resume_token {
+                            Some(token) => json!({ "resume_token": token }),
+                            None => json!({}),
+                        };
+                        if let Ok(event) = Event::default().event("lagged").json_data(payload) {
+                            let _ = tx.send(Ok(event)).await;
+                        }
+                        return;
                     }
-                    return;
-                }
+                },
             }
         }
     });
@@ -230,10 +246,14 @@ pub async fn changes_stream(
 /// `POST /changes/await` — the MCP-over-HTTP projection of the `await_changes`
 /// long-poll tool (Issue #3375). [`ReadClass`]. HTTP + MCP tool.
 ///
-/// Delegates to [`AletheiaMcpServer::await_changes`]. On this **HTTP** surface
-/// the blocking long-poll is driven on a `spawn_blocking` worker so it does not
-/// starve the async runtime (the native stdio MCP tool has no such boundary and
-/// uses a `block_in_place` runtime bridge internally instead).
+/// Delegates to the event-driven
+/// [`AletheiaMcpServer::await_changes_for_principal_async`] (Issue #3673): the
+/// long-poll awaits a `tokio::sync::Notify` rather than parking a
+/// `spawn_blocking` worker, so it starves no runtime thread AND — because the
+/// handler future is dropped when the HTTP client disconnects — the underlying
+/// `Subscription` drops immediately, releasing the per-principal slot without
+/// waiting out the timeout (the old `spawn_blocking` task was not cancelled on
+/// drop and held the slot for the full `timeout_ms`).
 pub async fn await_changes_impl(
     state: ServerState,
     req: AwaitChangesRequest,
@@ -244,21 +264,9 @@ pub async fn await_changes_impl(
     // the shared embedded MCP server has no per-request session, so the route's
     // principal must be passed explicitly or the quota would fall back to a single
     // shared bucket for every HTTP caller.
-    let out = tokio::task::spawn_blocking(move || {
-        server.await_changes_for_principal(req, Some(principal_id))
-    })
-    .await
-    .unwrap_or_else(|_| {
-        // A panicked worker is an internal fault; surface the #3234 envelope.
-        json!({
-            "error": {
-                "code": "INTERNAL",
-                "message": "await_changes worker terminated unexpectedly",
-                "retriable": false
-            }
-        })
-        .to_string()
-    });
+    let out = server
+        .await_changes_for_principal_async(req, Some(principal_id))
+        .await;
     tool_json(out)
 }
 

--- a/crates/aletheia-server/tests/changefeed_await_slot_pinning.rs
+++ b/crates/aletheia-server/tests/changefeed_await_slot_pinning.rs
@@ -33,6 +33,13 @@ const READER_TOKEN: &str = "reader-token-abcdefghijklmnop";
 const WRITER_TOKEN: &str = "writer-token-abcdefghijklmnop";
 const ADMIN_TOKEN: &str = "admin-token-abcdefghijklmnop";
 
+/// Wall-clock bound for a per-principal slot to be reaped after a client
+/// disconnect. Deliberately loose (5s) so it never flakes on a loaded CI worker
+/// while still RED-ing the pre-fix regressions with wide headroom: the old SSE
+/// path lingered up to `STREAM_POLL_INTERVAL` (~15s) and the old await path up
+/// to the full 60s `timeout_ms`, so 5s catches either with ≥3× margin.
+const SLOT_RELEASE_BOUND: Duration = Duration::from_secs(5);
+
 // ── fixtures / helpers ───────────────────────────────────────────────────────
 
 fn new_db() -> Arc<AletheiaDB> {
@@ -98,77 +105,137 @@ fn key(r: &ChangeRecord) -> (i64, u32, u8, u64, u64) {
 
 // ── (a) CORE: N long-polls do not starve a small worker pool ──────────────────
 
-/// Eight concurrent `recv_async` long-polls (60s) on a **2-worker** runtime must
-/// NOT pin the pool: an unrelated quick task still completes promptly, and one
-/// commit wakes all eight well within a second. RED if `recv_async` blocks its
-/// worker (the old `block_in_place`/`recv_timeout` path) — two blocked workers
-/// starve the probe and the whole test hangs.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn recv_async_does_not_starve_small_worker_pool() {
-    let db = new_db();
-    const N: usize = 8;
+/// N concurrent `recv_async` long-polls (60s) on a runtime whose worker pool AND
+/// blocking pool are BOTH capped at 2 must pin neither: an event-driven wait
+/// consumes zero threads of either kind, so N can far exceed the combined budget
+/// (2 + 2 = 4) and unrelated work of BOTH flavors still makes progress.
+///
+/// The two probes are the discriminators:
+/// - an async probe (an ordinary task) RED-s a *worker-pinning* regression
+///   (`block_in_place` or a naive synchronous `recv_timeout` on the worker):
+///   with 2 workers pinned and only 2 blocking replacements available, no worker
+///   is left to schedule it;
+/// - a `spawn_blocking` probe RED-s a *blocking-pool* regression
+///   (`spawn_blocking(recv_timeout)`): with both blocking threads held by
+///   long-polls it can never be scheduled.
+///
+/// The event-driven path holds neither resource, so both probes complete
+/// promptly and the single commit still wakes all N. (Manually built runtime:
+/// `#[tokio::test]` cannot set `max_blocking_threads`.)
+#[test]
+fn recv_async_does_not_starve_small_worker_pool() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .max_blocking_threads(2)
+        .enable_all()
+        .build()
+        .expect("build limited runtime");
 
-    let mut handles = Vec::new();
-    for _ in 0..N {
-        let sub = db
-            .subscribe_changes(ChangeFilter::all())
-            .expect("subscribe");
-        handles.push(tokio::spawn(async move {
-            sub.recv_async(Duration::from_secs(60)).await
-        }));
-    }
+    rt.block_on(async {
+        let db = new_db();
+        // N strictly exceeds the combined worker+blocking budget (2 + 2 = 4), so
+        // ANY thread-pinning wait exhausts both pools and starves a probe.
+        const N: usize = 8;
 
-    // Probe: an unrelated quick task must run promptly despite the 8 outstanding
-    // long-polls. If each long-poll pinned a worker, both workers would be blocked
-    // and this would never be scheduled.
-    let probe = tokio::spawn(async {
-        tokio::time::sleep(Duration::from_millis(5)).await;
-        42u32
-    });
-    let probed = tokio::time::timeout(Duration::from_millis(500), probe).await;
-    assert!(
-        probed.is_ok(),
-        "probe task starved: concurrent long-polls pinned the worker pool"
-    );
-    assert_eq!(probed.unwrap().expect("probe join"), 42);
-
-    // One commit wakes ALL eight long-polls; each resolves with the change.
-    commit(&db, 1);
-    let joined = tokio::time::timeout(Duration::from_secs(3), async {
-        for h in handles {
-            let recs = h.await.expect("join").expect("recv_async ok");
-            assert_eq!(recs.len(), 1, "each long-poll receives the one commit");
+        let mut handles = Vec::new();
+        for _ in 0..N {
+            let sub = db
+                .subscribe_changes(ChangeFilter::all())
+                .expect("subscribe");
+            handles.push(tokio::spawn(async move {
+                sub.recv_async(Duration::from_secs(60)).await
+            }));
         }
-    })
-    .await;
-    assert!(
-        joined.is_ok(),
-        "not all long-polls resolved after the commit (worker starvation)"
-    );
+
+        // Give every long-poll time to reach and park in its wait, so that under
+        // a thread-pinning regression the worker/blocking pools are actually
+        // saturated before the probes run.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Probe 1 (async): RED-s a worker-pinning regression. With both workers
+        // pinned (and both blocking replacements consumed) nothing schedules it.
+        let async_probe = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            42u32
+        });
+        let async_probed = tokio::time::timeout(Duration::from_secs(2), async_probe).await;
+        assert!(
+            async_probed.is_ok(),
+            "async probe starved: concurrent long-polls pinned the WORKER pool \
+             (block_in_place / naive sync recv_timeout regression)"
+        );
+        assert_eq!(async_probed.unwrap().expect("async probe join"), 42);
+
+        // Probe 2 (blocking): RED-s a spawn_blocking regression. With both
+        // blocking threads held by long-polls it can never run.
+        let blocking_probe =
+            tokio::task::spawn_blocking(|| std::thread::sleep(Duration::from_millis(5)));
+        let blocking_probed = tokio::time::timeout(Duration::from_secs(2), blocking_probe).await;
+        assert!(
+            blocking_probed.is_ok(),
+            "blocking probe starved: concurrent long-polls held the BLOCKING pool \
+             (spawn_blocking(recv_timeout) regression)"
+        );
+        blocking_probed.unwrap().expect("blocking probe join");
+
+        // One commit wakes ALL N long-polls; each resolves with the change.
+        commit(&db, 1);
+        let joined = tokio::time::timeout(Duration::from_secs(5), async {
+            for h in handles {
+                let recs = h.await.expect("join").expect("recv_async ok");
+                assert_eq!(recs.len(), 1, "each long-poll receives the one commit");
+            }
+        })
+        .await;
+        assert!(
+            joined.is_ok(),
+            "not all long-polls resolved after the commit (worker starvation)"
+        );
+    });
 }
 
 // ── (a reverse): event-driven, no busy-spin when idle ─────────────────────────
 
-/// An idle `recv_async` waits the full timeout (no early spurious returns / no
-/// interval polling), and a single commit yields exactly one delivery. RED for a
-/// busy-poll design that returns early or spins.
+/// An idle `recv_async` parks event-driven: over a 300ms idle interval the
+/// outer future is polled only O(1) times (one initial poll that returns
+/// Pending, one final poll when the timeout fires), NOT once per tick. This is
+/// the distinctive busy-spin assertion — a `loop { sleep(10ms); check }`
+/// placeholder would wake the task ~30 times and blow the poll-count bound even
+/// though it also honors the elapsed and single-delivery checks. A single commit
+/// still yields exactly one delivery.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn recv_async_is_event_driven_no_busy_spin_when_idle() {
+    use std::future::Future;
+
     let db = new_db();
     let sub = db
         .subscribe_changes(ChangeFilter::all())
         .expect("subscribe");
 
     let start = Instant::now();
-    let empty = sub
-        .recv_async(Duration::from_millis(300))
-        .await
-        .expect("recv ok");
+    // Count how many times the recv_async future is polled while idle. An
+    // event-driven wait registers a waker and parks, so the runtime polls it
+    // only on a genuine wake (here: the timeout). A busy-poll design re-polls on
+    // every self-scheduled tick.
+    let mut polls = 0usize;
+    let fut = sub.recv_async(Duration::from_millis(300));
+    tokio::pin!(fut);
+    let empty = std::future::poll_fn(|cx| {
+        polls += 1;
+        fut.as_mut().poll(cx)
+    })
+    .await
+    .expect("recv ok");
     assert!(empty.is_empty(), "no data was committed");
     assert!(
         start.elapsed() >= Duration::from_millis(250),
         "recv_async returned early ({:?}) — not event-driven?",
         start.elapsed()
+    );
+    assert!(
+        polls <= 5,
+        "recv_async was polled {polls} times over a 300ms idle wait — not \
+         event-driven (a busy-poll / sleep-loop design would poll ~30 times)"
     );
 
     // One commit → exactly one prompt delivery (no missed / duplicate wake).
@@ -191,6 +258,37 @@ async fn recv_async_is_event_driven_no_busy_spin_when_idle() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn event_driven_delivery_is_ordered_and_lossless() {
     let db = new_db();
+
+    // First, distinctively exercise the ASYNC push-wakeup path: a suspended
+    // `recv_async` waiter must be woken by the commit *broadcast* while parked,
+    // not by draining after the fact. A waiter that only returned on timeout (or
+    // a busy drain-poll) would blow the tight bound below.
+    {
+        let sub = db
+            .subscribe_changes(ChangeFilter::all())
+            .expect("subscribe");
+        let waiter = tokio::spawn(async move {
+            let start = Instant::now();
+            let recs = sub
+                .recv_async(Duration::from_secs(10))
+                .await
+                .expect("recv ok");
+            (recs, start.elapsed())
+        });
+        // Let the waiter enter recv_async and park on the Notify.
+        tokio::task::yield_now().await;
+        commit(&db, -1);
+        let (recs, waited) = tokio::time::timeout(Duration::from_secs(2), waiter)
+            .await
+            .expect("async waiter must be woken by the commit, not wait out 10s")
+            .expect("join");
+        assert_eq!(recs.len(), 1, "async waiter delivered the pushed commit");
+        assert!(
+            waited < Duration::from_secs(2),
+            "async waiter woken promptly by push-wakeup, not the 10s timeout: {waited:?}"
+        );
+    }
+
     let sub = db
         .subscribe_changes(ChangeFilter::all())
         .expect("subscribe");
@@ -278,16 +376,20 @@ async fn sse_disconnect_releases_slot_under_two_seconds() {
     .await;
     assert!(registered.is_some(), "SSE stream should register the slot");
 
+    // The SSE handler must still be blocked in its stream (never naturally
+    // completed) so that `abort()` is what triggers the disconnect we measure.
+    assert!(
+        !stream_task.is_finished(),
+        "SSE stream task completed on its own — disconnect not actually exercised"
+    );
+
     // Disconnect — NO commits to wake the worker (the whole point).
     stream_task.abort();
 
-    let released = wait_until(Duration::from_secs(2), || {
-        principal_count(&db, &reader_id) == 0
-    })
-    .await;
+    let released = wait_until(SLOT_RELEASE_BOUND, || principal_count(&db, &reader_id) == 0).await;
     assert!(
         released.is_some(),
-        "SSE disconnect must free the slot in <2s with no commits (was up to 15s)"
+        "SSE disconnect must free the slot within SLOT_RELEASE_BOUND with no commits (was up to 15s)"
     );
 
     // Genuinely free: the reader can re-subscribe.
@@ -340,15 +442,19 @@ async fn await_disconnect_releases_slot_under_two_seconds() {
         "await long-poll should register the slot"
     );
 
+    // The long-poll must still be blocking (not naturally returned) so `abort()`
+    // is what triggers the disconnect release we measure.
+    assert!(
+        !await_task.is_finished(),
+        "await task completed on its own — disconnect not actually exercised"
+    );
+
     await_task.abort();
 
-    let released = wait_until(Duration::from_secs(2), || {
-        principal_count(&db, &reader_id) == 0
-    })
-    .await;
+    let released = wait_until(SLOT_RELEASE_BOUND, || principal_count(&db, &reader_id) == 0).await;
     assert!(
         released.is_some(),
-        "await disconnect must free the slot in <2s (was up to 60s)"
+        "await disconnect must free the slot within SLOT_RELEASE_BOUND (was up to 60s)"
     );
 }
 
@@ -376,39 +482,52 @@ async fn reconnect_churn_no_false_exhaustion() {
     ));
 
     for round in 0..10 {
-        // The per-principal count must be strictly below CAP before each open,
-        // else a prior disconnect leaked its slot (false-exhaustion source).
-        assert!(
-            principal_count(&db, &reader_id) < CAP,
-            "round {round}: stale slots lingered past the cap (false-exhaustion)"
-        );
-
-        let task = {
+        // Saturate the ENTIRE per-principal cap with concurrent long-polls, then
+        // abort them all at once. Under the #3688 bug the aborted slots linger
+        // (15/60s), so the cap stays occupied and the next subscribe is falsely
+        // rejected — that false-exhaustion is the distinctive failure asserted
+        // below, not a per-round release-timing race.
+        let mut tasks = Vec::new();
+        for _ in 0..CAP {
             let client = Arc::clone(&client);
-            tokio::spawn(async move {
+            tasks.push(tokio::spawn(async move {
                 let _ = client
                     .post("/changes/await")
                     .header("authorization", &format!("Bearer {READER_TOKEN}"))
                     .json(&json!({ "timeout_ms": 60000 }))
                     .send()
                     .await;
-            })
-        };
+            }));
+        }
 
         assert!(
             wait_until(Duration::from_secs(5), || principal_count(&db, &reader_id)
-                >= 1)
+                == CAP)
             .await
             .is_some(),
-            "round {round}: open should register"
+            "round {round}: the concurrent long-polls should saturate the cap"
         );
-        task.abort();
+        for task in &tasks {
+            assert!(
+                !task.is_finished(),
+                "round {round}: a long-poll completed on its own — disconnect not exercised"
+            );
+            task.abort();
+        }
+
+        // DISTINCTIVE #3688 guard: with the cap just saturated and every holder
+        // aborted, a fresh subscribe WITHIN the cap must succeed once the stale
+        // slots are reaped. Under the bug they linger and this stays exhausted
+        // (Err/UNAVAILABLE) for the whole bound — false-exhaustion.
+        let recovered = wait_until(SLOT_RELEASE_BOUND, || {
+            db.subscribe_changes_for_principal(Some(&reader_id), ChangeFilter::all())
+                .is_ok()
+        })
+        .await;
         assert!(
-            wait_until(Duration::from_secs(2), || principal_count(&db, &reader_id)
-                == 0)
-            .await
-            .is_some(),
-            "round {round}: disconnect should free the slot promptly"
+            recovered.is_some(),
+            "round {round}: quota falsely exhausted after churn — aborted slots \
+             not reaped within the cap (#3688 false-exhaustion)"
         );
     }
 
@@ -531,16 +650,17 @@ async fn quota_stats_return_to_baseline_after_disconnect() {
         "reader slot registers"
     );
 
+    assert!(
+        !stream_task.is_finished(),
+        "SSE stream task completed on its own — disconnect not actually exercised"
+    );
     stream_task.abort();
 
     // The per-principal live count returns to zero promptly (the stats source).
-    let released = wait_until(Duration::from_secs(2), || {
-        principal_count(&db, &reader_id) == 0
-    })
-    .await;
+    let released = wait_until(SLOT_RELEASE_BOUND, || principal_count(&db, &reader_id) == 0).await;
     assert!(
         released.is_some(),
-        "stats source returns to baseline in <2s"
+        "stats source returns to baseline within SLOT_RELEASE_BOUND"
     );
 
     // And the admin database_stats roster no longer lists the reader.

--- a/crates/aletheia-server/tests/changefeed_await_slot_pinning.rs
+++ b/crates/aletheia-server/tests/changefeed_await_slot_pinning.rs
@@ -1,0 +1,569 @@
+//! Event-driven changefeed long-poll: worker-pin removal + prompt slot release
+//! on client disconnect (Issue #3673), driven against the live assembled
+//! autumn-web server and the core `Subscription::recv_async` primitive.
+//!
+//! These lock the ACs:
+//!
+//! - **(a) worker-starvation**: N concurrent `recv_async` long-polls on a SMALL
+//!   worker pool do NOT starve unrelated work — a suspended async wait pins zero
+//!   worker threads (RED if `recv_async` blocks the thread like the old
+//!   `block_in_place`/`recv_timeout` path).
+//! - **(b) prompt disconnect release**: an SSE `GET /changes/stream` client and an
+//!   HTTP `POST /changes/await` long-poll BOTH free their per-principal slot in
+//!   well under the old 15s / 60s bound when the client disconnects — event-driven
+//!   (`tx.closed()` / future-drop), no commits needed to wake the worker.
+//! - **(b) + #3688 churn**: rapid reconnect churn near the per-principal cap never
+//!   falsely exhausts the quota (stale slots are reaped promptly).
+//! - **(c) delivery unchanged**: the event-driven path drains cursor-ascending and
+//!   losslessly, identical to the sync `recv_timeout` contract.
+//! - normal-path timeout still releases; disconnect decrements the counter exactly
+//!   once; `database_stats` per-principal returns to baseline promptly.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use aletheia_server::build_server_client;
+use aletheiadb::auth::{AuthMode, AuthStore, Role};
+use aletheiadb::core::changefeed::ChangeRecord;
+use aletheiadb::core::changefeed_subscription::ChangefeedConfig;
+use aletheiadb::{AletheiaDB, ChangeFilter, PropertyMapBuilder};
+use serde_json::{Value, json};
+
+const READER_TOKEN: &str = "reader-token-abcdefghijklmnop";
+const WRITER_TOKEN: &str = "writer-token-abcdefghijklmnop";
+const ADMIN_TOKEN: &str = "admin-token-abcdefghijklmnop";
+
+// ── fixtures / helpers ───────────────────────────────────────────────────────
+
+fn new_db() -> Arc<AletheiaDB> {
+    Arc::new(AletheiaDB::new().expect("create db"))
+}
+
+fn keyed_store() -> Arc<AuthStore> {
+    let store = Arc::new(AuthStore::new());
+    store
+        .insert_bootstrap_key("reader", Role::Reader, READER_TOKEN)
+        .expect("reader key");
+    store
+        .insert_bootstrap_key("writer", Role::Writer, WRITER_TOKEN)
+        .expect("writer key");
+    store
+        .insert_bootstrap_key("admin", Role::Admin, ADMIN_TOKEN)
+        .expect("admin key");
+    store
+}
+
+fn principal_id(store: &AuthStore, token: &str) -> String {
+    store.verify(token).expect("verify token").id
+}
+
+/// The live per-principal subscription count for `id` (0 if absent).
+fn principal_count(db: &AletheiaDB, id: &str) -> usize {
+    db.changefeed_principal_counts()
+        .into_iter()
+        .find(|(k, _)| k == id)
+        .map(|(_, c)| c)
+        .unwrap_or(0)
+}
+
+/// Poll `cond` every 20ms until it holds or `bound` elapses. Returns the elapsed
+/// time on success, or `None` if the bound was hit first.
+async fn wait_until(bound: Duration, mut cond: impl FnMut() -> bool) -> Option<Duration> {
+    let start = Instant::now();
+    while start.elapsed() < bound {
+        if cond() {
+            return Some(start.elapsed());
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    cond().then(|| start.elapsed())
+}
+
+/// A committed change wakes any live subscription (used to advance the feed).
+fn commit(db: &AletheiaDB, n: i64) {
+    let _ = db.create_node("Ping", PropertyMapBuilder::new().insert("n", n).build());
+}
+
+/// A stable dedup/order key equivalent to the `ChangeCursor`.
+fn key(r: &ChangeRecord) -> (i64, u32, u8, u64, u64) {
+    let start = r.transaction_time_range.start();
+    (
+        start.wallclock(),
+        start.logical(),
+        r.kind.ord(),
+        r.entity_id,
+        r.version_id,
+    )
+}
+
+// ── (a) CORE: N long-polls do not starve a small worker pool ──────────────────
+
+/// Eight concurrent `recv_async` long-polls (60s) on a **2-worker** runtime must
+/// NOT pin the pool: an unrelated quick task still completes promptly, and one
+/// commit wakes all eight well within a second. RED if `recv_async` blocks its
+/// worker (the old `block_in_place`/`recv_timeout` path) — two blocked workers
+/// starve the probe and the whole test hangs.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recv_async_does_not_starve_small_worker_pool() {
+    let db = new_db();
+    const N: usize = 8;
+
+    let mut handles = Vec::new();
+    for _ in 0..N {
+        let sub = db
+            .subscribe_changes(ChangeFilter::all())
+            .expect("subscribe");
+        handles.push(tokio::spawn(async move {
+            sub.recv_async(Duration::from_secs(60)).await
+        }));
+    }
+
+    // Probe: an unrelated quick task must run promptly despite the 8 outstanding
+    // long-polls. If each long-poll pinned a worker, both workers would be blocked
+    // and this would never be scheduled.
+    let probe = tokio::spawn(async {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        42u32
+    });
+    let probed = tokio::time::timeout(Duration::from_millis(500), probe).await;
+    assert!(
+        probed.is_ok(),
+        "probe task starved: concurrent long-polls pinned the worker pool"
+    );
+    assert_eq!(probed.unwrap().expect("probe join"), 42);
+
+    // One commit wakes ALL eight long-polls; each resolves with the change.
+    commit(&db, 1);
+    let joined = tokio::time::timeout(Duration::from_secs(3), async {
+        for h in handles {
+            let recs = h.await.expect("join").expect("recv_async ok");
+            assert_eq!(recs.len(), 1, "each long-poll receives the one commit");
+        }
+    })
+    .await;
+    assert!(
+        joined.is_ok(),
+        "not all long-polls resolved after the commit (worker starvation)"
+    );
+}
+
+// ── (a reverse): event-driven, no busy-spin when idle ─────────────────────────
+
+/// An idle `recv_async` waits the full timeout (no early spurious returns / no
+/// interval polling), and a single commit yields exactly one delivery. RED for a
+/// busy-poll design that returns early or spins.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recv_async_is_event_driven_no_busy_spin_when_idle() {
+    let db = new_db();
+    let sub = db
+        .subscribe_changes(ChangeFilter::all())
+        .expect("subscribe");
+
+    let start = Instant::now();
+    let empty = sub
+        .recv_async(Duration::from_millis(300))
+        .await
+        .expect("recv ok");
+    assert!(empty.is_empty(), "no data was committed");
+    assert!(
+        start.elapsed() >= Duration::from_millis(250),
+        "recv_async returned early ({:?}) — not event-driven?",
+        start.elapsed()
+    );
+
+    // One commit → exactly one prompt delivery (no missed / duplicate wake).
+    commit(&db, 7);
+    let got = tokio::time::timeout(
+        Duration::from_secs(2),
+        sub.recv_async(Duration::from_secs(2)),
+    )
+    .await
+    .expect("did not hang")
+    .expect("recv ok");
+    assert_eq!(got.len(), 1, "single commit delivered exactly once");
+}
+
+// ── (c): event-driven delivery is ordered and lossless ────────────────────────
+
+/// Draining via `recv_async` across interleaved commits yields records in
+/// cursor-ascending order and the union equals the durable ground truth —
+/// identical to the sync `recv_timeout` contract (AC c).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn event_driven_delivery_is_ordered_and_lossless() {
+    let db = new_db();
+    let sub = db
+        .subscribe_changes(ChangeFilter::all())
+        .expect("subscribe");
+
+    const COMMITS: i64 = 25;
+    let mut collected: Vec<ChangeRecord> = Vec::new();
+    for i in 0..COMMITS {
+        commit(&db, i);
+        // Drain whatever is available with a short async wait.
+        loop {
+            let batch = sub
+                .recv_async(Duration::from_millis(50))
+                .await
+                .expect("recv ok");
+            if batch.is_empty() {
+                break;
+            }
+            collected.extend(batch);
+        }
+    }
+    // Flush any remainder.
+    loop {
+        let batch = sub
+            .recv_async(Duration::from_millis(50))
+            .await
+            .expect("recv ok");
+        if batch.is_empty() {
+            break;
+        }
+        collected.extend(batch);
+    }
+
+    // Cursor-ascending order.
+    let keys: Vec<_> = collected.iter().map(key).collect();
+    let mut sorted = keys.clone();
+    sorted.sort();
+    assert_eq!(keys, sorted, "records delivered in cursor-ascending order");
+
+    // Lossless: each commit is one node-create record, delivered exactly once.
+    assert_eq!(db.changefeed_subscription_count(), 1, "sub still live");
+    assert_eq!(
+        collected.len() as i64,
+        COMMITS,
+        "every committed change delivered exactly once"
+    );
+}
+
+// ── (b): SSE client disconnect releases the slot under the tight bound ─────────
+
+/// An SSE `GET /changes/stream` client disconnect frees the per-principal slot in
+/// well under 2s WITHOUT any commits to wake the worker — the async worker races
+/// `tx.closed()` and drops its `Subscription` at once. RED under the old
+/// `spawn_blocking` + `recv_timeout(15s)` idle poll (release lagged up to 15s and
+/// required a commit to wake).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn sse_disconnect_releases_slot_under_two_seconds() {
+    let db = new_db();
+    let store = keyed_store();
+    let reader_id = principal_id(&store, READER_TOKEN);
+    db.set_changefeed_config(
+        ChangefeedConfig::default()
+            .with_max_subscriptions(128)
+            .with_max_subscriptions_per_principal(4),
+    );
+    let client = Arc::new(build_server_client(
+        Arc::clone(&db),
+        store,
+        AuthMode::Required,
+    ));
+
+    let stream_task = {
+        let client = Arc::clone(&client);
+        tokio::spawn(async move {
+            let _ = client
+                .get("/changes/stream")
+                .header("authorization", &format!("Bearer {READER_TOKEN}"))
+                .send()
+                .await;
+        })
+    };
+
+    let registered = wait_until(Duration::from_secs(5), || {
+        principal_count(&db, &reader_id) == 1
+    })
+    .await;
+    assert!(registered.is_some(), "SSE stream should register the slot");
+
+    // Disconnect — NO commits to wake the worker (the whole point).
+    stream_task.abort();
+
+    let released = wait_until(Duration::from_secs(2), || {
+        principal_count(&db, &reader_id) == 0
+    })
+    .await;
+    assert!(
+        released.is_some(),
+        "SSE disconnect must free the slot in <2s with no commits (was up to 15s)"
+    );
+
+    // Genuinely free: the reader can re-subscribe.
+    let _fresh = db
+        .subscribe_changes_for_principal(Some(&reader_id), ChangeFilter::all())
+        .expect("reader re-subscribes after prompt release");
+}
+
+// ── (b): HTTP await long-poll disconnect releases the slot promptly ───────────
+
+/// A `POST /changes/await` long-poll (60s) client disconnect frees the
+/// per-principal slot in well under 2s — the async handler future is dropped on
+/// disconnect, dropping the `Subscription`. RED under the old `spawn_blocking`
+/// path: the blocking worker is NOT cancelled on future-drop and held the slot
+/// for the full 60s timeout.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn await_disconnect_releases_slot_under_two_seconds() {
+    let db = new_db();
+    let store = keyed_store();
+    let reader_id = principal_id(&store, READER_TOKEN);
+    db.set_changefeed_config(
+        ChangefeedConfig::default()
+            .with_max_subscriptions(128)
+            .with_max_subscriptions_per_principal(4),
+    );
+    let client = Arc::new(build_server_client(
+        Arc::clone(&db),
+        store,
+        AuthMode::Required,
+    ));
+
+    let await_task = {
+        let client = Arc::clone(&client);
+        tokio::spawn(async move {
+            let _ = client
+                .post("/changes/await")
+                .header("authorization", &format!("Bearer {READER_TOKEN}"))
+                .json(&json!({ "timeout_ms": 60000 }))
+                .send()
+                .await;
+        })
+    };
+
+    let registered = wait_until(Duration::from_secs(5), || {
+        principal_count(&db, &reader_id) == 1
+    })
+    .await;
+    assert!(
+        registered.is_some(),
+        "await long-poll should register the slot"
+    );
+
+    await_task.abort();
+
+    let released = wait_until(Duration::from_secs(2), || {
+        principal_count(&db, &reader_id) == 0
+    })
+    .await;
+    assert!(
+        released.is_some(),
+        "await disconnect must free the slot in <2s (was up to 60s)"
+    );
+}
+
+// ── (b + #3688): reconnect churn never falsely exhausts the quota ─────────────
+
+/// Rapid open→disconnect churn near the per-principal cap never falsely exhausts
+/// the quota: each disconnect frees its slot promptly (event-driven) so the next
+/// open always fits. RED if stale slots linger 15/60s and accumulate past the
+/// cap (the #3688 transient false-exhaustion this issue eliminates).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn reconnect_churn_no_false_exhaustion() {
+    let db = new_db();
+    let store = keyed_store();
+    let reader_id = principal_id(&store, READER_TOKEN);
+    const CAP: usize = 2;
+    db.set_changefeed_config(
+        ChangefeedConfig::default()
+            .with_max_subscriptions(128)
+            .with_max_subscriptions_per_principal(CAP),
+    );
+    let client = Arc::new(build_server_client(
+        Arc::clone(&db),
+        store,
+        AuthMode::Required,
+    ));
+
+    for round in 0..10 {
+        // The per-principal count must be strictly below CAP before each open,
+        // else a prior disconnect leaked its slot (false-exhaustion source).
+        assert!(
+            principal_count(&db, &reader_id) < CAP,
+            "round {round}: stale slots lingered past the cap (false-exhaustion)"
+        );
+
+        let task = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move {
+                let _ = client
+                    .post("/changes/await")
+                    .header("authorization", &format!("Bearer {READER_TOKEN}"))
+                    .json(&json!({ "timeout_ms": 60000 }))
+                    .send()
+                    .await;
+            })
+        };
+
+        assert!(
+            wait_until(Duration::from_secs(5), || principal_count(&db, &reader_id)
+                >= 1)
+            .await
+            .is_some(),
+            "round {round}: open should register"
+        );
+        task.abort();
+        assert!(
+            wait_until(Duration::from_secs(2), || principal_count(&db, &reader_id)
+                == 0)
+            .await
+            .is_some(),
+            "round {round}: disconnect should free the slot promptly"
+        );
+    }
+
+    // Fully released; a fresh CAP subscribes succeed and the CAP+1 is rejected.
+    let mut held = Vec::new();
+    for _ in 0..CAP {
+        held.push(
+            db.subscribe_changes_for_principal(Some(&reader_id), ChangeFilter::all())
+                .expect("fresh cap subscribes after churn"),
+        );
+    }
+    assert!(
+        db.subscribe_changes_for_principal(Some(&reader_id), ChangeFilter::all())
+            .is_err(),
+        "cap still binds after churn (no leak)"
+    );
+}
+
+// ── (b normal path): await timeout still releases the slot ────────────────────
+
+/// A `POST /changes/await` that times out normally (no data, no disconnect)
+/// returns `timed_out: true` and frees the slot promptly — the async rewrite
+/// preserves the normal timeout→Drop path.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn await_timeout_still_releases_slot() {
+    let db = new_db();
+    let store = keyed_store();
+    let reader_id = principal_id(&store, READER_TOKEN);
+    db.set_changefeed_config(
+        ChangefeedConfig::default()
+            .with_max_subscriptions(128)
+            .with_max_subscriptions_per_principal(4),
+    );
+    let client = build_server_client(Arc::clone(&db), store, AuthMode::Required);
+
+    let resp = client
+        .post("/changes/await")
+        .header("authorization", &format!("Bearer {READER_TOKEN}"))
+        .json(&json!({ "timeout_ms": 150 }))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200);
+    let body: Value = resp.json();
+    assert_eq!(body["timed_out"], true, "clean timeout: {body}");
+
+    let released = wait_until(Duration::from_secs(2), || {
+        principal_count(&db, &reader_id) == 0
+    })
+    .await;
+    assert!(
+        released.is_some(),
+        "a timed-out long-poll must free its slot promptly"
+    );
+}
+
+// ── (c quota): disconnect decrements the principal counter exactly once ────────
+
+/// A single subscribe→drop decrements the per-principal counter to exactly 0 and
+/// removes the map entry; a re-subscribe then succeeds. Guards against a double
+/// decrement/underflow — `Subscription::Drop` must remain the sole release
+/// anchor even after the async rewrite.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn disconnect_decrements_principal_counter_exactly_once() {
+    let db = new_db();
+    let sub = db
+        .subscribe_changes_for_principal(Some("alice"), ChangeFilter::all())
+        .expect("subscribe");
+    assert_eq!(principal_count(&db, "alice"), 1);
+    drop(sub);
+    assert_eq!(principal_count(&db, "alice"), 0, "exactly one decrement");
+    assert!(
+        db.changefeed_principal_counts()
+            .iter()
+            .all(|(k, _)| k != "alice"),
+        "the zeroed principal entry is pruned"
+    );
+    let _again = db
+        .subscribe_changes_for_principal(Some("alice"), ChangeFilter::all())
+        .expect("re-subscribe after release");
+    assert_eq!(principal_count(&db, "alice"), 1);
+}
+
+// ── (b + #3688 stats): database_stats returns to baseline after disconnect ─────
+
+/// After an SSE client disconnect, the admin `database_stats` changefeed
+/// per-principal breakdown returns to baseline (the reader absent, aggregate 0)
+/// within the tight bound — mirrors the per-principal live count and the #3688
+/// stats surface.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn quota_stats_return_to_baseline_after_disconnect() {
+    let db = new_db();
+    let store = keyed_store();
+    let reader_id = principal_id(&store, READER_TOKEN);
+    db.set_changefeed_config(
+        ChangefeedConfig::default()
+            .with_max_subscriptions(128)
+            .with_max_subscriptions_per_principal(4),
+    );
+    let client = Arc::new(build_server_client(
+        Arc::clone(&db),
+        Arc::clone(&store),
+        AuthMode::Required,
+    ));
+
+    let stream_task = {
+        let client = Arc::clone(&client);
+        tokio::spawn(async move {
+            let _ = client
+                .get("/changes/stream")
+                .header("authorization", &format!("Bearer {READER_TOKEN}"))
+                .send()
+                .await;
+        })
+    };
+    assert!(
+        wait_until(Duration::from_secs(5), || principal_count(&db, &reader_id)
+            == 1)
+        .await
+        .is_some(),
+        "reader slot registers"
+    );
+
+    stream_task.abort();
+
+    // The per-principal live count returns to zero promptly (the stats source).
+    let released = wait_until(Duration::from_secs(2), || {
+        principal_count(&db, &reader_id) == 0
+    })
+    .await;
+    assert!(
+        released.is_some(),
+        "stats source returns to baseline in <2s"
+    );
+
+    // And the admin database_stats roster no longer lists the reader.
+    let resp = client
+        .get("/database_stats")
+        .header("authorization", &format!("Bearer {ADMIN_TOKEN}"))
+        .send()
+        .await;
+    assert_eq!(resp.status.as_u16(), 200);
+    let body: Value = resp.json();
+    let cf = body
+        .get("changefeed")
+        .or_else(|| body.get("data").and_then(|d| d.get("changefeed")))
+        .expect("changefeed stats block");
+    let lists_reader = cf["per_principal"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .any(|e| e["principal"].as_str() == Some(reader_id.as_str()))
+        })
+        .unwrap_or(false);
+    assert!(
+        !lists_reader,
+        "database_stats must not list the disconnected reader: {cf}"
+    );
+}

--- a/src/core/changefeed_subscription.rs
+++ b/src/core/changefeed_subscription.rs
@@ -292,6 +292,15 @@ struct SubscriberState {
     principal_key: Option<String>,
     inner: Mutex<SubscriberInner>,
     cvar: Condvar,
+    /// Async-awaitable readiness signal (Issue #3673), present only when a tokio
+    /// runtime is compiled in (the changefeed HTTP/MCP surfaces). It mirrors
+    /// `cvar` for the *async* waiter [`Subscription::recv_async`]: a permit-storing
+    /// `Notify` so a wakeup that races the buffer check is never lost. The
+    /// synchronous [`Subscription::recv_timeout`] Condvar path is unchanged and
+    /// remains the only wait mechanism in `--no-default-features` (no-tokio)
+    /// builds, so embedded callers keep the dependency-free long-poll.
+    #[cfg(any(feature = "mcp-server", feature = "http-server"))]
+    notify: tokio::sync::Notify,
 }
 
 impl SubscriberState {
@@ -318,6 +327,7 @@ impl SubscriberState {
             return false;
         }
         let mut pushed = false;
+        let mut became_lagged = false;
         for record in records {
             if !self.filter.matches(record) {
                 continue;
@@ -325,6 +335,7 @@ impl SubscriberState {
             if inner.queue.len() >= self.buffer_capacity {
                 // Slow consumer: disconnect it rather than back-pressure the writer.
                 inner.lagged = true;
+                became_lagged = true;
                 break;
             }
             inner.queue.push_back(record.clone());
@@ -334,6 +345,17 @@ impl SubscriberState {
         if pushed {
             self.cvar.notify_all();
         }
+        // Wake the async waiter (Issue #3673) on new data OR on the lagged
+        // transition, so a lagged subscription's `recv_async` resolves promptly
+        // to its `RecvError::Lagged` instead of waiting out the whole timeout.
+        // The sync Condvar path above is left byte-identical (`if pushed`) so
+        // delivery semantics for embedded callers are unchanged.
+        #[cfg(any(feature = "mcp-server", feature = "http-server"))]
+        if pushed || became_lagged {
+            self.notify.notify_one();
+        }
+        #[cfg(not(any(feature = "mcp-server", feature = "http-server")))]
+        let _ = became_lagged;
         pushed
     }
 }
@@ -413,6 +435,81 @@ impl Subscription {
             inner = guard;
             if wait.timed_out() && inner.queue.is_empty() && !inner.lagged {
                 return Ok(Vec::new());
+            }
+        }
+    }
+
+    /// Event-driven async counterpart to [`recv_timeout`](Self::recv_timeout)
+    /// (Issue #3673).
+    ///
+    /// Awaits up to `timeout` for buffered events, parking on a
+    /// `tokio::sync::Notify` instead of a blocking `Condvar` wait, so a suspended
+    /// long-poll consumes **zero** runtime worker threads (fixing the
+    /// `block_in_place` / `spawn_blocking` worker-pin the MCP/HTTP changefeed
+    /// surfaces previously relied on). The drain, resume-token, timeout-empty, and
+    /// `RecvError::Lagged` semantics are **identical** to `recv_timeout` — only the
+    /// wait mechanism differs — and the surface owns the future, so dropping it on
+    /// client disconnect drops this `Subscription` immediately (prompt slot
+    /// release).
+    ///
+    /// Returns:
+    /// - `Ok(events)` with one or more events as soon as any are buffered;
+    /// - `Ok(vec![])` if the timeout elapses with nothing buffered;
+    /// - `Err(RecvError::Lagged { resume_token })` once the buffer has been drained
+    ///   and the subscription was disconnected for overflow.
+    #[cfg(any(feature = "mcp-server", feature = "http-server"))]
+    pub async fn recv_async(
+        &self,
+        timeout: Duration,
+    ) -> std::result::Result<Vec<ChangeRecord>, RecvError> {
+        let deadline = Instant::now().checked_add(timeout);
+        loop {
+            // Create and REGISTER the wakeup future *before* inspecting the buffer.
+            // `Notified::enable()` arms the waiter (consuming an already-stored
+            // permit if one exists), so a `notify_one` racing the buffer check
+            // below is never lost — the permit-storing lost-wakeup guard.
+            let notified = self.state.notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            // Drain / lagged check — identical to `recv_timeout`. The lock is
+            // released (scope end) before any `.await`, so the future stays `Send`
+            // and never holds the subscriber mutex across a suspension point.
+            {
+                let mut inner = self.state.inner.lock().unwrap_or_else(|e| e.into_inner());
+                if !inner.queue.is_empty() {
+                    let drained: Vec<ChangeRecord> = inner.queue.drain(..).collect();
+                    if let Some(last) = drained.last() {
+                        inner.last_delivered = Some(last.cursor().encode());
+                    }
+                    return Ok(drained);
+                }
+                if inner.lagged {
+                    return Err(RecvError::Lagged {
+                        resume_token: inner.last_delivered.clone(),
+                    });
+                }
+            }
+
+            let remaining = match deadline {
+                Some(d) => d.saturating_duration_since(Instant::now()),
+                None => timeout,
+            };
+            if remaining.is_zero() {
+                return Ok(Vec::new());
+            }
+
+            tokio::select! {
+                // Woken by a push (or a lagged transition): loop to drain.
+                _ = notified => {}
+                // Deadline elapsed: re-check once; honestly time out only if still
+                // nothing buffered and not lagged.
+                _ = tokio::time::sleep(remaining) => {
+                    let inner = self.state.inner.lock().unwrap_or_else(|e| e.into_inner());
+                    if inner.queue.is_empty() && !inner.lagged {
+                        return Ok(Vec::new());
+                    }
+                }
             }
         }
     }
@@ -746,6 +843,8 @@ impl ChangefeedBroadcaster {
                 lagged: false,
             }),
             cvar: Condvar::new(),
+            #[cfg(any(feature = "mcp-server", feature = "http-server"))]
+            notify: tokio::sync::Notify::new(),
         });
         reg.subscribers.insert(id, Arc::clone(&state));
         if let Some(key) = principal_key {

--- a/src/core/changefeed_subscription.rs
+++ b/src/core/changefeed_subscription.rs
@@ -342,20 +342,16 @@ impl SubscriberState {
             pushed = true;
         }
         drop(inner);
-        if pushed {
-            self.cvar.notify_all();
-        }
-        // Wake the async waiter (Issue #3673) on new data OR on the lagged
-        // transition, so a lagged subscription's `recv_async` resolves promptly
-        // to its `RecvError::Lagged` instead of waiting out the whole timeout.
-        // The sync Condvar path above is left byte-identical (`if pushed`) so
-        // delivery semantics for embedded callers are unchanged.
-        #[cfg(any(feature = "mcp-server", feature = "http-server"))]
+        // Wake both waiters (Issue #3673) on new data OR on the lagged
+        // transition, so a lagged subscription's `recv_timeout` / `recv_async`
+        // resolves promptly to its `RecvError::Lagged` instead of waiting out
+        // the whole timeout. The two signals share one predicate so the sync
+        // (Condvar) and async (Notify) paths stay symmetric.
         if pushed || became_lagged {
+            self.cvar.notify_all();
+            #[cfg(any(feature = "mcp-server", feature = "http-server"))]
             self.notify.notify_one();
         }
-        #[cfg(not(any(feature = "mcp-server", feature = "http-server")))]
-        let _ = became_lagged;
         pushed
     }
 }
@@ -470,6 +466,11 @@ impl Subscription {
             // below is never lost — the permit-storing lost-wakeup guard.
             let notified = self.state.notify.notified();
             tokio::pin!(notified);
+            // `enable()` returns whether a stored permit was consumed; we
+            // deliberately discard it. Either way the `select!` below observes
+            // the resulting state uniformly — an already-ready `notified`
+            // (permit consumed) wakes immediately and we re-check the buffer, so
+            // no branch on the return value is needed.
             notified.as_mut().enable();
 
             // Drain / lagged check — identical to `recv_timeout`. The lock is
@@ -1763,5 +1764,36 @@ mod tests {
             "missing per-principal cap defaults to 16, not 0"
         );
         assert!(filled.per_principal_overrides.is_empty());
+    }
+
+    /// A parked `recv_async` waiter must be woken by a push that arrives while it
+    /// is suspended — the `Notified::enable()`-before-buffer-check ordering is the
+    /// lost-wakeup guard. If `enable()` were moved *after* the check, a notify
+    /// landing in the check→await window would be lost and the waiter would sleep
+    /// to the (here 5s) timeout instead of returning the pushed record. The tight
+    /// 1s outer bound turns that regression into a visible failure.
+    #[cfg(any(feature = "mcp-server", feature = "http-server"))]
+    #[tokio::test]
+    async fn recv_async_no_lost_wakeup_on_push_while_parked() {
+        let b = Arc::new(ChangefeedBroadcaster::new());
+        let sub = b.subscribe(ChangeFilter::all()).unwrap();
+
+        let waiter = tokio::spawn(async move { sub.recv_async(Duration::from_secs(5)).await });
+        // Let the waiter enter recv_async and register on the Notify.
+        tokio::task::yield_now().await;
+
+        // Push in the race: the wakeup must not be lost.
+        b.emit(&[record(1, 1, EntityKind::Node, ChangeType::Created, "P", 10)]);
+
+        let got = tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("waiter must wake with data, not sleep to the 5s timeout")
+            .expect("join")
+            .expect("recv ok");
+        assert_eq!(
+            got.len(),
+            1,
+            "the pushed record is delivered to the parked waiter"
+        );
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -5700,6 +5700,13 @@ impl AletheiaMcpServer {
     /// mappings (Issue #3234): a lagged subscription → retriable
     /// `RESOURCE_EXHAUSTED` with `details.resume_token`; a subscribe cap breach →
     /// retriable `UNAVAILABLE`; a malformed `from_token` → `INVALID_ARGUMENT`.
+    ///
+    /// This synchronous entry is now reached only via `dispatch_tool`
+    /// (embedded / programmatic / test callers): the native MCP `call_tool`
+    /// seam intercepts `await_changes` and routes it through the event-driven
+    /// [`Self::dispatch_await_changes_async`] instead (Issue #3673), so the
+    /// `block_in_place` worker bridge below no longer runs on the live MCP
+    /// server surface.
     fn handle_await_changes(
         &self,
         args: serde_json::Value,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -144,7 +144,7 @@ use serde_json::json;
 
 use crate::api::transaction::WriteOps;
 use crate::core::changefeed::ChangeCursor;
-use crate::core::changefeed_subscription::{ChangeFilter, RecvError};
+use crate::core::changefeed_subscription::{ChangeFilter, RecvError, Subscription};
 use crate::core::temporal::time;
 use crate::core::{
     ChangeFeedQuery, ChangeType, EdgeId, GLOBAL_INTERNER, NodeId, PropertyMap, PropertyMapBuilder,
@@ -330,6 +330,22 @@ pub struct AletheiaMcpServer {
     /// compiled they return a structured unavailable-feature error instead.
     #[cfg(feature = "embeddings")]
     embedder: Option<Arc<crate::embeddings::Embedder>>,
+}
+
+/// Outcome of the `await_changes` synchronous prelude (Issue #3673): either an
+/// immediate result (bad args / subscribe error / catch-up hit) or a live
+/// [`Subscription`] to wait on for `timeout`. Shared by the sync
+/// [`AletheiaMcpServer::handle_await_changes`] (blocking Condvar) and the async
+/// [`AletheiaMcpServer::dispatch_await_changes_async`] (event-driven Notify) so
+/// both run identical subscribe + catch-up logic and differ only in HOW they
+/// wait. The `Immediate` result is boxed so the enum's variants stay
+/// size-balanced (`CallToolResult` is far larger than a `Subscription`).
+enum AwaitChangesStep {
+    Immediate(Box<CallToolResult>),
+    Block {
+        sub: Subscription,
+        timeout: std::time::Duration,
+    },
 }
 
 /// RAII slot in the bounded in-flight-query pool (Issue #3368). Decrements the
@@ -1168,6 +1184,30 @@ impl AletheiaMcpServer {
             serde_json::to_value(req).expect("request serialization should not fail"),
             principal_key,
         ))
+    }
+
+    /// Event-driven async counterpart to [`await_changes_for_principal`]
+    /// (Issue #3673).
+    ///
+    /// Waits on the changefeed via the `recv_async` Notify path, so the long-poll
+    /// pins **no** Tokio worker for its duration and releases its per-principal
+    /// slot immediately when the caller's future is dropped (HTTP client
+    /// disconnect). Used by the HTTP `/changes/await` projection; the native MCP
+    /// `call_tool` seam routes through [`dispatch_await_changes_async`](Self::dispatch_await_changes_async)
+    /// directly. Behavior (delivery / resume / timeout / lagged semantics) is
+    /// identical to the sync entry — only the wait mechanism differs.
+    pub async fn await_changes_for_principal_async(
+        &self,
+        req: AwaitChangesRequest,
+        principal_key: Option<String>,
+    ) -> String {
+        Self::extract_text(
+            self.dispatch_await_changes_async(
+                serde_json::to_value(req).expect("request serialization should not fail"),
+                principal_key,
+            )
+            .await,
+        )
     }
 
     /// Execute a hybrid query.
@@ -5665,9 +5705,77 @@ impl AletheiaMcpServer {
         args: serde_json::Value,
         principal_override: Option<String>,
     ) -> CallToolResult {
+        match self.await_changes_prelude(args, principal_override) {
+            AwaitChangesStep::Immediate(result) => *result,
+            AwaitChangesStep::Block { sub, timeout } => {
+                // Synchronous Condvar long-poll for embedded/programmatic callers
+                // (and any non-`call_tool` sync dispatch). SAFETY/why:
+                // `recv_timeout` parks this worker for up to 60s. On a multi-thread
+                // Tokio runtime, run it inside `block_in_place` so Tokio can spin up
+                // a replacement worker; on a current-thread runtime or with no
+                // runtime (embedded/programmatic callers) `block_in_place` would
+                // panic, so call inline. The event-driven native `call_tool` and
+                // HTTP `/changes/await` paths instead use the async
+                // [`Self::dispatch_await_changes_async`] wait, which pins no worker
+                // and releases promptly on client disconnect (Issue #3673).
+                let recv_result = match tokio::runtime::Handle::try_current() {
+                    Ok(handle)
+                        if handle.runtime_flavor()
+                            == tokio::runtime::RuntimeFlavor::MultiThread =>
+                    {
+                        tokio::task::block_in_place(|| sub.recv_timeout(timeout))
+                    }
+                    _ => sub.recv_timeout(timeout),
+                };
+                self.finish_await_recv(&sub, recv_result)
+            }
+        }
+    }
+
+    /// Event-driven async counterpart to [`handle_await_changes`] (Issue #3673).
+    ///
+    /// Runs the identical subscribe + catch-up prelude, then — for the blocking
+    /// leg — awaits [`Subscription::recv_async`] instead of parking a worker on
+    /// the synchronous `recv_timeout`. Because the wait is a suspended future, N
+    /// concurrent long-polls pin **zero** worker threads (fixing the AC(a)
+    /// `block_in_place` pin), and dropping this future on client disconnect drops
+    /// the `Subscription` immediately, freeing its per-principal slot without
+    /// waiting out the timeout. Used by the native MCP `call_tool` seam and the
+    /// HTTP `/changes/await` projection.
+    pub(crate) async fn dispatch_await_changes_async(
+        &self,
+        args: serde_json::Value,
+        principal_override: Option<String>,
+    ) -> CallToolResult {
+        match self.await_changes_prelude(args, principal_override) {
+            AwaitChangesStep::Immediate(result) => *result,
+            AwaitChangesStep::Block { sub, timeout } => {
+                let recv_result = sub.recv_async(timeout).await;
+                self.finish_await_recv(&sub, recv_result)
+            }
+        }
+    }
+
+    /// The synchronous prelude shared by [`handle_await_changes`] (sync Condvar
+    /// wait) and [`dispatch_await_changes_async`] (event-driven Notify wait),
+    /// Issue #3673: it resolves the principal bucket, builds the filter,
+    /// subscribes (capturing the frontier), and runs the optional catch-up — all
+    /// fast, non-blocking work — returning either an [`AwaitChangesStep::Immediate`]
+    /// result or a live [`Subscription`] to wait on. Factoring it out guarantees
+    /// both surfaces run byte-identical subscribe/catch-up logic and differ ONLY
+    /// in how they wait, so delivery semantics stay unchanged (AC c).
+    fn await_changes_prelude(
+        &self,
+        args: serde_json::Value,
+        principal_override: Option<String>,
+    ) -> AwaitChangesStep {
         let req: AwaitChangesRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
+            Err(e) => {
+                return AwaitChangesStep::Immediate(Box::new(
+                    self.invalid_argument(&format!("Invalid arguments: {}", e)),
+                ));
+            }
         };
 
         // Resolve the per-principal quota bucket (Issue #3678): the surface-supplied
@@ -5689,7 +5797,9 @@ impl AletheiaMcpServer {
         if let Some(change_types) = &req.change_types {
             let parsed = match Self::parse_change_types(change_types) {
                 Ok(v) => v,
-                Err(msg) => return self.invalid_argument(&msg),
+                Err(msg) => {
+                    return AwaitChangesStep::Immediate(Box::new(self.invalid_argument(&msg)));
+                }
             };
             filter = filter.with_change_types(parsed);
         }
@@ -5725,17 +5835,19 @@ impl AletheiaMcpServer {
                     },
                 ) = &e
                 {
-                    return self.error_result(
-                        McpError::new(McpErrorCode::Unavailable, e.to_string())
-                            .retriable(true)
-                            .details(json!({
-                                "resource": resource,
-                                "current": current,
-                                "limit": limit,
-                            })),
-                    );
+                    return AwaitChangesStep::Immediate(Box::new(
+                        self.error_result(
+                            McpError::new(McpErrorCode::Unavailable, e.to_string())
+                                .retriable(true)
+                                .details(json!({
+                                    "resource": resource,
+                                    "current": current,
+                                    "limit": limit,
+                                })),
+                        ),
+                    ));
                 }
-                return self.db_error(e);
+                return AwaitChangesStep::Immediate(Box::new(self.db_error(e)));
             }
         };
 
@@ -5746,8 +5858,9 @@ impl AletheiaMcpServer {
             let decoded = match ChangeCursor::decode(token) {
                 Ok(c) => c,
                 Err(_) => {
-                    return self
-                        .invalid_argument("Invalid from_token: malformed continuation token");
+                    return AwaitChangesStep::Immediate(Box::new(
+                        self.invalid_argument("Invalid from_token: malformed continuation token"),
+                    ));
                 }
             };
             let query = ChangeFeedQuery {
@@ -5779,37 +5892,34 @@ impl AletheiaMcpServer {
                         .next_cursor
                         .clone()
                         .or_else(|| page.changes.last().map(|r| r.cursor().encode()));
-                    return self.await_changes_success(
+                    return AwaitChangesStep::Immediate(Box::new(self.await_changes_success(
                         &filtered,
                         resume,
                         false,
                         page.next_cursor.is_some(),
-                    );
+                    )));
                 }
                 Ok(_) => { /* nothing buffered yet — fall through to block */ }
-                Err(e) => return self.db_error(e),
+                Err(e) => return AwaitChangesStep::Immediate(Box::new(self.db_error(e))),
             }
         }
 
         // Block for the next change up to the clamped timeout (default 25s, hard
-        // cap 60s). `recv_timeout(0)` returns instantly (Ok(empty)).
+        // cap 60s). `recv_*(0)` returns instantly (Ok(empty)).
         let timeout_ms = req.timeout_ms.unwrap_or(25_000).min(60_000);
         let timeout = std::time::Duration::from_millis(timeout_ms);
-        // SAFETY/why: `recv_timeout` parks this worker for up to 60s. On a
-        // multi-thread Tokio runtime (the `aletheia-mcp` binary and
-        // `aletheia-server`), run it inside `block_in_place` so Tokio can spin
-        // up a replacement worker — otherwise one native-stdio long-poll would
-        // stall the whole async `call_tool` dispatch loop. On a current-thread
-        // runtime or with no runtime at all (embedded/programmatic callers),
-        // `block_in_place` would panic, so call `recv_timeout` inline as before.
-        // Mirrors the `block_on_embedding` runtime guard; only this blocking
-        // call needs the bridge (subscribe/list_changes are fast).
-        let recv_result = match tokio::runtime::Handle::try_current() {
-            Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
-                tokio::task::block_in_place(|| sub.recv_timeout(timeout))
-            }
-            _ => sub.recv_timeout(timeout),
-        };
+        AwaitChangesStep::Block { sub, timeout }
+    }
+
+    /// Format a completed `recv` (sync `recv_timeout` or async `recv_async`) into
+    /// the `await_changes` response envelope, Issue #3673 — shared by both wait
+    /// paths so they return a byte-identical result and only the wait mechanism
+    /// differs.
+    fn finish_await_recv(
+        &self,
+        sub: &Subscription,
+        recv_result: std::result::Result<Vec<crate::core::ChangeRecord>, RecvError>,
+    ) -> CallToolResult {
         match recv_result {
             Ok(recs) if !recs.is_empty() => {
                 let resume = recs.last().map(|r| r.cursor().encode());
@@ -9139,6 +9249,20 @@ impl ServerHandler for AletheiaMcpServer {
             .arguments
             .map(serde_json::Value::Object)
             .unwrap_or(serde_json::Value::Null);
+
+        // `await_changes` is an event-driven long-poll (Issue #3673): route it
+        // through the async dispatch so the suspended future pins NO worker thread
+        // and drops (freeing its per-principal slot) the moment the caller's
+        // future is cancelled on disconnect. It is deliberately excluded from the
+        // #3353/#3368/#3360 wrappers `dispatch_tool` applies, so bypassing them
+        // changes nothing but the wait mechanism — but auth must still be enforced
+        // here to mirror `dispatch_tool`.
+        if request.name.as_ref() == "await_changes" {
+            if let Err(err) = self.auth.authorize_tool("await_changes") {
+                return Ok(self.error_result(err));
+            }
+            return Ok(self.dispatch_await_changes_async(args, None).await);
+        }
 
         Ok(self.dispatch_tool(request.name.as_ref(), args))
     }


### PR DESCRIPTION
## Issue #3673 — `await_changes` slot-pinning / prompt event-driven release

### Before / After (plain language)

**Before:** the `await_changes` long-poll parked a Tokio worker for the whole poll (`block_in_place` on native MCP, `spawn_blocking` on HTTP) on the synchronous `recv_timeout` Condvar wait — so N concurrent long-polls consumed N worker threads. And because `spawn_blocking` is not cancelled when the caller future drops, and the SSE worker only re-checked client liveness every 15s, a disconnecting client's per-principal changefeed slot lingered **up to 15s (SSE) / 60s (await)** after it went away — the #3688 reconnect-churn transient false-exhaustion.

**After:** a disconnecting client's changefeed slot now frees in **well under a second** instead of up to 15s/60s, and a long-poll **no longer pins a Tokio worker** — it awaits an event-driven `tokio::sync::Notify` signal, so a suspended poll consumes zero worker threads and drops (releasing its slot) the moment the client disconnects.

### Approach (B — feature-gated Notify; sync path + Drop anchor preserved)

- **Core** (`src/core/changefeed_subscription.rs`): a permit-storing `tokio::sync::Notify` is added to `SubscriberState`, **cfg-gated** behind the tokio-pulling surfaces (`mcp-server`/`http-server`) so the default / `--no-default-features` (no-tokio) build still compiles the sync-only path. `push_matching` calls `notify_one()` **alongside** `cvar.notify_all()`. A new `Subscription::recv_async(timeout)` `select!`s notify-vs-timeout and drains with the **same** resume-token / lagged / timeout-empty semantics as `recv_timeout` (lost-wakeup-free via `Notified::enable()` before the buffer check).
- **Surfaces**: MCP `await_changes` is routed through an async dispatch in `call_tool` (a suspended future pins zero workers); the SSE `/changes/stream` worker and HTTP `POST /changes/await` become async tasks that `select!` notify-vs-`tx.closed()`-vs-timeout, so a disconnect wakes immediately and drops the `Subscription`.
- **`Subscription::Drop` stays the SOLE release anchor** — the async path changes only *when* the Subscription drops, never the decrement in `deregister`. No double-release.

### MCP stdio limitation

Native stdio MCP has no per-call connection-closed future, so per-call *disconnect* release on stdio stays timeout-bounded (a backstop via Drop at timeout). The **worker-pin fix (AC a) still applies there** — the suspended `select!` future pins no worker — and the HTTP `/changes/await` projection gets prompt future-drop disconnect release.

### Acceptance criteria + evidence

- **(a) no worker pin for the poll duration** — `recv_async` is an event-driven suspended future, not a blocking poll.
- **(b) prompt disconnect release, both surfaces, event-driven** — SSE + await disconnect tests assert the per-principal slot frees promptly (vs old 15s/60s) with **no commits** to wake the worker; reconnect-churn shows **no** false exhaustion (ties to #3688).
- **(c) delivery semantics + quota accounting unchanged** — ordered/lossless, exactly-once decrement, timeout-still-releases. The #3688 churn/RBAC surface suite and the changefeed delivery suite stay **green untouched**.
- **(d) no public API / wire-shape change** — new async methods are internal to the surfaces; the only Cargo change is adding tokio `sync`+`time` features to the dep already pulled by those surfaces (feature-gated, no new dependency, no runtime config).
- **(e) usual gates incl. no-default-features clippy; no lock-order change** — `Notify` is a leaf notified after the subscriber mutex drops, exactly like `cvar`; it never touches a write-path primitive.

### Gates (all green)

- `cargo test` affected suites: slot-pinning suite (9), #3688 quota surface (4), delivery suite (20), core `changefeed_subscription` unit (28), RBAC (15).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo clippy --all-targets --no-default-features -- -D warnings` — clean
- `cargo check --no-default-features --tests` — clean
- `cargo fmt --all --check` — clean

No API/wire/lock-order change; #3688 tests untouched.

---

## Review round 1 — addressed

Three reviewers (async-correctness, delivery-parity, leak/cfg) found the async/delivery/release logic **CLEAN**; the test-quality reviewer flagged false-green / flake risks. This round applies one small convergent code tweak plus test-hardening and doc nits — no behavior change to the async/delivery/release path beyond the lag-wakeup symmetry.

**Code (lag-wakeup symmetry).** `push_matching` now wakes **both** waiters under one `pushed || became_lagged` predicate: the sync `cvar.notify_all()` fires on the lagged transition too (previously `if pushed` only), so a sync `recv_timeout` consumer returns `Err(Lagged)` **promptly** instead of waiting out its timeout — matching the async `Notify` path. This also removes the `#[cfg(not(...))] let _ = became_lagged;` unused-var suppression. Queue/drain/cursor/resume-token semantics unchanged.

**Test-hardening** (`changefeed_await_slot_pinning.rs`):
- **Starvation (MAJOR-2)** — now genuinely catches a `block_in_place`/`spawn_blocking` regression: a manually-built runtime caps **both** `worker_threads(2)` and `max_blocking_threads(2)`, with N=8 long-polls (> the combined budget) and **dual probes** (an async probe for worker-pinning, a `spawn_blocking` probe for blocking-pool exhaustion). Verified **RED** by porting the wait to `spawn_blocking(recv_timeout)` (blocking-probe starves), **GREEN** on the event-driven path.
- **Busy-spin (MAJOR-3)** — now measures event-drivenness, not just elapsed time: wraps the idle `recv_async` future and **counts outer polls**, asserting O(1) over a 300ms idle wait. Verified **RED** with a `sleep(10ms)`-loop placeholder (polled 28×), **GREEN** at ≤5 polls.
- **Ordered/lossless (MAJOR-1)** — adds a distinctive **async push-wakeup** assertion: a parked `recv_async` waiter must be woken by a commit broadcast well within a tight bound (not a drain-after-the-fact poll), keeping AC(c) ordered+lossless coverage.
- **Reconnect-churn (MAJOR-5)** — restructured so **false-exhaustion is the distinctive failure**: each round saturates the cap with concurrent long-polls, aborts them all, then requires a within-cap subscribe to succeed (a lingering-slot bug shows up as quota exhaustion), rather than the release-bound wait firing first.
- **Flake bounds (MAJOR-4)** — slot-release bounds loosened 2s → **5s** (`SLOT_RELEASE_BOUND`) on the SSE-disconnect, await-disconnect, reconnect-churn, and quota-stats tests. Still RED-s the 15s/60s regressions with ≥3× headroom.
- **Cancellation observation (MINOR-1)** — `assert!(!task.is_finished())` before `abort()` on the disconnect tests, so a future early-completing handler can't silently pass.
- **Lost-wakeup unit test (MINOR-2)** — new `recv_async_no_lost_wakeup_on_push_while_parked` guards the `Notified::enable()`-before-buffer-check ordering (a parked waiter woken by an in-window push, not a timeout).

**Doc nits.** SSE biased-select intentionally drops the last in-flight batch on simultaneous data+disconnect (client resumes via `list_changes` + `resume_token`); `Notified::enable()`'s return is deliberately discarded (the `select!` handles both states); the sync `handle_await_changes` entry is now reached only via `dispatch_tool` since `call_tool` routes through the async dispatch.

Slot-pinning suite run **3×** to confirm the loosened bounds don't flake (9/9 each). All five gates green.