### PR TITLE
Namespaces PR3a: MCP/HTTP namespace params + per-ns counts + ChangeFilter.namespace — #3349

### DIFF
--- a/crates/aletheia-server/tests/edge_parity.rs
+++ b/crates/aletheia-server/tests/edge_parity.rs
@@ -218,6 +218,7 @@ async fn create_edge_byte_parity_with_legacy_mcp() {
     assert_eq!(status, 200);
 
     let legacy: Value = serde_json::from_str(&mcp_server(&db_mcp).create_edge(CreateEdgeRequest {
+        namespace: None,
         source_id: a_mcp.as_u64(),
         target_id: b_mcp.as_u64(),
         label: "KNOWS".to_string(),
@@ -278,6 +279,7 @@ async fn create_edge_backdated_valid_time_honored() {
     );
 
     let legacy: Value = serde_json::from_str(&mcp_server(&db_mcp).create_edge(CreateEdgeRequest {
+        namespace: None,
         source_id: a_mcp.as_u64(),
         target_id: b_mcp.as_u64(),
         label: "KNOWS".to_string(),
@@ -316,6 +318,7 @@ async fn create_edge_anonymous_mode_parity() {
     assert_eq!(status, 200);
 
     let legacy: Value = serde_json::from_str(&mcp_server(&db_mcp).create_edge(CreateEdgeRequest {
+        namespace: None,
         source_id: a_mcp.as_u64(),
         target_id: b_mcp.as_u64(),
         label: "KNOWS".to_string(),
@@ -458,6 +461,7 @@ async fn update_edge_byte_parity_with_legacy_mcp() {
     assert_eq!(status, 200);
 
     let legacy: Value = serde_json::from_str(&mcp_server(&db_mcp).update_edge(UpdateEdgeRequest {
+        namespace: None,
         edge_id: e_mcp.as_u64(),
         properties: props(&[("since", json!(2021))]),
         valid_time: None,
@@ -490,6 +494,7 @@ async fn delete_edge_byte_parity() {
     assert_eq!(http_body["deleted_edge_id"], e_http.as_u64());
 
     let legacy: Value = serde_json::from_str(&mcp_server(&db_mcp).delete_edge(DeleteEdgeRequest {
+        namespace: None,
         edge_id: e_mcp.as_u64(),
         valid_time: None,
     }))

--- a/crates/aletheia-server/tests/edge_parity.rs
+++ b/crates/aletheia-server/tests/edge_parity.rs
@@ -368,6 +368,7 @@ async fn get_edge_byte_parity_and_temporal_block() {
     // Shared-db byte parity: get is a pure read, so both surfaces observe the
     // same version and are byte-identical without normalization.
     let legacy: Value = serde_json::from_str(&mcp_server(&db).get_edge(GetEdgeRequest {
+        namespace: None,
         edge_id: edge.as_u64(),
         include_vectors: None,
     }))
@@ -398,6 +399,7 @@ async fn get_edge_vector_elided_by_default_and_full_with_flag() {
         "vector elided by default: {elided}"
     );
     let legacy_elided: Value = serde_json::from_str(&mcp_server(&db).get_edge(GetEdgeRequest {
+        namespace: None,
         edge_id: edge.as_u64(),
         include_vectors: None,
     }))
@@ -417,6 +419,7 @@ async fn get_edge_vector_elided_by_default_and_full_with_flag() {
         "include_vectors=true returns the raw array: {full}"
     );
     let legacy_full: Value = serde_json::from_str(&mcp_server(&db).get_edge(GetEdgeRequest {
+        namespace: None,
         edge_id: edge.as_u64(),
         include_vectors: Some(true),
     }))
@@ -433,6 +436,7 @@ async fn get_edge_missing_returns_not_found_in_band() {
     assert_eq!(http_body["error"]["code"], "NOT_FOUND");
 
     let legacy: Value = serde_json::from_str(&mcp_server(&db).get_edge(GetEdgeRequest {
+        namespace: None,
         edge_id: 999,
         include_vectors: None,
     }))
@@ -556,6 +560,7 @@ async fn list_edges_byte_parity() {
     assert_eq!(status, 200);
 
     let legacy: Value = serde_json::from_str(&mcp_server(&db).list_edges(ListEdgesRequest {
+        namespace: None,
         label: None,
         limit: None,
         offset: None,

--- a/crates/aletheia-server/tests/node_writes_parity.rs
+++ b/crates/aletheia-server/tests/node_writes_parity.rs
@@ -147,6 +147,7 @@ async fn create_node_byte_parity_with_legacy_mcp() {
     assert_eq!(status, 200);
 
     let legacy: Value = serde_json::from_str(&mcp_server(&db_mcp).create_node(CreateNodeRequest {
+        namespace: None,
         label: "Person".to_string(),
         properties: Some(props(&[("name", json!("Alice")), ("age", json!(30))])),
         valid_time: None,
@@ -191,6 +192,7 @@ async fn create_node_backdated_valid_time_honored() {
     );
 
     let legacy: Value = serde_json::from_str(&mcp_server(&db_mcp).create_node(CreateNodeRequest {
+        namespace: None,
         label: "Person".to_string(),
         properties: Some(props(&[("name", json!("Alice"))])),
         valid_time: Some(vt.to_string()),
@@ -241,6 +243,7 @@ async fn create_node_anonymous_mode_parity() {
     assert_eq!(status, 200);
 
     let legacy: Value = serde_json::from_str(&mcp_server(&db_mcp).create_node(CreateNodeRequest {
+        namespace: None,
         label: "Person".to_string(),
         properties: Some(props(&[("name", json!("Alice"))])),
         valid_time: None,
@@ -284,6 +287,7 @@ async fn update_node_byte_parity_with_legacy_mcp() {
     assert_eq!(status, 200);
 
     let legacy: Value = serde_json::from_str(&mcp_server(&db_mcp).update_node(UpdateNodeRequest {
+        namespace: None,
         node_id: id_mcp.as_u64(),
         properties: props(&[("name", json!("Alice")), ("age", json!(31))]),
         valid_time: None,
@@ -337,6 +341,7 @@ async fn delete_node_refuses_without_detach_reports_connected_edges() {
     assert_eq!(http_body["success"], false);
 
     let legacy: Value = serde_json::from_str(&mcp_server(&db_mcp).delete_node(DeleteNodeRequest {
+        namespace: None,
         node_id: alice_mcp.as_u64(),
         detach: None,
         valid_time: None,
@@ -382,6 +387,7 @@ async fn delete_node_detach_removes_edges() {
     assert_eq!(http_body["edges_removed"], 1);
 
     let legacy: Value = serde_json::from_str(&mcp_server(&db_mcp).delete_node(DeleteNodeRequest {
+        namespace: None,
         node_id: alice_mcp.as_u64(),
         detach: Some(true),
         valid_time: None,
@@ -406,6 +412,7 @@ async fn delete_node_clean_when_no_edges() {
     assert_eq!(http_body["edges_removed"], 0);
 
     let legacy: Value = serde_json::from_str(&mcp_server(&db_mcp).delete_node(DeleteNodeRequest {
+        namespace: None,
         node_id: id_mcp.as_u64(),
         detach: None,
         valid_time: None,

--- a/crates/aletheia-server/tests/node_writes_parity.rs
+++ b/crates/aletheia-server/tests/node_writes_parity.rs
@@ -620,6 +620,7 @@ async fn find_nodes_at_time_byte_parity_and_elision() {
 
     let legacy: Value = serde_json::from_str(&mcp_server(&db_mcp).find_nodes_at_time(
         FindNodesAtTimeRequest {
+            namespace: None,
             label: "Person".to_string(),
             property_key: Some("name".to_string()),
             property_value: Some(json!("Alice")),
@@ -671,6 +672,7 @@ async fn find_nodes_at_time_include_vectors() {
 
     let legacy: Value = serde_json::from_str(&mcp_server(&db_mcp).find_nodes_at_time(
         FindNodesAtTimeRequest {
+            namespace: None,
             label: "Person".to_string(),
             property_key: None,
             property_value: None,

--- a/crates/aletheia-server/tests/server_parity.rs
+++ b/crates/aletheia-server/tests/server_parity.rs
@@ -321,6 +321,7 @@ async fn get_node_byte_parity_with_legacy_mcp() {
     assert_eq!(status, 200);
 
     let legacy: Value = serde_json::from_str(&mcp_server(&db).get_node(GetNodeRequest {
+        namespace: None,
         node_id: node_id.as_u64(),
         include_vectors: None,
     }))
@@ -349,6 +350,7 @@ async fn get_node_include_vectors_parity() {
     )
     .await;
     let legacy: Value = serde_json::from_str(&mcp_server(&db).get_node(GetNodeRequest {
+        namespace: None,
         node_id: node_id.as_u64(),
         include_vectors: Some(true),
     }))
@@ -368,6 +370,7 @@ async fn get_node_anonymous_mode_parity() {
     let (status, body) = new_get(&client, &format!("/nodes/{}", node_id.as_u64()), None).await;
     assert_eq!(status, 200);
     let legacy: Value = serde_json::from_str(&mcp_server(&db).get_node(GetNodeRequest {
+        namespace: None,
         node_id: node_id.as_u64(),
         include_vectors: None,
     }))
@@ -395,6 +398,7 @@ async fn list_nodes_byte_parity_with_legacy_mcp() {
     let (status, body) = new_get(&client, "/nodes?label=Person", Some(READER_TOKEN)).await;
     assert_eq!(status, 200);
     let legacy: Value = serde_json::from_str(&mcp_server(&db).list_nodes(ListNodesRequest {
+        namespace: None,
         label: Some("Person".to_string()),
         property_key: None,
         property_value: None,

--- a/crates/aletheia-server/tests/traverse_temporal_parity.rs
+++ b/crates/aletheia-server/tests/traverse_temporal_parity.rs
@@ -110,6 +110,7 @@ fn fixture() -> Fixture {
     // Second version of each entity so history/diff have two versions.
     let server = mcp_server(&db);
     let _ = server.update_node(UpdateNodeRequest {
+        namespace: None,
         node_id: alice,
         properties: [
             ("name".to_string(), json!("Alice")),
@@ -123,6 +124,7 @@ fn fixture() -> Fixture {
         derived_from: None,
     });
     let _ = server.update_edge(UpdateEdgeRequest {
+        namespace: None,
         edge_id: edge,
         properties: [("since".to_string(), json!(2021))].into_iter().collect(),
         valid_time: None,

--- a/crates/aletheia-server/tests/traverse_temporal_parity.rs
+++ b/crates/aletheia-server/tests/traverse_temporal_parity.rs
@@ -284,6 +284,7 @@ async fn assert_all_twelve_parity(mode: AuthMode, token: Option<&'static str>) {
     )
     .await;
     let legacy: Value = serde_json::from_str(&server.get_node_at_time(GetNodeAtTimeRequest {
+        namespace: None,
         node_id: fx.alice,
         valid_time: FUTURE_VT.to_string(),
         transaction_time: None,
@@ -304,6 +305,7 @@ async fn assert_all_twelve_parity(mode: AuthMode, token: Option<&'static str>) {
     )
     .await;
     let legacy: Value = serde_json::from_str(&server.get_edge_at_time(GetEdgeAtTimeRequest {
+        namespace: None,
         edge_id: fx.edge,
         valid_time: FUTURE_VT.to_string(),
         transaction_time: None,

--- a/src/db/namespace.rs
+++ b/src/db/namespace.rs
@@ -498,6 +498,10 @@ impl AletheiaDB {
     /// # Errors
     ///
     /// Propagates a registry persist failure (fsync error).
+    // The only callers are the MCP write handlers (`src/mcp/server.rs`, gated on
+    // the `mcp-server` feature), so under `--no-default-features` this method is
+    // unused; keep the surface but silence the dead-code lint in that build.
+    #[cfg_attr(not(feature = "mcp-server"), allow(dead_code))]
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub(crate) fn register_namespace_on_write(&self, namespace: &Namespace) -> Result<()> {
         self.namespaces.ensure_registered(namespace)

--- a/src/db/namespace.rs
+++ b/src/db/namespace.rs
@@ -489,6 +489,20 @@ impl AletheiaDB {
         self.namespaces.remove(&ns)
     }
 
+    /// Idempotently register a namespace after a successful namespaced write
+    /// (Issue #3349, PR3a). A no-op for the implicit `default`. Called by the
+    /// MCP/HTTP write handlers **after** the entity commits, so a failed write
+    /// never leaves a durable phantom namespace (see
+    /// [`create_node_in_namespace`](Self::create_node_in_namespace)).
+    ///
+    /// # Errors
+    ///
+    /// Propagates a registry persist failure (fsync error).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub(crate) fn register_namespace_on_write(&self, namespace: &Namespace) -> Result<()> {
+        self.namespaces.ensure_registered(namespace)
+    }
+
     /// Create a node in the given namespace (Issue #3349).
     ///
     /// The namespace is validated, auto-registered if new, and stamped onto the

--- a/src/db/stats.rs
+++ b/src/db/stats.rs
@@ -77,12 +77,9 @@ pub struct DatabaseStats {
     /// namespace with no explicit registrations (the `default` entry is still
     /// present when it holds entities).
     ///
-    /// **Not serialized in PR2**: surfacing this block through the MCP/HTTP
-    /// `database_stats` JSON is deliberately deferred to PR3 (the coordinated
-    /// surface slice), so the wire shape is unchanged here. The field is fully
-    /// populated on the Rust `AletheiaDB::stats()` value; only serialization is
-    /// skipped. PR3 removes this `skip` and updates the shape-stability test.
-    #[cfg_attr(feature = "serde", serde(skip_serializing))]
+    /// Serialized on the MCP/HTTP `database_stats` JSON since PR3a (the
+    /// coordinated surface slice); each entry is `{name, node_count,
+    /// edge_count}`.
     pub namespaces: Vec<crate::db::namespace_query::NamespaceCount>,
     /// Push-changefeed subscription state, including the per-principal quota
     /// breakdown (Issue #3678). This is the authenticated surface for the

--- a/src/mcp/error.rs
+++ b/src/mcp/error.rs
@@ -205,7 +205,8 @@ impl McpError {
         let details = e
             .as_constraint()
             .and_then(|ce| ce.structured_details())
-            .or_else(|| principal_quota_details(e));
+            .or_else(|| principal_quota_details(e))
+            .or_else(|| namespace_details(e));
         Self {
             code,
             message: e.to_string(),
@@ -301,6 +302,26 @@ fn principal_quota_details(e: &Error) -> Option<serde_json::Value> {
         }))
     } else {
         None
+    }
+}
+
+/// Structured `details` for a namespace error (Issue #3349). An unknown
+/// namespace (`NOT_FOUND`) and a malformed / empty scope (`INVALID_ARGUMENT`)
+/// both carry the offending `namespace` value so a caller can self-correct
+/// without substring-parsing the message; the `InvalidName` case also carries
+/// the validation `reason`. Shared by the MCP and HTTP surfaces so both render
+/// byte-identical metadata under `error.details`. Returns `None` for every
+/// other error.
+fn namespace_details(e: &Error) -> Option<serde_json::Value> {
+    use crate::core::namespace::NamespaceError;
+    match e {
+        Error::Namespace(NamespaceError::NotFound { namespace }) => {
+            Some(serde_json::json!({ "namespace": namespace }))
+        }
+        Error::Namespace(NamespaceError::InvalidName { name, reason }) => {
+            Some(serde_json::json!({ "namespace": name, "reason": reason }))
+        }
+        _ => None,
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -644,6 +644,7 @@ impl AletheiaMcpServer {
     ///     valid_time: None,
     ///     provenance: None,
     ///     derived_from: None,
+    ///     namespace: None,
     /// };
     /// ```
     ///
@@ -1364,8 +1365,21 @@ impl AletheiaMcpServer {
             id: node.id.as_u64(),
             label: self.interned_to_string(node.label),
             properties: self.property_map_to_json(&node.properties, include_vectors),
+            namespace: Self::namespace_field(node.namespace()),
             provenance,
             temporal,
+        }
+    }
+
+    /// Render an entity's namespace as the first-class response field
+    /// (Issue #3349): `None` for the implicit `default` namespace — so a
+    /// single-agent (`default`-only) response stays byte-identical to
+    /// pre-namespace behavior — and `Some(name)` for any non-default namespace.
+    fn namespace_field(ns: crate::core::namespace::Namespace) -> Option<String> {
+        if ns.is_default() {
+            None
+        } else {
+            Some(ns.into_string())
         }
     }
 
@@ -1382,6 +1396,7 @@ impl AletheiaMcpServer {
             target_id: edge.target.as_u64(),
             label: self.interned_to_string(edge.label),
             properties: self.property_map_to_json(&edge.properties, include_vectors),
+            namespace: Self::namespace_field(edge.namespace()),
             provenance,
             temporal,
         }
@@ -1593,6 +1608,45 @@ impl AletheiaMcpServer {
             .map(|s| self.parse_timestamp(s))
             .transpose()
             .map_err(|e| self.invalid_argument(&format!("Invalid {label}: {e}")))
+    }
+
+    /// Parse an optional namespace **write** argument (Issue #3349, PR3a),
+    /// returning a structured `INVALID_ARGUMENT` error result on a malformed
+    /// name. `None`/absent ⇒ the default namespace (unchanged behavior). A
+    /// supplied `"default"` resolves to the default namespace (equivalent to
+    /// omitting it).
+    // clippy::result_large_err: Err is rmcp's `CallToolResult` (~176B); see
+    // `parse_opt_timestamp`.
+    #[allow(clippy::result_large_err)]
+    fn parse_opt_namespace(
+        &self,
+        value: &Option<String>,
+    ) -> std::result::Result<Option<crate::core::namespace::Namespace>, CallToolResult> {
+        match value.as_deref() {
+            None => Ok(None),
+            Some(s) => match crate::core::namespace::Namespace::new(s) {
+                Ok(ns) => Ok(Some(ns)),
+                Err(e) => Err(self.db_error(crate::core::error::Error::Namespace(e))),
+            },
+        }
+    }
+
+    /// Reject an explicit namespace supplied to a **non-create** write
+    /// (update / delete — Issue #3349, PR3a): a namespace is immutable after
+    /// creation, so supplying one is `INVALID_ARGUMENT`
+    /// ([`NamespaceError::Immutable`]) rather than a silent no-op. `None` ⇒ OK.
+    // clippy::result_large_err: Err is rmcp's `CallToolResult`; see above.
+    #[allow(clippy::result_large_err)]
+    fn reject_namespace_on_write_update(
+        &self,
+        value: &Option<String>,
+    ) -> std::result::Result<(), CallToolResult> {
+        if value.is_some() {
+            return Err(self.db_error(crate::core::error::Error::Namespace(
+                crate::core::namespace::NamespaceError::Immutable,
+            )));
+        }
+        Ok(())
     }
 
     /// Resolve a pair of independently-optional `as_of_valid_time` /
@@ -2526,12 +2580,20 @@ impl AletheiaMcpServer {
             Err(result) => return result,
         };
 
+        let namespace = match self.parse_opt_namespace(&req.namespace) {
+            Ok(ns) => ns,
+            Err(result) => return result,
+        };
+
         let mut options = crate::api::transaction::WriteRequestOptions::new();
         if let Some(valid_from) = valid_from {
             options = options.with_valid_from(valid_from);
         }
         if let Some(provenance) = provenance {
             options = options.with_provenance(provenance);
+        }
+        if let Some(ns) = namespace.clone() {
+            options = options.with_namespace(ns);
         }
 
         let created = if derived_from.is_empty() {
@@ -2547,6 +2609,15 @@ impl AletheiaMcpServer {
                 )
                 .map(|(node_id, _version)| node_id)
         };
+
+        // Auto-register the (non-default) namespace only AFTER a successful
+        // commit, mirroring `create_node_in_namespace` (a failed write must not
+        // leave a durable phantom namespace).
+        if let (Ok(_), Some(ns)) = (&created, &namespace)
+            && let Err(e) = self.db.register_namespace_on_write(ns)
+        {
+            return self.db_error(e);
+        }
 
         match created {
             Ok(node_id) => match self.db.get_node(node_id) {
@@ -2578,6 +2649,12 @@ impl AletheiaMcpServer {
             // regression vs pre-#3234 responses).
             Err(e) => return self.invalid_argument(&e.to_string()),
         };
+
+        // A namespace is immutable after creation (Issue #3349): supplying one
+        // on an update is INVALID_ARGUMENT, never a silent no-op.
+        if let Err(result) = self.reject_namespace_on_write_update(&req.namespace) {
+            return result;
+        }
 
         let properties = match self.json_to_property_map(&req.properties) {
             Ok(map) => map,
@@ -2645,6 +2722,12 @@ impl AletheiaMcpServer {
             // regression vs pre-#3234 responses).
             Err(e) => return self.invalid_argument(&e.to_string()),
         };
+
+        // A namespace is immutable after creation (Issue #3349): supplying one
+        // on a delete is INVALID_ARGUMENT, never a silent no-op.
+        if let Err(result) = self.reject_namespace_on_write_update(&req.namespace) {
+            return result;
+        }
 
         let detach = req.detach.unwrap_or(false);
 
@@ -3360,12 +3443,20 @@ impl AletheiaMcpServer {
             Err(result) => return result,
         };
 
+        let namespace = match self.parse_opt_namespace(&req.namespace) {
+            Ok(ns) => ns,
+            Err(result) => return result,
+        };
+
         let mut options = crate::api::transaction::WriteRequestOptions::new();
         if let Some(valid_from) = valid_from {
             options = options.with_valid_from(valid_from);
         }
         if let Some(provenance) = provenance {
             options = options.with_provenance(provenance);
+        }
+        if let Some(ns) = namespace.clone() {
+            options = options.with_namespace(ns);
         }
 
         let created = if derived_from.is_empty() {
@@ -3383,6 +3474,14 @@ impl AletheiaMcpServer {
                 )
                 .map(|(edge_id, _version)| edge_id)
         };
+
+        // Auto-register the (non-default) namespace only AFTER a successful
+        // commit (see handle_create_node).
+        if let (Ok(_), Some(ns)) = (&created, &namespace)
+            && let Err(e) = self.db.register_namespace_on_write(ns)
+        {
+            return self.db_error(e);
+        }
 
         match created {
             Ok(edge_id) => match self.db.get_edge(edge_id) {
@@ -3414,6 +3513,12 @@ impl AletheiaMcpServer {
             // regression vs pre-#3234 responses).
             Err(e) => return self.invalid_argument(&e.to_string()),
         };
+
+        // A namespace is immutable after creation (Issue #3349): supplying one
+        // on an update is INVALID_ARGUMENT, never a silent no-op.
+        if let Err(result) = self.reject_namespace_on_write_update(&req.namespace) {
+            return result;
+        }
 
         let properties = match self.json_to_property_map(&req.properties) {
             Ok(map) => map,
@@ -3481,6 +3586,12 @@ impl AletheiaMcpServer {
             // regression vs pre-#3234 responses).
             Err(e) => return self.invalid_argument(&e.to_string()),
         };
+
+        // A namespace is immutable after creation (Issue #3349): supplying one
+        // on a delete is INVALID_ARGUMENT, never a silent no-op.
+        if let Err(result) = self.reject_namespace_on_write_update(&req.namespace) {
+            return result;
+        }
 
         let valid_from = match self.parse_opt_timestamp("valid_time", &req.valid_time) {
             Ok(v) => v,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1649,6 +1649,91 @@ impl AletheiaMcpServer {
         Ok(())
     }
 
+    /// Parse an optional namespace **read scope** argument (Issue #3349, PR3a).
+    ///
+    /// Accepts three JSON shapes:
+    /// - a **string** namespace name (single-namespace scope), or the special
+    ///   selector `"all"` (no filter);
+    /// - an **array of string** namespace names (the union scope);
+    /// - absent ⇒ `Ok(None)`, meaning "no explicit scope" — the caller keeps its
+    ///   current, unscoped behavior (byte-identical back-compat: the read is not
+    ///   narrowed). Note this is NOT the same as `Single(default)`: PR3a has no
+    ///   connection-default-scope config, so an omitted scope leaves the read
+    ///   exactly as it behaves today (all namespaces visible), not default-only.
+    ///
+    /// An **empty array** is `INVALID_ARGUMENT` (a scope that silently matches
+    /// nothing is forbidden). A malformed namespace name is `INVALID_ARGUMENT`
+    /// with `details.namespace`. An unknown (unregistered) namespace is not
+    /// rejected here — it surfaces as `NOT_FOUND` when the scoped read validates
+    /// the scope against the registry (`details.namespace`).
+    // clippy::result_large_err: Err is rmcp's `CallToolResult`; see above.
+    #[allow(clippy::result_large_err)]
+    fn parse_opt_scope(
+        &self,
+        value: &Option<serde_json::Value>,
+    ) -> std::result::Result<Option<crate::core::namespace::NamespaceScope>, CallToolResult> {
+        use crate::core::error::Error;
+        use crate::core::namespace::{Namespace, NamespaceScope};
+        let Some(value) = value else {
+            return Ok(None);
+        };
+        // An explicit JSON null is treated as "not supplied".
+        if value.is_null() {
+            return Ok(None);
+        }
+        let scope = match value {
+            serde_json::Value::String(s) if s == "all" => NamespaceScope::All,
+            serde_json::Value::String(s) => match Namespace::new(s.as_str()) {
+                Ok(ns) => NamespaceScope::Single(ns),
+                Err(e) => return Err(self.db_error(Error::Namespace(e))),
+            },
+            serde_json::Value::Array(arr) => {
+                let mut namespaces = Vec::with_capacity(arr.len());
+                for el in arr {
+                    let Some(name) = el.as_str() else {
+                        return Err(
+                            self.invalid_argument("namespace scope array elements must be strings")
+                        );
+                    };
+                    match Namespace::new(name) {
+                        Ok(ns) => namespaces.push(ns),
+                        Err(e) => return Err(self.db_error(Error::Namespace(e))),
+                    }
+                }
+                // Empty list ⇒ INVALID_ARGUMENT (never-silently-match-nothing).
+                match NamespaceScope::list(namespaces) {
+                    Ok(scope) => scope,
+                    Err(e) => return Err(self.db_error(Error::Namespace(e))),
+                }
+            }
+            _ => {
+                return Err(self.invalid_argument(
+                    "namespace must be a string, an array of strings, or \"all\"",
+                ));
+            }
+        };
+        Ok(Some(scope))
+    }
+
+    /// For a read tool that does **not** yet support a namespace scope in v1
+    /// (`list_edges`, `hybrid_query`, `query`): accept an absent scope or the
+    /// no-op `"all"` selector (both leave behavior unchanged), but reject any
+    /// narrowing scope with a structured `INVALID_ARGUMENT` — never a silently
+    /// unscoped result (never-silently-wrong). A malformed / empty scope still
+    /// surfaces its own `parse_opt_scope` error.
+    // clippy::result_large_err: Err is rmcp's `CallToolResult`; see above.
+    #[allow(clippy::result_large_err)]
+    fn reject_unsupported_scope(
+        &self,
+        value: &Option<serde_json::Value>,
+        message: &str,
+    ) -> std::result::Result<(), CallToolResult> {
+        match self.parse_opt_scope(value)? {
+            None | Some(crate::core::namespace::NamespaceScope::All) => Ok(()),
+            Some(_) => Err(self.invalid_argument(message)),
+        }
+    }
+
     /// Resolve a pair of independently-optional `as_of_valid_time` /
     /// `as_of_transaction_time` request fields into a single bi-temporal
     /// coordinate, shared by every MCP tool that supports point-in-time
@@ -2517,7 +2602,19 @@ impl AletheiaMcpServer {
             Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
-        match self.db.get_node(node_id) {
+        // Issue #3349: an explicit namespace scope narrows visibility (an
+        // out-of-scope node is reported NOT_FOUND, indistinguishable from
+        // missing). Omitted ⇒ current unscoped behavior.
+        let scope = match self.parse_opt_scope(&req.namespace) {
+            Ok(s) => s,
+            Err(result) => return result,
+        };
+        let node_result = match &scope {
+            Some(scope) => self.db.get_node_scoped(node_id, scope),
+            None => self.db.get_node(node_id),
+        };
+
+        match node_result {
             Ok(node) => {
                 let now = time::now();
                 let response =
@@ -3162,6 +3259,16 @@ impl AletheiaMcpServer {
             if Self::has_provenance_filter_args(&args) {
                 return self.provenance_filter_cursor_unsupported();
             }
+            // Issue #3349: a narrowing namespace scope does not yet compose with
+            // the #3360 cursor path — fail closed rather than page an unscoped
+            // scan under a scope the caller asked for.
+            if let Err(result) = self.reject_unsupported_scope(
+                &args.get("namespace").cloned(),
+                "namespace scope does not compose with cursor paging (use_cursor) in v1; page the \
+                 scoped scan with offset/limit instead, or use \"all\".",
+            ) {
+                return result;
+            }
             return self.handle_list_nodes_cursor(&args);
         }
 
@@ -3195,6 +3302,19 @@ impl AletheiaMcpServer {
         }
         if req.property_key.is_some() && req.label.is_none() {
             return self.invalid_argument("Property filtering requires 'label' to be specified");
+        }
+
+        // Issue #3349: a narrowing namespace scope routes through the scoped
+        // membership index. `All`/absent falls through to the full-featured
+        // unscoped path below (byte-identical back-compat).
+        let scope = match self.parse_opt_scope(&req.namespace) {
+            Ok(s) => s,
+            Err(result) => return result,
+        };
+        if let Some(scope) =
+            scope.filter(|s| !matches!(s, crate::core::namespace::NamespaceScope::All))
+        {
+            return self.handle_list_nodes_scoped(&req, &scope, prov_filter.as_ref());
         }
 
         // One request-scoped wallclock for every entity in the response
@@ -3347,6 +3467,80 @@ impl AletheiaMcpServer {
         }
     }
 
+    /// Namespace-scoped `list_nodes` page (Issue #3349): candidates come from
+    /// the membership index (not a full scan), filtered to the given
+    /// (narrowing) `scope`, then offset/limit-paginated and rendered exactly
+    /// like the unscoped path (temporal bounds, vector elision, first-class
+    /// `namespace` field, provenance filter). Unlike the unscoped path this does
+    /// not compose with the #3360 cursor or #3353 token-budget shaping in v1
+    /// (offset paging applies).
+    fn handle_list_nodes_scoped(
+        &self,
+        req: &ListNodesRequest,
+        scope: &crate::core::namespace::NamespaceScope,
+        prov_filter: Option<&crate::core::ProvenanceFilter>,
+    ) -> CallToolResult {
+        let limit = req
+            .limit
+            .unwrap_or(DEFAULT_RESULT_LIMIT)
+            .clamp(1, MAX_RESULT_LIMIT);
+        let offset = req.offset.unwrap_or(0).min(MAX_PAGINATION_OFFSET);
+        let include_vectors = req.include_vectors.unwrap_or(false);
+        let now = time::now();
+
+        // Resolve the candidate id set within scope (validates the scope against
+        // the registry — an unknown namespace ⇒ NOT_FOUND(details.namespace)).
+        let ids_result = if let (Some(label), Some(prop_key), Some(prop_val)) =
+            (&req.label, &req.property_key, &req.property_value)
+        {
+            let property_value = match self.json_to_property_value(prop_val) {
+                Some(v) => v,
+                None => {
+                    return self.invalid_argument(
+                        "Unsupported property_value type. Use strings, numbers, booleans, or null.",
+                    );
+                }
+            };
+            self.db
+                .find_nodes_by_property_scoped(label, prop_key, &property_value, scope)
+        } else {
+            self.db.list_nodes_scoped(req.label.as_deref(), scope)
+        };
+        let node_ids = match ids_result {
+            Ok(ids) => ids,
+            Err(e) => return self.db_error(e),
+        };
+
+        let total_matching = node_ids.len();
+        let mut nodes = Vec::with_capacity(limit.min(total_matching.saturating_sub(offset)));
+        for node_id in node_ids.into_iter().skip(offset).take(limit) {
+            if let Ok(node) = self.db.get_node(node_id) {
+                let resp = self.node_to_response(&node, include_vectors, now);
+                if prov_filter.is_none_or(|f| f.matches(resp.provenance.as_ref())) {
+                    nodes.push(resp);
+                }
+            }
+        }
+
+        let has_more = offset.saturating_add(limit) < total_matching;
+        let mut response = json!({
+            "nodes": nodes,
+            "count": nodes.len(),
+            "offset": offset,
+            "limit": limit,
+        });
+        // With a provenance filter active the materialized total is the
+        // *unfiltered* candidate count, so it would be misleading — omit it
+        // (mirroring the unscoped path); `has_more` still carries completeness.
+        let reported_total = if prov_filter.is_some() {
+            None
+        } else {
+            Some(total_matching)
+        };
+        Self::attach_completeness(&mut response, offset, limit, has_more, reported_total);
+        self.success_json(response)
+    }
+
     fn handle_count_nodes(&self, args: serde_json::Value) -> CallToolResult {
         let req: CountNodesRequest = match serde_json::from_value(args) {
             Ok(r) => r,
@@ -3391,7 +3585,17 @@ impl AletheiaMcpServer {
             Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
-        match self.db.get_edge(edge_id) {
+        // Issue #3349: an explicit namespace scope narrows visibility.
+        let scope = match self.parse_opt_scope(&req.namespace) {
+            Ok(s) => s,
+            Err(result) => return result,
+        };
+        let edge_result = match &scope {
+            Some(scope) => self.db.get_edge_scoped(edge_id, scope),
+            None => self.db.get_edge(edge_id),
+        };
+
+        match edge_result {
             Ok(edge) => {
                 let now = time::now();
                 let response =
@@ -3639,6 +3843,16 @@ impl AletheiaMcpServer {
                 )
                 .details(json!({ "cursorable_alternatives": ["get_outgoing_edges", "get_incoming_edges"] })),
             );
+        }
+
+        // Issue #3349: list_edges does not enumerate edges by namespace in v1;
+        // a narrowing scope is INVALID_ARGUMENT (never silently unscoped).
+        if let Err(result) = self.reject_unsupported_scope(
+            &args.get("namespace").cloned(),
+            "list_edges does not enumerate edges by namespace in v1; a namespace scope is not \
+             supported here. Use the scoped adjacency/traversal reads instead, or \"all\".",
+        ) {
+            return result;
         }
 
         let req: ListEdgesRequest = match serde_json::from_value(args) {
@@ -3935,6 +4149,15 @@ impl AletheiaMcpServer {
             if Self::has_provenance_filter_args(&args) {
                 return self.provenance_filter_cursor_unsupported();
             }
+            // Issue #3349: a narrowing namespace scope does not compose with the
+            // #3360 cursor path in v1 — fail closed.
+            if let Err(result) = self.reject_unsupported_scope(
+                &args.get("namespace").cloned(),
+                "namespace scope does not compose with cursor paging (use_cursor) in v1; use \
+                 offset/limit paging with the scope instead, or \"all\".",
+            ) {
+                return result;
+            }
             return self.handle_traverse_cursor(&args);
         }
 
@@ -3980,6 +4203,32 @@ impl AletheiaMcpServer {
         // (Issue #3391).
         let now = time::now();
 
+        // Issue #3349: a narrowing namespace scope routes through the
+        // boundary-enforcing scoped BFS (an edge is crossed only if the edge's
+        // own namespace AND the target node's namespace are in scope, so a scope
+        // cannot leak via transit through an out-of-scope node). `All`/absent
+        // falls through to the full unscoped DFS below.
+        let scope = match self.parse_opt_scope(&req.namespace) {
+            Ok(s) => s,
+            Err(result) => return result,
+        };
+        if let Some(scope) =
+            scope.filter(|s| !matches!(s, crate::core::namespace::NamespaceScope::All))
+        {
+            return self.handle_traverse_scoped(
+                &req,
+                &scope,
+                start_id,
+                direction,
+                depth,
+                limit,
+                offset,
+                temporal,
+                prov_filter.as_ref(),
+                now,
+            );
+        }
+
         let (mut results, has_more) = self.run_traversal(
             start_id,
             &req.edge_label,
@@ -4022,6 +4271,86 @@ impl AletheiaMcpServer {
         // `total_matching` is omitted; `has_more`/`next_offset` carry the
         // completeness signal.
         Self::attach_completeness(&mut response, offset, page_window, has_more, None);
+        self.success_json(response)
+    }
+
+    /// Namespace-scoped `traverse` (Issue #3349). Routes through the
+    /// boundary-enforcing scoped BFS (`traverse_scoped` / `traverse_scoped_as_of`)
+    /// so an edge is crossed only when the edge's own namespace AND the target
+    /// node's namespace are in scope — a scope can never leak across the
+    /// boundary or via transit through an out-of-scope node.
+    ///
+    /// v1 scope limitations vs the unscoped DFS: only `direction: "outgoing"` is
+    /// supported (incoming/both ⇒ `INVALID_ARGUMENT`); the scoped BFS returns
+    /// the reachable in-scope node set (sorted by id), so each result carries
+    /// its `node` (and `depth`/`path` are omitted — the boundary-correct set,
+    /// not per-path detail); it does not compose with the #3360 cursor /
+    /// #3353 token-budget shaping (offset paging applies).
+    #[allow(clippy::too_many_arguments)]
+    fn handle_traverse_scoped(
+        &self,
+        req: &TraverseRequest,
+        scope: &crate::core::namespace::NamespaceScope,
+        start_id: NodeId,
+        direction: &str,
+        depth: usize,
+        limit: usize,
+        offset: usize,
+        temporal: Option<(Timestamp, Timestamp)>,
+        prov_filter: Option<&crate::core::ProvenanceFilter>,
+        now: Timestamp,
+    ) -> CallToolResult {
+        if direction != "outgoing" {
+            return self.invalid_argument(
+                "namespace-scoped traverse supports only direction \"outgoing\" in v1; an \
+                 incoming/both scoped traversal is a follow-up.",
+            );
+        }
+        // The scoped BFS takes an optional edge label; the MCP tool always
+        // supplies one (a required field), so restrict to that relationship.
+        let edge_label = Some(req.edge_label.as_str());
+        let reachable = match temporal {
+            Some((vt, tt)) => self
+                .db
+                .traverse_scoped_as_of(start_id, edge_label, depth, vt, tt, scope),
+            None => self.db.traverse_scoped(start_id, edge_label, depth, scope),
+        };
+        let reachable = match reachable {
+            Ok(ids) => ids,
+            Err(e) => return self.db_error(e),
+        };
+
+        let total = reachable.len();
+        let include_vectors = req.include_vectors.unwrap_or(false);
+        let mut results: Vec<serde_json::Value> = Vec::new();
+        for node_id in reachable.into_iter().skip(offset).take(limit) {
+            let node = match temporal {
+                Some((vt, tt)) => self.db.get_node_at_time(node_id, vt, tt),
+                None => self.db.get_node(node_id),
+            };
+            if let Ok(node) = node {
+                let resp = self.node_to_response(&node, include_vectors, now);
+                if prov_filter.is_none_or(|f| f.matches(resp.provenance.as_ref())) {
+                    results.push(json!({ "node": resp }));
+                }
+            }
+        }
+
+        let has_more = offset.saturating_add(limit) < total;
+        let count = results.len();
+        let mut response = match temporal {
+            Some((vt, tt)) => json!({
+                "results": results,
+                "count": count,
+                "as_of_valid_time": time::to_iso8601(vt),
+                "as_of_transaction_time": time::to_iso8601(tt),
+            }),
+            None => json!({
+                "results": results,
+                "count": count,
+            }),
+        };
+        Self::attach_completeness(&mut response, offset, limit, has_more, Some(total));
         self.success_json(response)
     }
 
@@ -4710,6 +5039,20 @@ impl AletheiaMcpServer {
             return self.invalid_argument(&e);
         }
 
+        // Issue #3349: a narrowing namespace scope routes through the
+        // filter-complete scoped k-NN (over-fetches until it has k genuinely
+        // in-scope results — never k-then-drop). `All`/absent falls through to
+        // the full unscoped search below.
+        let scope = match self.parse_opt_scope(&req.namespace) {
+            Ok(s) => s,
+            Err(result) => return result,
+        };
+        if let Some(scope) =
+            scope.filter(|s| !matches!(s, crate::core::namespace::NamespaceScope::All))
+        {
+            return self.handle_find_similar_scoped(&req, &scope, k, offset, prov_filter.as_ref());
+        }
+
         // Over-fetch one past the requested page (offset + k + 1, capped at
         // MAX_VECTOR_K + 1 by the offset bound above) so we can tell whether
         // more similar nodes exist beyond this page (`has_more`) without a
@@ -4786,6 +5129,63 @@ impl AletheiaMcpServer {
             }
             Err(e) => self.db_error(e),
         }
+    }
+
+    /// Namespace-scoped `find_similar` (Issue #3349). Routes through the
+    /// filter-complete scoped k-NN (`find_similar_by_embedding_scoped`), which
+    /// over-fetches until it has the requested number of genuinely in-scope
+    /// results (never k-then-drop); scores and ranking order match the unscoped
+    /// search. Offset paging applies; it does not compose with the #3360 cursor
+    /// or #3353 token-budget shaping in v1.
+    fn handle_find_similar_scoped(
+        &self,
+        req: &FindSimilarRequest,
+        scope: &crate::core::namespace::NamespaceScope,
+        k: usize,
+        offset: usize,
+        prov_filter: Option<&crate::core::ProvenanceFilter>,
+    ) -> CallToolResult {
+        // Over-fetch one past the page window so `has_more` is exact, capped at
+        // the MAX_VECTOR_K resource horizon. When a provenance filter is active
+        // fetch the full horizon so the returned top-k are all filter-passing.
+        let fetch_k = if prov_filter.is_some() {
+            MAX_VECTOR_K.saturating_add(1)
+        } else {
+            offset
+                .saturating_add(k)
+                .saturating_add(1)
+                .min(MAX_VECTOR_K.saturating_add(1))
+        };
+        let ranked = match self
+            .db
+            .find_similar_by_embedding_scoped(&req.embedding, fetch_k, scope)
+        {
+            Ok(r) => r,
+            Err(e) => return self.db_error(e),
+        };
+
+        let include_vectors = req.include_vectors.unwrap_or(false);
+        let now = time::now();
+        let built: Vec<SimilarityResult> = ranked
+            .into_iter()
+            .filter_map(|(node_id, score)| {
+                self.db.get_node(node_id).ok().map(|node| SimilarityResult {
+                    node: self.node_to_response(&node, include_vectors, now),
+                    score,
+                })
+            })
+            .filter(|r| prov_filter.is_none_or(|f| f.matches(r.node.provenance.as_ref())))
+            .collect();
+
+        let has_more = built.len() > offset.saturating_add(k);
+        let page: Vec<SimilarityResult> = built.into_iter().skip(offset).take(k).collect();
+        let count = page.len();
+        let mut response = json!({
+            "results": page,
+            "count": count,
+        });
+        Self::attach_completeness(&mut response, offset, k, has_more, None);
+        self.success_json(response)
     }
 
     // ========================================================================
@@ -5471,7 +5871,20 @@ impl AletheiaMcpServer {
             Err(e) => return self.invalid_argument(&e),
         };
 
-        match self.db.get_node_at_time(node_id, valid_time, tx_time) {
+        // Issue #3349: reconstruct at the coordinate first, then filter by the
+        // (immutable) namespace scope; out of scope ⇒ NOT_FOUND.
+        let scope = match self.parse_opt_scope(&req.namespace) {
+            Ok(s) => s,
+            Err(result) => return result,
+        };
+        let node_result = match &scope {
+            Some(scope) => self
+                .db
+                .get_node_at_time_scoped(node_id, valid_time, tx_time, scope),
+            None => self.db.get_node_at_time(node_id, valid_time, tx_time),
+        };
+
+        match node_result {
             Ok(node) => {
                 let now = time::now();
                 let response = self.node_to_response(&node, true, now);
@@ -5510,7 +5923,19 @@ impl AletheiaMcpServer {
             Err(e) => return self.invalid_argument(&e),
         };
 
-        match self.db.get_edge_at_time(edge_id, valid_time, tx_time) {
+        // Issue #3349: reconstruct then filter by the (immutable) namespace scope.
+        let scope = match self.parse_opt_scope(&req.namespace) {
+            Ok(s) => s,
+            Err(result) => return result,
+        };
+        let edge_result = match &scope {
+            Some(scope) => self
+                .db
+                .get_edge_at_time_scoped(edge_id, valid_time, tx_time, scope),
+            None => self.db.get_edge_at_time(edge_id, valid_time, tx_time),
+        };
+
+        match edge_result {
             Ok(edge) => {
                 let now = time::now();
                 let response = self.edge_to_response(&edge, true, now);
@@ -5632,12 +6057,29 @@ impl AletheiaMcpServer {
         // Snapshot-anchored cursor paging (Issue #3360); offset paging below
         // is unchanged for backward compatibility.
         if Self::cursor_requested(&args) {
+            // Issue #3349: a narrowing namespace scope does not compose with the
+            // #3360 cursor path in v1 — fail closed.
+            if let Err(result) = self.reject_unsupported_scope(
+                &args.get("namespace").cloned(),
+                "namespace scope does not compose with cursor paging (use_cursor) in v1; use \
+                 offset/limit paging with the scope instead, or \"all\".",
+            ) {
+                return result;
+            }
             return self.handle_find_nodes_at_time_cursor(&args);
         }
 
         let req: FindNodesAtTimeRequest = match serde_json::from_value(args) {
             Ok(r) => r,
             Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
+        };
+
+        // Issue #3349: an explicit narrowing namespace scope routes each
+        // candidate (reconstructed at the coordinate) through the immutable
+        // namespace filter. `All`/absent falls through unchanged.
+        let scope = match self.parse_opt_scope(&req.namespace) {
+            Ok(s) => s.filter(|s| !matches!(s, crate::core::namespace::NamespaceScope::All)),
+            Err(result) => return result,
         };
 
         // Validate property filter: both key and value are required together
@@ -5673,15 +6115,30 @@ impl AletheiaMcpServer {
                         "Unsupported property_value type. Use strings, numbers, booleans, or null.",
                     ),
                 };
-                self.db.find_nodes_by_property_at(
-                    &req.label,
-                    prop_key,
-                    &property_value,
-                    valid_time,
-                    tx_time,
-                )
+                match &scope {
+                    Some(scope) => self.db.find_nodes_by_property_at_scoped(
+                        &req.label,
+                        prop_key,
+                        &property_value,
+                        valid_time,
+                        tx_time,
+                        scope,
+                    ),
+                    None => self.db.find_nodes_by_property_at(
+                        &req.label,
+                        prop_key,
+                        &property_value,
+                        valid_time,
+                        tx_time,
+                    ),
+                }
             } else {
-                self.db.find_nodes_at_time(&req.label, valid_time, tx_time)
+                match &scope {
+                    Some(scope) => self
+                        .db
+                        .find_nodes_at_time_scoped(&req.label, valid_time, tx_time, scope),
+                    None => self.db.find_nodes_at_time(&req.label, valid_time, tx_time),
+                }
             };
 
         match matches {
@@ -6514,12 +6971,31 @@ impl AletheiaMcpServer {
             })
             .collect();
 
+        // Per-namespace current node/edge counts (Issue #3349, PR3a): one
+        // `{name, node_count, edge_count}` entry per registered-or-populated
+        // namespace, sorted by name. Empty for a bi-temporal (`as_of`) schema
+        // (the membership index is a current-state acceleration structure).
+        // NamespaceCount.name is a user-facing namespace name, never the elided
+        // ride-along key.
+        let namespaces: Vec<serde_json::Value> = schema
+            .namespaces
+            .iter()
+            .map(|n| {
+                json!({
+                    "name": n.name,
+                    "node_count": n.node_count,
+                    "edge_count": n.edge_count,
+                })
+            })
+            .collect();
+
         json!({
             "node_labels": node_labels,
             "edge_types": edge_types,
             "total_nodes": schema.total_nodes,
             "total_edges": schema.total_edges,
             "sampled": schema.sampled,
+            "namespaces": namespaces,
             "as_of": schema.as_of.map(|instant| json!({
                 "valid_time": time::to_iso8601(instant.valid_time),
                 "transaction_time": time::to_iso8601(instant.transaction_time),
@@ -7023,6 +7499,18 @@ impl AletheiaMcpServer {
     }
 
     fn handle_hybrid_query(&self, args: serde_json::Value) -> CallToolResult {
+        // Issue #3349: a filter-complete namespace scope over the vector ranking
+        // is not implemented for hybrid_query in v1; a narrowing scope is
+        // INVALID_ARGUMENT (never silently unscoped / incorrectly post-filtered).
+        if let Err(result) = self.reject_unsupported_scope(
+            &args.get("namespace").cloned(),
+            "hybrid_query does not support a namespace scope in v1 (a filter-complete scope over \
+             vector ranking is a follow-up). Use find_similar or traverse with a namespace scope \
+             instead, or \"all\".",
+        ) {
+            return result;
+        }
+
         // Issue #3348: parse the optional provenance filter before consuming args.
         let prov_filter = match self.parse_provenance_filter(&args) {
             Ok(f) => f,
@@ -7566,6 +8054,18 @@ impl AletheiaMcpServer {
         // Cursor paging is not supported for the declarative query tool in v1
         // (Issue #3360); captured before `args` is consumed by deserialization.
         let cursor_requested = Self::cursor_requested(&args);
+
+        // Issue #3349: declarative (AQL/Cypher) namespace scoping is a follow-up;
+        // a narrowing scope is rejected (never silently unscoped). Captured
+        // before `args` is consumed by deserialization.
+        if let Err(result) = self.reject_unsupported_scope(
+            &args.get("namespace").cloned(),
+            "declarative (AQL/Cypher) namespace scoping is not supported by the query tool in v1; \
+             use USE NAMESPACE in the query language when it lands, or the structured scoped read \
+             tools. Pass \"all\" to run unscoped.",
+        ) {
+            return result;
+        }
 
         let req: QueryRequest = match serde_json::from_value(args) {
             Ok(r) => r,

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -88,6 +88,7 @@ mod node_tests {
     /// Helper to create two `Person` nodes and return their IDs.
     fn create_two_nodes(server: &AletheiaMcpServer) -> (u64, u64) {
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -96,6 +97,7 @@ mod node_tests {
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -111,6 +113,7 @@ mod node_tests {
         let server = create_test_server();
 
         let req = CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -134,6 +137,7 @@ mod node_tests {
         props.insert("age".to_string(), serde_json::json!(30));
 
         let req = CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -161,6 +165,7 @@ mod node_tests {
         props.insert("name".to_string(), serde_json::json!("Bob"));
 
         let create_req = CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -213,6 +218,7 @@ mod node_tests {
         props.insert("age".to_string(), serde_json::json!(25));
 
         let create_req = CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -229,6 +235,7 @@ mod node_tests {
         new_props.insert("city".to_string(), serde_json::json!("London"));
 
         let update_req = UpdateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             node_id: created.id,
@@ -252,6 +259,7 @@ mod node_tests {
 
         // Create a node
         let create_req = CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "ToDelete".to_string(),
@@ -265,6 +273,7 @@ mod node_tests {
 
         // Delete it
         let delete_req = DeleteNodeRequest {
+            namespace: None,
             node_id,
             detach: None,
             valid_time: None,
@@ -295,6 +304,7 @@ mod node_tests {
         let (source_id, target_id) = create_two_nodes(&server);
 
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id,
@@ -305,6 +315,7 @@ mod node_tests {
         });
 
         let delete_response = server.delete_node(DeleteNodeRequest {
+            namespace: None,
             node_id: source_id,
             detach: None,
             valid_time: None,
@@ -334,6 +345,7 @@ mod node_tests {
 
         // A third node so we have both an outgoing and an incoming edge.
         let third = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -344,6 +356,7 @@ mod node_tests {
         let third_id = third_id.id;
 
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id,
@@ -353,6 +366,7 @@ mod node_tests {
             provenance: None,
         });
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: third_id,
@@ -363,6 +377,7 @@ mod node_tests {
         });
 
         let delete_response = server.delete_node(DeleteNodeRequest {
+            namespace: None,
             node_id: source_id,
             detach: Some(true),
             valid_time: None,
@@ -415,6 +430,7 @@ mod node_tests {
         // A node with no edges deletes cleanly and reports zero edges removed.
         let server = create_test_server();
         let created: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Lonely".to_string(),
@@ -424,6 +440,7 @@ mod node_tests {
         .unwrap();
 
         let delete_response = server.delete_node(DeleteNodeRequest {
+            namespace: None,
             node_id: created.id,
             detach: None,
             valid_time: None,
@@ -444,6 +461,7 @@ mod node_tests {
             props.insert("index".to_string(), serde_json::json!(i));
 
             let req = CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "ListTest".to_string(),
@@ -476,6 +494,7 @@ mod node_tests {
         // Create nodes with different labels
         for _ in 0..3 {
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "TypeA".to_string(),
@@ -486,6 +505,7 @@ mod node_tests {
 
         for _ in 0..2 {
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "TypeB".to_string(),
@@ -520,6 +540,7 @@ mod node_tests {
             props.insert("index".to_string(), serde_json::json!(i));
 
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Paginated".to_string(),
@@ -572,6 +593,7 @@ mod node_tests {
         // Create some nodes
         for _ in 0..3 {
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Counted".to_string(),
@@ -593,6 +615,7 @@ mod node_tests {
         // Create nodes with different labels
         for _ in 0..3 {
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "CountA".to_string(),
@@ -603,6 +626,7 @@ mod node_tests {
 
         for _ in 0..2 {
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "CountB".to_string(),
@@ -634,6 +658,7 @@ mod edge_tests {
 
     fn create_two_nodes(server: &AletheiaMcpServer) -> (u64, u64) {
         let node1 = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -647,6 +672,7 @@ mod edge_tests {
         let n1: NodeResponse = parse_response(&node1).unwrap();
 
         let node2 = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -668,6 +694,7 @@ mod edge_tests {
         let (source_id, target_id) = create_two_nodes(&server);
 
         let req = CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id,
@@ -695,6 +722,7 @@ mod edge_tests {
         props.insert("strength".to_string(), serde_json::json!(0.9));
 
         let req = CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id,
@@ -723,6 +751,7 @@ mod edge_tests {
         let (source_id, target_id) = create_two_nodes(&server);
 
         let create_response = server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id,
@@ -750,6 +779,7 @@ mod edge_tests {
         let (source_id, target_id) = create_two_nodes(&server);
 
         let create_response = server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id,
@@ -764,6 +794,7 @@ mod edge_tests {
         new_props.insert("weight".to_string(), serde_json::json!(0.5));
 
         let update_response = server.update_edge(UpdateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             edge_id: created.id,
@@ -784,6 +815,7 @@ mod edge_tests {
         let (source_id, target_id) = create_two_nodes(&server);
 
         let create_response = server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id,
@@ -795,6 +827,7 @@ mod edge_tests {
         let created: EdgeResponse = parse_response(&create_response).unwrap();
 
         let delete_response = server.delete_edge(DeleteEdgeRequest {
+            namespace: None,
             edge_id: created.id,
             valid_time: None,
         });
@@ -817,6 +850,7 @@ mod edge_tests {
 
         // Create node3
         let node3 = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -827,6 +861,7 @@ mod edge_tests {
 
         // Create edges
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n1,
@@ -836,6 +871,7 @@ mod edge_tests {
             provenance: None,
         });
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n2,
@@ -870,6 +906,7 @@ mod edge_tests {
         assert_eq!(value.get("count"), Some(&serde_json::json!(0)));
 
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n1,
@@ -891,6 +928,7 @@ mod edge_tests {
 
         // Create node3
         let node3 = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -901,6 +939,7 @@ mod edge_tests {
 
         // Create edges from n1
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n1,
@@ -910,6 +949,7 @@ mod edge_tests {
             provenance: None,
         });
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n1,
@@ -945,6 +985,7 @@ mod edge_tests {
 
         // Create node3
         let node3 = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -955,6 +996,7 @@ mod edge_tests {
 
         // Create edges to n2
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n1,
@@ -964,6 +1006,7 @@ mod edge_tests {
             provenance: None,
         });
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n3.id,
@@ -995,6 +1038,7 @@ mod traversal_tests {
         let nodes: Vec<u64> = (0..4)
             .map(|i| {
                 let response = server.create_node(CreateNodeRequest {
+                    namespace: None,
                     derived_from: None,
                     valid_time: None,
                     label: "Node".to_string(),
@@ -1013,6 +1057,7 @@ mod traversal_tests {
         // Create edges
         for i in 0..3 {
             server.create_edge(CreateEdgeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 source_id: nodes[i],
@@ -1205,6 +1250,7 @@ mod vector_tests {
             );
 
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Document".to_string(),
@@ -1241,6 +1287,7 @@ mod temporal_tests {
 
         // Create a node
         let node_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -1266,6 +1313,7 @@ mod temporal_tests {
 
         // Create a node
         let node_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -1301,6 +1349,7 @@ mod temporal_tests {
 
         // Create nodes and edge
         let n1_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -1310,6 +1359,7 @@ mod temporal_tests {
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
         let n2_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -1319,6 +1369,7 @@ mod temporal_tests {
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
         let edge_response = server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n1.id,
@@ -1364,6 +1415,7 @@ mod temporal_tests {
     fn test_list_changes_success_shape() {
         let server = create_test_server();
         server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -1404,6 +1456,7 @@ mod temporal_tests {
     fn test_list_changes_empty_window_is_success() {
         let server = create_test_server();
         server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -1669,6 +1722,7 @@ mod changefeed_await_tests {
         // Window: created (Alice) + modified (Alice) + created (Carol) +
         // deleted (Carol) → a mix of all three change types.
         let alice: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -1679,6 +1733,7 @@ mod changefeed_await_tests {
         let mut bumped = HashMap::new();
         bumped.insert("age".to_string(), serde_json::json!(31));
         server.update_node(UpdateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             node_id: alice.id,
@@ -1686,6 +1741,7 @@ mod changefeed_await_tests {
             provenance: None,
         });
         let carol: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -1694,6 +1750,7 @@ mod changefeed_await_tests {
         }))
         .expect("create Carol");
         server.delete_node(DeleteNodeRequest {
+            namespace: None,
             node_id: carol.id,
             detach: None,
             valid_time: None,
@@ -1737,6 +1794,7 @@ mod changefeed_await_tests {
         // Four created changes; NONE are deletes.
         for _ in 0..4 {
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Person".to_string(),
@@ -1822,6 +1880,7 @@ mod hybrid_tests {
 
         // Create nodes
         let n1_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -1835,6 +1894,7 @@ mod hybrid_tests {
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
         let n2_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -1873,6 +1933,7 @@ mod hybrid_tests {
         // Create nodes with different labels
         for _ in 0..3 {
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Person".to_string(),
@@ -1883,6 +1944,7 @@ mod hybrid_tests {
 
         for _ in 0..2 {
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Document".to_string(),
@@ -1947,6 +2009,7 @@ mod hybrid_tests {
 
         // Create a simple graph
         let n1_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -1956,6 +2019,7 @@ mod hybrid_tests {
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
         let n2_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -1965,6 +2029,7 @@ mod hybrid_tests {
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n1.id,
@@ -2014,6 +2079,7 @@ mod conversion_tests {
         props.insert("array_val".to_string(), serde_json::json!([1, 2, 3]));
 
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Test".to_string(),
@@ -2049,6 +2115,7 @@ mod conversion_tests {
         );
 
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Document".to_string(),
@@ -2151,6 +2218,7 @@ mod coverage_tests {
 
         // Create a node first
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Event".to_string(),
@@ -2186,6 +2254,7 @@ mod coverage_tests {
 
         // Create a node first
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Event".to_string(),
@@ -2219,6 +2288,7 @@ mod coverage_tests {
 
         // Create a node first
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Event".to_string(),
@@ -2275,6 +2345,7 @@ mod coverage_tests {
         // Create a few nodes
         for i in 0..5 {
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "OffsetTest".to_string(),
@@ -2314,6 +2385,7 @@ mod coverage_tests {
         let mut prev_id: Option<u64> = None;
         for i in 0..5 {
             let response = server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "ChainNode".to_string(),
@@ -2328,6 +2400,7 @@ mod coverage_tests {
 
             if let Some(source_id) = prev_id {
                 server.create_edge(CreateEdgeRequest {
+                    namespace: None,
                     derived_from: None,
                     valid_time: None,
                     source_id,
@@ -2408,6 +2481,7 @@ mod error_handling_tests {
         let server = create_test_server();
 
         let req = UpdateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             node_id: 999999,
@@ -2426,6 +2500,7 @@ mod error_handling_tests {
         let server = create_test_server();
 
         let req = DeleteNodeRequest {
+            namespace: None,
             node_id: 999999,
             detach: None,
             valid_time: None,
@@ -2457,6 +2532,7 @@ mod error_handling_tests {
         let server = create_test_server();
 
         let req = UpdateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             edge_id: 999999,
@@ -2475,6 +2551,7 @@ mod error_handling_tests {
         let server = create_test_server();
 
         let req = DeleteEdgeRequest {
+            namespace: None,
             edge_id: 999999,
             valid_time: None,
         };
@@ -2491,6 +2568,7 @@ mod error_handling_tests {
 
         // Create only target node
         let target_resp = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Target".to_string(),
@@ -2501,6 +2579,7 @@ mod error_handling_tests {
 
         // Try to create edge with non-existent source
         let req = CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: 999999,
@@ -2522,6 +2601,7 @@ mod error_handling_tests {
 
         // Create only source node
         let source_resp = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Source".to_string(),
@@ -2532,6 +2612,7 @@ mod error_handling_tests {
 
         // Try to create edge with non-existent target
         let req = CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: source.id,
@@ -2664,6 +2745,7 @@ mod temporal_extended_tests {
 
         // Create a node
         let node_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Event".to_string(),
@@ -2709,6 +2791,7 @@ mod temporal_extended_tests {
 
         // Create nodes and edge
         let n1_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -2718,6 +2801,7 @@ mod temporal_extended_tests {
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
         let n2_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -2727,6 +2811,7 @@ mod temporal_extended_tests {
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
         let edge_response = server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n1.id,
@@ -2761,6 +2846,7 @@ mod temporal_extended_tests {
         let server = create_test_server();
 
         let node_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Test".to_string(),
@@ -2792,6 +2878,7 @@ mod temporal_extended_tests {
 
         // Create nodes and edge
         let n1_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -2801,6 +2888,7 @@ mod temporal_extended_tests {
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
         let n2_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -2810,6 +2898,7 @@ mod temporal_extended_tests {
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
         let edge_response = server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n1.id,
@@ -2836,6 +2925,7 @@ mod temporal_extended_tests {
         let server = create_test_server();
 
         let node_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Event".to_string(),
@@ -2875,6 +2965,7 @@ mod traversal_extended_tests {
         let nodes: Vec<u64> = (0..3)
             .map(|i| {
                 let response = server.create_node(CreateNodeRequest {
+                    namespace: None,
                     derived_from: None,
                     valid_time: None,
                     label: "BiNode".to_string(),
@@ -2893,6 +2984,7 @@ mod traversal_extended_tests {
         // Create bidirectional edges
         for i in 0..2 {
             server.create_edge(CreateEdgeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 source_id: nodes[i],
@@ -2902,6 +2994,7 @@ mod traversal_extended_tests {
                 provenance: None,
             });
             server.create_edge(CreateEdgeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 source_id: nodes[i + 1],
@@ -2954,6 +3047,7 @@ mod traversal_extended_tests {
 
         let a = {
             let response = server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Node".to_string(),
@@ -2965,6 +3059,7 @@ mod traversal_extended_tests {
         };
         let b = {
             let response = server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Node".to_string(),
@@ -2976,6 +3071,7 @@ mod traversal_extended_tests {
         };
         // Only B -> A exists; A has no outgoing edge back to B.
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: b,
@@ -3013,6 +3109,7 @@ mod traversal_extended_tests {
 
         // Create a single node
         let node_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Lonely".to_string(),
@@ -3046,6 +3143,7 @@ mod traversal_extended_tests {
 
         // Create A -> B
         let n1_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Node".to_string(),
@@ -3055,6 +3153,7 @@ mod traversal_extended_tests {
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
         let n2_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Node".to_string(),
@@ -3064,6 +3163,7 @@ mod traversal_extended_tests {
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n1.id,
@@ -3097,6 +3197,7 @@ mod traversal_extended_tests {
 
         // Create a star graph: center -> 10 spokes
         let center_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Center".to_string(),
@@ -3107,6 +3208,7 @@ mod traversal_extended_tests {
 
         for i in 0..10 {
             let spoke_response = server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Spoke".to_string(),
@@ -3120,6 +3222,7 @@ mod traversal_extended_tests {
             let spoke: NodeResponse = parse_response(&spoke_response).unwrap();
 
             server.create_edge(CreateEdgeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 source_id: center.id,
@@ -3162,6 +3265,7 @@ mod hybrid_extended_tests {
 
         // Create a node
         let node_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -3212,6 +3316,7 @@ mod hybrid_extended_tests {
         let nodes: Vec<u64> = (0..4)
             .map(|i| {
                 let response = server.create_node(CreateNodeRequest {
+                    namespace: None,
                     derived_from: None,
                     valid_time: None,
                     label: "ChainNode".to_string(),
@@ -3229,6 +3334,7 @@ mod hybrid_extended_tests {
 
         for i in 0..3 {
             server.create_edge(CreateEdgeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 source_id: nodes[i],
@@ -3266,6 +3372,7 @@ mod hybrid_extended_tests {
         let server = create_test_server();
 
         let node_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Test".to_string(),
@@ -3303,6 +3410,7 @@ mod hybrid_extended_tests {
         let server = create_test_server();
 
         let node_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Test".to_string(),
@@ -3342,6 +3450,7 @@ mod hybrid_extended_tests {
         // Create some nodes
         for i in 0..5 {
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "LimitTest".to_string(),
@@ -3419,6 +3528,7 @@ mod edge_extended_tests {
 
         // Create nodes
         let n1_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -3428,6 +3538,7 @@ mod edge_extended_tests {
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
         let n2_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -3438,6 +3549,7 @@ mod edge_extended_tests {
 
         // Create edges with different labels
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n1.id,
@@ -3447,6 +3559,7 @@ mod edge_extended_tests {
             provenance: None,
         });
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n1.id,
@@ -3476,6 +3589,7 @@ mod edge_extended_tests {
 
         // Create nodes and edges
         let n1_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -3485,6 +3599,7 @@ mod edge_extended_tests {
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
         let n2_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -3494,6 +3609,7 @@ mod edge_extended_tests {
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n1.id,
@@ -3526,6 +3642,7 @@ mod edge_extended_tests {
 
         // Create nodes
         let n1_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -3535,6 +3652,7 @@ mod edge_extended_tests {
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
         let n2_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -3544,6 +3662,7 @@ mod edge_extended_tests {
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
         let n3_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -3554,6 +3673,7 @@ mod edge_extended_tests {
 
         // Create edges with different labels pointing to n2
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n1.id,
@@ -3563,6 +3683,7 @@ mod edge_extended_tests {
             provenance: None,
         });
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n3.id,
@@ -3602,6 +3723,7 @@ mod list_nodes_extended_tests {
         // Create some nodes
         for i in 0..3 {
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: format!("Type{}", i),
@@ -3636,6 +3758,7 @@ mod list_nodes_extended_tests {
         // Create a few nodes
         for i in 0..5 {
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "LimitCap".to_string(),
@@ -3676,6 +3799,7 @@ mod list_nodes_extended_tests {
 
         // Create nodes with different names
         server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -3687,6 +3811,7 @@ mod list_nodes_extended_tests {
             provenance: None,
         });
         server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -3698,6 +3823,7 @@ mod list_nodes_extended_tests {
             provenance: None,
         });
         server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -3729,6 +3855,7 @@ mod list_nodes_extended_tests {
         let server = create_test_server();
 
         server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Sensor".to_string(),
@@ -3740,6 +3867,7 @@ mod list_nodes_extended_tests {
             provenance: None,
         });
         server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Sensor".to_string(),
@@ -3774,6 +3902,7 @@ mod list_nodes_extended_tests {
         let server = create_test_server();
 
         server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Item".to_string(),
@@ -3848,6 +3977,7 @@ mod list_nodes_extended_tests {
         // Create 5 nodes with same property
         for _ in 0..5 {
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Widget".to_string(),
@@ -3916,6 +4046,7 @@ mod query_tool_tests {
         let mut props = HashMap::new();
         props.insert("name".to_string(), serde_json::json!(name));
         let resp = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: label.to_string(),
@@ -4214,6 +4345,7 @@ mod query_tool_tests {
             props.insert("name".to_string(), serde_json::json!(name));
             props.insert("dept".to_string(), serde_json::json!(dept));
             let resp = server.create_node(CreateNodeRequest {
+                namespace: None,
                 valid_time: None,
                 label: "Person".to_string(),
                 properties: Some(props),
@@ -5050,6 +5182,7 @@ mod constraint_tests {
         let mut props = HashMap::new();
         props.insert("email".to_string(), serde_json::json!("dup@x"));
         server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -5057,6 +5190,7 @@ mod constraint_tests {
             provenance: None,
         });
         server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -5130,6 +5264,7 @@ mod constraint_tests {
         props.insert("email".to_string(), serde_json::json!("alice@x"));
 
         let first_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -5140,6 +5275,7 @@ mod constraint_tests {
             parse_response(&first_response).expect("first create must succeed");
 
         let dup_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -5176,6 +5312,7 @@ mod constraint_tests {
         let mut props_a = HashMap::new();
         props_a.insert("email".to_string(), serde_json::json!("a@x"));
         let resp_a = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -5187,6 +5324,7 @@ mod constraint_tests {
         let mut props_b = HashMap::new();
         props_b.insert("email".to_string(), serde_json::json!("b@x"));
         server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -5197,6 +5335,7 @@ mod constraint_tests {
         let mut collision = HashMap::new();
         collision.insert("email".to_string(), serde_json::json!("b@x"));
         let update_response = server.update_node(UpdateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             node_id: node_a.id,
@@ -5227,6 +5366,7 @@ mod constraint_tests {
         let server = create_test_server();
 
         let response = server.update_node(UpdateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             node_id: 99999,
@@ -5285,6 +5425,7 @@ mod schema_tests {
         let server = create_test_server();
 
         let alice_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -5298,6 +5439,7 @@ mod schema_tests {
         let alice: NodeResponse = parse_response(&alice_response).unwrap();
 
         let bob_response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -5311,6 +5453,7 @@ mod schema_tests {
         let bob: NodeResponse = parse_response(&bob_response).unwrap();
 
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: alice.id,
@@ -5372,6 +5515,7 @@ mod schema_tests {
         let server = create_test_server();
 
         server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Report".to_string(),
@@ -5409,6 +5553,7 @@ mod schema_tests {
         let server = create_test_server();
 
         server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Invoice".to_string(),
@@ -5450,6 +5595,7 @@ mod schema_tests {
 
         // Create a node now.
         server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Gadget".to_string(),
@@ -5502,6 +5648,7 @@ mod schema_tests {
 
         for _ in 0..3 {
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Person".to_string(),
@@ -5511,6 +5658,7 @@ mod schema_tests {
         }
         for _ in 0..2 {
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Company".to_string(),
@@ -5519,6 +5667,7 @@ mod schema_tests {
             });
         }
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -5527,6 +5676,7 @@ mod schema_tests {
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Company".to_string(),
@@ -5535,6 +5685,7 @@ mod schema_tests {
         }))
         .unwrap();
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n1.id,
@@ -5596,6 +5747,7 @@ mod vector_elision_tests {
             serde_json::json!(embedding.clone()),
         );
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Document".to_string(),
@@ -5758,6 +5910,7 @@ mod vector_elision_tests {
     fn test_get_edge_and_outgoing_incoming_edges_elide_vectors_by_default() {
         let server = create_test_server();
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -5766,6 +5919,7 @@ mod vector_elision_tests {
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -5778,6 +5932,7 @@ mod vector_elision_tests {
         let mut props = HashMap::new();
         props.insert("embedding".to_string(), serde_json::json!(embedding));
         let edge_response = server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n1.id,
@@ -5868,6 +6023,7 @@ mod vector_elision_tests {
         let (n1_id, _) = create_node_with_embedding(&server, 5);
         let (n2_id, _) = create_node_with_embedding(&server, 5);
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n1_id,
@@ -5939,6 +6095,7 @@ mod vector_elision_tests {
                 ]),
             );
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Document".to_string(),
@@ -6005,6 +6162,7 @@ mod vector_elision_tests {
                 ]),
             );
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Document".to_string(),
@@ -6068,6 +6226,7 @@ mod vector_elision_tests {
         let (n1_id, _) = create_node_with_embedding(&server, 4);
         let (n2_id, _) = create_node_with_embedding(&server, 4);
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: n1_id,
@@ -6173,6 +6332,7 @@ mod vector_elision_tests {
             serde_json::json!([0.1, 0.2, 0.3, 0.4]),
         );
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Document".to_string(),
@@ -6196,6 +6356,7 @@ mod vector_elision_tests {
             serde_json::json!([0.5, 0.6, 0.7, 0.8]),
         );
         let update_response = server.update_node(UpdateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             node_id: node.id,
@@ -6226,6 +6387,7 @@ mod vector_elision_tests {
         props.insert("tags".to_string(), serde_json::json!(["a", "b", "c"]));
 
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -6266,6 +6428,7 @@ mod retraction_tests {
     /// Create a Person node whose valid_from is `hours` hours before `now`.
     fn create_person_at(server: &AletheiaMcpServer, now: DateTime<Utc>, hours: i64) -> u64 {
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -6385,6 +6548,7 @@ mod retraction_tests {
         let a = create_person_at(&server, now, 2);
         let b = create_person_at(&server, now, 2);
         let _edge: EdgeResponse = parse_response(&server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id: a,
             target_id: b,
@@ -6431,6 +6595,7 @@ mod retraction_tests {
         let a = create_person_at(&server, now, 3);
         let b = create_person_at(&server, now, 3);
         let edge: EdgeResponse = parse_response(&server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id: a,
             target_id: b,
@@ -6586,6 +6751,7 @@ mod retraction_tests {
         let a = create_person_at(&server, now, 2);
         let b = create_person_at(&server, now, 2);
         let edge: EdgeResponse = parse_response(&server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id: a,
             target_id: b,
@@ -6652,6 +6818,7 @@ mod retraction_tests {
         let now = Utc::now();
         let a = create_person_at(&server, now, 3);
         let _self_loop: EdgeResponse = parse_response(&server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id: a,
             target_id: a,
@@ -6704,6 +6871,7 @@ mod retraction_tests {
         let b = create_person_at(&server, now, 3);
         let c = create_person_at(&server, now, 3);
         let e_out: EdgeResponse = parse_response(&server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id: x,
             target_id: b,
@@ -6714,6 +6882,7 @@ mod retraction_tests {
         }))
         .unwrap();
         let e_in: EdgeResponse = parse_response(&server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id: c,
             target_id: x,
@@ -6805,6 +6974,7 @@ mod valid_time_write_tests {
         let now = Utc::now();
 
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -6842,6 +7012,7 @@ mod valid_time_write_tests {
 
         let server = create_test_server();
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -6865,6 +7036,7 @@ mod valid_time_write_tests {
         let server = create_test_server();
 
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -6887,6 +7059,7 @@ mod valid_time_write_tests {
         let now = Utc::now();
 
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -6909,6 +7082,7 @@ mod valid_time_write_tests {
         let now = Utc::now();
 
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -6917,6 +7091,7 @@ mod valid_time_write_tests {
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -6926,6 +7101,7 @@ mod valid_time_write_tests {
         .unwrap();
 
         let response = server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id: n1.id,
             target_id: n2.id,
@@ -6961,6 +7137,7 @@ mod valid_time_write_tests {
         let mut props = HashMap::new();
         props.insert("city".to_string(), serde_json::json!("Paris"));
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: Some(props),
@@ -6973,6 +7150,7 @@ mod valid_time_write_tests {
         update_props.insert("city".to_string(), serde_json::json!("London"));
         let update_valid_time = rfc3339_hours_ago(now, 1);
         let response = server.update_node(UpdateNodeRequest {
+            namespace: None,
             derived_from: None,
             node_id: node.id,
             properties: update_props,
@@ -7004,6 +7182,7 @@ mod valid_time_write_tests {
         let server = create_test_server();
 
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7015,6 +7194,7 @@ mod valid_time_write_tests {
         let mut update_props = HashMap::new();
         update_props.insert("name".to_string(), serde_json::json!("Bob"));
         let response = server.update_node(UpdateNodeRequest {
+            namespace: None,
             derived_from: None,
             node_id: node.id,
             properties: update_props,
@@ -7037,6 +7217,7 @@ mod valid_time_write_tests {
         let now = Utc::now();
 
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7072,6 +7253,7 @@ mod valid_time_write_tests {
         let now = Utc::now();
 
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7080,6 +7262,7 @@ mod valid_time_write_tests {
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7091,6 +7274,7 @@ mod valid_time_write_tests {
         let mut props = HashMap::new();
         props.insert("strength".to_string(), serde_json::json!(1));
         let edge: EdgeResponse = parse_response(&server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id: n1.id,
             target_id: n2.id,
@@ -7105,6 +7289,7 @@ mod valid_time_write_tests {
         update_props.insert("strength".to_string(), serde_json::json!(9));
         let update_valid_time = rfc3339_hours_ago(now, 1);
         let response = server.update_edge(UpdateEdgeRequest {
+            namespace: None,
             derived_from: None,
             edge_id: edge.id,
             properties: update_props,
@@ -7140,6 +7325,7 @@ mod valid_time_write_tests {
         let now = Utc::now();
 
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7148,6 +7334,7 @@ mod valid_time_write_tests {
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7157,6 +7344,7 @@ mod valid_time_write_tests {
         .unwrap();
 
         let response = server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id: n1.id,
             target_id: n2.id,
@@ -7187,6 +7375,7 @@ mod valid_time_write_tests {
         let now = Utc::now();
 
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7197,6 +7386,7 @@ mod valid_time_write_tests {
 
         let delete_valid_time = rfc3339_hours_ago(now, 1);
         let response = server.delete_node(DeleteNodeRequest {
+            namespace: None,
             node_id: node.id,
             detach: None,
             valid_time: Some(delete_valid_time.clone()),
@@ -7237,6 +7427,7 @@ mod valid_time_write_tests {
         let now = Utc::now();
 
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7245,6 +7436,7 @@ mod valid_time_write_tests {
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7253,6 +7445,7 @@ mod valid_time_write_tests {
         }))
         .unwrap();
         let edge: EdgeResponse = parse_response(&server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id: n1.id,
             target_id: n2.id,
@@ -7265,6 +7458,7 @@ mod valid_time_write_tests {
 
         let delete_valid_time = rfc3339_hours_ago(now, 1);
         let response = server.delete_edge(DeleteEdgeRequest {
+            namespace: None,
             edge_id: edge.id,
             valid_time: Some(delete_valid_time.clone()),
         });
@@ -7305,6 +7499,7 @@ mod valid_time_write_tests {
         let now = Utc::now();
 
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7313,6 +7508,7 @@ mod valid_time_write_tests {
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7321,6 +7517,7 @@ mod valid_time_write_tests {
         }))
         .unwrap();
         parse_response::<EdgeResponse>(&server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id: n1.id,
             target_id: n2.id,
@@ -7332,6 +7529,7 @@ mod valid_time_write_tests {
         .unwrap();
 
         let response = server.delete_node(DeleteNodeRequest {
+            namespace: None,
             node_id: n1.id,
             detach: Some(true),
             valid_time: Some(rfc3339_hours_ago(now, 1)),
@@ -7356,6 +7554,7 @@ mod valid_time_write_tests {
         let server = create_test_server();
 
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7364,6 +7563,7 @@ mod valid_time_write_tests {
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7372,6 +7572,7 @@ mod valid_time_write_tests {
         }))
         .unwrap();
         parse_response::<EdgeResponse>(&server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id: n1.id,
             target_id: n2.id,
@@ -7383,6 +7584,7 @@ mod valid_time_write_tests {
         .unwrap();
 
         let response = server.delete_node(DeleteNodeRequest {
+            namespace: None,
             node_id: n1.id,
             detach: Some(true),
             valid_time: None,
@@ -7406,6 +7608,7 @@ mod provenance_write_tests {
         let server = create_test_server();
 
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7439,6 +7642,7 @@ mod provenance_write_tests {
         let server = create_test_server();
 
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7457,6 +7661,7 @@ mod provenance_write_tests {
         let server = create_test_server();
 
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7480,6 +7685,7 @@ mod provenance_write_tests {
         let server = create_test_server();
 
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7509,6 +7715,7 @@ mod provenance_write_tests {
         let server = create_test_server();
 
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7535,6 +7742,7 @@ mod provenance_write_tests {
 
         for confidence in [0.0, 1.0] {
             let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 label: "Person".to_string(),
                 properties: None,
@@ -7556,6 +7764,7 @@ mod provenance_write_tests {
         let server = create_test_server();
 
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7565,6 +7774,7 @@ mod provenance_write_tests {
         .unwrap();
 
         let updated: NodeResponse = parse_response(&server.update_node(UpdateNodeRequest {
+            namespace: None,
             derived_from: None,
             node_id: node.id,
             properties: HashMap::new(),
@@ -7598,6 +7808,7 @@ mod provenance_write_tests {
         let server = create_test_server();
 
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7607,6 +7818,7 @@ mod provenance_write_tests {
         .unwrap();
 
         let response = server.update_node(UpdateNodeRequest {
+            namespace: None,
             derived_from: None,
             node_id: node.id,
             properties: HashMap::new(),
@@ -7632,6 +7844,7 @@ mod provenance_write_tests {
         let server = create_test_server();
 
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7640,6 +7853,7 @@ mod provenance_write_tests {
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7649,6 +7863,7 @@ mod provenance_write_tests {
         .unwrap();
 
         let edge: EdgeResponse = parse_response(&server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id: n1.id,
             target_id: n2.id,
@@ -7678,6 +7893,7 @@ mod provenance_write_tests {
         let server = create_test_server();
 
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7686,6 +7902,7 @@ mod provenance_write_tests {
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7695,6 +7912,7 @@ mod provenance_write_tests {
         .unwrap();
 
         let response = server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id: n1.id,
             target_id: n2.id,
@@ -7718,6 +7936,7 @@ mod provenance_write_tests {
         let server = create_test_server();
 
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7726,6 +7945,7 @@ mod provenance_write_tests {
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7734,6 +7954,7 @@ mod provenance_write_tests {
         }))
         .unwrap();
         let edge: EdgeResponse = parse_response(&server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id: n1.id,
             target_id: n2.id,
@@ -7745,6 +7966,7 @@ mod provenance_write_tests {
         .unwrap();
 
         let _updated: EdgeResponse = parse_response(&server.update_edge(UpdateEdgeRequest {
+            namespace: None,
             derived_from: None,
             edge_id: edge.id,
             properties: HashMap::new(),
@@ -7771,6 +7993,7 @@ mod provenance_write_tests {
         let server = create_test_server();
 
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7797,6 +8020,7 @@ mod provenance_write_tests {
         let server = create_test_server();
 
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7818,6 +8042,7 @@ mod provenance_write_tests {
         let server = create_test_server();
 
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7841,6 +8066,7 @@ mod provenance_write_tests {
         let server = create_test_server();
 
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "ListProvenanceTest".to_string(),
             properties: None,
@@ -7874,6 +8100,7 @@ mod provenance_write_tests {
         let server = create_test_server();
 
         let start: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7882,6 +8109,7 @@ mod provenance_write_tests {
         }))
         .unwrap();
         let end: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7895,6 +8123,7 @@ mod provenance_write_tests {
         }))
         .unwrap();
         parse_response::<EdgeResponse>(&server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id: start.id,
             target_id: end.id,
@@ -7932,6 +8161,7 @@ mod provenance_write_tests {
         let server = create_test_server();
 
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: None,
@@ -7953,6 +8183,7 @@ mod provenance_write_tests {
         // Update with different provenance; the as-of query above must still
         // report the *original* version's provenance, not this new one.
         parse_response::<NodeResponse>(&server.update_node(UpdateNodeRequest {
+            namespace: None,
             derived_from: None,
             node_id: node.id,
             properties: HashMap::new(),
@@ -7993,6 +8224,7 @@ mod traverse_as_of_tests {
 
     fn create_node_at(server: &AletheiaMcpServer, label: &str, valid_time: &str) -> u64 {
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: label.to_string(),
             properties: None,
@@ -8011,6 +8243,7 @@ mod traverse_as_of_tests {
         valid_time: &str,
     ) -> u64 {
         let response = server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id,
             target_id,
@@ -8098,6 +8331,7 @@ mod traverse_as_of_tests {
 
         // Retire (delete) the edge, backdating the retirement itself.
         let delete_response = server.delete_edge(DeleteEdgeRequest {
+            namespace: None,
             edge_id,
             valid_time: Some(hours_ago(now, 2)),
         });
@@ -8545,6 +8779,7 @@ mod completeness_tests {
             let mut props = HashMap::new();
             props.insert("index".to_string(), serde_json::json!(i));
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: label.to_string(),
@@ -8641,6 +8876,7 @@ mod completeness_tests {
         let server = create_test_server();
         for _ in 0..150 {
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "WidgetHM".to_string(),
@@ -8728,6 +8964,7 @@ mod completeness_tests {
     fn seed_star(server: &AletheiaMcpServer, out: usize) -> u64 {
         let center = {
             let r = server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Hub".to_string(),
@@ -8740,6 +8977,7 @@ mod completeness_tests {
         for _ in 0..out {
             let leaf = {
                 let r = server.create_node(CreateNodeRequest {
+                    namespace: None,
                     derived_from: None,
                     valid_time: None,
                     label: "Leaf".to_string(),
@@ -8750,6 +8988,7 @@ mod completeness_tests {
                 n.id
             };
             server.create_edge(CreateEdgeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 source_id: center,
@@ -8790,6 +9029,7 @@ mod completeness_tests {
         // Build a hub with 2 incoming edges.
         let sink = {
             let r = server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Sink".to_string(),
@@ -8802,6 +9042,7 @@ mod completeness_tests {
         for _ in 0..2 {
             let src = {
                 let r = server.create_node(CreateNodeRequest {
+                    namespace: None,
                     derived_from: None,
                     valid_time: None,
                     label: "Src".to_string(),
@@ -8812,6 +9053,7 @@ mod completeness_tests {
                 n.id
             };
             server.create_edge(CreateEdgeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 source_id: src,
@@ -8838,6 +9080,7 @@ mod completeness_tests {
         let ids: Vec<u64> = (0..=len)
             .map(|_| {
                 let r = server.create_node(CreateNodeRequest {
+                    namespace: None,
                     derived_from: None,
                     valid_time: None,
                     label: "ChainHM".to_string(),
@@ -8850,6 +9093,7 @@ mod completeness_tests {
             .collect();
         for w in ids.windows(2) {
             server.create_edge(CreateEdgeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 source_id: w[0],
@@ -8992,6 +9236,7 @@ mod completeness_tests {
             };
             props.insert("embedding".to_string(), serde_json::json!(embedding));
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Document".to_string(),
@@ -9316,6 +9561,7 @@ mod find_nodes_at_time_tests {
 
     fn create_named(server: &AletheiaMcpServer, label: &str, name: &str) -> u64 {
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: label.to_string(),
             properties: Some(HashMap::from([(
@@ -9331,6 +9577,7 @@ mod find_nodes_at_time_tests {
 
     fn rename(server: &AletheiaMcpServer, node_id: u64, name: &str) {
         let _: NodeResponse = parse_response(&server.update_node(UpdateNodeRequest {
+            namespace: None,
             derived_from: None,
             node_id,
             properties: HashMap::from([("name".to_string(), serde_json::json!(name))]),
@@ -9342,6 +9589,7 @@ mod find_nodes_at_time_tests {
 
     fn delete(server: &AletheiaMcpServer, node_id: u64) {
         let response = server.delete_node(DeleteNodeRequest {
+            namespace: None,
             node_id,
             detach: None,
             valid_time: None,
@@ -9736,6 +9984,7 @@ mod find_nodes_at_time_tests {
         let server = create_test_server();
         let embedding: Vec<f32> = (0..16).map(|i| (i as f32) * 0.001 + 0.1).collect();
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Document".to_string(),
             properties: Some(HashMap::from([
@@ -9915,6 +10164,7 @@ mod structured_error_tests {
 
     fn seed_node(server: &AletheiaMcpServer, label: &str, name: &str) -> u64 {
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: label.to_string(),
             properties: Some(HashMap::from([(
@@ -10653,6 +10903,7 @@ mod temporal_extent_tests {
 
     fn create_node_at(server: &AletheiaMcpServer, label: &str, valid_time: &str) -> NodeResponse {
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: Some(valid_time.to_string()),
             label: label.to_string(),
@@ -10731,6 +10982,7 @@ mod temporal_extent_tests {
         let alice = create_node_at(&server, "Person", "2021-03-01T00:00:00Z");
         let acme = create_node_at(&server, "Company", "2023-06-15T00:00:00Z");
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: Some("2024-01-01T00:00:00Z".to_string()),
             source_id: alice.id,
@@ -10775,6 +11027,7 @@ mod temporal_extent_tests {
         // backdated start must still bound `earliest` (extent covers ALL
         // recorded history, not just current state).
         server.update_node(UpdateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: Some("2025-01-01T00:00:00Z".to_string()),
             node_id: alice.id,
@@ -10808,6 +11061,7 @@ mod temporal_extent_tests {
         let alice = create_node_at(&server, "Person", "2021-03-01T00:00:00Z");
         let acme = create_node_at(&server, "Company", "2023-06-15T00:00:00Z");
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: Some("2024-01-01T00:00:00Z".to_string()),
             source_id: alice.id,
@@ -10868,6 +11122,7 @@ mod temporal_extent_tests {
 
         let alice = create_node_at(&server, "Person", "2021-03-01T00:00:00Z");
         let delete_response = server.delete_node(DeleteNodeRequest {
+            namespace: None,
             node_id: alice.id,
             detach: None,
             valid_time: None,
@@ -10993,6 +11248,7 @@ mod database_stats_tests {
 
         let (a, b) = {
             let a: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Person".to_string(),
@@ -11001,6 +11257,7 @@ mod database_stats_tests {
             }))
             .unwrap();
             let b: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Person".to_string(),
@@ -11011,6 +11268,7 @@ mod database_stats_tests {
             (a.id, b.id)
         };
         server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: a,
@@ -11021,6 +11279,7 @@ mod database_stats_tests {
         });
         // An update creates an extra node version beyond the creates.
         server.update_node(UpdateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             node_id: a,
@@ -11155,6 +11414,7 @@ mod database_stats_tests {
         assert!(lsn_before >= 1, "LSN starts at 1: {value}");
 
         server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -11188,6 +11448,7 @@ mod database_stats_tests {
     fn test_database_stats_matches_public_api() {
         let server = create_test_server();
         server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -11424,6 +11685,7 @@ mod database_stats_tests {
 
         let (a, b) = {
             let a: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Person".to_string(),
@@ -11432,6 +11694,7 @@ mod database_stats_tests {
             }))
             .unwrap();
             let b: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Person".to_string(),
@@ -11442,6 +11705,7 @@ mod database_stats_tests {
             (a.id, b.id)
         };
         let edge: EdgeResponse = parse_response(&server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             source_id: a,
@@ -11465,6 +11729,7 @@ mod database_stats_tests {
         // Delete the edge, then node `a` (now unconnected).
         let del_edge: serde_json::Value =
             serde_json::from_str(&server.delete_edge(DeleteEdgeRequest {
+                namespace: None,
                 edge_id: edge.id,
                 valid_time: None,
             }))
@@ -11472,6 +11737,7 @@ mod database_stats_tests {
         assert_eq!(del_edge.get("success"), Some(&serde_json::json!(true)));
         let del_node: serde_json::Value =
             serde_json::from_str(&server.delete_node(DeleteNodeRequest {
+                namespace: None,
                 node_id: a,
                 detach: None,
                 valid_time: None,
@@ -11553,6 +11819,7 @@ mod temporal_bounds_tests {
         let mut props = HashMap::new();
         props.insert("name".to_string(), serde_json::json!(name));
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Person".to_string(),
@@ -11570,6 +11837,7 @@ mod temporal_bounds_tests {
         target_id: u64,
     ) -> serde_json::Value {
         let response = server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id,
             target_id,
@@ -11727,6 +11995,7 @@ mod temporal_bounds_tests {
         let mut props = HashMap::new();
         props.insert("age".to_string(), serde_json::json!(31));
         let update_node_response = server.update_node(UpdateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             node_id: a,
@@ -11737,6 +12006,7 @@ mod temporal_bounds_tests {
         assert_current_open_bounds(&temporal_of(&updated_node));
 
         let update_edge_response = server.update_edge(UpdateEdgeRequest {
+            namespace: None,
             derived_from: None,
             edge_id,
             properties: props,
@@ -11762,6 +12032,7 @@ mod temporal_bounds_tests {
         let mut props = HashMap::new();
         props.insert("name".to_string(), serde_json::json!("Alice v2"));
         parse_response::<NodeResponse>(&server.update_node(UpdateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             node_id,
@@ -11828,6 +12099,7 @@ mod temporal_bounds_tests {
         let mut props = HashMap::new();
         props.insert("name".to_string(), serde_json::json!("Alice v2"));
         parse_response::<NodeResponse>(&server.update_node(UpdateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             node_id,
@@ -11918,6 +12190,7 @@ mod temporal_bounds_tests {
         let mut props = HashMap::new();
         props.insert("name".to_string(), serde_json::json!("Alice"));
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: Some(future.to_string()),
             label: "Person".to_string(),
@@ -11974,6 +12247,7 @@ mod temporal_bounds_tests {
         let mut props = HashMap::new();
         props.insert("name".to_string(), serde_json::json!("Alice"));
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: Some(backdated.to_string()),
             label: "Person".to_string(),
@@ -12013,6 +12287,7 @@ mod temporal_bounds_tests {
         std::thread::sleep(std::time::Duration::from_millis(5));
 
         let delete_response = server.delete_node(DeleteNodeRequest {
+            namespace: None,
             node_id,
             detach: None,
             valid_time: None,
@@ -12399,6 +12674,7 @@ mod apply_batch_tests {
     /// single-op tool and return its id.
     fn seed_person(server: &AletheiaMcpServer, name: &str) -> u64 {
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: Some(HashMap::from([(
@@ -12415,6 +12691,7 @@ mod apply_batch_tests {
     /// Seed a committed edge between two committed nodes and return its id.
     fn seed_edge(server: &AletheiaMcpServer, source: u64, target: u64) -> u64 {
         let edge: EdgeResponse = parse_response(&server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id: source,
             target_id: target,
@@ -13407,6 +13684,7 @@ mod apply_batch_tests {
             "constraint enable should succeed: {response}"
         );
         let _existing: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: Some(HashMap::from([(
@@ -13885,6 +14163,7 @@ mod per_request_now_tests {
         let mut props = HashMap::new();
         props.insert("name".to_string(), serde_json::json!(name));
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: label.to_string(),
             properties: Some(props),
@@ -14008,6 +14287,7 @@ mod per_request_now_tests {
         let mut props = HashMap::new();
         props.insert("name".to_string(), serde_json::json!(name));
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: label.to_string(),
             properties: Some(props),
@@ -14022,6 +14302,7 @@ mod per_request_now_tests {
     /// Create an edge between two nodes.
     fn create_test_edge(server: &AletheiaMcpServer, source_id: u64, target_id: u64) {
         let response = server.create_edge(CreateEdgeRequest {
+            namespace: None,
             derived_from: None,
             source_id,
             target_id,
@@ -14203,6 +14484,7 @@ mod per_request_now_tests {
                 ]),
             );
             let response = server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 label: "Document".to_string(),
                 properties: Some(props),
@@ -16639,6 +16921,7 @@ mod provenance_filter_tests {
             None
         };
         let n: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             valid_time: None,
             label: "Doc".to_string(),
@@ -16863,6 +17146,7 @@ mod provenance_filter_tests {
         let c = create_doc(&server, "c", None, None);
         for (target, source) in [(b, "crm"), (c, "hr")] {
             server.create_edge(CreateEdgeRequest {
+                namespace: None,
                 source_id: a,
                 target_id: target,
                 label: "LINK".to_string(),
@@ -16897,6 +17181,7 @@ mod provenance_filter_tests {
         let lo = create_doc(&server, "lo", Some("crm"), Some(0.2));
         for t in [hi, lo] {
             server.create_edge(CreateEdgeRequest {
+                namespace: None,
                 source_id: a,
                 target_id: t,
                 label: "LINK".to_string(),
@@ -16950,6 +17235,7 @@ mod provenance_filter_tests {
             );
             let source = if i % 2 == 0 { "trusted" } else { "other" };
             server.create_node(CreateNodeRequest {
+                namespace: None,
                 derived_from: None,
                 valid_time: None,
                 label: "Doc".to_string(),
@@ -17099,6 +17385,7 @@ mod semantic_search_tools_tests {
                 props.insert("name".to_string(), json!(name));
                 props.insert("embedding".to_string(), json!([vec[0], vec[1]]));
                 let resp = server.create_node(CreateNodeRequest {
+                    namespace: None,
                     derived_from: None,
                     valid_time: None,
                     label: "Doc".to_string(),
@@ -17116,6 +17403,7 @@ mod semantic_search_tools_tests {
 
             for (s, t) in [(a, b), (b, c), (a, d)] {
                 server.create_edge(CreateEdgeRequest {
+                    namespace: None,
                     source_id: s,
                     target_id: t,
                     label: "NEXT".to_string(),
@@ -17207,6 +17495,7 @@ mod semantic_search_tools_tests {
                 let mut props = HashMap::new();
                 props.insert("embedding".to_string(), json!([1.0, 0.0]));
                 let resp = server.create_node(CreateNodeRequest {
+                    namespace: None,
                     derived_from: None,
                     valid_time: None,
                     label: "Doc".to_string(),
@@ -17221,6 +17510,7 @@ mod semantic_search_tools_tests {
             let ids: Vec<u64> = (0..1100).map(|_| mk(&server)).collect();
             for w in ids.windows(2) {
                 server.create_edge(CreateEdgeRequest {
+                    namespace: None,
                     source_id: w[0],
                     target_id: w[1],
                     label: "NEXT".to_string(),
@@ -17788,5 +18078,197 @@ mod namespace_surface_sweep_tests {
         assert!(out.contains("name"), "expected schema payload: {out}");
         // ...but the ride-along key must never surface as a schema property key.
         assert_no_reserved(&out, "get_schema");
+    }
+
+    // ========================================================================
+    // BLOCK 1 (PR3a): write-tool `namespace` param round-trips through MCP
+    // ========================================================================
+
+    fn as_json(s: &str) -> serde_json::Value {
+        serde_json::from_str(s).expect("valid JSON response")
+    }
+
+    #[test]
+    fn create_node_in_namespace_surfaces_field_and_registers() {
+        let server = create_test_server();
+        let out = server.dispatch_tool_json(
+            "create_node",
+            serde_json::json!({
+                "label": "Person",
+                "properties": { "name": "Alice" },
+                "namespace": "agent:planner"
+            }),
+        );
+        let v = as_json(&out);
+        assert_eq!(
+            v.get("namespace").and_then(|n| n.as_str()),
+            Some("agent:planner"),
+            "create_node response must surface the namespace field: {out}"
+        );
+        assert_no_reserved(&out, "create_node");
+        // Read it back: the namespace persists and is surfaced on get_node.
+        let id = v.get("id").and_then(|i| i.as_u64()).expect("id");
+        let got = server.dispatch_tool_json("get_node", serde_json::json!({ "node_id": id }));
+        assert_eq!(
+            as_json(&got).get("namespace").and_then(|n| n.as_str()),
+            Some("agent:planner"),
+            "get_node must echo the namespace: {got}"
+        );
+        // The write auto-registered the namespace.
+        let names: Vec<String> = server
+            .db()
+            .list_namespaces()
+            .into_iter()
+            .map(|i| i.name)
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "agent:planner"),
+            "namespace should be auto-registered: {names:?}"
+        );
+    }
+
+    #[test]
+    fn create_node_default_omits_namespace_field() {
+        // Byte-identical back-compat (design AC1): a default-namespace create
+        // carries NO `namespace` field.
+        let server = create_test_server();
+        let out = server.dispatch_tool_json(
+            "create_node",
+            serde_json::json!({ "label": "Person", "properties": { "name": "Bob" } }),
+        );
+        assert!(
+            as_json(&out).get("namespace").is_none(),
+            "default-namespace response must omit the namespace field: {out}"
+        );
+        // An explicit "default" is equivalent to omitting it.
+        let out2 = server.dispatch_tool_json(
+            "create_node",
+            serde_json::json!({
+                "label": "Person", "properties": { "name": "Carol" },
+                "namespace": "default"
+            }),
+        );
+        assert!(
+            as_json(&out2).get("namespace").is_none(),
+            "explicit default must also omit the namespace field: {out2}"
+        );
+    }
+
+    #[test]
+    fn create_edge_in_namespace_surfaces_field() {
+        let server = create_test_server();
+        let a = server
+            .db()
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap()
+            .as_u64();
+        let b = server
+            .db()
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap()
+            .as_u64();
+        let out = server.dispatch_tool_json(
+            "create_edge",
+            serde_json::json!({
+                "source_id": a, "target_id": b, "label": "KNOWS",
+                "namespace": "agent:planner"
+            }),
+        );
+        assert_eq!(
+            as_json(&out).get("namespace").and_then(|n| n.as_str()),
+            Some("agent:planner"),
+            "create_edge response must surface the namespace field: {out}"
+        );
+        assert_no_reserved(&out, "create_edge");
+    }
+
+    #[test]
+    fn create_node_invalid_namespace_name_rejected() {
+        let server = create_test_server();
+        let out = server.dispatch_tool_json(
+            "create_node",
+            serde_json::json!({ "label": "Person", "namespace": "has space" }),
+        );
+        let v = as_json(&out);
+        assert_eq!(
+            v.pointer("/error/code").and_then(|c| c.as_str()),
+            Some("INVALID_ARGUMENT"),
+            "a malformed namespace name must be INVALID_ARGUMENT: {out}"
+        );
+    }
+
+    #[test]
+    fn update_node_with_namespace_rejected_immutable() {
+        let (server, a, _b) = seed_namespaced();
+        let out = server.dispatch_tool_json(
+            "update_node",
+            serde_json::json!({
+                "node_id": a, "properties": { "age": 31 },
+                "namespace": "agent:planner"
+            }),
+        );
+        assert_eq!(
+            as_json(&out)
+                .pointer("/error/code")
+                .and_then(|c| c.as_str()),
+            Some("INVALID_ARGUMENT"),
+            "supplying a namespace on update must be INVALID_ARGUMENT (immutable): {out}"
+        );
+    }
+
+    #[test]
+    fn delete_node_with_namespace_rejected_immutable() {
+        let (server, a, _b) = seed_namespaced();
+        let out = server.dispatch_tool_json(
+            "delete_node",
+            serde_json::json!({ "node_id": a, "detach": true, "namespace": "agent:planner" }),
+        );
+        assert_eq!(
+            as_json(&out)
+                .pointer("/error/code")
+                .and_then(|c| c.as_str()),
+            Some("INVALID_ARGUMENT"),
+            "supplying a namespace on delete must be INVALID_ARGUMENT (immutable): {out}"
+        );
+    }
+
+    #[test]
+    fn update_edge_and_delete_edge_with_namespace_rejected() {
+        let (server, a, b) = seed_namespaced();
+        // Find the edge id via outgoing edges.
+        let edges =
+            server.dispatch_tool_json("get_outgoing_edges", serde_json::json!({ "node_id": a }));
+        let edge_id = as_json(&edges)
+            .get("edges")
+            .and_then(|e| e.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|e| e.get("id"))
+            .and_then(|i| i.as_u64())
+            .unwrap_or_else(|| panic!("expected an outgoing edge from {a} to {b}: {edges}"));
+        let upd = server.dispatch_tool_json(
+            "update_edge",
+            serde_json::json!({
+                "edge_id": edge_id, "properties": { "since": 2021 },
+                "namespace": "agent:planner"
+            }),
+        );
+        assert_eq!(
+            as_json(&upd)
+                .pointer("/error/code")
+                .and_then(|c| c.as_str()),
+            Some("INVALID_ARGUMENT"),
+            "namespace on update_edge must be INVALID_ARGUMENT: {upd}"
+        );
+        let del = server.dispatch_tool_json(
+            "delete_edge",
+            serde_json::json!({ "edge_id": edge_id, "namespace": "agent:planner" }),
+        );
+        assert_eq!(
+            as_json(&del)
+                .pointer("/error/code")
+                .and_then(|c| c.as_str()),
+            Some("INVALID_ARGUMENT"),
+            "namespace on delete_edge must be INVALID_ARGUMENT: {del}"
+        );
     }
 }

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -178,6 +178,7 @@ mod node_tests {
 
         // Now get it
         let get_req = GetNodeRequest {
+            namespace: None,
             node_id: created.id,
             include_vectors: None,
         };
@@ -198,6 +199,7 @@ mod node_tests {
         let server = create_test_server();
 
         let req = GetNodeRequest {
+            namespace: None,
             node_id: 999999,
             include_vectors: None,
         };
@@ -286,6 +288,7 @@ mod node_tests {
 
         // Verify it's gone
         let get_req = GetNodeRequest {
+            namespace: None,
             node_id,
             include_vectors: None,
         };
@@ -329,6 +332,7 @@ mod node_tests {
 
         // The node must still exist (refused, not destroyed).
         let get_value: serde_json::Value = serde_json::from_str(&server.get_node(GetNodeRequest {
+            namespace: None,
             node_id: source_id,
             include_vectors: None,
         }))
@@ -390,6 +394,7 @@ mod node_tests {
 
         // Node is gone.
         let get_value: serde_json::Value = serde_json::from_str(&server.get_node(GetNodeRequest {
+            namespace: None,
             node_id: source_id,
             include_vectors: None,
         }))
@@ -473,6 +478,7 @@ mod node_tests {
 
         // List with label filter (required for listing nodes efficiently)
         let list_req = ListNodesRequest {
+            namespace: None,
             label: Some("ListTest".to_string()),
             property_key: None,
             property_value: None,
@@ -516,6 +522,7 @@ mod node_tests {
 
         // List only TypeA
         let list_req = ListNodesRequest {
+            namespace: None,
             label: Some("TypeA".to_string()),
             property_key: None,
             property_value: None,
@@ -551,6 +558,7 @@ mod node_tests {
 
         // Get first page (with label filter required for efficient listing)
         let page1_req = ListNodesRequest {
+            namespace: None,
             label: Some("Paginated".to_string()),
             property_key: None,
             property_value: None,
@@ -566,6 +574,7 @@ mod node_tests {
 
         // Get second page
         let page2_req = ListNodesRequest {
+            namespace: None,
             label: Some("Paginated".to_string()),
             property_key: None,
             property_value: None,
@@ -763,6 +772,7 @@ mod edge_tests {
         let created: EdgeResponse = parse_response(&create_response).unwrap();
 
         let get_response = server.get_edge(GetEdgeRequest {
+            namespace: None,
             edge_id: created.id,
             include_vectors: None,
         });
@@ -836,6 +846,7 @@ mod edge_tests {
 
         // Verify it's gone
         let get_response = server.get_edge(GetEdgeRequest {
+            namespace: None,
             edge_id: created.id,
             include_vectors: None,
         });
@@ -884,6 +895,7 @@ mod edge_tests {
         // Note: list_edges doesn't support listing all edges without a node
         // It returns a message indicating to use get_outgoing_edges or get_incoming_edges
         let list_response = server.list_edges(ListEdgesRequest {
+            namespace: None,
             label: None,
             limit: None,
             offset: None,
@@ -1077,6 +1089,7 @@ mod traversal_tests {
         let nodes = create_graph(&server);
 
         let response = server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: nodes[0],
             edge_label: "NEXT".to_string(),
             direction: Some("outgoing".to_string()),
@@ -1100,6 +1113,7 @@ mod traversal_tests {
         let nodes = create_graph(&server);
 
         let response = server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: nodes[0],
             edge_label: "NEXT".to_string(),
             direction: Some("outgoing".to_string()),
@@ -1124,6 +1138,7 @@ mod traversal_tests {
 
         // Traverse incoming from Node3 (should find Node2)
         let response = server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: nodes[3],
             edge_label: "NEXT".to_string(),
             direction: Some("incoming".to_string()),
@@ -1146,6 +1161,7 @@ mod traversal_tests {
         let nodes = create_graph(&server);
 
         let response = server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: nodes[0],
             edge_label: "NEXT".to_string(),
             direction: None,
@@ -1213,6 +1229,7 @@ mod vector_tests {
         let server = create_test_server();
 
         let response = server.find_similar(FindSimilarRequest {
+            namespace: None,
             property_name: "embedding".to_string(),
             embedding: vec![0.1, 0.2, 0.3, 0.4],
             k: Some(5),
@@ -1261,6 +1278,7 @@ mod vector_tests {
 
         // Search for similar
         let response = server.find_similar(FindSimilarRequest {
+            namespace: None,
             property_name: "embedding".to_string(),
             embedding: vec![0.1, 0.2, 0.3, 0.4],
             k: Some(3),
@@ -1298,6 +1316,7 @@ mod temporal_tests {
 
         // Try to get with invalid timestamp format
         let response = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id: node.id,
             valid_time: "invalid-timestamp".to_string(),
             transaction_time: None,
@@ -1333,6 +1352,7 @@ mod temporal_tests {
             .as_micros() as i64;
 
         let response = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id: node.id,
             valid_time: now_micros.to_string(),
             transaction_time: None,
@@ -1386,6 +1406,7 @@ mod temporal_tests {
             .as_micros() as i64;
 
         let response = server.get_edge_at_time(GetEdgeAtTimeRequest {
+            namespace: None,
             edge_id: edge.id,
             valid_time: now_micros.to_string(),
             transaction_time: None,
@@ -1909,6 +1930,7 @@ mod hybrid_tests {
 
         // Execute hybrid query starting from n1
         let response = server.hybrid_query(HybridQueryRequest {
+            namespace: None,
             start_node_id: Some(n1.id),
             traverse_edge: None,
             traverse_depth: None,
@@ -1955,6 +1977,7 @@ mod hybrid_tests {
 
         // Query only Person nodes
         let response = server.hybrid_query(HybridQueryRequest {
+            namespace: None,
             start_node_id: None,
             traverse_edge: None,
             traverse_depth: None,
@@ -1986,6 +2009,7 @@ mod hybrid_tests {
 
         // Query without any criteria should error
         let response = server.hybrid_query(HybridQueryRequest {
+            namespace: None,
             start_node_id: None,
             traverse_edge: None,
             traverse_depth: None,
@@ -2041,6 +2065,7 @@ mod hybrid_tests {
 
         // Query with traversal
         let response = server.hybrid_query(HybridQueryRequest {
+            namespace: None,
             start_node_id: Some(n1.id),
             traverse_edge: Some("KNOWS".to_string()),
             traverse_depth: Some(1),
@@ -2156,6 +2181,7 @@ mod coverage_tests {
 
         // Try to search with wrong dimensions (3 instead of 4)
         let response = server.find_similar(FindSimilarRequest {
+            namespace: None,
             property_name: "embedding".to_string(),
             embedding: vec![0.1, 0.2, 0.3], // Wrong: 3 dimensions instead of 4
             k: Some(5),
@@ -2190,6 +2216,7 @@ mod coverage_tests {
 
         // Try hybrid query with wrong embedding dimensions
         let response = server.hybrid_query(HybridQueryRequest {
+            namespace: None,
             start_node_id: None,
             traverse_edge: None,
             traverse_depth: None,
@@ -2229,6 +2256,7 @@ mod coverage_tests {
 
         // Test with ISO 8601 timestamp format (with Z timezone)
         let response = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id: node.id,
             valid_time: "2024-01-15T10:30:00Z".to_string(),
             transaction_time: None,
@@ -2265,6 +2293,7 @@ mod coverage_tests {
 
         // Test with ISO 8601 timestamp without timezone (should assume UTC)
         let response = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id: node.id,
             valid_time: "2024-01-15T10:30:00".to_string(),
             transaction_time: None,
@@ -2299,6 +2328,7 @@ mod coverage_tests {
 
         // Get node at time without specifying transaction_time
         let response = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id: node.id,
             valid_time: "0".to_string(), // Use 0 for simplicity
             transaction_time: None,
@@ -2360,6 +2390,7 @@ mod coverage_tests {
 
         // Request with a very large offset (should be capped)
         let response = server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("OffsetTest".to_string()),
             property_key: None,
             property_value: None,
@@ -2415,6 +2446,7 @@ mod coverage_tests {
 
         // Try to traverse with a very large depth (should be capped to MAX_TRAVERSAL_DEPTH)
         let response = server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: 0,
             edge_label: "NEXT".to_string(),
             depth: Some(100), // Very large depth, should be capped
@@ -2517,6 +2549,7 @@ mod error_handling_tests {
         let server = create_test_server();
 
         let req = GetEdgeRequest {
+            namespace: None,
             edge_id: 999999,
             include_vectors: None,
         };
@@ -2714,6 +2747,7 @@ mod vector_distance_tests {
 
         // Try to request more than MAX_VECTOR_K results
         let response = server.find_similar(FindSimilarRequest {
+            namespace: None,
             property_name: "embedding".to_string(),
             embedding: vec![0.1, 0.2, 0.3, 0.4],
             k: Some(10000), // Much larger than MAX_VECTOR_K,
@@ -2765,6 +2799,7 @@ mod temporal_extended_tests {
 
         // Get node at time with explicit transaction time
         let response = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id: node.id,
             valid_time: now_micros.to_string(),
             transaction_time: Some(now_micros.to_string()),
@@ -2829,6 +2864,7 @@ mod temporal_extended_tests {
 
         // Get edge at time with explicit transaction time
         let response = server.get_edge_at_time(GetEdgeAtTimeRequest {
+            namespace: None,
             edge_id: edge.id,
             valid_time: now_micros.to_string(),
             transaction_time: Some(now_micros.to_string()),
@@ -2857,6 +2893,7 @@ mod temporal_extended_tests {
 
         // Try with invalid transaction time format
         let response = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id: node.id,
             valid_time: "0".to_string(),
             transaction_time: Some("not-a-valid-timestamp".to_string()),
@@ -2911,6 +2948,7 @@ mod temporal_extended_tests {
 
         // Try with invalid valid_time format
         let response = server.get_edge_at_time(GetEdgeAtTimeRequest {
+            namespace: None,
             edge_id: edge.id,
             valid_time: "invalid-time".to_string(),
             transaction_time: None,
@@ -2936,6 +2974,7 @@ mod temporal_extended_tests {
 
         // Test with offset timezone (+00:00)
         let response = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id: node.id,
             valid_time: "2024-01-15T10:30:00+00:00".to_string(),
             transaction_time: None,
@@ -3015,6 +3054,7 @@ mod traversal_extended_tests {
 
         // Traverse bidirectionally from middle node
         let response = server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: nodes[1], // Middle node
             edge_label: "CONNECTED".to_string(),
             direction: Some("both".to_string()),
@@ -3082,6 +3122,7 @@ mod traversal_extended_tests {
         });
 
         let response = server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: a,
             edge_label: "POINTS_AT".to_string(),
             direction: Some("both".to_string()),
@@ -3120,6 +3161,7 @@ mod traversal_extended_tests {
 
         // Traverse with non-existent edge label
         let response = server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: node.id,
             edge_label: "NONEXISTENT".to_string(),
             direction: None,
@@ -3175,6 +3217,7 @@ mod traversal_extended_tests {
 
         // Traverse without specifying direction (should default to outgoing)
         let response = server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: n1.id,
             edge_label: "NEXT".to_string(),
             direction: None, // Default to outgoing
@@ -3235,6 +3278,7 @@ mod traversal_extended_tests {
 
         // Traverse with limit
         let response = server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: center.id,
             edge_label: "SPOKE".to_string(),
             direction: Some("outgoing".to_string()),
@@ -3285,6 +3329,7 @@ mod hybrid_extended_tests {
 
         // Query with both valid_time and transaction_time
         let response = server.hybrid_query(HybridQueryRequest {
+            namespace: None,
             start_node_id: Some(node.id),
             traverse_edge: None,
             traverse_depth: None,
@@ -3347,6 +3392,7 @@ mod hybrid_extended_tests {
 
         // Query with depth > 1
         let response = server.hybrid_query(HybridQueryRequest {
+            namespace: None,
             start_node_id: Some(nodes[0]),
             traverse_edge: Some("CHAIN".to_string()),
             traverse_depth: Some(3),
@@ -3383,6 +3429,7 @@ mod hybrid_extended_tests {
 
         // Query with invalid valid_time
         let response = server.hybrid_query(HybridQueryRequest {
+            namespace: None,
             start_node_id: Some(node.id),
             traverse_edge: None,
             traverse_depth: None,
@@ -3421,6 +3468,7 @@ mod hybrid_extended_tests {
 
         // Query with invalid transaction_time
         let response = server.hybrid_query(HybridQueryRequest {
+            namespace: None,
             start_node_id: Some(node.id),
             traverse_edge: None,
             traverse_depth: None,
@@ -3465,6 +3513,7 @@ mod hybrid_extended_tests {
 
         // Query with very large limit (should be capped internally)
         let response = server.hybrid_query(HybridQueryRequest {
+            namespace: None,
             start_node_id: None,
             traverse_edge: None,
             traverse_depth: None,
@@ -3492,6 +3541,7 @@ mod hybrid_extended_tests {
 
         // Try vector search without enabling index
         let response = server.hybrid_query(HybridQueryRequest {
+            namespace: None,
             start_node_id: None,
             traverse_edge: None,
             traverse_depth: None,
@@ -3571,6 +3621,7 @@ mod edge_extended_tests {
 
         // List edges with label filter
         let response = server.list_edges(ListEdgesRequest {
+            namespace: None,
             label: Some("KNOWS".to_string()),
             limit: None,
             offset: None,
@@ -3734,6 +3785,7 @@ mod list_nodes_extended_tests {
 
         // List nodes without label filter
         let response = server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: None,
             property_key: None,
             property_value: None,
@@ -3773,6 +3825,7 @@ mod list_nodes_extended_tests {
 
         // Request with very large limit (should be capped to MAX_RESULT_LIMIT)
         let response = server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("LimitCap".to_string()),
             property_key: None,
             property_value: None,
@@ -3837,6 +3890,7 @@ mod list_nodes_extended_tests {
 
         // Filter by property
         let response = server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("Person".to_string()),
             property_key: Some("name".to_string()),
             property_value: Some(serde_json::json!("Alice")),
@@ -3880,6 +3934,7 @@ mod list_nodes_extended_tests {
         });
 
         let response = server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("Sensor".to_string()),
             property_key: Some("reading".to_string()),
             property_value: Some(serde_json::json!(42)),
@@ -3915,6 +3970,7 @@ mod list_nodes_extended_tests {
         });
 
         let response = server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("Item".to_string()),
             property_key: Some("color".to_string()),
             property_value: Some(serde_json::json!("blue")),
@@ -3934,6 +3990,7 @@ mod list_nodes_extended_tests {
 
         // property_key without label should error
         let response = server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: None,
             property_key: Some("name".to_string()),
             property_value: Some(serde_json::json!("Alice")),
@@ -3955,6 +4012,7 @@ mod list_nodes_extended_tests {
 
         // property_key without property_value should error
         let response = server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("Person".to_string()),
             property_key: Some("name".to_string()),
             property_value: None,
@@ -3992,6 +4050,7 @@ mod list_nodes_extended_tests {
 
         // Page 1: first 2
         let response = server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("Widget".to_string()),
             property_key: Some("status".to_string()),
             property_value: Some(serde_json::json!("active")),
@@ -4006,6 +4065,7 @@ mod list_nodes_extended_tests {
 
         // Page 2: next 2
         let response = server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("Widget".to_string()),
             property_key: Some("status".to_string()),
             property_value: Some(serde_json::json!("active")),
@@ -4020,6 +4080,7 @@ mod list_nodes_extended_tests {
 
         // Page 3: last 1
         let response = server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("Widget".to_string()),
             property_key: Some("status".to_string()),
             property_value: Some(serde_json::json!("active")),
@@ -4086,6 +4147,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "aql".to_string(),
                 query: "MATCH (n:Widget) RETURN n".to_string(),
                 params: None,
@@ -4129,6 +4191,7 @@ mod query_tool_tests {
             let value = run_query(
                 &server,
                 QueryRequest {
+                    namespace: None,
                     language: "cypher".to_string(),
                     query: stmt.to_string(),
                     params: None,
@@ -4162,6 +4225,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "aql".to_string(),
                 query: "this is not a valid query".to_string(),
                 params: None,
@@ -4182,6 +4246,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "sql".to_string(),
                 query: "MATCH (n) RETURN n".to_string(),
                 params: None,
@@ -4204,6 +4269,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "aql".to_string(),
                 query: "MATCH (n:Widget) RETURN n".to_string(),
                 params: Some(params),
@@ -4227,6 +4293,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "aql".to_string(),
                 query: "MATCH (n:Widget) RETURN n".to_string(),
                 params: None,
@@ -4253,6 +4320,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "cypher".to_string(),
                 query: "MATCH (n) RETURN n".to_string(),
                 params: None,
@@ -4275,6 +4343,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "cypher".to_string(),
                 query: "MATCH (n:Person {name: 'Alice'}) RETURN n".to_string(),
                 params: None,
@@ -4303,6 +4372,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "cypher".to_string(),
                 query: "MATCH (n:Person) RETURN count(*)".to_string(),
                 params: None,
@@ -4357,6 +4427,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "cypher".to_string(),
                 query: "MATCH (n:Person) RETURN n.dept, count(*)".to_string(),
                 params: None,
@@ -4397,6 +4468,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "cypher".to_string(),
                 query: "MATCH (n:Person) RETURN count(*) AS c".to_string(),
                 params: None,
@@ -4426,6 +4498,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "cypher".to_string(),
                 query: "MATCH (n:Person {name: 'Alice'}) RETURN n".to_string(),
                 params: None,
@@ -4469,6 +4542,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "cypher".to_string(),
                 query: "MATCH (a:Person {name: 'Alice'}) OPTIONAL MATCH (a)-[:KNOWS]->(x) RETURN x"
                     .to_string(),
@@ -4495,6 +4569,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "cypher".to_string(),
                 query: "MATCH (n:Person {name: $name}) RETURN n".to_string(),
                 params: Some(params),
@@ -4527,6 +4602,7 @@ mod query_tool_tests {
             let value = run_query(
                 &server,
                 QueryRequest {
+                    namespace: None,
                     language: "cypher".to_string(),
                     query: q.clone(),
                     params: None,
@@ -4559,6 +4635,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "cypher".to_string(),
                 query: "MATCH (n:Person) AS OF TIMESTAMP 'not-a-timestamp' RETURN n".to_string(),
                 params: None,
@@ -4589,6 +4666,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "aql".to_string(),
                 // String literal `it\'s fine` — backslash-escaped quote inside single quotes.
                 query: "MATCH (n:Person {note: 'it\\'s fine'}) RETURN n".to_string(),
@@ -4620,6 +4698,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "aql".to_string(),
                 query: "this is not valid".to_string(),
                 params: None,
@@ -4646,6 +4725,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "cypher".to_string(),
                 query: "MATCH (n) RETURN n".to_string(),
                 params: Some(params),
@@ -4675,6 +4755,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "cypher".to_string(),
                 query: "MATCH (n:Product) WHERE n.price < $threshold RETURN n".to_string(),
                 params: Some(params),
@@ -4703,6 +4784,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "aql".to_string(),
                 query: "// CREATE would mutate\nMATCH (n:Widget) RETURN n".to_string(),
                 params: None,
@@ -4733,6 +4815,7 @@ mod query_tool_tests {
             let value = run_query(
                 &server,
                 QueryRequest {
+                    namespace: None,
                     language: "aql".to_string(),
                     query: stmt.to_string(),
                     params: None,
@@ -4764,6 +4847,7 @@ mod query_tool_tests {
             let value = run_query(
                 &server,
                 QueryRequest {
+                    namespace: None,
                     language: "aql".to_string(),
                     query: stmt.to_string(),
                     params: None,
@@ -4795,6 +4879,7 @@ mod query_tool_tests {
             let value = run_query(
                 &server,
                 QueryRequest {
+                    namespace: None,
                     language: "aql".to_string(),
                     query: stmt.to_string(),
                     params: None,
@@ -4820,6 +4905,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "cypher".to_string(),
                 query: "MATCH (n) WHERE n.x = $x RETURN n".to_string(),
                 params: Some(params),
@@ -4847,6 +4933,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "cypher".to_string(),
                 query: "MATCH (n) WHERE n.flag = $flag AND n.count = $count RETURN n".to_string(),
                 params: Some(params),
@@ -4873,6 +4960,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "cypher".to_string(),
                 query: "MATCH (n) RETURN n".to_string(),
                 params: Some(params),
@@ -4898,6 +4986,7 @@ mod query_tool_tests {
         let value = run_query(
             &server,
             QueryRequest {
+                namespace: None,
                 language: "cypher".to_string(),
                 query: "MATCH (n) RETURN n".to_string(),
                 params: Some(params),
@@ -4922,6 +5011,7 @@ mod query_tool_tests {
     /// A `query` request with `limits` fields set on the override.
     fn query_req(language: &str, query: &str, limits: Option<QueryLimitsOverride>) -> QueryRequest {
         QueryRequest {
+            namespace: None,
             language: language.to_string(),
             query: query.to_string(),
             params: None,
@@ -5764,6 +5854,7 @@ mod vector_elision_tests {
         let (node_id, _embedding) = create_node_with_embedding(&server, 1536);
 
         let response = server.get_node(GetNodeRequest {
+            namespace: None,
             node_id,
             include_vectors: None,
         });
@@ -5787,6 +5878,7 @@ mod vector_elision_tests {
         let (node_id, embedding) = create_node_with_embedding(&server, 1536);
 
         let response = server.get_node(GetNodeRequest {
+            namespace: None,
             node_id,
             include_vectors: Some(true),
         });
@@ -5870,6 +5962,7 @@ mod vector_elision_tests {
         }
 
         let response = server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("Document".to_string()),
             property_key: None,
             property_value: None,
@@ -5890,6 +5983,7 @@ mod vector_elision_tests {
 
         // include_vectors: true restores the full arrays.
         let response = server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("Document".to_string()),
             property_key: None,
             property_value: None,
@@ -5945,6 +6039,7 @@ mod vector_elision_tests {
 
         // get_edge
         let response = server.get_edge(GetEdgeRequest {
+            namespace: None,
             edge_id: edge.id,
             include_vectors: None,
         });
@@ -5955,6 +6050,7 @@ mod vector_elision_tests {
         );
 
         let response = server.get_edge(GetEdgeRequest {
+            namespace: None,
             edge_id: edge.id,
             include_vectors: Some(true),
         });
@@ -6034,6 +6130,7 @@ mod vector_elision_tests {
         });
 
         let response = server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: n1_id,
             edge_label: "NEXT".to_string(),
             direction: None,
@@ -6053,6 +6150,7 @@ mod vector_elision_tests {
         );
 
         let response = server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: n1_id,
             edge_label: "NEXT".to_string(),
             direction: None,
@@ -6105,6 +6203,7 @@ mod vector_elision_tests {
         }
 
         let response = server.find_similar(FindSimilarRequest {
+            namespace: None,
             property_name: "embedding".to_string(),
             embedding: vec![0.1, 0.2, 0.3, 0.4],
             k: Some(3),
@@ -6123,6 +6222,7 @@ mod vector_elision_tests {
         }
 
         let response = server.find_similar(FindSimilarRequest {
+            namespace: None,
             property_name: "embedding".to_string(),
             embedding: vec![0.1, 0.2, 0.3, 0.4],
             k: Some(3),
@@ -6172,6 +6272,7 @@ mod vector_elision_tests {
         }
 
         let response = server.hybrid_query(HybridQueryRequest {
+            namespace: None,
             start_node_id: None,
             traverse_edge: None,
             traverse_depth: None,
@@ -6196,6 +6297,7 @@ mod vector_elision_tests {
         }
 
         let response = server.hybrid_query(HybridQueryRequest {
+            namespace: None,
             start_node_id: None,
             traverse_edge: None,
             traverse_depth: None,
@@ -6237,6 +6339,7 @@ mod vector_elision_tests {
         });
 
         let response = server.hybrid_query(HybridQueryRequest {
+            namespace: None,
             start_node_id: Some(n1_id),
             traverse_edge: Some("NEXT".to_string()),
             traverse_depth: Some(1),
@@ -6258,6 +6361,7 @@ mod vector_elision_tests {
         );
 
         let response = server.hybrid_query(HybridQueryRequest {
+            namespace: None,
             start_node_id: Some(n1_id),
             traverse_edge: Some("NEXT".to_string()),
             traverse_depth: Some(1),
@@ -6295,6 +6399,7 @@ mod vector_elision_tests {
             .expect("create node with sparse vector");
 
         let response = server.get_node(GetNodeRequest {
+            namespace: None,
             node_id: node_id.as_u64(),
             include_vectors: None,
         });
@@ -6305,6 +6410,7 @@ mod vector_elision_tests {
         );
 
         let response = server.get_node(GetNodeRequest {
+            namespace: None,
             node_id: node_id.as_u64(),
             include_vectors: Some(true),
         });
@@ -6400,6 +6506,7 @@ mod vector_elision_tests {
         let mut previous: Option<HashMap<String, serde_json::Value>> = None;
         for include_vectors in variants {
             let response = server.get_node(GetNodeRequest {
+                namespace: None,
                 node_id: node.id,
                 include_vectors,
             });
@@ -6484,6 +6591,7 @@ mod retraction_tests {
 
         // Gone from current state (structured NOT_FOUND).
         let after = server.get_node(GetNodeRequest {
+            namespace: None,
             node_id,
             include_vectors: None,
         });
@@ -6510,6 +6618,7 @@ mod retraction_tests {
 
         // Still visible at a valid time strictly before T...
         let before = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id,
             valid_time: rfc3339_hours_ago(now, 2),
             transaction_time: None,
@@ -6519,6 +6628,7 @@ mod retraction_tests {
 
         // ...and not at/after T.
         let at = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id,
             valid_time: rfc3339_hours_ago(now, 1),
             transaction_time: None,
@@ -6530,6 +6640,7 @@ mod retraction_tests {
         );
 
         let after = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id,
             valid_time: rfc3339_hours_ago(now, 0),
             transaction_time: None,
@@ -6581,6 +6692,7 @@ mod retraction_tests {
 
         // Never a success that strands edges: node is still present.
         let still_there = server.get_node(GetNodeRequest {
+            namespace: None,
             node_id: a,
             include_vectors: None,
         });
@@ -6622,6 +6734,7 @@ mod retraction_tests {
 
         // The co-retracted edge: queryable strictly before T, gone after.
         let before = server.get_edge_at_time(GetEdgeAtTimeRequest {
+            namespace: None,
             edge_id: edge.id,
             valid_time: rfc3339_hours_ago(now, 2),
             transaction_time: None,
@@ -6630,6 +6743,7 @@ mod retraction_tests {
         assert!(before.get("error").is_none(), "expected edge, got {before}");
 
         let after = server.get_edge_at_time(GetEdgeAtTimeRequest {
+            namespace: None,
             edge_id: edge.id,
             valid_time: rfc3339_hours_ago(now, 0),
             transaction_time: None,
@@ -6705,6 +6819,7 @@ mod retraction_tests {
 
         // Nothing was retracted.
         let still_there = server.get_node(GetNodeRequest {
+            namespace: None,
             node_id,
             include_vectors: None,
         });
@@ -6790,6 +6905,7 @@ mod retraction_tests {
 
         // History still shows the edge before the retraction instant.
         let before = server.get_edge_at_time(GetEdgeAtTimeRequest {
+            namespace: None,
             edge_id: edge.id,
             valid_time: rfc3339_hours_ago(now, 1),
             transaction_time: None,
@@ -6918,6 +7034,7 @@ mod retraction_tests {
         // Both edges: queryable strictly before T, gone at/after T.
         for edge_id in [e_out.id, e_in.id] {
             let before = server.get_edge_at_time(GetEdgeAtTimeRequest {
+                namespace: None,
                 edge_id,
                 valid_time: rfc3339_hours_ago(now, 2),
                 transaction_time: None,
@@ -6929,6 +7046,7 @@ mod retraction_tests {
             );
 
             let after = server.get_edge_at_time(GetEdgeAtTimeRequest {
+                namespace: None,
                 edge_id,
                 valid_time: rfc3339_hours_ago(now, 0),
                 transaction_time: None,
@@ -6940,6 +7058,7 @@ mod retraction_tests {
             );
 
             let current = server.get_edge(GetEdgeRequest {
+                namespace: None,
                 edge_id,
                 include_vectors: None,
             });
@@ -6985,6 +7104,7 @@ mod valid_time_write_tests {
 
         // Visible shortly after its valid_from.
         let visible = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id: node.id,
             valid_time: rfc3339_hours_ago(now, 0),
             transaction_time: None,
@@ -6994,6 +7114,7 @@ mod valid_time_write_tests {
 
         // Invisible strictly before its valid_from.
         let invisible = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id: node.id,
             valid_time: rfc3339_hours_ago(now, 2),
             transaction_time: None,
@@ -7023,6 +7144,7 @@ mod valid_time_write_tests {
         assert_eq!(node.label, "Person");
 
         let now_response = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id: node.id,
             valid_time: Utc::now().to_rfc3339(),
             transaction_time: None,
@@ -7113,6 +7235,7 @@ mod valid_time_write_tests {
         let edge: EdgeResponse = parse_response(&response).expect("create_edge should succeed");
 
         let visible = server.get_edge_at_time(GetEdgeAtTimeRequest {
+            namespace: None,
             edge_id: edge.id,
             valid_time: rfc3339_hours_ago(now, 0),
             transaction_time: None,
@@ -7121,6 +7244,7 @@ mod valid_time_write_tests {
         assert!(value.get("error").is_none(), "expected edge, got {value}");
 
         let invisible = server.get_edge_at_time(GetEdgeAtTimeRequest {
+            namespace: None,
             edge_id: edge.id,
             valid_time: rfc3339_hours_ago(now, 2),
             transaction_time: None,
@@ -7165,6 +7289,7 @@ mod valid_time_write_tests {
 
         // Visible from its own valid_from onward.
         let at_update = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id: node.id,
             valid_time: update_valid_time,
             transaction_time: None,
@@ -7230,6 +7355,7 @@ mod valid_time_write_tests {
         // had not happened yet -- the fact must not be retroactively knowable.
         let too_early_tx = (now - Duration::minutes(30)).to_rfc3339();
         let too_early = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id: node.id,
             valid_time: rfc3339_hours_ago(now, 0),
             transaction_time: Some(too_early_tx),
@@ -7239,6 +7365,7 @@ mod valid_time_write_tests {
 
         // Omitting transaction_time defaults to now, where the write is visible.
         let now_response = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id: node.id,
             valid_time: rfc3339_hours_ago(now, 0),
             transaction_time: None,
@@ -7303,6 +7430,7 @@ mod valid_time_write_tests {
         );
 
         let at_update = server.get_edge_at_time(GetEdgeAtTimeRequest {
+            namespace: None,
             edge_id: edge.id,
             valid_time: update_valid_time,
             transaction_time: None,
@@ -7411,6 +7539,7 @@ mod valid_time_write_tests {
 
         // No longer visible as of now.
         let gone = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id: node.id,
             valid_time: now.to_rfc3339(),
             transaction_time: None,
@@ -7482,6 +7611,7 @@ mod valid_time_write_tests {
 
         // No longer visible as of now.
         let gone = server.get_edge_at_time(GetEdgeAtTimeRequest {
+            namespace: None,
             edge_id: edge.id,
             valid_time: now.to_rfc3339(),
             transaction_time: None,
@@ -7540,6 +7670,7 @@ mod valid_time_write_tests {
 
         // Node and edge must be untouched by the rejected request.
         let get_value: serde_json::Value = serde_json::from_str(&server.get_node(GetNodeRequest {
+            namespace: None,
             node_id: n1.id,
             include_vectors: None,
         }))
@@ -8008,6 +8139,7 @@ mod provenance_write_tests {
         .unwrap();
 
         let fetched: NodeResponse = parse_response(&server.get_node(GetNodeRequest {
+            namespace: None,
             node_id: node.id,
             include_vectors: None,
         }))
@@ -8030,6 +8162,7 @@ mod provenance_write_tests {
         .unwrap();
 
         let response = server.get_node(GetNodeRequest {
+            namespace: None,
             node_id: node.id,
             include_vectors: None,
         });
@@ -8081,6 +8214,7 @@ mod provenance_write_tests {
         .unwrap();
 
         let response = server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("ListProvenanceTest".to_string()),
             property_key: None,
             property_value: None,
@@ -8135,6 +8269,7 @@ mod provenance_write_tests {
         .unwrap();
 
         let response = server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: start.id,
             edge_label: "KNOWS".to_string(),
             direction: Some("outgoing".to_string()),
@@ -8198,6 +8333,7 @@ mod provenance_write_tests {
         .unwrap();
 
         let response = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id: node.id,
             valid_time: as_of_micros.to_string(),
             transaction_time: Some(as_of_micros.to_string()),
@@ -8280,6 +8416,7 @@ mod traverse_as_of_tests {
         let (count_before, _) = traverse_count(
             &server,
             TraverseRequest {
+                namespace: None,
                 start_node_id: a,
                 edge_label: "KNOWS".to_string(),
                 direction: Some("outgoing".to_string()),
@@ -8300,6 +8437,7 @@ mod traverse_as_of_tests {
         let (count_after, _) = traverse_count(
             &server,
             TraverseRequest {
+                namespace: None,
                 start_node_id: a,
                 edge_label: "KNOWS".to_string(),
                 direction: Some("outgoing".to_string()),
@@ -8348,6 +8486,7 @@ mod traverse_as_of_tests {
         let (count_before_retirement, _) = traverse_count(
             &server,
             TraverseRequest {
+                namespace: None,
                 start_node_id: a,
                 edge_label: "KNOWS".to_string(),
                 direction: Some("outgoing".to_string()),
@@ -8368,6 +8507,7 @@ mod traverse_as_of_tests {
         let (count_after_retirement, _) = traverse_count(
             &server,
             TraverseRequest {
+                namespace: None,
                 start_node_id: a,
                 edge_label: "KNOWS".to_string(),
                 direction: Some("outgoing".to_string()),
@@ -8401,6 +8541,7 @@ mod traverse_as_of_tests {
         let (count_tx_gate_fails, _) = traverse_count(
             &server,
             TraverseRequest {
+                namespace: None,
                 start_node_id: a,
                 edge_label: "KNOWS".to_string(),
                 direction: Some("outgoing".to_string()),
@@ -8423,6 +8564,7 @@ mod traverse_as_of_tests {
         let (count_vt_gate_fails, _) = traverse_count(
             &server,
             TraverseRequest {
+                namespace: None,
                 start_node_id: a,
                 edge_label: "KNOWS".to_string(),
                 direction: Some("outgoing".to_string()),
@@ -8444,6 +8586,7 @@ mod traverse_as_of_tests {
         let (count_both_satisfied, _) = traverse_count(
             &server,
             TraverseRequest {
+                namespace: None,
                 start_node_id: a,
                 edge_label: "KNOWS".to_string(),
                 direction: Some("outgoing".to_string()),
@@ -8474,6 +8617,7 @@ mod traverse_as_of_tests {
         let (count, _) = traverse_count(
             &server,
             TraverseRequest {
+                namespace: None,
                 start_node_id: a,
                 edge_label: "KNOWS".to_string(),
                 direction: Some("outgoing".to_string()),
@@ -8497,6 +8641,7 @@ mod traverse_as_of_tests {
         let a = create_node_at(&server, "Person", &Utc::now().to_rfc3339());
 
         let response = server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: a,
             edge_label: "KNOWS".to_string(),
             direction: Some("outgoing".to_string()),
@@ -8524,6 +8669,7 @@ mod traverse_as_of_tests {
         let a = create_node_at(&server, "Person", &Utc::now().to_rfc3339());
 
         let response = server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: a,
             edge_label: "KNOWS".to_string(),
             direction: Some("outgoing".to_string()),
@@ -8569,6 +8715,7 @@ mod traverse_as_of_tests {
         let (count, _) = traverse_count(
             &server,
             TraverseRequest {
+                namespace: None,
                 start_node_id: start,
                 edge_label: "NEXT".to_string(),
                 direction: Some("outgoing".to_string()),
@@ -8595,6 +8742,7 @@ mod traverse_as_of_tests {
         let (count_no_temporal, value_no_temporal) = traverse_count(
             &server,
             TraverseRequest {
+                namespace: None,
                 start_node_id: a,
                 edge_label: "KNOWS".to_string(),
                 direction: Some("outgoing".to_string()),
@@ -8610,6 +8758,7 @@ mod traverse_as_of_tests {
         let (count_as_of_now, value_as_of_now) = traverse_count(
             &server,
             TraverseRequest {
+                namespace: None,
                 start_node_id: a,
                 edge_label: "KNOWS".to_string(),
                 direction: Some("outgoing".to_string()),
@@ -8646,6 +8795,7 @@ mod traverse_as_of_tests {
         let (count, _) = traverse_count(
             &server,
             TraverseRequest {
+                namespace: None,
                 start_node_id: a,
                 edge_label: "KNOWS".to_string(),
                 direction: Some("outgoing".to_string()),
@@ -8681,6 +8831,7 @@ mod traverse_as_of_tests {
         let (count, value) = traverse_count(
             &server,
             TraverseRequest {
+                namespace: None,
                 start_node_id: a,
                 edge_label: "POINTS_AT".to_string(),
                 direction: Some("both".to_string()),
@@ -8729,6 +8880,7 @@ mod traverse_as_of_tests {
         let (count, value) = traverse_count(
             &server,
             TraverseRequest {
+                namespace: None,
                 start_node_id: a,
                 edge_label: "KNOWS".to_string(),
                 direction: Some("outgoing".to_string()),
@@ -8798,6 +8950,7 @@ mod completeness_tests {
 
         // Page 1: full page, more remains.
         let page1 = parse(&server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("PersonHM".to_string()),
             property_key: None,
             property_value: None,
@@ -8819,6 +8972,7 @@ mod completeness_tests {
 
         // Page 2: full page, still more.
         let page2 = parse(&server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("PersonHM".to_string()),
             property_key: None,
             property_value: None,
@@ -8831,6 +8985,7 @@ mod completeness_tests {
 
         // Page 3: partial final page, no more.
         let page3 = parse(&server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("PersonHM".to_string()),
             property_key: None,
             property_value: None,
@@ -8855,6 +9010,7 @@ mod completeness_tests {
         seed_labeled(&server, "ScanHM", 5);
 
         let value = parse(&server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("ScanHM".to_string()),
             property_key: None,
             property_value: None,
@@ -8890,6 +9046,7 @@ mod completeness_tests {
         }
 
         let page1 = parse(&server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("WidgetHM".to_string()),
             property_key: Some("status".to_string()),
             property_value: Some(serde_json::json!("active")),
@@ -8907,6 +9064,7 @@ mod completeness_tests {
         assert_eq!(next_offset(&page1), Some(100));
 
         let page2 = parse(&server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("WidgetHM".to_string()),
             property_key: Some("status".to_string()),
             property_value: Some(serde_json::json!("active")),
@@ -8927,6 +9085,7 @@ mod completeness_tests {
         let server = create_test_server();
         seed_labeled(&server, "AnyHM", 3);
         let value = parse(&server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: None,
             property_key: None,
             property_value: None,
@@ -8946,6 +9105,7 @@ mod completeness_tests {
     fn test_list_edges_has_more_false() {
         let server = create_test_server();
         let value = parse(&server.list_edges(ListEdgesRequest {
+            namespace: None,
             label: None,
             limit: None,
             offset: None,
@@ -9114,6 +9274,7 @@ mod completeness_tests {
 
         // Truncate at 2 of the 5 reachable nodes.
         let truncated = parse(&server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: ids[0],
             edge_label: "NEXT".to_string(),
             direction: None,
@@ -9134,6 +9295,7 @@ mod completeness_tests {
 
         // A limit above the reachable count exhausts the traversal.
         let complete = parse(&server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: ids[0],
             edge_label: "NEXT".to_string(),
             direction: None,
@@ -9157,6 +9319,7 @@ mod completeness_tests {
         // Collect the ids returned across two offset pages of size 2 plus a
         // final page; the union must equal the single-shot full traversal.
         let full = parse(&server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: ids[0],
             edge_label: "NEXT".to_string(),
             direction: None,
@@ -9171,6 +9334,7 @@ mod completeness_tests {
         assert_eq!(full_count, 5);
 
         let page2 = parse(&server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: ids[0],
             edge_label: "NEXT".to_string(),
             direction: None,
@@ -9190,6 +9354,7 @@ mod completeness_tests {
         assert_eq!(next_offset(&page2), Some(4));
 
         let page3 = parse(&server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: ids[0],
             edge_label: "NEXT".to_string(),
             direction: None,
@@ -9254,6 +9419,7 @@ mod completeness_tests {
 
         // k=2 of 5 available -> more remains.
         let page1 = parse(&server.find_similar(FindSimilarRequest {
+            namespace: None,
             property_name: "embedding".to_string(),
             embedding: query.clone(),
             k: Some(2),
@@ -9266,6 +9432,7 @@ mod completeness_tests {
 
         // Offset into the middle.
         let page2 = parse(&server.find_similar(FindSimilarRequest {
+            namespace: None,
             property_name: "embedding".to_string(),
             embedding: query.clone(),
             k: Some(2),
@@ -9278,6 +9445,7 @@ mod completeness_tests {
 
         // k beyond the available set exhausts it.
         let complete = parse(&server.find_similar(FindSimilarRequest {
+            namespace: None,
             property_name: "embedding".to_string(),
             embedding: query,
             k: Some(50),
@@ -9301,6 +9469,7 @@ mod completeness_tests {
             (
                 "list_nodes(label)",
                 server.list_nodes(ListNodesRequest {
+                    namespace: None,
                     label: Some("Leaf".to_string()),
                     property_key: None,
                     property_value: None,
@@ -9312,6 +9481,7 @@ mod completeness_tests {
             (
                 "list_nodes(unfiltered)",
                 server.list_nodes(ListNodesRequest {
+                    namespace: None,
                     label: None,
                     property_key: None,
                     property_value: None,
@@ -9323,6 +9493,7 @@ mod completeness_tests {
             (
                 "list_edges",
                 server.list_edges(ListEdgesRequest {
+                    namespace: None,
                     label: None,
                     limit: None,
                     offset: None,
@@ -9348,6 +9519,7 @@ mod completeness_tests {
             (
                 "traverse",
                 server.traverse(TraverseRequest {
+                    namespace: None,
                     start_node_id: center,
                     edge_label: "LINK".to_string(),
                     direction: None,
@@ -9362,6 +9534,7 @@ mod completeness_tests {
             (
                 "find_similar",
                 server.find_similar(FindSimilarRequest {
+                    namespace: None,
                     property_name: "embedding".to_string(),
                     embedding: vec![0.1, 0.2, 0.3, 0.4],
                     k: Some(1),
@@ -9392,6 +9565,7 @@ mod completeness_tests {
         let server = create_test_server();
         seed_labeled(&server, "ClampHM", 3);
         let value = parse(&server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("ClampHM".to_string()),
             property_key: None,
             property_value: None,
@@ -9413,6 +9587,7 @@ mod completeness_tests {
         let server = create_test_server();
         let ids = seed_chain(&server, 3);
         let value = parse(&server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: ids[0],
             edge_label: "NEXT".to_string(),
             direction: None,
@@ -9437,6 +9612,7 @@ mod completeness_tests {
         let server = create_test_server();
         seed_vectors(&server, 3);
         let value = parse(&server.find_similar(FindSimilarRequest {
+            namespace: None,
             property_name: "embedding".to_string(),
             embedding: vec![0.1, 0.2, 0.3, 0.4],
             k: Some(0),
@@ -9482,6 +9658,7 @@ mod completeness_tests {
         // reports uncertainty as has_more:true in O(1) extra work rather
         // than an O(dangling-chain-length) walk that still gets it wrong.
         let response = parse(&server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: ids[0],
             edge_label: "NEXT".to_string(),
             direction: None,
@@ -9526,6 +9703,7 @@ mod find_nodes_at_time_tests {
 
     fn base_req(label: &str, valid_time: &str) -> FindNodesAtTimeRequest {
         FindNodesAtTimeRequest {
+            namespace: None,
             label: label.to_string(),
             property_key: None,
             property_value: None,
@@ -9539,6 +9717,7 @@ mod find_nodes_at_time_tests {
 
     fn name_req(label: &str, name: &str, valid_time: &str) -> FindNodesAtTimeRequest {
         FindNodesAtTimeRequest {
+            namespace: None,
             property_key: Some("name".to_string()),
             property_value: Some(serde_json::json!(name)),
             ..base_req(label, valid_time)
@@ -9620,6 +9799,7 @@ mod find_nodes_at_time_tests {
     /// the guide).
     fn name_req_at(label: &str, name: &str, t: &str) -> FindNodesAtTimeRequest {
         FindNodesAtTimeRequest {
+            namespace: None,
             transaction_time: Some(t.to_string()),
             ..name_req(label, name, t)
         }
@@ -9704,6 +9884,7 @@ mod find_nodes_at_time_tests {
         let value = find(
             &server,
             FindNodesAtTimeRequest {
+                namespace: None,
                 transaction_time: Some(t_before.clone()),
                 ..name_req("Person", "Alice", &t_before)
             },
@@ -9714,6 +9895,7 @@ mod find_nodes_at_time_tests {
         let value = find(
             &server,
             FindNodesAtTimeRequest {
+                namespace: None,
                 transaction_time: Some(t_after.clone()),
                 ..name_req("Person", "Alice", &t_after)
             },
@@ -9734,6 +9916,7 @@ mod find_nodes_at_time_tests {
         let value = find(
             &server,
             FindNodesAtTimeRequest {
+                namespace: None,
                 transaction_time: Some(t1.clone()),
                 ..base_req("Person", &t1)
             },
@@ -9743,6 +9926,7 @@ mod find_nodes_at_time_tests {
         let value = find(
             &server,
             FindNodesAtTimeRequest {
+                namespace: None,
                 transaction_time: Some(t2.clone()),
                 ..base_req("Person", &t2)
             },
@@ -9760,6 +9944,7 @@ mod find_nodes_at_time_tests {
 
         let list_value: serde_json::Value =
             serde_json::from_str(&server.list_nodes(ListNodesRequest {
+                namespace: None,
                 label: Some("Person".to_string()),
                 property_key: Some("name".to_string()),
                 property_value: Some(serde_json::json!("Alice")),
@@ -9792,6 +9977,7 @@ mod find_nodes_at_time_tests {
         let page1 = find(
             &server,
             FindNodesAtTimeRequest {
+                namespace: None,
                 limit: Some(1),
                 ..name_req("Person", "Alice", &now)
             },
@@ -9808,6 +9994,7 @@ mod find_nodes_at_time_tests {
         let page2 = find(
             &server,
             FindNodesAtTimeRequest {
+                namespace: None,
                 limit: Some(1),
                 offset: Some(1),
                 ..name_req("Person", "Alice", &now)
@@ -9821,6 +10008,7 @@ mod find_nodes_at_time_tests {
         let page3 = find(
             &server,
             FindNodesAtTimeRequest {
+                namespace: None,
                 limit: Some(1),
                 offset: Some(2),
                 ..name_req("Person", "Alice", &now)
@@ -9845,6 +10033,7 @@ mod find_nodes_at_time_tests {
         let value = find(
             &server,
             FindNodesAtTimeRequest {
+                namespace: None,
                 limit: Some(0),
                 ..name_req("Person", "Alice", &now)
             },
@@ -9871,6 +10060,7 @@ mod find_nodes_at_time_tests {
         let value = find(
             &server,
             FindNodesAtTimeRequest {
+                namespace: None,
                 limit: Some(1_000_000),
                 offset: Some(1_000_000),
                 ..name_req("Person", "Alice", &now)
@@ -9893,6 +10083,7 @@ mod find_nodes_at_time_tests {
         assert_invalid_argument(&response, "valid_time");
 
         let response = server.find_nodes_at_time(FindNodesAtTimeRequest {
+            namespace: None,
             transaction_time: Some("not-a-timestamp".to_string()),
             ..base_req("Person", &Utc::now().to_rfc3339())
         });
@@ -9905,12 +10096,14 @@ mod find_nodes_at_time_tests {
         let now = Utc::now().to_rfc3339();
 
         let response = server.find_nodes_at_time(FindNodesAtTimeRequest {
+            namespace: None,
             property_key: Some("name".to_string()),
             ..base_req("Person", &now)
         });
         assert_invalid_argument(&response, "property_key");
 
         let response = server.find_nodes_at_time(FindNodesAtTimeRequest {
+            namespace: None,
             property_value: Some(serde_json::json!("Alice")),
             ..base_req("Person", &now)
         });
@@ -9921,6 +10114,7 @@ mod find_nodes_at_time_tests {
     fn unsupported_property_value_type_returns_structured_error() {
         let server = create_test_server();
         let response = server.find_nodes_at_time(FindNodesAtTimeRequest {
+            namespace: None,
             property_key: Some("name".to_string()),
             property_value: Some(serde_json::json!({"nested": "object"})),
             ..base_req("Person", &Utc::now().to_rfc3339())
@@ -10011,6 +10205,7 @@ mod find_nodes_at_time_tests {
         let value = find(
             &server,
             FindNodesAtTimeRequest {
+                namespace: None,
                 include_vectors: Some(true),
                 ..base_req("Document", &now)
             },
@@ -11596,6 +11791,9 @@ mod database_stats_tests {
                 "cold_storage",
                 "current",
                 "historical",
+                // Per-namespace counts (Issue #3349, PR3a): serialized since the
+                // surface slice; empty array on a default-only database.
+                "namespaces",
                 "resource_limits",
                 "wal"
             ]
@@ -11866,6 +12064,7 @@ mod temporal_bounds_tests {
         assert_current_open_bounds(&temporal_of(&created));
 
         let get_response = server.get_node(GetNodeRequest {
+            namespace: None,
             node_id: created["id"].as_u64().unwrap(),
             include_vectors: None,
         });
@@ -11893,6 +12092,7 @@ mod temporal_bounds_tests {
         assert_current_open_bounds(&temporal_of(&created));
 
         let get_response = server.get_edge(GetEdgeRequest {
+            namespace: None,
             edge_id: created["id"].as_u64().unwrap(),
             include_vectors: None,
         });
@@ -11908,6 +12108,7 @@ mod temporal_bounds_tests {
         // "now" so both dimensions anchor the same bi-temporal instant.
         let now = now_micros().to_string();
         let at_time_response = server.get_edge_at_time(GetEdgeAtTimeRequest {
+            namespace: None,
             edge_id: created["id"].as_u64().unwrap(),
             valid_time: now.clone(),
             transaction_time: Some(now),
@@ -11929,6 +12130,7 @@ mod temporal_bounds_tests {
         create_knows_edge(&server, a, b);
 
         let list_response = server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some("Person".to_string()),
             property_key: None,
             property_value: None,
@@ -11944,6 +12146,7 @@ mod temporal_bounds_tests {
         }
 
         let traverse_response = server.traverse(TraverseRequest {
+            namespace: None,
             start_node_id: a,
             edge_label: "KNOWS".to_string(),
             direction: None,
@@ -12047,6 +12250,7 @@ mod temporal_bounds_tests {
         // (valid_to == null); only its transaction-time bound is closed by the
         // update. It is not current (its tx interval is closed).
         let at_time_response = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id,
             valid_time: anchor.to_string(),
             transaction_time: Some(anchor.to_string()),
@@ -12074,6 +12278,7 @@ mod temporal_bounds_tests {
         // A current read after the update shows the NEW version's bounds:
         // open-ended, current, and starting after the anchor.
         let current_response = server.get_node(GetNodeRequest {
+            namespace: None,
             node_id,
             include_vectors: None,
         });
@@ -12144,6 +12349,7 @@ mod temporal_bounds_tests {
             .expect("one current version");
 
         let at_time_response = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id,
             valid_time: anchor.to_string(),
             transaction_time: Some(anchor.to_string()),
@@ -12152,6 +12358,7 @@ mod temporal_bounds_tests {
         let superseded_temporal = temporal_of(&at_time["node"]);
 
         let current_response = server.get_node(GetNodeRequest {
+            namespace: None,
             node_id,
             include_vectors: None,
         });
@@ -12228,6 +12435,7 @@ mod temporal_bounds_tests {
         assert_future_not_current(&temporal_of(&created));
 
         let get_response = server.get_node(GetNodeRequest {
+            namespace: None,
             node_id: created["id"].as_u64().unwrap(),
             include_vectors: None,
         });
@@ -12306,6 +12514,7 @@ mod temporal_bounds_tests {
         // deletes -- the tombstone carries the valid-time closure -- so it is
         // deliberately not asserted here.)
         let at_time_response = server.get_node_at_time(GetNodeAtTimeRequest {
+            namespace: None,
             node_id,
             valid_time: anchor.to_string(),
             transaction_time: Some(anchor.to_string()),
@@ -12524,6 +12733,7 @@ mod temporal_bounds_tests {
             .unwrap();
 
         let response = server.get_node(GetNodeRequest {
+            namespace: None,
             node_id,
             include_vectors: None,
         });
@@ -12569,6 +12779,7 @@ mod temporal_bounds_tests {
         server.db().current.update_edge_direct(stored).unwrap();
 
         let response = server.get_edge(GetEdgeRequest {
+            namespace: None,
             edge_id,
             include_vectors: None,
         });
@@ -14178,6 +14389,7 @@ mod per_request_now_tests {
     /// `temporal.is_current` flag, in response order.
     fn list_is_current_flags(server: &AletheiaMcpServer, label: &str) -> Vec<bool> {
         let response = server.list_nodes(ListNodesRequest {
+            namespace: None,
             label: Some(label.to_string()),
             property_key: None,
             property_value: None,
@@ -14372,6 +14584,7 @@ mod per_request_now_tests {
 
         let traverse = |start_node_id: u64| {
             server.traverse(TraverseRequest {
+                namespace: None,
                 start_node_id,
                 edge_label: "NEXT".to_string(),
                 direction: Some("outgoing".to_string()),
@@ -14497,6 +14710,7 @@ mod per_request_now_tests {
 
         let find = |k: usize| {
             server.find_similar(FindSimilarRequest {
+                namespace: None,
                 property_name: "embedding".to_string(),
                 embedding: vec![0.1, 0.2, 0.3, 0.4],
                 k: Some(k),
@@ -14524,6 +14738,7 @@ mod per_request_now_tests {
 
         let find = |label: &str| {
             server.find_nodes_at_time(FindNodesAtTimeRequest {
+                namespace: None,
                 label: label.to_string(),
                 property_key: None,
                 property_value: None,
@@ -14556,6 +14771,7 @@ mod per_request_now_tests {
 
         let query = |label: &str| {
             server.hybrid_query(HybridQueryRequest {
+                namespace: None,
                 start_node_id: None,
                 traverse_edge: None,
                 traverse_depth: None,
@@ -18270,5 +18486,306 @@ mod namespace_surface_sweep_tests {
             Some("INVALID_ARGUMENT"),
             "namespace on delete_edge must be INVALID_ARGUMENT: {del}"
         );
+    }
+
+    // ========================================================================
+    // BLOCK 2 (PR3a): read-tool namespace scope + per-ns counts
+    // ========================================================================
+
+    /// Seed two isolated namespaces: agent:planner {Alice,Bob KNOWS} and
+    /// agent:researcher {Carol}. Returns (server, alice, bob, carol) u64 ids.
+    fn seed_two_namespaces() -> (AletheiaMcpServer, u64, u64, u64) {
+        let (server, alice, bob) = seed_namespaced();
+        let carol = server
+            .db()
+            .create_node_in_namespace(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Carol").build(),
+                "agent:researcher",
+            )
+            .expect("create carol")
+            .as_u64();
+        (server, alice, bob, carol)
+    }
+
+    #[test]
+    fn scoped_get_node_isolates_other_namespace() {
+        let (server, alice, _bob, carol) = seed_two_namespaces();
+        // Alice is visible when scoped to her namespace...
+        let ok = server.dispatch_tool_json(
+            "get_node",
+            serde_json::json!({ "node_id": alice, "namespace": "agent:planner" }),
+        );
+        assert_eq!(
+            as_json(&ok).get("namespace").and_then(|n| n.as_str()),
+            Some("agent:planner"),
+            "scoped get_node should return Alice: {ok}"
+        );
+        // ...but NOT when scoped to a different namespace (NOT_FOUND, never leaks).
+        let hidden = server.dispatch_tool_json(
+            "get_node",
+            serde_json::json!({ "node_id": alice, "namespace": "agent:researcher" }),
+        );
+        assert_eq!(
+            as_json(&hidden)
+                .pointer("/error/code")
+                .and_then(|c| c.as_str()),
+            Some("NOT_FOUND"),
+            "Alice must be NOT_FOUND when scoped to another namespace: {hidden}"
+        );
+        // Carol visible only in her own namespace.
+        let carol_hidden = server.dispatch_tool_json(
+            "get_node",
+            serde_json::json!({ "node_id": carol, "namespace": "agent:planner" }),
+        );
+        assert_eq!(
+            as_json(&carol_hidden)
+                .pointer("/error/code")
+                .and_then(|c| c.as_str()),
+            Some("NOT_FOUND"),
+            "Carol must be NOT_FOUND under agent:planner scope: {carol_hidden}"
+        );
+    }
+
+    #[test]
+    fn scoped_list_nodes_isolates_and_unions() {
+        let (server, _alice, _bob, _carol) = seed_two_namespaces();
+        // Scope to planner: only Alice + Bob.
+        let planner = server.dispatch_tool_json(
+            "list_nodes",
+            serde_json::json!({ "label": "Person", "namespace": "agent:planner" }),
+        );
+        let pj = as_json(&planner);
+        assert_eq!(
+            pj.get("count").and_then(|c| c.as_u64()),
+            Some(2),
+            "{planner}"
+        );
+        assert!(planner.contains("Alice") && planner.contains("Bob"));
+        assert!(
+            !planner.contains("Carol"),
+            "planner scope leaked Carol: {planner}"
+        );
+        assert_no_reserved(&planner, "list_nodes(scoped)");
+        // Scope to researcher: only Carol.
+        let research = server.dispatch_tool_json(
+            "list_nodes",
+            serde_json::json!({ "label": "Person", "namespace": "agent:researcher" }),
+        );
+        assert!(
+            research.contains("Carol") && !research.contains("Alice"),
+            "{research}"
+        );
+        // Union scope sees all three.
+        let both = server.dispatch_tool_json(
+            "list_nodes",
+            serde_json::json!({
+                "label": "Person",
+                "namespace": ["agent:planner", "agent:researcher"]
+            }),
+        );
+        assert_eq!(
+            as_json(&both).get("count").and_then(|c| c.as_u64()),
+            Some(3),
+            "{both}"
+        );
+        // "all" selector: no filter.
+        let all = server.dispatch_tool_json(
+            "list_nodes",
+            serde_json::json!({ "label": "Person", "namespace": "all" }),
+        );
+        assert_eq!(
+            as_json(&all).get("count").and_then(|c| c.as_u64()),
+            Some(3),
+            "{all}"
+        );
+    }
+
+    #[test]
+    fn scoped_traverse_respects_boundary() {
+        let (server, alice, _bob, _carol) = seed_two_namespaces();
+        // In-scope traversal reaches Bob (same namespace).
+        let ok = server.dispatch_tool_json(
+            "traverse",
+            serde_json::json!({
+                "start_node_id": alice, "edge_label": "KNOWS",
+                "namespace": "agent:planner"
+            }),
+        );
+        assert!(ok.contains("Bob"), "scoped traverse should reach Bob: {ok}");
+        assert_no_reserved(&ok, "traverse(scoped)");
+        // Traversing scoped to a namespace Alice is NOT in ⇒ NOT_FOUND (the
+        // start node is out of scope).
+        let bad = server.dispatch_tool_json(
+            "traverse",
+            serde_json::json!({
+                "start_node_id": alice, "edge_label": "KNOWS",
+                "namespace": "agent:researcher"
+            }),
+        );
+        assert_eq!(
+            as_json(&bad)
+                .pointer("/error/code")
+                .and_then(|c| c.as_str()),
+            Some("NOT_FOUND"),
+            "start out of scope must be NOT_FOUND: {bad}"
+        );
+    }
+
+    #[test]
+    fn scoped_find_similar_isolates() {
+        let server = create_test_server();
+        server
+            .db()
+            .vector_index("embedding")
+            .hnsw(crate::index::vector::HnswConfig::new(
+                3,
+                crate::index::vector::DistanceMetric::Cosine,
+            ))
+            .enable()
+            .expect("enable vector index");
+        let mk = |ns: &str, name: &str, v: [f32; 3]| {
+            server
+                .db()
+                .create_node_in_namespace(
+                    "Doc",
+                    PropertyMapBuilder::new()
+                        .insert("name", name)
+                        .insert_vector("embedding", &v)
+                        .build(),
+                    ns,
+                )
+                .expect("create doc");
+        };
+        mk("agent:planner", "P1", [1.0, 0.0, 0.0]);
+        mk("agent:planner", "P2", [0.9, 0.1, 0.0]);
+        mk("agent:researcher", "R1", [1.0, 0.0, 0.0]);
+        let out = server.dispatch_tool_json(
+            "find_similar",
+            serde_json::json!({
+                "property_name": "embedding",
+                "embedding": [1.0, 0.0, 0.0],
+                "k": 5,
+                "namespace": "agent:planner"
+            }),
+        );
+        assert!(
+            out.contains("P1") || out.contains("P2"),
+            "expected planner docs: {out}"
+        );
+        assert!(
+            !out.contains("R1"),
+            "researcher doc leaked into scoped search: {out}"
+        );
+        assert_no_reserved(&out, "find_similar(scoped)");
+    }
+
+    #[test]
+    fn scoped_read_unknown_namespace_is_not_found_with_details() {
+        let (server, alice, _bob) = seed_namespaced();
+        let out = server.dispatch_tool_json(
+            "get_node",
+            serde_json::json!({ "node_id": alice, "namespace": "agent:nonexistent" }),
+        );
+        let v = as_json(&out);
+        assert_eq!(
+            v.pointer("/error/code").and_then(|c| c.as_str()),
+            Some("NOT_FOUND"),
+            "unknown namespace must be NOT_FOUND: {out}"
+        );
+        assert_eq!(
+            v.pointer("/error/details/namespace")
+                .and_then(|c| c.as_str()),
+            Some("agent:nonexistent"),
+            "NOT_FOUND must carry details.namespace: {out}"
+        );
+    }
+
+    #[test]
+    fn scoped_read_empty_array_is_invalid_argument() {
+        let (server, _alice, _bob) = seed_namespaced();
+        let out = server.dispatch_tool_json(
+            "list_nodes",
+            serde_json::json!({ "label": "Person", "namespace": [] }),
+        );
+        assert_eq!(
+            as_json(&out)
+                .pointer("/error/code")
+                .and_then(|c| c.as_str()),
+            Some("INVALID_ARGUMENT"),
+            "empty namespace scope array must be INVALID_ARGUMENT: {out}"
+        );
+    }
+
+    #[test]
+    fn unsupported_scope_tools_reject_narrowing_scope() {
+        let (server, _a, _b) = seed_namespaced();
+        for tool in ["list_edges", "hybrid_query", "query"] {
+            let mut args = serde_json::json!({ "namespace": "agent:planner" });
+            if tool == "query" {
+                args["language"] = serde_json::json!("aql");
+                args["query"] = serde_json::json!("MATCH (n:Person) RETURN n");
+            }
+            let out = server.dispatch_tool_json(tool, args);
+            let v = as_json(&out);
+            let code = v
+                .pointer("/error/code")
+                .and_then(|c| c.as_str())
+                .or_else(|| v.pointer("/error/kind").and_then(|c| c.as_str()));
+            assert_eq!(
+                v.pointer("/error/code").and_then(|c| c.as_str()),
+                Some("INVALID_ARGUMENT"),
+                "{tool} must reject a narrowing scope with INVALID_ARGUMENT (code={code:?}): {out}"
+            );
+        }
+        // But "all" is accepted (no-op) by these tools.
+        let all_ok = server.dispatch_tool_json(
+            "hybrid_query",
+            serde_json::json!({ "filter_label": "Person", "namespace": "all" }),
+        );
+        assert!(
+            all_ok.get(0..1).is_some() && !all_ok.contains("\"error\""),
+            "hybrid_query with namespace:all should not error: {all_ok}"
+        );
+    }
+
+    #[test]
+    fn per_namespace_counts_in_database_stats() {
+        let (server, _alice, _bob, _carol) = seed_two_namespaces();
+        let out = server.dispatch_tool_json("database_stats", serde_json::json!({}));
+        let v = as_json(&out);
+        let namespaces = v
+            .get("namespaces")
+            .and_then(|n| n.as_array())
+            .expect("database_stats must carry a namespaces array");
+        let planner = namespaces
+            .iter()
+            .find(|e| e.get("name").and_then(|n| n.as_str()) == Some("agent:planner"))
+            .unwrap_or_else(|| panic!("agent:planner missing from stats: {out}"));
+        assert_eq!(planner.get("node_count").and_then(|c| c.as_u64()), Some(2));
+        assert_eq!(planner.get("edge_count").and_then(|c| c.as_u64()), Some(1));
+        let research = namespaces
+            .iter()
+            .find(|e| e.get("name").and_then(|n| n.as_str()) == Some("agent:researcher"))
+            .unwrap_or_else(|| panic!("agent:researcher missing from stats: {out}"));
+        assert_eq!(research.get("node_count").and_then(|c| c.as_u64()), Some(1));
+    }
+
+    #[test]
+    fn per_namespace_counts_in_get_schema() {
+        let (server, _alice, _bob, _carol) = seed_two_namespaces();
+        let out = server.dispatch_tool_json("get_schema", serde_json::json!({}));
+        let v = as_json(&out);
+        let namespaces = v
+            .get("namespaces")
+            .and_then(|n| n.as_array())
+            .expect("get_schema must carry a namespaces array");
+        assert!(
+            namespaces
+                .iter()
+                .any(|e| e.get("name").and_then(|n| n.as_str()) == Some("agent:planner")),
+            "get_schema namespaces must include agent:planner: {out}"
+        );
+        assert_no_reserved(&out, "get_schema(counts)");
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -147,6 +147,16 @@ pub struct GetNodeRequest {
                        {type, dim, elided:true} descriptor (default: false)"
     )]
     pub include_vectors: Option<bool>,
+
+    /// Optional namespace read scope (Issue #3349).
+    #[schemars(
+        description = "Optional namespace read scope: a single namespace name (string), an array \
+                       of names (union — the read sees any of them), or the selector \"all\" (no \
+                       filter). Omit for the current, unscoped behavior. Out of scope, the node is \
+                       reported NOT_FOUND (indistinguishable from missing). An unknown namespace is \
+                       NOT_FOUND (details.namespace); an empty array is INVALID_ARGUMENT."
+    )]
+    pub namespace: Option<serde_json::Value>,
 }
 
 /// Request to create a new node.
@@ -395,6 +405,16 @@ pub struct ListNodesRequest {
                        {type, dim, elided:true} descriptor (default: false)"
     )]
     pub include_vectors: Option<bool>,
+
+    /// Optional namespace read scope (Issue #3349).
+    #[schemars(
+        description = "Optional namespace read scope: a single namespace name (string), an array \
+                       of names (union), or \"all\" (no filter). Omit for the current, unscoped \
+                       behavior. When set, only nodes whose namespace is in scope are listed. An \
+                       unknown namespace is NOT_FOUND (details.namespace); an empty array is \
+                       INVALID_ARGUMENT."
+    )]
+    pub namespace: Option<serde_json::Value>,
 }
 
 /// Request to count nodes.
@@ -423,6 +443,15 @@ pub struct GetEdgeRequest {
                        {type, dim, elided:true} descriptor (default: false)"
     )]
     pub include_vectors: Option<bool>,
+
+    /// Optional namespace read scope (Issue #3349).
+    #[schemars(
+        description = "Optional namespace read scope: a single namespace name (string), an array \
+                       of names (union), or \"all\" (no filter). Omit for the current, unscoped \
+                       behavior. Out of scope, the edge is reported NOT_FOUND. An unknown namespace \
+                       is NOT_FOUND (details.namespace); an empty array is INVALID_ARGUMENT."
+    )]
+    pub namespace: Option<serde_json::Value>,
 }
 
 /// Request to create a new edge between nodes.
@@ -583,6 +612,16 @@ pub struct ListEdgesRequest {
                        {type, dim, elided:true} descriptor (default: false)"
     )]
     pub include_vectors: Option<bool>,
+
+    /// Optional namespace read scope (Issue #3349).
+    #[schemars(
+        description = "Optional namespace read scope: a single namespace name (string), an array \
+                       of names (union), or \"all\" (no filter). NOTE: list_edges does not enumerate \
+                       edges by namespace in v1; supplying a scope other than \"all\" returns a \
+                       structured INVALID_ARGUMENT rather than a silently-unscoped result. Use the \
+                       scoped adjacency/traversal reads instead."
+    )]
+    pub namespace: Option<serde_json::Value>,
 }
 
 /// Request to count edges.
@@ -711,6 +750,19 @@ pub struct TraverseRequest {
         description = "Optional transaction time (ISO 8601 or microseconds since epoch). Supplying this or as_of_valid_time switches to a bi-temporal, point-in-time traversal. If omitted while as_of_valid_time is set, defaults to the current time."
     )]
     pub as_of_transaction_time: Option<String>,
+
+    /// Optional namespace read scope (Issue #3349).
+    #[schemars(
+        description = "Optional namespace read scope: a single namespace name (string), an array \
+                       of names (union), or \"all\" (no filter). Omit for the current, unscoped \
+                       traversal. When set, an edge is crossed only if BOTH the edge's own \
+                       namespace AND the target node's namespace are in scope, so a scope can never \
+                       leak across the boundary. An unknown namespace is NOT_FOUND \
+                       (details.namespace); an empty array is INVALID_ARGUMENT. In v1 a scoped \
+                       traverse does not compose with the #3360 cursor / #3353 token-budget \
+                       shaping (offset paging still applies)."
+    )]
+    pub namespace: Option<serde_json::Value>,
 }
 
 // ============================================================================
@@ -757,6 +809,17 @@ pub struct FindSimilarRequest {
                        is always returned in full regardless of this flag."
     )]
     pub include_vectors: Option<bool>,
+
+    /// Optional namespace read scope (Issue #3349).
+    #[schemars(
+        description = "Optional namespace read scope: a single namespace name (string), an array \
+                       of names (union), or \"all\" (no filter). Omit for the current, unscoped \
+                       search. When set, the k-NN search is filter-complete: it over-fetches until \
+                       it has k genuinely in-scope results (never k-then-drop), with scores and \
+                       ordering unchanged. An unknown namespace is NOT_FOUND (details.namespace); \
+                       an empty array is INVALID_ARGUMENT."
+    )]
+    pub namespace: Option<serde_json::Value>,
 }
 
 // ============================================================================
@@ -993,6 +1056,17 @@ pub struct GetNodeAtTimeRequest {
         description = "Transaction time as ISO 8601 timestamp (when recorded). If not provided, uses current time."
     )]
     pub transaction_time: Option<String>,
+
+    /// Optional namespace read scope (Issue #3349).
+    #[schemars(
+        description = "Optional namespace read scope: a single namespace name (string), an array \
+                       of names (union), or \"all\" (no filter). Omit for the current, unscoped \
+                       behavior. The point-in-time reconstruction runs first, then the namespace \
+                       filter (immutable membership). Out of scope ⇒ NOT_FOUND. An unknown \
+                       namespace is NOT_FOUND (details.namespace); an empty array is \
+                       INVALID_ARGUMENT."
+    )]
+    pub namespace: Option<serde_json::Value>,
 }
 
 /// Request to get an edge at a specific point in time.
@@ -1014,6 +1088,17 @@ pub struct GetEdgeAtTimeRequest {
         description = "Transaction time as ISO 8601 timestamp (when recorded). If not provided, uses current time."
     )]
     pub transaction_time: Option<String>,
+
+    /// Optional namespace read scope (Issue #3349).
+    #[schemars(
+        description = "Optional namespace read scope: a single namespace name (string), an array \
+                       of names (union), or \"all\" (no filter). Omit for the current, unscoped \
+                       behavior. The point-in-time reconstruction runs first, then the namespace \
+                       filter (immutable membership). Out of scope ⇒ NOT_FOUND. An unknown \
+                       namespace is NOT_FOUND (details.namespace); an empty array is \
+                       INVALID_ARGUMENT."
+    )]
+    pub namespace: Option<serde_json::Value>,
 }
 
 /// Request to find nodes by label (and optional exact property match) as of
@@ -1071,6 +1156,16 @@ pub struct FindNodesAtTimeRequest {
                        {type, dim, elided:true} descriptor (default: false)"
     )]
     pub include_vectors: Option<bool>,
+
+    /// Optional namespace read scope (Issue #3349).
+    #[schemars(
+        description = "Optional namespace read scope: a single namespace name (string), an array \
+                       of names (union), or \"all\" (no filter). Omit for the current, unscoped \
+                       behavior. Each candidate is reconstructed at (valid_time, transaction_time) \
+                       first, then filtered by its immutable namespace. An unknown namespace is \
+                       NOT_FOUND (details.namespace); an empty array is INVALID_ARGUMENT."
+    )]
+    pub namespace: Option<serde_json::Value>,
 }
 
 /// Request to list graph-wide changes (node & edge versions) committed within a
@@ -1358,6 +1453,17 @@ pub struct HybridQueryRequest {
                        is always returned in full regardless of this flag."
     )]
     pub include_vectors: Option<bool>,
+
+    /// Optional namespace read scope (Issue #3349).
+    #[schemars(
+        description = "Optional namespace read scope: a single namespace name (string), an array \
+                       of names (union), or \"all\" (no filter). NOTE: hybrid_query does not yet \
+                       compose a filter-complete namespace scope with its vector ranking in v1; \
+                       supplying a scope other than \"all\" returns a structured INVALID_ARGUMENT \
+                       rather than a silently-unscoped (or incorrectly post-filtered) result. Use \
+                       find_similar / traverse with a namespace scope instead."
+    )]
+    pub namespace: Option<serde_json::Value>,
 }
 
 // ============================================================================
@@ -1405,6 +1511,17 @@ pub struct QueryRequest {
                        an unbounded ceiling)."
     )]
     pub limits: Option<super::limits::QueryLimitsOverride>,
+
+    /// Optional namespace read scope (Issue #3349).
+    #[schemars(
+        description = "Optional namespace read scope: a single namespace name (string), an array \
+                       of names (union), or \"all\" (no filter). NOTE: declarative (AQL/Cypher) \
+                       namespace scoping is a follow-up; supplying a scope other than \"all\" \
+                       returns a structured INVALID_ARGUMENT rather than a silently-unscoped \
+                       result. Use USE NAMESPACE in the query language when it lands, or the \
+                       structured scoped read tools."
+    )]
+    pub namespace: Option<serde_json::Value>,
 }
 
 // ============================================================================

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -188,6 +188,17 @@ pub struct CreateNodeRequest {
                        Omit for no lineage. Query it later via lineage_upstream/lineage_downstream."
     )]
     pub derived_from: Option<Vec<LineageRefRequest>>,
+
+    /// Optional namespace to create this node in (Issue #3349).
+    #[schemars(
+        description = "Optional namespace (agent/session scope) to create this node in, e.g. \
+                       'agent:planner'. Omit to use the default namespace ('default'), which is \
+                       byte-identical to pre-namespace behavior. An unknown namespace is \
+                       auto-registered. The namespace is fixed at creation and immutable \
+                       thereafter; it is surfaced back as the first-class `namespace` field on \
+                       reads and never as a user property. Charset [A-Za-z0-9._:/-], max 128 bytes."
+    )]
+    pub namespace: Option<String>,
 }
 
 /// Request to update an existing node's properties.
@@ -228,6 +239,16 @@ pub struct UpdateNodeRequest {
                        before any commit. Omit for no lineage."
     )]
     pub derived_from: Option<Vec<LineageRefRequest>>,
+
+    /// Optional namespace (Issue #3349). A namespace is immutable after
+    /// creation, so supplying one here is rejected.
+    #[schemars(
+        description = "A namespace is fixed at creation and immutable, so supplying one on an \
+                       update is rejected with INVALID_ARGUMENT rather than silently ignored. \
+                       Omit it; the node keeps its original namespace, echoed back as the \
+                       first-class `namespace` field."
+    )]
+    pub namespace: Option<String>,
 }
 
 /// Request to delete a node.
@@ -262,6 +283,15 @@ pub struct DeleteNodeRequest {
                        Transaction time is always system-assigned and cannot be set."
     )]
     pub valid_time: Option<String>,
+
+    /// Optional namespace (Issue #3349). A namespace is immutable, so supplying
+    /// one here is rejected.
+    #[schemars(
+        description = "A namespace is fixed at creation and immutable, so supplying one on a \
+                       delete is rejected with INVALID_ARGUMENT rather than silently ignored. \
+                       Omit it."
+    )]
+    pub namespace: Option<String>,
 }
 
 /// Request to retract a node: close its valid-time interval without
@@ -441,6 +471,17 @@ pub struct CreateEdgeRequest {
                        write with a structured error before any commit. Omit for no lineage."
     )]
     pub derived_from: Option<Vec<LineageRefRequest>>,
+
+    /// Optional namespace to create this edge in (Issue #3349).
+    #[schemars(
+        description = "Optional namespace (agent/session scope) to create this edge in, e.g. \
+                       'agent:planner'. Omit to use the default namespace ('default'). An unknown \
+                       namespace is auto-registered. A cross-namespace edge (endpoints in other \
+                       namespaces) is legal; the edge's own namespace governs whether a scoped \
+                       traversal crosses it. Immutable after creation; echoed back as the \
+                       first-class `namespace` field. Charset [A-Za-z0-9._:/-], max 128 bytes."
+    )]
+    pub namespace: Option<String>,
 }
 
 /// Request to update an existing edge's properties.
@@ -481,6 +522,16 @@ pub struct UpdateEdgeRequest {
                        write before any commit. Omit for no lineage."
     )]
     pub derived_from: Option<Vec<LineageRefRequest>>,
+
+    /// Optional namespace (Issue #3349). A namespace is immutable, so supplying
+    /// one here is rejected.
+    #[schemars(
+        description = "A namespace is fixed at creation and immutable, so supplying one on an \
+                       update is rejected with INVALID_ARGUMENT rather than silently ignored. \
+                       Omit it; the edge keeps its original namespace, echoed back as the \
+                       first-class `namespace` field."
+    )]
+    pub namespace: Option<String>,
 }
 
 /// Request to delete an edge.
@@ -499,6 +550,15 @@ pub struct DeleteEdgeRequest {
                        is always system-assigned and cannot be set."
     )]
     pub valid_time: Option<String>,
+
+    /// Optional namespace (Issue #3349). A namespace is immutable, so supplying
+    /// one here is rejected.
+    #[schemars(
+        description = "A namespace is fixed at creation and immutable, so supplying one on a \
+                       delete is rejected with INVALID_ARGUMENT rather than silently ignored. \
+                       Omit it."
+    )]
+    pub namespace: Option<String>,
 }
 
 /// Request to list edges with optional filtering.
@@ -1596,6 +1656,13 @@ pub struct NodeResponse {
     pub id: u64,
     pub label: String,
     pub properties: HashMap<String, serde_json::Value>,
+    /// The node's immutable namespace (Issue #3349), surfaced as a first-class
+    /// field (the ride-along property is elided). Omitted for `default`-namespace
+    /// entities so a single-agent (`default`-only) response stays byte-identical
+    /// to pre-namespace behavior (design AC1); present whenever the namespace is
+    /// non-default.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub namespace: Option<String>,
     /// The current version's write-time provenance bundle, if any. Omitted
     /// (never a fabricated `null`) when the version has none (Issue #3224).
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -1615,6 +1682,13 @@ pub struct EdgeResponse {
     pub target_id: u64,
     pub label: String,
     pub properties: HashMap<String, serde_json::Value>,
+    /// The edge's immutable namespace (Issue #3349), surfaced as a first-class
+    /// field (the ride-along property is elided). Omitted for `default`-namespace
+    /// entities so a single-agent (`default`-only) response stays byte-identical
+    /// to pre-namespace behavior (design AC1); present whenever the namespace is
+    /// non-default.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub namespace: Option<String>,
     /// The current version's write-time provenance bundle, if any. Omitted
     /// (never a fabricated `null`) when the version has none (Issue #3224).
     #[serde(skip_serializing_if = "Option::is_none", default)]

--- a/tests/auth_recovery.rs
+++ b/tests/auth_recovery.rs
@@ -148,6 +148,7 @@ fn recovery_preserves_data_provenance_principal_and_key_store() {
             .with_credential(SecretString::new(writer_key.as_str())),
     );
     let response = server.get_node(aletheiadb::mcp::GetNodeRequest {
+        namespace: None,
         node_id,
         include_vectors: None,
     });
@@ -265,6 +266,7 @@ fn crash_recovery_via_wal_replay_preserves_provenance_principal_and_key_store() 
             .with_credential(SecretString::new(writer_key.as_str())),
     );
     let response = server.get_node(aletheiadb::mcp::GetNodeRequest {
+        namespace: None,
         node_id,
         include_vectors: None,
     });

--- a/tests/auth_recovery.rs
+++ b/tests/auth_recovery.rs
@@ -64,6 +64,7 @@ fn recovery_preserves_data_provenance_principal_and_key_store() {
         // bundle must compose the caller's `source` with the server-stamped
         // `principal`.
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: Some(
@@ -198,6 +199,7 @@ fn crash_recovery_via_wal_replay_preserves_provenance_principal_and_key_store() 
         );
 
         let response = server.create_node(CreateNodeRequest {
+            namespace: None,
             derived_from: None,
             label: "Person".to_string(),
             properties: Some(

--- a/tests/parity_mcp.rs
+++ b/tests/parity_mcp.rs
@@ -496,6 +496,7 @@ fn query_over_ceiling_override_is_invalid_argument() {
     let v = run_query(
         &s,
         QueryRequest {
+            namespace: None,
             language: "aql".into(),
             query: "MATCH (n) RETURN n".into(),
             params: None,
@@ -528,6 +529,7 @@ fn query_byte_cap_is_resource_exhausted() {
     let v = run_query(
         &s,
         QueryRequest {
+            namespace: None,
             language: "aql".into(),
             query: "MATCH (n:Widget) RETURN n".into(),
             params: None,
@@ -559,6 +561,7 @@ fn query_row_cap_override_truncates_successfully() {
     let v = run_query(
         &s,
         QueryRequest {
+            namespace: None,
             language: "aql".into(),
             query: "MATCH (n:Widget) RETURN n".into(),
             params: None,


### PR DESCRIPTION
## Namespaces PR3a: MCP/HTTP namespace params + per-ns counts — #3349

Additive MCP/HTTP surface for AletheiaDB Namespaces (#3349), building on the merged
PR1 (core model) and PR2 (scoped query APIs in `src/db/namespace.rs` +
`src/db/namespace_query.rs`).

**No new tools — the MCP tool count stays exactly 58.** Everything here is an
additive optional `inputSchema` param or an additive response field, mirroring how
`valid_time` (#3221) and the token-budget params (#3353) were added.

### Block 1 — write-tool namespace param (committed earlier on this branch)
- Optional `namespace` on `create_node`/`create_edge` routes through the namespaced
  write API and auto-registers the namespace after commit.
- `update_*`/`delete_*` reject a supplied `namespace` with `INVALID_ARGUMENT`
  (namespace is immutable), never a silent no-op.
- `NodeResponse`/`EdgeResponse` gain a first-class `namespace` field (skip-when-default
  so single-agent responses stay byte-identical). The `__aletheia_ns` ride-along key
  stays elided from properties.

### Block 2 — read-tool namespace scope + per-ns counts (this change)
- Optional `namespace` **read scope** (string | array-union | `"all"`) on
  `get_node`/`list_nodes`/`get_edge`/`traverse`/`find_similar`/`get_node_at_time`/
  `get_edge_at_time`/`find_nodes_at_time`, routing to the PR2 `*_scoped` APIs.
  Unknown ns → `NOT_FOUND` (`details.namespace`); empty array → `INVALID_ARGUMENT`.
- Tools that cannot yet compose a filter-complete scope in v1 (`list_edges`,
  `hybrid_query`, `query`) reject a narrowing scope with `INVALID_ARGUMENT` rather
  than silently returning an unscoped result; `"all"`/absent are unchanged.
- Namespace scope does not compose with the #3360 cursor path in v1 (fails closed).
- `database_stats` and `get_schema` now surface per-namespace `{name, node_count,
  edge_count}` counts (un-skips `DatabaseStats.namespaces`); the stats key-set golden
  test is updated to include the new `namespaces` key.
- Reuses the #3234 `NamespaceError` classifier so MCP and HTTP render byte-identical
  `error.details.namespace` metadata.

### Block 3 (ChangeFilter.namespace) — NOT in this PR yet (follow-up)
> The title lists ChangeFilter.namespace for continuity with the PR3a plan, but it is
> **not implemented in this draft.**

`ChangeFilter.namespace` + `await_changes`/HTTP changefeed namespace filtering
requires threading the namespace through the core changefeed record-building path
(`ChangeRecord`/`RawChange`/`build_raw_change`, which does not currently receive the
version `PropertyMap`, across hot+cold node+edge scans) while preserving the documented
"byte-identical to `list_changes`" invariant — a deeper core change than the additive
surface work in Blocks 1-2. Deferred to a follow-up so this additive, low-risk surface
can land independently. **This PR stays DRAFT until Block 3 lands or is split out.**

### Verification (fresh isolated build)
- `cargo fmt --all --check`: clean
- clippy `config-toml,mcp-server,sharding-rpc,simulation` / `--all-features` /
  `--no-default-features`, all `-D warnings`: clean
- `cargo check --no-default-features --tests`: clean
- `cargo test --features mcp-server --no-fail-fast`: green except the two known uid-0
  havoc tests (`test_flush_deadlock_on_io_error`, `test_metadata_corruption_on_error`)
- `aletheia-server` conformance (`full_surface_parity_sweep` + `security_rbac`):
  green — `access_class_conformance_for_all_58`, `mcp_catalog_equals_inventory_exactly`,
  `registry_matches_inventory_exactly` all pass (tool count **58**).

### Guarantees
- **No WAL-format change.**
- **No MCP tool-registry change** — `tests/parity/inventory.json` untouched; the
  conformance sweep and `security_rbac` still assert exactly **58** tools.
- `__aletheia_ns` never leaks into any response payload (guarded by the
  `assert_no_reserved` / `sweep_*_elides_reserved_key` tests); surfaced only as the
  first-class `namespace` field.

Refs #3349.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3mvy2HNA1SWx6DTDcZe7x)_