### PR TITLE
fix(crypto-shred): fail-closed erase-vs-seal race + edge/field-level E2E + public erased accessor (#3359 PR-1b hardening)

### DIFF
--- a/docs/plans/2026-07-16-gdpr-crypto-shred.md
+++ b/docs/plans/2026-07-16-gdpr-crypto-shred.md
@@ -227,6 +227,40 @@ data path — no `src/encryption/`, `rotation.rs`, `wal_encryption.rs`, or
   erased value is never surfaced as plaintext on the MCP surface. Extending the
   Rust unseal hook to these is a follow-up.
 
+## ⚠️ PR-1b operational caveats (hardening follow-up — READ before enabling erasure)
+
+Three load-bearing caveats surfaced in the PR-1b hardening review. Flagged
+prominently here because each can silently mislead an operator:
+
+1. **`verify_chain` breaks after an erasure until slice 2 lands.** The provenance
+   hash chain's per-version leaf still binds **plaintext** properties — the
+   erasure-stable ciphertext commitment in `canonical.rs` / `verify.rs` is
+   **slice 2**, NOT yet implemented. The moment a subject is erased, its sealed
+   property's plaintext is gone, so `verify_chain` recomputes a leaf over the
+   now-opaque envelope and the digest no longer matches the recorded chain —
+   **verification fails**. Do **not** enable erasure in production on top of this
+   slice alone: either wait for slice 2 or explicitly accept post-erasure
+   chain-verify breakage. Designation + seal-at-write are safe without slice 2;
+   only *erasure* trips the chain (the sealed value hashed at write is the
+   plaintext, not yet the ciphertext).
+2. **Read-path unseal is wired only on `get_node` / `get_edge` /
+   `get_node_at_time` / `get_edge_at_time`.** Every other read path — `with_node`,
+   `list_nodes` / `list_edges`, adjacency (`get_outgoing_edges` /
+   `get_incoming_edges`), `traverse`, `find_nodes_at_time`, the query executor,
+   and `read_tx` reconstructs — returns the **raw sealed `Bytes`** (opaque
+   ciphertext) for an *active* subject, not the plaintext. This is **fail-safe**
+   (ciphertext is never surfaced as plaintext), but a caller using those paths
+   sees opaque bytes rather than the value. Extending the Rust unseal hook to them
+   is a tracked follow-up; the MCP funnel still renders the erased descriptor for
+   any envelope that reaches it.
+3. **The erase-vs-seal race is now fail-closed (aborts).** An in-flight write
+   buffered before an erasure that would otherwise commit *after* it — persisting
+   plaintext of an already-erased subject — now **aborts at commit** with
+   `CryptoShredError::WriteAfterErasure` (`FAILED_PRECONDITION`, non-retriable),
+   mirroring the #3416 first-committer-wins validation abort. Sealing is
+   impossible once the DEK is destroyed, so abort is the only fail-closed outcome;
+   the write never persists erasable plaintext.
+
 ## AC4 disclosure — sealed-property verify semantics
 
 The provenance hash chain's per-version leaf (`version_leaf`,

--- a/src/db/crypto_shred/api.rs
+++ b/src/db/crypto_shred/api.rs
@@ -190,4 +190,45 @@ impl AletheiaDB {
         edge.properties = props;
         edge
     }
+
+    /// The crypto-shred status of a node's current-state properties (PR-1b).
+    ///
+    /// Returns a typed [`ShredStatusMap`] keyed by property key: an entry is
+    /// present only for a property whose subject key has been **destroyed**
+    /// ([`super::ShredStatus::Erased`]); an absent key is
+    /// [`super::ShredStatus::Plaintext`] (never sealed, or sealed under a still
+    /// active subject and thus readable). The map is empty for a node with no
+    /// erased designated property, and empty (allocation-free) when the database
+    /// has never used crypto-shred. This is the **public Rust** surface for the
+    /// erased marker — the complement to [`AletheiaDB::get_node`], which returns
+    /// the (possibly opaque) values but discards the status side-channel.
+    ///
+    /// # Errors
+    /// Propagates the underlying node read error (e.g. the node does not exist).
+    pub fn node_shred_status(
+        &self,
+        node_id: crate::core::NodeId,
+    ) -> crate::core::error::Result<ShredStatusMap> {
+        // Read the RAW stored node (sealed bytes intact) directly from the
+        // current tier, bypassing the `get_node` unseal hook, so the status
+        // reflects the stored envelopes rather than already-unsealed plaintext.
+        let node = self.current.get_node(node_id)?;
+        let (_props, status) = self.materialize_shred(node.id.as_u64(), node.properties);
+        Ok(status)
+    }
+
+    /// The crypto-shred status of an edge's current-state properties (PR-1b).
+    ///
+    /// See [`AletheiaDB::node_shred_status`] — the edge analog.
+    ///
+    /// # Errors
+    /// Propagates the underlying edge read error (e.g. the edge does not exist).
+    pub fn edge_shred_status(
+        &self,
+        edge_id: crate::core::EdgeId,
+    ) -> crate::core::error::Result<ShredStatusMap> {
+        let edge = self.current.get_edge(edge_id)?;
+        let (_props, status) = self.materialize_shred(edge.id.as_u64(), edge.properties);
+        Ok(status)
+    }
 }

