### PR TITLE
test(crypto-shred): prove + guard AC4 provenance-chain erasure stability (#3359 slice 2)

### DIFF
--- a/docs/plans/2026-07-16-gdpr-crypto-shred.md
+++ b/docs/plans/2026-07-16-gdpr-crypto-shred.md
@@ -73,12 +73,39 @@ At the write choke point, a designated entity/property's erasable value is repla
 
 ## 6. Provenance-chain compatibility (AC4 — the hardest constraint)
 
-`version_leaf = SHA256(LEAF_DOMAIN || canon(version))` currently binds **plaintext** `properties` (`src/provenance_chain/canonical.rs`). Destroying plaintext would break `verify` for everyone.
+`version_leaf = SHA256(LEAF_DOMAIN || canon(version))` binds a version's
+`properties` (`src/provenance_chain/canonical.rs`). If it bound the **plaintext**
+of a sealed property, destroying that plaintext would break `verify` for everyone.
 
-**Fix:** for **sealed** properties, the canonical form binds the **stored sealed-envelope bytes** (which survive erasure — only the key is destroyed), not the plaintext value. Non-designated properties are unchanged. Result:
+**Status — already holds by construction as of #3689 (seal-before-apply):** the
+erasure-stable ciphertext leaf is **not** a new `version_leaf` rewrite in this
+slice. As of the PR-1b seal-at-write path (#3689), a designated property is
+sealed to a `PropertyValue::Bytes(SUBJ…)` envelope in the write buffer *before*
+`apply_changes`, so both the current and historical tiers store **ciphertext**.
+The chain leaf is computed *post-commit* by the sealer (`Sealer::seal_one`,
+`src/provenance_chain/engine.rs`) from `DbVersionSource`, which reconstructs
+properties via the **raw** `reconstruct_*_properties` storage path
+(`src/db/chain_source.rs`) — crypto-shred-**unaware**, so it returns the stored
+sealed bytes, never plaintext. `verify` recomputes from the *same* raw path, and
+`erase_subject` destroys only the subject key (never the stored envelope). So,
+with **zero special-casing** in `Canon::value`/`version_canonical`, the leaf
+already binds the stored sealed-envelope bytes for a designated property:
 - `verify` recomputes hash-of-envelope-bytes → matches post-shred (chain stays valid). ✓ AC4
 - Mutating the envelope ciphertext changes the hash → tamper still caught. ✓ AC4 tamper test
-- Single choke point: `Canon::value` / `version_canonical` in `canonical.rs` + `VersionSource` in `verify.rs`.
+- Non-designated properties are unchanged: with no designation, historical holds
+  plaintext and the leaf binds it exactly as before.
+
+**Consequence — Slice 2 is regression proof + a guardrail, not a leaf rewrite:**
+no `canonical.rs`/`verify.rs` code change and **no on-disk format change** — the
+`hash(plaintext)` → `hash(ciphertext)` shift for sealed properties landed with
+#3689, not here. Slice 2 delivers (1) regression tests
+(`crypto_shred_ac4_tests` in `src/db/chain.rs`) proving `verify_chain` still
+passes after a crypto-shred (node and edge) and that a byte-flip of the stored
+envelope is still detected, plus a non-designated no-regression check; and (2) a
+guardrail comment on `DbVersionSource::fetch_locked` pinning it to the raw
+`reconstruct_*_properties` path — it MUST NOT be rerouted through the db-API
+unsealing boundary (`materialize_shred`/`unseal_*_view`), which would make the
+leaf bind plaintext and break AC4.
 
 No separate commitment store needed — the ciphertext IS the erasure-stable commitment.
 
@@ -152,7 +179,7 @@ Pre-erasure `AS OF` still returns structure (ids, temporal coords, label, topolo
 ## 13. Implementation slices (serialized draft PRs — base=trunk, never stacked, no force-push)
 
 - **Slice 1 — Foundation (NO rotation.rs / wal_encryption.rs / reencrypt.rs touch):** subject key axis (random DEK, MEK-wrap, durable `subject_keyring.dat` + designation registry via `write_durable`); Rust API `designate_subject` / `erase_subject` (breadcrumb → key destroy → tombstone tx → signed attestation); sealed-envelope write/read choke point; erased read indicator; exclude designated vectors from HNSW. Tests R1–R11, R14, R15. **On-disk formats (keyring, registry, sealed envelope) → DRAFT, coordinator surfaces for user sign-off.**
-- **Slice 2 — Chain compat (AC4):** erasure-stable (ciphertext) commitment in `version_leaf` (`canonical.rs` + `verify.rs`). Tests R3, R4.
+- **Slice 2 — Chain compat (AC4):** the erasure-stable (ciphertext) commitment in the version leaf **already holds by construction as of #3689** (seal-before-apply + post-seal leaf capture from the raw historical reconstruct — see §6). This slice is therefore **regression proof + a guardrail, NOT a `version_leaf` rewrite and NO on-disk format change**: regression tests (`crypto_shred_ac4_tests`, `src/db/chain.rs`) proving `verify_chain` still passes after a crypto-shred (node + edge) and that an envelope-byte tamper is still caught, plus a guardrail comment pinning `DbVersionSource::fetch_locked` (`src/db/chain_source.rs`) to the raw `reconstruct_*_properties` path (never the unsealing boundary). Tests R3, R4.
 - **Slice 3 — Full-tier completeness (MAY touch WAL/cold — coordinate with encryption-migration session):** cold/checkpoint/`.albk` v6 pass-through + full sentinel scan across ALL artifacts. Tests R2, R9.
 - **Slice 4 — Surfaces:** CLI `aletheia erase-subject`, MCP tool (admin-gated #3350), attestation format, user guide + honest-limits doc.
 - **Slice 5 — Coordination-gated:** MEK-rotation re-wrap of the subject keyring (touches `rotation.rs`) — done with / handed to the encryption-migration session.
@@ -249,10 +276,14 @@ hidden:
 
 This ciphertext-binding is the erasure-stable commitment — no separate
 commitment store is needed, because the ciphertext IS the commitment that
-survives key destruction. The `canonical.rs` / `verify.rs` implementation of
-this binding is **slice 2** (this PR, slice PR-1a, is foundation-only: the
-cryptographic core in isolation, with no live seal/unseal integration and no
-chain changes yet).
+survives key destruction. This binding **already holds by construction** as of
+the seal-before-apply write path (#3689): sealing runs pre-apply so historical
+storage holds the ciphertext envelope, and the chain leaf is computed post-commit
+from that raw stored envelope (`DbVersionSource` → `reconstruct_*_properties`),
+with no special-casing in `canonical.rs`/`verify.rs`. **Slice 2** therefore does
+**not** rewrite `version_leaf` and makes **no on-disk format change** — it adds
+regression tests + a guardrail comment locking `DbVersionSource` to the raw
+reconstruct path (see §6). Existing non-crypto-shred chains are unaffected.
 
 ## Reconciliation with the prior VANTAGE hard-delete spec
 

--- a/src/db/chain.rs
+++ b/src/db/chain.rs
@@ -423,3 +423,339 @@ mod tamper_tests {
         assert!(v.earliest_broken_seq.is_some());
     }
 }
+
+#[cfg(all(test, feature = "audit-export"))]
+mod crypto_shred_ac4_tests {
+    //! AC4 (Issue #3359, GDPR crypto-shred slice 2): the provenance hash chain
+    //! stays verifiable **after** a subject is crypto-shredded, and a tamper of a
+    //! sealed value is still caught.
+    //!
+    //! This holds **by construction** as of the seal-before-apply write path
+    //! (#3689): a designated property is sealed to a `PropertyValue::Bytes(SUBJ…)`
+    //! envelope in the write buffer *before* `apply_changes`, so historical
+    //! storage records ciphertext. The chain leaf is computed *post-commit* by the
+    //! sealer from `DbVersionSource`, which reconstructs from the **raw**
+    //! `reconstruct_*_properties` storage path (crypto-shred-unaware) — so the leaf
+    //! binds the stored ciphertext, never plaintext. `erase_subject` destroys only
+    //! the subject key; the stored envelope bytes survive, so `verify_chain`
+    //! recomputes an identical leaf and the chain stays valid. Mutating the stored
+    //! envelope, by contrast, changes the recomputed leaf and is detected.
+    //!
+    //! These tests combine the `chain` + `encryption` + designation harnesses
+    //! (neither `tamper_tests::enabled_db` nor `crypto_shred::integration_tests`
+    //! configures both) and are the regression guard for that property.
+
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use crate::PropertyMapBuilder;
+    use crate::config::{AletheiaDBConfig, WalConfigBuilder};
+    use crate::core::property::PropertyValue;
+    use crate::core::version::VersionData;
+    use crate::db::AletheiaDB;
+    use crate::db::crypto_shred::DesignationTarget;
+    use crate::db::crypto_shred::envelope::is_envelope;
+    use crate::encryption::FileKeyProvider;
+    use crate::encryption::config::EncryptionConfig;
+    use crate::provenance_chain::{ChainConfig, ChainFsyncMode};
+    use crate::storage::index_persistence::PersistenceConfig;
+    use crate::storage::wal::DurabilityMode;
+
+    const SEALED: &str = "AC4_SEALED_PLAINTEXT_that_will_be_crypto_shredded_c1f2";
+
+    /// A combined config: WAL + index persistence + provenance chain + encryption,
+    /// so a single database exercises seal-at-write together with the chain
+    /// sealer. `enabled_db` (chain only) and the crypto-shred integration harness
+    /// (encryption only) each configure just one half; AC4 needs both.
+    fn enc_chain_db(dir: &std::path::Path) -> AletheiaDB {
+        let key_file = dir.join("mek.key");
+        if !key_file.exists() {
+            FileKeyProvider::generate_key_file(&key_file).unwrap();
+        }
+        let config = AletheiaDBConfig::builder()
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(dir.join("wal"))
+                    .durability_mode(DurabilityMode::Synchronous)
+                    .build(),
+            )
+            .persistence(PersistenceConfig {
+                enabled: true,
+                data_dir: dir.join("indexes"),
+                load_on_startup: true,
+                ..Default::default()
+            })
+            .chain(ChainConfig {
+                enabled: true,
+                fsync: ChainFsyncMode::PerTransaction,
+                dir: None,
+            })
+            .encryption(EncryptionConfig::file_based(&key_file))
+            .build();
+        AletheiaDB::with_unified_config(config).unwrap()
+    }
+
+    fn wait_seq(db: &AletheiaDB, expected: u64) {
+        for _ in 0..300 {
+            if db.export_chain_head().unwrap().seq >= expected {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!(
+            "chain head stuck at {}",
+            db.export_chain_head().unwrap().seq
+        );
+    }
+
+    /// Read the raw (stored) value of a node property through the *same* storage
+    /// reconstruction path the chain source uses — NOT the unsealing read
+    /// boundary — so the returned value is the on-disk sealed envelope.
+    fn stored_node_property(
+        db: &AletheiaDB,
+        node: crate::core::id::NodeId,
+        key: &str,
+    ) -> PropertyValue {
+        let hist = db.historical.read();
+        let vid = hist.get_current_node_version(node).unwrap();
+        let props = hist.reconstruct_node_properties(vid).unwrap();
+        props.get(key).unwrap().clone()
+    }
+
+    /// (a) The provenance chain still verifies after a **node** subject is
+    /// crypto-shredded: the leaf bound the ciphertext, which survives erasure.
+    #[test]
+    fn verify_chain_passes_after_crypto_shred_node() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = enc_chain_db(dir.path());
+
+        // Placeholder (plaintext) so we capture the id, THEN designate + replace so
+        // the sealed version carries the designated value.
+        let alice = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("stage", "placeholder")
+                    .build(),
+            )
+            .unwrap();
+        db.designate_subject(
+            "subject-A",
+            vec![DesignationTarget::WholeNode(alice.as_u64())],
+        )
+        .unwrap();
+        db.replace_node(
+            alice,
+            "Person",
+            PropertyMapBuilder::new().insert("email", SEALED).build(),
+        )
+        .unwrap();
+        // A second designated update, to exercise a multi-version sealed chain.
+        db.replace_node(
+            alice,
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("email", SEALED)
+                .insert("v", 2_i64)
+                .build(),
+        )
+        .unwrap();
+        wait_seq(&db, 3);
+
+        // Guardrail: the stored value is the sealed SUBJ envelope (ciphertext),
+        // not the plaintext — this is exactly what the chain leaf binds.
+        match &stored_node_property(&db, alice, "email") {
+            PropertyValue::Bytes(b) => {
+                assert!(is_envelope(b), "designated value must be sealed at rest");
+                assert_ne!(
+                    b.as_ref(),
+                    SEALED.as_bytes(),
+                    "leaf must not bind plaintext"
+                );
+            }
+            other => panic!("expected sealed Bytes envelope at rest, got {other:?}"),
+        }
+
+        // Chain verifies while the subject is active.
+        assert!(
+            db.verify_chain().unwrap().passed,
+            "chain must verify before erasure"
+        );
+
+        // Crypto-shred the subject: destroys the key only, not the ciphertext.
+        db.erase_subject("subject-A").unwrap();
+
+        // The stored value is still the same opaque SUBJ envelope (only the key is
+        // gone) — so the recomputed leaf is unchanged.
+        match &stored_node_property(&db, alice, "email") {
+            PropertyValue::Bytes(b) => {
+                assert!(is_envelope(b), "erased value stays a SUBJ envelope");
+                assert_ne!(
+                    b.as_ref(),
+                    SEALED.as_bytes(),
+                    "erased read never surfaces plaintext"
+                );
+            }
+            other => panic!("expected sealed Bytes envelope after erase, got {other:?}"),
+        }
+
+        // AC4: the chain STILL verifies after the crypto-shred. Clear the
+        // reconstruction cache first so verify re-reads the *surviving* ciphertext
+        // from storage rather than a warm cache — proving the leaf recomputes
+        // identically from the on-disk envelope, not from a stale plaintext read.
+        db.historical.read().__test_clear_property_cache();
+        let v = db.verify_chain().unwrap();
+        assert!(
+            v.passed,
+            "provenance chain must remain valid after crypto-shred (leaf bound ciphertext); earliest_broken_seq={:?}",
+            v.earliest_broken_seq
+        );
+    }
+
+    /// (a, edge variant) Same property for an **edge** subject.
+    #[test]
+    fn verify_chain_passes_after_crypto_shred_edge() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = enc_chain_db(dir.path());
+
+        let a = db
+            .create_node("Person", PropertyMapBuilder::new().insert("n", "a").build())
+            .unwrap();
+        let b = db
+            .create_node("Person", PropertyMapBuilder::new().insert("n", "b").build())
+            .unwrap();
+        let edge = db
+            .create_edge(
+                a,
+                b,
+                "KNOWS",
+                PropertyMapBuilder::new().insert("stage", "ph").build(),
+            )
+            .unwrap();
+        db.designate_subject(
+            "subject-E",
+            vec![DesignationTarget::WholeEdge(edge.as_u64())],
+        )
+        .unwrap();
+        db.replace_edge(
+            edge,
+            PropertyMapBuilder::new().insert("secret", SEALED).build(),
+        )
+        .unwrap();
+        wait_seq(&db, 4);
+
+        // Guardrail: stored edge value is a sealed envelope.
+        {
+            let hist = db.historical.read();
+            let vid = hist.get_current_edge_version(edge).unwrap();
+            let props = hist.reconstruct_edge_properties(vid).unwrap();
+            match props.get("secret").unwrap() {
+                PropertyValue::Bytes(bytes) => {
+                    assert!(is_envelope(bytes), "designated edge value must be sealed");
+                    assert_ne!(bytes.as_ref(), SEALED.as_bytes());
+                }
+                other => panic!("expected sealed edge Bytes, got {other:?}"),
+            }
+        }
+
+        assert!(
+            db.verify_chain().unwrap().passed,
+            "chain valid before erase"
+        );
+        db.erase_subject("subject-E").unwrap();
+        // Re-read the surviving ciphertext from storage (not a warm cache).
+        db.historical.read().__test_clear_edge_property_cache();
+        let v = db.verify_chain().unwrap();
+        assert!(
+            v.passed,
+            "edge chain must remain valid after crypto-shred; earliest_broken_seq={:?}",
+            v.earliest_broken_seq
+        );
+    }
+
+    /// (b) Tampering with the stored sealed envelope IS still detected — the chain
+    /// binds the ciphertext bytes, so any mutation of them breaks verification.
+    #[test]
+    fn tamper_of_sealed_envelope_still_detected() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = enc_chain_db(dir.path());
+
+        let alice = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("stage", "placeholder")
+                    .build(),
+            )
+            .unwrap();
+        db.designate_subject(
+            "subject-T",
+            vec![DesignationTarget::WholeNode(alice.as_u64())],
+        )
+        .unwrap();
+        db.replace_node(
+            alice,
+            "Person",
+            PropertyMapBuilder::new().insert("email", SEALED).build(),
+        )
+        .unwrap();
+        wait_seq(&db, 2);
+        assert!(db.verify_chain().unwrap().passed);
+
+        // Flip one byte of the stored sealed-envelope value in place, then clear
+        // the reconstruction cache. The cache assumes per-version immutability
+        // (`node_property_cache`, never invalidated), so a genuine on-disk tamper
+        // is only re-read after the cache misses — e.g. on a fresh process / cold
+        // reopen. Clearing it here reproduces that fresh read within one process.
+        {
+            let mut hist = db.historical.write();
+            let vid = hist.get_current_node_version(alice).unwrap();
+            let mut v = hist.get_node_version(vid).unwrap().clone();
+            let full = hist.reconstruct_node_properties(vid).unwrap();
+            let mut env = match full.get("email").unwrap() {
+                PropertyValue::Bytes(b) => {
+                    assert!(is_envelope(b), "value must be sealed to tamper it");
+                    b.to_vec()
+                }
+                other => panic!("expected sealed Bytes to tamper, got {other:?}"),
+            };
+            let last = env.len() - 1;
+            env[last] ^= 0xFF; // mutate the AEAD tag/ciphertext region
+            let tampered = full
+                .builder()
+                .insert("email", PropertyValue::Bytes(Arc::from(env)))
+                .build();
+            v.data = VersionData::anchor(tampered);
+            hist.insert_restored_node_version(v).unwrap();
+            hist.__test_clear_property_cache();
+        }
+
+        let v = db.verify_chain().unwrap();
+        assert!(!v.passed, "a mutated sealed envelope must be detected");
+        assert!(v.earliest_broken_seq.is_some(), "tamper is localized");
+    }
+
+    /// (c) Sanity: with encryption enabled but NO designation, a normal node's
+    /// value is stored as plaintext and the chain verifies — zero regression for
+    /// non-crypto-shred data.
+    #[test]
+    fn non_designated_node_chain_still_verifies() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = enc_chain_db(dir.path());
+        let bob = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Bob").build(),
+            )
+            .unwrap();
+        wait_seq(&db, 1);
+
+        // Non-designated: stored value is exactly the plaintext (never an envelope).
+        assert_eq!(
+            stored_node_property(&db, bob, "name"),
+            PropertyValue::from("Bob".to_string()),
+            "a non-designated write must not be sealed"
+        );
+        assert!(db.verify_chain().unwrap().passed);
+    }
+}

