### PR TITLE
⚡ Bolt: Optimize Vec allocations in SortIterator::drain

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,6 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+**Pre-allocating Vec in `SortIterator`**
+**Learning:** `Vec::new()` creates a vector with no capacity, which causes unnecessary heap allocations when collecting elements from an iterator with a known size.
+**Action:** Use `Vec::with_capacity(input.size_hint().0)` instead of `Vec::new()` to avoid multiple heap re-allocations when collecting results in a stream that already knows its minimum size.

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -4511,7 +4511,10 @@ impl SortIterator {
             Some(i) => i,
             None => return Ok(()),
         };
-        let mut rows: Vec<QueryRow> = Vec::new();
+        let (lower, _) = input.size_hint();
+        // ⚡ Bolt Optimization: Pre-allocate vector based on iterator's lower size bound
+        // to reduce heap allocations during collection of sorted results.
+        let mut rows: Vec<QueryRow> = Vec::with_capacity(lower);
         while let Some(row) = input.next() {
             rows.push(row?);
         }


### PR DESCRIPTION
💡 **What:** Replaced `Vec::new()` with `Vec::with_capacity(lower)` in `SortIterator::drain`, using the iterator's `size_hint().0` to pre-allocate capacity.
🎯 **Why:** Unnecessary heap reallocations occur when growing a `Vec` from scratch. The input stream's size can often be predicted or bounded, so it's more efficient to pre-allocate the memory.
📊 **Impact:** Reduces heap allocations for sorted query operations directly proportional to the result set size.
🔬 **Measurement:** Verified via `cargo test --lib query::executor::iterators` to ensure logic remains intact while taking advantage of `Vec::with_capacity`.

---
*PR created automatically by Jules for task [17781893397877153288](https://jules.google.com/task/17781893397877153288) started by @madmax983*