--- a/src/db/crypto_shred/error.rs
+++ b/src/db/crypto_shred/error.rs
@@ -27,6 +27,18 @@ pub enum CryptoShredError {
     #[error("subject '{0}' has been erased; its key was destroyed and cannot be recovered")]
     SubjectErased(String),
 
+    /// A write reached the seal hook carrying a property that is designated under
+    /// an **erased** subject (all covering subjects have had their key
+    /// destroyed), so the value cannot be sealed. Fail-closed: the enclosing
+    /// commit is **aborted** rather than persisting the erasable value as
+    /// plaintext (mirrors the #3416 first-committer-wins validation abort).
+    /// Maps to `FAILED_PRECONDITION`, non-retriable. The message carries only the
+    /// subject id — never the plaintext value being rejected.
+    #[error(
+        "write to a property designated under erased subject '{0}' aborted (fail-closed): its key was destroyed, so the value cannot be sealed and must not be persisted as plaintext"
+    )]
+    WriteAfterErasure(String),
+
     /// A subject already exists (designation conflict) or a re-designation would
     /// change immutable attributes. Maps to `CONFLICT`.
     #[error("{0}")]
@@ -58,7 +70,8 @@ impl CryptoShredError {
             CryptoShredError::InvalidArgument(_) => "INVALID_ARGUMENT",
             CryptoShredError::NotDesignated(_)
             | CryptoShredError::EncryptionNotConfigured
-            | CryptoShredError::SubjectErased(_) => "FAILED_PRECONDITION",
+            | CryptoShredError::SubjectErased(_)
+            | CryptoShredError::WriteAfterErasure(_) => "FAILED_PRECONDITION",
             CryptoShredError::Conflict(_) => "CONFLICT",
             CryptoShredError::Crypto(_)
             | CryptoShredError::Io(_)

--- a/src/db/crypto_shred/integration_tests.rs
+++ b/src/db/crypto_shred/integration_tests.rs
@@ -545,3 +545,572 @@ fn non_designated_write_read_is_unchanged() {
         }
     }
 }