--- a/src/db/chain_source.rs
+++ b/src/db/chain_source.rs
@@ -87,6 +87,27 @@ impl VersionSource for LockedDbVersionSource<'_> {
 /// from an already-locked historical store. Shared by the per-call
 /// [`DbVersionSource::fetch`] and the single-lock
 /// [`LockedDbVersionSource::fetch`] so both produce byte-identical leaves.
+///
+/// # GDPR crypto-shred invariant — DO NOT reroute through the unsealing boundary
+///
+/// Properties MUST be reconstructed via the **raw** `reconstruct_node_properties`
+/// / `reconstruct_edge_properties` storage path, which is crypto-shred-**unaware**
+/// and returns the bytes exactly as stored — for a designated property that is the
+/// sealed `PropertyValue::Bytes(SUBJ…)` envelope (ciphertext), never the plaintext.
+/// This is what makes the provenance-chain leaf **erasure-stable** (AC4, Issue
+/// #3359): the leaf binds the ciphertext, and `erase_subject` destroys only the
+/// subject key — never the stored envelope — so the recomputed leaf is unchanged
+/// and `verify_chain` still passes after a crypto-shred, while a tamper of the
+/// envelope bytes is still caught.
+///
+/// This function MUST NOT route through the db-API unsealing hooks
+/// (`materialize_shred` / `unseal_node_view` / `unseal_edge_view`,
+/// `src/db/crypto_shred/api.rs`). Doing so would make the leaf bind **plaintext**,
+/// which (1) breaks AC4 — a leaf over destroyed plaintext can no longer be
+/// recomputed after erasure, so `verify_chain` would spuriously fail — and (2)
+/// would defeat on-disk tamper detection for sealed values. Non-crypto-shred data
+/// is unaffected: with no designation, historical holds plaintext and the leaf
+/// binds it exactly as before.
 fn fetch_locked(
     historical: &HistoricalStorage,
     kind: EntityKind,


### PR DESCRIPTION
## GDPR crypto-shred — Slice 2 (AC4): provenance-chain erasure stability

A **test + guardrail** slice. **No on-disk change** — the `hash(plaintext) → hash(ciphertext)` semantics for sealed properties already landed with the seal-before-apply write path (#3689). There is **no `version_leaf` rewrite** here.

### Before / After

**Before:** No test proved the provenance chain still verifies after a GDPR crypto-shred, and nothing guarded the verify path from being "helpfully" rerouted through the unsealing boundary. AC4 held *by construction* (see below) but was un-pinned — a future refactor of `DbVersionSource` to unseal properties would silently make the leaf bind plaintext and break erasure stability, with no failing test.

**After:** Regression tests prove `verify_chain` still passes after `erase_subject` (node **and** edge) and that a byte-flip of the stored sealed envelope is still caught, plus a non-designated no-regression check. A guardrail comment on `DbVersionSource::fetch_locked` pins the leaf to the **raw** ciphertext reconstruct path.

### Why AC4 already holds by construction (as of #3689)

1. Sealing runs on the write path **pre-apply** (`seal_buffer`), so a designated property is a `PropertyValue::Bytes(SUBJ…)` ciphertext envelope in both the current and historical tiers before `apply_changes`.
2. The chain leaf is computed **post-commit** by `Sealer::seal_one` from `DbVersionSource`, which reconstructs via the **raw** `reconstruct_*_properties` storage path (crypto-shred-**unaware**) — so it binds the stored ciphertext, never plaintext, with zero special-casing in `canonical.rs`/`verify.rs`.
3. `verify` recomputes from the same raw path; `erase_subject` destroys **only** the subject key — never the stored envelope. Ciphertext survives → the recomputed leaf is identical → the chain stays valid post-shred.

### Changes

- **`src/db/chain.rs`** — new `crypto_shred_ac4_tests` module (combines the `chain` + `encryption` + designation harnesses; neither existing harness configured both):
  - `verify_chain_passes_after_crypto_shred_node` / `_edge` — verify passes after `erase_subject`.
  - `tamper_of_sealed_envelope_still_detected` — a mutated envelope byte breaks verify (property-reconstruction cache cleared to reproduce a fresh/cold read; labels tamper-detect without this, properties are cached under a version-immutability assumption).
  - `non_designated_node_chain_still_verifies` — zero regression for plaintext data.
- **`src/db/chain_source.rs`** — guardrail comment: `fetch_locked` MUST reconstruct via the raw `reconstruct_*_properties` path and MUST NOT route through `materialize_shred`/`unseal_*_view`, because that would bind plaintext and break AC4.
- **`docs/plans/2026-07-16-gdpr-crypto-shred.md`** — §6 / Slice-2 / AC4-disclosure corrected to state the by-construction status (no leaf rewrite, no on-disk format change); non-crypto-shred chains unaffected.

### Gate evidence (isolated `CARGO_TARGET_DIR`)

```
# tests
test result: ok. 87 passed; 0 failed  (--lib chain, default features)
test result: ok. 34 passed; 0 failed  (--lib crypto_shred, default features)
test result: ok. 94 passed; 0 failed  (--lib chain, --features mcp-server)
test result: ok. 35 passed; 0 failed  (--lib crypto_shred, --features mcp-server)
# the 4 new AC4 tests:
test db::chain::crypto_shred_ac4_tests::tamper_of_sealed_envelope_still_detected ... ok
test db::chain::crypto_shred_ac4_tests::verify_chain_passes_after_crypto_shred_node ... ok
test db::chain::crypto_shred_ac4_tests::verify_chain_passes_after_crypto_shred_edge ... ok
test db::chain::crypto_shred_ac4_tests::non_designated_node_chain_still_verifies ... ok

# clippy (all -D warnings, clean)
Finished  (--all-targets --features config-toml,mcp-server,sharding-rpc,simulation)
Finished  (--all-targets --all-features)
Finished  (--all-targets --no-default-features)

# checks
Finished  cargo check --no-default-features --tests
Finished  cargo check --no-default-features --tests --features {encryption,encryption-vault,encryption-aws-kms}

# fmt
cargo fmt --all --check → clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTu9hwjNh5FKc2ksJVXf9b

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTu9hwjNh5FKc2ksJVXf9b)_