+
+// ── helper: raw stored value bypassing the unseal hook ─────────────
+
+/// Read the RAW stored value of `key` on a node straight from the current tier,
+/// BYPASSING the crypto-shred unseal hook in [`AletheiaDB::get_node`]. On a cold
+/// reopen this is the **at-rest-decrypted but still crypto-shred-sealed** value,
+/// so asserting it is a `SUBJ` envelope proves sealing happened *independently*
+/// of at-rest encryption (the RAM current tier is not at-rest-encrypted; a cold
+/// reopen has already reversed the at-rest layer on load).
+fn raw_stored_node_value(
+    db: &AletheiaDB,
+    node_id: crate::core::NodeId,
+    key: &str,
+) -> Option<PropertyValue> {
+    let node = db.current.get_node(node_id).unwrap();
+    node.properties.get(key).cloned()
+}
+
+fn raw_stored_edge_value(
+    db: &AletheiaDB,
+    edge_id: crate::core::EdgeId,
+    key: &str,
+) -> Option<PropertyValue> {
+    let edge = db.current.get_edge(edge_id).unwrap();
+    edge.properties.get(key).cloned()
+}
+
+// ── M1: FAIL-CLOSED erase-vs-seal race ─────────────────────────────
+
+/// A write that reaches the seal hook carrying a property designated under a
+/// subject that was erased after the write was buffered must **abort** the
+/// commit (fail-closed) — sealing is impossible (DEK destroyed) and persisting
+/// plaintext of an erased subject is forbidden. Drives the exact `seal_map` code
+/// path deterministically: buffer a designated op, erase the subject mid-tx, then
+/// let the commit run the seal step.
+#[test]
+fn write_after_erasure_aborts_fail_closed() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Arc::new(enc_db(dir.path()));
+    let node_id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("stage", "placeholder")
+                .build(),
+        )
+        .unwrap();
+    db.designate_subject("S", vec![DesignationTarget::WholeNode(node_id.as_u64())])
+        .unwrap();
+
+    // Buffer a write to the designated node, then erase S BEFORE the buffered
+    // write commits. The commit's seal step now sees S erased and must abort.
+    let db2 = Arc::clone(&db);
+    let result: Result<(), crate::core::error::Error> = db.write(|tx| {
+        use crate::api::WriteOps;
+        tx.replace_node(
+            node_id,
+            "Person",
+            PropertyMapBuilder::new().insert("email", SENTINEL).build(),
+        )?;
+        // Erase mid-transaction: the shared CryptoShredState flips S -> Erased,
+        // and its DEK is destroyed. (erase takes only the keyring lock + file
+        // I/O — no write-path lock — so there is no deadlock with the in-flight
+        // transaction.)
+        db2.erase_subject("S").expect("erase should succeed");
+        Ok(())
+    });
+
+    assert!(
+        result.is_err(),
+        "a write carrying a property covered only by an erased subject must ABORT (fail-closed)"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        matches!(err, crate::core::error::Error::FailedPrecondition(_)),
+        "fail-closed abort must be a FailedPrecondition (non-retriable), got {err:?}"
+    );
+
+    // No plaintext landed: current state is still the placeholder (the write was
+    // rolled back), and the designated value was never persisted as plaintext.
+    let raw = raw_stored_node_value(&db, node_id, "email");
+    assert_ne!(
+        raw,
+        Some(PropertyValue::from(SENTINEL.to_string())),
+        "aborted write must not persist the designated plaintext into current state"
+    );
+    // And the sentinel is absent from EVERY persisted artifact (nothing was
+    // sealed nor WAL-logged for the aborted tx).
+    assert_no_designated_plaintext(dir.path(), SENTINEL.as_bytes());
+}
+
+// ── M2: sentinel scan ISOLATES crypto-shred from at-rest encryption ─
+
+/// The recursive on-disk sentinel scan alone is not load-bearing under this
+/// suite's `enc_config`: at-rest encryption already turns every persisted byte
+/// into component-DEK ciphertext, so the raw scan would pass even if `seal_map`
+/// were a no-op. This test makes the guarantee load-bearing:
+///
+/// (a) POSITIVE: the designated property is stored as a `SUBJ` envelope, read
+///     through the storage path that reverses the at-rest layer but NOT the
+///     crypto-shred seal (`db.current.get_node`, bypassing the unseal hook) —
+///     proving **sealing**, not at-rest encryption, produced the ciphertext; and
+/// (b) the inner (at-rest-decrypted) envelope bytes do NOT contain the plaintext
+///     sentinel, pre- and post-erase — proving the seal payload is ciphertext.
+///
+/// The raw recursive scan is kept too, as a belt-and-suspenders check.
+#[test]
+fn sealing_isolated_from_at_rest_encryption() {
+    let dir = tempfile::tempdir().unwrap();
+    let node_id;
+    {
+        let db = enc_db(dir.path());
+        node_id = db
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new().insert("stage", "ph").build(),
+            )
+            .unwrap();
+        db.designate_subject("S", vec![DesignationTarget::WholeNode(node_id.as_u64())])
+            .unwrap();
+        db.replace_node(
+            node_id,
+            "Doc",
+            PropertyMapBuilder::new().insert("secret", SENTINEL).build(),
+        )
+        .unwrap();
+        drop(db);
+    }
+
+    // Cold reopen: index persistence has reversed the AT-REST layer on load, so
+    // `db.current.get_node` yields the stored-but-at-rest-decrypted value.
+    {
+        let db = enc_db(dir.path());
+        // (a) POSITIVE: the stored value is a SUBJ envelope (sealing happened).
+        let stored =
+            raw_stored_node_value(&db, node_id, "secret").expect("secret property must be present");
+        let PropertyValue::Bytes(ref env) = stored else {
+            panic!("designated property must be stored as sealed Bytes, got {stored:?}");
+        };
+        assert!(
+            super::envelope::is_envelope(env),
+            "designated property must be a SUBJ envelope on disk — proves crypto-shred SEALING, \
+             not merely at-rest encryption, is responsible for the ciphertext"
+        );
+        // (b) The inner (at-rest-decrypted) envelope bytes are ciphertext: they
+        // do NOT contain the plaintext sentinel. This makes the negative scan
+        // load-bearing (it decrypts the at-rest layer, then checks the payload).
+        assert!(
+            !env.windows(SENTINEL.len())
+                .any(|w| w == SENTINEL.as_bytes()),
+            "the at-rest-decrypted SUBJ envelope must NOT contain the plaintext sentinel \
+             (its payload is sealed ciphertext)"
+        );
+        // While active, the public read path unseals it back to plaintext.
+        let node = db.get_node(node_id).unwrap();
+        assert_eq!(
+            node.properties.get("secret"),
+            Some(&PropertyValue::from(SENTINEL.to_string()))
+        );
+        drop(db);
+    }
+
+    // Erase, cold reopen: the stored value is STILL a SUBJ envelope whose inner
+    // bytes never expose the plaintext.
+    {
+        let db = enc_db(dir.path());
+        db.erase_subject("S").unwrap();
+        drop(db);
+    }
+    {
+        let db = enc_db(dir.path());
+        let stored = raw_stored_node_value(&db, node_id, "secret").unwrap();
+        let PropertyValue::Bytes(ref env) = stored else {
+            panic!("post-erase value must remain sealed Bytes");
+        };
+        assert!(super::envelope::is_envelope(env));
+        assert!(
+            !env.windows(SENTINEL.len())
+                .any(|w| w == SENTINEL.as_bytes()),
+            "post-erase envelope payload must never contain the plaintext sentinel"
+        );
+        drop(db);
+    }
+
+    // Belt-and-suspenders: the raw (still at-rest-encrypted) scan is clean too.
+    assert_no_designated_plaintext(dir.path(), SENTINEL.as_bytes());
+}
+
+// ── M3: EDGE end-to-end (AC1 covers edges) ─────────────────────────
+
+/// AC1 designates whole entities AND/OR property keys for **edges** too. Seal a
+/// designated edge property at write, round-trip it as plaintext through a cold
+/// restart while the key is present, then erase and confirm the edge property
+/// reads as the erased marker (never the sentinel).
+#[test]
+fn edge_e2e_seal_unseal_survives_restart_then_erase() {
+    let dir = tempfile::tempdir().unwrap();
+    let (src, tgt, edge_id);
+    {
+        let db = enc_db(dir.path());
+        src = db
+            .create_node("Person", PropertyMapBuilder::new().insert("n", "a").build())
+            .unwrap();
+        tgt = db
+            .create_node("Person", PropertyMapBuilder::new().insert("n", "b").build())
+            .unwrap();
+        // Placeholder edge -> designate -> replace so the sealed version carries
+        // the sentinel (robust to whatever edge id is assigned).
+        edge_id = db
+            .create_edge(
+                src,
+                tgt,
+                "KNOWS",
+                PropertyMapBuilder::new().insert("stage", "ph").build(),
+            )
+            .unwrap();
+        db.designate_subject("EG", vec![DesignationTarget::WholeEdge(edge_id.as_u64())])
+            .unwrap();
+        db.replace_edge(
+            edge_id,
+            PropertyMapBuilder::new()
+                .insert("relnote", SENTINEL)
+                .build(),
+        )
+        .unwrap();
+        // Sealed on disk (bypass the unseal hook to observe the raw envelope).
+        let stored = raw_stored_edge_value(&db, edge_id, "relnote").unwrap();
+        assert!(
+            matches!(&stored, PropertyValue::Bytes(b) if super::envelope::is_envelope(b)),
+            "designated edge property must be sealed at write, got {stored:?}"
+        );
+        drop(db);
+    }
+
+    // Cold reopen, key present: the edge property reads back as plaintext.
+    {
+        let db = enc_db(dir.path());
+        let edge = db.get_edge(edge_id).unwrap();
+        assert_eq!(
+            edge.properties.get("relnote"),
+            Some(&PropertyValue::from(SENTINEL.to_string())),
+            "cold reopen with key present must return edge plaintext"
+        );
+        drop(db);
+    }
+
+    // Erase, cold reopen: the edge property reads as the erased marker, never
+    // the sentinel — surfaced via the public edge_shred_status accessor.
+    {
+        let db = enc_db(dir.path());
+        db.erase_subject("EG").unwrap();
+        drop(db);
+    }
+    {
+        let db = enc_db(dir.path());
+        let edge = db.get_edge(edge_id).unwrap();
+        match edge.properties.get("relnote") {
+            Some(PropertyValue::Bytes(b)) => {
+                assert!(
+                    super::envelope::is_envelope(b),
+                    "erased edge value stays a SUBJ envelope"
+                );
+                assert_ne!(b.as_ref(), SENTINEL.as_bytes());
+            }
+            other => panic!("expected opaque sealed edge bytes after erase, got {other:?}"),
+        }
+        let status = db.edge_shred_status(edge_id).unwrap();
+        assert!(
+            matches!(
+                status.get("relnote"),
+                Some(super::ShredStatus::Erased { subject_id }) if subject_id == "EG"
+            ),
+            "public edge_shred_status must report Erased for the erased edge property"
+        );
+        drop(db);
+    }
+    assert_no_designated_plaintext(dir.path(), SENTINEL.as_bytes());
+}
+
+// ── M4: FIELD-LEVEL / MIXED designation (AC1 specific property keys) ─
+
+/// Designating only `email` under a subject must seal exactly that key: a
+/// sibling `name` stays cleartext, reads unaffected, and only `email` is erased
+/// after erasure — proving property-key-scoped designation end-to-end.
+#[test]
+fn field_level_designation_seals_only_named_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let node_id;
+    {
+        let db = enc_db(dir.path());
+        node_id = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("stage", "ph").build(),
+            )
+            .unwrap();
+        db.designate_subject(
+            "F",
+            vec![DesignationTarget::NodeProperties(
+                node_id.as_u64(),
+                vec!["email".to_string()],
+            )],
+        )
+        .unwrap();
+        db.replace_node(
+            node_id,
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("email", SENTINEL)
+                .insert("name", "plain-name")
+                .build(),
+        )
+        .unwrap();
+
+        // On disk: `email` is a SUBJ envelope; `name` is cleartext.
+        let stored_email = raw_stored_node_value(&db, node_id, "email").unwrap();
+        assert!(
+            matches!(&stored_email, PropertyValue::Bytes(b) if super::envelope::is_envelope(b)),
+            "designated `email` must be sealed, got {stored_email:?}"
+        );
+        assert_eq!(
+            raw_stored_node_value(&db, node_id, "name"),
+            Some(PropertyValue::from("plain-name".to_string())),
+            "undesignated sibling `name` must stay cleartext on disk"
+        );
+
+        // Read back: `email` unseals to the sentinel, `name` is plaintext.
+        let node = db.get_node(node_id).unwrap();
+        assert_eq!(
+            node.properties.get("email"),
+            Some(&PropertyValue::from(SENTINEL.to_string()))
+        );
+        assert_eq!(
+            node.properties.get("name"),
+            Some(&PropertyValue::from("plain-name".to_string()))
+        );
+        // Active subject: shred status is empty (nothing erased yet).
+        assert!(db.node_shred_status(node_id).unwrap().is_empty());
+        drop(db);
+    }
+
+    // After erase: only `email` is erased-marked; `name` stays plaintext.
+    {
+        let db = enc_db(dir.path());
+        db.erase_subject("F").unwrap();
+        drop(db);
+    }
+    {
+        let db = enc_db(dir.path());
+        let status = db.node_shred_status(node_id).unwrap();
+        assert_eq!(status.len(), 1, "only the designated `email` key is erased");
+        assert!(matches!(
+            status.get("email"),
+            Some(super::ShredStatus::Erased { subject_id }) if subject_id == "F"
+        ));
+        assert!(!status.contains_key("name"), "`name` was never designated");
+        let node = db.get_node(node_id).unwrap();
+        assert_eq!(
+            node.properties.get("name"),
+            Some(&PropertyValue::from("plain-name".to_string())),
+            "undesignated `name` stays plaintext after erasing `email`'s subject"
+        );
+        drop(db);
+    }
+}
+
+// ── M5: PUBLIC Rust erased-marker accessor ─────────────────────────
+
+/// The typed erased marker the design promised must be reachable through a
+/// PUBLIC Rust method — `AletheiaDB::node_shred_status` — not only the
+/// pub(crate) `materialize_shred`.
+#[test]
+fn public_node_shred_status_reports_erased_through_public_api() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = enc_db(dir.path());
+    let node_id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("stage", "ph").build(),
+        )
+        .unwrap();
+    db.designate_subject("P", vec![DesignationTarget::WholeNode(node_id.as_u64())])
+        .unwrap();
+    db.replace_node(
+        node_id,
+        "Person",
+        PropertyMapBuilder::new().insert("email", SENTINEL).build(),
+    )
+    .unwrap();
+
+    // Active: public accessor reports nothing erased.
+    assert!(
+        db.node_shred_status(node_id).unwrap().is_empty(),
+        "active subject: public accessor reports no erased keys"
+    );
+
+    db.erase_subject("P").unwrap();
+
+    // Erased: public accessor surfaces the typed ShredStatus::Erased.
+    let status = db.node_shred_status(node_id).unwrap();
+    assert!(
+        matches!(
+            status.get("email"),
+            Some(super::ShredStatus::Erased { subject_id }) if subject_id == "P"
+        ),
+        "public node_shred_status must surface ShredStatus::Erased{{subject_id}}"
+    );
+}
+
+// ── m1: AS-OF read returns the erased marker (AC3 point-in-time) ────
+
+/// A point-in-time read (`get_node_at_time`) of an erased subject must surface
+/// the erased marker (opaque envelope), never the plaintext.
+#[test]
+fn as_of_read_returns_erased_marker() {
+    use crate::core::temporal::time;
+
+    let dir = tempfile::tempdir().unwrap();
+    let db = enc_db(dir.path());
+    let node_id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("stage", "ph").build(),
+        )
+        .unwrap();
+    db.designate_subject("T", vec![DesignationTarget::WholeNode(node_id.as_u64())])
+        .unwrap();
+    db.replace_node(
+        node_id,
+        "Person",
+        PropertyMapBuilder::new().insert("email", SENTINEL).build(),
+    )
+    .unwrap();
+    db.erase_subject("T").unwrap();
+
+    let now = time::now();
+    let node = db.get_node_at_time(node_id, now, now).unwrap();
+    match node.properties.get("email") {
+        Some(PropertyValue::Bytes(b)) => {
+            assert!(
+                super::envelope::is_envelope(b),
+                "AS OF read of an erased subject must return the sealed envelope (erased marker)"
+            );
+            assert_ne!(
+                b.as_ref(),
+                SENTINEL.as_bytes(),
+                "AS OF read must never surface the plaintext of an erased subject"
+            );
+        }
+        other => panic!("expected opaque sealed bytes on AS OF read after erase, got {other:?}"),
+    }
+}
+
+// ── m2a: update of a designated property re-seals ──────────────────
+
+/// A PATCH update touching an already-designated property must re-seal the new
+/// value (the UpdateNode path runs through `seal_buffer` too).
+#[test]
+fn update_of_designated_property_reseals() {
+    const SENTINEL_V2: &str = "SENTINEL_GDPR_UPDATED_1b2c3d4e_PLAINTEXT_MUST_NOT_LEAK";
+
+    let dir = tempfile::tempdir().unwrap();
+    let db = enc_db(dir.path());
+    let node_id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("stage", "ph").build(),
+        )
+        .unwrap();
+    db.designate_subject("U", vec![DesignationTarget::WholeNode(node_id.as_u64())])
+        .unwrap();
+    // Create with the designated property sealed.
+    db.replace_node(
+        node_id,
+        "Person",
+        PropertyMapBuilder::new().insert("email", SENTINEL).build(),
+    )
+    .unwrap();
+
+    // PATCH update touching the designated property with a new value.
+    db.update_node_with_valid_time(
+        node_id,
+        PropertyMapBuilder::new()
+            .insert("email", SENTINEL_V2)
+            .build(),
+        None,
+    )
+    .unwrap();
+
+    // Still sealed on disk (the update re-sealed the new value).
+    let stored = raw_stored_node_value(&db, node_id, "email").unwrap();
+    assert!(
+        matches!(&stored, PropertyValue::Bytes(b) if super::envelope::is_envelope(b)),
+        "update of a designated property must re-seal, got {stored:?}"
+    );
+    // Read back: the new value unseals to plaintext.
+    let node = db.get_node(node_id).unwrap();
+    assert_eq!(
+        node.properties.get("email"),
+        Some(&PropertyValue::from(SENTINEL_V2.to_string()))
+    );
+    // Neither the old nor the new plaintext leaks to any artifact.
+    assert_no_designated_plaintext(dir.path(), SENTINEL.as_bytes());
+    assert_no_designated_plaintext(dir.path(), SENTINEL_V2.as_bytes());
+}
+
+// ── m2b: foreign SUBJ-looking bytes for an UNKNOWN subject pass through ─
+
+/// A `Bytes` value that merely *looks* like a `SUBJ` envelope but names a
+/// subject the keyring does not know must be passed through untouched on read —
+/// no panic, no false erased marker — even when the database has other active
+/// designations (so the unseal hook actually runs).
+#[test]
+fn foreign_subj_bytes_unknown_subject_pass_through() {
+    use crate::encryption::{Algorithm, create_cipher};
+    use zeroize::Zeroizing;
+
+    let dir = tempfile::tempdir().unwrap();
+    let db = enc_db(dir.path());
+
+    // Ensure the DB has an active designation on ANOTHER node, so the read hook
+    // is engaged (has_any_designations == true) rather than short-circuiting.
+    let other = db
+        .create_node("Person", PropertyMapBuilder::new().insert("s", "p").build())
+        .unwrap();
+    db.designate_subject("real", vec![DesignationTarget::WholeNode(other.as_u64())])
+        .unwrap();
+
+    // Craft a well-formed SUBJ envelope naming a subject we NEVER designate, so
+    // the read hook parses the header, finds no such subject, and passes it
+    // through as ordinary user bytes.
+    let cipher = create_cipher(Algorithm::Aes256Gcm, &Zeroizing::new([7u8; 32]));
+    let foreign = super::envelope::seal_property_value(
+        &PropertyValue::from("not-ours".to_string()),
+        "ghost-unknown-subject",
+        1,
+        b"ctx",
+        cipher.as_ref(),
+    )
+    .unwrap();
+    assert!(super::envelope::is_envelope(&foreign));
+
+    // Write it on an UNDESIGNATED node (so seal_buffer leaves it as-is).
+    let holder = db
+        .create_node(
+            "Blob",
+            PropertyMapBuilder::new()
+                .insert(
+                    "payload",
+                    PropertyValue::Bytes(std::sync::Arc::from(foreign.clone())),
+                )
+                .build(),
+        )
+        .unwrap();
+
+    // Read back: the foreign bytes are returned untouched (no panic, no unseal).
+    let node = db.get_node(holder).unwrap();
+    assert_eq!(
+        node.properties.get("payload"),
+        Some(&PropertyValue::Bytes(std::sync::Arc::from(foreign.clone()))),
+        "foreign SUBJ-looking bytes for an unknown subject must pass through untouched"
+    );
+    // And no false erased marker is fabricated for it.
+    let status = db.node_shred_status(holder).unwrap();
+    assert!(
+        !status.contains_key("payload"),
+        "unknown-subject bytes must not be reported as erased"
+    );
+}

--- a/src/db/crypto_shred/mod.rs
+++ b/src/db/crypto_shred/mod.rs
@@ -639,15 +639,25 @@ impl CryptoShredState {
     /// reverse index), the value is replaced with a sealed-envelope
     /// [`PropertyValue::Bytes`]. Engine-reserved keys (`__aletheia_*` /
     /// `__shred_*`) are never sealed (short-circuited by
-    /// [`designation::should_seal_key`]). Erased subjects do **not** re-seal
-    /// (their key is gone); their entities' new writes stay plaintext. The
-    /// returned map must be routed **byte-identically** to both the current and
-    /// historical tiers (seal exactly once — the envelope carries a random
-    /// per-encryption nonce).
+    /// [`designation::should_seal_key`]). The returned map must be routed
+    /// **byte-identically** to both the current and historical tiers (seal
+    /// exactly once — the envelope carries a random per-encryption nonce).
+    ///
+    /// # Fail-closed erase-vs-seal race
+    /// If a property key is designated but **every** covering subject has been
+    /// **erased** (no active subject can seal it — its DEK is destroyed), the
+    /// write is **aborted** with [`CryptoShredError::WriteAfterErasure`] rather
+    /// than persisting the erasable value as plaintext. This closes the race in
+    /// which an in-flight write buffered before an erasure would otherwise commit
+    /// afterward: sealing is impossible (the key is gone), so abort is the only
+    /// fail-closed outcome. A key designated by *some* active subject (even if
+    /// another covering subject is erased) still seals under the first active one.
     ///
     /// # Errors
-    /// [`CryptoShredError::Crypto`] on DEK unwrap / AEAD seal failure. Fail-closed:
-    /// a seal error aborts the enclosing write rather than persisting plaintext.
+    /// - [`CryptoShredError::WriteAfterErasure`] when a designated key is covered
+    ///   only by erased subjects (fail-closed abort — see above).
+    /// - [`CryptoShredError::Crypto`] on DEK unwrap / AEAD seal failure. Fail-closed:
+    ///   a seal error aborts the enclosing write rather than persisting plaintext.
     pub(crate) fn seal_map(
         &self,
         is_node: bool,
@@ -686,27 +696,45 @@ impl CryptoShredState {
             if designation::is_reserved_key(&key_str) {
                 continue;
             }
+            // Fail-closed erase-vs-seal race: choose the first ACTIVE subject that
+            // designates this key. If the key is designated only by ERASED
+            // subject(s) (their DEK is destroyed), we cannot seal it — abort the
+            // write rather than persist erasable plaintext.
+            let mut active: Option<(String, u32)> = None;
+            let mut designated_by_erased: Option<String> = None;
             for subject_id in &subjects {
                 let Some(entry) = guard.get(subject_id) else {
                     continue;
                 };
-                if entry.state != keyring::SubjectState::Active {
+                if !designation::any_should_seal(&entry.designation, is_node, entity_id, &key_str) {
                     continue;
                 }
-                if designation::any_should_seal(&entry.designation, is_node, entity_id, &key_str) {
-                    let key_version = entry
-                        .wrapped_key
-                        .as_ref()
-                        .map_or(keyring::INITIAL_SUBJECT_KEY_VERSION, |w| w.key_version);
-                    plan.push(SealItem {
-                        key: *key,
-                        key_str,
-                        value: value.clone(),
-                        subject_id: subject_id.clone(),
-                        key_version,
-                    });
-                    break;
+                match entry.state {
+                    keyring::SubjectState::Active => {
+                        let key_version = entry
+                            .wrapped_key
+                            .as_ref()
+                            .map_or(keyring::INITIAL_SUBJECT_KEY_VERSION, |w| w.key_version);
+                        active = Some((subject_id.clone(), key_version));
+                        break;
+                    }
+                    keyring::SubjectState::Erased => {
+                        designated_by_erased.get_or_insert_with(|| subject_id.clone());
+                    }
                 }
+            }
+            if let Some((subject_id, key_version)) = active {
+                plan.push(SealItem {
+                    key: *key,
+                    key_str,
+                    value: value.clone(),
+                    subject_id,
+                    key_version,
+                });
+            } else if let Some(subject_id) = designated_by_erased {
+                // Designated, but only by erased subject(s): sealing is
+                // impossible (key gone). Fail closed — abort the commit.
+                return Err(CryptoShredError::WriteAfterErasure(subject_id));
             }
         }
 


### PR DESCRIPTION
Follow-up **hardening** PR to the merged PR-1b (#3689), applying code-review findings to the GDPR crypto-shred seal-at-write / unseal-at-read integration. Production crypto — precision + security. TDD.

## Before / After

**Before** (as merged in #3689):
- An in-flight write buffered before an erasure that committed *after* it could persist the **plaintext** of an already-erased subject: `seal_map` skipped (`continue`) a designated key whose subject was no longer `Active`, leaving the value cleartext.
- Edges and field-level (specific-property-key) designation had **zero end-to-end** coverage (AC1 covers both).
- The sentinel byte-scan was **masked by at-rest encryption**: the suite's `enc_config` encrypts every tier, so the raw on-disk scan would pass even if `seal_map` were a no-op — the crypto-shred seal was not actually isolated.
- No **public Rust** method surfaced the typed erased marker: `materialize_shred` is `pub(crate)` and `unseal_node/edge_view` discard the `ShredStatusMap`.

**After:**
- The erase-vs-seal race is **fail-closed**: a write carrying a property covered only by erased subject(s) **aborts** the commit.
- Edges + field-level designation are proven **end-to-end** (seal → cold restart → plaintext with key → erase → erased marker).
- The scan **isolates crypto-shred**: a positive `SUBJ`-envelope assertion via the storage read path (which reverses the at-rest layer) proves *sealing*, not at-rest encryption, produced the ciphertext, and the at-rest-decrypted inner bytes never contain the plaintext.
- A **public erased-status accessor** exists.

## Fixes

**M1 — Fail-closed erase-vs-seal race.** In `seal_map` (`src/db/crypto_shred/mod.rs`), for each designated key we now pick the first **active** covering subject and seal under it; if the key is designated but every covering subject is **erased** (DEK destroyed, sealing impossible), the write **aborts** with the new `CryptoShredError::WriteAfterErasure` → `FAILED_PRECONDITION`, non-retriable, surfacing as a commit failure exactly like the #3416 first-committer-wins validation abort. Doc comments corrected to fail-closed. Test drives the exact `seal_map` path deterministically (buffer a designated op, erase mid-transaction, let the commit run the seal step) and asserts the abort + that no plaintext is persisted.

**M2 — Sentinel scan isolated from at-rest encryption.** New `sealing_isolated_from_at_rest_encryption` test: (a) reads the stored value via `current.get_node` (bypassing the unseal hook; on a cold reopen this is the at-rest-**decrypted** but still crypto-shred-**sealed** value) and asserts it is a `SUBJ` envelope — proving *sealing* is responsible; (b) asserts the inner envelope bytes never contain the plaintext sentinel, pre- and post-erase. The raw recursive scan is kept as belt-and-suspenders. Each assertion documents what it proves.

**M3 — Edge E2E.** `edge_e2e_seal_unseal_survives_restart_then_erase`: two nodes, `create_edge` with a designated edge property, sealed at write, cold reopen returns plaintext (key present), erase, cold reopen returns the erased marker via `get_edge` / `edge_shred_status` — never the sentinel.

**M4 — Field-level / mixed designation E2E.** `field_level_designation_seals_only_named_key`: `NodeProperties(id, ["email"])` seals exactly `email` (sibling `name` stays cleartext on disk and on read); after erase only `email` is erased-marked, `name` still plaintext.

**M5 — Public Rust erased-marker accessor.** New `AletheiaDB::node_shred_status(id)` / `edge_shred_status(id)` surface the typed `ShredStatus::Erased{subject_id}` (previously only reachable via `pub(crate) materialize_shred`). Tested through the public API.

**m1** — AS-OF erased-marker read (`get_node_at_time`).
**m2** — update-of-a-designated-property re-seals (PATCH/`UpdateNode` path); a foreign `Bytes` value beginning with `SUBJ` for an **unknown** subject passes through untouched (no panic, no false erased marker).
**m3** — Docs: prominent caveats in `docs/plans/2026-07-16-gdpr-crypto-shred.md` — (i) shipping this slice without slice 2 makes `verify_chain` fail after an erasure (leaf still hashes plaintext); (ii) read-path unseal wired only on `get_node`/`get_edge`/`get_*_at_time` (other paths return opaque ciphertext for active subjects — fail-safe, tracked follow-up); (iii) the erase-vs-seal race is now fail-closed (aborts).

## How

- `seal_map` per-key loop rewritten to first-active-wins / else-abort (M1).
- Decrypt-then-scan test via the storage read path that reverses the at-rest layer (M2).
- New public `node_shred_status` / `edge_shred_status` accessors (M5).

Not applied (per review): Gemini `unseal_map` refactors (style-only churn — left as-is), `let_chains` changes, remaining read-path wiring (separate follow-up), cold/`.albk`/rotation (later slices).

**No edits to `src/encryption/`, `rotation.rs`, `wal_encryption.rs`, or `reencrypt.rs`.**

## Gate evidence (fresh isolated build)

```
cargo test -p aletheiadb --lib crypto_shred
  test result: ok. 38 passed; 0 failed; 0 ignored; 4207 filtered out
cargo test -p aletheiadb --lib --features mcp-server crypto_shred
  test db::crypto_shred::integration_tests::mcp_renders_erased_marker_for_erased_designated_property ... ok
  test result: ok. 39 passed; 0 failed; 0 ignored; 4793 filtered out

New tests all PASS: write_after_erasure_aborts_fail_closed (M1),
  sealing_isolated_from_at_rest_encryption (M2),
  edge_e2e_seal_unseal_survives_restart_then_erase (M3),
  field_level_designation_seals_only_named_key (M4),
  public_node_shred_status_reports_erased_through_public_api (M5),
  as_of_read_returns_erased_marker (m1),
  update_of_designated_property_reseals + foreign_subj_bytes_unknown_subject_pass_through (m2)

cargo clippy --all-targets --features config-toml,mcp-server,sharding-rpc,simulation -- -D warnings
  Finished `dev` profile ... in 55.14s   (EXIT 0)
cargo clippy --all-targets --all-features -- -D warnings
  Finished `dev` profile ... in 3m 27s   (EXIT 0)
cargo clippy --all-targets --no-default-features -- -D warnings
  Finished `dev` profile ... in 56.88s   (EXIT 0)
cargo check --no-default-features --tests                       -> Finished (EXIT 0)
cargo check --no-default-features --tests --features encryption      -> Finished (EXIT 0)
cargo check --no-default-features --tests --features encryption-vault -> Finished (EXIT 0)
cargo check --no-default-features --tests --features encryption-aws-kms -> Finished (EXIT 0)
cargo fmt --all --check   -> clean
```

Kept as **draft**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTu9hwjNh5FKc2ksJVXf9b

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTu9hwjNh5FKc2ksJVXf9b)_